### PR TITLE
Added reference to eth2 phases

### DIFF
--- a/src/content/eth2/beacon-chain/index.md
+++ b/src/content/eth2/beacon-chain/index.md
@@ -7,6 +7,7 @@ sidebar: true
 summary1: The beacon chain doesn't change anything about the Ethereum we use today.
 summary3: It will coordinate the network.
 summary2: It introduces proof-of-stake to the Ethereum ecosystem.
+summary4: You might know this as "Phase 0" on the technical roadmap.
 ---
 
 <UpgradeStatus date="December 1, 2020">

--- a/src/content/eth2/beacon-chain/index.md
+++ b/src/content/eth2/beacon-chain/index.md
@@ -7,7 +7,7 @@ sidebar: true
 summary1: The beacon chain doesn't change anything about the Ethereum we use today.
 summary3: It will coordinate the network.
 summary2: It introduces proof-of-stake to the Ethereum ecosystem.
-summary4: You might know this as "Phase 0" on the technical roadmap.
+summary4: You might know this as "Phase 0" on technical roadmaps.
 ---
 
 <UpgradeStatus date="December 1, 2020">

--- a/src/content/eth2/docking/index.md
+++ b/src/content/eth2/docking/index.md
@@ -7,6 +7,7 @@ sidebar: true
 summary3: This will mark the end of proof-of-work for Ethereum, and the full transition to proof of stake.
 summary2: The docking will merge "Eth1" mainnet with Eth2's beacon chain and sharding system.
 summary1: Eventually the current Ethereum mainnet will "dock" with the rest of the Eth2 upgrades.
+summary4: You might know this as "Phase 1.5" on the technical roadmap.
 ---
 
 <UpgradeStatus date="~2021/22">

--- a/src/content/eth2/docking/index.md
+++ b/src/content/eth2/docking/index.md
@@ -7,7 +7,7 @@ sidebar: true
 summary3: This will mark the end of proof-of-work for Ethereum, and the full transition to proof of stake.
 summary2: The docking will merge "Eth1" mainnet with Eth2's beacon chain and sharding system.
 summary1: Eventually the current Ethereum mainnet will "dock" with the rest of the Eth2 upgrades.
-summary4: You might know this as "Phase 1.5" on the technical roadmap.
+summary4: You might know this as "Phase 1.5" on technical roadmaps.
 ---
 
 <UpgradeStatus date="~2021/22">

--- a/src/content/eth2/shard-chains/index.md
+++ b/src/content/eth2/shard-chains/index.md
@@ -7,7 +7,7 @@ sidebar: true
 summary1: Sharding is a multi-phase upgrade to improve Ethereum’s scalability and capacity.
 summary2: Shard chains spread the network's load across 64 new chains.
 summary3: They make it easier to run a node by keeping hardware requirements low.
-summary4: The technical roadmap includes work on shard chains in "Phase 1" and potentially "Phase 2".
+summary4: Technical roadmaps include work on shard chains in "Phase 1" and potentially "Phase 2".
 ---
 
 <UpgradeStatus date="~2021">

--- a/src/content/eth2/shard-chains/index.md
+++ b/src/content/eth2/shard-chains/index.md
@@ -6,7 +6,8 @@ template: eth2
 sidebar: true
 summary1: Sharding is a multi-phase upgrade to improve Ethereum’s scalability and capacity.
 summary2: Shard chains spread the network's load across 64 new chains.
-summary3: They make it easier to run a node by reducing the computational burden on validating transactions.
+summary3: They make it easier to run a node by keeping hardware requirements low.
+summary4: The technical roadmap includes work on shard chains in "Phase 1" and potentially "Phase 2".
 ---
 
 <UpgradeStatus date="~2021">

