### PR TITLE
Script to update internal links of translated files

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint 'docs/.vuepress/**/*.{js,vue}'",
     "lint:fix": "eslint --fix 'docs/.vuepress/**/*.{js,vue}'",
     "generate-heading-ids": "node scripts/generateHeadingIDs.js",
+    "update-internal-links": "node scripts/updateInternalLinks.js",
     "test": "jest"
   },
   "author": "Alan Woo (Bin Studio) <alan@bin.am>",
@@ -39,6 +40,7 @@
   },
   "dependencies": {
     "axios": "^0.19.0",
+    "glob": "^7.1.6",
     "markdown-it-attrs": "^3.0.2",
     "markdown-it-emoji": "^1.4.0",
     "moment": "^2.24.0",

--- a/scripts/updateInternalLinks.js
+++ b/scripts/updateInternalLinks.js
@@ -1,0 +1,55 @@
+var glob = require('glob')
+var fs = require('fs')
+
+function getMarkdownFiles(src, callback) {
+  glob(src + '/**/*.md', callback)
+}
+
+function updateInFile(data, link, lang) {
+  var r = /\(\/\S+\)/g
+  var [repl] = link.match(r)
+  var new_link
+
+  if (repl.charAt(repl.length - 2) != '/')
+    repl = repl.slice(0, repl.length - 1) + '/)'
+
+  if (!link.includes('/' + lang + '/')) {
+    repl = '(/' + lang + repl.slice(1, repl.length)
+  }
+
+  if ((new_link = link.replace(r, repl)) != link) {
+    console.log('changing ' + link + ' for ' + new_link)
+    data = data.replace(link, new_link)
+  }
+}
+
+function updateLinks(src, lang) {
+  fs.readFile(src, 'utf-8', function(err, data) {
+    if (err) {
+      return console.log(err)
+    }
+
+    var re = /\[.*?\]\(\/\S+\)/g
+    var m
+
+    do {
+      m = re.exec(data)
+      if (m) updateInFile(data, m[0], lang)
+    } while (m !== null)
+
+    fs.writeFile(src, data, 'utf8', function(err) {
+      if (err) return console.log(err)
+    })
+  })
+}
+
+const [lang] = process.argv.slice(2)
+getMarkdownFiles('docs/translations/' + lang, function(err, res) {
+  if (err) {
+    console.log('Cannot find folder', err)
+  } else {
+    console.log('Found results: ')
+    console.log(res)
+    res.forEach(e => updateLinks(e, lang))
+  }
+})

--- a/scripts/updateInternalLinks.js
+++ b/scripts/updateInternalLinks.js
@@ -5,7 +5,7 @@ function getMarkdownFiles(src, callback) {
   glob(src + '/**/*.md', callback)
 }
 
-function updateInFile(data, link, lang) {
+function updateInFile(data, link, index, lang) {
   var r = /\(\/\S+\)/g
   var [repl] = link.match(r)
   var new_link
@@ -18,12 +18,14 @@ function updateInFile(data, link, lang) {
   }
 
   if ((new_link = link.replace(r, repl)) != link) {
-    console.log('changing ' + link + ' for ' + new_link)
-    data = data.replace(link, new_link)
+    data = data.slice(0, index) + new_link + data.slice(index + link.length)
   }
+
+  return data
 }
 
 function updateLinks(src, lang) {
+  console.log('Updating links in' + src + ' ...')
   fs.readFile(src, 'utf-8', function(err, data) {
     if (err) {
       return console.log(err)
@@ -34,7 +36,9 @@ function updateLinks(src, lang) {
 
     do {
       m = re.exec(data)
-      if (m) updateInFile(data, m[0], lang)
+      if (m) {
+        data = updateInFile(data, m[0], m.index, lang)
+      }
     } while (m !== null)
 
     fs.writeFile(src, data, 'utf8', function(err) {
@@ -48,8 +52,6 @@ getMarkdownFiles('docs/translations/' + lang, function(err, res) {
   if (err) {
     console.log('Cannot find folder', err)
   } else {
-    console.log('Found results: ')
-    console.log(res)
     res.forEach(e => updateLinks(e, lang))
   }
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -4401,7 +4401,7 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
-glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
+glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==


### PR DESCRIPTION
## Description
The script will change all the internal links as follows:

- If the link does not contain the language directory passed in, add it (/learn/ —> /__lang__/learn/)
- If the link does not have a trailing slash, add it (/__lang__/learn → /__lang__/learn/)

Example usage (in project root directory):
```
yarn update-internal-links de
```

~~There is room for improvement (in terms of string manipulation), but for now I think it can do the work.~~
__EDIT__ fixed a bug in last commit and improved string manipulation

It works like this:

- retrieve all the Markdown files
- find all occourrences of links and apply rules to them
- replace the old links with the new correct links in the file body
- write the file

## Related Issue
#817 
