### PR TITLE
Add Terminal to "Other Tools" section

### DIFF
--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -93,6 +93,11 @@ Ethereum has a large and growing number of tools to help developers build, test,
 
 ### Other Tools
 
+**Terminal -** ***A platform to manage smart contracts, run forked ganache instances, build adjacent Ethereum infrastructure, and collect logs for any dapp***
+- [terminal.co](https://terminal.co/)
+- [Documentation](https://docs.terminal.co/)
+- [Discord](https://discord.gg/84hAKyZ)
+
 **Buidler -** ***A task runner for Ethereum smart contract developers.***
 
 - [buidler.dev](https://buidler.dev)


### PR DESCRIPTION
Would love to have Terminal be listed on here.  We provide a plethora of tools that would be useful for Ethereum developers.  Examples of what Terminal provides:

- Hosted ganache instances forked from any block
- Folder structure for organizing smart contracts alongside adjacent infrustructure
- Ethereum DB to construct complex queries for historical ETH data (see https://ethcarbonfootprint.me/ and https://uniswapstats.com/ for example usage)
- Hosted database infrastructure
- Event, function, and transaction webhooks
- Logging for dapps

Give the PR a look-over and if there's anything you'd like me to change, do let me know.

Thanks!
