### PR TITLE
Use correct word for Turkish (language)

### DIFF
--- a/src/data/translations.json
+++ b/src/data/translations.json
@@ -113,7 +113,7 @@
   },
   "tr": {
     "version": 1.1,
-    "language": "Türk"
+    "language": "Türkçe"
   },
   "uk": {
     "version": 1.1,


### PR DESCRIPTION
Use the correct word for Turkish language in Turkish.

## Description

Please see https://en.wikipedia.org/wiki/List_of_language_names or https://en.wikipedia.org/wiki/Turkish_language.
