### PR TITLE
fixed typo?

### DIFF
--- a/src/content/whitepaper/index.md
+++ b/src/content/whitepaper/index.md
@@ -1077,7 +1077,7 @@ will get the funds out eventually. If Bob turns out to be malicious,
 then she can turn off his ability to withdraw.
 
 **2. Crop insurance**. One can easily make a financial derivatives
-contract but using a data feed of the weather instead of any price
+contract by using a data feed of the weather instead of any price
 index. If a farmer in Iowa purchases a derivative that pays out
 inversely based on the precipitation in Iowa, then if there is a
 drought, the farmer will automatically receive money and if there is


### PR DESCRIPTION
Hello,

I think there is a typo under Further Applications section of the white paper:

_2. Crop insurance. One can easily make a financial derivatives
contract **but**  using a data feed of the weather instead of any price
index. If a farmer in Iowa purchases a derivative that pays out_

should be **by**

