### PR TITLE
Increase top to account for Nav

### DIFF
--- a/src/components/SideNav.js
+++ b/src/components/SideNav.js
@@ -14,7 +14,7 @@ const IconContainer = styled(motion.div)`
 
 const Nav = styled.nav`
   position: sticky;
-  top: 6.25rem; /* account for navbar */
+  top: 7.25rem; /* account for navbar */
   padding: 2rem 0;
   height: calc(100vh - 80px); /* TODO take footer into account for height? */
   width: calc((100% - 1448px) / 2 + 298px);

--- a/src/components/TableOfContents.js
+++ b/src/components/TableOfContents.js
@@ -13,7 +13,7 @@ const customIdRegEx = /^.+(\s*\{#([A-Za-z0-9\-_]+?)\}\s*)$/
 
 const Aside = styled.aside`
   position: sticky;
-  top: 6.25rem; /* account for navbar */
+  top: 7.25rem; /* account for navbar */
   padding: 1rem 0 1rem 1rem;
   max-width: 25%;
   min-width: 12rem;

--- a/src/pages/eth2/deposit-contract.js
+++ b/src/pages/eth2/deposit-contract.js
@@ -102,7 +102,7 @@ const AddressCard = styled.div`
   }
   @media (min-width: ${(props) => props.theme.breakpoints.l}) {
     position: sticky;
-    top: 6.25rem; /* account for navbar */
+    top: 7.25rem; /* account for navbar */
   }
 `
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Tweak `top` of sticky items to account for Nav.

Not sure what caused it but current overlap is too close:
![Image 2020-11-03 at 7 23 19 AM](https://user-images.githubusercontent.com/8097623/98005379-d24cf400-1da5-11eb-8fb2-28187e2f3de4.png)


## Related Issue
None
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
