### PR TITLE
Add active state styles for sidebars

### DIFF
--- a/docs/.vuepress/theme/components/SidebarLink.vue
+++ b/docs/.vuepress/theme/components/SidebarLink.vue
@@ -101,10 +101,18 @@ a.sidebar-link
   &.active
     font-weight 600
     color $accentColor
+    border-right .25rem solid $accentColor
   .sidebar-sub-headers &
     padding-top 0.25rem
     padding-bottom 0.25rem
-    border-left none
+    border-right-color transparent
+
+#wrapper.dark-mode
+  a.sidebar-link
     &.active
-      font-weight 500
+      border-right .25rem solid $accentColorDark
+  .sidebar-sub-headers
+    a
+      &.active
+        border-right-color transparent
 </style>

--- a/docs/.vuepress/theme/index.js
+++ b/docs/.vuepress/theme/index.js
@@ -1,9 +1,11 @@
-const path = require('path')
+const path = require('path');
 
 module.exports = {
-  plugins: ['@vuepress/register-components', {
-    componentsDir: [
-      path.resolve(__dirname, 'components')
-    ]
-  }]
-}
+  plugins: [
+    '@vuepress/register-components',
+    {
+      componentsDir: [path.resolve(__dirname, 'components')]
+    },
+    '@vuepress/active-header-links'
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "author": "Alan Woo (Bin Studio) <alan@bin.am>",
   "license": "MIT",
   "devDependencies": {
+    "@vuepress/plugin-active-header-links": "^1.0.0-rc.1",
     "vuepress": "^1.0.0-alpha.47"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -884,6 +884,13 @@
     markdown-it-table-of-contents "^0.4.0"
     prismjs "^1.13.0"
 
+"@vuepress/plugin-active-header-links@^1.0.0-rc.1":
+  version "1.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@vuepress/plugin-active-header-links/-/plugin-active-header-links-1.0.0-rc.1.tgz#46dc6f2efe6aef10c36f870e02b6d7af473de0cc"
+  integrity sha512-EC1SrnWHIsbpIzfjCumTTiXnKXxKayM6YJJ6cPZHVVaP5BdEIiJdRuecs5hM44u4LigDqFbXbvwWN769Ygn65Q==
+  dependencies:
+    lodash.throttle "^4.1.1"
+
 "@vuepress/plugin-active-header-links@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@vuepress/plugin-active-header-links/-/plugin-active-header-links-1.1.0.tgz#cd62c1712040676035f34fed16a088e1c08811d8"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Boldens, colors & sets right boarder on scrollbar section to illuminate progress on the page.

## Related Issue
No issue, found it while researching Vuepress plugins.
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
Locally
<!--- Please describe how you tested your changes and areas of the code your change affects -->

## Screenshots (if appropriate):

![Screen Recording 2019-10-01 at 12 51 PM](https://user-images.githubusercontent.com/8097623/65995441-61246a00-e44a-11e9-8897-1e9500464234.gif)


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the contributing guidelines in the project README.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
