### PR TITLE
Refactored codebase using `translateMessageId` [Fixes #2029]

### DIFF
--- a/src/components/Breadcrumbs.js
+++ b/src/components/Breadcrumbs.js
@@ -3,7 +3,7 @@ import styled from "styled-components"
 import { useIntl } from "gatsby-plugin-intl"
 
 import Link from "./Link"
-import { getDefaultMessage, supportedLanguages } from "../utils/translations"
+import { translateMessageId, supportedLanguages } from "../utils/translations"
 
 const Crumb = styled.h4`
   margin: 0;
@@ -67,10 +67,7 @@ const Breadcrumbs = ({ slug, startDepth = 0, className }) => {
   const crumbs = sliced.map((path, idx) => {
     // If homepage (e.g. "en"), set text to "home" translation
     const text = supportedLanguages.includes(path)
-      ? intl.formatMessage({
-          id: "page-home-meta-title",
-          defaultMessage: getDefaultMessage("page-home-meta-title"),
-        })
+      ? translateMessageId("page-home-meta-title", intl)
       : path.replace(/-/g, " ") // TODO support translations
     return {
       fullPath: split.slice(0, idx + 2 + startDepth).join("/") + "/",

--- a/src/components/ButtonDropdown.js
+++ b/src/components/ButtonDropdown.js
@@ -8,6 +8,7 @@ import Link from "./Link"
 import Translation from "./Translation"
 import { ButtonSecondary } from "./SharedStyledComponents"
 import { useOnClickOutside } from "../hooks/useOnClickOutside"
+import { translateMessageId } from "../utils/translations"
 
 const Container = styled.div`
   position: relative;
@@ -111,9 +112,7 @@ const ButtonDropdown = ({ list, className }) => {
     <Container
       className={className}
       ref={ref}
-      aria-label={`Select ${intl.formatMessage({
-        id: list.text,
-      })}`}
+      aria-label={`Select ${translateMessageId(list.text, intl)}`}
     >
       <Button
         onClick={() => setIsOpen(!isOpen)}

--- a/src/components/Nav/Dropdown.js
+++ b/src/components/Nav/Dropdown.js
@@ -8,6 +8,7 @@ import Icon from "../Icon"
 import Link from "../Link"
 
 import { useOnClickOutside } from "../../hooks/useOnClickOutside"
+import { translateMessageId } from "../../utils/translations"
 
 // TODO use framer-motion
 const StyledIcon = styled(Icon)`
@@ -114,7 +115,7 @@ const NavDropdown = ({ section, hasSubNav }) => {
   const ariaLabel = section.ariaLabel || section.text
 
   return (
-    <NavListItem ref={ref} aria-label={intl.formatMessage({ id: ariaLabel })}>
+    <NavListItem ref={ref} aria-label={translateMessageId(ariaLabel, intl)}>
       <DropdownTitle
         onClick={() => setIsOpen(!isOpen)}
         onKeyDown={onKeyDownHandler}

--- a/src/components/Nav/Mobile.js
+++ b/src/components/Nav/Mobile.js
@@ -9,6 +9,7 @@ import Link from "../Link"
 import Search from "../Search"
 import Emoji from "../Emoji"
 import { NavLink } from "../../components/SharedStyledComponents"
+import { translateMessageId } from "../../utils/translations"
 
 const MobileModal = styled(motion.div)`
   position: fixed;
@@ -228,9 +229,10 @@ const MobileNavMenu = ({
                 return (
                   <NavListItem
                     key={idx}
-                    aria-label={`Select ${intl.formatMessage({
-                      id: section.text,
-                    })}`}
+                    aria-label={`Select ${translateMessageId(
+                      section.text,
+                      intl
+                    )}`}
                   >
                     <SectionTitle>
                       <Translation id={section.text} />

--- a/src/components/Nav/index.js
+++ b/src/components/Nav/index.js
@@ -13,7 +13,10 @@ import Search from "../Search"
 import Translation from "../Translation"
 import { NavLink } from "../../components/SharedStyledComponents"
 
-import { getLangContentVersion } from "../../utils/translations"
+import {
+  translateMessageId,
+  getLangContentVersion,
+} from "../../utils/translations"
 
 const NavContainer = styled.div`
   position: sticky;
@@ -437,7 +440,7 @@ const Nav = ({ handleThemeChange, isDarkTheme, path }) => {
           <HomeLogoNavLink to="/">
             <HomeLogo
               fixed={data.file.childImageSharp.fixed}
-              alt={intl.formatMessage({ id: "ethereum-logo" })}
+              alt={translateMessageId("ethereum-logo", intl)}
             />
           </HomeLogoNavLink>
           {/* Desktop */}

--- a/src/components/PageMetadata.js
+++ b/src/components/PageMetadata.js
@@ -5,7 +5,7 @@ import { useStaticQuery, graphql } from "gatsby"
 import { useIntl } from "gatsby-plugin-intl"
 import { Location } from "@reach/router"
 
-import { getDefaultMessage, languageMetadata } from "../utils/translations"
+import { translateMessageId, languageMetadata } from "../utils/translations"
 
 const supportedLanguages = Object.keys(languageMetadata)
 
@@ -59,17 +59,9 @@ const PageMetadata = ({ description, meta, title, image, canonicalUrl }) => {
 
   const intl = useIntl()
 
-  const desc =
-    description ||
-    intl.formatMessage({
-      id: "site-description",
-      defaultMessage: getDefaultMessage("site-description"),
-    })
+  const desc = description || translateMessageId("site-description", intl)
 
-  const siteTitle = intl.formatMessage({
-    id: "site-title",
-    defaultMessage: getDefaultMessage("site-title"),
-  })
+  const siteTitle = translateMessageId("site-title", intl)
 
   return (
     <Location>

--- a/src/components/Search/Input.js
+++ b/src/components/Search/Input.js
@@ -4,7 +4,7 @@ import styled from "styled-components"
 import { connectSearchBox } from "react-instantsearch-dom"
 
 import Icon from "../Icon"
-import { getDefaultMessage } from "../../utils/translations"
+import { translateMessageId } from "../../utils/translations"
 
 const Form = styled.form`
   margin: 0;
@@ -42,10 +42,7 @@ const Input = ({ query, setQuery, refine, ...rest }) => {
   }
 
   const intl = useIntl()
-  const searchString = intl.formatMessage({
-    id: "search",
-    defaultMessage: getDefaultMessage("search"),
-  })
+  const searchString = translateMessageId("search", intl)
 
   return (
     <Form>

--- a/src/pages-conditional/developers/index.js
+++ b/src/pages-conditional/developers/index.js
@@ -4,7 +4,7 @@ import Img from "gatsby-image"
 import { graphql } from "gatsby"
 import { useIntl } from "gatsby-plugin-intl"
 
-import { getDefaultMessage } from "../../utils/translations"
+import { translateMessageId } from "../../utils/translations"
 import Card from "../../components/Card"
 import Callout from "../../components/Callout"
 import Link from "../../components/Link"
@@ -233,14 +233,8 @@ const DevelopersPage = ({ data }) => {
   return (
     <Page>
       <PageMetadata
-        title={intl.formatMessage({
-          id: "page-developer-meta-title",
-          defaultMessage: getDefaultMessage("page-developer-meta-title"),
-        })}
-        description={intl.formatMessage({
-          id: "page-developers-meta-desc",
-          defaultMessage: getDefaultMessage("page-developers-meta-desc"),
-        })}
+        title={translateMessageId("page-developer-meta-title", intl)}
+        description={translateMessageId("page-developers-meta-desc", intl)}
       />
       <Content>
         <HeroContainer>
@@ -307,18 +301,11 @@ const DevelopersPage = ({ data }) => {
           </IntroColumn>
           <StyledCallout
             image={data.developers.childImageSharp.fixed}
-            title={intl.formatMessage({
-              id: "page-developers-improve-ethereum",
-              defaultMessage: getDefaultMessage(
-                "page-developers-improve-ethereum"
-              ),
-            })}
-            description={intl.formatMessage({
-              id: "page-developers-improve-ethereum-desc",
-              defaultMessage: getDefaultMessage(
-                "page-developers-improve-ethereum-desc"
-              ),
-            })}
+            title={translateMessageId("page-developers-improve-ethereum", intl)}
+            description={translateMessageId(
+              "page-developers-improve-ethereum-desc",
+              intl
+            )}
           >
             <div>
               <ButtonLink to="https://github.com/ethereum/ethereum-org-website">

--- a/src/pages-conditional/developers/local-environment.js
+++ b/src/pages-conditional/developers/local-environment.js
@@ -10,7 +10,7 @@ import { useIntl } from "gatsby-plugin-intl"
 // import Link from "../../components/Link"
 // import ButtonLink from "../../components/ButtonLink"
 import Translation from "../../components/Translation"
-import { getDefaultMessage } from "../../utils/translations"
+import { translateMessageId } from "../../utils/translations"
 import PageMetadata from "../../components/PageMetadata"
 import ProductCard from "../../components/ProductCard"
 import {
@@ -348,18 +348,14 @@ const ChooseStackPage = ({ data }) => {
   return (
     <StyledPage>
       <PageMetadata
-        title={intl.formatMessage({
-          id: "page-local-environment-setup-meta-title",
-          defaultMessage: getDefaultMessage(
-            "page-local-environment-setup-meta-title"
-          ),
-        })}
-        description={intl.formatMessage({
-          id: "page-local-environment-setup-meta-desc",
-          defaultMessage: getDefaultMessage(
-            "page-local-environment-setup-meta-desc"
-          ),
-        })}
+        title={translateMessageId(
+          "page-local-environment-setup-meta-title",
+          intl
+        )}
+        description={translateMessageId(
+          "page-local-environment-setup-meta-desc",
+          intl
+        )}
       />
       <HeroContent>
         <Slogan>

--- a/src/pages-conditional/developers/tutorials.js
+++ b/src/pages-conditional/developers/tutorials.js
@@ -4,7 +4,7 @@ import { graphql } from "gatsby"
 import { useIntl } from "gatsby-plugin-intl"
 
 import Translation from "../../components/Translation"
-import { getDefaultMessage } from "../../utils/translations"
+import { translateMessageId } from "../../utils/translations"
 import Icon from "../../components/Icon"
 import ButtonLink from "../../components/ButtonLink"
 import Link from "../../components/Link"
@@ -242,14 +242,11 @@ const TutorialsPage = ({ data }) => {
   return (
     <StyledPage>
       <PageMetadata
-        title={intl.formatMessage({
-          id: "page-tutorials-meta-title",
-          defaultMessage: getDefaultMessage("page-tutorials-meta-title"),
-        })}
-        description={intl.formatMessage({
-          id: "page-tutorials-meta-description",
-          defaultMessage: getDefaultMessage("page-tutorials-meta-description"),
-        })}
+        title={translateMessageId("page-tutorials-meta-title", intl)}
+        description={translateMessageId(
+          "page-tutorials-meta-description",
+          intl
+        )}
       />
 
       <PageTitle>

--- a/src/pages-conditional/eth.js
+++ b/src/pages-conditional/eth.js
@@ -4,7 +4,7 @@ import Img from "gatsby-image"
 import { useIntl } from "gatsby-plugin-intl"
 import { graphql } from "gatsby"
 
-import { getDefaultMessage } from "../utils/translations"
+import { translateMessageId } from "../utils/translations"
 import Translation from "../components/Translation"
 import ActionCard from "../components/ActionCard"
 import ButtonLink from "../components/ButtonLink"
@@ -228,14 +228,8 @@ const WhatIsEthereumPage = (props) => {
   return (
     <Page>
       <PageMetadata
-        title={intl.formatMessage({
-          id: "page-eth-whats-eth-meta-title",
-          defaultMessage: getDefaultMessage("page-eth-whats-eth-meta-title"),
-        })}
-        description={intl.formatMessage({
-          id: "page-eth-whats-eth-meta-desc",
-          defaultMessage: getDefaultMessage("page-eth-whats-eth-meta-desc"),
-        })}
+        title={translateMessageId("page-eth-whats-eth-meta-title", intl)}
+        description={translateMessageId("page-eth-whats-eth-meta-desc", intl)}
         image={data.ogImage.childImageSharp.fixed.src}
       />
       <Content>
@@ -336,14 +330,11 @@ const WhatIsEthereumPage = (props) => {
           </div>
           <CentralActionCard
             to="/what-is-ethereum/"
-            title={intl.formatMessage({
-              id: "page-eth-whats-ethereum",
-              defaultMessage: getDefaultMessage("page-eth-whats-ethereum"),
-            })}
-            description={intl.formatMessage({
-              id: "page-eth-whats-ethereum-desc",
-              defaultMessage: getDefaultMessage("page-eth-whats-ethereum-desc"),
-            })}
+            title={translateMessageId("page-eth-whats-ethereum", intl)}
+            description={translateMessageId(
+              "page-eth-whats-ethereum-desc",
+              intl
+            )}
             image={data.ethereum.childImageSharp.fixed}
           />
           <TextDivider />
@@ -385,14 +376,8 @@ const WhatIsEthereumPage = (props) => {
           <Divider />
         </CentralColumn>
         <StyledCalloutBanner
-          title={intl.formatMessage({
-            id: "page-eth-where-to-buy",
-            defaultMessage: getDefaultMessage("page-eth-where-to-buy"),
-          })}
-          description={intl.formatMessage({
-            id: "page-eth-where-to-buy-desc",
-            defaultMessage: getDefaultMessage("page-eth-where-to-buy-desc"),
-          })}
+          title={translateMessageId("page-eth-where-to-buy", intl)}
+          description={translateMessageId("page-eth-where-to-buy-desc", intl)}
           image={data.ethCat.childImageSharp.fluid}
           maxImageWidth={300}
         >

--- a/src/pages-conditional/wallets/find-wallet.js
+++ b/src/pages-conditional/wallets/find-wallet.js
@@ -4,7 +4,7 @@ import { useIntl } from "gatsby-plugin-intl"
 import styled from "styled-components"
 import Img from "gatsby-image"
 
-import { getDefaultMessage } from "../../utils/translations"
+import { translateMessageId } from "../../utils/translations"
 import Translation from "../../components/Translation"
 import Breadcrumbs from "../../components/Breadcrumbs"
 import ButtonLink from "../../components/ButtonLink"
@@ -101,16 +101,11 @@ const FindWalletPage = ({ location, data }) => {
   return (
     <Page>
       <PageMetadata
-        title={intl.formatMessage({
-          id: "page-find-wallet-meta-title",
-          defaultMessage: getDefaultMessage("page-find-wallet-meta-title"),
-        })}
-        description={intl.formatMessage({
-          id: "page-find-wallet-meta-description",
-          defaultMessage: getDefaultMessage(
-            "page-find-wallet-meta-description"
-          ),
-        })}
+        title={translateMessageId("page-find-wallet-meta-title", intl)}
+        description={translateMessageId(
+          "page-find-wallet-meta-description",
+          intl
+        )}
       />
 
       <HeroContainer>
@@ -143,14 +138,11 @@ const FindWalletPage = ({ location, data }) => {
       <WalletCompare />
       <Divider />
       <CalloutBanner
-        title={intl.formatMessage({
-          id: "page-find-wallet-use-your-wallet",
-          defaultMessage: getDefaultMessage("page-find-wallet-use-your-wallet"),
-        })}
-        description={intl.formatMessage({
-          id: "page-find-wallet-use-wallet-desc",
-          defaultMessage: getDefaultMessage("page-find-wallet-use-wallet-desc"),
-        })}
+        title={translateMessageId("page-find-wallet-use-your-wallet", intl)}
+        description={translateMessageId(
+          "page-find-wallet-use-wallet-desc",
+          intl
+        )}
         image={data.dapps.childImageSharp.fluid}
         maxImageWidth={600}
       >

--- a/src/pages-conditional/what-is-ethereum.js
+++ b/src/pages-conditional/what-is-ethereum.js
@@ -4,7 +4,7 @@ import Img from "gatsby-image"
 import { graphql } from "gatsby"
 import { useIntl } from "gatsby-plugin-intl"
 
-import { getDefaultMessage, translateMessageId } from "../utils/translations"
+import { translateMessageId } from "../utils/translations"
 import Translation from "../components/Translation"
 import ActionCard from "../components/ActionCard"
 import Callout from "../components/Callout"
@@ -277,16 +277,11 @@ const WhatIsEthereumPage = ({ data }) => {
   return (
     <Page>
       <PageMetadata
-        title={intl.formatMessage({
-          id: "page-what-is-ethereum-meta-title",
-          defaultMessage: getDefaultMessage("page-what-is-ethereum-meta-title"),
-        })}
-        description={intl.formatMessage({
-          id: "page-what-is-ethereum-meta-description",
-          defaultMessage: getDefaultMessage(
-            "page-what-is-ethereum-meta-description"
-          ),
-        })}
+        title={translateMessageId("page-what-is-ethereum-meta-title", intl)}
+        description={translateMessageId(
+          "page-what-is-ethereum-meta-description",
+          intl
+        )}
         image={data.ogImage.childImageSharp.fixed.src}
       />
       <HeroContent>
@@ -307,12 +302,10 @@ const WhatIsEthereumPage = ({ data }) => {
           </Header>
           <Hero
             fluid={data.hero.childImageSharp.fluid}
-            alt={intl.formatMessage({
-              id: "page-what-is-ethereum-alt-img-bazaar",
-              defaultMessage: getDefaultMessage(
-                "page-what-is-ethereum-alt-img-bazaar"
-              ),
-            })}
+            alt={translateMessageId(
+              "page-what-is-ethereum-alt-img-bazaar",
+              intl
+            )}
             loading="eager"
           />
         </HeroContainer>
@@ -339,12 +332,7 @@ const WhatIsEthereumPage = ({ data }) => {
       <BannerContainer>
         <Banner
           fluid={data.banner.childImageSharp.fluid}
-          alt={intl.formatMessage({
-            id: "page-what-is-ethereum-alt-img-social",
-            defaultMessage: getDefaultMessage(
-              "page-what-is-ethereum-alt-img-social"
-            ),
-          })}
+          alt={translateMessageId("page-what-is-ethereum-alt-img-social", intl)}
         />
         <BannerMessage>
           <Translation id="page-what-is-ethereum-welcome" /> <br />
@@ -383,18 +371,14 @@ const WhatIsEthereumPage = ({ data }) => {
         <CardColumn>
           <SingleCard
             emoji=":gear:"
-            title={intl.formatMessage({
-              id: "page-what-is-ethereum-singlecard-title",
-              defaultMessage: getDefaultMessage(
-                "page-what-is-ethereum-singlecard-title"
-              ),
-            })}
-            description={intl.formatMessage({
-              id: "page-what-is-ethereum-singlecard-desc",
-              defaultMessage: getDefaultMessage(
-                "page-what-is-ethereum-singlecard-desc"
-              ),
-            })}
+            title={translateMessageId(
+              "page-what-is-ethereum-singlecard-title",
+              intl
+            )}
+            description={translateMessageId(
+              "page-what-is-ethereum-singlecard-desc",
+              intl
+            )}
           >
             <Link to="/learn/">
               <Translation id="page-what-is-ethereum-singlecard-link" />
@@ -441,22 +425,12 @@ const WhatIsEthereumPage = ({ data }) => {
         <CardContainer>
           <StyledCallout
             image={data.developers.childImageSharp.fixed}
-            title={intl.formatMessage({
-              id: "page-what-is-ethereum-build",
-              defaultMessage: getDefaultMessage("page-what-is-ethereum-build"),
-            })}
-            alt={intl.formatMessage({
-              id: "page-what-is-ethereum-alt-img-lego",
-              defaultMessage: getDefaultMessage(
-                "page-what-is-ethereum-alt-img-lego"
-              ),
-            })}
-            description={intl.formatMessage({
-              id: "page-what-is-ethereum-build-desc",
-              defaultMessage: getDefaultMessage(
-                "page-what-is-ethereum-build-desc"
-              ),
-            })}
+            title={translateMessageId("page-what-is-ethereum-build", intl)}
+            alt={translateMessageId("page-what-is-ethereum-alt-img-lego", intl)}
+            description={translateMessageId(
+              "page-what-is-ethereum-build-desc",
+              intl
+            )}
           >
             <div>
               <ButtonLink to="/developers/">
@@ -466,24 +440,12 @@ const WhatIsEthereumPage = ({ data }) => {
           </StyledCallout>
           <StyledCallout
             image={data.community.childImageSharp.fixed}
-            title={intl.formatMessage({
-              id: "page-what-is-ethereum-community",
-              defaultMessage: getDefaultMessage(
-                "page-what-is-ethereum-community"
-              ),
-            })}
-            alt={intl.formatMessage({
-              id: "page-what-is-ethereum-alt-img-comm",
-              defaultMessage: getDefaultMessage(
-                "page-what-is-ethereum-alt-img-comm"
-              ),
-            })}
-            description={intl.formatMessage({
-              id: "page-what-is-ethereum-comm-desc",
-              defaultMessage: getDefaultMessage(
-                "page-what-is-ethereum-comm-desc"
-              ),
-            })}
+            title={translateMessageId("page-what-is-ethereum-community", intl)}
+            alt={translateMessageId("page-what-is-ethereum-alt-img-comm", intl)}
+            description={translateMessageId(
+              "page-what-is-ethereum-comm-desc",
+              intl
+            )}
           >
             <div>
               <ButtonLink to="/community/">

--- a/src/pages/build.js
+++ b/src/pages/build.js
@@ -2,6 +2,7 @@ import React from "react"
 import { graphql } from "gatsby"
 import styled from "styled-components"
 import { useIntl } from "gatsby-plugin-intl"
+import { translateMessageId } from "../utils/translations"
 
 import PageMetadata from "../components/PageMetadata"
 import Translation from "../components/Translation"
@@ -245,8 +246,8 @@ const BuildPage = ({ data }) => {
   return (
     <Page>
       <PageMetadata
-        title={intl.formatMessage({ id: "page-build-meta-title" })}
-        description={intl.formatMessage({ id: "page-build-meta-description" })}
+        title={translateMessageId("page-build-meta-title", intl)}
+        description={translateMessageId("page-build-meta-description", intl)}
         image={data.ogImage.childImageSharp.fixed.src}
       />
       <Header>

--- a/src/pages/eth2/deposit-contract.js
+++ b/src/pages/eth2/deposit-contract.js
@@ -21,7 +21,7 @@ import {
   FakeLink,
 } from "../../components/SharedStyledComponents"
 import { DEPOSIT_CONTRACT_ADDRESS } from "../../data/addresses.js"
-import { getDefaultMessage } from "../../utils/translations"
+import { translateMessageId } from "../../utils/translations"
 
 const Page = styled.div`
   width: 100%;
@@ -291,26 +291,22 @@ const DepositContractPage = ({ data, location }) => {
     state.userWillCheckOtherSources
 
   const textToSpeechText = state.isSpeechActive
-    ? intl.formatMessage({ id: "page-eth2-deposit-contract-stop-reading" })
-    : intl.formatMessage({ id: "page-eth2-deposit-contract-read-aloud" })
+    ? translateMessageId("page-eth2-deposit-contract-stop-reading", intl)
+    : translateMessageId("page-eth2-deposit-contract-read-aloud", intl)
   const textToSpeechEmoji = state.isSpeechActive
     ? ":speaker_high_volume:"
     : ":speaker:"
   return (
     <Page>
       <PageMetadata
-        title={intl.formatMessage({
-          id: "page-eth2-deposit-contract-meta-title",
-          defaultMessage: getDefaultMessage(
-            "page-eth2-deposit-contract-meta-title"
-          ),
-        })}
-        description={intl.formatMessage({
-          id: "page-eth2-deposit-contract-meta-desc",
-          defaultMessage: getDefaultMessage(
-            "page-eth2-deposit-contract-meta-desc"
-          ),
-        })}
+        title={translateMessageId(
+          "page-eth2-deposit-contract-meta-title",
+          intl
+        )}
+        description={translateMessageId(
+          "page-eth2-deposit-contract-meta-desc",
+          intl
+        )}
       />
       <LeftColumn>
         <Breadcrumbs slug={location.pathname} startDepth={1} />
@@ -422,12 +418,10 @@ const DepositContractPage = ({ data, location }) => {
                   </TextToSpeech>
                 )}
                 <Tooltip
-                  content={intl.formatMessage({
-                    id: "page-eth2-deposit-contract-warning",
-                    defaultMessage: getDefaultMessage(
-                      "page-eth2-deposit-contract-warning"
-                    ),
-                  })}
+                  content={translateMessageId(
+                    "page-eth2-deposit-contract-warning",
+                    intl
+                  )}
                 >
                   <Address>{CHUNKED_ADDRESS}</Address>
                 </Tooltip>

--- a/src/pages/eth2/get-involved/index.js
+++ b/src/pages/eth2/get-involved/index.js
@@ -4,7 +4,7 @@ import styled from "styled-components"
 import { graphql } from "gatsby"
 import { useIntl } from "gatsby-plugin-intl"
 
-import { getDefaultMessage } from "../../../utils/translations"
+import { translateMessageId } from "../../../utils/translations"
 import Card from "../../../components/Card"
 import Leaderboard from "../../../components/Leaderboard"
 import CalloutBanner from "../../../components/CalloutBanner"
@@ -323,16 +323,11 @@ const GetInvolvedPage = ({ data, location }) => {
   return (
     <Page>
       <PageMetadata
-        title={intl.formatMessage({
-          id: "page-eth2-get-involved",
-          defaultMessage: getDefaultMessage("page-eth2-get-involved"),
-        })}
-        description={intl.formatMessage({
-          id: "page-eth2-get-involved-meta-description",
-          defaultMessage: getDefaultMessage(
-            "page-eth2-get-involved-meta-description"
-          ),
-        })}
+        title={translateMessageId("page-eth2-get-involved", intl)}
+        description={translateMessageId(
+          "page-eth2-get-involved-meta-description",
+          intl
+        )}
       />
       <Content>
         <HeroCard>
@@ -369,16 +364,11 @@ const GetInvolvedPage = ({ data, location }) => {
         </StyledCardContainer>
         <TemporaryCallout
           image={data.rhino.childImageSharp.fluid}
-          title={intl.formatMessage({
-            id: "page-eth2-get-involved-grants",
-            defaultMessage: getDefaultMessage("page-eth2-get-involved-grants"),
-          })}
-          description={intl.formatMessage({
-            id: "page-eth2-get-involved-grants-desc",
-            defaultMessage: getDefaultMessage(
-              "page-eth2-get-involved-grants-desc"
-            ),
-          })}
+          title={translateMessageId("page-eth2-get-involved-grants", intl)}
+          description={translateMessageId(
+            "page-eth2-get-involved-grants-desc",
+            intl
+          )}
         >
           <div>
             <ButtonLink to="/eth2/get-involved/staking-community-grants/">
@@ -420,16 +410,11 @@ const GetInvolvedPage = ({ data, location }) => {
       <Staking>
         <StyledCalloutBanner
           image={data.rhino.childImageSharp.fluid}
-          title={intl.formatMessage({
-            id: "page-eth2-get-involved-stake",
-            defaultMessage: getDefaultMessage("page-eth2-get-involved-stake"),
-          })}
-          description={intl.formatMessage({
-            id: "page-eth2-get-involved-stake-desc",
-            defaultMessage: getDefaultMessage(
-              "page-eth2-get-involved-stake-desc"
-            ),
-          })}
+          title={translateMessageId("page-eth2-get-involved-stake", intl)}
+          description={translateMessageId(
+            "page-eth2-get-involved-stake-desc",
+            intl
+          )}
         >
           <div>
             <ButtonLink to="/eth2/staking/">

--- a/src/pages/eth2/index.js
+++ b/src/pages/eth2/index.js
@@ -24,7 +24,7 @@ import {
   Eth2Header,
   Eth2HeaderGradient,
 } from "../../components/SharedStyledComponents"
-import { getDefaultMessage } from "../../utils/translations"
+import { translateMessageId } from "../../utils/translations"
 
 const HeroContainer = styled.div`
   padding-left: 4rem;
@@ -340,14 +340,8 @@ const Eth2IndexPage = ({ data }) => {
   return (
     <Page>
       <PageMetadata
-        title={intl.formatMessage({
-          id: "page-eth2-meta-title",
-          defaultMessage: getDefaultMessage("page-eth2-meta-title"),
-        })}
-        description={intl.formatMessage({
-          id: "page-eth2-meta-desc",
-          defaultMessage: getDefaultMessage("page-eth2-meta-desc"),
-        })}
+        title={translateMessageId("page-eth2-meta-title")}
+        description={translateMessageId("page-eth2-meta-desc")}
       />
       <Content>
         <HeroCard>
@@ -418,14 +412,8 @@ const Eth2IndexPage = ({ data }) => {
       </Content>
       <StyledCallout
         image={data.eth.childImageSharp.fluid}
-        title={intl.formatMessage({
-          id: "page-eth2-dive",
-          defaultMessage: getDefaultMessage("page-eth2-dive"),
-        })}
-        description={intl.formatMessage({
-          id: "page-eth2-dive-desc",
-          defaultMessage: getDefaultMessage("page-eth2-dive-desc"),
-        })}
+        title={translateMessageId("page-eth2-dive", intl)}
+        description={translateMessageId("page-eth2-dive-desc", intl)}
       >
         <div>
           <ButtonLink to="/en/eth2/vision/">
@@ -509,16 +497,11 @@ const Eth2IndexPage = ({ data }) => {
           <StakingRightColumn>
             <StakingCard
               emoji=":money_with_wings:"
-              title={intl.formatMessage({
-                id: "page-eth2-staking-learn",
-                defaultMessage: getDefaultMessage("page-eth2-staking-learn"),
-              })}
-              description={intl.formatMessage({
-                id: "page-eth2-staking-learn-desc",
-                defaultMessage: getDefaultMessage(
-                  "page-eth2-staking-learn-desc"
-                ),
-              })}
+              title={translateMessageId("page-eth2-staking-learn", intl)}
+              description={translateMessageId(
+                "page-eth2-staking-learn-desc",
+                intl
+              )}
             >
               <ButtonLink to="/eth2/staking/">
                 <Translation id="page-eth2-deposit-contract-staking-more-link" />
@@ -536,14 +519,11 @@ const Eth2IndexPage = ({ data }) => {
         <Faq>
           <LeftColumn>
             <ExpandableCard
-              contentPreview={intl.formatMessage({
-                id: "page-eth2-question-1-desc",
-                defaultMessage: getDefaultMessage("page-eth2-question-1-desc"),
-              })}
-              title={intl.formatMessage({
-                id: "page-eth2-question-1-title",
-                defaultMessage: getDefaultMessage("page-eth2-question-1-title"),
-              })}
+              contentPreview={translateMessageId(
+                "page-eth2-question-1-desc",
+                intl
+              )}
+              title={translateMessageId("page-eth2-question-1-title", intl)}
             >
               <p>
                 <Link to="/eth2/beacon-chain/">
@@ -569,14 +549,11 @@ const Eth2IndexPage = ({ data }) => {
               </p>
             </ExpandableCard>
             <ExpandableCard
-              contentPreview={intl.formatMessage({
-                id: "page-eth2-question-2-desc",
-                defaultMessage: getDefaultMessage("page-eth2-question-2-desc"),
-              })}
-              title={intl.formatMessage({
-                id: "page-eth2-question-2-title",
-                defaultMessage: getDefaultMessage("page-eth2-question-2-title"),
-              })}
+              contentPreview={translateMessageId(
+                "page-eth2-question-2-desc",
+                intl
+              )}
+              title={translateMessageId("page-eth2-question-2-title", intl)}
             >
               <p>
                 <Translation id="page-eth2-answer-1" />{" "}
@@ -604,14 +581,11 @@ const Eth2IndexPage = ({ data }) => {
               </p>
             </ExpandableCard>
             <ExpandableCard
-              contentPreview={intl.formatMessage({
-                id: "page-eth2-question-3-desc",
-                defaultMessage: getDefaultMessage("page-eth2-question-3-desc"),
-              })}
-              title={intl.formatMessage({
-                id: "page-eth2-question-3-title",
-                defaultMessage: getDefaultMessage("page-eth2-question-3-title"),
-              })}
+              contentPreview={translateMessageId(
+                "page-eth2-question-3-desc",
+                intl
+              )}
+              title={translateMessageId("page-eth2-question-3-title", intl)}
             >
               <p>
                 <Translation id="page-eth2-question3-answer-1" />
@@ -633,14 +607,11 @@ const Eth2IndexPage = ({ data }) => {
               </p>
             </ExpandableCard>
             <ExpandableCard
-              contentPreview={intl.formatMessage({
-                id: "page-eth2-question-4-desc",
-                defaultMessage: getDefaultMessage("page-eth2-question-4-desc"),
-              })}
-              title={intl.formatMessage({
-                id: "page-eth2-question-4-title",
-                defaultMessage: getDefaultMessage("page-eth2-question-4-title"),
-              })}
+              contentPreview={translateMessageId(
+                "page-eth2-question-4-desc",
+                intl
+              )}
+              title={translateMessageId("page-eth2-question-4-title", intl)}
             >
               <p>
                 <Translation id="page-eth2-question-4-answer-1" />{" "}
@@ -678,14 +649,11 @@ const Eth2IndexPage = ({ data }) => {
               </p>
             </ExpandableCard>
             <ExpandableCard
-              contentPreview={intl.formatMessage({
-                id: "page-eth2-question-5-desc",
-                defaultMessage: getDefaultMessage("page-eth2-question-5-desc"),
-              })}
-              title={intl.formatMessage({
-                id: "page-eth2-question-5-title",
-                defaultMessage: getDefaultMessage("page-eth2-question-5-title"),
-              })}
+              contentPreview={translateMessageId(
+                "page-eth2-question-5-desc",
+                intl
+              )}
+              title={translateMessageId("page-eth2-question-5-title", intl)}
             >
               <p>
                 <Translation id="page-eth2-question-5-answer-1" />
@@ -699,14 +667,11 @@ const Eth2IndexPage = ({ data }) => {
           </LeftColumn>
           <RightColumn>
             <ExpandableCard
-              contentPreview={intl.formatMessage({
-                id: "page-eth2-question-6-desc",
-                defaultMessage: getDefaultMessage("page-eth2-question-6-desc"),
-              })}
-              title={intl.formatMessage({
-                id: "page-eth2-question-6-title",
-                defaultMessage: getDefaultMessage("page-eth2-question-6-title"),
-              })}
+              contentPreview={translateMessageId(
+                "page-eth2-question-6-desc",
+                intl
+              )}
+              title={translateMessageId("page-eth2-question-6-title", intl)}
             >
               <p>
                 <Translation id="page-eth2-question-6-answer-1" />{" "}
@@ -741,14 +706,11 @@ const Eth2IndexPage = ({ data }) => {
               </p>
             </ExpandableCard>
             <ExpandableCard
-              contentPreview={intl.formatMessage({
-                id: "page-eth2-question-7-desc",
-                defaultMessage: getDefaultMessage("page-eth2-question-7-desc"),
-              })}
-              title={intl.formatMessage({
-                id: "page-eth2-question-7-title",
-                defaultMessage: getDefaultMessage("page-eth2-question-7-title"),
-              })}
+              contentPreview={translateMessageId(
+                "page-eth2-question-7-desc",
+                intl
+              )}
+              title={translateMessageId("page-eth2-question-7-title", intl)}
             >
               <p>
                 <Translation id="page-eth2-question-7-teams" />
@@ -801,14 +763,11 @@ const Eth2IndexPage = ({ data }) => {
               </p>
             </ExpandableCard>
             <ExpandableCard
-              contentPreview={intl.formatMessage({
-                id: "page-eth2-question-8-desc",
-                defaultMessage: getDefaultMessage("page-eth2-question-8-desc"),
-              })}
-              title={intl.formatMessage({
-                id: "page-eth2-question-8-title",
-                defaultMessage: getDefaultMessage("page-eth2-question-8-title"),
-              })}
+              contentPreview={translateMessageId(
+                "page-eth2-question-8-desc",
+                intl
+              )}
+              title={translateMessageId("page-eth2-question-8-title", intl)}
             >
               <p>
                 <Translation id="page-eth2-question-8-answer-1" />
@@ -835,14 +794,11 @@ const Eth2IndexPage = ({ data }) => {
               </p>
             </ExpandableCard>
             <ExpandableCard
-              contentPreview={intl.formatMessage({
-                id: "page-eth2-question-9-desc",
-                defaultMessage: getDefaultMessage("page-eth2-question-9-desc"),
-              })}
-              title={intl.formatMessage({
-                id: "page-eth2-question-9-title",
-                defaultMessage: getDefaultMessage("page-eth2-question-9-title"),
-              })}
+              contentPreview={translateMessageId(
+                "page-eth2-question-9-desc",
+                intl
+              )}
+              title={translateMessageId("page-eth2-question-9-title", intl)}
             >
               <p>
                 <Translation id="page-eth2-question-9-answer-1" />{" "}
@@ -871,16 +827,11 @@ const Eth2IndexPage = ({ data }) => {
               </p>
             </ExpandableCard>
             <ExpandableCard
-              contentPreview={intl.formatMessage({
-                id: "page-eth2-question-10-desc",
-                defaultMessage: getDefaultMessage("page-eth2-question-10-desc"),
-              })}
-              title={intl.formatMessage({
-                id: "page-eth2-question-10-title",
-                defaultMessage: getDefaultMessage(
-                  "page-eth2-question-10-title"
-                ),
-              })}
+              contentPreview={translateMessageId(
+                "page-eth2-question-10-desc",
+                intl
+              )}
+              title={translateMessageId("page-eth2-question-10-title", intl)}
             >
               <p>
                 <Translation id="page-eth2-question-10-answer-1" />{" "}

--- a/src/pages/eth2/index.js
+++ b/src/pages/eth2/index.js
@@ -340,8 +340,8 @@ const Eth2IndexPage = ({ data }) => {
   return (
     <Page>
       <PageMetadata
-        title={translateMessageId("page-eth2-meta-title")}
-        description={translateMessageId("page-eth2-meta-desc")}
+        title={translateMessageId("page-eth2-meta-title", intl)}
+        description={translateMessageId("page-eth2-meta-desc", intl)}
       />
       <Content>
         <HeroCard>

--- a/src/pages/eth2/staking.js
+++ b/src/pages/eth2/staking.js
@@ -4,7 +4,7 @@ import Img from "gatsby-image"
 import { graphql } from "gatsby"
 import { useIntl } from "gatsby-plugin-intl"
 
-import { getDefaultMessage } from "../../utils/translations"
+import { translateMessageId } from "../../utils/translations"
 import Translation from "../../components/Translation"
 import Breadcrumbs from "../../components/Breadcrumbs"
 import ButtonLink from "../../components/ButtonLink"
@@ -217,16 +217,11 @@ const StakingPage = ({ data, location }) => {
   return (
     <Page>
       <PageMetadata
-        title={intl.formatMessage({
-          id: "page-eth2-staking-meta-title",
-          defaultMessage: getDefaultMessage("page-eth2-staking-meta-title"),
-        })}
-        description={intl.formatMessage({
-          id: "page-eth2-staking-meta-description",
-          defaultMessage: getDefaultMessage(
-            "page-eth2-staking-meta-description"
-          ),
-        })}
+        title={translateMessageId("page-eth2-staking-meta-title", intl)}
+        description={translateMessageId(
+          "page-eth2-staking-meta-description",
+          intl
+        )}
       />
       <Content>
         <HeroCard>
@@ -372,16 +367,11 @@ const StakingPage = ({ data, location }) => {
       <Divider />
       <StyledCallout
         image={data.rhino.childImageSharp.fluid}
-        title={intl.formatMessage({
-          id: "page-eth2-staking-join-community",
-          defaultMessage: getDefaultMessage("page-eth2-staking-join-community"),
-        })}
-        description={intl.formatMessage({
-          id: "page-eth2-staking-join-community-desc",
-          defaultMessage: getDefaultMessage(
-            "page-eth2-staking-join-community-desc"
-          ),
-        })}
+        title={translateMessageId("page-eth2-staking-join-community", intl)}
+        description={translateMessageId(
+          "page-eth2-staking-join-community-desc",
+          intl
+        )}
       >
         <div>
           <ButtonLink to="https://www.reddit.com/r/ethstaker/">
@@ -462,46 +452,27 @@ const StakingPage = ({ data, location }) => {
         <CardContainer>
           <StyledCard
             emoji=":evergreen_tree:"
-            title={intl.formatMessage({
-              id: "page-eth2-staking-sustainability",
-              defaultMessage: getDefaultMessage(
-                "page-eth2-staking-sustainability"
-              ),
-            })}
-            description={intl.formatMessage({
-              id: "page-eth2-staking-sustainability-desc",
-              defaultMessage: getDefaultMessage(
-                "page-eth2-staking-sustainability-desc"
-              ),
-            })}
+            title={translateMessageId("page-eth2-staking-sustainability", intl)}
+            description={translateMessageId(
+              "page-eth2-staking-sustainability-desc",
+              intl
+            )}
           />
           <StyledCard
             emoji=":globe_showing_americas:"
-            title={intl.formatMessage({
-              id: "page-eth2-staking-accessibility",
-              defaultMessage: getDefaultMessage(
-                "page-eth2-staking-accessibility"
-              ),
-            })}
-            description={intl.formatMessage({
-              id: "page-eth2-staking-accessibility-desc",
-              defaultMessage: getDefaultMessage(
-                "page-eth2-staking-accessibility-desc"
-              ),
-            })}
+            title={translateMessageId("page-eth2-staking-accessibility", intl)}
+            description={translateMessageId(
+              "page-eth2-staking-accessibility-desc",
+              intl
+            )}
           />
           <StyledCard
             emoji=":old_key:"
-            title={intl.formatMessage({
-              id: "page-eth2-staking-sharding",
-              defaultMessage: getDefaultMessage("page-eth2-staking-sharding"),
-            })}
-            description={intl.formatMessage({
-              id: "page-eth2-staking-sharding-desc",
-              defaultMessage: getDefaultMessage(
-                "page-eth2-staking-sharding-desc"
-              ),
-            })}
+            title={translateMessageId("page-eth2-staking-sharding", intl)}
+            description={translateMessageId(
+              "page-eth2-staking-sharding-desc",
+              intl
+            )}
           >
             <Link to="/eth2/shard-chains/">
               <Translation id="page-eth2-staking-more-sharding" />

--- a/src/pages/eth2/vision.js
+++ b/src/pages/eth2/vision.js
@@ -4,7 +4,7 @@ import Img from "gatsby-image"
 import { graphql } from "gatsby"
 import { useIntl } from "gatsby-plugin-intl"
 
-import { getDefaultMessage } from "../../utils/translations"
+import { translateMessageId } from "../../utils/translations"
 import Translation from "../../components/Translation"
 import Card from "../../components/Card"
 import Link from "../../components/Link"
@@ -192,14 +192,8 @@ const VisionPage = ({ data, location }) => {
   return (
     <Page>
       <PageMetadata
-        title={intl.formatMessage({
-          id: "page-eth2-vision-meta-title",
-          defaultMessage: getDefaultMessage("page-eth2-vision-meta-title"),
-        })}
-        description={intl.formatMessage({
-          id: "page-eth2-vision-meta-desc",
-          defaultMessage: getDefaultMessage("page-eth2-vision-meta-desc"),
-        })}
+        title={translateMessageId("page-eth2-vision-meta-title", intl)}
+        description={translateMessageId("page-eth2-vision-meta-desc", intl)}
       />
       <Content>
         <HeroCard>

--- a/src/pages/get-eth.js
+++ b/src/pages/get-eth.js
@@ -4,7 +4,7 @@ import { useIntl } from "gatsby-plugin-intl"
 import Img from "gatsby-image"
 import { graphql } from "gatsby"
 
-import { getDefaultMessage } from "../utils/translations"
+import { translateMessageId } from "../utils/translations"
 import Translation from "../components/Translation"
 import CardList from "../components/CardList"
 import EthExchanges from "../components/EthExchanges"
@@ -236,14 +236,8 @@ const GetETHPage = ({ data }) => {
   return (
     <Page>
       <PageMetadata
-        title={intl.formatMessage({
-          id: "page-get-eth-meta-title",
-          defaultMessage: getDefaultMessage("page-get-eth-meta-title"),
-        })}
-        description={intl.formatMessage({
-          id: "page-get-eth-meta-description",
-          defaultMessage: getDefaultMessage("page-get-eth-meta-description"),
-        })}
+        title={translateMessageId("page-get-eth-meta-title", intl)}
+        description={translateMessageId("page-get-eth-meta-description", intl)}
       />
 
       <HeroContainer>
@@ -271,25 +265,13 @@ const GetETHPage = ({ data }) => {
       <CardContainer>
         <StyledCard
           emoji=":office_building:"
-          title={intl.formatMessage({
-            id: "page-get-eth-CEX",
-            defaultMessage: getDefaultMessage("page-get-eth-CEX"),
-          })}
-          description={intl.formatMessage({
-            id: "page-get-eth-CEX-desc",
-            defaultMessage: getDefaultMessage("page-get-eth-CEX-desc"),
-          })}
+          title={translateMessageId("page-get-eth-CEX", intl)}
+          description={translateMessageId("page-get-eth-CEX-desc", intl)}
         />
         <StyledCard
           emoji=":busts_in_silhouette:"
-          title={intl.formatMessage({
-            id: "page-get-eth-DEX",
-            defaultMessage: getDefaultMessage("page-get-eth-DEX"),
-          })}
-          description={intl.formatMessage({
-            id: "page-get-eth-DEX-desc",
-            defaultMessage: getDefaultMessage("page-get-eth-DEX-desc"),
-          })}
+          title={translateMessageId("page-get-eth-DEX", intl)}
+          description={translateMessageId("page-get-eth-DEX-desc", intl)}
         >
           <Link to="#dex">
             <Translation id="page-get-eth-Try-Dex" />
@@ -297,16 +279,11 @@ const GetETHPage = ({ data }) => {
         </StyledCard>
         <StyledCard
           emoji=":robot:"
-          title={intl.formatMessage({
-            id: "page-get-eth-wallets",
-            defaultMessage: getDefaultMessage("page-get-eth-wallets"),
-          })}
-          description={intl.formatMessage({
-            id: "page-get-eth-wallets-purchasing",
-            defaultMessage: getDefaultMessage(
-              "page-get-eth-wallets-purchasing"
-            ),
-          })}
+          title={translateMessageId("page-get-eth-wallets", intl)}
+          description={translateMessageId(
+            "page-get-eth-wallets-purchasing",
+            intl
+          )}
         >
           <Link to="/wallets/">
             <Translation id="page-get-eth-wallets-link" />
@@ -447,14 +424,11 @@ const GetETHPage = ({ data }) => {
       </TwoColumnContent>
       <Divider />
       <CalloutBanner
-        title={intl.formatMessage({
-          id: "page-get-eth-use-your-eth",
-          defaultMessage: getDefaultMessage("page-get-eth-use-your-eth"),
-        })}
-        description={intl.formatMessage({
-          id: "page-get-eth-use-your-eth-dapps",
-          defaultMessage: getDefaultMessage("page-get-eth-use-your-eth-dapps"),
-        })}
+        title={translateMessageId("page-get-eth-use-your-eth", intl)}
+        description={translateMessageId(
+          "page-get-eth-use-your-eth-dapps",
+          intl
+        )}
         image={data.dapps.childImageSharp.fluid}
         maxImageWidth={600}
       >

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -4,7 +4,10 @@ import { graphql } from "gatsby"
 import Img from "gatsby-image"
 import styled from "styled-components"
 
-import { getLangContentVersion, getDefaultMessage } from "../utils/translations"
+import {
+  getLangContentVersion,
+  translateMessageId,
+} from "../utils/translations"
 import Morpher from "../components/Morpher"
 import PageMetadata from "../components/PageMetadata"
 import Translation from "../components/Translation"
@@ -311,14 +314,8 @@ const HomePage = ({ data }) => {
   return (
     <Page>
       <PageMetadata
-        title={intl.formatMessage({
-          id: "page-home-meta-title",
-          defaultMessage: getDefaultMessage("page-home-meta-title"),
-        })}
-        description={intl.formatMessage({
-          id: "page-home-meta-description",
-          defaultMessage: getDefaultMessage("page-home-meta-description"),
-        })}
+        title={translateMessageId("page-home-meta-title", intl)}
+        description={translateMessageId("page-home-meta-description", intl)}
       />
       <Hero
         fluid={data.hero.childImageSharp.fluid}
@@ -370,10 +367,7 @@ const HomePage = ({ data }) => {
                 <Section key={idx}>
                   <Img
                     fixed={section.img.src.childImageSharp.fixed}
-                    alt={intl.formatMessage({
-                      id: section.img.alt,
-                      defaultMessage: getDefaultMessage(section.img.alt),
-                    })}
+                    alt={translateMessageId(section.img.alt, intl)}
                   />
                   <h2>
                     <Translation id={section.title} />

--- a/src/pages/languages.js
+++ b/src/pages/languages.js
@@ -10,6 +10,7 @@ import { Page, Content } from "../components/SharedStyledComponents"
 import { Mixins } from "../theme"
 
 import languageMetadata from "../data/translations"
+import { translateMessageId } from "../utils/translations"
 
 const StyledPage = styled(Page)`
   margin-top: 4rem;
@@ -56,9 +57,7 @@ const LanguagesPage = () => {
   for (const lang in languageMetadata) {
     const langMetadata = languageMetadata[lang]
     langMetadata["path"] = `/${lang}/`
-    langMetadata["name"] = intl.formatMessage({
-      id: `language-${lang}`,
-    })
+    langMetadata["name"] = translateMessageId(`language-${lang}`, intl)
     translationsCompleted.push(languageMetadata[lang])
   }
   translationsCompleted.sort((a, b) => a["name"].localeCompare(b["name"]))
@@ -66,8 +65,8 @@ const LanguagesPage = () => {
   return (
     <StyledPage>
       <PageMetadata
-        title={intl.formatMessage({ id: "page-translations-meta-title" })}
-        description={intl.formatMessage({ id: "page-translations-meta-desc" })}
+        title={translateMessageId("page-translations-meta-title", intl)}
+        description={translateMessageId("page-translations-meta-desc", intl)}
       />
       <Content>
         <ContentContainer>


### PR DESCRIPTION
## Description
Replaces `intl.formatMessage` instances with `translateMessageId` which does not require explicitly (and redundantly) declaring the id for `defaultMessage`. 

## Related Issue #2029