### PR TITLE
fix: Tabbing across links skips dropdown items (#735)

### DIFF
--- a/docs/.vuepress/components/__tests__/__snapshots__/AssetItem.spec.js.snap
+++ b/docs/.vuepress/components/__tests__/__snapshots__/AssetItem.spec.js.snap
@@ -6,6 +6,7 @@ exports[`AssetItem render icon successfully 1`] = `
 >
   <a
     href="[object Object]"
+    rel="noopener noreferrer"
     target="_blank"
   >
     <img
@@ -23,6 +24,7 @@ exports[`AssetItem render icon successfully 1`] = `
     <span>
       <a
         href="[object Object]"
+        rel="noopener noreferrer"
         target="_blank"
       >
         PNG
@@ -35,6 +37,7 @@ exports[`AssetItem render icon successfully 1`] = `
       
       <a
         href="[object Object]"
+        rel="noopener noreferrer"
         target="_blank"
       >
         SVG
@@ -47,6 +50,7 @@ exports[`AssetItem render icon successfully 1`] = `
       
       <a
         href="[object Object]"
+        rel="noopener noreferrer"
         target="_blank"
       >
         JPG

--- a/docs/.vuepress/components/__tests__/__snapshots__/DefaultList.spec.js.snap
+++ b/docs/.vuepress/components/__tests__/__snapshots__/DefaultList.spec.js.snap
@@ -10,8 +10,8 @@ exports[`DefaultList list items 1`] = `
       >
         Bitcoin
       </a>
-      , The 1st Crytocurrency in the world 
-		
+      , The 1st Crytocurrency in the world
+    
     </li>
     <li>
       <a
@@ -20,8 +20,8 @@ exports[`DefaultList list items 1`] = `
       >
         Ethereum
       </a>
-      , The smart contract blockchain 
-		
+      , The smart contract blockchain
+    
     </li>
   </ul>
 </div>

--- a/docs/.vuepress/components/__tests__/__snapshots__/HomePage.spec.js.snap
+++ b/docs/.vuepress/components/__tests__/__snapshots__/HomePage.spec.js.snap
@@ -14,12 +14,14 @@ exports[`HomePage render successfully with Deutsch 1`] = `
     <div
       class="headline-subtitle"
     >
+      
       Auf Ethereum kannst du Code schreiben, der digitale Werte verwaltet, der exakt wie programmiert ausgeführt wird und der von überall auf der Welt zugänglich ist.
+    
     </div>
      
     <router-link-stub
       class="button headline-button"
-      to="/beginners/"
+      to="/de/what-is-ethereum/"
     >
       Learn more
     </router-link-stub>
@@ -35,7 +37,7 @@ exports[`HomePage render successfully with Deutsch 1`] = `
     >
       <h3>
         <router-link-stub
-          to="/de/beginners/"
+          to="/de/what-is-ethereum/"
         >
           <span
             class="arrow"
@@ -53,7 +55,7 @@ exports[`HomePage render successfully with Deutsch 1`] = `
         >
           <router-link-stub
             class="black"
-            to="/de/beginners/"
+            to="/de/what-is-ethereum/"
           >
             
             Neu bei Ethereum?
@@ -64,7 +66,7 @@ exports[`HomePage render successfully with Deutsch 1`] = `
         <li>
           <router-link-stub
             class="black"
-            to="/de/beginners/"
+            to="/de/what-is-ethereum/"
           >
             
             Was ist Ethereum?
@@ -75,7 +77,7 @@ exports[`HomePage render successfully with Deutsch 1`] = `
         <li>
           <router-link-stub
             class="black"
-            to="/de/beginners/"
+            to="/de/what-is-ethereum/"
           >
             
             Welchen Nutzen bringt es mir?
@@ -212,13 +214,15 @@ exports[`HomePage render successfully with Deutsch 1`] = `
         <li>
           <router-link-stub
             class="black"
-            to="/de/build"
+            to="/de/developers/#getting-started"
           >
             
             Erste Schritte
           
           </router-link-stub>
         </li>
+         
+        <!---->
          
         <li>
           <router-link-stub
@@ -263,12 +267,14 @@ exports[`HomePage show enterprise with en-US 1`] = `
     <div
       class="headline-subtitle"
     >
+      
       On Ethereum, you can write code that controls digital value, runs exactly as programmed, and is accessible anywhere in the world.
+    
     </div>
      
     <router-link-stub
       class="button headline-button"
-      to="/beginners/"
+      to="/what-is-ethereum/"
     >
       Learn more
     </router-link-stub>
@@ -298,7 +304,7 @@ exports[`HomePage show enterprise with en-US 1`] = `
         >
           <router-link-stub
             class="black"
-            to="/beginners/"
+            to="/what-is-ethereum/"
           >
             
             What is Ethereum?
@@ -309,7 +315,7 @@ exports[`HomePage show enterprise with en-US 1`] = `
         <li>
           <router-link-stub
             class="black"
-            to="/use/"
+            to="/dapps/"
           >
             
             Use Ethereum
@@ -324,6 +330,17 @@ exports[`HomePage show enterprise with en-US 1`] = `
           >
             
             Guides & Resources
+          
+          </router-link-stub>
+        </li>
+         
+        <li>
+          <router-link-stub
+            class="black"
+            to="/community/"
+          >
+            
+            Ethereum Community
           
           </router-link-stub>
         </li>
@@ -354,10 +371,12 @@ exports[`HomePage show enterprise with en-US 1`] = `
       </h3>
        
       <ul>
+        <!---->
+         
         <li>
           <router-link-stub
             class="black"
-            to="/build"
+            to="/build/"
           >
             
             Getting started guides

--- a/docs/.vuepress/components/__tests__/__snapshots__/LanguagesPage.spec.js.snap
+++ b/docs/.vuepress/components/__tests__/__snapshots__/LanguagesPage.spec.js.snap
@@ -72,6 +72,7 @@ exports[`LanguagesPage render page after querying incomplete languages from crow
     <a
       class="lang-item border-box-shadow-hover"
       href="https://crowdin.com/project/ethereumfoundation/ph"
+      rel="noopener noreferrer"
       target="_blank"
     >
       <div
@@ -90,6 +91,7 @@ exports[`LanguagesPage render page after querying incomplete languages from crow
        
       <a
         href="https://crowdin.com/project/ethereumfoundation/ph"
+        rel="noopener noreferrer"
         target="_blank"
       >
         Contribute
@@ -98,6 +100,7 @@ exports[`LanguagesPage render page after querying incomplete languages from crow
     <a
       class="lang-item border-box-shadow-hover"
       href="https://crowdin.com/project/ethereumfoundation/gu"
+      rel="noopener noreferrer"
       target="_blank"
     >
       <div
@@ -116,6 +119,7 @@ exports[`LanguagesPage render page after querying incomplete languages from crow
        
       <a
         href="https://crowdin.com/project/ethereumfoundation/gu"
+        rel="noopener noreferrer"
         target="_blank"
       >
         Contribute

--- a/docs/.vuepress/theme/components/DropdownLink.vue
+++ b/docs/.vuepress/theme/components/DropdownLink.vue
@@ -1,9 +1,15 @@
 <template>
   <div class="dropdown-wrapper" :class="{ open }" @mouseleave="closeMenu">
-    <a class="dropdown-title" @click="toggle" @mouseover="openMenu">
+    <button
+      type="button"
+      class="dropdown-title"
+      @click="toggle"
+      @mouseover="openMenu"
+      :aria-label="`Select ${item.text.toLowerCase()}`"
+    >
       <span class="title">{{ item.text }}</span>
       <span class="arrow" :class="open ? 'down' : 'right'"></span>
-    </a>
+    </button>
 
     <DropdownTransition>
       <ul class="nav-dropdown border-box-shadow" v-show="open">
@@ -79,6 +85,14 @@ export default {
     display flex
     align-items center
     color $subduedColor
+    background transparent
+    border none
+    font-size inherit
+    font-family inherit
+    cursor inherit
+    padding inherit
+    line-height 1.4rem
+    font-weight 500
     &:hover
       border-color transparent
     .arrow

--- a/docs/.vuepress/theme/components/Header.vue
+++ b/docs/.vuepress/theme/components/Header.vue
@@ -31,7 +31,13 @@
           src="../images/icon-github-white.svg"
         />
       </a>
-      <span class="pointer view-mode" @click="$emit('toggle-mode')">
+      <span
+        class="pointer view-mode"
+        tabindex="0"
+        @keydown.enter="$emit('toggle-mode')"
+        @click="$emit('toggle-mode')"
+        :aria-label="'Toggle View Mode'"
+      >
         <img
           alt="Switch to Dark Mode"
           class="hide-dark"

--- a/docs/.vuepress/theme/components/__tests__/DropdownLink.spec.js
+++ b/docs/.vuepress/theme/components/__tests__/DropdownLink.spec.js
@@ -1,44 +1,54 @@
 import { shallowMount } from '@vue/test-utils'
-import DropdownLink from "@/theme/components/DropdownLink"
+import DropdownLink from '@/theme/components/DropdownLink'
 
 describe('DropdownLink', () => {
-  test('non-languages dropdown list; some items\' type are links', () => {
+  test("non-languages dropdown list; some items' type are links", () => {
     const wrapper = shallowMount(DropdownLink, {
       propsData: {
         item: {
-          text: "Choices",
-          items: [{
-            text: "currency",
-            link: "http://currency.com",
-            type: "links",
-            items: [{
-                text: "USD",
-                link: "http://currency.com/USD"
-              }, {
-                text: "BTC",
-                link: "http://currency.com/BTC"
-              }
-            ]}, {
-              text: "planet",
-              link: "http://planets.com",
-              type: "images"
-            }, {
-              text: "color",
-              link: "http://colors.com",
-              type: "links",
-              items: [{
-                  text: "red",
-                  link: "http://color.com/red"
-                }, {
-                  text: "blue",
-                  link: "http://color.com/blue"
-                }, {
-                  text: "green",
-                  link: "http://color.com/green"
+          text: 'Choices',
+          items: [
+            {
+              text: 'currency',
+              link: 'http://currency.com',
+              type: 'links',
+              items: [
+                {
+                  text: 'USD',
+                  link: 'http://currency.com/USD'
+                },
+                {
+                  text: 'BTC',
+                  link: 'http://currency.com/BTC'
                 }
               ]
-            }]
-          }
+            },
+            {
+              text: 'planet',
+              link: 'http://planets.com',
+              type: 'images'
+            },
+            {
+              text: 'color',
+              link: 'http://colors.com',
+              type: 'links',
+              items: [
+                {
+                  text: 'red',
+                  link: 'http://color.com/red'
+                },
+                {
+                  text: 'blue',
+                  link: 'http://color.com/blue'
+                },
+                {
+                  text: 'green',
+                  link: 'http://color.com/green'
+                }
+              ]
+            }
+          ]
+        }
       },
       stubs: ['router-link']
     })
@@ -49,17 +59,21 @@ describe('DropdownLink', () => {
     const wrapper = shallowMount(DropdownLink, {
       propsData: {
         item: {
-          text: "Languages",
-          items: [{
-            text: "English",
-            link: "en"
-          }, {
-            text: "Deutsch",
-            link: "de",
-          }, {
-            text: "Italiano",
-            link: "it"
-          }]
+          text: 'Languages',
+          items: [
+            {
+              text: 'English',
+              link: 'en'
+            },
+            {
+              text: 'Deutsch',
+              link: 'de'
+            },
+            {
+              text: 'Italiano',
+              link: 'it'
+            }
+          ]
         }
       },
       stubs: ['router-link']
@@ -71,26 +85,29 @@ describe('DropdownLink', () => {
     const wrapper = shallowMount(DropdownLink, {
       propsData: {
         item: {
-          text: "Languages",
-          items: [{
-            text: "English",
-            link: "en"
-          }, {
-            text: "Deutsch",
-            link: "de",
-          }, {
-            text: "Italiano",
-            link: "it"
-          }]
+          text: 'Languages',
+          items: [
+            {
+              text: 'English',
+              link: 'en'
+            },
+            {
+              text: 'Deutsch',
+              link: 'de'
+            },
+            {
+              text: 'Italiano',
+              link: 'it'
+            }
+          ]
         }
       },
       stubs: ['router-link']
     })
-    wrapper.find("a.dropdown-title").trigger("click")
+    wrapper.find('button.dropdown-title').trigger('click')
     wrapper.vm.$nextTick(() => {
       expect(wrapper.element).toMatchSnapshot()
       done()
     })
   })
-
 })

--- a/docs/.vuepress/theme/components/__tests__/__snapshots__/DropdownLink.spec.js.snap
+++ b/docs/.vuepress/theme/components/__tests__/__snapshots__/DropdownLink.spec.js.snap
@@ -4,8 +4,10 @@ exports[`DropdownLink languages dropdown list; item.text === Languages 1`] = `
 <div
   class="dropdown-wrapper"
 >
-  <a
+  <button
+    aria-label="Select languages"
     class="dropdown-title"
+    type="button"
   >
     <span
       class="title"
@@ -16,7 +18,7 @@ exports[`DropdownLink languages dropdown list; item.text === Languages 1`] = `
     <span
       class="arrow right"
     />
-  </a>
+  </button>
    
   <dropdowntransition-stub>
     <ul
@@ -29,6 +31,7 @@ exports[`DropdownLink languages dropdown list; item.text === Languages 1`] = `
         <!---->
          
         <navlink-stub
+          closemenu="function () { [native code] }"
           item="[object Object]"
         />
       </li>
@@ -38,6 +41,7 @@ exports[`DropdownLink languages dropdown list; item.text === Languages 1`] = `
         <!---->
          
         <navlink-stub
+          closemenu="function () { [native code] }"
           item="[object Object]"
         />
       </li>
@@ -47,6 +51,7 @@ exports[`DropdownLink languages dropdown list; item.text === Languages 1`] = `
         <!---->
          
         <navlink-stub
+          closemenu="function () { [native code] }"
           item="[object Object]"
         />
       </li>
@@ -70,8 +75,10 @@ exports[`DropdownLink non-languages dropdown list; some items' type are links 1`
 <div
   class="dropdown-wrapper"
 >
-  <a
+  <button
+    aria-label="Select choices"
     class="dropdown-title"
+    type="button"
   >
     <span
       class="title"
@@ -82,7 +89,7 @@ exports[`DropdownLink non-languages dropdown list; some items' type are links 1`
     <span
       class="arrow right"
     />
-  </a>
+  </button>
    
   <dropdowntransition-stub>
     <ul
@@ -103,6 +110,7 @@ exports[`DropdownLink non-languages dropdown list; some items' type are links 1`
             class="dropdown-subitem"
           >
             <navlink-stub
+              closemenu="function () { [native code] }"
               item="[object Object]"
             />
           </li>
@@ -110,6 +118,7 @@ exports[`DropdownLink non-languages dropdown list; some items' type are links 1`
             class="dropdown-subitem"
           >
             <navlink-stub
+              closemenu="function () { [native code] }"
               item="[object Object]"
             />
           </li>
@@ -121,6 +130,7 @@ exports[`DropdownLink non-languages dropdown list; some items' type are links 1`
         <!---->
          
         <navlink-stub
+          closemenu="function () { [native code] }"
           item="[object Object]"
         />
       </li>
@@ -138,6 +148,7 @@ exports[`DropdownLink non-languages dropdown list; some items' type are links 1`
             class="dropdown-subitem"
           >
             <navlink-stub
+              closemenu="function () { [native code] }"
               item="[object Object]"
             />
           </li>
@@ -145,6 +156,7 @@ exports[`DropdownLink non-languages dropdown list; some items' type are links 1`
             class="dropdown-subitem"
           >
             <navlink-stub
+              closemenu="function () { [native code] }"
               item="[object Object]"
             />
           </li>
@@ -152,6 +164,7 @@ exports[`DropdownLink non-languages dropdown list; some items' type are links 1`
             class="dropdown-subitem"
           >
             <navlink-stub
+              closemenu="function () { [native code] }"
               item="[object Object]"
             />
           </li>
@@ -168,8 +181,10 @@ exports[`DropdownLink toggle dropdownlist to be open 1`] = `
 <div
   class="dropdown-wrapper open"
 >
-  <a
+  <button
+    aria-label="Select languages"
     class="dropdown-title"
+    type="button"
   >
     <span
       class="title"
@@ -180,7 +195,7 @@ exports[`DropdownLink toggle dropdownlist to be open 1`] = `
     <span
       class="arrow down"
     />
-  </a>
+  </button>
    
   <dropdowntransition-stub>
     <ul
@@ -193,6 +208,7 @@ exports[`DropdownLink toggle dropdownlist to be open 1`] = `
         <!---->
          
         <navlink-stub
+          closemenu="function () { [native code] }"
           item="[object Object]"
         />
       </li>
@@ -202,6 +218,7 @@ exports[`DropdownLink toggle dropdownlist to be open 1`] = `
         <!---->
          
         <navlink-stub
+          closemenu="function () { [native code] }"
           item="[object Object]"
         />
       </li>
@@ -211,6 +228,7 @@ exports[`DropdownLink toggle dropdownlist to be open 1`] = `
         <!---->
          
         <navlink-stub
+          closemenu="function () { [native code] }"
           item="[object Object]"
         />
       </li>

--- a/docs/.vuepress/theme/components/__tests__/__snapshots__/Footer.spec.js.snap
+++ b/docs/.vuepress/theme/components/__tests__/__snapshots__/Footer.spec.js.snap
@@ -8,37 +8,48 @@ exports[`Footer render successfully 1`] = `
     class="credits"
   >
     
-    Artwork by 
+    Artwork by
+    
     <a
       href="https://impermanence.co"
+      rel="noopener noreferrer"
       target="_blank"
     >
       Lili Feyerabend
     </a>
-     feat. 
+    
+    feat.
+    
     <a
       href="https://ilankatin.com"
+      rel="noopener noreferrer"
       target="_blank"
     >
       ilan katin
     </a>
-    , 
+    ,
+    
     <a
       href="https://linktr.ee/mattiacprodukt"
+      rel="noopener noreferrer"
       target="_blank"
     >
       Mattia Cuttini
     </a>
-    , 
+    ,
+    
     <a
       href="https://oficinastk.github.io"
+      rel="noopener noreferrer"
       target="_blank"
     >
       Oficinas TK
     </a>
-    , 
+    ,
+    
     <a
       href="https://xcopyart.com"
+      rel="noopener noreferrer"
       target="_blank"
     >
       XCOPY
@@ -57,6 +68,7 @@ exports[`Footer render successfully 1`] = `
     <li>
       <a
         href="https://github.com/ethereum"
+        rel="noopener noreferrer"
         target="_blank"
       >
         GitHub
@@ -66,6 +78,7 @@ exports[`Footer render successfully 1`] = `
     <li>
       <a
         href="https://twitter.com/ethereum"
+        rel="noopener noreferrer"
         target="_blank"
       >
         Twitter
@@ -74,7 +87,18 @@ exports[`Footer render successfully 1`] = `
      
     <li>
       <a
+        href="https://www.youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        YouTube
+      </a>
+    </li>
+     
+    <li>
+      <a
         href="https://blog.ethereum.org/"
+        rel="noopener noreferrer"
         target="_blank"
       >
         Blog
@@ -127,6 +151,16 @@ exports[`Footer render successfully 1`] = `
       >
         Language Support
       </router-link-stub>
+    </li>
+     
+    <li>
+      <a
+        href="https://ecosystem.support/"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Ecosystem Support Program
+      </a>
     </li>
   </ul>
 </footer>

--- a/docs/.vuepress/theme/components/__tests__/__snapshots__/Header.spec.js.snap
+++ b/docs/.vuepress/theme/components/__tests__/__snapshots__/Header.spec.js.snap
@@ -32,6 +32,7 @@ exports[`Header render header with searchbox 1`] = `
     <a
       class="sm-hide"
       href="https://github.com/ethereum/ethereum-org-website"
+      rel="noopener noreferrer"
       target="_blank"
       title="Fork This Page (GitHub)"
     >
@@ -50,6 +51,7 @@ exports[`Header render header with searchbox 1`] = `
      
     <span
       class="pointer view-mode"
+      tabindex="0"
     >
       <img
         alt="Switch to Dark Mode"
@@ -66,7 +68,7 @@ exports[`Header render header with searchbox 1`] = `
      
     <router-link-stub
       class="nav-link"
-      to="/languages"
+      to="/languages/"
     >
       <languageicon-stub />
        
@@ -112,6 +114,7 @@ exports[`Header render header without searchbox 1`] = `
     <a
       class="sm-hide"
       href="https://github.com/ethereum/ethereum-org-website"
+      rel="noopener noreferrer"
       target="_blank"
       title="Fork This Page (GitHub)"
     >
@@ -130,6 +133,7 @@ exports[`Header render header without searchbox 1`] = `
      
     <span
       class="pointer view-mode"
+      tabindex="0"
     >
       <img
         alt="Switch to Dark Mode"
@@ -146,7 +150,7 @@ exports[`Header render header without searchbox 1`] = `
      
     <router-link-stub
       class="nav-link"
-      to="/languages"
+      to="/languages/"
     >
       <languageicon-stub />
        

--- a/docs/.vuepress/theme/components/__tests__/__snapshots__/NavLinks.spec.js.snap
+++ b/docs/.vuepress/theme/components/__tests__/__snapshots__/NavLinks.spec.js.snap
@@ -20,7 +20,7 @@ exports[`NavLinks render as sidebar, with navigation and sub-items 1`] = `
     >
       <router-link
         class="nav-link"
-        to="/languages"
+        to="/languages/"
       >
         Languages
       </router-link>


### PR DESCRIPTION
Apart from fixing the a11y issues with the dropdown items, I also fixed the view mode toggle from being skipped when tabbing through and made it usable with `@keydown.enter`.

There were various snapshot tests failing, which are unrelated to my changes, I updated them anyways. 

Fixes #735. 