### PR TITLE
Only display artwork announcement on homepage [Fixes #186]

### DIFF
--- a/docs/.vuepress/theme/Layout.vue
+++ b/docs/.vuepress/theme/Layout.vue
@@ -7,7 +7,7 @@
     <Footer :class="{ 'home': isLanding }" />
 
     <a href="https://hackernoon.com/rethinking-the-identity-of-ethereumorg-l718w347l" target="_blank">
-      <button v-if="!isRelaunch" class="announcement">
+      <button v-if="isLanding" class="announcement">
         {{linkText}} <span class="accent">{{linkTextMore}}</span>
       </button>
       
@@ -55,9 +55,6 @@
     computed: {
       isLanding() {
         return this.$page.frontmatter && this.$page.frontmatter.layout === "home"
-      },
-      isRelaunch() {
-        return this.$page.path === "/relaunch.html"
       },
       posts() {
         return this.$site.pages


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Only display artwork announcement on homepage

## Related Issue
https://github.com/ethereum/ethereum-org-website/issues/186
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
Locally
<!--- Please describe how you tested your changes and areas of the code your change affects -->

## Screenshots (if appropriate):

<img width="793" alt="Image 2019-09-18 at 9 27 07 PM" src="https://user-images.githubusercontent.com/8097623/65213525-54237600-da5b-11e9-9058-40a258b6830d.png">


<img width="785" alt="Image 2019-09-18 at 9 27 14 PM" src="https://user-images.githubusercontent.com/8097623/65213519-4ec62b80-da5b-11e9-8406-cc3d026a0427.png">

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the contributing guidelines in the project README.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
