### PR TITLE
added keyboard up + down arrow nav for navigation and search

### DIFF
--- a/docs/.vuepress/components/CardInner.vue
+++ b/docs/.vuepress/components/CardInner.vue
@@ -118,7 +118,7 @@ export default {
 }
 </script>
 
-<style lang="stylus">
+<style lang="stylus" scoped>
 @import '../theme/styles/config.styl';
 
 .header

--- a/docs/.vuepress/components/CardList.vue
+++ b/docs/.vuepress/components/CardList.vue
@@ -51,7 +51,7 @@ export default {
 }
 </script>
 
-<style lang="stylus">
+<style lang="stylus" scoped>
 @import '../theme/styles/config.styl';
 .grid
   display grid

--- a/docs/.vuepress/theme/components/NavDropdown.vue
+++ b/docs/.vuepress/theme/components/NavDropdown.vue
@@ -5,6 +5,8 @@
     @focusin="focused = true"
     @focusout="unFocus"
     @click="unFocus"
+    @keydown.down="down"
+    @keydown.up="up"
     :aria-label="`Select ${item.text.toLowerCase()}`"
   >
     <span
@@ -20,6 +22,7 @@
         v-for="(subItem, index) in item.items"
       >
         <NavLink
+          tabindex="-1"
           :item="subItem"
           childClass="link-item child-link-item block mb-1 md-up-m-0 md-up-pa-05 md-up-pl-05 md-up-pr-05"
           @nav-toggle="$emit('nav-toggle', false)"
@@ -27,6 +30,7 @@
       </li>
       <li class="languages-dropdown-item" v-if="item.text === 'Languages'">
         <router-link
+          tabindex="-1"
           class="languages-link nav-link child-link-item"
           to="/languages/"
           @nav-toggle="$emit('nav-toggle', false)"
@@ -51,21 +55,43 @@ export default {
   },
   data() {
     return {
-      focused: false
+      focused: false,
+      focusIndex: -1
     }
   },
   methods: {
     unFocus(e) {
       e.relatedTarget
         ? !e.relatedTarget.className.includes('child-link-item') &&
-          (this.focused = false)
+          ((this.focused = false), this.focusIndex != -1)
         : e.type == 'click' &&
           ((this.focused = false),
+          this.focusIndex != -1,
           // clear css hover
           e.target.closest('.dropdown-items').classList.add('blur-el'),
           window.setTimeout(function() {
             e.target.closest('.dropdown-items').classList.remove('blur-el')
           }, 50))
+    },
+    down(e) {
+      e.preventDefault()
+      this.focusIndex < this.item.items.length - 1 && this.focusIndex++
+      var target
+      this.focusIndex < this.item.items.length &&
+        ((target = e.target
+          .closest('.dropdown-item-wrapper')
+          .getElementsByClassName('child-link-item')),
+        target && target[this.focusIndex].focus())
+    },
+    up(e) {
+      e.preventDefault()
+      this.focusIndex != -1 && this.focusIndex--
+      var items
+      var wrapper = e.target.closest('.dropdown-item-wrapper')
+      this.focusIndex == -1
+        ? wrapper.focus()
+        : (items = wrapper.getElementsByClassName('child-link-item'))
+      items && items[this.focusIndex].focus()
     }
   }
 }

--- a/docs/.vuepress/theme/components/SearchBox.vue
+++ b/docs/.vuepress/theme/components/SearchBox.vue
@@ -11,6 +11,8 @@
     @keydown.enter="
       $emit('search-toggle'), $emit('nav-toggle', false), forceUnFocus()
     "
+    @keydown.down="down"
+    @keydown.up="up"
   >
     <h1 class="search-title l3 mt-0 flex flex-center md-up-hidden">
       <icon
@@ -32,6 +34,7 @@
         autocomplete="off"
         spellcheck="false"
         @keyup.enter="go(focusIndex)"
+        @keyup.down="down(-1)"
         placeholder="Search"
       />
       <icon name="search" class="icon-search-field" />
@@ -54,6 +57,7 @@
           <router-link
             :to="s.path"
             class="result-link pa-05 flex flex-column align-center md-up-ma-0"
+            tabindex="-1"
             @mousedown.native="
               $router.push(s.path),
                 $emit('search-toggle'),
