### PR TITLE
Fix 404s

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -31,7 +31,7 @@ module.exports = {
         // language file path
         defaultLanguage,
         // redirect to `/en/` when connecting `/`
-        redirect: true,
+        redirect: false,
       },
     },
     // Web app manifest

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -4,14 +4,15 @@ require("dotenv").config()
 
 const supportedLanguages = Object.keys(translations.languageMetadata)
 const defaultLanguage = `en`
+const siteUrl = `https://ethereum.org`
 
 module.exports = {
   siteMetadata: {
     // `title` & `description` pulls from respective ${lang}.json files in PageMetadata.js
     title: `ethereum.org`,
     description: `Ethereum is a global, decentralized platform for money and new kinds of applications. On Ethereum, you can write code that controls money, and build applications accessible anywhere in the world.`,
-    url: "https://ethereum.org",
-    siteUrl: "https://ethereum.org",
+    url: siteUrl,
+    siteUrl,
     author: `@ethereum`,
     defaultLanguage,
     supportedLanguages,
@@ -53,7 +54,7 @@ module.exports = {
       options: {
         siteId: "4",
         matomoUrl: "https://matomo.ethereum.org",
-        siteUrl: "https://ethereum.org",
+        siteUrl,
         matomoPhpScript: "matomo.php",
         matomoJsScript: "matomo.js",
         trackLoad: false,
@@ -132,6 +133,12 @@ module.exports = {
     },
     // SEO tags
     `gatsby-plugin-react-helmet`,
+    {
+      resolve: `gatsby-plugin-react-helmet-canonical-urls`,
+      options: {
+        siteUrl,
+      },
+    },
     // Needed for `gatsby-image`
     `gatsby-plugin-sharp`,
     // CSS in JS

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -103,7 +103,7 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
           messages: getMessages("./src/intl/", node.frontmatter.lang),
           routed: true,
           originalPath: slug.substr(3),
-          redirect: true,
+          redirect: false,
         },
       },
     })
@@ -127,7 +127,7 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
           messages: getMessages("./src/intl/", "en"),
           routed: true,
           originalPath: `/en/${page}/`,
-          redirect: true,
+          redirect: false,
         },
       },
     })

--- a/netlify.toml
+++ b/netlify.toml
@@ -118,6 +118,7 @@
   to = "/sk/dapps/"
 
 # English path redirects
+# Force because the files exist (root paths still resolve to English)
 [[redirects]]
   from = "/"
   to = "/en/"
@@ -125,78 +126,103 @@
 [[redirects]]
   from = "/what-is-ethereum/"
   to = "/en/what-is-ethereum/"
+  force = true
 [[redirects]]
   from = "/eth/"
   to = "/en/eth/"
+  force = true
 [[redirects]]
   from = "/dapps/"
   to = "/en/dapps/"
+  force = true
 [[redirects]]
   from = "/wallets/"
   to = "/en/wallets/"
+  force = true
 [[redirects]]
   from = "/learn/"
   to = "/en/learn/"
+  force = true
 [[redirects]]
   from = "/community/"
   to = "/en/community/"
+  force = true
 [[redirects]]
   from = "/build/"
   to = "/en/build/"
+  force = true
 [[redirects]]
   from = "/developers/"
   to = "/en/developers/"
+  force = true
 [[redirects]]
   from = "/enterprise/"
   to = "/en/enterprise/"
+  force = true
 [[redirects]]
   from = "/whitepaper/"
   to = "/en/whitepaper/"
+  force = true
 [[redirects]]
   from = "/foundation/"
   to = "/en/foundation/"
+  force = true
 [[redirects]]
   from = "/eips/"
   to = "/en/eips/"
+  force = true
 [[redirects]]
   from = "/about/"
   to = "/en/about/"
+  force = true
 [[redirects]]
   from = "/privacy-policy/"
   to = "/en/privacy-policy/"
+  force = true
 [[redirects]]
   from = "/terms-of-use/"
   to = "/en/terms-of-use/"
+  force = true
 [[redirects]]
   from = "/cookie-policy/"
   to = "/en/cookie-policy/"
