### PR TITLE
Remove Matomo tracking pixel

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -46,8 +46,6 @@ module.exports = {
       {},
       `
         var _paq = window._paq || [];
-        /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-        _paq.push(['setCookieDomain', '*.ethereum.org']);
         _paq.push(['trackPageView']);
         _paq.push(['enableLinkTracking']);
         (function() {
@@ -58,11 +56,6 @@ module.exports = {
           g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
         })();
         `
-    ],
-    [
-      'noscript',
-      {},
-      `<p><img src="//matomo.ethereum.org/piwik/matomo.php?idsite=4&amp;rec=1" style="border:0;" alt="" /></p>`
     ],
     [
       'script',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Introducing the `vuepress-plugin-ipfs` appears to have created some havoc in our HTML builds when interacting with the Matomo tracking pixel.

Before adding it: 
`view-source:https://5e82199f98b4cc0007b721be--ethereumorg.netlify.app/`
```
<noscript><p><img src="//matomo.ethereum.org/piwik/matomo.php?idsite=4&amp;rec=1" style="border:0;" alt="" /></p></noscript>
```

After adding it:
`view-source:https://5e87b5c66f385800079a016c--ethereumorg.netlify.app/`
```
<noscript></noscript></head><body><p><img src="//matomo.ethereum.org/piwik/matomo.php?idsite=4&#x26;rec=1" style="border:0;" alt=""></p>
```
This resulted in the pixel (& other scripts) being injected into the `<body>` vs. the `<head>` of the HTML. Our reported site traffic basically doubled as a result (visits were being double-counted), all reported as direct entry (as the pixel can't attribute source channel).
<!--- Describe your changes in detail -->

This PR removes the [Matomo tracking pixel](https://matomo.org/docs/tracking-api/#image-tracker-code), which resolves the conflict with `vuepress-plugin-ipfs`.  The tracking pixel ultimately didn't provide much value anyway, merely providing a back up in case a  browser had JS disabled.

## Related Issue
None
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Screenshots (if appropriate):
