### PR TITLE
Add canonical tag to tutorials that have sourceUrl

### DIFF
--- a/src/components/PageMetadata.js
+++ b/src/components/PageMetadata.js
@@ -9,7 +9,7 @@ import { getDefaultMessage, languageMetadata } from "../utils/translations"
 
 const supportedLanguages = Object.keys(languageMetadata)
 
-const PageMetadata = ({ description, meta, title, image }) => {
+const PageMetadata = ({ description, meta, title, image, canonicalUrl }) => {
   const { site, ogImageDefault, ogImageDevelopers } = useStaticQuery(
     graphql`
       query {
@@ -64,7 +64,8 @@ const PageMetadata = ({ description, meta, title, image }) => {
         if (!supportedLanguages.includes(firstDirectory)) {
           canonicalPath = `/en${pathname}`
         }
-        const canonical = `${site.siteMetadata.url}${canonicalPath}`
+        const canonical =
+          canonicalUrl || `${site.siteMetadata.url}${canonicalPath}`
 
         {
           /* Set fallback ogImage based on path */

--- a/src/content/developers/tutorials/write-hello-world-contract/index.md
+++ b/src/content/developers/tutorials/write-hello-world-contract/index.md
@@ -2,8 +2,6 @@
 title: Write a "hello world" smart contract
 description: A beginners tutorial for deploying a smart contract using Ethereum studio
 author: ethereum.org
-source: Ethereum Studio
-sourceUrl: https://studio.ethereum.org/
 tags: ["smart contracts", "solidity", "ethereum studio"]
 skill: beginner
 lang: en

--- a/src/templates/tutorial.js
+++ b/src/templates/tutorial.js
@@ -178,6 +178,7 @@ const TutorialPage = ({ data, pageContext }) => {
       <PageMetadata
         title={pageData.frontmatter.title}
         description={pageData.frontmatter.description}
+        canonicalUrl={pageData.frontmatter.sourceUrl}
       />
       <ContentContainer>
         <H1>{pageData.frontmatter.title}</H1>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This update should eliminate any negative SEO consequences of hosting community tutorials on ethereum.org.

If a tutorial contains a `sourceUrl` frontmatter field (meaning it was originally published on a different site), we set the canonical tag to the `sourceUrl`.

More on canonical tags & duplicate content:
- https://moz.com/learn/seo/canonicalization
- https://support.google.com/webmasters/answer/139066?hl=en

## Related Issue
None