### PR TITLE
Added Link to Etherscan Gas Tracker

### DIFF
--- a/src/content/developers/docs/gas/index.md
+++ b/src/content/developers/docs/gas/index.md
@@ -35,6 +35,7 @@ In short, gas fees help keep the Ethereum network secure. By requiring a fee for
 ## Related Tools {#related-tools}
 
 - [ETH Gas Station](https://ethgasstation.info/) _Consumer oriented metrics for the Ethereum gas market_
+- [Etherscan Gas Tracker](https://etherscan.io/gastracker) _Transaction gas price estimator_
 - [Bloxy Gas Analytics](https://stat.bloxy.info/superset/dashboard/gas/?standalone=true) _Ethereum network gas stats_
 
 ## Related Topics {#related-topics}


### PR DESCRIPTION
This PR adds a link to [Etherscan Gas Tracker](https://etherscan.io/gastracker) on the "Gas and fees" doc.

## Description

The rationale adding this is that during times of high congestion, I've noticed that [ETH Gas Station](https://ethgasstation.info)'s numbers were unreliable whereas Etherscan's were on point. Not only do I find this resource to be more accurate, I think it is quite user-friendly as well.