### PR TITLE
Use full URL for Twitter meta image [Fixes #1910]

### DIFF
--- a/src/components/PageMetadata.js
+++ b/src/components/PageMetadata.js
@@ -155,7 +155,7 @@ const PageMetadata = ({ description, meta, title, image, canonicalUrl }) => {
               },
               {
                 name: `twitter:image`,
-                content: ogImage,
+                content: ogImageUrl,
               },
               {
                 property: `og:url`,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use full URL for Twitter meta image

## Related Issue
#1910

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
