### PR TITLE
Refactor BannerNotification [Fixes #1768]

### DIFF
--- a/src/components/BannerNotification.js
+++ b/src/components/BannerNotification.js
@@ -18,12 +18,10 @@ const Banner = styled.div`
   }
 `
 
-const BannerNotification = ({ children, className, shouldShow }) => {
-  return (
-    <Banner shouldShow={shouldShow} className={className}>
-      {children}
-    </Banner>
-  )
-}
+const BannerNotification = ({ children, className, shouldShow }) => (
+  <Banner shouldShow={shouldShow} className={className}>
+    {children}
+  </Banner>
+)
 
 export default BannerNotification

--- a/src/components/BannerNotification.js
+++ b/src/components/BannerNotification.js
@@ -5,6 +5,7 @@ import styled from "styled-components"
 // parent element should have `position: relative;`
 const Banner = styled.div`
   position: absolute;
+  display: ${(props) => (props.shouldShow ? `block` : `none`)};
   width: 100%;
   background-color: ${(props) => props.theme.colors.primary};
   color: ${(props) => props.theme.colors.background};
@@ -20,8 +21,12 @@ const Banner = styled.div`
   }
 `
 
-const BannerNotification = ({ children, className }) => {
-  return <Banner className={className}>{children}</Banner>
+const BannerNotification = ({ children, className, shouldShow }) => {
+  return (
+    <Banner shouldShow={shouldShow} className={className}>
+      {children}
+    </Banner>
+  )
 }
 
 export default BannerNotification

--- a/src/components/BannerNotification.js
+++ b/src/components/BannerNotification.js
@@ -1,10 +1,7 @@
 import React from "react"
 import styled from "styled-components"
 
-// Note: to avoid width overflow,
-// parent element should have `position: relative;`
 const Banner = styled.div`
