### PR TITLE
Remove Veil

### DIFF
--- a/docs/use/index.md
+++ b/docs/use/index.md
@@ -25,7 +25,6 @@ Here are just a few apps built on Ethereum - we rotate this list frequently!
 
 - [Gitcoin](https://gitcoin.co), a network of incentivized open-source developers
 - [Cent](https://beta.cent.co), a social network where you earn money by posting
-- [Veil](https://app.veil.co), a trading platform that lets you place bets on real world events
 - [CryptoKitties](https://www.cryptokitties.co), a game where you collect and breed digital collectible cats
 - [DAI](https://makerdao.com/en/), a stable cryptocurrency that holds value at $1 USD
 


### PR DESCRIPTION
As of July 11, the Veil product is being sunsetted - removing from list of "recommended" applications for new users. 

Reference: https://twitter.com/veil/status/1149443647965814784.