### PR TITLE
Sanitizes tutorial tags before grouping [Fixes #2020]

### DIFF
--- a/src/pages-conditional/developers/tutorials.js
+++ b/src/pages-conditional/developers/tutorials.js
@@ -192,7 +192,7 @@ const TutorialsPage = ({ data }) => {
       title: tutorial.frontmatter.title,
       description: tutorial.frontmatter.description,
       author: tutorial.frontmatter.author,
-      tags: tutorial.frontmatter.tags,
+      tags: tutorial.frontmatter.tags.map((tag) => tag.toLowerCase().trim()),
       skill: tutorial.frontmatter.skill,
       timeToRead: tutorial.timeToRead,
       published: tutorial.frontmatter.published,

--- a/src/pages-conditional/developers/tutorials.js
+++ b/src/pages-conditional/developers/tutorials.js
@@ -187,17 +187,12 @@ const TutorialsPage = ({ data }) => {
   const intl = useIntl()
 
   const allTutorials = data.allTutorials.nodes.map((tutorial) => {
-    const { tags } = tutorial.frontmatter
-    const sanitizedTags = Array.from(
-      tags.reduce((m, tag) => m.set(tag.toLowerCase().trim(), true), new Map()),
-      ([tag]) => tag
-    )
     return {
       to: tutorial.fields.slug,
       title: tutorial.frontmatter.title,
       description: tutorial.frontmatter.description,
       author: tutorial.frontmatter.author,
-      tags: sanitizedTags,
+      tags: tutorial.frontmatter.tags,
       skill: tutorial.frontmatter.skill,
       timeToRead: tutorial.timeToRead,
       published: tutorial.frontmatter.published,

--- a/src/pages-conditional/developers/tutorials.js
+++ b/src/pages-conditional/developers/tutorials.js
@@ -187,18 +187,34 @@ const TutorialsPage = ({ data }) => {
   const intl = useIntl()
 
   const allTutorials = data.allTutorials.nodes.map((tutorial) => {
+    const { tags } = tutorial.frontmatter
+    const sanitizedTags = Array.from(
+      tags.reduce((m, tag) => m.set(tag.toLowerCase().trim(), true), new Map()),
+      ([tag]) => tag
+    )
     return {
       to: tutorial.fields.slug,
       title: tutorial.frontmatter.title,
       description: tutorial.frontmatter.description,
       author: tutorial.frontmatter.author,
-      tags: tutorial.frontmatter.tags,
+      tags: sanitizedTags,
       skill: tutorial.frontmatter.skill,
       timeToRead: tutorial.timeToRead,
       published: tutorial.frontmatter.published,
     }
   })
   const allTags = data.allTags.group
+  const sanitizedAllTags = Array.from(
+    allTags.reduce(
+      (m, { name, totalCount }) =>
+        m.set(
+          name.toLowerCase().trim(),
+          (m.get(name.toLowerCase().trim()) || 0) + totalCount
+        ),
+      new Map()
+    ),
+    ([name, totalCount]) => ({ name, totalCount })
+  ).sort((a, b) => a.name.localeCompare(b.name))
 
   const [state, setState] = useState({
     activeTagNames: [],
@@ -318,7 +334,7 @@ const TutorialsPage = ({ data }) => {
       <TutorialContainer>
         <TagsContainer>
           <TagContainer>
-            {allTags.map((tag) => {
+            {sanitizedAllTags.map((tag) => {
               const name = `${tag.name} (${tag.totalCount})`
               const isActive = state.activeTagNames.includes(tag.name)
               return (


### PR DESCRIPTION
## Description
Reduces `allTags` down to array of unique tags after sanitizing them with `.toLowerCase().trim()`. This array is then sorted by name, since the previously capitalized tags are at the top from the returned query data.

Now for example: If you list "JavaScript " when making a new tutorial markdown, it will lump with "javascript", sum up the totals for each, and display "JAVASCRIPT" with the proper sum on the UI. Clicking this will properly filter for all of them, as all tags are forced to lowercase and trimmed before being stored in the `allTutorials` constant.

Kept styling logic separate, leaving the CSS to style these as uppercase.

## Related Issue #2020 