### PR TITLE
Removes color styling override of external links [Fixes #1788]

### DIFF
--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -15,7 +15,6 @@ const isHashLink = (to) => HASH_PATTERN.test(to)
 
 const ExternalLink = styled.a`
   &:after {
-    color: ${(props) => props.theme.colors.primary};
     margin-left: 0.125em;
     margin-right: 0.3em;
     display: inline;


### PR DESCRIPTION
## Description
This is one possible fix to issue #1788. 
I may be missing something but when I remove the `color: ${(props) => props.theme.colors.primary}` styling that is placed on all external links, this allows all links to keep the color styling from its parent. I tried a few different pages, in light and dark mode, and they all seem to work just fine without that override. Not sure why we could want this, but again, still new so I may be missing something deeper.
![image](https://user-images.githubusercontent.com/54227730/98856935-2f365300-2413-11eb-9e5f-79bd20eb3982.png)
![image](https://user-images.githubusercontent.com/54227730/98856844-06ae5900-2413-11eb-9982-3756ad7daaf4.png)
![image](https://user-images.githubusercontent.com/54227730/98856789-f5654c80-2412-11eb-82e0-634648c3d87b.png)
![image](https://user-images.githubusercontent.com/54227730/98856996-45dcaa00-2413-11eb-83cf-e65078c0bcd0.png)

## Related Issue #1788