### PR TITLE
Fixed broken link at staking page

### DIFF
--- a/src/pages/eth2/staking.js
+++ b/src/pages/eth2/staking.js
@@ -384,7 +384,7 @@ const StakingPage = ({ data, location }) => {
                 <H2>Do your own research</H2>
                 <div>
                   Most staking services are waiting for the{" "}
-                  <Link to="/eth2/beaon-chain/">Beacon Chain upgrade</Link> to
+                  <Link to="/eth2/beacon-chain/">Beacon Chain upgrade</Link> to
                   go live before they accept any deposits. Use this time to do
                   some research and figure out which service might be best for
                   you.


### PR DESCRIPTION
Fixed a typo that broke a link

## Description
At the staking page there was a link pointing to the "beaon-chain" instead of "beacon-chain"

## Related Issue
issue at:
https://ethereum.org/en/eth2/staking/
steps to replicate:
At the "How much are you willing to stake?" section click "Less than 32 ETH"
Click at the "Beacon Chain upgrade" link
Get 404 error

