### PR TITLE
Fix translated alt tags

### DIFF
--- a/src/pages-conditional/what-is-ethereum.js
+++ b/src/pages-conditional/what-is-ethereum.js
@@ -4,7 +4,7 @@ import Img from "gatsby-image"
 import { graphql } from "gatsby"
 import { useIntl } from "gatsby-plugin-intl"
 
-import { getDefaultMessage } from "../utils/translations"
+import { getDefaultMessage, translateMessageId } from "../utils/translations"
 import Translation from "../components/Translation"
 import ActionCard from "../components/ActionCard"
 import Callout from "../components/Callout"
@@ -254,14 +254,14 @@ const WhatIsEthereumPage = ({ data }) => {
     {
       title: <Translation id="page-what-is-ethereum-native-title" />,
       to: "/eth/",
-      alt: <Translation id="page-what-is-ethereum-native-alt" />,
+      alt: translateMessageId("page-what-is-ethereum-native-alt", intl),
       image: data.eth.childImageSharp.fixed,
       description: <Translation id="page-what-is-ethereum-native-crypto" />,
     },
     {
       title: <Translation id="page-what-is-ethereum-wallets" />,
       to: "/wallets/",
-      alt: <Translation id="page-what-is-ethereum-native-img-alt" />,
+      alt: translateMessageId("page-what-is-ethereum-native-img-alt", intl),
       image: data.wallets.childImageSharp.fixed,
 
       description: <Translation id="page-what-is-ethereum-wallets-desc" />,
@@ -269,7 +269,7 @@ const WhatIsEthereumPage = ({ data }) => {
     {
       title: <Translation id="page-what-is-ethereum-dapps-title" />,
       to: "/dapps/",
-      alt: <Translation id="page-what-is-ethereum-dapps-img-alt" />,
+      alt: translateMessageId("page-what-is-ethereum-dapps-img-alt", intl),
       image: data.dapps.childImageSharp.fixed,
       description: <Translation id="page-what-is-ethereum-dapps-desc" />,
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Update component to string to make alt prop valid.

## Related Issue

Console.error message:
```
index.js:2177 Warning: Failed prop type: Invalid prop `alt` of type `object` supplied to `Image`, expected `string`.
    in Image (created by ActionCard__Image)
    in ActionCard__Image (at ActionCard.js:67)
    in div (created by ActionCard__ImageWrapper)
    in ActionCard__ImageWrapper (at ActionCard.js:66)
    in a (created by Context.Consumer)
    in Location (created by Context.Consumer)
    in Link (created by Context.Consumer)
    in Location (created by GatsbyLink)
    in GatsbyLink (created by ForwardRef)
    in ForwardRef (created by Context.Consumer)
    in Link (created by Link__InternalLink)
    in Link__InternalLink (at Link.js:140)
    in Link (created by ActionCard__Card)
    in ActionCard__Card (at ActionCard.js:65)
    in ActionCard (at what-is-ethereum.js:421)
    in div (created by what-is-ethereum__ActionCardContainer)
    in what-is-ethereum__ActionCardContainer (at what-is-ethereum.js:418)
    in div (created by SharedStyledComponents__Content)
    in SharedStyledComponents__Content (at what-is-ethereum.js:405)
    in div (created by SharedStyledComponents__Page)
    in SharedStyledComponents__Page (at what-is-ethereum.js:278)
    in WhatIsEthereumPage (created by HotExportedWhatIsEthereumPage)
    in AppContainer (created by HotExportedWhatIsEthereumPage)
    in HotExportedWhatIsEthereumPage (created by PageRenderer)
    in IntlProvider (created by PageRenderer)
    in main (created by Layout__Main)
    in Layout__Main (at Layout.js:138)
    in div (created by Layout__MainContent)
    in Layout__MainContent (at Layout.js:130)
    in div (created by Layout__MainContainer)
    in Layout__MainContainer (at Layout.js:127)
    in div (created by Layout__ContentContainer)
    in Layout__ContentContainer (at Layout.js:121)
    in ThemeProvider (at Layout.js:119)
    in IntlProvider (at Layout.js:113)
    in Layout (at gatsby-browser.js:20)
    in PageRenderer (at query-result-store.js:86)
    in PageQueryStore (at root.js:56)
    in RouteHandler (at root.js:78)
    in div (created by FocusHandlerImpl)
    in FocusHandlerImpl (created by Context.Consumer)
    in FocusHandler (created by RouterImpl)
    in RouterImpl (created by Context.Consumer)
    in Location (created by Context.Consumer)
    in Router (at root.js:73)
    in ScrollHandler (at root.js:69)
    in RouteUpdates (at root.js:68)
    in EnsureResources (at root.js:66)
    in LocationHandler (at root.js:124)
    in LocationProvider (created by Context.Consumer)
    in Location (at root.js:123)
    in Root (at root.js:131)
    in MDXProvider (at wrap-root-element.js:65)
    in MDXScopeProvider (at wrap-root-element.js:64)
    in Unknown
    in Unknown (at wrap-root-element.js:72)
    in StaticQueryStore (at root.js:138)
    in _default (at app.js:103)
```