### PR TITLE
fix anchor scroll position [fixes #832]

### DIFF
--- a/docs/.vuepress/theme/styles/theme.styl
+++ b/docs/.vuepress/theme/styles/theme.styl
@@ -159,16 +159,9 @@ table
 // These target mainly our markdown content, and whenever a .l# class is not used
 // They should eventually be moved out of utils.styl
 
-h1, h2, h3, h4, h5, h6, p, span, li {
+h1, h2, h3, h4, h5, h6, p, span, li
   max-width: $contentWidth;
-  // This prevents content from being hidden from the fixed header when an anchor tag is used
-  &:target:before {
-    content: "";
-    display: block;
-    height: 60px; /* fixed header height*/
-    margin: -60px 0 0; /* negative fixed header height */
-  }
-}
+
 
 h1:not(.l1):not(.l2):not(.l3):not(.l4):not(.l5):not(.l6):not(.l7):not(.l8)
   @extend .l1
@@ -217,6 +210,13 @@ p
       &.highlight
         background url(../images/highlight.svg)
         background-repeat no-repeat
+  h2, h3
+    &:before
+      display: block; 
+      content: " "; 
+      margin-top: -120px; 
+      height: 120px; 
+      visibility: hidden; 
 
 :not(.rtl)
   .content__default


### PR DESCRIPTION
Removed `:target` css for anchor tags. I'm not 100% sure why it wasn't working, but this update is
Tested in:
- Chrome 80.0.3987.132
- Safari 13.0.5
- Brave 1.4.96
- iOS 13.0 Safari

## Description

Changed `:target:before` to a combination of padding & margin values applied to `:before`. Also moved this inside `.content__default`

## Related Issue

#832