### PR TITLE
Mobile menu closes when tapping outside on larger devices [Fixes #1850]

### DIFF
--- a/src/components/Nav/Mobile.js
+++ b/src/components/Nav/Mobile.js
@@ -228,6 +228,7 @@ const MobileNavMenu = ({
         animate={isOpen ? "open" : "closed"}
         variants={mobileModalVariants}
         initial="closed"
+        onClick={handleClose}
       ></MobileModal>
       <MenuContainer
         animate={isOpen ? "open" : "closed"}


### PR DESCRIPTION
## Description
Triggers menu close when tapping outside the menu area on larger mobile devices. Does not trigger by clicking between menu items.

https://share.getcloudapp.com/geuqnGRK

Short and sweet.

## Related Issue #1850 
