### PR TITLE
Eth2 style bugs

### DIFF
--- a/src/content/eth2/docking/index.md
+++ b/src/content/eth2/docking/index.md
@@ -60,9 +60,3 @@ Once the docking happens, stakers will be assigned to validate the Ethereum main
 With mainnet becoming a shard, the successful implementation of the shard chains is critical to this upgrade. It’s likely that the transition will play an important role in helping the community to decide whether to roll out a second upgrade to sharding. This upgrade will make the other shards like mainnet: they’ll be able to handle transactions and smart contracts and not just provide more data.
 
 <ButtonLink to="/eth2/shard-chains/">Shard chains</ButtonLink>
-
-<Divider />
-
-### Read more {#read-more}
-
-<Eth2DockingList />

--- a/src/content/eth2/shard-chains/index.md
+++ b/src/content/eth2/shard-chains/index.md
@@ -51,7 +51,7 @@ The plan was always to add extra functionality to shards, to make them more like
 
 Vitalik Buterin, when talking to Bankless podcast, presented 3 potential options that are worth discussing.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/-R0j5AMUSzA?start=5841" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="100%" height="315" src="https://www.youtube.com/embed/-R0j5AMUSzA?start=5841" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 #### 1. State execution not needed {#state-execution-not-needed}
 

--- a/src/pages/eth2/staking.js
+++ b/src/pages/eth2/staking.js
@@ -11,7 +11,6 @@ import GhostCard from "../../components/GhostCard"
 import CalloutBanner from "../../components/CalloutBanner"
 import Link from "../../components/Link"
 import Warning from "../../components/Warning"
-import CardList from "../../components/CardList"
 
 import PageMetadata from "../../components/PageMetadata"
 import {
@@ -207,10 +206,6 @@ const OptionText = styled.div`
   }
 `
 
-const StyledLink = styled(Link)`
-  color: ${(props) => props.theme.colors.warningLink};
-`
-
 const StakeContainer = styled.div`
   margin: 0 auto;
   max-width: ${(props) => props.theme.breakpoints.m};
@@ -301,7 +296,7 @@ const StakingPage = ({ data, location }) => {
                   title={path.title}
                   description={path.description}
                 >
-                  <a href={path.url}>{path.link}</a>
+                  {path.url && <Link to={path.url}>{path.link}</Link>}
                 </StyledCard>
               )
             })}

--- a/src/pages/eth2/staking.js
+++ b/src/pages/eth2/staking.js
@@ -111,8 +111,8 @@ const Subtitle = styled.div`
   color: ${(props) => props.theme.colors.text200};
   max-width: 480px;
   margin-top: 1rem;
-  @media (max-width: ${(props) => props.theme.breakpoints.l}) {
-    font-size: 40px;
+  @media (max-width: ${(props) => props.theme.breakpoints.m}) {
+    font-size: 20px;
   }
 `
 

--- a/src/pages/eth2/vision.js
+++ b/src/pages/eth2/vision.js
@@ -94,7 +94,7 @@ const Subtitle = styled.div`
   max-width: 480px;
   margin-top: 1rem;
   @media (max-width: ${(props) => props.theme.breakpoints.l}) {
-    font-size: 40px;
+    font-size: 20px;
   }
 `
 

--- a/src/templates/eth2.js
+++ b/src/templates/eth2.js
@@ -207,6 +207,7 @@ const InfoColumn = styled.aside`
     margin-right: 0rem;
     flex-direction: column-reverse;
     margin-top: 2rem;
+    top: 0;
   }
 `
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Some fixes for some style bugs: 

- [ ]  Banner not displaying bug – #1768
- [ ]  Warning message on upgrade pages mobile: not enough padding-top - #1772 
- [x] Title on `/staking/` not displaying properly. - #1773 
- [x] Link to /developers/docs/apis/backend/#available-libraries doesn't seem to work on /staking (appears it needs language path) – this link however does work on /shard-chains.
- [x]  “Read more” on “docking” page doesn’t make sense now we’ve removed phase 1.x content
- [x]  Video on shard chains page isn’t responsive
- [x]  Crazy font sizes for subtitle on staking page and vision page

## Related Issue

#1768, #1772 and #1773
