### PR TITLE
Update index.md to include Solidity & Vyper cheat sheet

### DIFF
--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -46,12 +46,14 @@ Any program that runs on the Ethereum Virtual Machine (EVM) is commonly referred
 - [Documentation](https://solidity.readthedocs.io)
 - [GitHub](https://github.com/ethereum/solidity/)
 - [Solidity Gitter Chatroom](https://gitter.im/ethereum/solidity/)
+- [Cheat Sheet](https://reference.auditless.com/cheatsheet)
 
 **Vyper -** **_Security focused language for Ethereum, based on Python._**
 
 - [Documentation](https://vyper.readthedocs.io)
 - [GitHub](https://github.com/ethereum/vyper)
 - [Vyper Gitter Chatroom](https://gitter.im/ethereum/vyper)
+- [Cheat Sheet](https://reference.auditless.com/cheatsheet)
 
 **Looking for other options?**
 


### PR DESCRIPTION
## Description

I've added the links for the Solidity & Vyper cheat sheet at [http://reference.auditless.com/cheatsheet](http://reference.auditless.com/cheatsheet). This cheat sheet is open source and already has contributions from Solidity/Vyper devs/core team.

I'm not happy with the placement since there is no joint section for Solidity/Vyper so proposing a separate link in both (but it's one side-by-side cheat sheet in reality).

## Screenshots (if appropriate):

<img width="1380" alt="image" src="https://user-images.githubusercontent.com/224585/71522460-6c622700-28cd-11ea-82ba-a20df92e7daa.png">

