### PR TITLE
Links to static image assets bypass intl and open in new tab [Closes #1807, Closes #1918]

### DIFF
--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -69,14 +69,10 @@ const Link = ({
   const isGlossary = to.includes("glossary")
   const isStatic = to.includes("static")
 
-  if (isStatic) {
-    return <span className={className}>{children}</span>
-  }
-
   // Must use <a> tags for anchor links
   // Otherwise <Link> functionality will navigate to homepage
   // See https://github.com/gatsbyjs/gatsby/issues/21909
-  if (isHash) {
+  if (isHash || isStatic) {
     return (
       <a className={className} href={to}>
         {children}

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -67,6 +67,11 @@ const Link = ({
   const isExternal = to.includes("http") || to.includes("mailto:")
   const isHash = isHashLink(to)
   const isGlossary = to.includes("glossary")
+  const isStatic = to.includes("static")
+
+  if (isStatic) {
+    return <span className={className}>{children}</span>
+  }
 
   // Must use <a> tags for anchor links
   // Otherwise <Link> functionality will navigate to homepage

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -72,9 +72,19 @@ const Link = ({
   // Must use <a> tags for anchor links
   // Otherwise <Link> functionality will navigate to homepage
   // See https://github.com/gatsbyjs/gatsby/issues/21909
-  if (isHash || isStatic) {
+  if (isHash) {
     return (
       <a className={className} href={to}>
+        {children}
+      </a>
+    )
+  }
+
+  // Links to static image assets must use <a> to avoid
+  // <Link> redirection. Opens in separate window.
+  if (isStatic) {
+    return (
+      <a className={className} href={to} target="_blank">
         {children}
       </a>
     )


### PR DESCRIPTION
## Description
Images parsed by mdx renderer are being passed through Link to be wrapped in anchor tag, but these links result in 404. These links all involve the directory "static" which as far as I can tell we never want to link to. This PR places a conditional within the `Link.js` component to look for links including "static" and returns `{children}` wrapped in a `span` instead of returning a `<Link>` component (intentionally didn't use `div` as this needs to be compatible within `<p>` tags.) 

This prevents images within EDN from being rendered as links, and are no longer clickable. Remaining link types continue to work appropriately.

## Related Issue #1807 