--- a/src/pages/eth2/index.js
+++ b/src/pages/eth2/index.js
@@ -796,14 +796,14 @@ const Eth2IndexPage = ({ data }) => {
                 outcomes:{" "}
                 <Link to="/eth2/beacon-chain/">the Eth2 upgrades</Link>. But if
                 you've followed the discussions, here's how the upgrades fit
-                into the roadmap.
+                into technical roadmaps.
               </p>
               <p>
                 Phase 0 describes the work to get{" "}
                 <Link to="/eth2/beacon-chain/">The Beacon Chain</Link> live.
               </p>
               <p>
-                Phase 1 of the roadmap focusses on implementing{" "}
+                Phase 1 of technical roadmaps focus on implementing{" "}
                 <Link to="/eth2/shard-chains/">the shard chains</Link>.
               </p>
               <p>

--- a/src/pages/eth2/index.js
+++ b/src/pages/eth2/index.js
@@ -785,6 +785,49 @@ const Eth2IndexPage = ({ data }) => {
                 <Link to="https://ethresear.ch">ethresear.ch</Link>.
               </p>
             </ExpandableCard>
+            <ExpandableCard
+              contentPreview="Phases relate to phases of work and focus in the Eth2 technical roadmap."
+              title="What are the Eth2 phases?"
+            >
+              <p>
+                We're reluctant to talk too much in terms of a technical roadmap
+                because this is software: things can change. We think it's
+                easier to understand what's happening when you read about the
+                outcomes:{" "}
+                <Link to="/eth2/beacon-chain/">the Eth2 upgrades</Link>. But if
+                you've followed the discussions, here's how the upgrades fit
+                into the roadmap.
+              </p>
+              <p>
+                Phase 0 describes the work to get{" "}
+                <Link to="/eth2/beacon-chain/">The Beacon Chain</Link> live.
+              </p>
+              <p>
+                Phase 1 of the roadmap focusses on implementing{" "}
+                <Link to="/eth2/shard-chains/">the shard chains</Link>.
+              </p>
+              <p>
+                <Link to="/eth2/docking/">Docking mainnet into Eth2</Link> is an
+                extension of the work done to implement shard chains and has
+                been referred to as Phase 1.5. But it's a significant moment as
+                the Ethereum we know today merges with the other Eth2 upgrades.
+                Plus it's when Ethereum fully transitions to{" "}
+                <Link to="/developers/docs/consensus-mechanisms/pos/">
+                  proof of stake
+                </Link>
+                .
+              </p>
+              <p>
+                It's currently unclear what will happen around Phase 2. It's
+                still a point of intense research and discussion. The initial
+                plan was to add extra functionality to{" "}
+                <Link to="/eth2/shard-chains/">the shard chains</Link> but{" "}
+                <Link to="/eth2/shard-chains/#code-execution">
+                  it might not be necessary
+                </Link>
+                .
+              </p>
+            </ExpandableCard>
           </RightColumn>
         </Faq>
       </Content>

--- a/src/templates/eth2.js
+++ b/src/templates/eth2.js
@@ -326,6 +326,7 @@ const Eth2Page = ({ data: { mdx } }) => {
             <SummaryPoint>{mdx.frontmatter.summary1}</SummaryPoint>
             <SummaryPoint>{mdx.frontmatter.summary2}</SummaryPoint>
             <SummaryPoint>{mdx.frontmatter.summary3}</SummaryPoint>
+            <SummaryPoint>{mdx.frontmatter.summary4}</SummaryPoint>
           </ul>
         </SummaryBox>
         <MDXProvider components={components}>
@@ -354,6 +355,7 @@ export const eth2PageQuery = graphql`
         summary1
         summary2
         summary3
+        summary4
       }
       body
       tableOfContents


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Due to the extent of communication around phases through eth2 content in the community, we thought it best to at least reference the phases in our content, despite positioning it around outcomes/results rather than phases of work.

Have added an FAQ that explains relationship between upgrades and phases. Have added an additional summary point to eah upgrade page that references what users might know it as in terms of phases.

We might also include references to phases in an interactive Eth2 diagram being worked on separately from this PR.
