### PR TITLE
changed from isn't to is as that makes more sense.

### DIFF
--- a/src/content/developers/docs/consensus-mechanisms/pos/index.md
+++ b/src/content/developers/docs/consensus-mechanisms/pos/index.md
@@ -49,7 +49,7 @@ When you submit a transaction on a shard a validator will be responsible for add
 
 #### Attestation {#attestation}
 
-If a validator is chosen to propose a new shard block, they'll have to attest to the proposal and confirm that everything looks as it should. It's the attestation that is recorded in the beacon chain, rather than the transaction itself.
+If a validator isn't chosen to propose a new shard block, they'll have to attest to another validator's proposal and confirm that everything looks as it should. It's the attestation that is recorded in the beacon chain, rather than the transaction itself.
 
 At least 128 validators are required to attest to each shard block – this is known as a "committee".
 

--- a/src/content/developers/docs/consensus-mechanisms/pos/index.md
+++ b/src/content/developers/docs/consensus-mechanisms/pos/index.md
@@ -49,7 +49,7 @@ When you submit a transaction on a shard a validator will be responsible for add
 
 #### Attestation {#attestation}
 
-If a validator isn't chosen to propose a new shard block, they'll have to attest to the proposal and confirm that everything looks as it should. It's the attestation that is recorded in the beacon chain, rather than the transaction itself.
+If a validator is chosen to propose a new shard block, they'll have to attest to the proposal and confirm that everything looks as it should. It's the attestation that is recorded in the beacon chain, rather than the transaction itself.
 
 At least 128 validators are required to attest to each shard block – this is known as a "committee".
 


### PR DESCRIPTION
I was reading through the Ethereum documentation and came across this sentence and felt that this is a mistake. I am not a blockchain expert so if I am wrong, an explanation would be appreciated.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
