### PR TITLE
Pass isGlossary to InternalLink [Fixes #1921]

### DIFF
--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -148,6 +148,7 @@ const Link = ({
       to={to}
       activeClassName="active"
       partiallyActive={isPartiallyActive}
+      isGlossary={isGlossary}
     >
       {children}
       {isGlossary && (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds custom styles to Link component if it's a glossary link

Builds off #2130 - we need to pass the prop to the component for styling logic to work.

## Related Issue
#1921 
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
