### PR TITLE
Fixes isGlossary console warnings [Fixes #2259]

### DIFF
--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -31,7 +31,7 @@ const ExternalLink = styled.a`
 `
 
 const InternalLink = styled(IntlLink)`
-  .isGlossary {
+  .is-glossary {
     white-space: nowrap;
   }
   &.active {
@@ -146,7 +146,7 @@ const Link = ({
   // Use `gatsby-plugin-intl` Link (which prepends lang path)
   return (
     <InternalLink
-      className={isGlossary ? `isGlossary ${className}` : className}
+      className={isGlossary ? `is-glossary ${className}` : className}
       to={to}
       activeClassName="active"
       partiallyActive={isPartiallyActive}

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -31,7 +31,9 @@ const ExternalLink = styled.a`
 `
 
 const InternalLink = styled(IntlLink)`
-  white-space: ${(props) => (props.isGlossary ? `nowrap` : `normal`)};
+  .isGlossary {
+    white-space: nowrap;
+  }
   &.active {
     color: ${(props) => props.theme.colors.primary};
   }
@@ -144,11 +146,10 @@ const Link = ({
   // Use `gatsby-plugin-intl` Link (which prepends lang path)
   return (
     <InternalLink
-      className={className}
+      className={isGlossary ? `isGlossary ${className}` : className}
       to={to}
       activeClassName="active"
       partiallyActive={isPartiallyActive}
-      isGlossary={isGlossary}
     >
       {children}
       {isGlossary && (


### PR DESCRIPTION
## Description
- Switched `isGlossary` prop to a className
- Selected for `.isGlossary` className in CSS, and applied `whitespace: nowrap;` styling

Now rendering appropriately without DOM warnings

## Related Issue #2259
