### PR TITLE
Add page to build translation files

### DIFF
--- a/docs/.vuepress/components/TranslationsBuild.vue
+++ b/docs/.vuepress/components/TranslationsBuild.vue
@@ -1,0 +1,47 @@
+<template>
+  <div>
+    <div class="m-0 mt-2 mb-2">
+      <pre>
+        {{ message }}
+        </pre
+      >
+      <p>
+        Visit our project to bulk download translation files:
+        <a
+          href="https://crowdin.com/project/ethereumfoundation"
+          target="_blank"
+          rel="noopener noreferrer"
+          >https://crowdin.com/project/ethereumfoundation</a
+        >
+      </p>
+    </div>
+  </div>
+</template>
+
+<script>
+const axios = require('axios')
+
+export default {
+  data() {
+    return {
+      message: 'Loading...'
+    }
+  },
+
+  mounted() {
+    axios
+      .get('/.netlify/functions/translation-build')
+      .then(response => {
+        const data = response.data.data
+        if (data && data.success) {
+          this.message = `Build ${data.success.status}. Files are up to date!`
+        }
+      })
+      // TODO create error case
+      .catch(error => {
+        console.log(error)
+        this.message = error
+      })
+  }
+}
+</script>

--- a/docs/translation-build/index.md
+++ b/docs/translation-build/index.md
@@ -1,0 +1,11 @@
+---
+lang: en-US
+---
+
+# Translation Builder
+
+Welcome. Thanks for building with us!
+
+Loading this page updates our translation files to the latest build, so folks can export our latest content translations.
+
+<TranslationsBuild />

--- a/lambda/translation-build.js
+++ b/lambda/translation-build.js
@@ -1,0 +1,27 @@
+const axios = require('axios')
+
+exports.handler = async function(event, context) {
+  try {
+    const baseURL =
+      'https://api.crowdin.com/api/project/ethereumfoundation/export'
+    const { CROWDIN_API_KEY } = process.env
+
+    const resp = await axios.get(`${baseURL}?key=${CROWDIN_API_KEY}&json`)
+
+    if (resp.status < 200 || resp.status >= 300) {
+      return { statusCode: resp.status, body: resp.statusText }
+    }
+
+    const data = await resp.data
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ data })
+    }
+  } catch (err) {
+    console.log(err) // output to netlify function log
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ msg: err.message })
+    }
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As demonstrated in #1029, currently there's no way for volunteers to bulk download our translation files. The project must be "built" first & only admins can do that in the UI. The only other option is seemingly downloading the files in the UI one by one.

This creates a public page that anyone can hit to build our project files. This ensures we're using the latest versions of our translated content.

## Related Issue
Any site translation issue, e.g. #1028
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Screenshots (if appropriate):
