### PR TITLE
Hide 2nd external link icon [fixes 844]

### DIFF
--- a/docs/.vuepress/components/LanguagesPage.vue
+++ b/docs/.vuepress/components/LanguagesPage.vue
@@ -91,6 +91,9 @@ export default {
   border-radius .5rem
   width 100%
 
+  & > h3:before
+    display none
+
 #wrapper.dark-mode
   .lang-item
     &:hover

--- a/docs/.vuepress/components/LanguagesPage.vue
+++ b/docs/.vuepress/components/LanguagesPage.vue
@@ -23,7 +23,7 @@
         :href="lang.url"
         target="_blank"
         rel="noopener noreferrer"
-        class="lang-item w-100 ma-1 pt-15 pb-15 pr-1 pl-1 border-box-shadow-hover"
+        class="lang-item w-100 ma-1 pt-15 pb-15 pr-1 pl-1 border-box-shadow-hover hide-icon"
         v-for="lang in incomplete"
         :key="lang.code"
       >


### PR DESCRIPTION
Added hide icon class to language card

## Description

The nested `a` tags with external hrefs were causing two external link icons to be displayed. The `hide-icon` class has been added to the wrapper to hide the 2nd.

## Related Issue

#844