### PR TITLE
Add fallback redirect to /en/ [Fixes #1374]

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -256,6 +256,14 @@
   from = "/en/delphi/"
   to = "/en/developers/docs/programming-languages/delphi/"
 
+
+# English fallback redirect
+# If no page exists at /request-url, redirect to /en/request-url
+[[redirects]]
+  from = "/*"
+  to = "/en/:splat"
+  force = false
+
 # A redirect rule with all the supported properties
 # [[redirects]]
 #   from = "/old-path"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Redirect request URLs to add the English directory (`/en/`) if the requested URL doesn't exist.

## Related Issue
#1374
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
