### PR TITLE
CardGrid adjusted to prevent overflow/horiz scroll on small screen [Fixed #1953]

### DIFF
--- a/src/components/SharedStyledComponents.js
+++ b/src/components/SharedStyledComponents.js
@@ -177,7 +177,7 @@ export const CardContainer = styled.div`
 
 export const CardGrid = styled.div`
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 280px), 1fr));
   gap: 2rem;
 `
 


### PR DESCRIPTION
## Description
This places one further condition for `grid-template-columns` so when the screen is below 280px the `min(100%, 280px)` function will result with 100%, which will then collapse properly with smaller screens.
This article explains this nicely for reference: https://ishadeed.com/article/css-grid-minmax/

Screen recording w/ fix: https://share.getcloudapp.com/4guObxDQ
## Related Issue #1953 
