### PR TITLE
Scroll to anchor links [Fixes: #294]

### DIFF
--- a/docs/.vuepress/theme/Layout.vue
+++ b/docs/.vuepress/theme/Layout.vue
@@ -29,7 +29,8 @@ export default {
   data() {
     return {
       isSidebarOpen: false,
-      darkMode: false
+      darkMode: false,
+      reducedMotion: false
     };
   },
   components: {
@@ -55,6 +56,20 @@ export default {
           this.darkMode = matches;
         }
       });
+    this.reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    window
+      .matchMedia('(prefers-reduced-motion: reduce)')
+      .addListener(({ matches }) => {
+          this.reducedMotion = matches;
+      });
+  },
+  updated() {
+    if(window.location.hash){
+      this.setScrollBehavior('smooth');
+      this.$nextTick(function() {
+        this.setScrollBehavior('auto');
+      });
+    }
   },
   computed: {
     isLandingPage() {
@@ -123,6 +138,12 @@ export default {
       if (localStorage) {
         localStorage.setItem("dark-mode", this.darkMode);
       }
+    },
+    setScrollBehavior(behavior) {
+      if(behavior === 'smooth' && this.reducedMotion){
+        return;
+      }
+      document.documentElement.style.scrollBehavior = behavior;
     }
   },
   watch: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Smooth scroll to anchor links.
- The smooth scroll is only honored if the URL contains a `#` symbol using 'window.location.hash' 'method.
- a11y compliant, for users who are prone to motion sickness. (can be disabled by OS, most browsers honor this setting, eg. on android the user can disable animations)

<!--- Describe your changes in detail -->

## Related Issue

Fixes #294 

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Screenshots (if appropriate):
