### PR TITLE
Remove gatsby-plugin-catch-links

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -21,9 +21,6 @@ module.exports = {
     editContentUrl: `https://github.com/ethereum/ethereum-org-website/tree/dev/`,
   },
   plugins: [
-    // Replace markdown links w/ Gatsby <Link/>
-    // This avoids page refreshes
-    `gatsby-plugin-catch-links`,
     // i18n support
     {
       resolve: `gatsby-plugin-intl`,

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "framer-motion": "^1.11.1",
     "gatsby": "^2.23.1",
     "gatsby-image": "^2.4.7",
-    "gatsby-plugin-catch-links": "^2.3.7",
     "gatsby-plugin-intl": "^0.3.3",
     "gatsby-plugin-lodash": "^3.3.11",
     "gatsby-plugin-manifest": "^2.4.13",

--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -214,17 +214,17 @@ const BackToTop = styled.div`
   }
 `
 
-// Passing components to MDXProvider allows
-// component use across all .md/.mdx files
+// Passing components to MDXProvider allows use across all .md/.mdx files
+// https://www.gatsbyjs.com/plugins/gatsby-plugin-mdx/#mdxprovider
 const components = {
-  p: P,
+  a: Link,
   h1: H1,
   h2: H2,
   h3: H3,
   h4: H4,
   h5: H5,
+  p: P,
   pre: Codeblock,
-  a: Link,
   table: MarkdownTable,
   Button,
   InfoBanner,

--- a/src/templates/static.js
+++ b/src/templates/static.js
@@ -186,17 +186,17 @@ const Pre = styled.pre`
   white-space: pre-wrap;
 `
 
-// Passing components to MDXProvider allows
-// component use across all .md/.mdx files
+// Passing components to MDXProvider allows use across all .md/.mdx files
+// https://www.gatsbyjs.com/plugins/gatsby-plugin-mdx/#mdxprovider
 const components = {
-  p: P,
+  a: Link,
   h1: H1,
   h2: H2,
   h3: H3,
   h4: H4,
   h5: H5,
+  p: P,
   pre: Pre,
-  a: Link,
   table: MarkdownTable,
   MeetupList,
   RandomAppList,

--- a/src/templates/tutorial.js
+++ b/src/templates/tutorial.js
@@ -203,17 +203,17 @@ const H5 = styled.h5`
   ${Mixins.textLevel5}
 `
 
-// Passing components to MDXProvider allows
-// component use across all .md/.mdx files
+// Passing components to MDXProvider allows use across all .md/.mdx files
+// https://www.gatsbyjs.com/plugins/gatsby-plugin-mdx/#mdxprovider
 const components = {
-  p: P,
+  a: Link,
   h1: H1,
   h2: H2,
   h3: H3,
   h4: H4,
   h5: H5,
+  p: P,
   pre: Codeblock,
-  a: Link,
   table: MarkdownTable,
   Button,
   InfoBanner,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7117,14 +7117,6 @@ gatsby-page-utils@^0.2.20:
     lodash "^4.17.15"
     micromatch "^3.1.10"
 
-gatsby-plugin-catch-links@^2.3.7:
-  version "2.3.11"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-catch-links/-/gatsby-plugin-catch-links-2.3.11.tgz#6a61a126a2ffcc3b155a1647123eb069a0b9e5d6"
-  integrity sha512-30oNCe85evOmyEQ4THwfV0Uokv0GVQv+VpR6ztabLDF78J3p3yFQNQhtcyXPjHrLU2EeuWutSZYk3v1etdh9Hw==
-  dependencies:
-    "@babel/runtime" "^7.10.3"
-    escape-string-regexp "^1.0.5"
-
 gatsby-plugin-intl@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-intl/-/gatsby-plugin-intl-0.3.3.tgz#3a0e55e6641bfcb09fae20215b8f72e2a0ec3de4"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This plugin is no longer necessary since we replace all `a` tags with our internal `<Link />` component.

## Related Issue
None
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
