### PR TITLE
Lists [fixes #767]

### DIFF
--- a/docs/.vuepress/components/ListCard.vue
+++ b/docs/.vuepress/components/ListCard.vue
@@ -1,0 +1,142 @@
+<template>
+  <div class="list-new max-w-768px">
+    <template v-for="(item, i) in items">
+      <router-link
+        v-if="item.isInternal"
+        :to="item.link"
+        :aria-label="item.title + ' by ' + item.meta"
+        class="tc-text500 pa-1 block w-100 hide-icon"
+      >
+        <article :class="{ 'has-meta': item.meta }">
+          <h3 class="l7 mb-0 mt-0 tc-text500 art-title" :is="itemTitleTag">
+            {{ item.title }}
+          </h3>
+          <p v-if="item.subtitle" class="l7 mb-0 mt-0 tc-text100 art-subtitle">
+            {{ item.subtitle }}
+          </p>
+          <p
+            v-if="item.meta"
+            class="l7 mb-0 mt-0 tc-text100 art-meta flex flex-center"
+          >
+            {{ item.meta }}
+          </p>
+        </article>
+      </router-link>
+      <a
+        v-else
+        :href="item.link"
+        :aria-label="item.title + ' by ' + item.meta"
+        class="tc-text500 pa-1 block w-100 hide-icon"
+      >
+        <article :class="{ 'has-meta': item.meta }">
+          <h3 class="l7 mb-0 mt-0 tc-text500 art-title" :is="itemTitleTag">
+            {{ item.title }}
+          </h3>
+          <p v-if="item.subtitle" class="l7 mb-0 mt-0 tc-text100 art-subtitle">
+            {{ item.subtitle }}
+          </p>
+          <p
+            v-if="item.meta"
+            class="l7 mb-0 mt-0 tc-text100 art-meta flex flex-center"
+          >
+            {{ item.meta }}
+          </p>
+        </article>
+      </a>
+    </template>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'list-card',
+  props: {
+    level: {
+      required: false,
+      default: 3
+    },
+    items: {
+      required: false,
+      default: []
+    }
+  },
+  computed: {
+    itemTitleTag() {
+      return 'h' + this.level
+    }
+  }
+}
+</script>
+
+<style lang="stylus">
+@import '../theme/styles/config.styl';
+
+.list-new
+  counter-reset i
+  position relative
+  article
+    display grid
+    grid-template-columns auto 1fr auto
+    grid-column-gap 1rem
+    &:before, &:after
+      grid-row 1/99
+    &:before
+      grid-column 1
+      counter-increment: i
+      content: counters(i, ".")" ";
+    .art-title
+      grid-row 1
+    .art-subtitle
+      grid-row 2
+    .art-meta
+      grid-row 3
+    &:after
+      display flex
+      align-items center
+      grid-column 3
+      content '↗️'
+
+    @media (min-width: $breakM)
+      &.has-meta
+        grid-template-columns auto 3fr 1fr auto
+        .art-title
+          grid-row 1
+        .art-subtitle
+          grid-row 2
+        .art-meta
+          grid-column 3
+          grid-row 1/999
+        &:after
+          grid-column 4
+          content '↗️'
+
+.list-new
+  box-shadow 0px 14px 66px rgba(0, 0, 0, 0.07), 0px 10px 17px rgba(0, 0, 0, 0.03), 0px 4px 7px rgba(0, 0, 0, 0.05)
+  a
+    background $white
+    box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.1);
+    margin-bottom 1px
+    &:hover
+      border-radius 4px
+      box-shadow: 0 0 1px $colorPrimary500
+      background alpha($colorPrimary500, 0.025)
+    article
+      &:before
+        opacity .4
+      &:after
+        color $colorPrimary500
+
+.dark-mode
+  .list-new
+    box-shadow 0px 14px 66px rgba(245, 245, 245, 0.07), 0px 10px 17px rgba(245, 245, 245, 0.03), 0px 4px 7px rgba(245, 245, 245, 0.05)
+    a
+      background $colorBlack400
+      box-shadow 0px 1px 1px rgba(255, 255, 255, 0.1);
+      &:hover
+        border-radius 4px
+        box-shadow: 0 0 1px $colorPrimaryDark500
+        background alpha($colorPrimaryDark500, 0.0125)
+      article
+        &:after
+          color $colorPrimaryDark500
+</style>

--- a/docs/.vuepress/components/ListCard.vue
+++ b/docs/.vuepress/components/ListCard.vue
@@ -2,12 +2,13 @@
   <div class="list-new max-w-768px">
     <template v-for="(item, i) in items">
       <router-link
