### PR TITLE
Fixed installation instructions in tutorial so it now works in .zsh [Fixes #1526]

### DIFF
--- a/src/content/developers/tutorials/a-developers-guide-to-ethereum-part-one/index.md
+++ b/src/content/developers/tutorials/a-developers-guide-to-ethereum-part-one/index.md
@@ -97,7 +97,7 @@ $ pip install web3
 One more thing – we're going to simulate a blockchain later, which requires a couple more dependencies. You can install those via:
 
 ```bash
-$ pip install web3[tester]
+$ pip install 'web3[tester]'
 ```
 
 You’re all set up to go!


### PR DESCRIPTION
## Description

Quotation marks have been added around the package name in the installation instructions for the `A Python developer's introduction to Ethereum, part 1` tutorial.  This was previously not working in .zsh.

## Related Issue

https://github.com/ethereum/ethereum-org-website/issues/1526
