### PR TITLE
Fix nav behaviour [fixes #868, fixes #908]

### DIFF
--- a/docs/.vuepress/theme/components/NavDropdown.vue
+++ b/docs/.vuepress/theme/components/NavDropdown.vue
@@ -81,7 +81,7 @@ export default {
           e.relatedTarget.className.includes('child-link-item')
         ) && (this.focused = false)
       } else if (e.type === 'keydown') {
-        this.focused = false
+        this.focused = !this.focused
       }
     },
 

--- a/docs/.vuepress/theme/components/NavDropdown.vue
+++ b/docs/.vuepress/theme/components/NavDropdown.vue
@@ -11,8 +11,9 @@
       @focusin="handleDropdown"
       @focusout="handleDropdown"
       @mousedown="handleDropdown"
-      class="dropdown-title flex flex-center ma-1 mr-0 ml-0 l-up-ma-0 l-up-pt-05 l-up-pb-05"
-      >{{ item.text }}<icon class="chevron-icon hidden" name="chevron-down"
+      class="dropdown-title tc-text500 tc-h-primary500 tc-f-primary500 flex flex-center ma-1 mr-0 ml-0 l-up-ma-0 l-up-pt-05 l-up-pb-05"
+      >{{ item.text
+      }}<icon class="chevron-icon hidden l-up-inline-block" name="chevron-down"
     /></span>
     <ul
       class="dropdown-items no-bullets ma-0 pa-0 l-up-pt-05 l-up-pb-05 l-up-hidden l-up-absolute"
@@ -25,7 +26,7 @@
         <NavLink
           tabindex="-1"
           :item="subItem"
-          childClass="link-item child-link-item block mb-1 l-up-m-0 l-up-pa-05 l-up-pl-05 l-up-pr-05"
+          childClass="link-item child-link-item tc-text400 tc-h-primary500 tc-f-primary500 block mb-1 l-up-m-0 l-up-pa-05 l-up-pl-05 l-up-pr-05 l-up-ma-0"
           @mouseup.native="handleDropdown"
           @focusout.native="handleDropdown"
           @nav-toggle="$emit('nav-toggle', false)"
@@ -109,56 +110,30 @@ export default {
 }
 </script>
 
-// Unscoped css for icons
 <style lang="stylus" scoped>
 @import '../styles/config.styl';
 
 .dropdown-title
-  cursor  pointer
+  pointer-events none
 
-// Light mode Colors
-.dropdown-title
-  color $colorBlack500
-  &:hover, &:focus
-    color $colorPrimary500
-  .chevron-icon
-    path
-      fill $colorBlack200
+.child-link-item
+  &:not(.router-link-exact-active)
+    opacity: 0.7
+  &:hover,
+  &:focus,
+  &:active
+    opacity 1
 
-.link-item
-  color $colorBlack200
-  &:hover, &:focus, &.router-link-exact-active
-    color $colorPrimary500
-
-// Dark Mode Colors
-.dark-mode
-  .dropdown-title
-    color $colorWhite500
-    &:hover, &:focus
-      color $colorPrimaryDark500
-    .chevron-icon
-      path
-        fill $colorBlack500
-
-  .link-item
-    color $colorWhite900
-    &:hover, &:focus
-      color $colorPrimaryDark500
-  .router-link-exact-active
-    color $colorPrimaryDark500
 
 @media (min-width: $breakL)
   .dropdown-title
-    .chevron-icon
-      display inline-block
+    pointer-events initial
+    cursor pointer
 
   .dropdown-items
     top 100%
     width auto
     border-radius .5em
-
-    .link-item
-      margin 0
 
   .dropdown-item-wrapper
     &.focus-within
@@ -168,30 +143,20 @@ export default {
         transform: rotate(180deg)
       }
 
-  .link-item, .dropdown-title
-    width 100%;
-    width auto
-
   // Light Mode
   .dropdown-items
     background $colorWhite500
     border 1px solid $colorWhite700
 
-  .link-item:not(.dropdown-item-wrapper)
-      &:hover
-        background $colorWhite600
+  .child-link-item:hover
+    background $colorWhite600
 
   // Dark mode
