### PR TITLE
Update body font-size to 1rem [Fixes #290]

### DIFF
--- a/docs/.vuepress/theme/styles/config.styl
+++ b/docs/.vuepress/theme/styles/config.styl
@@ -17,9 +17,10 @@ $white = #fff
 // font sizes
 $fsXSmall = 0.75rem // 12px
 $fsSmall = 0.875rem // 14px
+$fsMedium = 1rem // 16px
 $fsRegular = 1.125rem // 18px
-$fsLarge = 1.25rem // 20px
-$fsXLarge = 1.5rem // 24px
+$fsLarge = 1.5rem // 20px
+$fsXLarge = 2rem // 24px
 
 $lhRegular = 1.2em
 $lhMedium = 1.5em

--- a/docs/.vuepress/theme/styles/theme.styl
+++ b/docs/.vuepress/theme/styles/theme.styl
@@ -104,6 +104,9 @@ button
   .hide-home
     display none
 
+  h1
+    font-size $fsLarge
+
 #wrapper.home>div.content, .content-block
   max-width 996px
   margin 0 auto
@@ -199,7 +202,7 @@ span.arrow
   margin-left -1em
 
 div#wrapper:not(.home)>.content, .page
-  font-size $fsSmall
+  font-size $fsMedium
   line-height $lhLarge
   max-width $contentWidth
   margin-left 10em


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Respects browsers' default font size as the body font size. In practice, this typically results in body font of 16px vs 14px.
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/ethereum/ethereum-org-website/issues/290
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Screenshots (if appropriate):

Now
<img width="935" alt="Image 2019-10-04 at 7 19 23 PM" src="https://user-images.githubusercontent.com/8097623/66200394-f5593000-e6db-11e9-984a-003a8a68aafb.png">


Before
<img width="927" alt="Image 2019-10-04 at 7 19 34 PM" src="https://user-images.githubusercontent.com/8097623/66200391-f1c5a900-e6db-11e9-8372-8c63853facc2.png">


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the contributing guidelines in the project README.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
