### PR TITLE
Add eth2 attacknet winners to eth2 bug bounty leaderboard

### DIFF
--- a/src/data/eth2-bounty-hunters.csv
+++ b/src/data/eth2-bounty-hunters.csv
@@ -1,6 +1,6 @@
 username, name, score
-samajammin, "Sam Richards", 0
-ryancreatescopy, "Ryan Corell", 0
-jjmstark , "Josh Stark", 0
-vbuterin, "Vitalik Buterin", 0
-djrtwo, "Danny Ryan", 0
+jrhea, "Jonny Rhea", 5500
+AlexSSD7, "Alexander Sadovskyi", 2500
+tintinweb, "tintin", 2500
+holiman, "Martin Holst Swende", 2500
+atoulme, "Antoine Toulme", 5000


### PR DESCRIPTION
## Description

Initializes the bug bounty leaderboard with the winners of attacknet bounties (see https://github.com/ethereum/public-attacknets#trophies-). 