### PR TITLE
fix: Arrow icon wraps with the last word of the link

### DIFF
--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -11,7 +11,7 @@ const ExternalLink = styled.a`
     color: ${(props) => props.theme.colors.primary};
     margin-left: 0.125em;
     margin-right: 0.3em;
-    display: inline-block;
+    display: inline;
     content: "↗";
     transition: all 0.1s ease-in-out;
     font-style: normal;

--- a/src/components/SharedStyledComponents.js
+++ b/src/components/SharedStyledComponents.js
@@ -18,7 +18,7 @@ export const FakeLink = styled.div`
   &:after {
     margin-left: 0.125em;
     margin-right: 0.3em;
-    display: inline-block;
+    display: inline;
     content: "↗";
     transition: all 0.1s ease-in-out;
     font-style: normal;

--- a/src/templates/static.js
+++ b/src/templates/static.js
@@ -160,7 +160,7 @@ const StyledLink = styled.a`
     &:after {
       margin-left: 0.125em;
       margin-right: 0.3em;
-      display: inline-block;
+      display: inline;
       content: "↗";
       transition: all 0.1s ease-in-out;
       font-style: normal;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Changes display attribute of external link style to inline

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes: #980[https://github.com/ethereum/ethereum-org-website/issues/980]
## Screenshots (if appropriate):
