### PR TITLE
Add Ethereum Grid to tools [Closes #558]

### DIFF
--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -97,6 +97,11 @@ Ethereum has a large and growing number of tools to help developers build, test,
 
 ### Other Tools {#other-tools}
 
+**Ethereum Grid -** **_A desktop application for downloading, configuring, and running Ethereum clients and tools._**
+
+- [grid.ethereum.org](https://grid.ethereum.org)
+- [GitHub](https://github.com/ethereum/grid)
+
 **Buidler -** **_A task runner for Ethereum smart contract developers._**
 
 - [buidler.dev](https://buidler.dev)

--- a/docs/javascript/index.md
+++ b/docs/javascript/index.md
@@ -55,7 +55,13 @@ Need a more basic primer first? Check out [ethereum.org/learn](/learn/) or [ethe
 - [GitHub](https://github.com/ethers-io/ethers.js/)
 
 **ethereumjs-vm -** **_The Ethereum VM implemented in JavaScript_**
+
 - [GitHub](https://github.com/ethereumjs/ethereumjs-vm)
+
+**Ethereum Grid -** **\_A desktop application for Ethereum tools, extensible with JavaScript.**
+
+- [grid.ethereum.org](https://grid.ethereum.org)
+- [GitHub](https://github.com/ethereum/grid)
 
 Looking for more resources? Check out [ethereum.org/developers.](/developers/)
 


### PR DESCRIPTION
## Description
Adds [Ethereum Grid](https://grid.ethereum.org) to the list of developer tools and JavaScript tools.

## Related Issue
Addresses #558. One remaining question about the `build` page.