### PR TITLE
Fix wrong link to site translation discord

### DIFF
--- a/src/pages/languages.js
+++ b/src/pages/languages.js
@@ -158,7 +158,7 @@ const LanguagesPage = () => {
         </ol>
         <p>
           <Translation id="page-translations-program-question" />{" "}
-          <Link to="https://crowdin.com/project/ethereumfoundation/fil#">
+          <Link to="https://discord.gg/MdCRwD">
             <Translation id="page-translations-program-discord" />
           </Link>{" "}
           <Translation id="page-translations-program-channel" />.

--- a/src/pages/languages.js
+++ b/src/pages/languages.js
@@ -158,7 +158,7 @@ const LanguagesPage = () => {
         </ol>
         <p>
           <Translation id="page-translations-program-question" />{" "}
-          <Link to="https://discord.gg/MdCRwD">
+          <Link to="https://discord.gg/6WX7E97">
             <Translation id="page-translations-program-discord" />
           </Link>{" "}
           <Translation id="page-translations-program-channel" />.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The link to our translation discord was mistakenly a link to the fillipino translation page on Crowdin. This PR inserts the correct link instead. 

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Screenshots (if appropriate):
