### PR TITLE
Adding Geneva DevChain community to the meetup list

### DIFF
--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -74,6 +74,8 @@ This is a non-exhaustive list built by our community. Know of an active meetup g
   - [Cape Town Ethereum Meetup](https://www.meetup.com/Cape-Town-Ethereum-Meetup/)
 - Denver
   - [Ethereum Denver](https://www.meetup.com/Ethereum-Denver/)
+- Geneva, Switzerland
+  - [Geneva DevChain](https://www.meetup.com/devchain-geneva/)
 - Hong Kong
   - [Ethereum Hong Kong](https://www.meetup.com/Ethereum-Hong-Kong/)
 - Jakarta


### PR DESCRIPTION
Geneva DevChain is advanced blockchain community with main focus in Ethereum ecosystem. We have solid monthly meetups with hands on sessions.
