### PR TITLE
Adding link to Alchemy's documentation for developer resources

### DIFF
--- a/src/content/developers/index.md
+++ b/src/content/developers/index.md
@@ -240,6 +240,7 @@ Ethereum has a large and growing number of tools to help developers build, test,
 **Alchemy -** **_Ethereum API and developer tools._**
 
 - [alchemyapi.io](https://alchemyapi.io)
+- [Documentation](https://docs.alchemyapi.io/)
 - [GitHub](https://github.com/alchemyplatform)
 
 **Infura -** **_The Ethereum API as a service._**


### PR DESCRIPTION


## Description

Added a link to Alchemy's documentation. 

## Related Issue

  ##https://github.com/ethereum/ethereum-org-website/issues/1306
