### PR TITLE
Eth2 bug fixes (nesting/margin)

### DIFF
--- a/src/pages/eth2/get-involved/index.js
+++ b/src/pages/eth2/get-involved/index.js
@@ -400,14 +400,12 @@ const GetInvolvedPage = ({ data, location }) => {
                 place on the leaderboard.
               </p>
               <p>A bug might be:</p>
-              <p>
-                <ul>
-                  <li>specification non-compliance issues</li>
-                  <li>finality breaking bugs</li>
-                  <li>denial of service (DOS) vectors</li>
-                  <li>and more...</li>
-                </ul>
-              </p>
+              <ul>
+                <li>specification non-compliance issues</li>
+                <li>finality breaking bugs</li>
+                <li>denial of service (DOS) vectors</li>
+                <li>and more...</li>
+              </ul>
               <ButtonLink to="/eth2/get-involved/bug-bounty/">
                 Go bug hunting
               </ButtonLink>

--- a/src/pages/eth2/index.js
+++ b/src/pages/eth2/index.js
@@ -428,7 +428,7 @@ const Eth2IndexPage = ({ data }) => {
         <Vision>
           <H2>
             The vision
-            <Emoji marginLeft={0.5} text=":sparkles:" />
+            <Emoji ml={`0.5rem`} text=":sparkles:" />
           </H2>
           <p>
             To bring Ethereum into the mainstream and serve all of humanity, we


### PR DESCRIPTION
## Description
When navigating to `/en/eth2/get-involved/` a console warning generates as a result of a `<ul>` tag being nested within a `<p>` tag. This is in `/pages/eth2/get-involved/index.js`. The `<p>` tag here is not needed and has been removed, eliminating the warning. 

#### Related Issue (none filed):
![image](https://user-images.githubusercontent.com/54227730/98773504-eb553680-239d-11eb-97e0-e80bbc7a3672.png)

#### Update
Also added commit to update `marginLeft` prop for `<Emoji>` component to use new `ml` format