### PR TITLE
Update dark mode menu color [Fixes #252]

### DIFF
--- a/docs/.vuepress/theme/components/DropdownLink.vue
+++ b/docs/.vuepress/theme/components/DropdownLink.vue
@@ -76,6 +76,7 @@ export default {
   .nav-dropdown
       display flex
       flex-direction column
+
     .dropdown-item
       color inherit
       line-height 1.7rem
@@ -156,7 +157,6 @@ export default {
       overflow-y auto
       top 100%
       right 0
-      background-color #fff
       padding 0.6rem 0
       border 1px dotted $textColor
       border-radius 1rem
@@ -164,4 +164,9 @@ export default {
       white-space nowrap
       margin 0
       margin-top 8px
+
+@media (min-width: $breakM)  
+  #wrapper.dark-mode
+    .nav-dropdown
+      background-color $textColorDark
 </style>

--- a/docs/.vuepress/theme/components/SearchBox.vue
+++ b/docs/.vuepress/theme/components/SearchBox.vue
@@ -170,7 +170,7 @@ export default {
     padding 0.2em 0.5em 0.2em 2rem
     outline none
     transition width .2s ease
-    background #fff url(../images/icon-search.svg) 0.5rem 0.35rem no-repeat
+    background $white url(../images/icon-search.svg) 0.5rem 0.35rem no-repeat
     background-size 1.25rem
     &:focus
       cursor auto
@@ -178,7 +178,7 @@ export default {
       border-color $accentColor
   .suggestions
     font-size $fsSmall
-    background #fff
+    background $white
     width 20rem
     position absolute
     top 1.5rem
@@ -218,7 +218,7 @@ export default {
       padding-left 2.3rem
 
       &:focus
-        background #fff url(../images/icon-search.svg) 0.5rem 0.25rem no-repeat
+        background $white url(../images/icon-search.svg) 0.5rem 0.25rem no-repeat
         cursor text
         left 0
         width 10rem

--- a/docs/.vuepress/theme/styles/config.styl
+++ b/docs/.vuepress/theme/styles/config.styl
@@ -11,6 +11,7 @@ $subduedColor = rgb(180,180,180)
 $borderColor = $accentColor
 $codeBgColor = #282c34
 $arrowBgColor = #ccc
+$white = #fff
 
 // typical browser default font size is 16px
 // font sizes


### PR DESCRIPTION
## Description
Removed the white background setting for larger than small screens, set to gray.

## Related Issue
https://github.com/ethereum/ethereum-org-website/issues/252
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
Locally
<!--- Please describe how you tested your changes and areas of the code your change affects -->

## Screenshots (if appropriate):

Dark background looked a bit too dark:
<img width="206" alt="Image 2019-09-29 at 11 21 31 AM" src="https://user-images.githubusercontent.com/8097623/65837503-17524d00-e2ad-11e9-81b1-77de491a91a3.png">

So I went with the `$textColorDark = rgb(180,180,180)`:
<img width="162" alt="Image 2019-09-29 at 11 21 46 AM" src="https://user-images.githubusercontent.com/8097623/65837500-0b668b00-e2ad-11e9-9a23-cfaf10e5ad99.png">

No change needed on mobile:
<img width="177" alt="Image 2019-09-29 at 11 35 16 AM" src="https://user-images.githubusercontent.com/8097623/65837522-508abd00-e2ad-11e9-8d29-31bf2e4542ca.png">





## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the contributing guidelines in the project README.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