+  force = true
 [[redirects]]
   from = "/languages/"
   to = "/en/languages/"
+  force = true
 [[redirects]]
   from = "/enterprise/"
   to = "/en/enterprise/"
+  force = true
 [[redirects]]
   from = "/java/"
   to = "/en/java/"
+  force = true
 [[redirects]]
   from = "/python/"
   to = "/en/python/"
+  force = true
 [[redirects]]
   from = "/javascript/"
   to = "/en/javascript/"
+  force = true
 [[redirects]]
   from = "/golang/"
   to = "/en/golang/"
+  force = true
 [[redirects]]
   from = "/rust/"
   to = "/en/rust/"
+  force = true
 [[redirects]]
   from = "/dot-net/"
   to = "/en/dot-net/"
+  force = true
 [[redirects]]
   from = "/delphi/"
   to = "/en/delphi/"
+  force = true
 
 # Norwegian update
 ## All translations

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "gatsby-plugin-matomo": "^0.8.3",
     "gatsby-plugin-mdx": "^1.2.15",
     "gatsby-plugin-react-helmet": "^3.3.4",
+    "gatsby-plugin-react-helmet-canonical-urls": "^1.4.0",
     "gatsby-plugin-sharp": "^2.6.11",
     "gatsby-plugin-sitemap": "^2.4.7",
     "gatsby-plugin-styled-components": "^3.3.3",

--- a/src/components/PageMetadata.js
+++ b/src/components/PageMetadata.js
@@ -3,8 +3,11 @@ import PropTypes from "prop-types"
 import { Helmet } from "react-helmet"
 import { useStaticQuery, graphql } from "gatsby"
 import { useIntl } from "gatsby-plugin-intl"
+import { Location } from "@reach/router"
 
