### PR TITLE
Avoid running GH labeler on forks [Fixes #344]

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -7,6 +7,6 @@ jobs:
 
     steps:
       - uses: actions/labeler@v2
-        if: github.repository == 'ethereum/ethereum-org-website'
+        if: contains(github.repository, 'ethereum/ethereum-org-website')
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/ethereum/ethereum-org-website/issues/344
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the contributing guidelines in the project README.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