-        v-if="item.isInternal"
+        v-if="!isExternal(ensureExt(item.link))"
         :to="item.link"
-        :aria-label="item.title + ' by ' + item.meta"
+        :aria-label="item.title"
         class="tc-text500 pa-1 block w-100 hide-icon"
       >
         <article :class="{ 'has-meta': item.meta }">
+          <!-- h3 is overridden by the level prop. Default is 3 (h3) -->
           <h3 class="l7 mb-0 mt-0 tc-text500 art-title" :is="itemTitleTag">
             {{ item.title }}
           </h3>
@@ -27,8 +28,11 @@
         :href="item.link"
         :aria-label="item.title + ' by ' + item.meta"
         class="tc-text500 pa-1 block w-100 hide-icon"
+        target="_blank"
+        rel="noopener noreferrer"
       >
         <article :class="{ 'has-meta': item.meta }">
+          <!-- h3 is overridden by the level prop. Default is 3 (h3) -->
           <h3 class="l7 mb-0 mt-0 tc-text500 art-title" :is="itemTitleTag">
             {{ item.title }}
           </h3>
@@ -48,6 +52,8 @@
 </template>
 
 <script>
+import { isExternal, ensureExt } from '../theme/utils/util'
+
 export default {
   name: 'list-card',
   props: {
@@ -61,9 +67,16 @@ export default {
     }
   },
   computed: {
+    link(href) {
+      return ensureExt(href)
+    },
     itemTitleTag() {
       return 'h' + this.level
     }
+  },
+  methods: {
+    isExternal,
+    ensureExt
   }
 }
 </script>

--- a/docs/.vuepress/theme/components/Footer.vue
+++ b/docs/.vuepress/theme/components/Footer.vue
@@ -25,7 +25,7 @@
       <h3 class="l8 c-text500">
         <b>{{ linkCluster.title }}</b>
       </h3>
-      <ul class="l8 ma-0 pl-0 no-list">
+      <ul class="l8 ma-0 pl-0 no-bullets">
         <template v-for="item in linkCluster.items">
           <!-- is it a router link or href -->
           <li class="mb-1">

--- a/docs/.vuepress/theme/components/NavDropdown.vue
+++ b/docs/.vuepress/theme/components/NavDropdown.vue
@@ -12,7 +12,7 @@
       >{{ item.text }}<icon class="chevron-icon hidden" name="chevron-down"
     /></span>
     <ul
-      class="dropdown-items no-list ma-0 pa-0 md-up-pt-05 md-up-pb-05 md-up-hidden md-up-absolute"
+      class="dropdown-items no-bullets ma-0 pa-0 md-up-pt-05 md-up-pb-05 md-up-hidden md-up-absolute"
     >
       <li
         class="dropdown-item ma-0 pa-0"

--- a/docs/.vuepress/theme/components/NavLinks.vue
+++ b/docs/.vuepress/theme/components/NavLinks.vue
@@ -3,7 +3,7 @@
     <div v-if="this.isMobileNavVisible" class="modal-bg fixed md-up-hidden" />
     <div :class="navWrapperClasses">
       <!-- Links on left -->
-      <ul class="left-items pa-1 pb-8 md-up-pa-0" v-if="userLinks.length">
+      <ul class="left-items no-bullets pa-1 pb-8 md-up-pa-0" v-if="userLinks.length">
         <li
           class="menu-link-item block ma-2 ml-0 mr-0 mb-3 md-up-ma-0 md-up-ml-2 md-up-flex flex-center"
           v-for="item in userLinks"
@@ -20,7 +20,7 @@
           <NavLink
             v-else
             :item="item"
-            class="link-item"
+            class="link-item hide-icon"
             @nav-toggle="$emit('nav-toggle', false)"
           />
         </li>

--- a/docs/.vuepress/theme/components/SearchBox.vue
+++ b/docs/.vuepress/theme/components/SearchBox.vue
@@ -45,7 +45,11 @@
       <h2 v-if="!blankState" class="results-title l4 md-up-hidden">
         Results
       </h2>
-      <ul v-if="!blankState" class="suggestions pl-0 mt-0 no-list md-up-hidden">
+
+      <ul
+        v-if="!blankState"
+        class="suggestions pl-0 mt-0 no-bullets md-up-hidden"
+      >
         <li v-for="(s, i) in suggestions">
           <router-link
             :to="s.path"

--- a/docs/.vuepress/theme/components/Sidebar.vue
+++ b/docs/.vuepress/theme/components/Sidebar.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="sidebar pa-1 hidden sm-up-block" id="outline">
     <slot name="top" />
