### PR TITLE
Add Gatsby flags to speed up local development

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -233,4 +233,8 @@ module.exports = {
     // Needed for `gatsby-image`
     `gatsby-transformer-sharp`,
   ],
+  flags: {
+    PRESERVE_WEBPACK_CACHE: true,
+    QUERY_ON_DEMAND: true,
+  },
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Effort to speed up local development
- Attempt to prevent GH API rate limits by querying on demand vs. on app start
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/gatsbyjs/gatsby/discussions/28680
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
