### PR TITLE
Add mixin to dedup definition of translateString [Fixes #979]

### DIFF
--- a/docs/.vuepress/components/BuildPage.vue
+++ b/docs/.vuepress/components/BuildPage.vue
@@ -121,22 +121,19 @@
 </template>
 
 <script>
-import { translate } from '../theme/utils/translations'
+import { translateMixin } from '../theme/utils/translations'
 const { inlineMd } = require('../theme/utils/inline-md')
 
 export default {
+  mixins: [translateMixin],
   methods: {
-    inlineMd: function(str) {
+    inlineMd: function (str) {
       return inlineMd(str)
     },
 
-    translateString: function(str) {
-      return translate(str, this.$lang)
+    langPath: function () {
+      return this.translateString('path')
     },
-
-    langPath: function() {
-      return translate('path', this.$lang)
-    }
   },
   computed: {
     templates() {
@@ -148,9 +145,9 @@ export default {
           ),
           to: {
             url: 'https://studio.ethereum.org/1',
-            text: this.translateString('page-build-hello-world-link-text')
+            text: this.translateString('page-build-hello-world-link-text'),
           },
-          icon: ':wave:'
+          icon: ':wave:',
         },
         {
           title: this.translateString('page-build-coin-contract-title'),
@@ -159,9 +156,9 @@ export default {
           ),
           to: {
             url: 'https://studio.ethereum.org/2',
-            text: this.translateString('page-build-coin-contract-link-text')
+            text: this.translateString('page-build-coin-contract-link-text'),
           },
-          icon: ':key:'
+          icon: ':key:',
         },
         {
           title: this.translateString('page-build-crypto-pizza-title'),
@@ -170,10 +167,10 @@ export default {
           ),
           to: {
             url: 'https://studio.ethereum.org/3',
-            text: this.translateString('page-build-crypto-pizza-link-text')
+            text: this.translateString('page-build-crypto-pizza-link-text'),
           },
-          icon: ':pizza:'
-        }
+          icon: ':pizza:',
+        },
       ]
     },
     learningPlatforms() {
@@ -186,8 +183,8 @@ export default {
           to: 'https://cryptozombies.io/',
           img: {
             src: '/ecosystem/crypto-zombie.png',
-            alt: 'CryptoZombies'
-          }
+            alt: 'CryptoZombies',
+          },
         },
         {
           title: 'Ethernauts',
@@ -197,8 +194,8 @@ export default {
           to: 'https://ethernaut.openzeppelin.com/',
           img: {
             src: '/ecosystem/oz.png',
-            alt: 'Open Zeppelin Ethernaut'
-          }
+            alt: 'Open Zeppelin Ethernaut',
+          },
         },
         {
           title: 'Remix',
@@ -206,8 +203,8 @@ export default {
           to: 'https://remix.ethereum.org',
           img: {
             src: '/ecosystem/remix.png',
-            alt: 'Remix'
-          }
+            alt: 'Remix',
+          },
         },
         {
           title: 'ChainShot',
@@ -215,8 +212,8 @@ export default {
           to: 'https://www.chainshot.com',
           img: {
             src: '/ecosystem/chainshot.png',
-            alt: 'ChainShot'
-          }
+            alt: 'ChainShot',
+          },
         },
         {
           title: 'ConsenSys Academy',
@@ -226,12 +223,12 @@ export default {
           to: 'https://consensys.net/academy/bootcamp/',
           img: {
             src: '/ecosystem/consensys.png',
-            alt: 'ConsenSys Academy'
-          }
-        }
+            alt: 'ConsenSys Academy',
+          },
+        },
       ]
-    }
-  }
+    },
+  },
 }
 </script>
 

--- a/docs/.vuepress/components/HomePage.vue
+++ b/docs/.vuepress/components/HomePage.vue
@@ -35,7 +35,7 @@
 </template>
 
 <script>
-import { translate } from '../theme/utils/translations'
+import { translateMixin } from '../theme/utils/translations'
 
 export default {
   computed: {
@@ -195,17 +195,14 @@ export default {
       ]
     }
   },
+  mixins: [translateMixin],
   methods: {
-    translateString: function(str) {
-      return translate(str, this.$lang)
-    },
-
     langPath: function() {
-      return translate('path', this.$lang)
+      return this.translateString('path')
     },
 
     contentVersion() {
-      return translate('version', this.$lang)
+      return this.translateString('version')
     }
   }
 }

--- a/docs/.vuepress/theme/components/AlgoliaSearchBox.vue
+++ b/docs/.vuepress/theme/components/AlgoliaSearchBox.vue
@@ -33,7 +33,7 @@
 </template>
 
 <script>
-import { translate } from '../utils/translations'
+import { translateMixin } from '../utils/translations'
 
 export default {
   name: 'AlgoliaSearchBox',
@@ -83,7 +83,7 @@ export default {
   mounted() {
     this.initialize(this.options, this.$lang)
   },
-
+  mixins: [translateMixin],
   methods: {
     initialize(userOptions, lang) {
       Promise.all([
@@ -124,10 +124,6 @@ export default {
     update(options, lang) {
       this.$el.innerHTML = this.$el.innerHTML // Needed to reset language index
       this.initialize(options, lang)
-    },
-
-    translateString: function(str) {
-      return translate(str, this.$lang)
     }
   }
 }

--- a/docs/.vuepress/theme/components/NavLinks.vue
+++ b/docs/.vuepress/theme/components/NavLinks.vue
@@ -102,7 +102,7 @@
 
 <script>
 import { isActive, resolveNavLinkItem } from '../utils/util'
-import { translate } from '../utils/translations'
+import { translateMixin } from '../utils/translations'
 import NavLink from './NavLink.vue'
 import NavDropdown from './NavDropdown.vue'
 import SearchBox from './SearchBox.vue'
@@ -142,11 +142,11 @@ export default {
 
     darkOrLightModeText() {
       const key = this.isDarkMode ? 'light-mode' : 'dark-mode'
-      return translate(key, this.$lang)
+      return this.translateString(key)
     },
 
     nav() {
-      const languagePath = translate('path', this.$lang)
+      const languagePath = this.translateString('path')
       return this.$site.locales[languagePath].nav || []
     },
 
@@ -168,16 +168,12 @@ export default {
       return this.algolia && this.algolia.apiKey && this.algolia.indexName
     }
   },
-
+  mixins: [translateMixin],
   methods: {
     isActive,
 
     handleSearchToggle() {
       this.isSearchVisible = !this.isSearchVisible
-    },
-
-    translateString: function(str) {
-      return translate(str, this.$lang)
     }
   },
 

--- a/docs/.vuepress/theme/utils/translations.js
+++ b/docs/.vuepress/theme/utils/translations.js
@@ -232,7 +232,16 @@ const translate = (lookup, lang = 'en-US') => {
   return translation || ''
 }
 
+const translateMixin = {
+  methods: {
+    translateString(str) {
+      return translate(str, this.$lang)
+    }
+  }
+}
+
 module.exports = {
   translate,
-  translations
+  translations,
+  translateMixin
 }


### PR DESCRIPTION
## Description
Created a mixin which defines `translateString` to dedup the definition for the same in BuildPage, HomePage, AlgoliaSearchBox, NavLinks components and enables easy sharing of the method. 

Also enables to remove imports of the `translate` method as the above-defined method from the mixin can be used for the same.

## Related Issue
Fixes #979 
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/ethereum/ethereum-org-website/issues/979
## Screenshots (if appropriate):
