### PR TITLE
Adding EDCON2020 to upcoming events

### DIFF
--- a/src/content/community/index.md
+++ b/src/content/community/index.md
@@ -42,6 +42,7 @@ Hundreds of thousands of Ethereum enthusiasts gather in these online forums to s
 - [SFBW Hackathon](https://gitcoin.co/hackathon/unitize/onboard) (Gitcoin) - _Virtual Hackathon_ (July 6-July 27 2020)
 - [Arweave Open Web Incubator](https://gitcoin.co/hackathon/hackathon:27/onboard) (Gitcoin, Arweave) - _Virtual Hackathon_ (July 1-August 12 2020)
 - [HackFS](https://hackfs.com/) (ETHGlobal & Protocol Labs) - _Virtual Hackathon_ (July 6-August 6 2020)
+- [EDCON2020](https://edcon.io/) (EDCON) - _Virtual Developer Conference_ (August 9-11, 2020)
 - [ETHOnline](https://www.ethonline.org/) (ETHGlobal) - _Virtual Summit and Hackathon_ (October 2-30, 2020)
 
 _Have an event to add to this list? [Add it](https://github.com/ethereum/ethereum-org-website#how-can-i-contribute)!_


### PR DESCRIPTION
## Description

I added the upcoming EDCON2020 event to the "Upcoming Events" section on the Community page.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Screenshots (if appropriate):
