### PR TITLE
Update what is ethereum content structure, remove videos

### DIFF
--- a/docs/what-is-ethereum/index.md
+++ b/docs/what-is-ethereum/index.md
@@ -8,6 +8,13 @@ meta:
   - property: og:description
     content: Guides, resources, and tools for users completely new to Ethereum.
 lang: en-US
+lastresources:
+  - title: Get started using ethereum
+    link: /dapps/
+  - title: Learn more about Ethereum and its technology
+    link: /learn/
+  - title: Build on Ethereum as a Developer
+    link: /developers/
 ---
 
 # What is Ethereum? {#what-is-ethereum}
@@ -21,7 +28,7 @@ New to Ethereum? You’re in the right place. Let’s start with the big picture
 - An internet where everyone has access to an open financial system.
 - An internet built on neutral, open-access infrastructure, controlled by no company or person.
 
-**Launched in 2015, Ethereum is the world’s leading programmable blockchain.**
+## Launched in 2015, Ethereum is the world’s leading programmable blockchain.
 
 **Like other blockchains, Ethereum has a native cryptocurrency called Ether (ETH).** [ETH is digital money](/eth/). If you’ve heard of [Bitcoin](http://bitcoin.org/), ETH has many of the same features. It is purely digital, and can be sent to anyone anywhere in the world instantly. The supply of ETH isn’t controlled by any government or company - it is decentralized, and it is scarce. People all over the world use ETH to make payments, as a store of value, or as collateral.
 
@@ -37,28 +44,16 @@ These decentralized applications (or “dapps”) gain the benefits of cryptocur
 - **Games** where you own in-game assets, and can even make real money
 - **And much,** much more.
 
-**The Ethereum community is the largest and most active blockchain community in the world.** It includes core protocol developers, cryptoeconomic researchers, cypherpunks, mining organizations, ETH holders, app developers, ordinary users, anarchists, fortune 500 companies, and, as of now, **you**.
+### The Ethereum community is the largest and most active blockchain community in the world. {.mt-3}
 
-**There is no company or centralized organization that controls Ethereum.** Ethereum is maintained and improved over time by a diverse global community of contributors who work on everything from the core protocol to consumer applications. This website, just like the rest of Ethereum, was built - and continues to be built - by a collection of people working together.
+It includes core protocol developers, cryptoeconomic researchers, cypherpunks, mining organizations, ETH holders, app developers, ordinary users, anarchists, fortune 500 companies, and, as of now, **you**.
 
-**Welcome to Ethereum.**
+### There is no company or centralized organization that controls Ethereum. {.mt-3}
 
-**Not sure where to go next?**
+Ethereum is maintained and improved over time by a diverse global community of contributors who work on everything from the core protocol to consumer applications. This website, just like the rest of Ethereum, was built - and continues to be built - by a collection of people working together.
 
-- Want to get started using Ethereum? [ethereum.org/dapps](/dapps/)
-- Curious to learn more about Ethereum and its technology? [ethereum.org/learn](/learn/)
-- Are you a developer interested in building on ethereum? [ethereum.org/developers](/developers/)
+## Where to go next:
 
-**Looking for more beginner resources about Ethereum?**
+<ListCard :items="$page.frontmatter.lastresources" />
 
-[Decentralized Everything with Vitalik Buterin](https://youtu.be/WSN5BaCzsbo)
-
-<div class="iframe-container">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/WSN5BaCzsbo" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-</div>
-
-[Ethereum’s Blockchain by TechCrunch](https://www.youtube.com/watch?v=WfULutvxvzY)
-
-<div class="iframe-container">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/WfULutvxvzY" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-</div>
+<br><br><br>


### PR DESCRIPTION
Added headings to the page, a list component, and removed the long videos from the footer

## Description

This page has been broken down with headings, to make it more digestible. A list component has been added to the end of the page to give clear next steps to visitors, and videos have been removed.

This content structure should be iterated over again in the future to include illustrations, links to dapps types, etc

## Related Issue

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4670881/77678546-16eef200-6f70-11ea-9cf3-58f55e300197.png)
