### PR TITLE
Update stale bot timeline

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,5 +14,5 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-label: 'Status: Stale'
           stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days'
-          days-before-stale: 30
-          days-before-close: 5
+          days-before-stale: 45
+          days-before-close: 7


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Update our bot to label stale issues after 45 days & close after an additional 7 days.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
