### PR TITLE
Adds GIF support with gatsby-remark-copy-linked-files [Fixes #1845]

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -124,6 +124,7 @@ module.exports = {
     `gatsby-remark-autolink-headers`,
     // Image support in markdown
     `gatsby-remark-images`,
+    `gatsby-remark-copy-linked-files`,
     // MDX support
     {
       resolve: `gatsby-plugin-mdx`,
@@ -144,6 +145,12 @@ module.exports = {
           },
           {
             resolve: `gatsby-remark-images`,
+            options: {
+              maxWidth: 1200,
+            },
+          },
+          {
+            resolve: `gatsby-remark-copy-linked-files`,
             options: {
               maxWidth: 1200,
             },

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "gatsby-plugin-sitemap": "^2.4.7",
     "gatsby-plugin-styled-components": "^3.3.3",
     "gatsby-remark-autolink-headers": "^2.3.5",
+    "gatsby-remark-copy-linked-files": "^2.4.0",
     "gatsby-remark-images": "^3.3.12",
     "gatsby-source-filesystem": "^2.3.10",
     "gatsby-source-graphql": "^2.7.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7470,6 +7470,20 @@ gatsby-remark-autolink-headers@^2.3.5:
     mdast-util-to-string "^1.1.0"
     unist-util-visit "^1.4.1"
 
+gatsby-remark-copy-linked-files@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/gatsby-remark-copy-linked-files/-/gatsby-remark-copy-linked-files-2.4.0.tgz#b9e38c77f187b13aada2cdaa84260281a7774585"
+  integrity sha512-Vh/7RoGTO77FsiVqMEJ5tG5FUr9HFV5NTF2Dz9VEWJzasAa+k5Sd9EVUB18Lz6IA8E+Su2/IJGU4MOkVqwaT5g==
+  dependencies:
+    "@babel/runtime" "^7.11.2"
+    cheerio "^1.0.0-rc.3"
+    fs-extra "^8.1.0"
+    is-relative-url "^3.0.0"
+    lodash "^4.17.20"
+    path-is-inside "^1.0.2"
+    probe-image-size "^5.0.0"
+    unist-util-visit "^1.4.1"
+
 gatsby-remark-images@^3.3.12:
   version "3.3.25"
   resolved "https://registry.yarnpkg.com/gatsby-remark-images/-/gatsby-remark-images-3.3.25.tgz#138d0010d31c23a1de23e87ac92ed9b5d84673aa"
@@ -12462,6 +12476,17 @@ probe-image-size@^4.1.1:
   integrity sha512-42LqKZqTLxH/UvAZ2/cKhAsR4G/Y6B7i7fI2qtQu9hRBK4YjS6gqO+QRtwTjvojUx4+/+JuOMzLoFyRecT9qRw==
   dependencies:
     any-promise "^1.3.0"
+    deepmerge "^4.0.0"
+    inherits "^2.0.3"
+    next-tick "^1.0.0"
+    request "^2.83.0"
+    stream-parser "~0.3.1"
+
+probe-image-size@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/probe-image-size/-/probe-image-size-5.0.0.tgz#1b87d20340ab8fcdb4324ec77fbc8a5f53419878"
+  integrity sha512-V6uBYw5eBc5UVIE7MUZD6Nxg0RYuGDWLDenEn0B1WC6PcTvn1xdQ6HLDDuznefsiExC6rNrCz7mFRBo0f3Xekg==
+  dependencies:
     deepmerge "^4.0.0"
     inherits "^2.0.3"
     next-tick "^1.0.0"


### PR DESCRIPTION
##  Description
Per Gatsby documentation, `gatsby-remark-images` does not support GIFs, and requires `gatsby-remark-copy-linked-files` plugin. This was added using `yarn add gatsby-remark-copy-linked-files` and updated in `gatsby-config.js` file. 

## Related Issue #1845 