### PR TITLE
Corrected chinese traditional characters

### DIFF
--- a/docs/.vuepress/theme/utils/translations.js
+++ b/docs/.vuepress/theme/utils/translations.js
@@ -218,7 +218,7 @@ const languageMetaData = {
   },
   'zh-TW': {
     version: 1.1,
-    language: '中國傳統的',
+    language: '傳統中文',
     'language-english': 'Chinese Traditional',
     path: '/zh-tw/'
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Bug was identified by @sorumfactory so have amended the expression.

_ I received a message from one of our  translators that the Chinese Traditional 「中國傳統的」 on the language support page is not correctly written. The common expressions are such as 「傳統中文」or「正體中文」. It's a good catch :open_mouth: 

Would you please change the 中國傳統的 to 傳統中文?_

## Related Issue

N/A

## Screenshots (if appropriate):

Before:
![image](https://user-images.githubusercontent.com/40891631/85153269-e60c1980-b24d-11ea-950b-a5bd41e2d183.png)

After:
![image](https://user-images.githubusercontent.com/40891631/85153306-f15f4500-b24d-11ea-9eeb-d3296b0350e7.png)
