### PR TITLE
Added mobile ToC component to static template [Fixed #1705]

### DIFF
--- a/src/templates/static.js
+++ b/src/templates/static.js
@@ -81,6 +81,11 @@ const Pre = styled.pre`
   white-space: pre-wrap;
 `
 
+const MobileTableOfContents = styled(TableOfContents)`
+  position: relative;
+  z-index: 2;
+`
+
 // Passing components to MDXProvider allows use across all .md/.mdx files
 // https://www.gatsbyjs.com/plugins/gatsby-plugin-mdx/#mdxprovider
 const components = {
@@ -133,6 +138,11 @@ const StaticPage = ({ data: { mdx } }) => {
           <Translation id="page-last-updated" />:{" "}
           {getLocaleTimestamp(intl.locale, lastUpdatedDate)}
         </LastUpdated>
+        <MobileTableOfContents
+          items={tocItems}
+          maxDepth={mdx.frontmatter.sidebarDepth}
+          isMobile={true}
+        />
         <MDXProvider components={components}>
           <MDXRenderer>{mdx.body}</MDXRenderer>
         </MDXProvider>


### PR DESCRIPTION
## Description
Placed `<TableOfContents>` component within static template, styled for proper placement and functioning. Placed in same region as `docs.js` at the top of the content. Does not display on desktop, and desktop ToC does not display on mobile. (Links highlight after activated)

#### Mobile:
![image](https://user-images.githubusercontent.com/54227730/97765918-721e2f80-1ad1-11eb-9dd2-b54e82ae45ac.png)
#### Desktop (no change):
![image](https://user-images.githubusercontent.com/54227730/97765969-a8f44580-1ad1-11eb-9485-1742397dc727.png)

## Related Issue 
#1705 