### PR TITLE
Reword "Ethereum developer network"

### DIFF
--- a/src/content/developers/docs/index.md
+++ b/src/content/developers/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: Ethereum development documentation
-description: Introducing the Ethereum developer network documentation.
+description: Introducing the ethereum.org developer documentation.
 lang: en
 sidebar: true
 ---


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Minor re-wording after the decision to not brand our docs as the "Ethereum developer network" due to potential confusion with development networks (i.e. https://ethereum.org/en/developers/docs/development-networks/)

## Related Issue
None
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
