### PR TITLE
Add Epirus to Ethereum for Enterprise and Developer Resources pages

### DIFF
--- a/src/content/developers/index.md
+++ b/src/content/developers/index.md
@@ -105,6 +105,12 @@ Ethereum has a large and growing number of tools to help developers build, test,
 - [Documentation](https://embark.status.im/docs/)
 - [GitHub](https://github.com/embark-framework/embark)
 
+**Epirus -** **_A platform for developing, deploying and monitoring blockchain applications on the JVM_**
+
+- [Homepage](https://www.web3lab.com/epirus)
+- [Documentation](https://docs.epirus.io)
+- [GitHub](https://github.com/epirus-io/epirus-cli)
+
 **Waffle -** **_A framework for advanced smart contract development and testing (based on ethers.js)._**
 
 - [getwaffle.io](https://getwaffle.io/)
@@ -160,7 +166,6 @@ Ethereum has a large and growing number of tools to help developers build, test,
 
 **web3j -** **_A Java/Android/Kotlin/Scala integration library for Ethereum._**
 
-- [web3j.io](https://web3j.io)
 - [GitHub](https://github.com/web3j/web3j)
 - [Docs](https://docs.web3j.io/)
 - [Gitter](https://gitter.im/web3j/web3j)

--- a/src/content/developers/index.md
+++ b/src/content/developers/index.md
@@ -107,7 +107,7 @@ Ethereum has a large and growing number of tools to help developers build, test,
 
 **Epirus -** **_A platform for developing, deploying and monitoring blockchain applications on the JVM_**
 
-- [Homepage](https://www.web3lab.com/epirus)
+- [Homepage](https://www.web3labs.com/epirus)
 - [Documentation](https://docs.epirus.io)
 - [GitHub](https://github.com/epirus-io/epirus-cli)
 

--- a/src/content/enterprise/index.md
+++ b/src/content/enterprise/index.md
@@ -136,6 +136,7 @@ Public and private Ethereum networks might need specific features required by ne
 ### Tooling {#tooling}
 
 - [Alethio](https://aleth.io/) _Ethereum Data Analytics Platform_
+- [Epirus](https://www.web3labs.com/epirus) _A platform for developing, deploying and monitoring blockchain applications by Web3 Labs_
 - [Tenderly](https://tenderly.co/) _A Data Platform providing real-time analytics, alerting and monitoring with support for private networks._
 - [Treum](https://treum.io/) _bringing transparency, traceability, and tradability to supply chains, using blockchain technology_
 - [Truffle Suite](https://trufflesuite.com) _blockchain development suite (Truffle, Ganache, Drizzle)_
@@ -151,3 +152,4 @@ Public and private Ethereum networks might need specific features required by ne
 - [PegaSys Twitter](https://twitter.com/PegaSysEng)
 - [Quorum Slack channel](http://bit.ly/quorum-slack)
 - [Chainstack Gitter](https://gitter.im/chainstack/Lobby)
+- [Web3 Labs Discourse](https://community.web3labs.com)


### PR DESCRIPTION
## Description

This is a small change that adds references to the Epirus Platform by Web3 Labs to the Enterprise and Developer Resources page.

Epirus enhances the developer experience by simplifying the project creation and deployment process to live networks with Web3j. It also provides a widely used and battle tested blockchain expolorer.

## Related Issue

#1294 

## Screenshots (if appropriate):

N/A