### PR TITLE
fix: Arrow icon wraps with the last word of the link

### DIFF
--- a/src/templates/static.js
+++ b/src/templates/static.js
@@ -159,7 +159,7 @@ const StyledLink = styled.a`
     &:after {
       margin-left: 0.125em;
       margin-right: 0.3em;
-      display: inline-block;
+      display: inline;
       content: "↗";
       transition: all 0.1s ease-in-out;
       font-style: normal;


### PR DESCRIPTION
## Description
Changes display attribute of external link style to inline

## Related Issue
Fixes: #980 

## Screenshot
![Screenshot_2020-07-21 About Us Ethereum org](https://user-images.githubusercontent.com/21157929/88052087-5a9ce580-cb77-11ea-9400-33bbd41792f0.png)
