### PR TITLE
 Add Exodus to wallets page [Fixes #1109]

### DIFF
--- a/docs/wallets/index.md
+++ b/docs/wallets/index.md
@@ -27,6 +27,7 @@ Want to install a wallet? Here are a few options:
 - [Argent](https://www.argent.xyz/) _mobile wallet for iOS and Android, optimized for DeFi_
 - [Coinbase Wallet](https://wallet.coinbase.com/) _mobile wallet for iOS and Android_
 - [Gnosis Safe](https://gnosis-safe.io/) _security oriented multi-signature wallet_
+- [Exodus](https://www.exodus.io/ethereum-wallet) _user-friendly desktop and mobile wallet_
 
 Want to learn more about Ethereum wallets?
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Wallets page (https://ethereum.org/wallets/) lists some ETH wallets but is missing Exodus. Exodus would be a good addition given its popularity with users and how easy it makes crypto and DeFi. The last part aligns with Ethereum.org's mission to help new users get started with ETH.
<!--- Describe your changes in detail -->

## Related Issue
1109
https://github.com/ethereum/ethereum-org-website/issues/1109
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Screenshots (if appropriate):
