### PR TITLE
Add CODEOWNERS for Eth2 bounties

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# This file defines the code owners of the repository
+# Code owners are automatically requested for review when someone opens a PR that modifies code that they own
+# Each line is a file pattern followed by one or more owners. Learn more here:
+# https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+*       @samajammin @ryancreatescopy
+
+# Owners of specific files
+/src/data/eth2-bounty-hunters.csv @lsankar4033 @djrtwo


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add @lsankar4033 @djrtwo as code owners for Eth2 bounties data
https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners

Note: they need to be granted write permission on the repo in order for this to work:
https://github.com/ethereum/devops/issues/598

## Related Issue
None
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
