### PR TITLE
Remove paragraph color style [Fixes #1714]

### DIFF
--- a/src/components/SharedStyledComponents.js
+++ b/src/components/SharedStyledComponents.js
@@ -190,7 +190,6 @@ export const ButtonSecondary = styled(Button)`
 export const Paragraph = styled.p`
   font-size: 1rem;
   margin: 2rem 0 1rem;
-  color: ${(props) => props.theme.colors.text300};
 `
 
 export const Header1 = styled.h1`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove paragraph color style, so all body copy is `text` vs. only markdown paragraphs as `text300`.

## Related Issue
#1714
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
