### PR TITLE
Prevent Nav overlap on Page [Fixes #1299]

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -26,7 +26,7 @@ const Page = styled.div`
   align-items: center;
 
   width: 100%;
-  margin: 0 auto;
+  margin: 4rem auto 0;
 `
 
 const Content = styled.div`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add margin to Page to prevent Nav from overlapping hero image.
<!--- Describe your changes in detail -->

## Related Issue
#1299
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
