### PR TITLE
Add "Last Updated" To The Website

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -216,10 +216,19 @@ module.exports = {
       ]
     }
   },
-  plugins: {
-    'sitemap': {
-      hostname: 'https://ethereum.org',
-      changefreq: 'weekly'
-    }
-  }
+  plugins: [
+    [
+      '@vuepress/last-updated',
+      {
+        transformer: (timestamp) => timestamp
+      },
+    ],
+    [
+      'sitemap',
+      {
+        hostname: 'https://ethereum.org',
+        changefreq: 'weekly'
+      }
+    ]
+  ]
 };

--- a/docs/.vuepress/theme/Layout.vue
+++ b/docs/.vuepress/theme/Layout.vue
@@ -8,6 +8,7 @@
     />
     <Hero v-if="showHero" :dark="darkMode" />
     <main :class="contentClasses">
+      <p v-if="!isLanding">Page last updated: {{lastUpdatedDate}}</p>
       <Content />
     </main>
     <Sidebar :items="sidebarItems" @close-sidebar="closeSidebar" />
@@ -16,6 +17,7 @@
 </template>
 
 <script>
+import moment from 'moment';
 import Footer from "@theme/components/Footer";
 import Header from "@theme/components/Header";
 import Hero from "@theme/components/Hero";
@@ -100,6 +102,10 @@ export default {
         },
         userPageClass
       ];
+    },
+    lastUpdatedDate() {
+      moment.locale(this.$page.lang)
+      return moment(this.$page.lastUpdated).format('MMM DD, YYYY')
     }
   },
   methods: {

--- a/docs/.vuepress/theme/Layout.vue
+++ b/docs/.vuepress/theme/Layout.vue
@@ -8,8 +8,8 @@
     />
     <Hero v-if="showHero" :dark="darkMode" />
     <main :class="contentClasses">
-      <p v-if="!isLanding">Page last updated: {{lastUpdatedDate}}</p>
-      <Content />
+      <p v-if="!isLanding" class="updated-date">Page last updated: {{lastUpdatedDate}}</p>
+      <Content/>
     </main>
     <Sidebar :items="sidebarItems" @close-sidebar="closeSidebar" />
     <Footer :class="{ 'home': isLanding }" />
@@ -143,5 +143,9 @@ export default {
     right 3em
     border-radius 25px
     padding 1em 2em
+
+  p.updated-date
+    color $subduedColor
+
 </style>
 <style src="./styles/theme.styl" lang="stylus"></style>

--- a/docs/.vuepress/theme/components/Footer.vue
+++ b/docs/.vuepress/theme/components/Footer.vue
@@ -19,23 +19,24 @@
 </template>
 
 <script>
+  import moment from 'moment';
+
   export default {
     computed: {
       lastUpdatedDate() {
-        const moment = require('moment')
-
-        function compareTimestamps(a, b) {
-          if (a.lastUpdated < b.lastUpdated)
-            return -1;
-          if (a.lastUpdated > b.lastUpdated)
-            return 1;
-          return 0;
-        }
-
-        const pagesSortedByDate = this.$site.pages.sort(compareTimestamps)
+        const pagesSortedByDate = this.$site.pages.sort(this.compareTimestamps)
 
         moment.locale(this.$lang)
         return moment(pagesSortedByDate[pagesSortedByDate.length - 1].lastUpdated).format('MMM DD, YYYY')
+      }
+    },
+    methods: {
+      compareTimestamps: function(a, b) {
+        if (a.lastUpdated < b.lastUpdated)
+          return -1;
+        if (a.lastUpdated > b.lastUpdated)
+          return 1;
+        return 0;
       }
     },
   }
@@ -66,6 +67,7 @@
         display block
 
     p.updated-date
+      color $subduedColor
       margin 1em 0
 
     ul

--- a/docs/.vuepress/theme/components/Footer.vue
+++ b/docs/.vuepress/theme/components/Footer.vue
@@ -3,6 +3,7 @@
     <div class="credits">
       Artwork by <a href="https://impermanence.co" target="_blank">Lili Feyerabend</a> feat. <a href="https://ilankatin.com" target="_blank">ilan katin</a>, <a href="https://linktr.ee/mattiacprodukt" target="_blank">Mattia Cuttini</a>, <a href="https://oficinastk.github.io" target="_blank">Oficinas TK</a>, <a href="https://xcopyart.com" target="_blank">XCOPY</a>.
     </div>
+    <p class="updated-date">Site last updated: {{lastUpdatedDate}}</p>
     <ul>
       <li><a href="https://github.com/ethereum" target="_blank">GitHub</a></li>
       <li><a href="https://twitter.com/ethereum" target="_blank">Twitter</a></li>
@@ -16,6 +17,29 @@
     </ul>
   </footer>
 </template>
+
+<script>
+  export default {
+    computed: {
+      lastUpdatedDate() {
+        const moment = require('moment')
+
+        function compareTimestamps(a, b) {
+          if (a.lastUpdated < b.lastUpdated)
+            return -1;
+          if (a.lastUpdated > b.lastUpdated)
+            return 1;
+          return 0;
+        }
+
+        const pagesSortedByDate = this.$site.pages.sort(compareTimestamps)
+
+        moment.locale(this.$lang)
+        return moment(pagesSortedByDate[pagesSortedByDate.length - 1].lastUpdated).format('MMM DD, YYYY')
+      }
+    },
+  }
+</script>
 
 <style lang="stylus" scoped>
   @require '../styles/config'
@@ -40,6 +64,9 @@
 
       div.credits
         display block
+
+    p.updated-date
+      margin 1em 0
 
     ul
       margin 0

--- a/package.json
+++ b/package.json
@@ -18,9 +18,10 @@
     "vuepress": "^1.0.0-alpha.47"
   },
   "dependencies": {
-    "random-js": "^2.1.0",
-    "vuepress-plugin-sitemap": "^2.3.0",
     "axios": "^0.19.0",
-    "netlify-lambda": "^1.6.3"
+    "moment": "^2.24.0",
+    "netlify-lambda": "^1.6.3",
+    "random-js": "^2.1.0",
+    "vuepress-plugin-sitemap": "^2.3.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4854,6 +4854,11 @@ mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1, mkdirp@~0.5.x:
   dependencies:
     minimist "0.0.8"
 
+moment@^2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"


### PR DESCRIPTION
## Description

This PR adds the current updated page date to the Layout and  the last updated page date to the Footer.

## Related Issue

https://github.com/ethereum/ethereum-org-website/issues/49

## Screenshots (if appropriate):

<img width="749" alt="Screenshot 2019-10-28 at 19 34 41" src="https://user-images.githubusercontent.com/2401738/67719739-a9e02c00-f9d2-11e9-87f5-628462f48d8c.png">
<img width="998" alt="Screenshot 2019-10-28 at 22 31 53" src="https://user-images.githubusercontent.com/2401738/67719773-c2504680-f9d2-11e9-87c7-a28d08ea306f.png">

## Checklist:

- [x] I have read the contributing guidelines in the project README.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
