### PR TITLE
[ERC-20|721] Fixing links and using same pattern for both pages

### DIFF
--- a/src/components/SideNav.js
+++ b/src/components/SideNav.js
@@ -193,6 +193,10 @@ export const links = [
                 title: "ERC-20",
                 to: "/developers/docs/standards/tokens/erc-20/",
               },
+              {
+                title: "ERC-721",
+                to: "/developers/docs/standards/tokens/erc-721/",
+              },
             ],
           },
         ],

--- a/src/content/developers/docs/standards/index.md
+++ b/src/content/developers/docs/standards/index.md
@@ -29,7 +29,7 @@ Certain EIPs relate to application-level standards (e.g. a standard smart-contra
 ### Token standards {#token-standards}
 
 - [ERC20 - A standard interface for tokens](/developers/docs/standards/tokens/erc-20/)
-- [ERC721 - A standard interface for non-fungible tokens](https://eips.ethereum.org/EIPS/eip-721)
+- [ERC721 - A standard interface for non-fungible tokens](/developers/docs/standards/tokens/erc-721/)
 
 Learn more about [token standards](/developers/docs/standards/tokens/).
 

--- a/src/content/developers/docs/standards/tokens/erc-20/index.md
+++ b/src/content/developers/docs/standards/tokens/erc-20/index.md
@@ -40,62 +40,24 @@ will be responsible to keep track of the created tokens on Ethereum.
 
 From [EIP-20](https://eips.ethereum.org/EIPS/eip-20):
 
-#### Methods: {#events}
+#### Methods {#methods}
 
 ```solidity
-# Returns the name of the token - e.g. "MyToken".
 function name() public view returns (string)
-```
-
-```solidity
-# Returns the symbol of the token. E.g. “HIX”.
 function symbol() public view returns (string)
-```
-
-```solidity
-# Returns the number of decimals the token uses - e.g. 8, means to divide the token amount by 100000000 to get its user representation.
 function decimals() public view returns (uint8)
-```
-
-```solidity
-# Returns the total token supply.
 function totalSupply() public view returns (uint256)
-```
-
-```solidity
-# Returns the account balance of another account with address _owner.
 function balanceOf(address _owner) public view returns (uint256 balance)
-```
-
-```solidity
-# Transfers _value amount of tokens to address _to.
 function transfer(address _to, uint256 _value) public returns (bool success)
-```
-
-```solidity
-# Transfers _value amount of tokens from address _from to address _to
 function transferFrom(address _from, address _to, uint256 _value) public returns (bool success)
-```
-
-```solidity
-# Allows _spender to withdraw from your account multiple times, up to the _value amount.
 function approve(address _spender, uint256 _value) public returns (bool success)
-```
-
-```solidity
-# Returns the amount which _spender is still allowed to withdraw from _owner.
 function allowance(address _owner, address _spender) public view returns (uint256 remaining)
 ```
 
-#### Events: {#events}
+#### Events {#events}
 
 ```solidity
-# MUST trigger when tokens are transferred, including zero value transfers.
 event Transfer(address indexed _from, address indexed _to, uint256 _value)
-```
-
-```solidity
-# MUST trigger on any successful call to approve().
 event Approval(address indexed _owner, address indexed _spender, uint256 _value)
 ```
 

--- a/src/content/developers/docs/standards/tokens/erc-721/index.md
+++ b/src/content/developers/docs/standards/tokens/erc-721/index.md
@@ -5,7 +5,7 @@ lang: en
 sidebar: true
 ---
 
-## Introduction
+## Introduction {#introduction}
 
 **What is a Non-Fungible Token?**
 
@@ -24,13 +24,13 @@ Yes! All NFTs have a `uint256` variable called `tokenId`, so for any ERC-721 Con
 `contract address, uint256 tokenId` must be globally unique. Said that a dApp can have a "converter" that
 uses the `tokenId` as input and outputs an image of something cool, like zombies, weapons, skills or amazing kitties!
 
-## Prerequisites
+## Prerequisites {#prerequisites}
 
 - [Accounts](/developers/docs/accounts)
 - [Smart Contracts](/developers/docs/smart-contracts/)
 - [Token standards](/developers/docs/standards/tokens/)
 
-## Body
+## Body {#body}
 
 The ERC-721 (Ethereum Request for Comments 721), proposed by William Entriken, Dieter Shirley, Jacob Evans, 
 Nastassia Sachs in January 2018, is a Non-Fungible Token Standard that implements an API for tokens within Smart Contracts.
@@ -45,7 +45,7 @@ and, once deployed, it will be responsible to keep track of the created tokens o
 
 From [EIP-721](https://eips.ethereum.org/EIPS/eip-721):
 
-#### Methods:
+#### Methods {#methods}
 
 ```solidity
     function balanceOf(address _owner) external view returns (uint256);
@@ -59,7 +59,7 @@ From [EIP-721](https://eips.ethereum.org/EIPS/eip-721):
     function isApprovedForAll(address _owner, address _operator) external view returns (bool);
 ```
 
-#### Events:
+#### Events {#events}
 
 ```solidity
     event Transfer(address indexed _from, address indexed _to, uint256 indexed _tokenId);
@@ -67,13 +67,13 @@ From [EIP-721](https://eips.ethereum.org/EIPS/eip-721):
     event ApprovalForAll(address indexed _owner, address indexed _operator, bool _approved);
 ```
 
-### Examples
+### Examples {#web3py-example}
 
 Let's see how a Standard is so important to make things simple for us to inspect any ERC-721 Token Contract on Ethereum.
 We just need the Contract Application Binary Interface (ABI) to create an interface to any ERC-721 Token. As you can
 see below we will use a simplified ABI, to make it a low friction example.
 
-#### Web3.py Example
+#### Web3.py Example {#web3py-example}
 
 First, make sure you have installed [Web3.py](https://web3py.readthedocs.io/en/stable/quickstart.html#installation) Python library:
 
@@ -240,7 +240,7 @@ birth_logs = w3.eth.getLogs({
 recent_births = [get_event_data(ck_extra_events_abi[1], log)["args"] for log in birth_logs]
 ```
 
-## Popular NFTs:
+## Popular NFTs {#popular-nfts}
 
 - [Etherscan NFT Tracker](https://etherscan.io/tokens-nft) list the top NFT on Ethereum by tranfers volume.
 - [CryptoKitties](https://www.cryptokitties.co/) is a game centered around breedable, collectible, and oh-so-adorable 
@@ -255,13 +255,13 @@ censorship-resistant websites.
 - [Gods Unchained Cards](https://godsunchained.com/) is a TCG on the Ethereum blockchain that uses NFT's to bring real ownership 
 to in-game assets.
 
-## Further reading
+## Further reading {#further-reading}
 
 - [EIP-721: ERC-721 Non-Fungible Token Standard](https://eips.ethereum.org/EIPS/eip-721)
 - [OpenZeppelin - ERC-721 Docs](https://docs.openzeppelin.com/contracts/3.x/erc721)
 - [OpenZeppelin - ERC-721 Implementation](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC721/ERC721.sol)
 
-## Related topics
+## Related topics {#related-topics}
 
 - [ERC-20](/developers/docs/standards/tokens/erc-20/)
 - [ERC-777](/developers/docs/standards/tokens/erc-777/)

--- a/src/content/developers/docs/standards/tokens/index.md
+++ b/src/content/developers/docs/standards/tokens/index.md
@@ -20,7 +20,7 @@ One of the many Ethereum development standards focus on token interfaces. These 
 Here are some of the most popular token standards on Ethereum:
 
 - [ERC20 - A standard interface for tokens](/developers/docs/standards/tokens/erc-20/)
-- [ERC721 - A standard interface for non-fungible tokens](https://eips.ethereum.org/EIPS/eip-721)
+- [ERC721 - A standard interface for non-fungible tokens](/developers/docs/standards/tokens/erc-721/)
 
 ## Further reading {#further-reading}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Fixing links to the `ERC-721` page and also using the same pattern of the `ERC-20`.
@samajammin the `ERC-721` page is still not a left menu item, does this PR fix that (the proper links on the "parent" pages)?

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