-import { getDefaultMessage } from "../utils/translations"
+import { getDefaultMessage, languageMetadata } from "../utils/translations"
+
+const supportedLanguages = Object.keys(languageMetadata)
 
 const PageMetadata = ({ description, meta, title, image }) => {
   const { site, ogImageDefault } = useStaticQuery(
@@ -46,75 +49,90 @@ const PageMetadata = ({ description, meta, title, image }) => {
     : site.siteMetadata.url.concat(ogImageDefault.childImageSharp.fixed.src)
 
   return (
-    <Helmet
-      htmlAttributes={{ lang: intl.locale }}
-      title={title}
-      titleTemplate={`%s | ${siteTitle}`}
-      meta={[
+    <Location>
+      {({ location }) => {
         {
-          name: `description`,
-          content: desc,
-        },
-        {
-          name: `image`,
-          content: site.siteMetadata.image,
-        },
-        {
-          property: `og:title`,
-          content: `${title} | ${siteTitle}`,
-        },
-        {
-          property: `og:description`,
-          content: desc,
-        },
-        {
-          property: `og:type`,
-          content: `website`,
-        },
-        {
-          name: `twitter:card`,
-          content: `summary_large_image`,
-        },
-        {
-          name: `twitter:creator`,
-          content: site.siteMetadata.author,
-        },
-        {
-          name: `twitter:site`,
-          content: site.siteMetadata.author,
-        },
-        {
-          name: `twitter:title`,
-          content: `${title} | ${siteTitle}`,
-        },
-        {
-          name: `twitter:description`,
-          content: desc,
-        },
-        {
-          name: `twitter:image`,
-          content: ogImage,
-        },
-        {
-          property: `og:url`,
-          content: site.siteMetadata.url,
-        },
-        {
-          property: `og:image`,
-          content: ogImage,
-        },
-        {
-          property: `og:video`,
-          content: `https://www.youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g`,
-        },
-        {
-          property: `og:site_name`,
-          content: `ethereum.org`,
-        },
-      ].concat(meta)}
-    >
-      <script type="application/ld+json">
-        {`
+          /* Set canonocial URL w/ language path to avoid duplicate content */
+          /* e.g. set ethereum.org/about/ to ethereum.org/en/about/ */
+        }
+        const { pathname } = location
+        let canonicalPath = pathname
+        const firstDirectory = canonicalPath.split("/")[1]
+        if (!supportedLanguages.includes(firstDirectory)) {
+          canonicalPath = `/en${pathname}`
+        }
+        const canonical = `${site.siteMetadata.url}${canonicalPath}`
+        return (
+          <Helmet
+            htmlAttributes={{ lang: intl.locale }}
+            title={title}
+            titleTemplate={`%s | ${siteTitle}`}
+            link={[{ rel: "canonical", key: canonical, href: canonical }]}
+            meta={[
+              {
+                name: `description`,
+                content: desc,
+              },
+              {
+                name: `image`,
+                content: site.siteMetadata.image,
+              },
+              {
+                property: `og:title`,
+                content: `${title} | ${siteTitle}`,
+              },
+              {
+                property: `og:description`,
+                content: desc,
+              },
+              {
+                property: `og:type`,
+                content: `website`,
+              },
+              {
+                name: `twitter:card`,
+                content: `summary_large_image`,
+              },
+              {
+                name: `twitter:creator`,
+                content: site.siteMetadata.author,
+              },
+              {
+                name: `twitter:site`,
+                content: site.siteMetadata.author,
+              },
+              {
+                name: `twitter:title`,
+                content: `${title} | ${siteTitle}`,
+              },
+              {
+                name: `twitter:description`,
+                content: desc,
+              },
+              {
+                name: `twitter:image`,
+                content: ogImage,
+              },
+              {
+                property: `og:url`,
+                content: site.siteMetadata.url,
+              },
+              {
+                property: `og:image`,
+                content: ogImage,
+              },
+              {
+                property: `og:video`,
+                content: `https://www.youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g`,
+              },
+              {
+                property: `og:site_name`,
+                content: `ethereum.org`,
+              },
+            ].concat(meta)}
+          >
+            <script type="application/ld+json">
+              {`
         {
           "@context": "https://schema.org",
           "@type": "Organization",
@@ -124,8 +142,11 @@ const PageMetadata = ({ description, meta, title, image }) => {
           "logo": "https://ethereum.org/og-image.png"
         }
       `}
-      </script>
-    </Helmet>
+            </script>
+          </Helmet>
+        )
+      }}
+    </Location>
   )
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1181,7 +1181,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.3.1", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4":
   version "7.11.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
   integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
@@ -7003,6 +7003,13 @@ gatsby-plugin-page-creator@^2.3.22:
     graphql "^14.6.0"
     lodash "^4.17.15"
     slugify "^1.4.4"
+
+gatsby-plugin-react-helmet-canonical-urls@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-react-helmet-canonical-urls/-/gatsby-plugin-react-helmet-canonical-urls-1.4.0.tgz#9a0f3a6e75b0ff54c6a8e70c2bc48219903a8296"
+  integrity sha512-5g2eqFNh8GSCTvL25sNm84IJ6G79qKHSnOa9druxBj6x5Iw3EujZMv6I4nGMlW5EZlaSf9D5QHNGypUW6idPTg==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
 
 gatsby-plugin-react-helmet@^3.3.4:
   version "3.3.10"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Our internationalization plugin was [redirecting traffic based on the user's browser preference](https://github.com/wiziple/gatsby-plugin-intl#how-it-works). This led to issues of redirecting users to pages that did not exist (e.g. someone with browser language set to Spanish landing on ethereum.org/get-eth/ was being redirected to ethereum.org/es/get-eth/, which does not exist).

To fix this I removed the redirect functionality of the plugin. This resulted in both the base paths & English paths resolving as English (e.g. both https://ethereum.org/get-eth/ & https://ethereum.org/en/get-eth/), which creates a duplicate content issue. To resolve this, I added a [canonical tag](https://support.google.com/webmasters/answer/139066?hl=en) to every page, specifying the appropriate language path (e.g. so the canonical tag on https://ethereum.org/get-eth/ is set to https://ethereum.org/en/get-eth/).

<!--- Describe your changes in detail -->

## Related Issue
#1347

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
