### PR TITLE
Added icon fills [fixes #876]

### DIFF
--- a/docs/.vuepress/theme/components/Footer.vue
+++ b/docs/.vuepress/theme/components/Footer.vue
@@ -15,7 +15,11 @@
             class="hide-icon"
             :aria-labelledby="item.icon + '-link'"
           >
-            <icon :name="item.icon" size="36" />
+            <icon
+              :name="item.icon"
+              size="36"
+              class="fill-text100 fill-h-text300"
+            />
           </a>
         </li>
       </ul>
@@ -263,19 +267,4 @@ footer
       min-width 40%
     @media L
       min-width 20%
-
-footer
-  .social-links
-    a
-      svg path
-        fill $subduedColor
-      &:hover
-        svg path
-          fill $colorPrimary
-
-.dark-mode footer
-  .social-links
-    a:hover
-        svg path
-          fill $colorPrimaryDark
 </style>

--- a/docs/.vuepress/theme/styles/utils.styl
+++ b/docs/.vuepress/theme/styles/utils.styl
@@ -243,6 +243,14 @@ generateClasses('tc-h-primary', ':hover', 'color', $colorPrimaryObj)
   generateClasses('tc-primary', null, 'color', $colorPrimaryDarkObj)
   generateClasses('tc-h-primary', ':hover', 'color', $colorPrimaryDarkObj)
 
+// Backgrounds & Fills
+// Add to this list as & when used
+generateClasses('fill-text', null, 'fill', $textColorObj)
+generateClasses('fill-h-text', ':hover', 'fill', $textColorObj)
+.dark-mode
+  generateClasses('fill-text', null, 'fill', $textColorDarkObj)
+  generateClasses('fill-h-text', ':hover', 'fill', $textColorDarkObj)
+
 
 ///////////////////////////////////////
 // BORDERS                           //


### PR DESCRIPTION
This adds icon fill classes and fixes the footer icon issue.

## Description

Added icon fill classes using text colors, across dark mode, including hover states.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4670881/77594476-63d1ba80-6ed5-11ea-9a02-885332d83e3a.png)
![image](https://user-images.githubusercontent.com/4670881/77594491-6b915f00-6ed5-11ea-9296-2aecc54999ed.png)
