### PR TITLE
/enterprise url with enterprise ethereum information and resources

### DIFF
--- a/docs/enterprise/index.md
+++ b/docs/enterprise/index.md
@@ -1,0 +1,30 @@
+---
+title: Enterprise
+lang: en-US
+sidebar: auto
+sidebarDepth: 0
+---
+
+# Enterprise Resources
+
+<div class="featured"></div>
+
+## Why Enterprise Ethereum?
+
+## Organisations
+
+## Projects
+
+## Infrastructure
+
+## Tooling
+
+## Enterprise Features
+
+### Permissioning
+
+### Privacy
+
+### Security
+
+### Performance

--- a/docs/enterprise/index.md
+++ b/docs/enterprise/index.md
@@ -7,24 +7,89 @@ sidebarDepth: 0
 
 # Enterprise Resources
 
-<div class="featured"></div>
+<div class="featured">Guides, articles, and tools for Enterprise Ethereum.</div>
 
 ## Why Enterprise Ethereum?
+Why should businesses care about Enterprise Ethereum?
+- New business models and value creation opportunities
+- Reduced cost of trust and coordination between business parties
+- Improved business network accountability and operational efficiency
+- Competitively future-proof your business
+
+For more in depth information, here are some related articles:
+
+- [5 Reasons Why Enterprise Ethereum Is so Much More Than a Distributed Ledger Technology](https://media.consensys.net/5-reasons-why-enterprise-ethereum-is-so-much-more-than-a-distributed-ledger-technology-c9a89db82cb5)
+- [Blockchain Use Cases and Applications by Industry](https://media.consensys.net/enterprise-ethereum-blockchain-use-cases-and-applications-by-industry-3914d1210049)
+- [EY releases zero-knowledge proof blockchain transaction technology to the public domain to advance blockchain privacy standards](https://www.ey.com/en_gl/news/2019/04/ey-releases-zero-knowledge-proof-blockchain-transaction-technology-to-the-public-domain-to-advance-blockchain-privacy-standards)
+- [Introduction to Quorum: Blockchain for the Financial Sector](https://medium.com/blockchain-at-berkeley/introduction-to-quorum-blockchain-for-the-financial-sector-58813f84e88c)
+
+Of course, there are countless more out there...
+
 
 ## Organisations
 
-## Projects
+Some collaborative efforts to make Ethereum more enterprise friendly have been put together by different organisations:
 
-## Infrastructure
+- [EEA](https://entethalliance.org/)  
+*The Enterprise Ethereum Alliance is a member-driven standards organization whose charter is to develop open, blockchain specifications that drive harmonization and interoperability for businesses and consumers worldwide. Our global community of members is made up of leaders, adopters, innovators, developers, and businesses who collaborate to create an open, decentralized web for the benefit of everyone.*
 
-## Tooling
+- [HyperLedger Foundation](https://hyperledger.org)  
+*Hyperledger is an open source collaborative effort created to advance cross-industry blockchain technologies. It is a global collaboration, hosted by The Linux Foundation, including leaders in finance, banking, Internet of Things, supply chains, manufacturing and Technology.*
+*The foundation has some projects in it that work with the Ethereum stack:*
+    - [Besu](https://www.hyperledger.org/blog/2019/08/29/announcing-hyperledger-besu)
+    - [Burrow](https://www.hyperledger.org/projects/hyperledger-burrow)
+    - [Sawtooth](https://www.hyperledger.org/projects/sawtooth)
+
+## Enterprise Focused Projects
+
+The following projects provide blockchain services for enterprises grade systems:
+
+- [PegaSys Plus](https://pegasys.tech/enterprise/) *extension of Hyperledger Besu, with added enterprise focused features*
+- [Quorum](https://www.goquorum.com/) *
+
+## Protocol and Infrastructure
+
+- [Besu](https://www.hyperledger.org/projects/besu) *open-source Ethereum client developed under the Apache 2.0 license and written in Java*
+- [Infura](https://infura.io/) *scalable API access to the Ethereum and IPFS networks*
+- [Kaleido](https://kaleido.io/) *full-stack platform for building and running cross-cloud, hybrid enterprise ecosystems*
+- [Burrow](https://kaleido.io/) *modular blockchain client with a permissioned smart contract interpreter partially developed to the specification of the Ethereum Virtual Machine (EVM)*
+- [Sawtooth](https://kaleido.io/) *modular platform for building, deploying, and running distributed ledgers.*
 
 ## Enterprise Features
 
+Private Ethereum networks might need specific features required by network participants. The following are some of those features:
+
 ### Permissioning
+
+- [Pegasys Permissioning Contracts](https://github.com/PegaSysEng/permissioning-smart-contracts)
+
 
 ### Privacy
 
+- [Ernst & Young's ‘Nightfall'](https://github.com/EYBlockchain/nightfall)
+*More information [here](https://bravenewcoin.com/insights/ernst-and-young-rolls-out-'nightfall-to-enable-private-transactions-on)*
+- [HyperLedger Besu's Orion](https://docs.pantheon.pegasys.tech/en/stable/Concepts/Privacy/Privacy-Overview/)
+*More information [here](https://pegasys.tech/privacy-in-pantheon-how-it-works-and-why-your-enterprise-should-care/)*
+- [Quorum's Tessera](https://docs.goquorum.com/en/latest/Privacy/Tessera/Tessera/) *More information [here](https://github.com/jpmorganchase/tessera/wiki/How-Tessera-works)*
+
+### Tooling
+
+- [Alethio](https://aleth.io/) *Ethereum Data Analytics Platform*
+- [Truffle Suite](https://trufflesuite.com) *blockchain development suite (Truffle, Ganache,* Drizzle())
+
 ### Security
 
-### Performance
+- [Clef](https://geth.ethereum.org/clef/Overview) *used to sign transactions and data and is meant as a replacement for geth’s account management*
+- [EthSigner](https://gitter.im/PegaSysEng/EthSigner) *A transaction signing application to be used with a web3 provider*
+
+## Enterprise Developer Community
+
+- [Infura ]()
+- [Kaleido twitter](https://twitter.com/Kaleido_io)
+- [Hyperledger Besu Rocketchat](https://chat.hyperledger.org/channel/besu)
+- [Hyperledger Burrow Rocketchat](https://chat.hyperledger.org/channel/burrow)
+- [Hyperledger Sawtooth Rocketchat](https://chat.hyperledger.org/channel/sawtooth)
+- [Pantheon gitter](https://gitter.im/PegaSysEng/pantheon)
+- [PegaSys twitter](https://twitter.com/Kaleido_io)
+- [Quorum Slack channel](https://clh7rniov2.execute-api.us-east-1.amazonaws.com/Express/)
+- [Infura ]()

--- a/docs/enterprise/index.md
+++ b/docs/enterprise/index.md
@@ -7,7 +7,7 @@ sidebarDepth: 0
 
 # Enterprise Resources
 
-<div class="featured">Guides, articles, and tools for Enterprise Ethereum.</div>
+<div class="featured">Guides, articles, and tools for delivering both public and private chain Ethereum for enterprise.</div>
 
 ## Why Enterprise Ethereum?
 Why should businesses care about Enterprise Ethereum?
@@ -15,6 +15,7 @@ Why should businesses care about Enterprise Ethereum?
 - Reduced cost of trust and coordination between business parties
 - Improved business network accountability and operational efficiency
 - Competitively future-proof your business
+- Compatibility with public mainnet or permissioned, private networks
 
 For more in depth information, here are some related articles:
 
@@ -24,9 +25,9 @@ For more in depth information, here are some related articles:
 - [Introduction to Quorum: Blockchain for the Financial Sector](https://medium.com/blockchain-at-berkeley/introduction-to-quorum-blockchain-for-the-financial-sector-58813f84e88c)
 
 
-## Organisations
+## Organizations
 
-Some collaborative efforts to make Ethereum more enterprise friendly have been put together by different organisations:
+Some collaborative efforts to make Ethereum enterprise friendly have been put together by different organizations:
 
 - [EEA](https://entethalliance.org/)  
 *The Enterprise Ethereum Alliance is a member-driven standards organization whose charter is to develop open, blockchain specifications that drive harmonization and interoperability for businesses and consumers worldwide. Our global community of members is made up of leaders, adopters, innovators, developers, and businesses who collaborate to create an open, decentralized web for the benefit of everyone.*
@@ -38,7 +39,7 @@ Some collaborative efforts to make Ethereum more enterprise friendly have been p
     - [Hyperledger Burrow](https://www.hyperledger.org/projects/hyperledger-burrow)
     - [Hyperledger Sawtooth](https://www.hyperledger.org/projects/sawtooth)
 
-## Enterprise Focused Projects
+## Enterprise Focused Services
 
 The following projects provide blockchain services for enterprises grade systems:
 
@@ -53,13 +54,13 @@ The following projects provide blockchain services for enterprises grade systems
 - [Hyperledger Burrow](https://kaleido.io/) *modular blockchain client with a permissioned smart contract interpreter partially developed to the specification of the Ethereum Virtual Machine (EVM)*
 - [Infura](https://infura.io/) *scalable API access to the Ethereum and IPFS networks*
 - [Kaleido](https://kaleido.io/) *full-stack platform for building and running cross-cloud, hybrid enterprise ecosystems*
-- [Hyperledger Sawtooth](https://kaleido.io/) *modular platform for building, deploying, and running distributed ledgers.*
+- [Hyperledger Sawtooth](https://www.hyperledger.org/projects/sawtooth) *modular platform for building, deploying, and running distributed ledgers.*
 - [Autonity](https://www.clearmatics.com/about/) *protocol suite that implements p2p protocols and provides client software and infrastructure*
 
 
 ## Enterprise Features
 
-Private Ethereum networks might need specific features required by network participants. The following are some of those features:
+Public and private Ethereum networks might need specific features required by network participants. The following are some of those features:
 
 ### Permissioning
 

--- a/docs/enterprise/index.md
+++ b/docs/enterprise/index.md
@@ -33,12 +33,12 @@ Some collaborative efforts to make Ethereum more enterprise friendly have been p
 - [EEA](https://entethalliance.org/)  
 *The Enterprise Ethereum Alliance is a member-driven standards organization whose charter is to develop open, blockchain specifications that drive harmonization and interoperability for businesses and consumers worldwide. Our global community of members is made up of leaders, adopters, innovators, developers, and businesses who collaborate to create an open, decentralized web for the benefit of everyone.*
 
-- [HyperLedger Foundation](https://hyperledger.org)  
+- [Hyperledger Foundation](https://hyperledger.org)  
 *Hyperledger is an open source collaborative effort created to advance cross-industry blockchain technologies. It is a global collaboration, hosted by The Linux Foundation, including leaders in finance, banking, Internet of Things, supply chains, manufacturing and Technology.*
 *The foundation has some projects in it that work with the Ethereum stack:*
-    - [Besu](https://www.hyperledger.org/blog/2019/08/29/announcing-hyperledger-besu)
-    - [Burrow](https://www.hyperledger.org/projects/hyperledger-burrow)
-    - [Sawtooth](https://www.hyperledger.org/projects/sawtooth)
+    - [Hyperledger Besu](https://www.hyperledger.org/blog/2019/08/29/announcing-hyperledger-besu)
+    - [Hyperledger Burrow](https://www.hyperledger.org/projects/hyperledger-burrow)
+    - [Hyperledger Sawtooth](https://www.hyperledger.org/projects/sawtooth)
 
 ## Enterprise Focused Projects
 
@@ -68,7 +68,7 @@ Private Ethereum networks might need specific features required by network parti
 
 - [Ernst & Young's ‘Nightfall'](https://github.com/EYBlockchain/nightfall)
 *More information [here](https://bravenewcoin.com/insights/ernst-and-young-rolls-out-'nightfall-to-enable-private-transactions-on)*
-- [HyperLedger Besu's Orion](https://docs.pantheon.pegasys.tech/en/stable/Concepts/Privacy/Privacy-Overview/)
+- [Pegasys' Orion](https://docs.pantheon.pegasys.tech/en/stable/Concepts/Privacy/Privacy-Overview/)
 *More information [here](https://pegasys.tech/privacy-in-pantheon-how-it-works-and-why-your-enterprise-should-care/)*
 - [Quorum's Tessera](https://docs.goquorum.com/en/latest/Privacy/Tessera/Tessera/) *More information [here](https://github.com/jpmorganchase/tessera/wiki/How-Tessera-works)*
 
@@ -81,6 +81,7 @@ Private Ethereum networks might need specific features required by network parti
 
 - [Alethio](https://aleth.io/) *Ethereum Data Analytics Platform*
 - [Truffle Suite](https://trufflesuite.com) *blockchain development suite (Truffle, Ganache,* Drizzle())
+- [Treum](https://treum.io/) *bringing transparency, traceability, and tradability to supply chains, using blockchain technology*
 
 ## Enterprise Developer Community
 

--- a/docs/enterprise/index.md
+++ b/docs/enterprise/index.md
@@ -45,7 +45,7 @@ Some collaborative efforts to make Ethereum more enterprise friendly have been p
 The following projects provide blockchain services for enterprises grade systems:
 
 - [PegaSys Plus](https://pegasys.tech/enterprise/) *extension of Hyperledger Besu, with added enterprise focused features*
-- [Quorum](https://www.goquorum.com/) *
+- [Quorum](https://www.goquorum.com/) *open source blockchain platform that combines the innovation of the public Ethereum community with enhancements to support enterprise needs*
 
 ## Protocol and Infrastructure
 
@@ -62,7 +62,7 @@ Private Ethereum networks might need specific features required by network parti
 ### Permissioning
 
 - [Pegasys Permissioning Contracts](https://github.com/PegaSysEng/permissioning-smart-contracts)
-
+- [Quorum Permissioning solution](https://github.com/jpmorganchase/quorum/wiki/Security)
 
 ### Privacy
 
@@ -72,24 +72,24 @@ Private Ethereum networks might need specific features required by network parti
 *More information [here](https://pegasys.tech/privacy-in-pantheon-how-it-works-and-why-your-enterprise-should-care/)*
 - [Quorum's Tessera](https://docs.goquorum.com/en/latest/Privacy/Tessera/Tessera/) *More information [here](https://github.com/jpmorganchase/tessera/wiki/How-Tessera-works)*
 
-### Tooling
-
-- [Alethio](https://aleth.io/) *Ethereum Data Analytics Platform*
-- [Truffle Suite](https://trufflesuite.com) *blockchain development suite (Truffle, Ganache,* Drizzle())
-
 ### Security
 
 - [Clef](https://geth.ethereum.org/clef/Overview) *used to sign transactions and data and is meant as a replacement for geth’s account management*
 - [EthSigner](https://gitter.im/PegaSysEng/EthSigner) *A transaction signing application to be used with a web3 provider*
 
+### Tooling
+
+- [Alethio](https://aleth.io/) *Ethereum Data Analytics Platform*
+- [Truffle Suite](https://trufflesuite.com) *blockchain development suite (Truffle, Ganache,* Drizzle())
+
 ## Enterprise Developer Community
 
-- [Infura ]()
+- [Alethio discord](https://discord.gg/d2t8NuU)
+- [Infura Discourse](https://community.infura.io/)
 - [Kaleido twitter](https://twitter.com/Kaleido_io)
 - [Hyperledger Besu Rocketchat](https://chat.hyperledger.org/channel/besu)
 - [Hyperledger Burrow Rocketchat](https://chat.hyperledger.org/channel/burrow)
 - [Hyperledger Sawtooth Rocketchat](https://chat.hyperledger.org/channel/sawtooth)
 - [Pantheon gitter](https://gitter.im/PegaSysEng/pantheon)
 - [PegaSys twitter](https://twitter.com/Kaleido_io)
-- [Quorum Slack channel](https://clh7rniov2.execute-api.us-east-1.amazonaws.com/Express/)
-- [Infura ]()
+- [Quorum Slack channel](http://bit.ly/quorum-slack)

--- a/docs/enterprise/index.md
+++ b/docs/enterprise/index.md
@@ -23,8 +23,6 @@ For more in depth information, here are some related articles:
 - [EY releases zero-knowledge proof blockchain transaction technology to the public domain to advance blockchain privacy standards](https://www.ey.com/en_gl/news/2019/04/ey-releases-zero-knowledge-proof-blockchain-transaction-technology-to-the-public-domain-to-advance-blockchain-privacy-standards)
 - [Introduction to Quorum: Blockchain for the Financial Sector](https://medium.com/blockchain-at-berkeley/introduction-to-quorum-blockchain-for-the-financial-sector-58813f84e88c)
 
-Of course, there are countless more out there...
-
 
 ## Organisations
 
@@ -44,16 +42,20 @@ Some collaborative efforts to make Ethereum more enterprise friendly have been p
 
 The following projects provide blockchain services for enterprises grade systems:
 
-- [PegaSys Plus](https://pegasys.tech/enterprise/) *extension of Hyperledger Besu, with added enterprise focused features*
+- [Blockapps](https://blockapps.net/) *implementation of the Enterprise Ethereum protocol, tooling and APIs that form the STRATO platform*
+- [Clearmatics](https://www.clearmatics.com/about) *protocols and peer-to-peer platform architecture, blockchain R&D company*
+- [PegaSys Plus](https://pegasys.tech/enterprise/) *offers the same features and functionalities as HF Besu, plus additional enterprise focused benefits*
 - [Quorum](https://www.goquorum.com/) *open source blockchain platform that combines the innovation of the public Ethereum community with enhancements to support enterprise needs*
 
 ## Protocol and Infrastructure
 
-- [Besu](https://www.hyperledger.org/projects/besu) *open-source Ethereum client developed under the Apache 2.0 license and written in Java*
+- [Hyperledger Besu](https://www.hyperledger.org/projects/besu) *open-source Ethereum client developed under the Apache 2.0 license and written in Java*
+- [Hyperledger Burrow](https://kaleido.io/) *modular blockchain client with a permissioned smart contract interpreter partially developed to the specification of the Ethereum Virtual Machine (EVM)*
 - [Infura](https://infura.io/) *scalable API access to the Ethereum and IPFS networks*
 - [Kaleido](https://kaleido.io/) *full-stack platform for building and running cross-cloud, hybrid enterprise ecosystems*
-- [Burrow](https://kaleido.io/) *modular blockchain client with a permissioned smart contract interpreter partially developed to the specification of the Ethereum Virtual Machine (EVM)*
-- [Sawtooth](https://kaleido.io/) *modular platform for building, deploying, and running distributed ledgers.*
+- [Hyperledger Sawtooth](https://kaleido.io/) *modular platform for building, deploying, and running distributed ledgers.*
+- [Autonity](https://www.clearmatics.com/about/) *protocol suite that implements p2p protocols and provides client software and infrastructure*
+
 
 ## Enterprise Features
 
@@ -80,7 +82,7 @@ Private Ethereum networks might need specific features required by network parti
 ### Tooling
 
 - [Alethio](https://aleth.io/) *Ethereum Data Analytics Platform*
-- [Truffle Suite](https://trufflesuite.com) *blockchain development suite (Truffle, Ganache,* Drizzle())
+- [Truffle Suite](https://trufflesuite.com) *blockchain development suite (Truffle, Ganache, Drizzle)*
 - [Treum](https://treum.io/) *bringing transparency, traceability, and tradability to supply chains, using blockchain technology*
 
 ## Enterprise Developer Community

--- a/docs/enterprise/index.md
+++ b/docs/enterprise/index.md
@@ -82,8 +82,8 @@ Private Ethereum networks might need specific features required by network parti
 ### Tooling
 
 - [Alethio](https://aleth.io/) *Ethereum Data Analytics Platform*
-- [Truffle Suite](https://trufflesuite.com) *blockchain development suite (Truffle, Ganache, Drizzle)*
 - [Treum](https://treum.io/) *bringing transparency, traceability, and tradability to supply chains, using blockchain technology*
+- [Truffle Suite](https://trufflesuite.com) *blockchain development suite (Truffle, Ganache, Drizzle)*
 
 ## Enterprise Developer Community
 

--- a/docs/enterprise/index.md
+++ b/docs/enterprise/index.md
@@ -2,11 +2,11 @@
 title: Enterprise
 meta:
     - name: description
-    content: Guides, articles, and tools about public and private Ethereum blockchains for enterprise
+      content: Guides, articles, and tools about public and private Ethereum blockchains for enterprise
     - property: og:title
-    content: Enterprise Ethereum
+      content: Enterprise Ethereum
     - property: og:description
-    content: Guides, articles, and tools about public and private Ethereum blockchains for enterprise
+      content: Guides, articles, and tools about public and private Ethereum blockchains for enterprise
 lang: en-US
 sidebar: auto
 sidebarDepth: 0

--- a/docs/enterprise/index.md
+++ b/docs/enterprise/index.md
@@ -1,5 +1,12 @@
 ---
 title: Enterprise
+meta:
+    - name: description
+    content: Guides, articles, and tools about public and private Ethereum blockchains for enterprise
+    - property: og:title
+    content: Enterprise Ethereum
+    - property: og:description
+    content: Guides, articles, and tools about public and private Ethereum blockchains for enterprise
 lang: en-US
 sidebar: auto
 sidebarDepth: 0
@@ -7,7 +14,7 @@ sidebarDepth: 0
 
 # Enterprise Resources
 
-<div class="featured">Guides, articles, and tools for delivering both public and private chain Ethereum for enterprise.</div>
+<div class="featured">Guides, articles, and tools for delivering both public and private Ethereum blockchains for enterprise.</div>
 
 ## Why Enterprise Ethereum?
 Why should businesses care about Enterprise Ethereum?
@@ -37,7 +44,6 @@ Some collaborative efforts to make Ethereum enterprise friendly have been put to
 *The foundation has some projects in it that work with the Ethereum stack:*
     - [Hyperledger Besu](https://www.hyperledger.org/blog/2019/08/29/announcing-hyperledger-besu)
     - [Hyperledger Burrow](https://www.hyperledger.org/projects/hyperledger-burrow)
-    - [Hyperledger Sawtooth](https://www.hyperledger.org/projects/sawtooth)
 
 ## Enterprise Focused Services
 
@@ -54,7 +60,6 @@ The following projects provide blockchain services for enterprises grade systems
 - [Hyperledger Burrow](https://kaleido.io/) *modular blockchain client with a permissioned smart contract interpreter partially developed to the specification of the Ethereum Virtual Machine (EVM)*
 - [Infura](https://infura.io/) *scalable API access to the Ethereum and IPFS networks*
 - [Kaleido](https://kaleido.io/) *full-stack platform for building and running cross-cloud, hybrid enterprise ecosystems*
-- [Hyperledger Sawtooth](https://www.hyperledger.org/projects/sawtooth) *modular platform for building, deploying, and running distributed ledgers.*
 - [Autonity](https://www.clearmatics.com/about/) *protocol suite that implements p2p protocols and provides client software and infrastructure*
 
 
@@ -93,7 +98,6 @@ Public and private Ethereum networks might need specific features required by ne
 - [Kaleido twitter](https://twitter.com/Kaleido_io)
 - [Hyperledger Besu Rocketchat](https://chat.hyperledger.org/channel/besu)
 - [Hyperledger Burrow Rocketchat](https://chat.hyperledger.org/channel/burrow)
-- [Hyperledger Sawtooth Rocketchat](https://chat.hyperledger.org/channel/sawtooth)
 - [Pantheon gitter](https://gitter.im/PegaSysEng/pantheon)
 - [PegaSys twitter](https://twitter.com/Kaleido_io)
 - [Quorum Slack channel](http://bit.ly/quorum-slack)

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,5 +48,16 @@ sidebar: false
       <li><router-link to="/developers/#developer-tools" class="black">Find the latest developer tools</router-link></li>
     </ul>
   </div>
+  
+  </router-link>
+
+  <div class="intro-block">
+    <ul>
+      <li><router-link to="/enterprise/"><span class="arrow">→</span>Enterprise Ethereum</router-link></li>
+      <li><router-link to="/enterprise/#why-enterprise-ethereum" class="black">Why Enterprise Ethereum?</router-link></li>
+      <li><router-link to="/enterprise/#enterprise-features" class="black">Enterprise Features</router-link></li>
+      <li><router-link to="/enterprise/#enterprise-developer-community" class="black">Enterprise Developer Community</router-link></li>
+    </ul>
+  </div>
 
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,7 +53,7 @@ sidebar: false
 
   <div class="intro-block">
     <ul>
-      <li><router-link to="/enterprise/"><span class="arrow">→</span>Enterprise Ethereum</router-link></li>
+      <li><router-link to="/enterprise/"><span class="arrow">→</span>Enterprise</router-link></li>
       <li><router-link to="/enterprise/#why-enterprise-ethereum" class="black">Why Enterprise Ethereum?</router-link></li>
       <li><router-link to="/enterprise/#enterprise-features" class="black">Enterprise Features</router-link></li>
       <li><router-link to="/enterprise/#enterprise-developer-community" class="black">Enterprise Developer Community</router-link></li>

--- a/docs/learn/index.md
+++ b/docs/learn/index.md
@@ -79,8 +79,6 @@ Enterprise Ethereum refers to private, consortium, and hybrid implementations of
 Read more about [Enterprise Ethereum](/enterprise).
 
 
-
-
 ## Improving Ethereum’s Scalability
 
 There are many efforts underway to make Ethereum more “scalable” by improving its speed and overall transaction throughput. Generally these are sorted into “Layer 1” and “Layer 2” solutions.

--- a/docs/learn/index.md
+++ b/docs/learn/index.md
@@ -72,6 +72,14 @@ The Ethereum network is made up of many nodes, each of which runs compatible cli
 - Want to learn how to run a node of your own? → [ethereum.org/developers](/developers/#clients-running-your-own-node)
 - [Comprehensive list of all Ethereum clients](https://github.com/ConsenSys/ethereum-developer-tools-list#ethereum-clients)
 
+## Enterprise Ethereum
+
+Enterprise Ethereum refers to private, consortium, and hybrid implementations of the Ethereum codebase for business applications. Companies across the globe are already using Enterprise Ethereum to streamline financial markets, manage supply chains, and create new business models.
+
+Read more about [Enterprise Ethereum](/enterprise).
+
+
+
 
 ## Improving Ethereum’s Scalability
 
@@ -135,5 +143,3 @@ Critical views of Ethereum and Cryptocurrencies.
 - [The Challenges of Building Ethereum Infrastructure](https://medium.com/@lopp/the-challenges-of-building-ethereum-infrastructure-87e443e47a4b) *Jan 8, 2018 - Jameson Lopp*
 - [Parsimonious Answers to Difficult Questions](https://www.youtube.com/watch?v=GOkSg0BuSdw&feature=youtu.be) *(Video) March 10, 2019 - Rick Dudley*
 - [There’s no good reason to trust blockchain technology](https://www.wired.com/story/theres-no-good-reason-to-trust-blockchain-technology/) *Feb 6, 2019 - Bruce Schneier*
-
-


### PR DESCRIPTION
There are 3 main changes proposed in this PR:

- added an `/enterprise` page path with information on enterprise ethereum
- added a enterprise intro-block section to the homepage with links to /enterprise resources
- added an "Enterprise Ethereum" h2+section on the `/learn` page with a link to the /enterprise page

I decided not to change the styling on the homepage intro-section (ie. to center align the block), but this could be done if needed.