-  position: absolute;
   display: ${(props) => (props.shouldShow ? `block` : `none`)};
   width: 100%;
   background-color: ${(props) => props.theme.colors.primary};

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -144,15 +144,13 @@ class Layout extends React.Component {
                 isDarkTheme={this.state.isDarkTheme}
                 path={path}
               />
-              {shouldShowBanner && (
-                <StyledBannerNotification>
-                  Staking has arrived! If you're looking to stake your ETH,{" "}
-                  <Link to="/eth2/deposit-contract/">
-                    confirm the deposit contract address
-                  </Link>
-                  .
-                </StyledBannerNotification>
-              )}
+              <StyledBannerNotification shouldShow={shouldShowBanner}>
+                Staking has arrived! If you're looking to stake your ETH,{" "}
+                <Link to="/eth2/deposit-contract/">
+                  confirm the deposit contract address
+                </Link>
+                .
+              </StyledBannerNotification>
               <MainContainer
                 shouldShowBanner={shouldShowBanner}
                 shouldShowSubNav={shouldShowSubNav}

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -36,13 +36,14 @@ const MainContainer = styled.div`
   /* Adjust margin-top depending nav, subnav & banner */
   margin-top: ${(props) =>
     props.shouldShowSubNav
-      ? props.theme.variables.navBannerHeightDesktop
+      ? props.theme.variables.navSubNavHeightDesktop
       : props.theme.variables.navHeight};
 `
 
-const BannerWrapper = styled.div`
+const MainContent = styled.div`
   display: flex;
   flex-direction: column;
+  width: 100%;
 `
 
 const Main = styled.main`
@@ -59,6 +60,7 @@ const StyledBannerNotification = styled(BannerNotification)`
 `
 
 // TODO `Layout` renders twice on page load - why?
+// TODO refactor into function component
 class Layout extends React.Component {
   constructor(props) {
     super(props)
@@ -117,6 +119,7 @@ class Layout extends React.Component {
     const shouldShowSubNav = path.includes("/developers/")
     const shouldShowBanner =
       path.includes("/eth2/") && !path.includes("/eth2/deposit-contract/")
+
     return (
       <IntlProvider
         locale={intl.language}
@@ -140,7 +143,7 @@ class Layout extends React.Component {
               >
                 {shouldShowSideNav && <SideNav path={path} />}
                 {shouldShowSideNav && <SideNavMobile path={path} />}
-                <BannerWrapper>
+                <MainContent>
                   <StyledBannerNotification shouldShow={shouldShowBanner}>
                     Staking has arrived! If you're looking to stake your ETH,{" "}
                     <Link to="/eth2/deposit-contract/">
@@ -149,7 +152,7 @@ class Layout extends React.Component {
                     .
                   </StyledBannerNotification>
                   <Main>{this.props.children}</Main>
-                </BannerWrapper>
+                </MainContent>
               </MainContainer>
               <Footer />
             </ContentContainer>

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -35,27 +35,14 @@ const MainContainer = styled.div`
 
   /* Adjust margin-top depending nav, subnav & banner */
   margin-top: ${(props) =>
-    props.shouldShowBanner
-      ? props.theme.variables.navBannerHeightDesktop
-      : props.shouldShowSubNav
+    props.shouldShowSubNav
       ? props.theme.variables.navBannerHeightDesktop
       : props.theme.variables.navHeight};
-  @media (max-width: ${(props) => props.theme.breakpoints.m}) {
-    margin-top: ${(props) =>
-      props.shouldShowBanner
-        ? props.theme.variables.navBannerHeightTablet
-        : props.shouldShowSideNav
-        ? props.theme.variables.navSideNavHeightMobile
-        : props.theme.variables.navHeight};
-  }
-  @media (max-width: ${(props) => props.theme.breakpoints.s}) {
-    margin-top: ${(props) =>
-      props.shouldShowBanner
-        ? props.theme.variables.navBannerHeightMobile
-        : props.shouldShowSideNav
-        ? props.theme.variables.navSideNavHeightMobile
-        : props.theme.variables.navHeight};
-  }
+`
+
+const BannerWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
 `
 
 const Main = styled.main`
@@ -68,7 +55,6 @@ const Main = styled.main`
 `
 
 const StyledBannerNotification = styled(BannerNotification)`
-  margin-top: ${(props) => props.theme.variables.navHeight};
   text-align: center;
 `
 
@@ -131,7 +117,6 @@ class Layout extends React.Component {
     const shouldShowSubNav = path.includes("/developers/")
     const shouldShowBanner =
       path.includes("/eth2/") && !path.includes("/eth2/deposit-contract/")
-    console.log("shouldShowBanner: ", shouldShowBanner)
     return (
       <IntlProvider
         locale={intl.language}
@@ -147,13 +132,7 @@ class Layout extends React.Component {
                 isDarkTheme={this.state.isDarkTheme}
                 path={path}
               />
-              <StyledBannerNotification shouldShow={shouldShowBanner}>
-                Staking has arrived! If you're looking to stake your ETH,{" "}
-                <Link to="/eth2/deposit-contract/">
-                  confirm the deposit contract address
-                </Link>
-                .
-              </StyledBannerNotification>
+
               <MainContainer
                 shouldShowBanner={shouldShowBanner}
                 shouldShowSubNav={shouldShowSubNav}
@@ -161,7 +140,16 @@ class Layout extends React.Component {
               >
                 {shouldShowSideNav && <SideNav path={path} />}
                 {shouldShowSideNav && <SideNavMobile path={path} />}
-                <Main>{this.props.children}</Main>
+                <BannerWrapper>
+                  <StyledBannerNotification shouldShow={shouldShowBanner}>
+                    Staking has arrived! If you're looking to stake your ETH,{" "}
+                    <Link to="/eth2/deposit-contract/">
+                      confirm the deposit contract address
+                    </Link>
+                    .
+                  </StyledBannerNotification>
+                  <Main>{this.props.children}</Main>
+                </BannerWrapper>
               </MainContainer>
               <Footer />
             </ContentContainer>

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -129,6 +129,7 @@ class Layout extends React.Component {
     const shouldShowSubNav = path.includes("/developers/")
     const shouldShowBanner =
       path.includes("/eth2/") && !path.includes("/eth2/deposit-contract/")
+    console.log("shouldShowBanner: ", shouldShowBanner)
     return (
       <IntlProvider
         locale={intl.language}

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -35,7 +35,9 @@ const MainContainer = styled.div`
 
   /* Adjust margin-top depending nav, subnav & banner */
   margin-top: ${(props) =>
-    props.shouldShowBanner || props.shouldShowSubNav
+    props.shouldShowBanner
+      ? props.theme.variables.navBannerHeightDesktop
+      : props.shouldShowSubNav
       ? props.theme.variables.navBannerHeightDesktop
       : props.theme.variables.navHeight};
   @media (max-width: ${(props) => props.theme.breakpoints.m}) {

--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -34,7 +34,11 @@ import Emoji from "../components/Emoji"
 import DocsNav from "../components/DocsNav"
 
 const Page = styled.div`
-  position: relative; /* for <BannerNotification /> */
+  display: flex;
+  flex-direction: column;
+`
+
+const ContentWrapper = styled.div`
   display: flex;
   justify-content: space-between;
   width: 100%;
@@ -195,40 +199,42 @@ const DocsPage = ({ data, pageContext }) => {
 
   return (
     <Page dir={isRightToLeft ? "rtl" : "ltr"}>
-      <PageMetadata
-        title={mdx.frontmatter.title}
-        description={mdx.frontmatter.description}
-      />
       <BannerNotification shouldShow={isPageIncomplete}>
         This page is incomplete. If you’re an expert on the topic, please edit
         this page and sprinkle it with your wisdom.
       </BannerNotification>
-      <ContentContainer isPageIncomplete={isPageIncomplete}>
-        <H1 id="top">{mdx.frontmatter.title}</H1>
-        <Contributors gitCommits={gitCommits} editPath={absoluteEditPath} />
-        <TableOfContents
-          items={tocItems}
-          maxDepth={mdx.frontmatter.sidebarDepth}
-          editPath={absoluteEditPath}
-          isMobile={true}
+      <ContentWrapper>
+        <PageMetadata
+          title={mdx.frontmatter.title}
+          description={mdx.frontmatter.description}
         />
-        <MDXProvider components={components}>
-          <MDXRenderer>{mdx.body}</MDXRenderer>
-        </MDXProvider>
-        {isPageIncomplete && <CallToContribute editPath={absoluteEditPath} />}
-        <BackToTop>
-          <a href="#top">Back to top ↑</a>
-        </BackToTop>
-        <DocsNav relativePath={relativePath}></DocsNav>
-      </ContentContainer>
-      {mdx.frontmatter.sidebar && tocItems && (
-        <DesktopTableOfContents
-          items={tocItems}
-          maxDepth={mdx.frontmatter.sidebarDepth}
-          editPath={absoluteEditPath}
-          isPageIncomplete={isPageIncomplete}
-        />
-      )}
+        <ContentContainer isPageIncomplete={isPageIncomplete}>
+          <H1 id="top">{mdx.frontmatter.title}</H1>
+          <Contributors gitCommits={gitCommits} editPath={absoluteEditPath} />
+          <TableOfContents
+            items={tocItems}
+            maxDepth={mdx.frontmatter.sidebarDepth}
+            editPath={absoluteEditPath}
+            isMobile={true}
+          />
+          <MDXProvider components={components}>
+            <MDXRenderer>{mdx.body}</MDXRenderer>
+          </MDXProvider>
+          {isPageIncomplete && <CallToContribute editPath={absoluteEditPath} />}
+          <BackToTop>
+            <a href="#top">Back to top ↑</a>
+          </BackToTop>
+          <DocsNav relativePath={relativePath}></DocsNav>
+        </ContentContainer>
+        {mdx.frontmatter.sidebar && tocItems && (
+          <DesktopTableOfContents
+            items={tocItems}
+            maxDepth={mdx.frontmatter.sidebarDepth}
+            editPath={absoluteEditPath}
+            isPageIncomplete={isPageIncomplete}
+          />
+        )}
+      </ContentWrapper>
     </Page>
   )
 }

--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -36,13 +36,14 @@ import DocsNav from "../components/DocsNav"
 const Page = styled.div`
   display: flex;
   flex-direction: column;
+  width: 100%;
+  border-bottom: 1px solid ${(props) => props.theme.colors.border};
 `
 
-const ContentWrapper = styled.div`
+const ContentContainer = styled.div`
   display: flex;
   justify-content: space-between;
   width: 100%;
-  border-bottom: 1px solid ${(props) => props.theme.colors.border};
   padding: 0 2rem 0 0;
   @media (max-width: ${(props) => props.theme.breakpoints.l}) {
     padding: 0;
@@ -55,17 +56,15 @@ const DesktopTableOfContents = styled(TableOfContents)`
 `
 
 // Apply styles for classes within markdown here
-const ContentContainer = styled.article`
+const Content = styled.article`
   flex: 1 1 ${(props) => props.theme.breakpoints.m};
   max-width: ${(props) => props.theme.breakpoints.m};
-  padding: ${(props) =>
-    props.isPageIncomplete ? `6rem 4rem 4rem` : `3rem 4rem 4rem`};
+  padding: 3rem 4rem 4rem;
   @media (max-width: ${(props) => props.theme.breakpoints.l}) {
     max-width: 100%;
   }
   @media (max-width: ${(props) => props.theme.breakpoints.m}) {
-    padding: ${(props) =>
-      props.isPageIncomplete ? `15rem 2rem 2rem` : `8rem 2rem 2rem`};
+    padding: 8rem 2rem 2rem;
   }
 
   .featured {
@@ -199,16 +198,16 @@ const DocsPage = ({ data, pageContext }) => {
 
   return (
     <Page dir={isRightToLeft ? "rtl" : "ltr"}>
+      <PageMetadata
+        title={mdx.frontmatter.title}
+        description={mdx.frontmatter.description}
+      />
       <BannerNotification shouldShow={isPageIncomplete}>
         This page is incomplete. If you’re an expert on the topic, please edit
         this page and sprinkle it with your wisdom.
       </BannerNotification>
-      <ContentWrapper>
-        <PageMetadata
-          title={mdx.frontmatter.title}
-          description={mdx.frontmatter.description}
-        />
-        <ContentContainer isPageIncomplete={isPageIncomplete}>
+      <ContentContainer>
+        <Content>
           <H1 id="top">{mdx.frontmatter.title}</H1>
           <Contributors gitCommits={gitCommits} editPath={absoluteEditPath} />
           <TableOfContents
@@ -225,7 +224,7 @@ const DocsPage = ({ data, pageContext }) => {
             <a href="#top">Back to top ↑</a>
           </BackToTop>
           <DocsNav relativePath={relativePath}></DocsNav>
-        </ContentContainer>
+        </Content>
         {mdx.frontmatter.sidebar && tocItems && (
           <DesktopTableOfContents
             items={tocItems}
@@ -234,7 +233,7 @@ const DocsPage = ({ data, pageContext }) => {
             isPageIncomplete={isPageIncomplete}
           />
         )}
-      </ContentWrapper>
+      </ContentContainer>
     </Page>
   )
 }

--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -199,12 +199,10 @@ const DocsPage = ({ data, pageContext }) => {
         title={mdx.frontmatter.title}
         description={mdx.frontmatter.description}
       />
-      {isPageIncomplete && (
-        <BannerNotification>
-          This page is incomplete. If you’re an expert on the topic, please edit
-          this page and sprinkle it with your wisdom.
-        </BannerNotification>
-      )}
+      <BannerNotification shouldShow={isPageIncomplete}>
+        This page is incomplete. If you’re an expert on the topic, please edit
+        this page and sprinkle it with your wisdom.
+      </BannerNotification>
       <ContentContainer isPageIncomplete={isPageIncomplete}>
         <H1 id="top">{mdx.frontmatter.title}</H1>
         <Contributors gitCommits={gitCommits} editPath={absoluteEditPath} />

--- a/src/templates/eth2.js
+++ b/src/templates/eth2.js
@@ -314,7 +314,7 @@ const Eth2Page = ({ data: { mdx } }) => {
           <h2>An Eth2 service announcement</h2>
           <p>
             You do not need to do anything with any ETH you’re already holding.
-            Beware of scammers asking you to send ETH to exchange it.{" "}
+            Beware of scammers asking you to send ETH to exchange it.
           </p>
         </AnnouncementCard>
       </InfoColumn>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This should actually fix it this time 🤞 

- Update position to `relative` (vs `absolute`) to avoid complex Layout margin logic
- Add container divs (flex-direction: column) to wrap BannerNotification in Layout & Docs template

## Related Issue
#1768
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
