### PR TITLE
Remove eth-utils from the Rust projects list

### DIFF
--- a/docs/rust/index.md
+++ b/docs/rust/index.md
@@ -59,7 +59,6 @@ Need a more basic primer first? Check out [ethereum.org/learn](/learn/) or [ethe
 - [pwasm-ethereum](https://github.com/paritytech/pwasm-ethereum) - _Collection of externs to interact with ethereum-like network._
 - [Ethereum WebAssembly](https://ewasm.readthedocs.io/en/mkdocs/)
 - [oasis_std](https://docs.rs/oasis-std/0.2.7/oasis_std/) - _OASIS API reference_
-- [eth-utils](https://github.com/ethereum/eth-utils/) - _utility functions for working with Ethereum related codebases_
 - [Solaris](https://github.com/paritytech/sol-rs)
 - [SputnikVM](https://github.com/sorpaas/rust-evm) - _Rust Ethereum Virtual Machine Implementation_
 - [Parity](https://github.com/paritytech/parity-ethereum) - _Ethereum Rust client_


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Because [eth-utils](https://github.com/ethereum/eth-utils/) is not a Rust project but a Python project, I would suggest to remove it from the Rust projects list.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Screenshots (if appropriate):
