### PR TITLE
Adjusts mobile docs navbar and content position [Fixes #1677]

### DIFF
--- a/src/components/SideNavMobile.js
+++ b/src/components/SideNavMobile.js
@@ -28,7 +28,7 @@ const getPageTitle = (to, links) => {
 const Container = styled.div`
   position: fixed;
   z-index: 2; /* Prevents header overlap */
-  top: 73px; /* account for mobile nav */
+  top: 66px; /* account for mobile nav */
   background-color: ${(props) => props.theme.colors.ednBackground};
   height: auto;
   width: 100%;

--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -41,7 +41,7 @@ const Page = styled.div`
   padding: 0 2rem 0 0;
   @media (max-width: ${(props) => props.theme.breakpoints.l}) {
     padding: 0;
-    margin-top: 8.5rem; /* adjust for top navs */
+    margin-top: 8rem; /* adjust for top navs */
   }
   background-color: ${(props) => props.theme.colors.ednBackground};
 `


### PR DESCRIPTION
## Description
Gap was formed from merge commit 3858a39 after nav bar alignment reduced height by 7px. This adjusts the position of the fixed navbar and document content to compensate for previous changes.

Note: docs content `margin-top: 8.5rem` was reduced by 0.5rem (8px) off by 1px which I felt was negligible for the sake of `rem` readability, and still leaves no gap.

#### Screenshot w/ adjustment
![image](https://user-images.githubusercontent.com/54227730/97127157-1ed56700-16f6-11eb-9d38-2cfb98577249.png)

## Related Issue #1677 