### PR TITLE
Fix broken link

### DIFF
--- a/src/content/developers/docs/programming-languages/rust/index.md
+++ b/src/content/developers/docs/programming-languages/rust/index.md
@@ -24,7 +24,7 @@ Need a more basic primer first? Check out [ethereum.org/learn](/en/learn/) or [e
 ## Beginner articles {#beginner-articles}
 
 - [Choosing an Ethereum Client](https://www.trufflesuite.com/docs/truffle/reference/choosing-an-ethereum-client)
-- [The Rust Ethereum Client](https://wiki.parity.io/Setup)
+- [The Rust Ethereum Client](https://openethereum.github.io/)
 - [Sending Transaction to Ethereum Using Rust](https://kauri.io/article/97c85229c66445759bb0ce642224d364/sending-ethereum-transactions-with-rust)
 - [An Introduction to Smart Contracts with Parity Ethereum Client](https://wiki.parity.io/Smart-Contracts)
 - [Setting up your Oasis SDK dev environment](https://docs.oasis.dev/quickstart.html#set-up-the-oasis-sdk)


### PR DESCRIPTION
Update link to one that works, for what appears to be the new project that replaced the old one.

<!--- Provide a general summary of your changes in the Title above -->

## Description

wiki.parity.io redirects to openethereum.github.io/wiki but it's a 404. There is a project by that name, which is a Rust ethereum wallet, but the URL just needs fixing.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
