### PR TITLE
Prevent mobile search results from covering bottom menu [Fixes #1959]

### DIFF
--- a/src/components/Nav/Mobile.js
+++ b/src/components/Nav/Mobile.js
@@ -131,6 +131,7 @@ const BottomMenu = styled.div`
   align-items: center;
   width: 100%;
   max-width: 450px;
+  z-index: 102;
 `
 const BottomItem = styled.div`
   flex: 1 1 120px;
@@ -292,7 +293,7 @@ const MobileNavMenu = ({
               <Translation id={isDarkTheme ? "dark-mode" : "light-mode"} />
             </BottomItemText>
           </BottomItem>
-          <BottomItem onClick={toggleMenu}>
+          <BottomItem onClick={handleClose}>
             <BottomLink to="/en/languages/">
               <MenuIcon name="language" />
               <BottomItemText>


### PR DESCRIPTION
## Description
Adds `z-index: 102` to be one higher than the search results panel that slides down, to maintain access to the bottom menu while searching. Adjusted `onClick` for language button so menu reopens to main listings.

## Demo
https://share.getcloudapp.com/bLu0DB2b

## Related Issue
#1959 