### PR TITLE
Add The Graph to the developer tools section

### DIFF
--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -79,8 +79,8 @@ Ethereum has a large and growing number of tools to help developers build, test,
 ### The Graph *A protocol for indexing Ethereum and IPFS data and querying it using GraphQL.*
 - [The Graph](https://thegraph.com/)
 - [Graph Explorer](https://thegraph.com/explorer/)
-- [GitHub](https://github.com/graphprotocol/)
 - [Documentation](https://thegraph.com/docs/)
+- [GitHub](https://github.com/graphprotocol/)
 - [Discord](https://thegraph.com/discord)
 
 ### Tenderly *A platform to easily monitor your smart contracts with error tracking, alerting, performance metrics, and detailed contract analytics.*

--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -76,8 +76,9 @@ Ethereum has a large and growing number of tools to help developers build, test,
 - [Github](https://github.com/OpenZeppelin/openzeppelin-sdk)
 - [Community Forum](https://forum.openzeppelin.com/c/sdk)
 
-### The Graph *A protocol for indexing Ethereum and IPFS data and querying it with GraphQL.*
+### The Graph *A protocol for indexing Ethereum and IPFS data and querying it using GraphQL.*
 - [The Graph](https://thegraph.com/)
+- [Graph Explorer](https://thegraph.com/explorer/)
 - [GitHub](https://github.com/graphprotocol/)
 - [Documentation](https://thegraph.com/docs/)
 - [Discord](https://thegraph.com/discord)

--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -76,6 +76,12 @@ Ethereum has a large and growing number of tools to help developers build, test,
 - [Github](https://github.com/OpenZeppelin/openzeppelin-sdk)
 - [Community Forum](https://forum.openzeppelin.com/c/sdk)
 
+### The Graph *A protocol for indexing Ethereum and IPFS data and querying it with GraphQL.*
+- [The Graph](https://thegraph.com/)
+- [GitHub](https://github.com/graphprotocol/)
+- [Documentation](https://thegraph.com/docs/)
+- [Discord](https://thegraph.com/discord)
+
 ### Tenderly *A platform to easily monitor your smart contracts with error tracking, alerting, performance metrics, and detailed contract analytics.*
 - [tenderly.dev](https://tenderly.dev/)
 - [Github](https://github.com/Tenderly)


### PR DESCRIPTION
A growing number of projects (such as ENS, Moloch, Melon) is using The Graph in production. We feel it is a tool worth for any Ethereum contract/dApp developer to have in their toolbox. We'd love to have it included in the developer tools section.

Let me know if anything could be improved and I'll happily make changes.