### PR TITLE
Add Rivet to Developer Resources under Backend APIs [Fixes #1419]

### DIFF
--- a/src/content/developers/index.md
+++ b/src/content/developers/index.md
@@ -242,6 +242,12 @@ Ethereum has a large and growing number of tools to help developers build, test,
 
 ## Backend APIs {#backend-apis}
 
+**Rivet -** **_Ethereum and Ethereum Classic APIs as a service—powered by open source software._**
+
+- [rivet.cloud](https://rivet.cloud)
+- [Documentation](https://rivet.cloud/docs/)
+- [GitHub](https://github.com/openrelayxyz/ethercattle-deployment)
+
 **Alchemy -** **_Ethereum API and developer tools._**
 
 - [alchemyapi.io](https://alchemyapi.io)

--- a/src/content/developers/index.md
+++ b/src/content/developers/index.md
@@ -242,7 +242,7 @@ Ethereum has a large and growing number of tools to help developers build, test,
 
 ## Backend APIs {#backend-apis}
 
-**Rivet -** **_Ethereum and Ethereum Classic APIs as a service—powered by open source software._**
+**Rivet -** **_Ethereum and Ethereum Classic APIs as a service powered by open source software._**
 
 - [rivet.cloud](https://rivet.cloud)
 - [Documentation](https://rivet.cloud/docs/)


### PR DESCRIPTION
## Description

[Rivet](https://rivet.cloud) offers a backend API that supports Ethereum mainnet, the Goerli, Rinkeby, and Ropsten testnets, and Ethereum Classic's mainnet. The service includes 500k free requests/month and pay-as-you-go service at a flat rate of $1/100,000 requests after that. It will also soon allow developers to purchase request capacity with ETH and DAI.

This PR adds [Rivet](https://rivet.cloud) to the **Backend APIs** section of the [Developer Resources page](https://ethereum.org/en/developers/), along with links to Rivet's [Documentation](https://rivet.cloud/docs/) and the [Github repository for the open source code that powers Rivet](https://github.com/openrelayxyz/ethercattle-deployment).

## Related Issue

The related issue can be found here: [Issue #1419](https://github.com/ethereum/ethereum-org-website/issues/1419).
