### PR TITLE
List highlight adjustment [fixes #895]

### DIFF
--- a/docs/.vuepress/components/HomePage.vue
+++ b/docs/.vuepress/components/HomePage.vue
@@ -22,9 +22,7 @@
         <ul class="tc-text500 ml-05">
           <li
             v-for="item in block.items"
-            :class="
-              `mb-05 ml-025 ${item.highlight && 'highlight highlight-small'}`
-            "
+            :class="`mb-05 ml-025 ${item.highlight && 'highlight'}`"
           >
             <router-link :to="item.to" class="tc-text300 tc-h-primary500">
               {{ translateString(item.text) }}

--- a/docs/.vuepress/theme/styles/lists.styl
+++ b/docs/.vuepress/theme/styles/lists.styl
@@ -27,8 +27,9 @@
         position absolute
 
       &.highlight
-        background url(../images/highlight.svg)
+        background-image url(../images/highlight.svg)
         background-repeat no-repeat
+        background-size contain
     
     &.link-list
       color: $textColorObj['200']
@@ -69,9 +70,6 @@
     li
       &.highlight
         background-image: url(../images/highlight-dark.svg)
-        background-repeat no-repeat
-      &.highlight-small
-        background-size 240px !important
       &:before
         color $colorPrimaryDark500
   

--- a/docs/.vuepress/theme/styles/theme.styl
+++ b/docs/.vuepress/theme/styles/theme.styl
@@ -133,9 +133,6 @@ table
   .header-anchor
     margin-left 0
 
-  li.highlight
-    background-position right !important
-
   .updated-date
     text-align right
 


### PR DESCRIPTION
Prevents the highlight image from overflowing the container.

## Description

Constrained the image using `background-size: contain`
This works in the one location the highlight is being used. Also removed `.highlight-small`, which is redundant as a result of the change.

## Related Issue

Resolves #895