### PR TITLE
Add reference to Nethereum new Discord group

### DIFF
--- a/src/content/developers/docs/programming-languages/dot-net/index.md
+++ b/src/content/developers/docs/programming-languages/dot-net/index.md
@@ -77,7 +77,7 @@ Looking for more resources? Check out [ethereum.org/developers](/en/developers/)
 
 ## .NET Community Contributors {#dot-net-community-contributors}
 
-At Nethereum, we mostly hang out on [Gitter](https://gitter.im/Nethereum/Nethereum) where everyone is welcome to ask/answer questions, get help, or just chill. Feel free to do a PR or open an issue on the [Nethereum Github repository](https://github.com/Nethereum), or just to browse through the many side/sample projects we have.
+At Nethereum, we mostly hang out on [Gitter](https://gitter.im/Nethereum/Nethereum) where everyone is welcome to ask/answer questions, get help, or just chill. Feel free to do a PR or open an issue on the [Nethereum Github repository](https://github.com/Nethereum), or just to browse through the many side/sample projects we have. You can also find us on [Discord](https://discord.gg/jQPrR58FxX)!
 
 At Nethermind, let's get in touch through [Gitter](https://gitter.im/nethermindeth/nethermind). For PRs or issues, check out the [Nethermind Github repository](https://github.com/NethermindEth/nethermind).
 


### PR DESCRIPTION
The Nethereum project now has a Discord channel. See https://discord.gg/jQPrR58FxX 