### PR TITLE
Quick fix, change "Besu" to "Hyperledger Besu"

### DIFF
--- a/docs/java/index.md
+++ b/docs/java/index.md
@@ -25,7 +25,7 @@ Need a more basic primer first? Check out [ethereum.org/learn](/learn/) or [ethe
 - [Write your First Smart Contract](https://kauri.io/article/124b7db1d0cf4f47b414f8b13c9d66e2/remix-ide-your-first-smart-contract)
 - [Learn How to Compile and Deploy Solidity](https://kauri.io/article/973c5f54c4434bb1b0160cff8c695369/understanding-smart-contract-compilation-and-deployment)
 
-## Using Web3J and Besu (Pantheon) (Ethereum Client in Java)
+## Using Web3J and Hyperledger Besu (Pantheon) (Ethereum Client in Java)
 
 - [Connecting to an Ethereum client with Java, Eclipse, and Web3J](https://kauri.io/article/b9eb647c47a546bc95693acc0be72546/connecting-to-an-ethereum-client-with-java-eclipse-and-web3j)
 - [Manage an Ethereum account with Java and Web3j](https://kauri.io/article/925d923e12c543da9a0a3e617be963b4/manage-an-ethereum-account-with-java-and-web3j)
@@ -47,7 +47,7 @@ Need a more basic primer first? Check out [ethereum.org/learn](/learn/) or [ethe
 
 
 ## Projects and Tools
-- [Besu (Pantheon) (Ethereum Client)](https://docs.pantheon.pegasys.tech/en/stable/)
+- [Hyperledger Besu (Pantheon) (Ethereum Client)](https://docs.pantheon.pegasys.tech/en/stable/)
 - [Web3J (Library for Interacting with Ethereum Clients)](https://github.com/web3j/web3j)
 - [Eventeum (Event Listener)](https://github.com/ConsenSys/eventeum)
 - [Mahuta (IPFS Dev Tools)](https://github.com/ConsenSys/mahuta)


### PR DESCRIPTION
For technical reasons, Besu should at least contain one mention of Hyperledger Besu in it.