### PR TITLE
Disable overflow: scroll for desktop [fixes #857]

### DIFF
--- a/docs/.vuepress/theme/components/NavLinks.vue
+++ b/docs/.vuepress/theme/components/NavLinks.vue
@@ -3,7 +3,10 @@
     <div v-if="this.isMobileNavVisible" class="modal-bg fixed md-up-hidden" />
     <div :class="navWrapperClasses">
       <!-- Links on left -->
-      <ul class="left-items no-bullets pa-1 pb-8 md-up-pa-0" v-if="userLinks.length">
+      <ul
+        class="left-items no-bullets pa-1 pb-8 md-up-pa-0"
+        v-if="userLinks.length"
+      >
         <li
           class="menu-link-item block ma-2 ml-0 mr-0 mb-3 md-up-ma-0 md-up-ml-2 md-up-flex flex-center"
           v-for="item in userLinks"
@@ -279,6 +282,8 @@ $navIconHoverColorDark = $colorPrimaryDark500
 @media (min-width: $breakM)
   .nav-wrapper
     background transparent
+  .left-items
+    overflow initial
 
 // dark mode colors
 .dark-mode


### PR DESCRIPTION
Adds `overflow: initial` to the nav wrapper above the $breakM breakpoint.