### PR TITLE
"Build" page doesn't list tools to run a dev client

### DIFF
--- a/docs/build/index.md
+++ b/docs/build/index.md
@@ -160,6 +160,9 @@ The Ethereum network is made up of many nodes who run compatible client software
 - [parity.io](https://www.parity.io/)
 - [Gitub](https://github.com/paritytech/parity-ethereum)
 
+### Ethnode *Run an Ethereum node (Geth or Parity) for local development.*
+- [Github](https://github.com/vrde/ethnode)
+
 ### Ethereum Node Resources
 - [Node Configuration Cheat Sheet](https://dev.to/5chdn/ethereum-node-configuration-modes-cheat-sheet-25l8) *Jan 5, 2019 - Afri Schoeden*
 


### PR DESCRIPTION
In the *Build* page I see information on how to testnet and how to run your own node, but it doesn't mention any tool on how to run a local node for development and testing, and it's not obvious to a newcomer that they can run `geth` or `parity` in *single player mode* to just practice interacting with a real node.

I've added a link to [ethnode](https://github.com/vrde/ethnode), a simple tool to locally run **Geth** or **Parity** in development mode.