### PR TITLE
Exclude empty search queries from analytics [Fixes #1153]

### DIFF
--- a/src/components/Search/index.js
+++ b/src/components/Search/index.js
@@ -197,10 +197,23 @@ const Search = ({ handleSearchSelect }) => {
   const ref = createRef()
   const [query, setQuery] = useState(``)
   const [focus, setFocus] = useState(false)
-  const searchClient = algoliasearch(
+  const algoliaClient = algoliasearch(
     process.env.GATSBY_ALGOLIA_APP_ID,
     process.env.GATSBY_ALGOLIA_SEARCH_KEY
   )
+  const searchClient = {
+    search(requests) {
+      const newRequests = requests.map((request) => {
+        // test for empty string and change request parameter: analytics
+        // https://www.algolia.com/doc/guides/getting-insights-and-analytics/search-analytics/out-of-the-box-analytics/how-to/how-to-remove-empty-search-from-analytics/#exclude-searches-from-your-analytics
+        if (!request.params.query || request.params.query.length === 0) {
+          request.params.analytics = false
+        }
+        return request
+      })
+      return algoliaClient.search(newRequests)
+    },
+  }
   useOnClickOutside(ref, () => setFocus(false))
 
   const handleSelect = () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Exclude empty search queries from Algolia's analytics

## Related Issue
#1153