### PR TITLE
Switch wallet results to grid `auto-fill`

### DIFF
--- a/src/components/WalletCompare.js
+++ b/src/components/WalletCompare.js
@@ -98,7 +98,7 @@ const ResultsContainer = styled.div`
 
 const ResultsGrid = styled.div`
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 280px), 1fr));
   gap: 2rem;
 `
 


### PR DESCRIPTION
## Description
- Changes wallet results `ResultsGrid` to `auto-fill` instead of `auto-fit` to prevent extra-wide cards when only 1 or 2 results result on desktop
- Adds slight adjustment to flexibility of cards on same style line with `min(100%, 280px)` as done in other "cards" on the site

## Related Issue (none filed)
Currently:
![image](https://user-images.githubusercontent.com/54227730/102157090-b8d2a980-3e33-11eb-8b64-e8ee9399503b.png)
With fix:
![image](https://user-images.githubusercontent.com/54227730/102157191-e6b7ee00-3e33-11eb-9e68-70f8ceb9b5ea.png)
