### PR TITLE
add 0.000000001 in scientific notation as well

### DIFF
--- a/src/content/developers/docs/gas/index.md
+++ b/src/content/developers/docs/gas/index.md
@@ -18,7 +18,7 @@ Gas refers to the unit that measures the amount of computational effort required
 
 Since each Ethereum transaction requires computational resources to execute, each transaction requires a fee. Gas refers to the fee required to successfully conduct a transaction on Ethereum.
 
-In essence, gas fees are paid in Ethereum's native currency, ether (ETH). Gas prices are denoted in Gwei, which itself is a denomination of ETH - each Gwei is equal to 0.000000001 ETH. For example, instead of saying that your gas costs 0.000000001 Ether, you can say your gas costs 1 Gwei.
+In essence, gas fees are paid in Ethereum's native currency, ether (ETH). Gas prices are denoted in Gwei, which itself is a denomination of ETH - each Gwei is equal to 0.000000001 ETH (10<sup>-9</sup> ETH). For example, instead of saying that your gas costs 0.000000001 Ether, you can say your gas costs 1 Gwei.
 
 This video offers a concise overview of gas and why it exists:
 


### PR DESCRIPTION
I am new to Ethereum right now. While reading Gas documentation, I felt it would be easier for new users to remember Gwei-ETH relation if it was specified in scientific notation as well. So, I just added a 10<sup>-9</sup> in brackets.