### PR TITLE
Add BlockCypher to list of libraries and tools

### DIFF
--- a/src/content/developers/docs/apis/backend/index.md
+++ b/src/content/developers/docs/apis/backend/index.md
@@ -30,6 +30,11 @@ These libraries abstract away much of the complexity of interacting directly wit
 - [GitHub](https://github.com/alchemyplatform)
 - [Discord](https://discord.gg/kwqVnrA)
 
+**BlockCypher -** **_Ethereum Web APIs_**
+
+- [blockcypher.com](https://www.blockcypher.com/)
+- [Documentation](https://www.blockcypher.com/dev/ethereum/)
+
 **Infura -** **_The Ethereum API as a service._**
 
 - [infura.io](https://infura.io)


### PR DESCRIPTION
## Description

Adding BlockCypher, the web APIs seem like a good fit for this page. Going for alphabetical order. The other links should be reordered a bit if that's the intent.
