### PR TITLE
Add read-only GH token [Fixes #1472]

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -6,6 +6,8 @@ const supportedLanguages = translations.supportedLanguages
 const defaultLanguage = `en`
 const siteUrl = `https://ethereum.org`
 
+const READ_ONLY_GITHUB_TOKEN = `b809cbd0bd021c349291f0425871ea981a2e290f`
+
 module.exports = {
   siteMetadata: {
     // `title` & `description` pulls from respective ${lang}.json files in PageMetadata.js
@@ -198,7 +200,7 @@ module.exports = {
         fieldName: `github`,
         url: `https://api.github.com/graphql`,
         headers: {
-          Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+          Authorization: `Bearer ${READ_ONLY_GITHUB_TOKEN}`,
         },
       },
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Hard-coded Github OAuth token (with [no scope](https://docs.github.com/en/developers/apps/scopes-for-oauth-apps#available-scopes)) for read-only uses. This prevents the project from failing when contributors run it locally or Netlify builds when they submit PRs.

## Related Issue
#1472
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
