### PR TITLE
fix(search): use correct selector for meta tags

### DIFF
--- a/.github/workflows/docsearchConfig.json
+++ b/.github/workflows/docsearchConfig.json
@@ -44,7 +44,8 @@
     },
     "lvl1": "#___gatsby h1",
     "lvl2": {
-      "selector": "meta[name=description]",
+      "selector": "//meta[@name='description']/@content",
+      "type": "xpath",
       "global": true
     },
     "lvl3": "#___gatsby h2",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Following our conversation from DocSearch support, this PR should solve the issue you are struggling with when attempting to extract textual information from meta tags. By default, the crawler extract textual informations from HTML node [via the `textContent` method](https://wiki.developer.mozilla.org/en-US/docs/Web/API/Node/textContent#Differences_from_innerHTML). Since `<meta/>` tags do not wrap any textual informations, the crawler must know that the coveted text is in the `content` attribute of the node.

## Related Issue

N/A

## Screenshots (if appropriate):

N/A