### PR TITLE
Update colors

### DIFF
--- a/docs/.vuepress/components/BuildPage.vue
+++ b/docs/.vuepress/components/BuildPage.vue
@@ -247,10 +247,6 @@ export default {
     .button
       margin 2em
       font-size $fsRegular
-      font-weight 700
-      color $textColor
-      &:hover
-        color $accentColor
     .terminal-gif
       margin-top 3em
       border-radius 8px
@@ -265,7 +261,7 @@ export default {
       a
         color $subduedColor
         &:hover
-          color $accentColor
+          color $colorPrimary
 
     .features
       display flex
@@ -351,6 +347,6 @@ export default {
     border-bottom none
   .button
     &:hover
-      color $accentColorDark
-      border-color $accentColorDark
+      color $colorPrimaryDark500
+      border-color $colorPrimaryDark500
 </style>

--- a/docs/.vuepress/components/HomePage.vue
+++ b/docs/.vuepress/components/HomePage.vue
@@ -261,4 +261,48 @@ export default {
   #wrapper.dark-mode
     .header
       color $colorPrimaryDark500
+
+.intro-blocks
+  margin-top 1.5em
+  display flex
+  flex-wrap wrap
+
+  .intro-block,
+  .intro-block-content-version-1
+    flex 1 1 29%
+    padding-left 1em
+    padding-right 1em
+    display inline-block
+    line-height $lhMedium
+    margin-bottom 1em
+    h3
+      span.arrow
+        margin-right 1.25em
+    ul
+      li
+        color $textColor
+        &.highlight
+          background-image: url(../theme/images/highlight.svg)
+          background-repeat no-repeat
+        a
+          color: $colorBlack400
+          &:hover
+            color: $colorPrimary500
+
+  // TODO remove once translations are updated w/ new personas
+  .intro-block-content-version-1
+    flex 1 1 40%
+    padding-left 2em
+    padding-right 2em
+
+.dark-mode
+  .intro-blocks
+    ul
+      li
+        a
+          color $colorWhite900
+          &:hover
+            color $colorPrimaryDark500
+        &.highlight
+          background-image url(../theme/images/highlight-dark.svg)
 </style>

--- a/docs/.vuepress/components/HomePage.vue
+++ b/docs/.vuepress/components/HomePage.vue
@@ -253,12 +253,12 @@ export default {
     font-size $fsRegular
 
   .header
-    color $accentColor
+    color $colorPrimary
 
 .highlight-small
     background-size 240px !important
 
   #wrapper.dark-mode
     .header
-      color $accentColorDark
+      color $colorPrimaryDark500
 </style>

--- a/docs/.vuepress/components/LanguagesPage.vue
+++ b/docs/.vuepress/components/LanguagesPage.vue
@@ -116,7 +116,7 @@ p
 
   .lang-item
     &:hover
-      border 1px dotted $accentColorDark
+      border 1px dotted $colorPrimaryDark500
 
   .lang-english-name
     color $textColorDark

--- a/docs/.vuepress/theme/Layout.vue
+++ b/docs/.vuepress/theme/Layout.vue
@@ -183,10 +183,14 @@ export default {
   padding 1em 2em
 
 p.updated-date
-  color $subduedColor
+  color $colorBlack50
 
 header
   margin 0px auto
+
+.dark-mode
+  .updated-date
+    color $colorWhite900
 
 @media only screen and (min-width:$breakL)
   #formatter,header

--- a/docs/.vuepress/theme/components/DropdownLink.vue
+++ b/docs/.vuepress/theme/components/DropdownLink.vue
@@ -84,7 +84,7 @@ export default {
   .dropdown-title
     display flex
     align-items center
-    color $subduedColor
+    color $colorBlack200
     background transparent
     border none
     font-size inherit
@@ -95,13 +95,14 @@ export default {
     font-weight 500
     &:hover
       border-color transparent
+      color: $colorPrimary500
     .arrow
       vertical-align middle
       margin-top -1px
       margin-left 0.4rem
   .nav-dropdown
-      display flex
-      flex-direction column
+    display flex
+    flex-direction column
 
     .dropdown-item
       color inherit
@@ -123,17 +124,11 @@ export default {
         font-weight 400
         margin-bottom 0
         padding 0 1.5rem 0 1.25rem
-        &:hover
-          color $accentColor
         &.router-link-active
-          color $accentColor
           &::after
             content ""
             width 0
             height 0
-            border-left 5px solid $accentColor
-            border-top 3px solid transparent
-            border-bottom 3px solid transparent
             position absolute
             top calc(50% - 2px)
             left 9px
@@ -141,6 +136,34 @@ export default {
         margin-top 0
         padding-top 0
         border-top 0
+
+.dropdown-item
+  a
+    &:hover
+      color $colorPrimary
+    &.router-link-active
+      color $colorPrimary
+      &::after
+        border-left 5px solid $colorPrimary
+        border-top 3px solid transparent
+        border-bottom 3px solid transparent
+
+.dark-mode
+  .dropdown-title
+    color: $colorWhite900
+    &:hover
+      border-color transparent
+      color: $colorPrimaryDark500
+  .dropdown-item
+    a
+      &:hover
+        color $colorPrimaryDark
+      &.router-link-active
+        color $colorPrimaryDark
+        &::after
+          border-left 5px solid $colorPrimaryDark
+          border-top 3px solid transparent
+          border-bottom 3px solid transparent
 
 @media (max-width: $MQMobile)
   .dropdown-wrapper
@@ -184,7 +207,7 @@ export default {
       white-space nowrap
       margin 0
       margin-top 8px
-      background-color $white
+      background-color $colorWhite
 
 .languages-dropdown-item
   line-height 1.7rem
@@ -192,7 +215,7 @@ export default {
     padding 0 1.5rem 0 1.25rem
 
 @media (min-width: $breakM)
-  #wrapper.dark-mode
+  .dark-mode
     .nav-dropdown
       background-color $lightBorderColorDark
     .nav-dropdown
@@ -200,5 +223,5 @@ export default {
         a
           &.router-link-active
             &::after
-              border-left 5px solid $accentColorDark
+              border-left 5px solid $colorPrimaryDark500
 </style>

--- a/docs/.vuepress/theme/components/Footer.vue
+++ b/docs/.vuepress/theme/components/Footer.vue
@@ -116,7 +116,7 @@ footer
       color $subduedColor
 
       &:hover
-        color $accentColor
+        color $colorPrimary
 
   &.home
     margin-left 2em
@@ -146,7 +146,7 @@ footer
         color $subduedColor
 
         &:hover
-          color $accentColor
+          color $colorPrimary
 
 @media (min-width: $breakS)
   footer

--- a/docs/.vuepress/theme/components/Header.vue
+++ b/docs/.vuepress/theme/components/Header.vue
@@ -81,20 +81,20 @@ export default {
   padding-left: 0.5em
 
 .nav-link
-  color: $subduedColor
+  color $colorBlack200
   svg path
     fill $subduedColor
   &:hover, &.router-link-active
-    color $accentColor
+    color $colorPrimary
     svg path
-      fill $accentColor
+      fill $colorPrimary
 
-#wrapper.dark-mode a.nav-link
-  color: $subduedColor
-  &:hover, &.router-link-active
-    color $accentColorDark
+.dark-mode .nav-link
+  color: $colorWhite900
+  &:hover, &:active, &:focus, &.router-link-active
+    color $colorPrimaryDark500
     svg path
-      fill $accentColorDark
+      fill $colorPrimaryDark500
 </style>
 
 <style lang="stylus" scoped>
@@ -133,14 +133,17 @@ header
 .button
   color $textColor
 
+.dark-mode
+  header {
+    background: $colorBgDark
+  }
 @media (max-width: $breakS)
   .sidebar-open
     header
-      background rgba(255,255,255,0.95)
-      border-bottom 1px dotted $accentColor
+      border-bottom 1px dotted $colorPrimary
 
   #wrapper.dark-mode
     .sidebar-open
       header
-        border-bottom 1px dotted $accentColorDark
+        border-bottom 1px dotted $colorPrimaryDark500
 </style>

--- a/docs/.vuepress/theme/components/SearchBox.vue
+++ b/docs/.vuepress/theme/components/SearchBox.vue
@@ -185,10 +185,10 @@ export default {
     &:focus
       cursor auto
       border-style solid
-      border-color $accentColor
+      border-color $colorPrimary
   .suggestions
     font-size $fsSmall
-    background $white
+    background $colorWhite
     width 20rem
     position absolute
     top 1.5rem
@@ -213,9 +213,9 @@ export default {
       .header
         margin-left 0.25em
     &.focused
-      background-color lighten($accentColor, 95%)
+      background-color lighten($colorPrimary, 95%)
       a
-        color $accentColor
+        color $colorPrimary
 
 .dark-mode .search-box
   input

--- a/docs/.vuepress/theme/components/Sidebar.vue
+++ b/docs/.vuepress/theme/components/Sidebar.vue
@@ -92,7 +92,7 @@ function resolveOpenGroupIndex(route, items) {
   font-size $fsXSmall
   padding-left 1em
   padding-right 2em
-  border-left 1px dotted $accentColor
+  border-left 1px dotted $colorPrimary
   transition all 0.2s ease-in-out
   transition transform .2s ease
 
@@ -117,11 +117,6 @@ function resolveOpenGroupIndex(route, items) {
       margin-right 0
       line-height 2em
 
-      a
-        color $textColor
-
-        &.router-link-active
-          color $accentColor
 
 @media (max-width: $breakS)
   .sidebar
@@ -135,7 +130,7 @@ function resolveOpenGroupIndex(route, items) {
     border-left none
     left 0
     background white
-    border-right 1px dotted $accentColor
+    border-right 1px dotted $colorPrimary
     height "calc(100vh - %s)" % $navbarHeight
     z-index 1
 

--- a/docs/.vuepress/theme/components/SidebarButton.vue
+++ b/docs/.vuepress/theme/components/SidebarButton.vue
@@ -37,10 +37,10 @@ export default {
     cursor: pointer
     margin-right 1em
     path
-      fill: $black
+      fill: $colorBlack
 
 .dark-mode .sidebar-button path
-    fill: $white
+    fill: $colorWhite
 
 @media (max-width $breakS)
   .sidebar-button

--- a/docs/.vuepress/theme/components/SidebarLink.vue
+++ b/docs/.vuepress/theme/components/SidebarLink.vue
@@ -1,86 +1,88 @@
 <script>
-import { isActive, hashRE, groupHeaders, resolveHeaderTitle } from "../utils/util";
+import {
+  isActive,
+  hashRE,
+  groupHeaders,
+  resolveHeaderTitle
+} from '../utils/util'
 
 export default {
   functional: true,
 
-  props: ["item"],
+  props: ['item'],
 
-  render(
-    h,
-    {
-      parent: { $page, $site, $route },
-      props: { item }
-    }
-  ) {
+  render(h, { parent: { $page, $site, $route }, props: { item } }) {
     // use custom active class matching logic
     // due to edge case of paths ending with / + hash
-    const selfActive = isActive($route, item.path);
+    const selfActive = isActive($route, item.path)
     // for sidebar: auto pages, a hash link should be active if one of its child
     // matches
     const active =
-      item.type === "auto"
+      item.type === 'auto'
         ? selfActive ||
           item.children.some(c =>
-            isActive($route, item.basePath + "#" + c.slug)
+            isActive($route, item.basePath + '#' + c.slug)
           )
-        : selfActive;
-    const link = renderLink(h, item.path, item.title || item.path, active);
+        : selfActive
+    const link = renderLink(h, item.path, item.title || item.path, active)
     const configDepth =
       $page.frontmatter.sidebarDepth != null
         ? $page.frontmatter.sidebarDepth
-        : $site.themeConfig.sidebarDepth;
-    const maxDepth = configDepth == null ? 1 : configDepth;
-    const displayAllHeaders = !!$site.themeConfig.displayAllHeaders;
-    if (item.type === "auto") {
-      return h("div", {}, [
+        : $site.themeConfig.sidebarDepth
+    const maxDepth = configDepth == null ? 1 : configDepth
+    const displayAllHeaders = !!$site.themeConfig.displayAllHeaders
+    if (item.type === 'auto') {
+      return h('div', {}, [
         link,
         renderChildren(h, item.children, item.basePath, $route, maxDepth)
-      ]);
+      ])
     } else if (
       (active || displayAllHeaders) &&
       item.headers &&
       !hashRE.test(item.path)
     ) {
-      const children = groupHeaders(item.headers);
-      return h("div", {}, [link, renderChildren(h, children, item.path, $route, maxDepth)]);
+      const children = groupHeaders(item.headers)
+      return h('div', {}, [
+        link,
+        renderChildren(h, children, item.path, $route, maxDepth)
+      ])
     } else {
-      return link;
+      return link
     }
   }
-};
+}
 
 function renderLink(h, to, text, active) {
   return h(
-    "router-link",
+    'router-link',
     {
       props: {
         to,
-        activeClass: "",
-        exactActiveClass: ""
+        activeClass: '',
+        exactActiveClass: ''
       },
       class: {
         active,
-        "sidebar-link": true
+        'sidebar-link': true
       }
     },
     resolveHeaderTitle(text)
-  );
+  )
 }
 
 function renderChildren(h, children, path, route, maxDepth, depth = 1) {
-  if (!children || depth > maxDepth) return null;
+  if (!children || depth > maxDepth) return null
   return h(
-    "ul",
-    { class: "sidebar-sub-headers" },
+    'ul',
+    { class: 'sidebar-sub-headers' },
     children.map(c => {
-      const active = isActive(route, path + "#" + c.slug);
-      return h("li", { class: "sidebar-sub-header" }, [
-        renderLink(h, path + "#" + c.slug, c.title, active),
+      const active = isActive(route, path + '#' + c.slug)
+      return h('li', { class: 'sidebar-sub-header' }, [
+        renderLink(h, path + '#' + c.slug, c.title, active),
         renderChildren(h, c.children, path, route, maxDepth, depth + 1)
-      ]);
+      ])
     })
-  );
+  )
 }
 </script>
 
@@ -88,31 +90,36 @@ function renderChildren(h, children, path, route, maxDepth, depth = 1) {
 @import '../styles/config.styl'
 .sidebar .sidebar-sub-headers
   padding-left 1rem
-a.sidebar-link
+.sidebar-link
   font-weight 400
   display inline-block
-  color $textColor
+  color: $colorBlack100
   padding 0.35rem 1rem 0.35rem 0
   line-height 1.4
   width: 100%
   box-sizing: border-box
   &:hover
-    color $accentColor
+    color $colorPrimary
   &.active
     font-weight 600
-    color $accentColor
-    border-right .25rem solid $accentColor
+    color $colorPrimary
+    border-right .25rem solid $colorPrimary
   .sidebar-sub-headers &
     padding-top 0.25rem
     padding-bottom 0.25rem
     border-right-color transparent
 
-#wrapper.dark-mode
-  a.sidebar-link
-    &.active
-      border-right .25rem solid $accentColorDark
-  .sidebar-sub-headers
-    a
+.dark-mode
+  .sidebar
+    .sidebar-link
+      color: $colorBlack50
+      &.hover
+        color $colorPrimaryDark
       &.active
-        border-right-color transparent
+        color $colorPrimaryDark
+        border-right .25rem solid $colorPrimaryDark500
+    .sidebar-sub-headers
+      a
+        &.active
+          border-right-color transparent
 </style>

--- a/docs/.vuepress/theme/styles/config.styl
+++ b/docs/.vuepress/theme/styles/config.styl
@@ -37,8 +37,8 @@ $colorPrimary200 = mix($colorWhite, $colorPrimary, 60%)
 $colorPrimary100 = mix($colorWhite, $colorPrimary, 80%)
 
 // primary mixes (dark)
-$colorPrimaryDark800 = mix($colorBlack, $colorPrimaryDark, 60%)
 $colorPrimaryDark900 = mix($colorBlack, $colorPrimaryDark, 80%)
+$colorPrimaryDark800 = mix($colorBlack, $colorPrimaryDark, 60%)
 $colorPrimaryDark700 = mix($colorBlack, $colorPrimaryDark, 40%)
 $colorPrimaryDark600 = mix($colorBlack, $colorPrimaryDark, 20%)
 $colorPrimaryDark500 = $colorPrimaryDark
@@ -48,8 +48,8 @@ $colorPrimaryDark200 = mix($colorWhite, $colorPrimaryDark, 60%)
 $colorPrimaryDark100 = mix($colorWhite, $colorPrimaryDark, 80%)
 
 // Success
-$colorSuccess800 = mix($colorBlack, $colorSuccess, 60%)
 $colorSuccess900 = mix($colorBlack, $colorSuccess, 80%)
+$colorSuccess800 = mix($colorBlack, $colorSuccess, 60%)
 $colorSuccess700 = mix($colorBlack, $colorSuccess, 40%)
 $colorSuccess600 = mix($colorBlack, $colorSuccess, 20%)
 $colorSuccess500 = $colorSuccess
@@ -59,8 +59,8 @@ $colorSuccess200 = mix($colorWhite, $colorSuccess, 60%)
 $colorSuccess100 = mix($colorWhite, $colorSuccess, 80%)
 
 // Fail
-$colorFail800 = mix($colorBlack, $colorFail, 60%)
 $colorFail900 = mix($colorBlack, $colorFail, 80%)
+$colorFail800 = mix($colorBlack, $colorFail, 60%)
 $colorFail700 = mix($colorBlack, $colorFail, 40%)
 $colorFail600 = mix($colorBlack, $colorFail, 20%)
 $colorFail500 = $colorFail

--- a/docs/.vuepress/theme/styles/config.styl
+++ b/docs/.vuepress/theme/styles/config.styl
@@ -11,10 +11,10 @@ $colorFail = rgb(184,0,0)
 $legacyBgDark = rgb(34,34,34)
 
 // white mixes (for light grays)
-$colorWhite900 = mix($colorBlack, $colorWhite, 12%)
-$colorWhite800 = mix($colorBlack, $colorWhite, 9%)
-$colorWhite700 = mix($colorBlack, $colorWhite, 6%)
-$colorWhite600 = mix($colorBlack, $colorWhite, 3%)
+$colorWhite900 = mix($colorBlack, $colorWhite, 30%)
+$colorWhite800 = mix($colorBlack, $colorWhite, 20%)
+$colorWhite700 = mix($colorBlack, $colorWhite, 10%)
+$colorWhite600 = mix($colorBlack, $colorWhite, 5%)
 $colorWhite500 = $colorWhite
 
 // black mixes (for dark grays)
@@ -72,10 +72,9 @@ $colorFail100 = mix($colorWhite, $colorFail, 80%)
 
 // LEGACY COLORS
 $colorBgDark = $legacyBgDark
-$colorPrimary = rgb(28,28,225)
-$textColor = rgb(20,20,20)
-$textColorDark = rgb(180,180,180)
-$subduedColor = rgb(180,180,180)
+$textColor = $colorBlack300
+$textColorDark = $colorWhite600
+$subduedColor = $colorWhite900
 $borderColor = $colorPrimary
 $lightBorderColor = #ececec
 $lightBorderColorDark = #404040

--- a/docs/.vuepress/theme/styles/config.styl
+++ b/docs/.vuepress/theme/styles/config.styl
@@ -1,17 +1,86 @@
 // colors
-$black = rgb(0,0,0)
-$bgDark = rgb(34,34,34)
-$accentColor = rgb(28,28,225)
-$accentColorDark = rgb(42,97,255)
+// 500 values first
+$colorWhite = #fff
+$colorBlack = rgb(0,0,0)
+$colorPrimary = rgb(28,28,225)
+$colorPrimaryDark = rgb(255, 115, 36)
+$colorSuccess = rgb(16,158,98)
+$colorFail = rgb(184,0,0)
+
+// use this with the header video
+$legacyBgDark = rgb(34,34,34)
+
+// white mixes (for light grays)
+$colorWhite900 = mix($colorBlack, $colorWhite, 12%)
+$colorWhite800 = mix($colorBlack, $colorWhite, 9%)
+$colorWhite700 = mix($colorBlack, $colorWhite, 6%)
+$colorWhite600 = mix($colorBlack, $colorWhite, 3%)
+$colorWhite500 = $colorWhite
+
+// black mixes (for dark grays)
+$colorBlack500 = $colorBlack
+$colorBlack400 = mix($colorWhite, $colorBlack, 10%)
+$colorBlack300 = mix($colorWhite, $colorBlack, 20%)
+$colorBlack200 = mix($colorWhite, $colorBlack, 30%)
+$colorBlack100 = mix($colorWhite, $colorBlack, 40%)
+$colorBlack50 = mix($colorWhite, $colorBlack, 50%)
+
+// primary mixes
+$colorPrimary900 = mix($colorBlack, $colorPrimary, 80%)
+$colorPrimary800 = mix($colorBlack, $colorPrimary, 60%)
+$colorPrimary700 = mix($colorBlack, $colorPrimary, 40%)
+$colorPrimary600 = mix($colorBlack, $colorPrimary, 20%)
+$colorPrimary500 = $colorPrimary
+$colorPrimary400 = mix($colorWhite, $colorPrimary, 20%)
+$colorPrimary300 = mix($colorWhite, $colorPrimary, 40%)
+$colorPrimary200 = mix($colorWhite, $colorPrimary, 60%)
+$colorPrimary100 = mix($colorWhite, $colorPrimary, 80%)
+
+// primary mixes (dark)
+$colorPrimaryDark800 = mix($colorBlack, $colorPrimaryDark, 60%)
+$colorPrimaryDark900 = mix($colorBlack, $colorPrimaryDark, 80%)
+$colorPrimaryDark700 = mix($colorBlack, $colorPrimaryDark, 40%)
+$colorPrimaryDark600 = mix($colorBlack, $colorPrimaryDark, 20%)
+$colorPrimaryDark500 = $colorPrimaryDark
+$colorPrimaryDark400 = mix($colorWhite, $colorPrimaryDark, 20%)
+$colorPrimaryDark300 = mix($colorWhite, $colorPrimaryDark, 40%)
+$colorPrimaryDark200 = mix($colorWhite, $colorPrimaryDark, 60%)
+$colorPrimaryDark100 = mix($colorWhite, $colorPrimaryDark, 80%)
+
+// Success
+$colorSuccess800 = mix($colorBlack, $colorSuccess, 60%)
+$colorSuccess900 = mix($colorBlack, $colorSuccess, 80%)
+$colorSuccess700 = mix($colorBlack, $colorSuccess, 40%)
+$colorSuccess600 = mix($colorBlack, $colorSuccess, 20%)
+$colorSuccess500 = $colorSuccess
+$colorSuccess400 = mix($colorWhite, $colorSuccess, 20%)
+$colorSuccess300 = mix($colorWhite, $colorSuccess, 40%)
+$colorSuccess200 = mix($colorWhite, $colorSuccess, 60%)
+$colorSuccess100 = mix($colorWhite, $colorSuccess, 80%)
+
+// Fail
+$colorFail800 = mix($colorBlack, $colorFail, 60%)
+$colorFail900 = mix($colorBlack, $colorFail, 80%)
+$colorFail700 = mix($colorBlack, $colorFail, 40%)
+$colorFail600 = mix($colorBlack, $colorFail, 20%)
+$colorFail500 = $colorFail
+$colorFail400 = mix($colorWhite, $colorFail, 20%)
+$colorFail300 = mix($colorWhite, $colorFail, 40%)
+$colorFail200 = mix($colorWhite, $colorFail, 60%)
+$colorFail100 = mix($colorWhite, $colorFail, 80%)
+
+
+// LEGACY COLORS
+$colorBgDark = $legacyBgDark
+$colorPrimary = rgb(28,28,225)
 $textColor = rgb(20,20,20)
 $textColorDark = rgb(180,180,180)
 $subduedColor = rgb(180,180,180)
-$borderColor = $accentColor
+$borderColor = $colorPrimary
 $lightBorderColor = #ececec
 $lightBorderColorDark = #404040
 $codeBgColor = #282c34
 $arrowBgColor = #ccc
-$white = #fff
 $boxShadowColor = rgba(0,0,0,0.12)
 $boxShadowHoverColor = rgba(0,0,0,0.24)
 

--- a/docs/.vuepress/theme/styles/dark.styl
+++ b/docs/.vuepress/theme/styles/dark.styl
@@ -2,8 +2,8 @@
 .show-dark
   display none !important
 
-#wrapper.dark-mode
-  background $bgDark
+.dark-mode
+  background $colorBgDark
   color $textColorDark
   .text-color, a.text-color
     color $textColorDark !important
@@ -14,53 +14,54 @@
   .hide-dark
     display none !important
   a, .accent
-    color $accentColorDark
+    color $colorPrimaryDark500
     &.black
       color $textColorDark
   .button
     border-color $textColorDark
     color $textColorDark
-    background $bgDark
+    background $colorBgDark
     color $textColorDark
     &:hover
-      border-color $accentColorDark
-      color $accentColorDark
+      border-color $colorPrimaryDark500
+      color $colorPrimaryDark500
   h2
     border-bottom 1px solid $textColorDark
   header
-    background $bgDark
+    background $colorBgDark
   div.intro-blocks
-    a
-      ul
-        li
-          color $textColorDark
-          &.highlight
-            background-image url(../images/highlight-dark.svg)
+    ul
+      li
+        color $textColorDark
+        &.highlight
+          background-image url(../images/highlight-dark.svg)
   ul
     list-style-image url(../images/dash-white.svg)
     li.highlight
-      background-image url(../images/highlight-dark.svg)
+      &.highlight
+        background-image: url(../images/highlight-dark.svg)
+        background-repeat no-repeat
   .suggestions
     border-color $textColorDark
-    background-color $bgDark
+    background-color $colorBgDark
     .suggestion
       a
         color $textColorDark
       &.focused
-        background-color lighten($bgDark, 5%)
+        background-color lighten($colorBgDark, 5%)
         a
-          color $accentColorDark
+          color $colorPrimaryDark500
   .sidebar
-    background $bgDark
-    border-color $accentColorDark
+    background $colorBgDark
+    border-color $colorPrimaryDark500
     ul
       list-style-image none
 
   .router-link-active
     svg
-      fill $accentColorDark
+      fill $colorPrimaryDark500
   .featured
-    border-color $accentColorDark
+    border-color $colorPrimaryDark500
   a.header-anchor
     color $textColorDark
 
@@ -75,7 +76,7 @@
   footer.footer a
     color $subduedColor
     &:hover
-      color $accentColorDark
+      color $colorPrimaryDark500
       opacity 1
 
   // borders & shadows

--- a/docs/.vuepress/theme/styles/dark.styl
+++ b/docs/.vuepress/theme/styles/dark.styl
@@ -29,12 +29,6 @@
     border-bottom 1px solid $textColorDark
   header
     background $colorBgDark
-  div.intro-blocks
-    ul
-      li
-        color $textColorDark
-        &.highlight
-          background-image url(../images/highlight-dark.svg)
   ul
     list-style-image url(../images/dash-white.svg)
     li.highlight

--- a/docs/.vuepress/theme/styles/responsive.styl
+++ b/docs/.vuepress/theme/styles/responsive.styl
@@ -35,7 +35,7 @@
 
   #wrapper.dark-mode.sidebar-open
     header
-      border-bottom 1px dotted $accentColorDark
+      border-bottom 1px dotted $colorPrimaryDark500
 
   #wrapper:not(.has-sidebar)
     main.page, footer.footer

--- a/docs/.vuepress/theme/styles/theme.styl
+++ b/docs/.vuepress/theme/styles/theme.styl
@@ -70,7 +70,7 @@ h4, h5, h6
 
 a
   text-decoration none
-  color $accentColor
+  color $colorPrimary
 
   &+em
     font-style normal
@@ -97,8 +97,8 @@ a
   transition all 0.5s cubic-bezier(.25,.8,.25,1)
 
   &:hover
-    border-color $accentColor
-    color $accentColor
+    border-color $colorPrimary
+    color $colorPrimary
     box-shadow 0 4px 8px $boxShadowHoverColor
 
 
@@ -115,7 +115,7 @@ a
   color $textColor !important
 
 .accent
-  color $accentColor
+  color $colorPrimary
 
 ol
   padding-left 1.1em
@@ -142,7 +142,7 @@ ul
     font-size $fsRegular
     line-height $lhRegular
     margin 0
-    border-left 1px dotted $accentColor
+    border-left 1px dotted $colorPrimary
     padding-left 1em
     margin-left -1em
 
@@ -199,7 +199,7 @@ ul
   font-size $fsRegular
   line-height $lhMedium
   margin 0
-  border-left 1px dotted $accentColor
+  border-left 1px dotted $colorPrimary
   padding-left 1em
   margin-left -1em
 
@@ -308,7 +308,7 @@ table
   transition all 0.5s cubic-bezier(.25,.8,.25,1)
 
   &:hover
-    border 1px dotted $accentColor
+    border 1px dotted $colorPrimary
     box-shadow 0 4px 8px $boxShadowHoverColor
 
 @require './responsive'

--- a/docs/.vuepress/theme/styles/theme.styl
+++ b/docs/.vuepress/theme/styles/theme.styl
@@ -79,9 +79,6 @@ a
   .icon.outbound
     display none
 
-  &.black
-    color $textColor
-
 .pointer
   cursor pointer
 
@@ -155,38 +152,6 @@ ul
       em
         display block
         font-size $fsSmall
-
-.intro-blocks
-  margin-top 1.5em
-  display flex
-  flex-wrap wrap
-
-  .intro-block,
-  .intro-block-content-version-1
-    flex 1 1 29%
-    padding-left 1em
-    padding-right 1em
-    display inline-block
-    line-height $lhMedium
-    margin-bottom 1em
-
-    h3
-      span.arrow
-        margin-right 1.25em
-
-    ul
-      li
-        color $textColor
-
-        &.highlight
-          background-image: url(../images/highlight.svg)
-          background-repeat no-repeat
-
-  // TODO remove once translations are updated w/ new personas
-  .intro-block-content-version-1
-    flex 1 1 40%
-    padding-left 2em
-    padding-right 2em
 
 .header-anchor
   opacity 0.15


### PR DESCRIPTION
updated color system to reflect Figma files.
Note: there *may* be conflict with outstanding PRs

## Description

Stylus color variables now reflect the figma file, e.g.

```
// primary mixes
$colorPrimary900 = mix($colorBlack, $colorPrimary, 80%)
$colorPrimary800 = mix($colorBlack, $colorPrimary, 60%)
$colorPrimary700 = mix($colorBlack, $colorPrimary, 40%)
$colorPrimary600 = mix($colorBlack, $colorPrimary, 20%)
$colorPrimary500 = $colorPrimary
$colorPrimary400 = mix($colorWhite, $colorPrimary, 20%)
$colorPrimary300 = mix($colorWhite, $colorPrimary, 40%)
$colorPrimary200 = mix($colorWhite, $colorPrimary, 60%)
$colorPrimary100 = mix($colorWhite, $colorPrimary, 80%)

$colorPrimaryDark
$colorSuccess
$colorFail
```

These have been rolled out across the site, legacy variables have been left in place with a view to removing them in future

## Related Issue

Resolves #760, partly #759 #755

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4670881/75505215-9f499980-59a8-11ea-8f04-5379a6c5cc2e.png)
![image](https://user-images.githubusercontent.com/4670881/75505243-ad97b580-59a8-11ea-8117-682ea9d2d29a.png)
![image](https://user-images.githubusercontent.com/4670881/75505273-c011ef00-59a8-11ea-8605-7048a3697a99.png)
