### PR TITLE
Added border-right to docs SideNav [Fixes #1710]

### DIFF
--- a/src/components/SideNav.js
+++ b/src/components/SideNav.js
@@ -24,6 +24,7 @@ const Nav = styled.nav`
   transition: transform 0.2s ease;
   background-color: ${(props) => props.theme.colors.background};
   box-shadow: 1px 0px 0px rgba(0, 0, 0, 0.1);
+  border-right: 1px solid ${(props) => props.theme.colors.border};
 
   @media (max-width: ${(props) => props.theme.breakpoints.l}) {
     display: none;


### PR DESCRIPTION
## Description
Added `border-right: 1px solid ${(props) => props.theme.colors.border};` to `<Nav>` component within `SideNav.js`.

![image](https://user-images.githubusercontent.com/54227730/97761637-74798d00-1ac3-11eb-9e21-165533aef87f.png)

## Related Issue
#1710 
