### PR TITLE
Replace EVMC with evmone in EVM implementations list

### DIFF
--- a/src/content/developers/docs/evm/index.md
+++ b/src/content/developers/docs/evm/index.md
@@ -60,7 +60,7 @@ Over Ethereum's 5 year history, the EVM has undergone several revisions, and the
 All [Ethereum clients](/developers/docs/nodes-and-clients/#clients) include an EVM implementation. Additionally there are multiple standalone implementations, including:
 
 - [Py-EVM](https://github.com/ethereum/py-evm) - _Python_
-- [EVMC](https://github.com/ethereum/evmc) - _C++, C_
+- [evmone](https://github.com/ethereum/evmone) - _C++_
 - [ethereumjs-vm](https://github.com/ethereumjs/ethereumjs-vm) - _JavaScript_
 - [eEVM](https://github.com/microsoft/eevm) - _C++_
 - [Hyperledger Burrow](https://github.com/hyperledger/burrow) - _Go_


### PR DESCRIPTION
EVMC is not an EVM implementation itself, it's an interface between EVM implementations and EVM users.

evmone is such EVM implementation.