### PR TITLE
Added plugins to IDE docs [Fixes #1947]

### DIFF
--- a/src/content/developers/docs/ides/index.md
+++ b/src/content/developers/docs/ides/index.md
@@ -32,6 +32,11 @@ Most established IDEs have built plugins to enhance the Ethereum development exp
 - [Code samples](https://github.com/Azure-Samples/blockchain/blob/master/blockchain-workbench/application-and-smart-contract-samples/readme.md)
 - [GitHub](https://github.com/microsoft/vscode)
 
+> _Recommended VS Code Extensions/Plugins_
+>
+> - [solidity](https://marketplace.visualstudio.com/items?itemName=JuanBlanco.solidity) - Ethereum Solidity Language for Visual Studio Code
+> - [Prettier - Code formatter](https://marketplace.visualstudio.com/items?itemName=SimonSiefke.prettier-vscode) - Code formatter using prettier
+
 **Atom -** **_A hackable text editor for the 21st Century_**
 
 - [Atom](https://atom.io/)

--- a/src/content/developers/docs/ides/index.md
+++ b/src/content/developers/docs/ides/index.md
@@ -32,16 +32,16 @@ Most established IDEs have built plugins to enhance the Ethereum development exp
 - [Code samples](https://github.com/Azure-Samples/blockchain/blob/master/blockchain-workbench/application-and-smart-contract-samples/readme.md)
 - [GitHub](https://github.com/microsoft/vscode)
 
-> _Recommended VS Code Extensions/Plugins_
->
-> - [solidity](https://marketplace.visualstudio.com/items?itemName=JuanBlanco.solidity) - Ethereum Solidity Language for Visual Studio Code
-> - [Prettier - Code formatter](https://marketplace.visualstudio.com/items?itemName=SimonSiefke.prettier-vscode) - Code formatter using prettier
-
 **Atom -** **_A hackable text editor for the 21st Century_**
 
 - [Atom](https://atom.io/)
 - [GitHub](https://github.com/atom)
 - [Ethereum packages](https://atom.io/packages/search?utf8=%E2%9C%93&q=keyword%3Aethereum&commit=Search)
+
+## Plugins and Extensions
+
+- [solidity](https://marketplace.visualstudio.com/items?itemName=JuanBlanco.solidity) - Ethereum Solidity Language for Visual Studio Code
+- [Prettier Solidity](https://github.com/prettier-solidity/prettier-plugin-solidity) - Code formatter using prettier
 
 ## Further reading {#further-reading}
 


### PR DESCRIPTION
## Description
- Adds section for VS Code extensions/plugins to the IDE dev docs page
- Includes [solidity](https://marketplace.visualstudio.com/items?itemName=JuanBlanco.solidity) (245k downloads) and [Prettier - Code formatter](https://marketplace.visualstudio.com/items?itemName=SimonSiefke.prettier-vscode)

If anyone has more suggestions happy to add them

## Related Issue #1947