### PR TITLE
Account for if user is null [Fixes #2148]

### DIFF
--- a/src/components/FileContributors.js
+++ b/src/components/FileContributors.js
@@ -166,10 +166,13 @@ const FileContributors = ({ gitCommits, className, editPath }) => {
           <Avatar src={lastContributor.avatarUrl} alt={lastContributor.name} />
           <Info>
             <Translation id="last-edit" />:{" "}
-            <Link to={lastContributor.user.url}>
-              @{lastContributor.user.login}
-            </Link>
-            , {getLocaleTimestamp(intl.locale, lastCommit.committedDate)}
+            {lastContributor.user && (
+              <Link to={lastContributor.user.url}>
+                @{lastContributor.user.login}
+              </Link>
+            )}
+            {!lastContributor.user && <span>{lastContributor.name}</span>},{" "}
+            {getLocaleTimestamp(intl.locale, lastCommit.committedDate)}
           </Info>
         </LeftContent>
         <ButtonContainer>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Display author's name if no user object exists in FileContributors component

## Related Issue
#2148 
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
