### PR TITLE
Add tools to "Dapp Tools"

### DIFF
--- a/src/content/developers/docs/dapps/index.md
+++ b/src/content/developers/docs/dapps/index.md
@@ -74,6 +74,16 @@ Tokens must be generated in order to prove the value nodes that contribute to th
 - [rimble.consensys.design](https://rimble.consensys.design)
 - [GitHub](https://github.com/ConsenSys/rimble-ui)
 
+**One Click Dapp** **_- FOSS tool for generating dapp frontends from an ABI._**
+
+- [oneclickdapp.com](https://oneclickdapp.com)
+- [GitHub](https://github.com/One-Click-Dapp/one-click-dApp)
+
+**Etherflow** **_- FOSS tool for Ethereum developers to test their node, and compose & debug RPC calls from the browser._**
+
+- [etherflow.quiknode.io](https://etherflow.quiknode.io/)
+- [GitHub](https://github.com/abunsen/etherflow)
+
 ## Further reading {#further-reading}
 
 _Know of a community resource that helped you? Edit this page and add it!_


### PR DESCRIPTION
I noticed that the new version of the site doesn't have the dapp tools list anymore (for example: https://github.com/ethereum/ethereum-org-website/blob/385a2334acd2410f1f02c31fced099b4c0fa7710/src/content/translations/de/developers/index.md#entwicklerwerkzeuge-developer-tools).

If this isn't the best place to put this, please let me know. 

Thanks yall!

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