@@ -88,7 +92,7 @@ export default {
   data() {
     return {
       query: '',
-      focusIndex: 0,
+      focusIndex: -1,
       focused: false
     }
   },
@@ -164,8 +168,8 @@ export default {
     unFocus(e) {
       e.relatedTarget
         ? !e.relatedTarget.classList.contains('result-link') &&
-          (this.focused = false)
-        : (this.focused = false)
+          ((this.focused = false), (this.focusIndex = -1))
+        : ((this.focused = false), (this.focusIndex = -1))
       e.target.blur()
     },
     forceUnFocus(e) {
@@ -187,6 +191,27 @@ export default {
       this.$router.push(this.suggestions[i].path)
       this.query = ''
       this.focusIndex = 0
+    },
+
+    down(e) {
+      !this.blankState &&
+        (e.preventDefault(),
+        this.focusIndex < this.suggestions.length - 1 && this.focusIndex++,
+        this.focusIndex < this.suggestions.length &&
+          document.getElementsByClassName('result-link') &&
+          document
+            .getElementsByClassName('result-link')
+            [this.focusIndex].focus())
+    },
+    up(e) {
+      e.preventDefault()
+      this.focusIndex != -1 && this.focusIndex--
+      this.focusIndex == -1
+        ? document.getElementById('main-search-field').focus()
+        : document.getElementsByClassName('result-link') &&
+          document
+            .getElementsByClassName('result-link')
+            [this.focusIndex].focus()
     }
   }
 }

--- a/docs/.vuepress/theme/components/SearchBox.vue
+++ b/docs/.vuepress/theme/components/SearchBox.vue
@@ -31,7 +31,6 @@
         :value="query"
         autocomplete="off"
         spellcheck="false"
-        @keyup.down="down(-1)"
         placeholder="Search"
       />
       <icon name="search" class="icon-search-field" />

--- a/docs/.vuepress/theme/components/SearchBox.vue
+++ b/docs/.vuepress/theme/components/SearchBox.vue
@@ -8,7 +8,7 @@
     @focusin="focused = true"
     @focusout="unFocus"
     @keydown.esc="unFocus"
-    @keydown.enter="
+    @keyup.enter="
       $emit('search-toggle'), $emit('nav-toggle', false), forceUnFocus()
     "
     @keydown.down="down"
@@ -33,7 +33,6 @@
         :value="query"
         autocomplete="off"
         spellcheck="false"
-        @keyup.enter="go(focusIndex)"
         @keyup.down="down(-1)"
         placeholder="Search"
       />
@@ -64,7 +63,6 @@
                 $emit('nav-toggle', false),
                 forceUnFocus()
             "
-            @keydown.enter="$emit('search-toggle'), $emit('nav-toggle', false)"
           >
             <span v-if="s.header" class="mb-025 tc-text400">{{
               s.header.title
@@ -172,8 +170,9 @@ export default {
         : ((this.focused = false), (this.focusIndex = -1))
       e.target.blur()
     },
-    forceUnFocus(e) {
+    forceUnFocus() {
       this.focused = false
+      this.query = ''
     },
     getPageLocalePath(page) {
       for (const localePath in this.$site.locales || {}) {
@@ -182,15 +181,6 @@ export default {
         }
       }
       return '/'
-    },
-
-    go(i) {
-      if (!this.suggestions) {
-        return
-      }
-      this.$router.push(this.suggestions[i].path)
-      this.query = ''
-      this.focusIndex = 0
     },
 
     down(e) {

--- a/docs/.vuepress/theme/components/SearchBox.vue
+++ b/docs/.vuepress/theme/components/SearchBox.vue
@@ -8,9 +8,7 @@
     @focusin="focused = true"
     @focusout="unFocus"
     @keydown.esc="unFocus"
-    @keyup.enter="
-      $emit('search-toggle'), $emit('nav-toggle', false), forceUnFocus()
-    "
+    @keyup.enter="forceUnFocus()"
     @keydown.down="down"
     @keydown.up="up"
   >
@@ -57,12 +55,7 @@
             :to="s.path"
             class="result-link pa-05 flex flex-column align-center md-up-ma-0"
             tabindex="-1"
-            @mousedown.native="
-              $router.push(s.path),
-                $emit('search-toggle'),
-                $emit('nav-toggle', false),
-                forceUnFocus()
-            "
+            @mousedown.native="$router.push(s.path), forceUnFocus()"
           >
             <span v-if="s.header" class="mb-025 tc-text400">{{
               s.header.title
@@ -171,8 +164,11 @@ export default {
       e.target.blur()
     },
     forceUnFocus() {
-      this.focused = false
-      this.query = ''
+      event.srcElement.id != 'main-search-field' &&
+        (this.$emit('search-toggle'),
+        this.$emit('nav-toggle', false),
+        (this.focused = false),
+        (this.query = ''))
     },
     getPageLocalePath(page) {
       for (const localePath in this.$site.locales || {}) {


### PR DESCRIPTION
You can now use arrows to navigate through the menu drop downs and the search results

## Description

Added `up()` and `down()` functions to `SearchBox.vue` and `NavDropdown.vue` which ensure that keypresses & focus are only triggered when relevant.