### PR TITLE
updated outline styline styling [fixes #766]

### DIFF
--- a/docs/.vuepress/theme/components/Sidebar.vue
+++ b/docs/.vuepress/theme/components/Sidebar.vue
@@ -80,74 +80,36 @@ function resolveOpenGroupIndex(route, items) {
 @import '../styles/config.styl'
 
 .sidebar
-  position sticky
-  top 7.5em
-  bottom 0
-  right 0
-  width $sidebarWidth
-  height calc(100vh - 80px)
-  overflow-y auto
-  font-size $fsXSmall
-  padding 1em 2em 1em 1em
-  border-left 1px dotted $colorPrimary
-  transition all 0.2s ease-in-out
-  transition transform .2s ease
-
-  p.sidebar-heading
-    display none
-
-  ul
-    padding 0
-    margin 0
-    list-style-type none
-    list-style-image none
-  a
-    display inline-block
-
-  .nav-links
-    display none
-    padding 1.5em 0 1.5rem 0
-
-    .nav-item, .repo-link
-      display block
-      padding-left 1em
-      margin-right 0
-      line-height 2em
+  display none
 
 
-@media (max-width: $breakS)
+.sidebar-links
+  border-left 1px solid $colorWhite700
+.dark-mode
+  .sidebar-links
+    border-left 1px solid $colorBlack200
+
+
+@media (min-width: $breakS)
   .sidebar
-    display block !important
-    font-size $fsMedium
-    position fixed
-    top 68px
-    padding-right 1em
-    transform translateX(-100%)
+    display initial
+    position sticky
+    top 7.5em
+    bottom 0
+    right 0
+    width $sidebarWidth
+    height calc(100vh - 80px)
+    overflow-y auto
+    font-size $fsXSmall
+    padding 1em 2em 1em 1em
+    transition all 0.2s ease-in-out
     transition transform .2s ease
-    border-left none
-    left 0
-    background white
-    border-right 1px dotted $colorPrimary
-    height "calc(100vh - %s)" % $navbarHeight
-    z-index 1
 
-    .nav-links
-      display flex
-      flex-direction column
-      .dropdown-wrapper .nav-dropdown .dropdown-item a.router-link-active::after
-        top calc(1rem - 2px)
-    .sidebar-links
-      padding 1rem 0
-
-  .sidebar-group-items
-    font-size $fsSmall
-
-  .sidebar-open
-    .sidebar
-      display block !important
-      transform translateX(0)
-
-@media only screen and (min-width:$breakL + 1px)
-  .sidebar
-    right "calc(50vw - 1460px / 2)" % $breakL
+    ul
+      padding 0
+      margin 0
+      list-style-type none
+      list-style-image none
+    a
+      display inline-block
 </style>

--- a/docs/.vuepress/theme/components/SidebarGroup.vue
+++ b/docs/.vuepress/theme/components/SidebarGroup.vue
@@ -1,29 +1,9 @@
 <template>
-  <div
-    class="sidebar-group"
-    :class="{ first, collapsable }"
-  >
-    <p
-      class="sidebar-heading"
-      :class="{ open }"
-      @click="$emit('toggle')"
-    >
-      <span>{{ item.title }}</span>
-      <span
-        class="arrow"
-        v-if="collapsable"
-        :class="open ? 'down' : 'right'">
-      </span>
-    </p>
-
+  <div class="sidebar-group" :class="{ first, collapsable }">
     <DropdownTransition>
-      <ul
-        ref="items"
-        class="sidebar-group-items"
-        v-if="open || !collapsable"
-      >
+      <ul ref="items" class="sidebar-group-items" v-if="open || !collapsable">
         <li v-for="child in item.children">
-          <SidebarLink :item="child"/>
+          <SidebarLink :item="child" />
         </li>
       </ul>
     </DropdownTransition>
@@ -40,38 +20,3 @@ export default {
   components: { SidebarLink, DropdownTransition }
 }
 </script>
-
-<style lang="stylus">
-.sidebar-group
-  &:not(.first)
-    margin-top 1em
-  .sidebar-group
-    padding-left 0.5em
-  &:not(.collapsable)
-    .sidebar-heading
-      cursor auto
-      color inherit
-
-.sidebar-heading
-  color #999
-  transition color .15s ease
-  cursor pointer
-  font-size 1.1em
-  font-weight bold
-  // text-transform uppercase
-  padding 0 1.5rem
-  margin-top 0
-  margin-bottom 0.5rem
-  &.open, &:hover
-    color inherit
-  .arrow
-    position relative
-    top -0.12em
-    left 0.5em
-  &:.open .arrow
-    top -0.18em
-
-.sidebar-group-items
-  transition height .1s ease-out
-  overflow hidden
-</style>

--- a/docs/.vuepress/theme/components/SidebarLink.vue
+++ b/docs/.vuepress/theme/components/SidebarLink.vue
@@ -60,10 +60,12 @@ function renderLink(h, to, text, active, isSubHeader = false) {
         href: to
       },
       class: {
-        'tc-primary500 active': active,
-        'bc-primary500': active && !isSubHeader,
+        'tc-primary500': active,
+        'active relative': active && !isSubHeader,
+        'header relative pl-1': !isSubHeader,
+        'subheader relative pl-075': isSubHeader,
         'tc-text100': !active,
-        'sidebar-link br-25rem w-100 l8 tc-h-primary500 mt-0 mb-05 pr-025': true
+        'sidebar-link w-100 l8 tc-h-primary500 mt-0 mb-05 pr-025': true
       }
     },
     resolveHeaderTitle(text)
@@ -74,7 +76,6 @@ function renderChildren(h, children, path, route, maxDepth, depth = 1) {
   if (!children || depth > maxDepth) return null
   return h(
     'ul',
-    { class: 'pl-1' },
     children.map(c => {
       const active = isActive(route, path + '#' + c.slug)
       return h('li', { class: 'pl-1' }, [
@@ -85,3 +86,52 @@ function renderChildren(h, children, path, route, maxDepth, depth = 1) {
   )
 }
 </script>
+
+<style lang="stylus" scoped>
+@import '../../theme/styles/config.styl';
+.active,
+.subheader:hover,
+.header:hover
+  &:after
+    content ''
+    background-color $colorPrimary500
+    border 1px solid $colorPrimary500
+    border-radius 50%
+    width .5rem
+    height .5rem
+    position absolute
+    left -.29rem
+    top 50%
+    margin-top -.25rem
+
+.subheader:hover,
+.header:not(.active):hover
+  &:after
+    background-color $colorWhite
+
+.subheader
+  &:hover
+    &:after
+      left: -1.29rem
+  &:before
+    content '⌞'
+    opacity 0.5
+    display inline-flex
+    position absolute
+    left 0
+    top -2px
+
+.dark-mode
+  .active,
+  .subheader:hover,
+  .header:hover
+    &:after
+      content ''
+      background-color $colorPrimaryDark500
+      border 1px solid $colorPrimaryDark500
+
+  .subheader:hover,
+  .header:not(.active):hover
+    &:after
+      background-color $colorBlack
+</style>


### PR DESCRIPTION
Updated outline styles

## Description

This is a css update, altering the styles of the sidebar to match the styles in the Figma Style Guide.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4670881/76919300-42eee100-68a7-11ea-831c-c639f7f22e8b.png)
![image](https://user-images.githubusercontent.com/4670881/76919317-500bd000-68a7-11ea-8da1-b25badbfd194.png)
