### PR TITLE
Fix pre tag overflow [fixes #860]

### DIFF
--- a/docs/.vuepress/theme/styles/theme.styl
+++ b/docs/.vuepress/theme/styles/theme.styl
@@ -52,6 +52,16 @@ a:not([href^="https://ethereum.org"]):not([href^="http://ethereum.org"]):not([hr
 .pointer
   cursor pointer
 
+pre
+  overflow-x: scroll;
+  background-color: $colorWhite600;
+  border-radius: 0.25rem;
+  padding: 1rem;
+  border: 1px solid rgba(0,0,0,.05);
+.dark-mode 
+    pre
+      background-color: $colorBlack400
+      border: 1px solid rgba(255,255,255,.05)
 
 #wrapper.home
   .hide-home


### PR DESCRIPTION
This adds `overflow-x: scroll` to `pre` tags, with some small style updates

## Related Issue

Resolves #860

## Screenshots (if appropriate):
Desktop:
![image](https://user-images.githubusercontent.com/4670881/78149828-cf9fb000-740c-11ea-9cd1-37439ec03f22.png)
![image](https://user-images.githubusercontent.com/4670881/78149849-d8908180-740c-11ea-8156-7a48292b9063.png)

Mobile:
![image](https://user-images.githubusercontent.com/4670881/78149900-eba35180-740c-11ea-904a-7de64700bbb2.png)
