### PR TITLE
Add protect privacy hackathon [Fixes #1077]

### DIFF
--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -164,6 +164,7 @@ Hundreds of thousands of Ethereum enthusiasts gather in these online forums to s
 
 - [GitxChange](https://gitcoin.co/hackathon/GitxChange/onboard) (Gitcoin) - _Virtual Hackathon_ (May 27-June 10, 2020)
 - [Planet Wide SOS Hackathon](https://soshackathon.com/) (CryptoChicks) - _Virtual Hackathon_ (May 29-June 16, 2020)
+- [Protect Privacy](https://gitcoin.co/hackathon/privacy/onboard) (Gitcoin) - _Virtual Hackathon_ (June 15-June 29, 2020)
 - [EthBarcelona](http://ethbarcelona.io/) - _Conference_ (Barcelona) (June 17, 2020)
 - [ETHOnline](https://www.ethonline.org/) (ETHGlobal) - _Virtual Summit and Hackathon_ (October 2-30, 2020)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Added a line [here](https://github.com/Solexplorer/ethereum-org-website/blob/dev/docs/community/index.md#upcoming-events-upcoming-events) to have the Gitcoin hackathon show up in the community website

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#1077

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/50027175/83393537-40f0e480-a3f7-11ea-9d80-c3814772c8b2.png)