-
   .dark-mode
     .dropdown-items
       background $colorBlack400
       border 1px solid $colorBlack300
 
-    .link-item:not(.dropdown-item-wrapper)
-        &:hover
+    .child-link-item:hover
           background $colorBlack500
-
-    .dropdown-title
-      color $colorWhite500
 </style>

--- a/docs/.vuepress/theme/components/NavLinks.vue
+++ b/docs/.vuepress/theme/components/NavLinks.vue
@@ -4,11 +4,11 @@
     <div :class="navWrapperClasses">
       <!-- Links on left -->
       <ul
-        class="left-items no-bullets pa-1 pb-8 l-up-pa-0"
+        class="left-items no-bullets pa-1 pb-8 pt-3 l-up-pa-0 ml-0 l-up-ml-2"
         v-if="userLinks.length"
       >
         <li
-          class="menu-link-item block ma-2 ml-0 mr-0 mb-3 l-up-ma-0 l-up-ml-2 l-up-flex flex-center"
+          class="menu-link-item block l-up-flex flex-center mb-3 l-up-mb-0"
           v-for="item in userLinks"
           :key="item.link"
         >
@@ -16,14 +16,14 @@
           <NavDropdown
             v-if="item.type === 'links'"
             :item="item"
-            class="link-item pt-05 pb-05 pl-0 pr-0 l-up-pa-0"
+            class="link-item pl-0 pr-0 l-up-pa-0 l-up-mr-15"
             @nav-toggle="$emit('nav-toggle', false)"
           />
           <!-- If individual link -->
           <NavLink
             v-else
             :item="item"
-            class="link-item hide-icon"
+            class="link-item hide-icon pt-05 pb-05 ml-0 mr-0 l-up-ma-0 l-up-mr-2"
             @nav-toggle="$emit('nav-toggle', false)"
           />
         </li>

--- a/docs/.vuepress/theme/components/NavLinks.vue
+++ b/docs/.vuepress/theme/components/NavLinks.vue
@@ -23,7 +23,7 @@
           <NavLink
             v-else
             :item="item"
-            class="link-item hide-icon pt-05 pb-05 ml-0 mr-0 l-up-ma-0 l-up-mr-2"
+            class="link-item tc-text500 tc-h-primary500 hide-icon pt-05 pb-05 ml-0 mr-0 l-up-ma-0 l-up-mr-2"
             @nav-toggle="$emit('nav-toggle', false)"
           />
         </li>
@@ -45,7 +45,7 @@
           />
           <div
             tabindex="0"
-            class="search-click-target flex flex-column flex-center"
+            class="search-click-target l6 l-up-l7 ma-0 tc-text500 tc-h-primary500 flex flex-column flex-center"
             @keyup.enter="handleSearchToggle"
             @click="handleSearchToggle"
           >
@@ -55,25 +55,25 @@
         </div>
         <!-- Dark Mode Toggle -->
         <span
-          class="icon-link l-up-ml-1 flex flex-column flex-center view-mode"
+          class="icon-link l6 l-up-l7 tc-text500 tc-h-primary500 l-up-ma-0 l-up-ml-1 flex flex-column flex-center view-mode"
           tabindex="0"
           @keydown.enter="$emit('dark-mode-toggle')"
           @click="$emit('dark-mode-toggle')"
           :aria-label="'Toggle View Mode'"
         >
           <icon :name="darkOrLightModeIcon" />
