### PR TITLE
Adds className prop to CardList component

### DIFF
--- a/src/components/CardList.js
+++ b/src/components/CardList.js
@@ -56,9 +56,9 @@ const Image = styled(Img)`
   margin-top: 4px;
 `
 
-const CardList = ({ content }) => {
+const CardList = ({ content, className }) => {
   return (
-    <Table>
+    <Table className={className}>
       {content.map((listItem, idx) => {
         const { title, description, caption, link, image, id } = listItem
         return (


### PR DESCRIPTION
## Description
Follow-up to #1958, only other component I found that was being styled with `styled-components` without the `className` prop being passed. This adds it to the component. 

## Related Issue (none new filed)
https://github.com/ethereum/ethereum-org-website/blob/689d9d6ecc462a27d79d94eecbabd44548632a93/src/pages/eth2/get-involved/index.js#L132
