### PR TITLE
Mobile menu links: Tappable region fix [Fixes #1621]

### DIFF
--- a/src/components/Nav/Mobile.js
+++ b/src/components/Nav/Mobile.js
@@ -262,14 +262,15 @@ const MobileNavMenu = ({
                         .filter((item) => item.shouldDisplay)
                         .map((item, idx) => {
                           return (
-                            <SectionItem onClick={toggleMenu} key={idx}>
-                              <NavLink
-                                to={item.to}
-                                isPartiallyActive={item.isPartiallyActive}
-                              >
+                            <NavLink
+                              to={item.to}
+                              isPartiallyActive={item.isPartiallyActive}
+                              key={idx}
+                            >
+                              <SectionItem onClick={toggleMenu}>
                                 <Translation id={item.text} />
-                              </NavLink>
-                            </SectionItem>
+                              </SectionItem>
+                            </NavLink>
                           )
                         })}
                     </SectionItems>


### PR DESCRIPTION
## Description
#### src/components/Nav/Mobile.js
Reversed nesting order of `<SectionItem>` (now child) and `<NavLink>` (now parent) within mobile menu links list in order to make entire `<SectionItem>` component tappable with proper subsequent routing. The `key` property was kept on parent component (now `<NavLink>`) to allow proper list indexing.

## Related Issue #1621 