### PR TITLE
Add event tracking to external link clicks

### DIFF
--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -4,8 +4,8 @@ import { Link as IntlLink } from "gatsby-plugin-intl"
 import styled from "styled-components"
 
 import { languageMetadata } from "../utils/translations"
+import { trackCustomEvent } from "../utils/matomo"
 
-// TODO set globally to apply to markdown files
 const ExternalLink = styled.a`
   &:after {
     color: ${(props) => props.theme.colors.primary};
@@ -38,6 +38,13 @@ const Link = ({
 }) => {
   const isExternal = to.includes("http") || to.includes("mailto:")
 
+  const eventOptions = {
+    eventCategory: `External link`,
+    eventAction: `Clicked`,
+    eventName: `url`,
+    eventValue: to,
+  }
+
   if (isExternal) {
     return hideArrow ? (
       <a
@@ -45,6 +52,7 @@ const Link = ({
         href={to}
         target="_blank"
         rel="noopener noreferrer"
+        onClick={() => trackCustomEvent(eventOptions)}
       >
         {children}
       </a>
@@ -54,6 +62,7 @@ const Link = ({
         href={to}
         target="_blank"
         rel="noopener noreferrer"
+        onClick={() => trackCustomEvent(eventOptions)}
       >
         {children}
       </ExternalLink>

--- a/src/utils/matomo.js
+++ b/src/utils/matomo.js
@@ -1,0 +1,20 @@
+export const trackCustomEvent = ({
+  eventCategory,
+  eventAction,
+  eventName,
+  eventValue,
+}) => {
+  if (process.env.NODE_ENV === "production" || window.dev === true) {
+    if (!window._paq) return
+
+    const { _paq, dev } = window
+
+    _paq.push([`trackEvent`, eventCategory, eventAction, eventName, eventValue])
+
+    if (dev) {
+      console.debug(
+        `[Matomo] event tracked, category: ${eventCategory}, action: ${eventAction}, name: ${eventName}, value: ${eventValue}`
+      )
+    }
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Noticed certain outlinks are not being tracked correctly (e.g. Exchange clicks on /get-eth/), likely because those links aren't rendered on page load.
- Adds function for custom events & add to external link clicks

## Related Issue
None