### PR TITLE
Remove external icon on netlify links [fixes #897]

### DIFF
--- a/docs/.vuepress/theme/styles/theme.styl
+++ b/docs/.vuepress/theme/styles/theme.styl
@@ -37,7 +37,7 @@ a
   .icon.outbound
     display none
 
-a:not([href^="https://ethereum.org"]):not([href^="http://ethereum.org"]):not([href^="/"]):not([href^="#"]):not(.hide-icon)
+a:not([href^="https://ethereum.org"]):not([href^="http://ethereum.org"]):not([href^="/"]):not([href^="#"]):not([href^="."]):not([href^="https://deploy-preview-"]):not([href^="deploy-preview-"]):not(.hide-icon)
   &:after
     margin-left: .125em
     margin-right: .3em


### PR DESCRIPTION
This removes the external link icon from netlify/relative links

## Description

adds the following `:not()` rules to the default anchor styles:
`:not([href^="."]):not([href^="https://deploy-preview-"]):not([href^="deploy-preview-"])`

## Related Issue
Resolves #897
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Screenshots (if appropriate):
