### PR TITLE
Fixes links within mdx h2/h3, adjusts `code` css [Fixes #1843]

### DIFF
--- a/src/components/SharedStyledComponents.js
+++ b/src/components/SharedStyledComponents.js
@@ -317,7 +317,7 @@ export const Header2 = styled.h2`
   }
 
   /* Anchor tag styles */
-  a {
+  a.header-anchor {
     position: relative;
     display: none;
     margin-left: -1.5em;
@@ -335,7 +335,7 @@ export const Header2 = styled.h2`
   }
 
   &:hover {
-    a {
+    a.header-anchor {
       display: initial;
       fill: ${(props) => props.theme.colors.primary};
     }

--- a/src/components/SharedStyledComponents.js
+++ b/src/components/SharedStyledComponents.js
@@ -330,6 +330,10 @@ export const Header2 = styled.h2`
     }
   }
 
+  code {
+    font-size: 0.8em;
+  }
+
   &:hover {
     a {
       display: initial;
@@ -370,6 +374,10 @@ export const Header3 = styled.h3`
       display: initial;
       fill: ${(props) => props.theme.colors.primary};
     }
+  }
+
+  code {
+    font-size: 0.85em;
   }
 
   &:hover {

--- a/src/components/SharedStyledComponents.js
+++ b/src/components/SharedStyledComponents.js
@@ -317,6 +317,7 @@ export const Header2 = styled.h2`
   }
 
   /* Anchor tag styles */
+  /* Selected specifically for mdx rendered side icon link */
   a.header-anchor {
     position: relative;
     display: none;
@@ -328,10 +329,6 @@ export const Header2 = styled.h2`
       display: initial;
       fill: ${(props) => props.theme.colors.primary};
     }
-  }
-
-  code {
-    font-size: 0.8em;
   }
 
   &:hover {
@@ -363,6 +360,7 @@ export const Header3 = styled.h3`
   }
 
   /* Anchor tag styles */
+  /* Selected specifically for mdx rendered side icon link */
   a.header-anchor {
     position: relative;
     display: none;
@@ -374,10 +372,6 @@ export const Header3 = styled.h3`
       display: initial;
       fill: ${(props) => props.theme.colors.primary};
     }
-  }
-
-  code {
-    font-size: 0.85em;
   }
 
   &:hover {

--- a/src/components/SharedStyledComponents.js
+++ b/src/components/SharedStyledComponents.js
@@ -363,7 +363,7 @@ export const Header3 = styled.h3`
   }
 
   /* Anchor tag styles */
-  a {
+  a.header-anchor {
     position: relative;
     display: none;
     margin-left: -1.5em;
@@ -381,7 +381,7 @@ export const Header3 = styled.h3`
   }
 
   &:hover {
-    a {
+    a.header-anchor {
       display: initial;
       fill: ${(props) => props.theme.colors.primary};
     }

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -533,8 +533,8 @@ li > p {
   margin-bottom: calc(1.45rem / 2);
 }
 code {
-  font-size: 0.85rem;
-  line-height: 1.45rem;
+  font-size: 1em;
+  line-height: 1.45em;
 }
 kbd {
   font-size: 0.85rem;
@@ -588,15 +588,14 @@ code {
   font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
     "Liberation Mono", Menlo, Courier, monospace;
   padding: 0;
-  padding-top: 0.2em;
-  padding-bottom: 0.2em;
+  padding-top: 0.15em;
+  padding-bottom: 0.15em;
 }
 pre code {
   background: none;
   line-height: 1.42;
 }
 code:before,
-code:after,
 tt:before,
 tt:after {
   letter-spacing: -0.2em;


### PR DESCRIPTION
## Description
- This adds a css selector to the `Header2` and `Header3` components within `SharedStyledComponents.js`, selecting for `<code>` children, and adjusts height to be relative to its parent.
- Changed the `a` sub-styling on these two components to `a.header-anchor` to select _only_ for the link being generator when parsing mdx (the chain-link to the left of the header). This leaves intentionally placed links within a header to render normally.
- Note this does not actually create nested anchor tags (as I previously expressed concern for), because the actual header text is not a link (only the side chain-link icon), and the ToC only strips the text, and does not apply a second link or additional styling (like `code` styling for example)

## Related Issue #1843

![image](https://user-images.githubusercontent.com/54227730/99916168-5ddae600-2cbd-11eb-85d4-8552b744766d.png)
