### PR TITLE
Add Status to the Ethereum Wallets page

### DIFF
--- a/docs/wallets/index.md
+++ b/docs/wallets/index.md
@@ -29,6 +29,7 @@ Want to install a wallet?
 - [TrustWallet](https://trustwallet.com/) _mobile wallet for iOS and Android_
 - [MyEtherWallet](https://www.myetherwallet.com/) _client-side wallet_
 - [Opera](https://www.opera.com/crypto) _major browser with integrated wallet_
+- [Status](https://status.im/) _mobile wallet for iOS and Android with integrated messenger and browser_
 
 Want to learn more about Ethereum wallets?
 


### PR DESCRIPTION
Thank you for adding me to the list of contributors [last time](https://github.com/ethereum/ethereum-org-website/pull/694)! The Status Network would like to add Status to the https://ethereum.org/wallets/ page.

## Description

Status integrates multiple wallets into a single Status account enabling users to manage their assets more conveniently. For ultimate privacy, a chat key of a Status account is entirely decoupled from wallets so random people cannot find our wallet addresses until we add the user to our contacts.

Also, users can choose a wallet to send their ETH or ERC-20 assets to others in chat.

Please find more details [here](https://our.status.im/what-is-status-multi-account/) if you'd like to learn more about these features.

## Related Issue
https://github.com/ethereum/ethereum-org-website/issues/791
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Screenshots (if appropriate):
![Picture1](https://user-images.githubusercontent.com/41753422/75790620-c809ce80-5dae-11ea-8766-2b3a7fe05fb8.png)
