### PR TITLE
Remove OpenZeppelin SDK from local environments

### DIFF
--- a/src/pages-conditional/developers/local-environment.js
+++ b/src/pages-conditional/developers/local-environment.js
@@ -287,13 +287,6 @@ const frameworksList = [
     description: "page-local-environment-truffle-desc",
   },
   {
-    id: "openzeppelin",
-    url: "https://openzeppelin.com/sdk/",
-    background: "#4E5EE4",
-    name: "OpenZeppelin SDK",
-    description: "page-local-environment-openZeppelin-desc",
-  },
-  {
     id: "embark",
     url: "https://framework.embarklabs.io/",
     background: "#1B3E5F",
@@ -636,14 +629,6 @@ export const query = graphql`
     }
     truffleGitHub: github {
       repository(owner: "trufflesuite", name: "truffle") {
-        ...repoInfo
-      }
-    }
-    openzeppelin: file(relativePath: { eq: "devtools/openzeppelin.png" }) {
-      ...devtoolImage
-    }
-    openzeppelinGitHub: github {
-      repository(owner: "OpenZeppelin", name: "openzeppelin-sdk") {
         ...repoInfo
       }
     }


### PR DESCRIPTION
At OpenZeppelin we've halted development of the SDK in order to focus on Contracts and plugins for Hardhat and Truffle. See [this post](https://forum.openzeppelin.com/t/building-for-interoperability-why-we-re-focusing-on-upgrades-plugins/4088) for more info.
