### PR TITLE
Fixed invalid DOM nesting [Fixes #2267]

### DIFF
--- a/src/components/ExpandableCard.js
+++ b/src/components/ExpandableCard.js
@@ -38,7 +38,7 @@ const TextPreview = styled.p`
   margin-bottom: 0rem;
 `
 
-const Text = styled.p`
+const Text = styled.div`
   font-size: 16px;
   font-weight: 400;
   color: ${(props) => props.theme.colors.text};

--- a/src/pages/eth2/index.js
+++ b/src/pages/eth2/index.js
@@ -637,52 +637,50 @@ const Eth2IndexPage = ({ data }) => {
               <p>
                 <Translation id="page-eth2-question-7-teams" />
               </p>
-              <p>
-                <ul>
-                  <li>
-                    <Link to="https://trinity.ethereum.org/">
-                      <Translation id="page-eth2-question-7-trinity" />
-                    </Link>{" "}
-                    <Translation id="page-eth2-question-7-trinity-lang" />
-                  </li>
-                  <li>
-                    <Link to="https://sigmaprime.io/">
-                      <Translation id="page-eth2-question-7-lighthouse" />
-                    </Link>{" "}
-                    <Translation id="page-eth2-question-7-lighthouse-lang" />
-                  </li>
-                  <li>
-                    <Link to="https://nimbus.team/">
-                      <Translation id="page-eth2-question-7-nimbus" />
-                    </Link>{" "}
-                    <Translation id="page-eth2-question-7-nimbus-lang" />
-                  </li>
-                  <li>
-                    <Link to="https://prysmaticlabs.com/">
-                      <Translation id="page-eth2-question-7-prysm" />
-                    </Link>{" "}
-                    <Translation id="page-eth2-question-7-prysm-lang" />
-                  </li>
-                  <li>
-                    <Link to="https://nethermind.io/">
-                      <Translation id="page-eth2-question-7-cortex" />
-                    </Link>{" "}
-                    <Translation id="page-eth2-question-7-cortex-lang" />
-                  </li>
-                  <li>
-                    <Link to="https://pegasys.tech/teku-ethereum-2-for-enterprise/">
-                      <Translation id="page-eth2-question-7-teku" />
-                    </Link>{" "}
-                    <Translation id="page-eth2-question-7-teku-lang" />
-                  </li>
-                  <li>
-                    <Link to="https://github.com/chainsafe/lodestar#getting-started">
-                      <Translation id="page-eth2-question-7-lodestar" />
-                    </Link>{" "}
-                    <Translation id="page-eth2-question-7-lodestar-lang" />
-                  </li>
-                </ul>
-              </p>
+              <ul>
+                <li>
+                  <Link to="https://trinity.ethereum.org/">
+                    <Translation id="page-eth2-question-7-trinity" />
+                  </Link>{" "}
+                  <Translation id="page-eth2-question-7-trinity-lang" />
+                </li>
+                <li>
+                  <Link to="https://sigmaprime.io/">
+                    <Translation id="page-eth2-question-7-lighthouse" />
+                  </Link>{" "}
+                  <Translation id="page-eth2-question-7-lighthouse-lang" />
+                </li>
+                <li>
+                  <Link to="https://nimbus.team/">
+                    <Translation id="page-eth2-question-7-nimbus" />
+                  </Link>{" "}
+                  <Translation id="page-eth2-question-7-nimbus-lang" />
+                </li>
+                <li>
+                  <Link to="https://prysmaticlabs.com/">
+                    <Translation id="page-eth2-question-7-prysm" />
+                  </Link>{" "}
+                  <Translation id="page-eth2-question-7-prysm-lang" />
+                </li>
+                <li>
+                  <Link to="https://nethermind.io/">
+                    <Translation id="page-eth2-question-7-cortex" />
+                  </Link>{" "}
+                  <Translation id="page-eth2-question-7-cortex-lang" />
+                </li>
+                <li>
+                  <Link to="https://pegasys.tech/teku-ethereum-2-for-enterprise/">
+                    <Translation id="page-eth2-question-7-teku" />
+                  </Link>{" "}
+                  <Translation id="page-eth2-question-7-teku-lang" />
+                </li>
+                <li>
+                  <Link to="https://github.com/chainsafe/lodestar#getting-started">
+                    <Translation id="page-eth2-question-7-lodestar" />
+                  </Link>{" "}
+                  <Translation id="page-eth2-question-7-lodestar-lang" />
+                </li>
+              </ul>
             </ExpandableCard>
             <ExpandableCard
               contentPreview={translateMessageId(


### PR DESCRIPTION
## Description
`<ExpandableCard>` component has nested elements that are passed as `children` to this component, but `{children}` was being nested within a `styled.p` within `ExpandableCard.js` component which is not valid HTML. One `<ul>` was also nested within a `<p>` tag on the `/eth2/index.js` page.
- Changed to `styled.div`
- Removed unneeded wrapping `<p>` tag for the problematic `<ul>`

## Related Issue #2267