### PR TITLE
Update solidity example

### DIFF
--- a/src/content/developers/docs/smart-contracts/languages/index.md
+++ b/src/content/developers/docs/smart-contracts/languages/index.md
@@ -43,31 +43,37 @@ You'll need to know some JavaScript or Python to make sense of differences in sm
 ### Example contract
 
 ```solidity
-pragma solidity ^0.4.21;
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >= 0.7.0;
 
 contract Coin {
-    // The keyword "public" makes those variables
-    // readable from outside.
+    // The keyword "public" makes variables
+    // accessible from other contracts
     address public minter;
     mapping (address => uint) public balances;
 
-    // Events allow light clients to react on
-    // changes efficiently.
+    // Events allow clients to react to specific
+    // contract changes you declare
     event Sent(address from, address to, uint amount);
 
-    // This is the constructor whose code is
-    // run only when the contract is created.
-    function Coin() public {
+    // Constructor code is only run when the contract
+    // is created
+    constructor() {
         minter = msg.sender;
     }
 
+    // Sends an amount of newly created coins to an address
+    // Can only be called by the contract creator
     function mint(address receiver, uint amount) public {
-        if (msg.sender != minter) return;
+        require(msg.sender == minter);
+        require(amount < 1e60);
         balances[receiver] += amount;
     }
 
+    // Sends an amount of existing coins
+    // from any caller to an address
     function send(address receiver, uint amount) public {
-        if (balances[msg.sender] < amount) return;
+        require(amount <= balances[msg.sender], "Insufficient balance.");
         balances[msg.sender] -= amount;
         balances[receiver] += amount;
         emit Sent(msg.sender, receiver, amount);


### PR DESCRIPTION
## Description

Updated the example since the older one uses syntax that is deprecated. The example is the same as the one here https://solidity.readthedocs.io/en/v0.7.1/introduction-to-smart-contracts.html#subcurrency-example

<!--- Describe your changes in detail -->
