### PR TITLE
About page bug fix (Missing custom ID on header)

### DIFF
--- a/src/content/about/index.md
+++ b/src/content/about/index.md
@@ -9,9 +9,9 @@ sidebar: true
 
 ethereum.org is a public, open-source resource for the Ethereum community that anyone can contribute to. We have a small team dedicated to maintaining and developing the site which is funded by the [Ethereum Foundation](/foundation/).
 
-## Our vision
+## Our vision {#our-vision}
 
-### ethereum.org's mission is to be the best portal for Ethereum's growing community
+### ethereum.org's mission is to be the best portal for Ethereum's growing community {#mission}
 
 We're an educational resource, designed to help new users become familiar with Ethereum and its key concepts. We want to:
 
@@ -24,15 +24,15 @@ We're an educational resource, designed to help new users become familiar with E
 
 We have some core principles that help us do this.
 
-## Core principles
+## Core principles {#core-principles}
 
-### 1. ethereum.org is a portal to Ethereum 🌏
+### 1. ethereum.org is a portal to Ethereum 🌏 {#core-principles-1}
 
 We want our users to have their interest piqued and their questions answered. So our portal needs to combine information, "magic moments" and links to the brilliant community resources that exist out there. The purpose of our content is to be an “onboarding portal” and not a substitute for the extensive resources that already exist. We're keen to support and integrate with community built resources, giving them more visibility and making them more discoverable.
 
 [Ethereum's community](/en/community/) is at the heart of this: we need to not just serve the community, but work with them and incorporate their feedback. The website isn't just for the community we have now but for the community we hope to grow into. We must remember our community is global, containing people from many languages, regions, and cultures.
 
-### 2. ethereum.org is always evolving 🛠
+### 2. ethereum.org is always evolving 🛠 {#core-principles-2}
 
 Ethereum and the community are always evolving, so ethereum.org will too. That's why the site has a simple design system & modular structure. We make iterative changes as we learn more about how people use the site and what the community wants from it.
 
@@ -40,14 +40,14 @@ We're open source, with a community of contributors, so you can propose changes 
 
 [Learn about contributing](/en/contributing/)
 
-### 3. ethereum.org is not a typical product website 🦄
+### 3. ethereum.org is not a typical product website 🦄 {#core-principles-3}
 
 Ethereum is a big thing: it includes a community, a technology, a set of ideas and ideologies, and more.
 This means the website needs to handle many different user journeys, from “a developer who wants a specific tool” and “a newcomer who just bought some ETH and doesn’t know what a wallet is"
 
 "What is the best website for a blockchain platform?" remains an open question - we are pioneers. Building this requires experimentation.
 
-## Design principles
+## Design principles {#design-principles}
 
 We use design principles to guide our content and design decisions on the site: [design principles](/en/contributing/design-principles/).
 
@@ -55,6 +55,6 @@ We welcome feedback on them. Remember, ethereum.org is for the community, by the
 
 Make sure you read the principles if you'd like to [contribute to the site](/en/contributing/).
 
-## Roadmap
+## Roadmap {#roadmap}
 
 <Roadmap />


### PR DESCRIPTION
## Description
`/about/` page missing custom header IDs causing console warnings. Added them, resolving warnings.

#### Related Issue (none filed)
![image](https://user-images.githubusercontent.com/54227730/98992895-93741800-24e2-11eb-9531-c97efd2eb570.png)
