### PR TITLE
Added python landing page + link to it

### DIFF
--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -60,9 +60,9 @@ Any program that runs on the Ethereum Virtual Machine (EVM) is commonly referred
 We're building a suite of language-specific landing pages for developer to learn about Ethereum in their preferred programming langauge.
 
 - [Ethereum for Java developers](/java/)
-- [Ethereum for Python developers (coming soon)](#)
-- [Ethereum for Javascript developers (coming soon)](#)
-- [Others coming soon!](#)
+- [Ethereum for Python developers](/python/)
+- Ethereum for Javascript developers (coming soon)
+- Others coming soon
 
 ## Developer Tools
 

--- a/docs/python/index.md
+++ b/docs/python/index.md
@@ -1,0 +1,75 @@
+---
+title: Ethereum for Python Developers
+meta:
+  - name: description
+    content: Learn how to develop for Ethereum using python-based projects and tooling
+  - property: og:title
+    content: Ethereum for Python Developers
+  - property: og:description
+    content: Learn how to develop for Ethereum using Python-based projects and tooling
+lang: en-US
+sidebar: auto
+sidebarDepth: 0
+---
+
+# Ethereum for Python Developers
+
+<div class="featured">Learn how to develop for Ethereum using Python-based projects and tooling</div><br>
+
+Use Ethereum to create decentralized applications (or “dapps”) that utilize the benefits of cryptocurrency and blockchain technology. These dapps can be trustworthy, meaning that once they are deployed to Ethereum, they will always run as programmed. They can control digital assets in order to create new kinds of financial applications. They can be decentralized, meaning that no single entity or person controls them and are nearly impossible to censor.
+
+<img src="https://i.imgur.com/VhoX4LM.png" width="100%" />
+
+## Getting Started with Smart Contracts and the Solidity Language
+
+**Take your first steps to integrating Python with Ethereum**
+
+Need a more basic primer first? Check out [ethereum.org/learn](/learn) or [ethereum.org/developers](/developers).
+
+- [Blockchain Explained](https://kauri.io/article/d55684513211466da7f8cc03987607d5/blockchain-explained)
+- [Understanding Smart Contracts](https://kauri.io/article/e4f66c6079e74a4a9b532148d3158188/ethereum-101-part-5-the-smart-contract)
+- [Write your First Smart Contract](https://kauri.io/article/124b7db1d0cf4f47b414f8b13c9d66e2/remix-ide-your-first-smart-contract)
+- [Learn How to Compile and Deploy Solidity](https://kauri.io/article/973c5f54c4434bb1b0160cff8c695369/understanding-smart-contract-compilation-and-deployment)
+
+
+## Beginner articles
+- [An Introduction to Smart Contracts with Vyper](https://kauri.io/article/af913a853eaf4db88627b3ff9572b770/v1/an-introduction-to-smart-contracts-with-vyper)
+- [How to develop Ethereum contract using Python Flask?](https://medium.com/coinmonks/how-to-develop-ethereum-contract-using-python-flask-9758fe65976e)  
+- [Intro to Web3.py · Ethereum For Python Developers](https://www.dappuniversity.com/articles/web3-py-intro)  
+- [How to call a Smart Contract function using Python and web3.py](https://stackoverflow.com/questions/57580702/how-to-call-a-smart-contract-function-using-python-and-web3-py)
+
+## Intermediate Articles
+- [DApp Development for Python Programmers](https://levelup.gitconnected.com/dapps-development-for-python-developers-f52b32b54f28)  
+- [Creating a Python Ethereum Interface: Part 1](https://hackernoon.com/creating-a-python-ethereum-interface-part-1-4d2e47ea0f4d)
+- [Ethereum Smart Contracts in Python: a comprehensive(ish) guide](https://hackernoon.com/ethereum-smart-contracts-in-python-a-comprehensive-ish-guide-771b03990988)
+- [Everything you need to know about the Trinity Ethereum client](https://medium.com/@pipermerriam/everything-you-need-to-know-about-the-trinity-ethereum-client-b093c756d1de)
+
+## Advanced Use Patterns
+- [Compiling, deploying and calling Ethereum smartcontract using Python](https://yohanes.gultom.me/2018/11/28/compiling-deploying-and-calling-ethereum-smartcontract-using-python/)
+- [Analyze Solidity Smart Contracts with Slither](https://kauri.io/article/4f4dcf7d105d4714b212a86da742baf6/v1/analyze-solidity-smart-contracts-with-slither)
+
+
+## Projects and Tools
+- [Brownie](https://github.com/iamdefinitelyahuman/brownie) - *Python framework for deploying, testing and interacting with Ethereum smart contracts*
+- [eth-utils](https://github.com/ethereum/eth-utils/) - *utility functions for working with Ethereum related codebases*
+- [py-evm](https://github.com/ethereum/py-evm) - *implementation of the Ethereum Virtual Machine*
+- [py-solc-x](https://pypi.org/project/py-solc-x/) - *Python wrapper around the solc solidity compiler with 0.5.x support*
+- [py-wasm](https://github.com/ethereum/py-wasm) - *Python implementation of the web assembly interpreter*
+- [pydevp2p](https://github.com/ethereum/pydevp2p) - *Implementation of the Ethereum P2P stack*
+- [pymaker](https://github.com/makerdao/pymaker) - *Python API for Maker contracts*
+- [Mamba](https://mamba.black) - *framework to write, compile, and deploy smart contracts written in Vyper language*
+- [Trinity](https://github.com/ethereum/trinity) - *Ethereum Python client*
+- [Vyper](https://github.com/ethereum/vyper/) - *Pythonic Smart Contract Language for the EVM*
+- [Web3.py](https://github.com/ethereum/web3.py) - *Python library for interacting with Ethereum*
+
+
+## Python Community Contributors
+- [Py-EVM Gitter](https://gitter.im/ethereum/py-evm)
+- [Trinity Gitter](https://gitter.im/ethereum/trinity)
+- [Vyper Gitter](https://gitter.im/ethereum/vyper)
+- [Webpy Gitter](https://gitter.im/ethereum/web3.py)
+
+
+## Other Aggregated Lists
+The Vyper wiki has an [inceredible list of resources for Vyper](https://github.com/ethereum/vyper/wiki/Vyper-tools-and-resources)  
+For a compiled source of Python related tools, check out [py-eth.com](http://py-eth.com/).


### PR DESCRIPTION


Continuation of https://github.com/ethereum/ethereum-org-website/pull/246

I've added a /python path with resources to python-ethereum related information.


## Description

- updated the link to the /python page from the /developers page
- added py-eth articles, divided in 3 categories, beginner, intermediate and advanced use patterns
- list of projects and tools tht use python on eth today
- community links to gitters of some of those projects

## Related Issue

https://github.com/ethereum/ethereum-org-website/issues/223

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?

<!--- Please describe how you tested your changes and areas of the code your change affects -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the contributing guidelines in the project README.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
