### PR TITLE
change json-rpc to be the correct external link

### DIFF
--- a/src/content/developers/docs/transactions/index.md
+++ b/src/content/developers/docs/transactions/index.md
@@ -51,7 +51,7 @@ But a transaction object needs to be signed using the sender's private key. This
 
 An Ethereum client like Geth will handle this signing process.
 
-Example [JSON-RPC](/https://eth.wiki/json-rpc/API) call:
+Example [JSON-RPC](https://eth.wiki/json-rpc/API) call:
 
 ```json
 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In the transactions page, the external link to external json-rpc document is incorrect. The rendered URL is '/https://eth.wiki/json-rpc/API' which navigates users to Page Not Found.

<!--- Describe your changes in detail -->
Remove leading typo '/' in the url


## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