-          <span class="icon-text l6 mt-05 mb-0 l-up-hidden">{{
+          <span class="icon-text mt-05 mb-0 l-up-hidden">{{
             darkOrLightModeText
           }}</span>
         </span>
         <!-- Languages link -->
         <router-link
-          class="icon-link l-up-ml-1 flex flex-column flex-center l-up-flex-row"
+          class="icon-link l6 l-up-l7 tc-text500 tc-h-primary500 l-up-ma-0 l-up-ml-1 flex flex-column flex-center l-up-flex-row"
           to="/languages/"
           @click.native="$emit('nav-toggle', false)"
         >
           <icon name="language" />
-          <span class="icon-text l6 mt-05 mb-0 l-up-l7 l-up-mt-0 l-up-pl-05"
+          <span class="icon-text mt-05 mb-0 l-up-mt-0 l-up-pl-05"
             >Languages</span
           >
         </router-link>
@@ -163,50 +163,14 @@ export default {
 <style lang="stylus">
 @import '../styles/config.styl';
 
-$navIconColor = $colorBlack500
-$navIconHoverColor = $colorPrimary500
-$navIconColorDark = $colorWhite500
-$navIconHoverColorDark = $colorPrimaryDark500
-
 .nav-wrapper
-  svg
-    path
-      fill $navIconColor
-    &:hover, &:focus
-      cursor pointer
-      path
-        fill $navIconHoverColor
-
-.dark-mode
-  .nav-wrapper
-    svg
-      path
-        fill $navIconColorDark
-      &:hover, &:focus
-        cursor pointer
-        path
-          fill $navIconHoverColorDark
-
-.icon-link:not(.search-link), .search-click-target
   svg path
-    fill $navIconColor
-  &:hover, &:focus, &.router-link-exact-active
-    .icon-text
-      color $colorPrimary500
-    svg path
-      fill $navIconHoverColor
+    fill currentColor
+a.router-link-exact-active
+  color $colorPrimary500
 
-// Dark Mode
-.dark-mode
-  .icon-link:not(.search-link), .search-click-target
-    svg path
-      fill $colorWhite500
-
-    &:hover, &:focus, &.router-link-exact-active
-      .icon-text
-        color $colorPrimaryDark500
-      svg path
-        fill $navIconHoverColorDark
+.dark-mode a.router-link-exact-active
+  color $colorPrimaryDark500
 </style>
 
 <style lang="stylus" scoped>
@@ -250,6 +214,9 @@ $navIconHoverColorDark = $colorPrimaryDark500
   height $mobileBottomDrawerHeight
   align-items center
 
+.icon-text
+  opacity 0.7
+
 .icon-link, .search-click-target
   flex 1 1 auto
 
@@ -262,11 +229,6 @@ $navIconHoverColorDark = $colorPrimaryDark500
   right 16px
 
 // light mode
-.icon-text
-  color $colorBlack100
-  &:hover, &:focus
-    .icon-text
-      color $colorPrimary500
 .nav-wrapper
   background $colorWhite500
 .modal-bg
@@ -274,21 +236,23 @@ $navIconHoverColorDark = $colorPrimaryDark500
 .right-items
   background: $colorWhite
   border-top: 1px solid rgba(0,0,0,0.1)
-.menu-link-item > .link-item
-  color $colorBlack500
-  &:hover, &:focus, &.router-link-exact-active
-    color $colorPrimary500
 
 @media (min-width: $breakL)
+  .icon-text
+    opacity 1
   .nav-wrapper
     background transparent
   .left-items
     overflow initial
+  .icon-link, .search-click-target
+    text-transform none
 
+.child-link-item
+  opacity: 0.8
 // dark mode colors
 .dark-mode
-  .icon-text
-    color $colorWhite900
+  // .icon-text
+  //   color $colorWhite900
   .nav-wrapper
     background $colorBlack500
   .modal-bg
@@ -296,17 +260,6 @@ $navIconHoverColorDark = $colorPrimaryDark500
   .right-items
     background: $colorBlack500
     border-top: 1px solid rgba(255,255,255,.1)
-  .menu-link-item > .link-item
-    color $colorWhite500
-    &:hover, &:focus, &.router-link-exact-active
-      color $colorPrimaryDark500
-  .dropdown-link-item
-    .link-item
-      color $colorWhite900
-      &:hover, &:focus
-        color $colorPrimaryDark500
-  .router-link-exact-active
-    color $colorPrimaryDark500
 
   @media (min-width: $breakL)
     .nav-wrapper

--- a/docs/.vuepress/theme/components/Navigation.vue
+++ b/docs/.vuepress/theme/components/Navigation.vue
@@ -25,7 +25,7 @@
       >
         <icon
           name="menu"
-          class="icon-menu"
+          class="icon-menu tc-text500"
           @click.native="handleNavToggle(true)"
         />
       </span>
@@ -97,15 +97,10 @@ export default {
 @require '../styles/config'
 .icon-menu
   position fixed
+  cursor pointer
   right 16px
   top 16px
 
-.icon-menu
   svg path
-    fill $colorBlack500
-
-.dark-mode
-  .icon-menu
-    svg path
-      fill $colorWhite500
+    fill currentColor
 </style>

--- a/docs/.vuepress/theme/components/SearchBox.vue
+++ b/docs/.vuepress/theme/components/SearchBox.vue
@@ -36,7 +36,7 @@
       <icon name="search" class="icon-search-field" />
     </div>
 
-    <div v-if="blankState" class="blank-state l-up-hidden">
+    <div v-if="blankState" class="blank-state tc-text200 l-up-hidden">
       <div class="blank-state-emoji">{{ blankState.emoji }}</div>
       <span>{{ blankState.text }}</span>
     </div>
@@ -209,6 +209,7 @@ export default {
   line-height 1
 
 .search-box
+  z-index 10
   top unquote('calc( -100 * var(--vh) + ' + $mobileBottomDrawerHeight + ')')
   left 0
   right 0
@@ -240,6 +241,7 @@ export default {
   right 6px
 
 .icon-back
+  cursor pointer
   transform rotate(180deg)
 
 .blank-state
@@ -291,6 +293,7 @@ export default {
   .suggestions, .blank-state
     margin 0
     flex-direction column
+    left 0
     width 120%
     position absolute
     top calc(100% + 4px)
@@ -312,7 +315,6 @@ export default {
   color: $colorBlack100
 
 .blank-state
-  color $colorBlack50
   background $colorWhite600
 
 @media (min-width: $breakL)

--- a/docs/.vuepress/theme/styles/utils.styl
+++ b/docs/.vuepress/theme/styles/utils.styl
@@ -175,10 +175,14 @@ generateClasses(prependClass, appendClass, property, obj)
   margin 1.14em 0
   font-weight 400
 
-.l-up-l7
-  text-transform none
-  letter-spacing 0
-  @extend .l7
+@media (min-width: $breakL)
+  .l-up-l7
+    font-size 1rem
+    line-height 1.6
+    font-weight 400
+    margin 2rem 0 1rem
+    text-transform none
+    letter-spacing 0
 
 
 
@@ -253,6 +257,7 @@ generateClasses('tc-text', null, 'color', $textColorObj)
 generateClasses('tc-h-text', ':hover', 'color', $textColorObj)
 generateClasses('tc-primary', null, 'color', $colorPrimaryObj)
 generateClasses('tc-h-primary', ':hover', 'color', $colorPrimaryObj)
+generateClasses('tc-f-primary', ':focus', 'color', $colorPrimaryObj)
 
 // Which map directly to defaults for dark mode
 .dark-mode
@@ -260,6 +265,7 @@ generateClasses('tc-h-primary', ':hover', 'color', $colorPrimaryObj)
   generateClasses('tc-h-text', ':hover', 'color', $textColorDarkObj)
   generateClasses('tc-primary', null, 'color', $colorPrimaryDarkObj)
   generateClasses('tc-h-primary', ':hover', 'color', $colorPrimaryDarkObj)
+  generateClasses('tc-f-primary', ':focus', 'color', $colorPrimaryDarkObj)
 
 // Backgrounds & Fills
 // Add to this list as & when used


### PR DESCRIPTION
This updates the way the nav is being handled, and simplifies things to a certain degree.

## Description
- Nav only opens on focus or on click
- Nav closes on a link click or enter keypress
- Title links have hover states
- Removes the `a` tag from nav dropdown wrappers to prevent event propagation issues

To prevent unwanted `focusin` `focusout` interference during a click event, `mouseup` is used for links. This allows the navigation event to fire.

`keydown.enter` is on the wrapper and toggles visibility when a child is focused & enter pressed. This closes the nav when navigating to a link.