### PR TITLE
Add QuikNode.io to Backend APIs in Developers

### DIFF
--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -238,6 +238,10 @@ Ethereum has a large and growing number of tools to help developers build, test,
 - [chainstack.com](https://chainstack.com)
 - [Documentation](https://docs.chainstack.com)
 
+**QuikNode -** **_Blockchain developer platform._**
+
+- [quiknode.io](https://quiknode.io)
+
 ## Storage {#storage}
 
 **IPFS -** **_InterPlanetary File System is a decentralized storage and file referencing system for Ethereum._**


### PR DESCRIPTION
QuikNode.io has been an active member of the Ethereum infrastructure group since 2017.

Its dedicated to blockchain education and supporting the Ethereum ecosystem.

More information on https://blog.quiknode.io and https://twitter.com/quiknode