### PR TITLE
Make docs links full width on mobile

### DIFF
--- a/src/components/DocsNav.js
+++ b/src/components/DocsNav.js
@@ -5,7 +5,6 @@ import docLinks from "../data/developer-docs-links.yaml"
 import Link from "./Link"
 import Emoji from "./Emoji"
 
-// Styled components
 const Container = styled.div`
   display: flex;
   justify-content: space-between;
@@ -15,6 +14,7 @@ const Container = styled.div`
   }
 `
 
+// TODO make entire card a link
 const Card = styled.div`
   display: flex;
   flex-direction: row;
@@ -25,6 +25,9 @@ const Card = styled.div`
   background-color: ${(props) => props.theme.colors.background};
   border: 1px solid ${(props) => props.theme.colors.border};
   border-radius: 4px;
+  @media (max-width: ${(props) => props.theme.breakpoints.s}) {
+    width: 100%;
+  }
 `
 
 const PreviousCard = styled(Card)`

--- a/src/components/DocsNav.js
+++ b/src/components/DocsNav.js
@@ -25,7 +25,7 @@ const Card = styled.div`
   background-color: ${(props) => props.theme.colors.background};
   border: 1px solid ${(props) => props.theme.colors.border};
   border-radius: 4px;
-  @media (max-width: ${(props) => props.theme.breakpoints.s}) {
+  @media (max-width: 604px) {
     width: 100%;
   }
 `


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Make docs links full width on mobile
<!--- Describe your changes in detail -->

**Before:**
![Image 2020-11-14 at 4 03 07 PM](https://user-images.githubusercontent.com/8097623/99159631-f2788f00-2692-11eb-8757-a9cfeccfb447.png)

**After:**
![Image 2020-11-14 at 4 02 06 PM](https://user-images.githubusercontent.com/8097623/99159632-f6a4ac80-2692-11eb-8cd6-30eb9fd3b5f0.png)


## Related Issue
None
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
