### PR TITLE
Mobile nav bar layout adjustment [Fixes #1605]

### DIFF
--- a/src/components/Nav/Mobile.js
+++ b/src/components/Nav/Mobile.js
@@ -66,8 +66,8 @@ const CloseIconContainer = styled.span`
   z-index: 102;
   position: absolute;
   cursor: pointer;
-  top: 1rem;
-  right: 1rem;
+  top: 1.5rem;
+  right: 1.5rem;
 
   & > svg {
     fill: ${(props) => props.theme.colors.text};

--- a/src/components/Nav/index.js
+++ b/src/components/Nav/index.js
@@ -22,7 +22,7 @@ const NavContainer = styled.div`
 `
 
 const StyledNav = styled.nav`
-  padding: 1rem 2rem;
+  padding: 1rem 1.5rem;
   box-sizing: border-box;
   display: flex;
   justify-content: center;
@@ -48,6 +48,7 @@ const NavContent = styled.div`
   max-width: ${(props) => props.theme.breakpoints.xl};
   @media (max-width: ${(props) => props.theme.breakpoints.l}) {
     justify-content: space-between;
+    align-items: center;
   }
 `
 const NavMobileButton = styled.span`
@@ -110,6 +111,7 @@ const RightNavLink = styled(NavLink)`
 `
 
 const HomeLogo = styled(Img)`
+  vertical-align: bottom;
   opacity: 0.85;
   &:hover {
     opacity: 1;


### PR DESCRIPTION
## Description
Fixes layout of hamburger menu icon and Ethereum wire logo to lay vertically centered along the same horizontal axis as one another. 'X' close button on menu adjusted to align with hamburger icon for improved UX on mobile.
### src/components/Nav/index.js
- Adjusted horizontal padding of `StyledNav` from `2rem` to `1.5rem`, which lays the hamburger menu with an even distribution between top/right/bottom container edges. 
- Added `align-items: center` to styling of `NavContent`, correcting vertical alignment of hamburger icon, and the `Link` component containing `HomeLogo` (note: `Link` is now centered vertically within `NavContent` but this leaves a small gap below the `HomeLogo` image component it holds due to default inline styling, corrected next).
- Added `vertical-align: bottom` to styling of `HomeLogo` to prevent inline styling from adding slight spacing below logo image.
### src/components/Nav/Mobile.js
- Adjusted `top` and `right` styling of `CloseIconContainer ` from `1rem` each to `1.5rem` each allowing alignment with the hamburger menu icon on mobile sized devices. (See #1605 for screenshots)

## Related Issue #1605 