### PR TITLE
Adds list item styling [alternative fix to #1714]

### DIFF
--- a/src/components/SharedStyledComponents.js
+++ b/src/components/SharedStyledComponents.js
@@ -333,6 +333,10 @@ export const Header4 = styled.h4`
   }
 `
 
+export const ListItem = styled.li`
+  color: ${(props) => props.theme.colors.text300};
+`
+
 // Variants (for `framer-motion`)
 
 export const dropdownIconContainerVariant = {

--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -28,6 +28,7 @@ import {
   Header3,
   Header4,
   H5,
+  ListItem,
 } from "../components/SharedStyledComponents"
 import Emoji from "../components/Emoji"
 import DocsNav from "../components/DocsNav"
@@ -155,6 +156,7 @@ const components = {
   h4: H4,
   h5: H5,
   p: Paragraph,
+  li: ListItem,
   pre: Codeblock,
   table: MarkdownTable,
   ButtonLink,

--- a/src/templates/static.js
+++ b/src/templates/static.js
@@ -35,6 +35,7 @@ import {
   Header3,
   Header4,
   H5,
+  ListItem,
 } from "../components/SharedStyledComponents"
 import Emoji from "../components/Emoji"
 
@@ -96,6 +97,7 @@ const components = {
   h4: Header4,
   h5: H5,
   p: Paragraph,
+  li: ListItem,
   pre: Pre,
   table: MarkdownTable,
   MeetupList,

--- a/src/templates/tutorial.js
+++ b/src/templates/tutorial.js
@@ -28,6 +28,7 @@ import {
   Header3,
   Header4,
   H5,
+  ListItem,
 } from "../components/SharedStyledComponents"
 import Emoji from "../components/Emoji"
 
@@ -140,6 +141,7 @@ const components = {
   h4: H4,
   h5: H5,
   p: Paragraph,
+  li: ListItem,
   pre: Codeblock,
   table: MarkdownTable,
   ButtonLink,


### PR DESCRIPTION
## Description
Currently the `<li>` list items have no explicit styling and default to a color of `.text`, while body paragraph text is styled with a shaded text color, `.text300`. 
This adds a `styled.li` component `ListItem` to `SharedStyledComponents.js` with `color: ${(props) => props.theme.colors.text300};`
Styles list items with `.text300` color shading to match body paragraph text (instead of default `.text`).
Passed to `docs.js`, `static.js` and `tutorial.js` so all list items get styled appropriately. 

(@samajammin @ryancreatescopy sorry for extra PR, I didn't know how to add to #1715 with my own branch changes... feel free to ignore, but wanted to offer this as an alternative approach which I feel is more declarative, and in line with existing theming)

![image](https://user-images.githubusercontent.com/54227730/97791447-af48f700-1b8f-11eb-8d25-b67a6d2f369e.png)

## Related Issue
#1714