### PR TITLE
Add ethscan.org eth2 explorer with a free public API

### DIFF
--- a/src/content/developers/docs/data-and-analytics/block-explorers/index.md
+++ b/src/content/developers/docs/data-and-analytics/block-explorers/index.md
@@ -262,7 +262,7 @@ The Eth2 top-level data includes the following:
 - [https://beaconcha.in/](https://beaconcha.in/)
 - [https://beaconscan.com/](https://beaconscan.com/)
 - [https://eth2stats.io/](https://eth2stats.io/medalla-testnet)
-- [https://ethscan.org/](https://ethscan.org/)
+- [https://ethscan.org/](https://ethscan.org/) (fork of beaconcha.in)
 
 ## Further reading {#further-reading}
 

--- a/src/content/developers/docs/data-and-analytics/block-explorers/index.md
+++ b/src/content/developers/docs/data-and-analytics/block-explorers/index.md
@@ -262,6 +262,7 @@ The Eth2 top-level data includes the following:
 - [https://beaconcha.in/](https://beaconcha.in/)
 - [https://beaconscan.com/](https://beaconscan.com/)
 - [https://eth2stats.io/](https://eth2stats.io/medalla-testnet)
+- [https://ethscan.org/](https://ethscan.org/)
 
 ## Further reading {#further-reading}
 


### PR DESCRIPTION
Add ethscan.org eth2 explorer with a free public API

## Description

Open-source eth2 beacon chain explorer based on the original eth2 explorer by bitfly, offering a free public API.
Maintained by [Redot.com](https://redot.com/)

## Related Issue

#2292
