### PR TITLE
Display SubNav for contentVersion > 1.1 [Fixes #1543]

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -106,7 +106,7 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
     let template = `static`
     if (slug.includes(`/tutorials/`)) {
       template = `tutorial`
-    } else if (slug.includes(`/developers/`)) {
+    } else if (slug.includes(`/docs/`)) {
       template = `docs`
     }
 

--- a/src/components/Nav/index.js
+++ b/src/components/Nav/index.js
@@ -304,7 +304,7 @@ const Nav = ({ handleThemeChange, isDarkTheme, path }) => {
     setIsMenuOpen(!isMenuOpen)
   }
 
-  const shouldShowSubNav = path.includes("/developers/")
+  const shouldShowSubNav = path.includes("/developers/") && contentVersion > 1.1
 
   return (
     <NavContainer>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Only display the SubNav component if contentVersion of the language is > 1.1

## Related Issue
#1543 
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
