### PR TITLE
docs: fix typo in intro-to-ethereum

### DIFF
--- a/src/content/developers/docs/intro-to-ethereum/index.md
+++ b/src/content/developers/docs/intro-to-ethereum/index.md
@@ -63,7 +63,7 @@ The native cryptocurrency of Ethereum. Users pay ether to other users to have th
 
 ### EVM {#evm}
 
-The Ethereum Virtual Machine is the global virtual computer who’s state every participant on the Ethereum network stores and agrees on. Any participant can request the execution of arbitrary code on the EVM; code execution changes the state of the EVM.
+The Ethereum Virtual Machine is the global virtual computer whose state every participant on the Ethereum network stores and agrees on. Any participant can request the execution of arbitrary code on the EVM; code execution changes the state of the EVM.
 
 [More on the EVM](/developers/docs/evm/)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`whose` should be used instead of `who's`:
> The Ethereum Virtual Machine is the global virtual computer **whose** state every participant on the Ethereum network stores and agrees on.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
