### PR TITLE
Added new buttons [fixes #757]

### DIFF
--- a/docs/.vuepress/components/BuildPage.vue
+++ b/docs/.vuepress/components/BuildPage.vue
@@ -9,7 +9,7 @@
           {{ translateString('page-build-subtitle') }}
         </div>
       </div>
-      <Button newTab isA to="https://studio.ethereum.org">
+      <Button isExternal to="https://studio.ethereum.org">
         {{ translateString('page-build-try-button') }}
       </Button>
       <div class="terminal-gif">
@@ -178,7 +178,7 @@
         <p>
           {{ translateString('page-build-learn-more-description') }}
         </p>
-        <Button secondary isRouter :to="langPath() + 'learn/'">
+        <Button secondary :to="langPath() + 'learn/'">
           {{ translateString('learn-more') }}
         </Button>
       </div>

--- a/docs/.vuepress/components/BuildPage.vue
+++ b/docs/.vuepress/components/BuildPage.vue
@@ -9,14 +9,9 @@
           {{ translateString('page-build-subtitle') }}
         </div>
       </div>
-      <a
-        class="button"
-        href="https://studio.ethereum.org"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
+      <Button newTab isA to="https://studio.ethereum.org">
         {{ translateString('page-build-try-button') }}
-      </a>
+      </Button>
       <div class="terminal-gif">
         <img src="/ethereum-studio.gif" />
       </div>
@@ -183,9 +178,9 @@
         <p>
           {{ translateString('page-build-learn-more-description') }}
         </p>
-        <router-link class="button" :to="langPath() + 'learn/'">
+        <Button secondary isRouter :to="langPath() + 'learn/'">
           {{ translateString('learn-more') }}
-        </router-link>
+        </Button>
       </div>
       <!-- TODO how to include links within translations? -->
       <p class="collaboration">
@@ -246,11 +241,6 @@ export default {
         max-width 60%
     .button
       margin 2em
-      font-size $fsRegular
-      font-weight 700
-      color $textColor
-      &:hover
-        color $accentColor
     .terminal-gif
       margin-top 3em
       border-radius 8px
@@ -349,8 +339,4 @@ export default {
 #wrapper.dark-mode
   h2
     border-bottom none
-  .button
-    &:hover
-      color $accentColorDark
-      border-color $accentColorDark
 </style>

--- a/docs/.vuepress/components/Button.vue
+++ b/docs/.vuepress/components/Button.vue
@@ -1,0 +1,119 @@
+<template>
+  <!-- <h1>Test</h1> -->
+  <router-link v-if="isRouter" :to="to" :class="buttonClasses">
+    <slot />
+  </router-link>
+  <a href v-else-if="isA" :class="buttonClasses" :target="target" :rel="rel">
+    <slot />
+  </a>
+</template>
+
+<script>
+export default {
+  name: 'Button',
+  props: {
+    isA: {
+      type: Boolean,
+      default: true
+    },
+    isRouter: {
+      type: Boolean,
+      default: false
+    },
+    isButton: {
+      type: Boolean,
+      default: false
+    },
+    to: {
+      type: String
+    },
+    newTab: {
+      type: Boolean,
+      default: false
+    },
+    primary: {
+      type: Boolean,
+      default: true
+    },
+    secondary: {
+      type: Boolean,
+      default: false
+    }
+  },
+  computed: {
+    buttonClasses() {
+      if (this.secondary) {
+        return 'button secondary'
+      } else {
+        return 'button primary'
+      }
+    },
+    target() {
+      return this.newTab && '_blank'
+    },
+    rel() {
+      return this.newTab && 'noopener noreferrer'
+    }
+  }
+}
+</script>
+
+<style lang="stylus" scoped>
+@import '../theme/styles/config.styl';
+
+  .button
+    font-size 1rem
+    border-radius .25em
+    padding .5em .75em
+    text-align: center;
+
+  .primary
+    color $white
+    background-color $accentColor
+    border: 1px solid transparent
+
+    &:hover
+      background-color alpha($accentColor, 0.8)
+
+    &:focus
+      box-shadow 0 0 0 1px $white, 0 0 0 3px $accentColor
+      outline: none;
+
+  .secondary
+    color $accentColor
+    background-color: $white
+    border: 1px solid $subduedColor
+
+    &:hover
+      background-color $subduedColor
+
+    &:focus
+      box-shadow 0 0 0 1px $white, 0 0 0 3px $subduedColor
+      outline: none;
+
+  .dark-mode
+
+    .primary
+      color $white
+      background-color $accentColorDark
+
+      &:hover
+        color $white
+        background-color alpha($accentColorDark, 0.8)
+
+      &:focus
+        box-shadow 0 0 0 1px $black, 0 0 0 3px $accentColorDark
+        outline: none;
+
+    .secondary
+      color $white
+      background-color: $bgDark
+
+      &:hover
+        border-color $white
+        background-color $black
+
+      &:focus
+        // border-color $accentColorDark
+        box-shadow 0 0 0 1px $bgDark, 0 0 0 3px $white
+</style>

--- a/docs/.vuepress/components/Button.vue
+++ b/docs/.vuepress/components/Button.vue
@@ -26,10 +26,6 @@ export default {
       type: String,
       required: true
     },
-    primary: {
-      type: Boolean,
-      default: true
-    },
     secondary: {
       type: Boolean,
       default: false

--- a/docs/.vuepress/components/Button.vue
+++ b/docs/.vuepress/components/Button.vue
@@ -1,31 +1,30 @@
 <template>
-  <!-- <h1>Test</h1> -->
-  <router-link v-if="isRouter" :to="to" :class="buttonClasses">
-    <slot />
-  </router-link>
-  <a href v-else-if="isA" :class="buttonClasses" :target="target" :rel="rel">
+  <a
+    href
+    v-if="isExternal"
+    :href="to"
+    :class="buttonClasses"
+    target="_blank"
+    rel="noopener noreferrer"
+  >
     <slot />
   </a>
+  <router-link v-else :to="to" :class="buttonClasses">
+    <slot />
+  </router-link>
 </template>
 
 <script>
 export default {
   name: 'Button',
   props: {
-    isA: {
-      type: Boolean,
-      default: true
-    },
-    isRouter: {
+    isExternal: {
       type: Boolean,
       default: false
     },
     to: {
-      type: String
-    },
-    newTab: {
-      type: Boolean,
-      default: false
+      type: String,
+      required: true
     },
     primary: {
       type: Boolean,
@@ -43,12 +42,6 @@ export default {
       } else {
         return 'button primary'
       }
-    },
-    target() {
-      return this.newTab && '_blank'
-    },
-    rel() {
-      return this.newTab && 'noopener noreferrer'
     }
   }
 }
@@ -110,6 +103,5 @@ export default {
         background-color $black
 
       &:focus
-        // border-color $accentColorDark
         box-shadow 0 0 0 1px $bgDark, 0 0 0 3px $white
 </style>

--- a/docs/.vuepress/components/Button.vue
+++ b/docs/.vuepress/components/Button.vue
@@ -20,10 +20,6 @@ export default {
       type: Boolean,
       default: false
     },
-    isButton: {
-      type: Boolean,
-      default: false
-    },
     to: {
       type: String
     },

--- a/docs/.vuepress/components/HomePage.vue
+++ b/docs/.vuepress/components/HomePage.vue
@@ -5,11 +5,7 @@
       <div class="headline-subtitle">
         {{ translateString('page-home-subtitle') }}
       </div>
-      <Button
-        isRouter
-        class="headline-button"
-        :to="langPath() + 'what-is-ethereum/'"
-      >
+      <Button class="headline-button" :to="langPath() + 'what-is-ethereum/'">
         {{ translateString('learn-more') }}
       </Button>
     </div>

--- a/docs/.vuepress/components/HomePage.vue
+++ b/docs/.vuepress/components/HomePage.vue
@@ -5,11 +5,13 @@
       <div class="headline-subtitle">
         {{ translateString('page-home-subtitle') }}
       </div>
-      <router-link
+      <Button
+        isRouter
+        class="headline-button"
         :to="langPath() + 'what-is-ethereum/'"
-        class="button headline-button"
-        >{{ translateString('learn-more') }}</router-link
       >
+        {{ translateString('learn-more') }}
+      </Button>
     </div>
 
     <div class="intro-blocks">
@@ -250,7 +252,6 @@ export default {
 
   .headline-button
     margin-top 2rem
-    font-size $fsRegular
 
   .header
     color $accentColor

--- a/docs/.vuepress/theme/styles/dark.styl
+++ b/docs/.vuepress/theme/styles/dark.styl
@@ -22,12 +22,11 @@
   header
     background $bgDark
   div.intro-blocks
-    a
-      ul
-        li
-          color $textColorDark
-          &.highlight
-            background-image url(../images/highlight-dark.svg)
+    ul
+      li
+        color $textColorDark
+        &.highlight
+          background-image url(../images/highlight-dark.svg)
   ul
     list-style-image url(../images/dash-white.svg)
     li.highlight

--- a/docs/.vuepress/theme/styles/dark.styl
+++ b/docs/.vuepress/theme/styles/dark.styl
@@ -2,7 +2,7 @@
 .show-dark
   display none !important
 
-#wrapper.dark-mode
+.dark-mode
   background $bgDark
   color $textColorDark
   .text-color, a.text-color
@@ -17,14 +17,6 @@
     color $accentColorDark
     &.black
       color $textColorDark
-  .button
-    border-color $textColorDark
-    color $textColorDark
-    background $bgDark
-    color $textColorDark
-    &:hover
-      border-color $accentColorDark
-      color $accentColorDark
   h2
     border-bottom 1px solid $textColorDark
   header


### PR DESCRIPTION
A new `Button` component which can be called

## Description

This doesn't perfectly match the colors outlined in Figma, however that is because it is leveraging *current* darkmode colors.
- `isA` boolean, creates `<a href=...`
- `isRouter` boolean, creates `<router-link`
- `to` string, used inside `href` or `to` props,
- `secondary`, boolean, used to show secondary button style. Default is `primary`.
- `newTab`, boolean, creates `target="_blank" rel="noopener noreferrer"` when `isA` is used

## Related Issue

Resolves #757

## Screenshots (if appropriate):
