### PR TITLE
Adjusted StyledEmoji margin prop names to lowercase [Fixes #1667]

### DIFF
--- a/src/components/Emoji.js
+++ b/src/components/Emoji.js
@@ -14,10 +14,10 @@ const Emoji = ({
     <StyledEmoji
       size={size}
       text={text}
-      marginLeft={marginLeft}
-      marginRight={marginRight}
-      marginBottom={marginBottom}
-      marginTop={marginTop}
+      marginleft={marginLeft}
+      marginright={marginRight}
+      marginbottom={marginBottom}
+      margintop={marginTop}
       svg
     />
   )
@@ -27,10 +27,10 @@ const StyledEmoji = styled(Twemoji)`
   & > img {
     width: ${(props) => props.size}em !important;
     height: ${(props) => props.size}em !important;
-    margin-left: ${(props) => props.marginLeft}em !important;
-    margin-right: ${(props) => props.marginRight}em !important;
-    margin-bottom: ${(props) => props.marginBottom}em !important;
-    margin-top: ${(props) => props.marginTop}em !important;
+    margin-left: ${(props) => props.marginleft}em !important;
+    margin-right: ${(props) => props.marginright}em !important;
+    margin-bottom: ${(props) => props.marginbottom}em !important;
+    margin-top: ${(props) => props.margintop}em !important;
   }
 `
 


### PR DESCRIPTION
## Description
Per error in issue #1667, margin prop names for `<StyledEmoji>` made all lowercase. Continues to pass props appropriately, and eliminates console error messages. Emojis being used behaving appropriately.

## Related Issue #1667