### PR TITLE
Remove old upcoming events, add ETHOnline to upcoming events

### DIFF
--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -156,10 +156,6 @@ Hundreds of thousands of Ethereum enthusiasts gather in these online forums to s
 
 **Every month, there are major Ethereum events around the world.** Consider attending one near you to meet more people in the community, learn about employment opportunities, and develop new skills.
 
-- [Dragon Quest](https://hackathon.metacartel.org/) (MetaCartel) - _Virtual Hackathon_ (April 1-30, 2020)
-- [HackMoney](https://hackathon.money/) - (ETHGlobal) _Virtual Hackathon_ (30 days, Starting Mid-April, 2020)
-- [ETHTurin](https://ethturin.com/) - _Virtual Hackathon_ (April 24-26, 2020)
-- [Ethereal](https://www.etherealsummit.com/) (ConsenSys) - _Virtual Conference_ (May 7-8, 2020)
 - [ETHOnline](https://www.ethonline.org/) (ETHGlobal) - _Virtual Summit and Hackathon_ (October 2-30, 2020)
 
 _Have an event to add to this list? [Add it](https://github.com/ethereum/ethereum-org-website#how-can-i-contribute)!_

--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -160,6 +160,7 @@ Hundreds of thousands of Ethereum enthusiasts gather in these online forums to s
 - [HackMoney](https://hackathon.money/) - (ETHGlobal) _Virtual Hackathon_ (30 days, Starting Mid-April, 2020)
 - [ETHTurin](https://ethturin.com/) - _Virtual Hackathon_ (April 24-26, 2020)
 - [Ethereal](https://www.etherealsummit.com/) (ConsenSys) - _Virtual Conference_ (May 7-8, 2020)
+- [ETHOnline](https://www.ethonline.org/) (ETHGlobal) - _Virtual Summit and Hackathon_ (October 2-30, 2020)
 
 _Have an event to add to this list? [Add it](https://github.com/ethereum/ethereum-org-website#how-can-i-contribute)!_
 


### PR DESCRIPTION
## Description
Two commits, one adds the recently announced ETHOnline to the upcoming events in the community page, another removed past events that should no longer be in the upcoming events heading.