### PR TITLE
Fix links in RandomList component [Fixes #1040]

### DIFF
--- a/docs/.vuepress/components/RandomList.vue
+++ b/docs/.vuepress/components/RandomList.vue
@@ -1,42 +1,42 @@
 <template>
-	<component :is="comp" :items="selected">
-		<slot/>
-	</component>
+  <component :is="comp" :items="selected">
+    <slot />
+  </component>
 </template>
 
 <script>
 /*
-*  Implements a component showing elements from the array `items` after shuffling it
-*  using random.js APIs. The component can be used as a child component (e.g. RandomAppList.vue)
-*  to implement a random selection of items.
-*/
-import DefaultList from './DefaultList.vue';
-import {MersenneTwister19937, shuffle} from "random-js"
+ *  Implements a component showing elements from the array `items` after shuffling it
+ *  using random.js APIs. The component can be used as a child component (e.g. RandomAppList.vue)
+ *  to implement a random selection of items.
+ */
+import DefaultList from './DefaultList.vue'
+import { MersenneTwister19937, shuffle } from 'random-js'
 
 export default {
-	props: {
-		n: Number,
-		items: Array,
-		comp: {
-			type: [String, Object],
-			default: () => (DefaultList),
-		}
-	},
+  props: {
+    n: Number,
+    items: Array,
+    comp: {
+      type: [String, Object],
+      default: () => DefaultList
+    }
+  },
 
-	data() {
-		const random = MersenneTwister19937.autoSeed();
-		return {random: random, selected: []}
-	},
+  data() {
+    const random = MersenneTwister19937.autoSeed()
+    return { random: random, selected: [] }
+  },
 
-	created() {
-		this.selectItems();
-	},
+  beforeMount() {
+    this.selectItems()
+  },
 
-	methods: {
-		selectItems() {
-			shuffle(this.random, this.items);
-			this.selected = this.items.slice(0, this.n);
-		}
-	}
+  methods: {
+    selectItems() {
+      shuffle(this.random, this.items)
+      this.selected = this.items.slice(0, this.n)
+    }
+  }
 }
 </script>


### PR DESCRIPTION
## Description

I moved the selectItems() call to beforeMount() instead of created(). This makes the links work the same in both dev and my test deployment. Seeing as RandomList is only reference on this page, this appears to fix the bug reported in [Fixes #1040] without affecting any other pages.

## Related Issue

https://github.com/ethereum/ethereum-org-website/issues/1040

## Screenshots (if appropriate):
