### PR TITLE
Adds "run a node" page to developer docs [Fixes #2270]

### DIFF
--- a/src/content/developers/docs/nodes-and-clients/index.md
+++ b/src/content/developers/docs/nodes-and-clients/index.md
@@ -25,7 +25,7 @@ Simplified diagram of what Ethereum client features.
 
 ## Node types {#node-types}
 
-If you want to run your own node, you should understand that there are different types of node that consume data differently. In fact, clients can run 3 different types of node - light, full and archive. There are also options of different sync strategies which enables faster synchronization time. Synchronization refers to how quickly it can get the most up-to-date information on Ethereum's state.
+If you want to [run your own node](/developers/docs/nodes-and-clients/run-a-node/), you should understand that there are different types of node that consume data differently. In fact, clients can run 3 different types of node - light, full and archive. There are also options of different sync strategies which enables faster synchronization time. Synchronization refers to how quickly it can get the most up-to-date information on Ethereum's state.
 
 ### Full node {#full-node}
 
@@ -72,7 +72,7 @@ If you run a full node, the whole Ethereum network benefits from it.
 
 ## Running your own node {#running-your-own-node}
 
-Interested in running your own Ethereum client? Learn how to [spin up your own node article](/en/developers/docs/spin-up-your-node/). 
+Interested in running your own Ethereum client? Learn how to [spin up your own node](/en/developers/docs/nodes-and-clients/run-a-node/)!
 
 ### Projects {#projects}
 
@@ -82,7 +82,7 @@ Interested in running your own Ethereum client? Learn how to [spin up your own n
 
 - [GitHub](https://github.com/vrde/ethnode)
 
-**DAppNode -** **_An operating system for running Web3 nodes, including Ethereum, on a dedicated machine._**
+**DAppNode -** **_An operating system GUI for running Web3 nodes, including Ethereum and the beacon chain, on a dedicated machine._**
 
 - [dappnode.io](https://dappnode.io)
 
@@ -195,8 +195,8 @@ Depending on which software and sync mode are you going to use, hundreds of GBs 
 
 | Client       | Disk size (fast sync) | Disk size (full archive) |
 | ------------ | --------------------- | ------------------------ |
-| Geth         | 400GB+                | 6TB+                   |
-| OpenEthereum | 280GB+                | 6TB+                   |
+| Geth         | 400GB+                | 6TB+                     |
+| OpenEthereum | 280GB+                | 6TB+                     |
 | Nethermind   | 200GB+                | 5TB+                     |
 | Besu         | 750GB+                | 5TB+                     |
 
@@ -204,7 +204,7 @@ Depending on which software and sync mode are you going to use, hundreds of GBs 
 
 ![A chart showing that GB needed for an archive sync is trending up](./archive-sync.png)
 
-These charts show how storage requirements are always changing. For the most up-to-date data for Geth and OpenEthereum, see the [full sync data](https://etherscan.io/chartsync/chaindefault) and [archive sync data](https://etherscan.io/chartsync/chainarchive). 
+These charts show how storage requirements are always changing. For the most up-to-date data for Geth and OpenEthereum, see the [full sync data](https://etherscan.io/chartsync/chaindefault) and [archive sync data](https://etherscan.io/chartsync/chainarchive).
 
 ### Ethereum on a single-board computer {#ethereum-on-a-single-board-computer}
 

--- a/src/content/developers/docs/nodes-and-clients/run-a-node/index.md
+++ b/src/content/developers/docs/nodes-and-clients/run-a-node/index.md
@@ -1,6 +1,6 @@
 ---
 title: Spin up your own Ethereum node
-description: General introduction to running your own instance of an Ethereum client. 
+description: General introduction to running your own instance of an Ethereum client.
 lang: en
 sidebar: true
 sidebarDepth: 2
@@ -10,11 +10,11 @@ Running your own node provides you various benefits, opens new possibilities, an
 
 ## Prerequisites {#prerequisites}
 
-You should understand what an Ethereum node is and why you might want to run a client. This is covered in [Nodes and clients](/en/developers/docs/nodes-and-clients/). 
+You should understand what an Ethereum node is and why you might want to run a client. This is covered in [Nodes and clients](/en/developers/docs/nodes-and-clients/).
 
 ## Choosing an approach {#choosing-approach}
 
-The first step in spinning up your node is choosing your approach. You have to choose the client (the software), the environment, and the parameters you want to start with. 
+The first step in spinning up your node is choosing your approach. You have to choose the client (the software), the environment, and the parameters you want to start with.
 See all the available [mainnet clients](/en/developers/docs/nodes-and-clients/#advantages-of-different-implementations).
 
 #### Client settings {#client-settings}
@@ -22,44 +22,48 @@ See all the available [mainnet clients](/en/developers/docs/nodes-and-clients/#a
 Client implementations enable different sync modes and various other options. [Sync modes](/en/developers/docs/nodes-and-clients/#sync-modes) represent different methods of downloading and validating blockchain data. Before starting the node, you should decide what network and sync mode to use. The most important things to consider is the disk space and sync time client will need.
 
 All features and options can be found in documentation of each client. Various client configurations can be set by executing client with corresponding flags. You can get more information on flags from [EthHub](https://docs.ethhub.io/using-ethereum/running-an-ethereum-node/#client-settings) or client documentation.
-For testing purposes, you might prefer running client on one of testnet networks. [See overview of supported networks](/en/developers/docs/nodes-and-clients/#clients). 
+For testing purposes, you might prefer running client on one of testnet networks. [See overview of supported networks](/en/developers/docs/nodes-and-clients/#clients).
 
 ### Environment and hardware {#environment-and-hardware}
 
 #### Local or cloud {#local-vs-cloud}
-Ethereum clients are able to run on consumer grade computers and don't require special hardware like mining for example. Therefore you have various options for deploying based on your needs. 
+
+Ethereum clients are able to run on consumer grade computers and don't require special hardware like mining for example. Therefore you have various options for deploying based on your needs.
 To simplify let's think about running a node on both a local physical machine and a cloud server:
+
 - Cloud
-    - Providers offer high server uptime, static public IP addresses
-    - Getting dedicated or virtual server can be more comfortable then building your own
-    - Trade off is trusting a third party - server provider
-    - Because of required storage size for full node, price of a rented server might get high
+  - Providers offer high server uptime, static public IP addresses
+  - Getting dedicated or virtual server can be more comfortable then building your own
+  - Trade off is trusting a third party - server provider
+  - Because of required storage size for full node, price of a rented server might get high
 - Own hardware
-    - More trustless and sovereign approach
-    - One time investment 
-    - An option to buy preconfigured machines 
-    - You have to physically prepare, maintain, and potentially troubleshoot the machine
+  - More trustless and sovereign approach
+  - One time investment
+  - An option to buy preconfigured machines
+  - You have to physically prepare, maintain, and potentially troubleshoot the machine
 
 Both options have different advantages summed up above. If you are looking for a cloud solution, in addition to many traditional cloud computing providers, there are also services focused on deploying nodes, for example:
-- [QuikNode](https://www.quiknode.io/), 
-- [Blockdaemon](https://blockdaemon.com), 
-- [LunaNode](https://www.lunanode.com/). 
+
+- [QuikNode](https://www.quiknode.io/),
+- [Blockdaemon](https://blockdaemon.com),
+- [LunaNode](https://www.lunanode.com/).
 
 #### Hardware {#hardware}
 
 However, a censorship-resistant, decentralized network should not rely on cloud providers. It's healthier for the ecosystem if you run your own node on hardware. The easiest options are preconfigured machines like:
-- [DappNode](https://dappnode.io/)
-- [Avado](https://ava.do/). 
 
-Check the minimum and recommended [disk space requirements for each client and sync mod](/en/developers/docs/nodes-and-clients/#requirements). 
-Generally, modest computing power should be enough. The problem is usually drive speed. During initial sync, Ethereum clients perform a lot of read/write operations, therefore SSD is strongly recommended. A client might not even  [be able to sync current state on HDD](https://github.com/ethereum/go-ethereum/issues/16796#issuecomment-391649278) and get stuck a few blocks behind mainnet. 
+- [DappNode](https://dappnode.io/)
+- [Avado](https://ava.do/).
+
+Check the minimum and recommended [disk space requirements for each client and sync mod](/en/developers/docs/nodes-and-clients/#requirements).
+Generally, modest computing power should be enough. The problem is usually drive speed. During initial sync, Ethereum clients perform a lot of read/write operations, therefore SSD is strongly recommended. A client might not even [be able to sync current state on HDD](https://github.com/ethereum/go-ethereum/issues/16796#issuecomment-391649278) and get stuck a few blocks behind mainnet.
 You can run most of the clients on a [single board computer with ARM](/en/developers/docs/nodes-and-clients/#ethereum-on-a-single-board-computer/). You can also use the [Ethbian](https://ethbian.org/index.html) operating system for Raspberry Pi 4. This lets you [[run a client by flashing the SD card](/en/developers/tutorials/run-node-raspberry-pi/).
 Based on your software and the hardware choices, the initial synchronization time and storage requirements may vary. Be sure to [check sync times and storage requirements](/en/developers/docs/nodes-and-clients/#recommended-specifications).
-Also make sure your internet connection is not limited by a [bandwidth cap](https://en.wikipedia.org/wiki/Data_cap). It's recommended to use an unmetered connection since initial sync and data broadcasted to the network could exceed your limit. 
+Also make sure your internet connection is not limited by a [bandwidth cap](https://en.wikipedia.org/wiki/Data_cap). It's recommended to use an unmetered connection since initial sync and data broadcasted to the network could exceed your limit.
 
 #### Operating system {#operating-system}
 
-All clients support major operating systems - Linux, MacOS, Windows. This means you can run nodes on regular desktop or server machines with the operating system (OS) that suits you the best. Make sure your OS is up to date to avoid potential issues and security vulnerabilities. 
+All clients support major operating systems - Linux, MacOS, Windows. This means you can run nodes on regular desktop or server machines with the operating system (OS) that suits you the best. Make sure your OS is up to date to avoid potential issues and security vulnerabilities.
 
 ## Spinning up the node {#spinning-up-node}
 
@@ -71,33 +75,36 @@ You can simply download an executable application or installation package which 
 If you prefer, you can build from source. All of the clients are open source so you can build them from source code with the proper compiler.
 
 Executable binaries for stable mainnet client implementations can be downloaded from their release pages:
-- [Geth](https://geth.ethereum.org/downloads/), 
-- [OpenEthereum,](https://github.com/openethereum/openethereum/releases), 
-- [Nethermind](https://downloads.nethermind.io/), 
-- [Besu](https://pegasys.tech/solutions/hyperledger-besu/). 
+
+- [Geth](https://geth.ethereum.org/downloads/),
+- [OpenEthereum,](https://github.com/openethereum/openethereum/releases),
+- [Nethermind](https://downloads.nethermind.io/),
+- [Besu](https://pegasys.tech/solutions/hyperledger-besu/).
 
 ### Starting the client {#starting-the-client}
 
 Before starting Ethereum client software, perform a last check that your environment is ready. For example, make sure:
+
 - There is enough disk space considering chosen network and sync mode.
 - Memory and CPU is not halted by other programs.
 - Operating system is updated to latest version.
 - System has correct time and date.
 - Your router and firewall accept connections on listening ports. By default Ethereum clients use a listener (TCP) port and a discovery (UDP) port, both on 30303 by default.
 
-Run your client on a testnet first to help make sure everything is working correctly. [Running a Geth light node](/en/developers/tutorials/run-light-node-geth/) should help. 
+Run your client on a testnet first to help make sure everything is working correctly. [Running a Geth light node](/en/developers/tutorials/run-light-node-geth/) should help.
 You need to declare any client settings that aren't default at the start. You can use flags or the config file to declare your preferred configuration. Check out your client's documentation for the specifics
 Client execution will initiate its core functions, chosen endpoints, and start looking for peers. After successfully discovering peers, the client starts synchronization. Current blockchain data will be available once the client is successfully synced to the current state.
 
 ### Using the client {#using-the-client}
 
 Clients offer RPC API endpoints that you can use to control the client and interact with the Ethereum network in various ways:
+
 - Manually calling them with a suitable protocol (e.g. using `curl`)
 - Attaching a provided console (e.g. `geth attach`)
-- Implementing them in applications 
+- Implementing them in applications
 
-Different clients have different implementations of the RPC endpoints. But there is a standard JSON-RPC which you can use with every client. For an overview [read the JSON-RPC docs](https://eth.wiki/json-rpc/API). 
-Applications that need information from the Ethereum network can use this RPC. For example, popular wallet MetaMask lets you [run a local blockchain instance and connect to it](https://metamask.zendesk.com/hc/en-us/articles/360015290012-Using-a-Local-Node). 
+Different clients have different implementations of the RPC endpoints. But there is a standard JSON-RPC which you can use with every client. For an overview [read the JSON-RPC docs](https://eth.wiki/json-rpc/API).
+Applications that need information from the Ethereum network can use this RPC. For example, popular wallet MetaMask lets you [run a local blockchain instance and connect to it](https://metamask.zendesk.com/hc/en-us/articles/360015290012-Using-a-Local-Node).
 
 #### Reaching RPC {#reaching-rpc}
 
@@ -109,8 +116,9 @@ A way around this is to prevent potentially harmful RPC methods from being modif
 
 You can also host access to your RPC interface by pointing service of web server, like Nginx, to your client's local address and port.
 
-The most privacy-preserving and simple way to set up a publicly reachable endpoint, you can host it on your own [Tor](https://www.torproject.org/) onion service. This will let you reach the RPC outside your local network without a static public IP address or opened ports. 
+The most privacy-preserving and simple way to set up a publicly reachable endpoint, you can host it on your own [Tor](https://www.torproject.org/) onion service. This will let you reach the RPC outside your local network without a static public IP address or opened ports.
 To do this:
+
 - Install `tor`
 - Edit `torrc` config to enable hidden service with address of your client's RPC address and port
 - Restart `tor` service
@@ -124,28 +132,29 @@ You should regularly monitor your node to make sure it's running properly. You m
 #### Keeping node online {#keeping-node-online}
 
 Your node doesn't have to be online nonstop but you should keep it online as much as possible to keep it in sync with the network. You can shut it down to restart it but keep in mind that:
+
 - Shutting down can take up to a few minutes if the recent state is still being written on disk.
 - Forced shut downs can damage the database.
 - Your client will go out of sync with the network and will need to resync when you restart it.
 
-*This doesn't apply on Eth2 validator nodes.* Taking your node offline will affect all services dependent on it. If you are running a node for *staking* purposes you should try to minimize downtime as much as possible.
+_This doesn't apply on Eth2 validator nodes._ Taking your node offline will affect all services dependent on it. If you are running a node for _staking_ purposes you should try to minimize downtime as much as possible.
 
 #### Creating client service {#creating-client-service}
 
 Consider creating a service to run your client automatically on startup. For example on Linux servers, good practice would be creating a service that executes the client with proper config, under user with limited privileges and automatically restarts.
- 
+
 #### Updating client {#updating-client}
 
 You need to keep your client software up-to-date with the latest security patches, features, and [EIPs](/eips/). Especially before [hard forks](/history/), make sure you are running the correct client version.
 
 #### Running additional services {#running-additional-services}
 
-Running your own node lets you use services that require direct access to Ethereum client RPC. These are services built on top of Ethereum like [layer 2 solutions](/en/developers/docs/layer-2-scaling/#top), [Eth2 clients](/en/eth2/get-involved/#clients), and other Ethereum infrastructure. 
+Running your own node lets you use services that require direct access to Ethereum client RPC. These are services built on top of Ethereum like [layer 2 solutions](/en/developers/docs/layer-2-scaling/#top), [Eth2 clients](/en/eth2/get-involved/#clients), and other Ethereum infrastructure.
 
 #### Monitoring the node {#monitoring-the-node}
 
 "To properly monitor your node, consider collecting metrics. Clients provide metrics endpoints so you can get comprehensive data about your node. Use tools like [InfluxDB](https://www.influxdata.com/get-influxdb/) or [Prometheus](https://prometheus.io/) to create databases which you can turn into visualizations and charts in software like [Grafana](grafana.com/). There are many setups for using this software and different Grafana dashboards for you to visualise your node and the network as a whole.
-TAs part of your monitoring, make sure to keep an eye on your machine's performance. During your node's initial sync, the client software may be very heavy on CPU and RAM. In addition to Grafana, you can use the tools your OS offers like `htop` or `uptime` to do this. 
+TAs part of your monitoring, make sure to keep an eye on your machine's performance. During your node's initial sync, the client software may be very heavy on CPU and RAM. In addition to Grafana, you can use the tools your OS offers like `htop` or `uptime` to do this.
 
 ## Further reading {#further-reading}
 
@@ -153,11 +162,10 @@ TAs part of your monitoring, make sure to keep an eye on your machine's performa
 - [Running Ethereum Full Nodes: A Guide for the Barely Motivated](https://medium.com/@JustinMLeroux/running-ethereum-full-nodes-a-guide-for-the-barely-motivated-a8a13e7a0d31) _– Justin Leroux, 7 November 2019_
 - [Running an Ethereum Node](https://docs.ethhub.io/using-ethereum/running-an-ethereum-node/) _– ETHHub, updated often_
 - [Running a Hyperledger Besu Node on the Ethereum Mainnet: Benefits, Requirements, and Setup](https://pegasys.tech/running-a-hyperledger-besu-node-on-the-ethereum-mainnet-benefits-requirements-and-setup/) _– Felipe Faraggi, 7 May 2020_
-- [Deploying Nethermind Ethereum Client with Monitoring Stack](https://medium.com/nethermind-eth/deploying-nethermind-ethereum-client-with-monitoring-stack-55ce1622edbd ) _– Nethermind.eth, 8 July 2020_
+- [Deploying Nethermind Ethereum Client with Monitoring Stack](https://medium.com/nethermind-eth/deploying-nethermind-ethereum-client-with-monitoring-stack-55ce1622edbd) _– Nethermind.eth, 8 July 2020_
 
 ## Related topics {#related-topics}
 
-- [Nodes and clients](/en/developers/docs/nodes-and-clients/) 
+- [Nodes and clients](/en/developers/docs/nodes-and-clients/)
 - [Blocks](/en/developers/docs/blocks/)
 - [Networks](/en/developers/docs/networks/)
-

--- a/src/content/glossary/index.md
+++ b/src/content/glossary/index.md
@@ -437,6 +437,8 @@ Also known as a "deed," this is a token standard introduced by the ERC-721 propo
 
 A software client that participates in the network.
 
+<DocLink to="/developers/docs/nodes-and-clients/run-a-node/" title="Nodes and Clients" />
+
 <DocLink to="/developers/docs/nodes-and-clients/" title="Nodes and Clients" />
 
 ### nonce {#nonce}

--- a/src/content/glossary/index.md
+++ b/src/content/glossary/index.md
@@ -437,7 +437,7 @@ Also known as a "deed," this is a token standard introduced by the ERC-721 propo
 
 A software client that participates in the network.
 
-<DocLink to="/developers/docs/nodes-and-clients/run-a-node/" title="Nodes and Clients" />
+<DocLink to="/developers/docs/nodes-and-clients/" title="Nodes and Clients" />
 
 <DocLink to="/developers/docs/nodes-and-clients/" title="Nodes and Clients" />
 

--- a/src/data/developer-docs-links.yaml
+++ b/src/data/developer-docs-links.yaml
@@ -27,6 +27,8 @@
     - id: docs-nav-nodes-and-clients
       to: /developers/docs/nodes-and-clients/
       items:
+        - id: docs-nav-run-a-node
+          to: /developers/docs/nodes-and-clients/run-a-node/
         - id: docs-nav-nodes-as-a-service
           to: /developers/docs/nodes-and-clients/nodes-as-a-service/
     - id: docs-nav-networks

--- a/src/intl/en/page-developers-docs.json
+++ b/src/intl/en/page-developers-docs.json
@@ -31,6 +31,7 @@
   "docs-nav-mining": "Mining",
   "docs-nav-networks": "Networks",
   "docs-nav-nodes-and-clients": "Nodes and clients",
+  "docs-nav-run-a-node": "Run a node",
   "docs-nav-nodes-as-a-service": "Nodes as a service",
   "docs-nav-oracles": "Oracles",
   "docs-nav-programming-languages": "Programming languages",


### PR DESCRIPTION
## Description
- Relocates new "Spin up your own Ethereum node" documentation to `developers/docs/nodes-and-clients/run-a-node/`
- Adds linking to documentation via EDN yaml (documents navigation)
- Updated translation json with this entry
- Added link from "node" glossary definition, a new link near top of "Nodes and Clients" from previous copy, and updated original link on "nodes and clients" page midway down the page to new path

Note, it may be beneficial to add a link to this somewhere in the Eth2/staking sections (since validators running their own nodes should be encouraged), but to limit translation issues I held this for now. 

## Related Issue #2270
