### PR TITLE
Replaced "Build" with "Developers" (fixes #72)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Keeping in mind the above core principles, there are many ways you can get invol
 
 If you want to suggest changes to particular sub-pages, keep in mind the purpose of each page:
 
-### 🛠 Build
+### 🛠 Developers
 
 - The purpose of this page is to collect core technical resources helpful to someone building on Ethereum
 - Information should be kept as up to date as possible, as new tools appear, standards are adopted, or material is deprecated

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -7,7 +7,7 @@ module.exports = {
       { text: 'Beginners', link: '/beginners/' },
       { text: 'Use', link: '/use/' },
       { text: 'Learn', link: '/learn/' },
-      { text: 'Build', link: '/build/' }
+      { text: 'Developers', link: '/developers/' }
     ]
   },
   head: [

--- a/docs/.vuepress/theme/components/Hero.vue
+++ b/docs/.vuepress/theme/components/Hero.vue
@@ -19,8 +19,8 @@
     </div>
 
     <div class="hero-block build sm-hide">
-      <router-link class="block header" to="/build/">→ Build</router-link>
-      <div class="content"><router-link class="text-color" to="/build/">Looking to build<br/>on Ethereum?</router-link></div>
+      <router-link class="block header" to="/developers/">→ Developers</router-link>
+      <div class="content"><router-link class="text-color" to="/developers/">Looking to build<br/>on Ethereum?</router-link></div>
     </div>
   </div>
 </template>

--- a/docs/beginners/index.md
+++ b/docs/beginners/index.md
@@ -42,7 +42,7 @@ These decentralized applications (or “dapps”) gain the benefits of cryptocur
 
 - Want to get started using Ethereum? [ethereum.org/use](/use/)
 - Curious to learn more about Ethereum and its technology? [ethereum.org/learn](/learn/)
-- Are you a developer interested in building on ethereum? [ethereum.org/build](/build/)
+- Are you a developer interested in building on ethereum? [ethereum.org/developers](/developers/)
 
 
 **Looking for more beginner resources about Ethereum?**

--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -1,11 +1,11 @@
 ---
-title: Build
+title: Developers
 lang: en-US
 sidebar: auto
 sidebarDepth: 0
 ---
 
-# Build on Ethereum
+# Developer Resources
 
 <div class="featured">Guides, resources, and tools for developers building on Ethereum.</div>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,10 +40,10 @@ sidebar: false
 
   </router-link>
 
-  <router-link to="/build/">
+  <router-link to="/developers/">
 
   <ul>
-    <li><span class="arrow">→</span>Build</li>
+    <li><span class="arrow">→</span>Developers</li>
     <li>Getting started guides</li>
     <li>Learn to program smart contracts</li>
     <li>Find the latest developer tools</li>

--- a/docs/learn/index.md
+++ b/docs/learn/index.md
@@ -51,7 +51,7 @@ These articles are non-technical explanations of Ethereum and blockchain technol
 A “smart contract” is simply a piece of code that is running on Ethereum. It’s called a “contract” because code that runs on Ethereum can control valuable things like ETH or other digital assets.
 
 
-- Want to learn how to program on Ethereum with smart contracts? [ethereum.org/build](/build/)
+- Want to learn how to program on Ethereum with smart contracts? [ethereum.org/developers](/developers/)
 
 ## Proof of Work and Mining
 
@@ -66,7 +66,7 @@ In ETH 2.0, Ethereum will be moving to a different system called “Proof of Sta
 ## Clients and Nodes
 The Ethereum network is made up of many nodes, each of which runs compatible client software. There are two clients that are used by a majority of nodes: [Geth](https://geth.ethereum.org/) (written in Go) and [Parity](https://www.parity.io/ethereum/) (written in Rust).
 
-- Want to learn how to run a node of your own? → [ethereum.org/build](/build/#clients-running-your-own-node)
+- Want to learn how to run a node of your own? → [ethereum.org/developers](/developers/#clients-running-your-own-node)
 - [Comprehensive list of all Ethereum clients](https://github.com/ConsenSys/ethereum-developer-tools-list#ethereum-clients)
 
 


### PR DESCRIPTION
I've changed all the links and text manually, so there shouldn't be any unintended renaming/replacing. Doesn't seem to break anything either.