### PR TITLE
Moves layout of Hero image to below HeroContent on mobile

### DIFF
--- a/src/pages/stablecoins.js
+++ b/src/pages/stablecoins.js
@@ -38,7 +38,7 @@ const HeroContainer = styled.div`
   padding: 0rem 4rem;
 
   @media (max-width: ${(props) => props.theme.breakpoints.l}) {
-    flex-direction: column-reverse;
+    flex-direction: column;
     padding: 0;
   }
 `
@@ -55,7 +55,7 @@ const HeroContent = styled.div`
   max-width: 640px;
   padding: 8rem 0 8rem 2rem;
   @media (max-width: ${(props) => props.theme.breakpoints.l}) {
-    padding: 4rem 0;
+    padding: 2rem 0 0;
     max-width: 100%;
   }
 `
@@ -70,8 +70,7 @@ const Hero = styled(Img)`
   width: 100%;
   max-width: 624px;
   @media (max-width: ${(props) => props.theme.breakpoints.l}) {
-    margin-top: 0;
-    margin-right: 0;
+    margin: -1rem 0 -5rem;
     max-width: 560px;
   }
 `


### PR DESCRIPTION
## Description
Per request on Discord, tried a re-deign of top of stablecoins page placing hero image below the intro hero content text
- Flips column layout of `<Hero>` and `<HeroContent>` on stablecoins page to avoid mobile devices landing a screen consumed entirely by the hero image
- Adjusts vertical margins to accommodate having text above image instead of below on mobile sizes < `breakpoint.l`

![image](https://user-images.githubusercontent.com/54227730/101574812-aa951100-398d-11eb-82f5-17e252ea632d.png)

## Related Issue (none filed)