### PR TITLE
Adds className prop to DocLink component [Fixes #1869]

### DIFF
--- a/src/components/DocLink.js
+++ b/src/components/DocLink.js
@@ -48,19 +48,16 @@ const EmojiCell = styled.div`
   align-items: center;
 `
 
-const DocLink = ({ to, title }) => {
+const DocLink = ({ to, title, className }) => {
   return (
-    <Container to={to}>
+    <Container to={to} className={className}>
       <EmojiCell>
         <Emoji size={1} text=":page_with_curl:" mr={`1rem`} />
       </EmojiCell>
       <TextCell>
         <Title>{title}</Title>
       </TextCell>
-      <Arrow
-        name="arrowRight"
-        color={(props) => props.theme.colors.text}
-      ></Arrow>
+      <Arrow name="arrowRight" color={(props) => props.theme.colors.text} />
     </Container>
   )
 }


### PR DESCRIPTION
## Description
Adds the `className` prop to `DocLink` custom component to allow styling with styled-components. 
(Also a small clean up with `<Arrow />`)

## Related Issue
#1869 