-    <ul class="sidebar-links no-list ma-0 pa-0 l8" v-if="items.length">
+    <ul class="sidebar-links no-bullets ma-0 pa-0 l8" v-if="items.length">
       <li v-for="(item, i) in items" :key="i">
         <SidebarGroup
           v-if="item.type === 'group'"

--- a/docs/.vuepress/theme/components/SidebarGroup.vue
+++ b/docs/.vuepress/theme/components/SidebarGroup.vue
@@ -1,7 +1,7 @@
 <template>
   <ul
     ref="items"
-    class="sidebar-group-items ma-0 pa-0 no-list"
+    class="sidebar-group-items ma-0 pa-0 no-bullets"
     v-if="open || !collapsable"
   >
     <li v-for="child in item.children">

--- a/docs/.vuepress/theme/components/SidebarLink.vue
+++ b/docs/.vuepress/theme/components/SidebarLink.vue
@@ -76,7 +76,7 @@ function renderChildren(h, children, path, route, maxDepth, depth = 1) {
   if (!children || depth > maxDepth) return null
   return h(
     'ul',
-    { class: 'no-list pl-0' },
+    { class: 'no-bullets pl-0' },
     children.map(c => {
       const active = isActive(route, path + '#' + c.slug)
       return h('li', { class: 'pl-1 ml-0' }, [

--- a/docs/.vuepress/theme/styles/lists.styl
+++ b/docs/.vuepress/theme/styles/lists.styl
@@ -31,12 +31,7 @@
         margin-bottom 1rem
       a
         text-decoration underline
-        // force a line break after the link
-        &:after
-          display: block;
-          content: '';
-          /* height: 1px; */
-          width: 100%;
+        display: block
     &.no-bullets
       margin-left 0
       li

--- a/docs/.vuepress/theme/styles/lists.styl
+++ b/docs/.vuepress/theme/styles/lists.styl
@@ -1,5 +1,6 @@
 @import 'config'
 
+// This class is automatically added to the built-in <Content /> component
 .content__default
   ul
     @extend .l7
@@ -29,20 +30,19 @@
       li
         margin-bottom 1rem
       a
-        display block
         text-decoration underline
+        // force a line break after the link
+        &:after
+          display: block;
+          content: '';
+          /* height: 1px; */
+          width: 100%;
     &.no-bullets
       margin-left 0
       li
         padding-left 0
         &:before
           display none
-          
-    &.list-link-description
-      li
-        display: flex;
-        flex-direction: column;
-        color: $textColorObj['200']
   
 :not(.rtl)
   .content__default
@@ -75,6 +75,6 @@
       &:before
         color $colorPrimaryDark500
   
-    &.list-link-description
+    &.link-list
       li
         color: $textColorDarkObj['200']

--- a/docs/.vuepress/theme/styles/lists.styl
+++ b/docs/.vuepress/theme/styles/lists.styl
@@ -1,0 +1,80 @@
+@import 'config'
+
+.content__default
+  ul
+    @extend .l7
+    padding 0
+    margin 1em
+    list-style-type none
+    list-style-image none
+
+    li
+      padding-left .5em
+      margin-bottom .5em
+
+      &:before
+        content "\2022"
+        color $colorPrimary500
+        display inline-block
+        width 1em
+        margin-left -1em
+        position absolute
+
+      &.highlight
+        background url(../images/highlight.svg)
+        background-repeat no-repeat
+    
+    &.link-list
+      color: $textColorObj['200']
+      li
+        margin-bottom 1rem
+      a
+        display block
+        text-decoration underline
+    &.no-bullets
+      margin-left 0
+      li
+        padding-left 0
+        &:before
+          display none
+          
+    &.list-link-description
+      li
+        display: flex;
+        flex-direction: column;
+        color: $textColorObj['200']
+  
+:not(.rtl)
+  .content__default
+    ul
+      li
+        padding-left .5em
+        &:before
+          margin-left -1em
+      &.no-bullets
+        @extend .no-bullets
+
+.rtl
+  .content__default
+    ul
+      li
+        padding-right .5em
+        &:before
+          margin-right -1em
+      &.no-bullets
+        @extend .no-bullets
+  
+.dark-mode
+  ul
+    li
+      &.highlight
+        background-image: url(../images/highlight-dark.svg)
+        background-repeat no-repeat
+      &.highlight-small
+        background-size 240px !important
+      &:before
+        color $colorPrimaryDark500
+  
+    &.list-link-description
+      li
+        color: $textColorDarkObj['200']

--- a/docs/.vuepress/theme/styles/theme.styl
+++ b/docs/.vuepress/theme/styles/theme.styl
@@ -1,6 +1,7 @@
 @require './arrow'
 @require './config'
 @require './utils'
+@import './lists'
 
 *
   font-variant-ligatures none
@@ -185,65 +186,6 @@ p
   
 .dark-mode p
   @extend .dark-mode .tc-text300
-
-// This class is automatically added to the built-in <Content /> component
-.content__default
-  ul
-    @extend .l7
-    padding 0
-    margin 1em
-    list-style-type none
-    list-style-image none
-
-    li
-      padding-left .5em
-      margin-bottom .5em
-
-      &:before
-        content "\2022"
-        color $colorPrimary500
-        display inline-block
-        width 1em
-        margin-left -1em
-        position absolute
-
-      &.highlight
-        background url(../images/highlight.svg)
-        background-repeat no-repeat
-  h2, h3
-    &:before
-      display: block; 
-      content: " "; 
-      margin-top: -120px; 
-      height: 120px; 
-      visibility: hidden; 
-
-:not(.rtl)
-  .content__default
-    ul
-      li
-        padding-left .5em
-        &:before
-          margin-left -1em
-.rtl
-  .content__default
-    ul
-      li
-        padding-right .5em
-        &:before
-          margin-right -1em
-  
-.dark-mode
-  ul
-    li
-      &.highlight
-        background-image: url(../images/highlight-dark.svg)
-        background-repeat no-repeat
-      &.highlight-small
-        background-size 240px !important
-      &:before
-        color $colorPrimaryDark500
-
 
 @require './responsive'
 @require './dark'

--- a/docs/.vuepress/theme/styles/utils.styl
+++ b/docs/.vuepress/theme/styles/utils.styl
@@ -285,10 +285,12 @@ b, &.b, strong {
   font-weight 600
 }
 
-.no-list
+.no-bullets
   list-style-type: none
   list-style-image: none
+  margin-left 0
   li
+    padding-left 0
     &:before
       display: none
 

--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -26,17 +26,28 @@ Need a more basic primer first? Check out our [learning resources](/learn/).
 
 **Helpful Resources**
 
-- [Getting up to speed on Ethereum](https://medium.com/@mattcondon/getting-up-to-speed-on-ethereum-63ed28821bbe) _Aug 7, 2017 - Matt Condon_
-- [Ethereum In Depth, Part 1](https://blog.openzeppelin.com/ethereum-in-depth-part-1-968981e6f833/) _May 11, 2018 - Facu Spagnuolo_
-- [Ethereum In Depth, Part 2](https://blog.openzeppelin.com/ethereum-in-depth-part-2-6339cf6bddb9/) _July 24, 2018 - Facu Spagnuolo_
-- [Ethereum Development Walkthrough, Parts 1-5](https://hackernoon.com/ethereum-development-walkthrough-part-1-smart-contracts-b3979e6e573e) _Jan 14, 2018 - dev_zl_
-- [Ethereum 101, Parts 1-7](https://kauri.io/collection/5bb65f0f4f34080001731dc2/ethereum-101) _Feb 13, 2019 - Wil Barnes_
-- [Full Stack Hello World Voting Ethereum Dapp Tutorial](https://medium.com/@mvmurthy/full-stack-hello-world-voting-ethereum-dapp-tutorial-part-1-40d2d0d807c2)  _Feb 2019 - Mahesh Murthy_
-- [Mastering Ethereum - A comprehensive textbook available for free online](https://github.com/ethereumbook/ethereumbook) _Dec 1, 2018 - Andreas Antonopoulos & Gavin Wood_
-- [Ethereum Developer Portal - Everything you need to get started building on Ethereum](https://ethereum.consensys.net/ethereum-dev-portal) _Updated often - ConsenSys_
-- [Deconstructing a Solidity Contract](https://blog.openzeppelin.com/deconstructing-a-solidity-contract-part-i-introduction-832efd2d7737/) _Aug 13, 2018 - Alejandro Santander & Leo Arias_
-- [Full Stack Dapp Tutorial Series](https://kauri.io/collection/5b8e401ee727370001c942e3)  _Updated Often - Joshua Cassidy_
+- [Getting up to speed on Ethereum](https://medium.com/@mattcondon/getting-up-to-speed-on-ethereum-63ed28821bbe)
+  Aug 7, 2017 - Matt Condon
+- [Ethereum In Depth, Part 1](https://blog.openzeppelin.com/ethereum-in-depth-part-1-968981e6f833/)
+  May 11, 2018 - Facu Spagnuolo
+- [Ethereum In Depth, Part 2](https://blog.openzeppelin.com/ethereum-in-depth-part-2-6339cf6bddb9/)
+  July 24, 2018 - Facu Spagnuolo
+- [Ethereum Development Walkthrough, Parts 1-5](https://hackernoon.com/ethereum-development-walkthrough-part-1-smart-contracts-b3979e6e573e)
+  Jan 14, 2018 - dev_zl
+- [Ethereum 101, Parts 1-7](https://kauri.io/collection/5bb65f0f4f34080001731dc2/ethereum-101)
+  Feb 13, 2019 - Wil Barnes
+- [Full Stack Hello World Voting Ethereum Dapp Tutorial](https://medium.com/@mvmurthy/full-stack-hello-world-voting-ethereum-dapp-tutorial-part-1-40d2d0d807c2) 
+  Feb 2019 - Mahesh Murthy
+- [Mastering Ethereum - A comprehensive textbook available for free online](https://github.com/ethereumbook/ethereumbook)
+  Dec 1, 2018 - Andreas Antonopoulos & Gavin Wood
+- [Ethereum Developer Portal - Everything you need to get started building on Ethereum](https://ethereum.consensys.net/ethereum-dev-portal)
+  Updated often - ConsenSys
+- [Deconstructing a Solidity Contract](https://blog.openzeppelin.com/deconstructing-a-solidity-contract-part-i-introduction-832efd2d7737/)
+  Aug 13, 2018 - Alejandro Santander & Leo Arias
+- [Full Stack Dapp Tutorial Series](https://kauri.io/collection/5b8e401ee727370001c942e3)
+  Updated Often - Joshua Cassidy
 - [How to become a Blockchain developer?](https://youtu.be/R6AJAwTXjo4)
+  {.link-list .no-bullets}
 
 ## Smart Contract Languages {#smart-contract-languages}
 

--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -26,26 +26,16 @@ Need a more basic primer first? Check out our [learning resources](/learn/).
 
 **Helpful Resources**
 
-- [Getting up to speed on Ethereum](https://medium.com/@mattcondon/getting-up-to-speed-on-ethereum-63ed28821bbe)
-  Aug 7, 2017 - Matt Condon
-- [Ethereum In Depth, Part 1](https://blog.openzeppelin.com/ethereum-in-depth-part-1-968981e6f833/)
-  May 11, 2018 - Facu Spagnuolo
-- [Ethereum In Depth, Part 2](https://blog.openzeppelin.com/ethereum-in-depth-part-2-6339cf6bddb9/)
-  July 24, 2018 - Facu Spagnuolo
-- [Ethereum Development Walkthrough, Parts 1-5](https://hackernoon.com/ethereum-development-walkthrough-part-1-smart-contracts-b3979e6e573e)
-  Jan 14, 2018 - dev_zl
-- [Ethereum 101, Parts 1-7](https://kauri.io/collection/5bb65f0f4f34080001731dc2/ethereum-101)
-  Feb 13, 2019 - Wil Barnes
-- [Full Stack Hello World Voting Ethereum Dapp Tutorial](https://medium.com/@mvmurthy/full-stack-hello-world-voting-ethereum-dapp-tutorial-part-1-40d2d0d807c2) 
-  Feb 2019 - Mahesh Murthy
-- [Mastering Ethereum - A comprehensive textbook available for free online](https://github.com/ethereumbook/ethereumbook)
-  Dec 1, 2018 - Andreas Antonopoulos & Gavin Wood
-- [Ethereum Developer Portal - Everything you need to get started building on Ethereum](https://ethereum.consensys.net/ethereum-dev-portal)
-  Updated often - ConsenSys
-- [Deconstructing a Solidity Contract](https://blog.openzeppelin.com/deconstructing-a-solidity-contract-part-i-introduction-832efd2d7737/)
-  Aug 13, 2018 - Alejandro Santander & Leo Arias
-- [Full Stack Dapp Tutorial Series](https://kauri.io/collection/5b8e401ee727370001c942e3)
-  Updated Often - Joshua Cassidy
+- [Getting up to speed on Ethereum](https://medium.com/@mattcondon/getting-up-to-speed-on-ethereum-63ed28821bbe) Aug 7, 2017 - Matt Condon
+- [Ethereum In Depth, Part 1](https://blog.openzeppelin.com/ethereum-in-depth-part-1-968981e6f833/) May 11, 2018 - Facu Spagnuolo
+- [Ethereum In Depth, Part 2](https://blog.openzeppelin.com/ethereum-in-depth-part-2-6339cf6bddb9/) July 24, 2018 - Facu Spagnuolo
+- [Ethereum Development Walkthrough, Parts 1-5](https://hackernoon.com/ethereum-development-walkthrough-part-1-smart-contracts-b3979e6e573e) Jan 14, 2018 - dev_zl
+- [Ethereum 101, Parts 1-7](https://kauri.io/collection/5bb65f0f4f34080001731dc2/ethereum-101) Feb 13, 2019 - Wil Barnes
+- [Full Stack Hello World Voting Ethereum Dapp Tutorial](https://medium.com/@mvmurthy/full-stack-hello-world-voting-ethereum-dapp-tutorial-part-1-40d2d0d807c2) Feb 2019 - Mahesh Murthy
+- [Mastering Ethereum - A comprehensive textbook available for free online](https://github.com/ethereumbook/ethereumbook) Dec 1, 2018 - Andreas Antonopoulos & Gavin Wood
+- [Ethereum Developer Portal - Everything you need to get started building on Ethereum](https://ethereum.consensys.net/ethereum-dev-portal) Updated often - ConsenSys
+- [Deconstructing a Solidity Contract](https://blog.openzeppelin.com/deconstructing-a-solidity-contract-part-i-introduction-832efd2d7737/) Aug 13, 2018 - Alejandro Santander & Leo Arias
+- [Full Stack Dapp Tutorial Series](https://kauri.io/collection/5b8e401ee727370001c942e3) Updated Often - Joshua Cassidy
 - [How to become a Blockchain developer?](https://youtu.be/R6AJAwTXjo4)
   {.link-list .no-bullets}
 

--- a/docs/style-guide/index.md
+++ b/docs/style-guide/index.md
@@ -5,7 +5,6 @@ componentLinks:
   - title: Lists
     link: '/style-guide/lists'
     meta: 14 March 2020
-    internal: true
 ---
 
 # Component usage

--- a/docs/style-guide/index.md
+++ b/docs/style-guide/index.md
@@ -1,0 +1,17 @@
+---
+title: Style Guide Documentation
+lang: en-US
+componentLinks:
+  - title: Lists
+    link: '/style-guide/lists'
+    meta: 14 March 2020
+    internal: true
+---
+
+# Component usage
+
+Find guides on pre-made components made avaialable for use in `.md`
+
+#### Components {.list-title}
+
+<list-card :items="$page.frontmatter.componentLinks" level="5"/>

--- a/docs/style-guide/lists/index.md
+++ b/docs/style-guide/lists/index.md
@@ -83,7 +83,7 @@ Markdown:
 - [Nunc habitasse et portitor demi](#) An example link followed by text
 - [Nunc habitasse et portitor demi](#) An example link followed by text
 - [Nunc habitasse et portitor demi](#) An example link followed by text
-  {.list-link-description}
+  {.link-list}
 
 Markdown:
 
@@ -93,7 +93,7 @@ Markdown:
 - [Nunc habitasse et portitor demi](#) An example link followed by text
 - [Nunc habitasse et portitor demi](#) An example link followed by text
 - [Nunc habitasse et portitor demi](#) An example link followed by text
-{.list-link-description}
+{.link-list}
 ```
 
 #### Links with descriptions without bullets {.list-title .mt-8}
@@ -101,7 +101,7 @@ Markdown:
 - [Nunc habitasse et portitor demi](#) An example link followed by text
 - [Nunc habitasse et portitor demi](#) An example link followed by text
 - [Nunc habitasse et portitor demi](#) An example link followed by text
-  {.no-bullets .list-link-description}
+  {.no-bullets .link-list}
 
 Markdown:
 
@@ -111,7 +111,7 @@ Markdown:
 - [Nunc habitasse et portitor demi](#) An example link followed by text
 - [Nunc habitasse et portitor demi](#) An example link followed by text
 - [Nunc habitasse et portitor demi](#) An example link followed by text
-{.no-bullets .list-link-description}
+{.no-bullets .link-list}
 ```
 
 #### Ordered List {.list-title .mt-8}
@@ -135,7 +135,6 @@ There are multiple versions of lists to be generated. To use them, create a fron
 - `subtitle: optional` If used, this will render a second line below the title.
 - `meta: optional` If used, this will render a new column to the right (desktop). Use for things such as dates.
 - `link: required` This will be the `href`.
-- `internal: optional (Boolean)` Use internal: true when passing internal links.
 
 <br><br><br>
 

--- a/docs/style-guide/lists/index.md
+++ b/docs/style-guide/lists/index.md
@@ -1,0 +1,240 @@
+---
+title: Style Guide Documentation — Lists
+lang: en-US
+sampleListOne:
+  - title: Getting up to speed on Ethereum
+    subtitle: Matt Condon
+    meta: Aug 7, 2017
+    link: https://medium.com/@mattcondon/getting-up-to-speed-on-ethereum-63ed28821bbe
+  - title: Ethereum In Depth, Part 1
+    subtitle: Facu Spagnuolo
+    meta: May 11, 2018
+    link: https://blog.openzeppelin.com/ethereum-in-depth-part-1-968981e6f833/
+  - title: Ethereum In Depth, Part 2
+    subtitle: Facu Spagnuolo
+    meta: July 24, 2018
+    link: https://blog.openzeppelin.com/ethereum-in-depth-part-2-6339cf6bddb9/
+sampleListTwo:
+  - title: EEA
+    subtitle: The Enterprise Ethereum Alliance is a member-driven standards organization whose charter is to develop open, blockchain specifications that drive harmonization and interoperability for businesses and consumers worldwide. Our global community of members is made up of leaders, adopters, innovators, developers, and businesses who collaborate to create an open, decentralized web for the benefit of everyone.
+    link: https://entethalliance.org/
+  - title: Hyperledger
+    subtitle: Hyperledger is an open source collaborative effort created to advance cross-industry blockchain technologies. It is a global collaboration, hosted by The Linux Foundation, including leaders in finance, banking, Internet of Things, supply chains, manufacturing and Technology. The foundation has some projects in it that work with the Ethereum stack.
+    link: https://hyperledger.org/
+sampleListThree:
+  - title: EEA
+    link: https://entethalliance.org/
+  - title: Hyperledger
+    link: https://hyperledger.org/
+sampleListFour:
+  - title: EEA
+    meta: John Owens
+    link: https://entethalliance.org/
+  - title: Hyperledger
+    meta: John Owens
+    link: https://hyperledger.org/
+---
+
+# Component Usage
+
+## Standard Lists
+
+Standard lists can be called anywhere in markdown by using
+
+```
+- Lorem ipsum
+- Si dolor et amet
+- nunc habitasse portitor demi
+```
+
+Ensure that the list is always preceeded with one of the following, taking care to ensure that your markup is semantic:
+
+```
+Your heading text {.list-title}
+# Your heading text {.list-title}
+## Your heading text {.list-title}
+### Your heading text {.list-title}
+#### Your heading text {.list-title}
+##### Your heading text {.list-title}
+###### Your heading text  {.list-title}
+```
+
+{.mb-4}
+
+--- {.mb-4}
+
+### Examples{.mt-8}
+
+#### Unordered List {.list-title .mt-4}
+
+- Lorem ipsum si dolor et amet
+- Nunc habitasse et portitor demi
+
+Markdown:
+
+```
+#### List Example One {.list-title}
+- Lorem ipsum si dolor et amet
+- Nunc habitasse et portitor demi
+```
+
+#### Links with descriptions {.list-title .mt-8}
+
+- [Nunc habitasse et portitor demi](#) An example link followed by text
+- [Nunc habitasse et portitor demi](#) An example link followed by text
+- [Nunc habitasse et portitor demi](#) An example link followed by text
+  {.list-link-description}
+
+Markdown:
+
+```
+#### Links with descriptions {.list-title}
+
+- [Nunc habitasse et portitor demi](#) An example link followed by text
+- [Nunc habitasse et portitor demi](#) An example link followed by text
+- [Nunc habitasse et portitor demi](#) An example link followed by text
+{.list-link-description}
+```
+
+#### Links with descriptions without bullets {.list-title .mt-8}
+
+- [Nunc habitasse et portitor demi](#) An example link followed by text
+- [Nunc habitasse et portitor demi](#) An example link followed by text
+- [Nunc habitasse et portitor demi](#) An example link followed by text
+  {.no-bullets .list-link-description}
+
+Markdown:
+
+```
+#### Links with descriptions {.list-title}
+
+- [Nunc habitasse et portitor demi](#) An example link followed by text
+- [Nunc habitasse et portitor demi](#) An example link followed by text
+- [Nunc habitasse et portitor demi](#) An example link followed by text
+{.no-bullets .list-link-description}
+```
+
+#### Ordered List {.list-title .mt-8}
+
+1. Lorem ipsum si dolor et amet
+2. Nunc habitasse et portitor demi
+
+Markdown:
+
+```
+#### Ordered List Example {.list-title}
+1. Lorem ipsum si dolor et amet
+2. Nunc habitasse et portitor demi
+```
+
+## Rich Lists
+
+There are multiple versions of lists to be generated. To use them, create a frontmatter array of objects, with the following properties:
+
+- `title: required` The title text
+- `subtitle: optional` If used, this will render a second line below the title.
+- `meta: optional` If used, this will render a new column to the right (desktop). Use for things such as dates.
+- `link: required` This will be the `href`.
+- `internal: optional (Boolean)` Use internal: true when passing internal links.
+
+<br><br><br>
+
+### Examples
+
+#### List Example One {.list-title .mt-4}
+
+<list-card :items="$page.frontmatter.sampleListOne" level="5"/>
+
+##### Frontmatter:
+
+```
+sampleListOne:
+  - title: Getting up to speed on Ethereum
+    subtitle: Matt Condon
+    meta: Aug 7, 2017
+    link: https://medium.com/@mattcondon/getting-up-to-speed-on-ethereum-63ed28821bbe
+  - title: Ethereum In Depth, Part 1
+    subtitle: Facu Spagnuolo
+    meta: May 11, 2018
+    link: https://blog.openzeppelin.com/ethereum-in-depth-part-1-968981e6f833/
+  - title: Ethereum In Depth, Part 2
+    subtitle: Facu Spagnuolo
+    meta: July 24, 2018
+    link: https://blog.openzeppelin.com/ethereum-in-depth-part-2-6339cf6bddb9/
+```
+
+##### Markdown:
+
+`level="5"` is used to show here that a `<h5>` should be rendered for each child title. Aim to output semantic markup.
+
+```
+### List Example One {.list-title}
+<list-card :items="$page.frontmatter.sampleListOne" level="4"/>
+```
+
+#### List Example Two {.list-title .mt-8}
+
+<list-card :items="$page.frontmatter.sampleListTwo" level="5"/>
+
+##### Frontmatter:
+
+```
+sampleListTwo:
+  - title: EEA
+    subtitle: The Enterprise Ethereum Alliance is a member-driven standards organization whose charter is to develop open, blockchain specifications that drive harmonization and interoperability for businesses and consumers worldwide. Our global community of members is made up of leaders, adopters, innovators, developers, and businesses who collaborate to create an open, decentralized web for the benefit of everyone.
+    link: https://entethalliance.org/
+  - title: Hyperledger
+    subtitle: Hyperledger is an open source collaborative effort created to advance cross-industry blockchain technologies. It is a global collaboration, hosted by The Linux Foundation, including leaders in finance, banking, Internet of Things, supply chains, manufacturing and Technology. The foundation has some projects in it that work with the Ethereum stack.
+    link: https://hyperledger.org/
+```
+
+##### Markdown:
+
+```
+### List Example Two {.list-title}
+<list-card :items="$page.frontmatter.sampleListTwo" level="5"/>
+```
+
+#### List Example Three {.list-title .mt-8}
+
+<list-card :items="$page.frontmatter.sampleListThree" level="5"/>
+
+##### Frontmatter:
+
+```
+sampleListThree:
+  - title: EEA
+    link: https://entethalliance.org/
+  - title: Hyperledger
+    link: https://hyperledger.org/
+```
+
+##### Markdown:
+
+```
+### List Example Three {.list-title}
+<list-card :items="$page.frontmatter.sampleListThree" level="5"/>
+```
+
+#### List Example Four {.list-title .mt-8}
+
+<list-card :items="$page.frontmatter.sampleListFour" level="5"/>
+
+##### Frontmatter:
+
+```
+sampleListThree:
+  - title: EEA
+    meta: John Owens
+    link: https://entethalliance.org/
+  - title: Hyperledger
+    meta: John Owens
+    link: https://hyperledger.org/
+```
+
+##### Markdown:
+
+```
+### List Example Three {.list-title}
+<list-card :items="$page.frontmatter.sampleListThree" level="5"/>
+```


### PR DESCRIPTION
Added lists & documentation for them Implemented simple list on `/developers` page

## Description

Added multiple list variations based on the Figma Style Guide. These include lists with descriptions, and list cards in multiple layouts.

An array of objects should be passed to leverage the card format, and a class should be added to the standard lists to enable their modification.

## Screenshots (if appropriate):
![Style Guide Documentation — Lists   Ethereum org](https://user-images.githubusercontent.com/4670881/76915912-a247f380-689d-11ea-8ee6-637140a6e296.png)
![Style Guide Documentation — Lists   Ethereum org](https://user-images.githubusercontent.com/4670881/76915931-b4299680-689d-11ea-9272-bac9a44f9ccc.png)