### PR TITLE
Corrects raspi-eth1.img.zip sha256 checksum [Fixes #1901]

### DIFF
--- a/src/content/developers/tutorials/run-node-raspberry-pi/index.md
+++ b/src/content/developers/tutorials/run-node-raspberry-pi/index.md
@@ -91,7 +91,7 @@ Keep in mind that you need to plug the disk to an USB 3.0 port (blue)
 
 <ButtonLink to="https://ethraspbian.com/downloads/ubuntu-20.04-preinstalled-server-arm64+raspi-eth1.img.zip">Download Eth 1.0 image</ButtonLink>
 
-sha256 34f105201482279a5e83decd265bd124d167b0fefa43bc05e4268ff899b46f19
+sha256 7fa9370d13857dd6abcc8fde637c7a9a7e3a66b307d5c28b0c0d29a09c73c55c
 
 <ButtonLink to="https://ethraspbian.com/downloads/ubuntu-20.04-preinstalled-server-arm64+raspi-eth2.img.zip">Download Eth2 image</ButtonLink>
 


### PR DESCRIPTION
## Description
https://ethraspbian.com/downloads/ubuntu-20.04-preinstalled-server-arm64+raspi-eth1.img.zip
This file has a sha256 checksum of 7fa9370d13857dd6abcc8fde637c7a9a7e3a66b307d5c28b0c0d29a09c73c55c

@ryancreatescopy Just wanted to double check that there isn't a security issue with this before just changing this (if the file has been altered), or if this was more likely to be an accident.

## Related Issue #1901 