### PR TITLE
Correction for typo "an" to "can"

### DIFF
--- a/src/content/developers/docs/consensus-mechanisms/pos/index.md
+++ b/src/content/developers/docs/consensus-mechanisms/pos/index.md
@@ -39,7 +39,7 @@ If you attest to malicious blocks, you lose your stake.
 
 When Ethereum replaces proof-of-work with proof-of-stake, there will be the added complexity of [shard chains](/eth2/shard-chains/). These are separate blockchains that will need validators to process transactions and create new blocks. The plan is to have 64 shard chains and they all need a shared understanding of the state of the network. So extra coordination is needed and this will be done by [the beacon chain](/eth2/beacon-chain/).
 
-The beacon chain receives state information from shards and makes it available for other shards so that the network an stay in sync. The beacon chain will also manage the validators, from registering their stake deposits to issuing their rewards and penalties.
+The beacon chain receives state information from shards and makes it available for other shards so that the network can stay in sync. The beacon chain will also manage the validators, from registering their stake deposits to issuing their rewards and penalties.
 
 Here's how that process works.
 


### PR DESCRIPTION
## Description
Correction for "The beacon chain receives state information from shards and makes it available for other shards so that the network an stay in sync." to "The beacon chain receives state information from shards and makes it available for other shards so that the network can stay in sync."



