### PR TITLE
Link styling

### DIFF
--- a/docs/.vuepress/components/BuildPage.vue
+++ b/docs/.vuepress/components/BuildPage.vue
@@ -42,6 +42,7 @@
               <a
                 target="_blank"
                 rel="noopener noreferrer"
+                class="hide-icon"
                 href="https://studio.ethereum.org/1"
                 >{{ translateString('page-build-hello-world-link-text') }}</a
               >
@@ -61,6 +62,7 @@
               <a
                 target="_blank"
                 rel="noopener noreferrer"
+                class="hide-icon"
                 href="https://studio.ethereum.org/2"
                 >{{ translateString('page-build-coin-contract-link-text') }}</a
               >
@@ -80,6 +82,7 @@
               <a
                 target="_blank"
                 rel="noopener noreferrer"
+                class="hide-icon"
                 href="https://studio.ethereum.org/3"
                 >{{ translateString('page-build-crypto-pizza-link-text') }}</a
               >
@@ -98,6 +101,7 @@
               <a
                 href="https://cryptozombies.io/"
                 target="_blank"
+                class="hide-icon"
                 rel="noopener noreferrer"
               >
                 <img src="/ecosystem/crypto-zombie.png" alt="CryptoZombies" />
@@ -113,6 +117,7 @@
               <a
                 href="https://ethernaut.openzeppelin.com/"
                 target="_blank"
+                class="hide-icon"
                 rel="noopener noreferrer"
               >
                 <img
@@ -132,6 +137,7 @@
               <a
                 href="https://remix.ethereum.org"
                 target="_blank"
+                class="hide-icon"
                 rel="noopener noreferrer"
               >
                 <img src="/ecosystem/remix.png" alt="Remix" />
@@ -147,6 +153,7 @@
               <a
                 href="https://www.chainshot.com"
                 target="_blank"
+                class="hide-icon"
                 rel="noopener noreferrer"
               >
                 <img src="/ecosystem/chainshot.png" alt="ChainShot" />
@@ -162,6 +169,7 @@
               <a
                 href="https://consensys.net/academy/bootcamp/"
                 target="_blank"
+                class="hide-icon"
                 rel="noopener noreferrer"
               >
                 <img src="/ecosystem/consensys.png" alt="Consensys Academy" />
@@ -188,6 +196,7 @@
           href="https://studio.ethereum.org"
           target="_blank"
           rel="noopener noreferrer"
+          class="hide-icon"
           >Ethereum Studio</a
         >
         is a collaboration between

--- a/docs/.vuepress/theme/components/Footer.vue
+++ b/docs/.vuepress/theme/components/Footer.vue
@@ -12,6 +12,7 @@
             :href="item.to"
             target="_blank"
             rel="noopener noreferrer"
+            class="hide-icon"
             :aria-labelledby="item.icon + '-link'"
           >
             <icon :name="item.icon" size="36" />

--- a/docs/.vuepress/theme/components/Header.vue
+++ b/docs/.vuepress/theme/components/Header.vue
@@ -26,7 +26,7 @@
         target="_blank"
         rel="noopener noreferrer"
         title="Fork This Page (GitHub)"
-        class="sm-hide nav-link"
+        class="sm-hide nav-link hide-icon"
       >
         <icon name="github" />
       </a>

--- a/docs/.vuepress/theme/components/NavLink.vue
+++ b/docs/.vuepress/theme/components/NavLink.vue
@@ -10,7 +10,7 @@
   <a
     v-else
     :href="link"
-    class="nav-link external"
+    class="nav-link external hide-icon"
     :target="isMailto(link) || isTel(link) ? null : '_blank'"
     :rel="isMailto(link) || isTel(link) ? null : 'noopener noreferrer'"
   >

--- a/docs/.vuepress/theme/styles/theme.styl
+++ b/docs/.vuepress/theme/styles/theme.styl
@@ -84,7 +84,6 @@ a:not([href^="https://ethereum.org"]):not([href^="http://ethereum.org"]):not([hr
     margin-right: .3em
     display: inline-block
     content:'↗'
-    // transform: translateY(.15em) 
     transition: all 0.1s ease-in-out
   &:hover
     &:after

--- a/docs/.vuepress/theme/styles/theme.styl
+++ b/docs/.vuepress/theme/styles/theme.styl
@@ -78,6 +78,18 @@ a
   .icon.outbound
     display none
 
+a:not([href^="https://ethereum.org"]):not([href^="http://ethereum.org"]):not([href^="/"]):not([href^="#"]):not(.hide-icon)
+  &:after
+    margin-left: .125em
+    margin-right: .3em
+    display: inline-block
+    content:'↗'
+    transform: translateY(.15em) 
+    transition: all 0.1s ease-in-out
+  &:hover
+    &:after
+      transform: translateY(-.1em) translateX(.1em)
+
 .pointer
   cursor pointer
 

--- a/docs/.vuepress/theme/styles/theme.styl
+++ b/docs/.vuepress/theme/styles/theme.styl
@@ -84,11 +84,11 @@ a:not([href^="https://ethereum.org"]):not([href^="http://ethereum.org"]):not([hr
     margin-right: .3em
     display: inline-block
     content:'↗'
-    transform: translateY(.15em) 
+    // transform: translateY(.15em) 
     transition: all 0.1s ease-in-out
   &:hover
     &:after
-      transform: translateY(-.1em) translateX(.1em)
+      transform: translate(.15em, -.2em)
 
 .pointer
   cursor pointer


### PR DESCRIPTION
Added a glyph to external links. Resolves #759

## Description

All external links (anchor tags) now show a north east glyph by default, which can be disabled with a `hide-icon` class. It has been disabled in navigation, and in the build-page cards.

It is shown under the following conditions via CSS
```
:not([href^="https://ethereum.org"])
:not([href^="http://ethereum.org"])
:not([href^="/"])
:not([href^="#"])
:not(.hide-icon)
```

It should be noted that this doesn't enforce complete parity with the Figma file (underlines), as the existing lists may become unwieldy.

## Related Issue

#759

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4670881/76293123-3eb33a00-628f-11ea-8eed-41872f26a21a.png)
![image](https://user-images.githubusercontent.com/4670881/76293140-483ca200-628f-11ea-9c9c-eb158a4f62b6.png)
