### PR TITLE
Re-adds mobile menu close button [Fixes #2071]

### DIFF
--- a/src/components/Nav/Mobile.js
+++ b/src/components/Nav/Mobile.js
@@ -68,6 +68,12 @@ const CloseIconContainer = styled.span`
   }
 `
 
+const CloseMenuIconContainer = styled(CloseIconContainer)`
+  position: absolute;
+  top: 1.5rem;
+  right: 1.5rem;
+`
+
 const MenuItems = styled.ul`
   margin: 0;
   height: 100vh;
@@ -291,6 +297,9 @@ const MobileNavMenu = ({
             </BottomLink>
           </BottomItem>
         </BottomMenu>
+        <CloseMenuIconContainer onClick={() => toggleMenu()}>
+          <Icon name="close" />
+        </CloseMenuIconContainer>
       </MenuContainer>
       <SearchContainer
         animate={isSearchOpen ? "open" : "closed"}


### PR DESCRIPTION
## Description
Mobile menu close button was accidentally removed during Mobile Search upgrade, while being placed only on the Search panel, with alterations to the styled component's layout.

This adds a second styled component, based on the other "close" button, which adds back in the absolute positioning that the original menu close button previously had, and places the component back in the menu render. 

## Related Issue #2071 