### PR TITLE
Biconomy added

### DIFF
--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -199,6 +199,14 @@ Ethereum has a large and growing number of tools to help developers build, test,
 - [DApp Integration Center](https://status.im/developer_tools/)
 - [Get Help](https://status.im/docs/FAQs.html)
 
+**Biconomy -** **_Scalable Relayer infrastructure network and transaction platform enabling you to build applications easily and reduce the friction between your applications built on the blockchain and your end-users._**
+
+- [Website](https://biconomy.io)
+- [Mexa SDK](https://github.com/bcnmy/mexa-sdk)
+- [Documentation](https://docs.biconomy.io)
+- [GitHub](https://github.com/bcnmy)
+- [Discord](https://discord.gg/7cf6xc)
+
 **Looking for other options?**
 
 - [Ethereum Developer Tools List #Frameworks](https://github.com/ConsenSys/ethereum-developer-tools-list#frameworks)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Reopening this PR :- https://github.com/ethereum/ethereum-org-website/pull/948 
Hi @samajammin & @CPSTL , Last week we have successfully launched our infrastructure on ethereum mainnet and have also added the projects building on top of biconomy section in our documentation.

Docs: https://docs.biconomy.io/examples/projects-building-on-biconomy

Mainnet launch relevant links :-
1). https://medium.com/biconomy/biconomy-beta-launch-d6ad979fffce
2). https://decrypt.co/27768/biconomy-brings-gasless-transactions-to-ethereum

I was bit occupied and about to update it here. Can you please proceed with review process now?
