### PR TITLE
Adds glossary contribution page [Helps with #1718]

### DIFF
--- a/.github/ISSUE_TEMPLATE/suggest_glossary_term.md
+++ b/.github/ISSUE_TEMPLATE/suggest_glossary_term.md
@@ -1,0 +1,33 @@
+---
+name: Suggest a glossary term
+about: Suggest a new ethereum.org glossary term
+title: ""
+labels: "Type: Feature, Type: Content"
+assignees: ""
+---
+
+**Checklist**
+
+- [ ] This is a term not already found in the glossary (for similar terms, please consider the benefits of a new term vs updating an existing term)
+- [ ] This term/definition is not a product advertisement or contain other promotional content
+- [ ] This term/definition is directly relevant to Ethereum
+
+**Term Name:**
+
+<!-- Name of new term -->
+
+**Term Definition:**
+
+<!-- Definition of new term -->
+
+**Sources, if any (please do not submit copywrited content without appropriate approval):**
+
+<!-- Please list any sources utilized -->
+
+**Ethereum.org links?**
+
+<!-- If appropriate/available, please suggest an internal ethereum.org link that would expand someones learning of this term -->
+
+**Additional context**
+
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/src/content/contributing/adding-glossary-terms/index.md
+++ b/src/content/contributing/adding-glossary-terms/index.md
@@ -1,0 +1,27 @@
+---
+title: Adding glossary terms
+lang: en
+description: Our criteria for adding new terms to the ethereum.org glossary
+sidebar: true
+---
+
+# Adding glossary terms {#contributing-to-ethereumorg-}
+
+This space is changing every day. New terms are constantly entering the lexicon of Ethereum users, and we need your help providing an accurate, up to date reference for all things Ethereum. Check out the current [glossary](/en/glossary/) and see below if you want to help!
+
+## Criteria {#criteria}
+
+New glossary terms will be assessed by the following criteria:
+
+- Is the term/definition up to date and currently relevant?
+- Is there a similar term already in the dictionary? (If so, consider the benefits of a new term vs updating an existing term)
+- Is the term/definition void of product advertisement or other promotional content?
+- Is the term/definition directly relevant to Ethereum?
+- Is the definition objective, accurate and void of subjective judgement or opinion?
+- Is the source credible? Do they reference their sources?
+
+---
+
+## Add your term {#how-decisions-about-the-site-are-made}
+
+If you want to add a glossary term to ethereum.org and it meets the criteria, [create an issue on GitHub](https://github.com/ethereum/ethereum-org-website/issues/new?template=suggest_glossary_term.md).

--- a/src/content/contributing/index.md
+++ b/src/content/contributing/index.md
@@ -27,6 +27,8 @@ ethereum.org is an open-source project. So if you want to help improve [our port
   _– Let us know your feedback on our research or contribute your own_
 - [Request a feature](https://github.com/ethereum/ethereum-org-website/issues/new?assignees=&labels=Type%3A+Feature&template=feature_request.md&title=)
   _– Let us know about any ideas you have for a new feature or design_
+- [Add a glossary term](/en/contributing/adding-glossary-terms)
+  _– Help us continue to expand the Ethereum [glossary](/en/glossary/)_
 - [Create/edit content ](/en/contributing/#how-to-update-content)
   _– Suggest new pages or makes tweaks to what's here already_
 

--- a/src/content/glossary/index.md
+++ b/src/content/glossary/index.md
@@ -484,4 +484,14 @@ A special Ethereum address, composed entirely of zeros, that is specified as the
 
 <Divider />
 
+## Sources {#sources}
+
 _Provided in part by [Mastering Ethereum](https://github.com/ethereumbook/ethereumbook) by [Andreas M. Antonopoulos, Gavin Wood](https://ethereumbook.info) under CC-BY-SA_
+
+<Divider />
+
+## Contribute to this page {#contribute-to-this-page}
+
+Did we miss something? Is something incorrect? Help us improve by contributing to this glossary on GitHub!
+
+[Learn more about how to contribute](/en/contributing/adding-glossary-terms)


### PR DESCRIPTION
## Description
- Adds glossary to list of ways to contribute on `/en/contributing/` with link to `/en/conributing/adding-glossary-terms/` where a new `.md` file provides layout and expectations for new glossary terms
- Link provided to GitHub, where new issue template `suggest_glossary_term.md` has been created and is referenced, to help organize future submissions
- Updated bottom of glossary page with 'Sources' and 'Contribute' section headers, with link to new contribution page

## Related Issue
#1718 
Does not "fix" this issue, as it will be ongoing with future glossary term additions, but this aims to help clarify and streamline submission process for future contributors by giving clear guidelines, directions, and templating.