### PR TITLE
Changed the Tenderly domain from .dev to .co

### DIFF
--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -148,7 +148,7 @@ Ethereum has a large and growing number of tools to help developers build, test,
 
 **Tenderly -** **_A platform to easily monitor your smart contracts with error tracking, alerting, performance metrics, and detailed contract analytics._**
 
-- [tenderly.dev](https://tenderly.dev/)
+- [tenderly.co](https://tenderly.co/)
 - [GitHub](https://github.com/Tenderly)
 - [Discord](https://discord.gg/eCWjuvt)
 

--- a/docs/enterprise/index.md
+++ b/docs/enterprise/index.md
@@ -126,7 +126,7 @@ Public and private Ethereum networks might need specific features required by ne
 ### Tooling {#tooling}
 
 - [Alethio](https://aleth.io/) _Ethereum Data Analytics Platform_
-- [Tenderly](https://tenderly.dev/) _A Data Platform providing real-time analytics, alerting and monitoring with support for private networks._
+- [Tenderly](https://tenderly.co/) _A Data Platform providing real-time analytics, alerting and monitoring with support for private networks._
 - [Treum](https://treum.io/) _bringing transparency, traceability, and tradability to supply chains, using blockchain technology_
 - [Truffle Suite](https://trufflesuite.com) _blockchain development suite (Truffle, Ganache, Drizzle)_
 

--- a/docs/translations/ar/developers/index.md
+++ b/docs/translations/ar/developers/index.md
@@ -123,7 +123,7 @@ sidebarDepth: 1
 
 **Tenderly -** **_منصة لمراجعة العقود الذكية بسهولة من خلال تتبع الأخطاء والتنبيه و قياس الأداء وتحليلات مفصلة للعقود._**
 
-- [tenderly.dev](https://tenderly.dev/)
+- [tenderly.co](https://tenderly.co/)
 - [GitHub](https://github.com/Tenderly)
 - [Discord](https://discord.gg/eCWjuvt)
 

--- a/docs/translations/bn/developers/index.md
+++ b/docs/translations/bn/developers/index.md
@@ -123,7 +123,7 @@ sidebarDepth: 1
 
 **টেন্ডারলি -** **_ত্রুটি সনাক্ত করা, সতর্ক করা, পারফরমেন্স মেট্রিক্স এবং বিশদ কন্ট্র্যাক্ট অ্যানালিটিক্স-এর সাথে আপনার স্মার্ট কন্ট্র্যাক্টগুলির ওপরে সহজেই নজরদারী করার জন্য একটি প্ল্যাটফর্ম।_**
 
-- [tenderly.dev](https://tenderly.dev/)
+- [tenderly.co](https://tenderly.co/)
 - [গিটহাব](https://github.com/Tenderly)
 - [ডিসকর্ড](https://discord.gg/eCWjuvt)
 

--- a/docs/translations/de/developers/index.md
+++ b/docs/translations/de/developers/index.md
@@ -123,7 +123,7 @@ Ethereum verfügt über eine große und wachsende Anzahl von Tools, um Programmi
 
 **Tenderly -** **_Eine Plattform zur einfachen Überwachung deiner Smart Contracts mit Fehlerverfolgung, Warnhinweisen, Leistungsmetriken und detaillierten Vertragsanalysen._**
 
-- [tenderly.dev](https://tenderly.dev/)
+- [tenderly.co](https://tenderly.co/)
 - [GitHub](https://github.com/Tenderly)
 - [Discord](https://discord.gg/eCWjuvt)
 

--- a/docs/translations/fa/developers/index.md
+++ b/docs/translations/fa/developers/index.md
@@ -122,7 +122,7 @@ sidebarDepth: 1
 
 **تندرلی (Tenderly)** _پلتفرمی برای نظارت آسان بر قرارداد‌های هوشمند شما، همراه با ردیابی خطا‌ها، اعلام خطر‌ها، ارزیابی‌های کارایی، و تحلیل جزئیات قرارداد._
 
-- [tenderly.dev](https://tenderly.dev/)
+- [tenderly.co](https://tenderly.co/)
 - [GitHub](https://github.com/Tenderly)
 - [Discord](https://discord.gg/eCWjuvt)
 

--- a/docs/translations/fr/developers/index.md
+++ b/docs/translations/fr/developers/index.md
@@ -123,7 +123,7 @@ Ethereum dispose d'un nombre croissant d'outils pour aider les développeurs à 
 
 **Tenderly -** **_Une plateforme pour suivre facilement vos contrats intelligents, qui intègre le suivi d'erreur, des alertes, des indicateurs de performances, et des analyses détaillées des contrats._**
 
-- [tenderly.dev](https://tenderly.dev/)
+- [tenderly.co](https://tenderly.co/)
 - [GitHub](https://github.com/Tenderly)
 - [Discord](https://discord.gg/eCWjuvt)
 

--- a/docs/translations/id/developers/index.md
+++ b/docs/translations/id/developers/index.md
@@ -123,7 +123,7 @@ Ethereum punya banyak perangkat yang jumlahnya terus bertambah yang dapat diguna
 
 **Tenderly -** **_Sebuah platform untuk memonitor smart contracts dengan fitur pelacakan kesalahan, alerting, metrik kinerja, dan analitik kontrak yang detail._**
 
-- [tenderly.dev](https://tenderly.dev/)
+- [tenderly.co](https://tenderly.co/)
 - [GitHub](https://github.com/Tenderly)
 - [Discord](https://discord.gg/eCWjuvt)
 

--- a/docs/translations/ro/developers/index.md
+++ b/docs/translations/ro/developers/index.md
@@ -126,7 +126,7 @@ Ethereum are o colecție amplă și din ce în ce mai bogată de instrumente car
 
 **Tenderly -** ***Platformă pentru monitorizarea ușoară a contractelor smart. Include urmărirea erorilor, alerte, indicatori de performanță și analize detaliate ale contractelor.***
 
-- [tenderly.dev](https://tenderly.dev/)
+- [tenderly.co](https://tenderly.co/)
 - [GitHub](https://github.com/Tenderly)
 - [Discord](https://discord.gg/eCWjuvt)
 

--- a/docs/translations/se/developers/index.md
+++ b/docs/translations/se/developers/index.md
@@ -123,7 +123,7 @@ Ethereum har ett stort och växande antal verktyg som hjälper utvecklare att by
 
 **Tenderly -** **_En plattform för att enkelt övervaka din smarta kontrakt med felspårning, larm, prestandavärden och detaljerad kontraktsanalys._**
 
-- [tenderly.dev](https://tenderly.dev/)
+- [tenderly.co](https://tenderly.co/)
 - [GitHub](https://github.com/Tenderly)
 - [Discord](https://discord.gg/eCWjuvt)
 

--- a/docs/translations/sk/developers/index.md
+++ b/docs/translations/sk/developers/index.md
@@ -123,7 +123,7 @@ Ethereum ponúka čoraz viac nástrojov, ktoré vývojárom pomáhajú vytvára�
 
 **Tenderly -** **_platforma na jednoduché monitorovanie smart kontraktov so sledovaním chýb, výstrahami, meraním výkonnostných metrík a podrobnými analýzami kontraktov_**
 
-- [tenderly.dev](https://tenderly.dev/)
+- [tenderly.co](https://tenderly.co/)
 - [GitHub](https://github.com/Tenderly)
 - [Discord](https://discord.gg/eCWjuvt)
 

--- a/docs/translations/tr/developers/index.md
+++ b/docs/translations/tr/developers/index.md
@@ -123,7 +123,7 @@ Ethereum, geliştiricilere uygulamalarının yapım, test ve dağıtım aşamala
 
 **Tenderly -** **_A platform to easily monitor your smart contracts with error tracking, alerting, performance metrics, and detailed contract analytics._**
 
-- [tenderly.dev](https://tenderly.dev/)
+- [tenderly.co](https://tenderly.co/)
 - [GitHub](https://github.com/Tenderly)
 - [Discord](https://discord.gg/eCWjuvt)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

As the title suggests, Tenderly is moving to a new domain, and this PR reflects that change.

## Related Issue

N / A

## Screenshots (if appropriate):

N / A