### PR TITLE
POAP contributors banner 

### DIFF
--- a/src/content/contributing/index.md
+++ b/src/content/contributing/index.md
@@ -3,9 +3,17 @@ title: Contributing
 description: Learn about the different ways you can contribute to ethereum.org
 lang: en
 sidebar: true
+contributors: true
 ---
 
 # Contributing to ethereum.org 🦄 {#contributing-to-ethereumorg-}
+
+<InfoBanner>
+  <Emoji text=":tada:" size={5} /> 
+  <b>Claim your POAP!</b>
+  <p>If you contributed to ethereum.org in 2020, there's a unique POAP waiting for you.</p>
+  <a href="#poap">More on POAPs</a>
+</InfoBanner>
 
 ethereum.org is an open-source project. So if you want to help improve [our portal to Ethereum](/en/about/), here's how you can help out.
 
@@ -59,6 +67,18 @@ Decisions about individual PRs, design evolution and major upgrades are made by 
 - [website@ethereum.org](mailto:website@ethereum.org)
 - [@ethdotorg](https://twitter.com/ethdotorg)
 - [Discord server](https://discord.gg/CetY6Y4)
+
+## Claim your contributor POAP {#poap}
+
+If your contribution gets merged into ethereum.org, we'll mint you a unique contributors POAP. A Proof of Attendance Protocol (POAP) token is on-chain proof that you helped make the ecosystem a little more awesome.
+
+[More on POAPs](https://www.poap.xyz/)
+
+### How to claim:
+
+1. Join our [Discord server](https://discord.gg/CetY6Y4)
+2. paste a link to your contribution in the #POAP channel
+3. wait for a member of our team to send you a link to your minted POAP
 
 ## Contributors {#contributors}
 

--- a/src/content/contributing/index.md
+++ b/src/content/contributing/index.md
@@ -3,7 +3,6 @@ title: Contributing
 description: Learn about the different ways you can contribute to ethereum.org
 lang: en
 sidebar: true
-contributors: true
 ---
 
 # Contributing to ethereum.org 🦄 {#contributing-to-ethereumorg-}

--- a/src/content/contributing/index.md
+++ b/src/content/contributing/index.md
@@ -73,9 +73,9 @@ If your contribution gets merged into ethereum.org, we'll mint you a unique cont
 
 ### How to claim
 
-1. Join our [Discord server](https://discord.gg/CetY6Y4)
-2. Paste a link to your contribution in the #poaps-🏆 channel
-3. Wait for a member of our team to send you a link to your minted POAP
+1. Join our [Discord server](https://discord.gg/CetY6Y4).
+2. Paste a link to your contribution in the #poaps-🏆 channel.
+3. Wait for a member of our team to send you a link to your minted POAP.
 4. Claim your POAP!
 
 ## Contributors {#contributors}

--- a/src/content/contributing/index.md
+++ b/src/content/contributing/index.md
@@ -74,7 +74,7 @@ If your contribution gets merged into ethereum.org, we'll mint you a unique cont
 ### How to claim
 
 1. Join our [Discord server](https://discord.gg/CetY6Y4)
-2. Paste a link to your contribution in the #contributing channel
+2. Paste a link to your contribution in the #poaps-🏆 channel
 3. Wait for a member of our team to send you a link to your minted POAP
 4. Claim your POAP!
 

--- a/src/content/contributing/index.md
+++ b/src/content/contributing/index.md
@@ -8,10 +8,8 @@ contributors: true
 
 # Contributing to ethereum.org 🦄 {#contributing-to-ethereumorg-}
 
-<InfoBanner>
-  <Emoji text=":tada:" size={5} /> 
-  <b>Claim your POAP!</b>
-  <p>If you contributed to ethereum.org in 2020, there's a unique POAP waiting for you.</p>
+<InfoBanner shouldCenter emoji=":tada:">
+  Claim your POAP token! If you contributed to ethereum.org in 2020, there's a unique POAP waiting for you.{" "}
   <a href="#poap">More on POAPs</a>
 </InfoBanner>
 
@@ -74,11 +72,12 @@ If your contribution gets merged into ethereum.org, we'll mint you a unique cont
 
 [More on POAPs](https://www.poap.xyz/)
 
-### How to claim:
+### How to claim
 
 1. Join our [Discord server](https://discord.gg/CetY6Y4)
-2. paste a link to your contribution in the #POAP channel
-3. wait for a member of our team to send you a link to your minted POAP
+2. Paste a link to your contribution in the #contributing channel
+3. Wait for a member of our team to send you a link to your minted POAP
+4. Claim your POAP!
 
 ## Contributors {#contributors}
 

--- a/src/templates/static.js
+++ b/src/templates/static.js
@@ -94,6 +94,10 @@ const MobileTableOfContents = styled(TableOfContents)`
   z-index: 2;
 `
 
+const StyledBannerNotification = styled(BannerNotification)`
+  text-align: center;
+`
+
 const HR = styled.hr`
   width: 100%;
   margin: 2rem 0rem;
@@ -151,10 +155,12 @@ const StaticPage = ({ data: { mdx } }) => {
 
   return (
     <PageContainer>
-      <BannerNotification shouldShow={isContributors}>
+      <StyledBannerNotification shouldShow={isContributors}>
         {/* TODO move to common.json */}
-        Claim your POAP
-      </BannerNotification>
+        Claim your POAP token! If you contributed to ethereum.org in 2020,
+        there's a unique POAP waiting for you.{" "}
+        <Link to="#poap">How to claim</Link>
+      </StyledBannerNotification>
       <Page dir={isRightToLeft ? "rtl" : "ltr"}>
         <PageMetadata
           title={mdx.frontmatter.title}

--- a/src/templates/static.js
+++ b/src/templates/static.js
@@ -4,13 +4,11 @@ import { useIntl } from "gatsby-plugin-intl"
 import { MDXProvider } from "@mdx-js/react"
 import { MDXRenderer } from "gatsby-plugin-mdx"
 import styled from "styled-components"
-
 import ButtonLink from "../components/ButtonLink"
 import Breadcrumbs from "../components/Breadcrumbs"
 import Card from "../components/Card"
 import Contributors from "../components/Contributors"
 import InfoBanner from "../components/InfoBanner"
-import BannerNotification from "../components/BannerNotification"
 import Link from "../components/Link"
 import MarkdownTable from "../components/MarkdownTable"
 import Logo from "../components/Logo"
@@ -25,7 +23,6 @@ import Translation from "../components/Translation"
 import TranslationsInProgress from "../components/TranslationsInProgress"
 import SectionNav from "../components/SectionNav"
 import DocLink from "../components/DocLink"
-import DismissibleCard from "../components/DismissibleCard"
 import GhostCard from "../components/GhostCard"
 import { getLocaleTimestamp } from "../utils/time"
 import { isLangRightToLeft } from "../utils/translations"
@@ -52,10 +49,6 @@ const Page = styled.div`
   @media (min-width: ${(props) => props.theme.breakpoints.l}) {
     padding-top: 4rem;
   }
-`
-
-const PageContainer = styled.div`
-  width: 100%;
 `
 
 // Apply styles for classes within markdown here
@@ -92,10 +85,6 @@ const Pre = styled.pre`
 const MobileTableOfContents = styled(TableOfContents)`
   position: relative;
   z-index: 2;
-`
-
-const StyledBannerNotification = styled(BannerNotification)`
-  text-align: center;
 `
 
 const HR = styled.hr`
@@ -138,15 +127,12 @@ const components = {
   ExpandableCard,
   CardContainer,
   GhostCard,
-  DismissibleCard,
-  BannerNotification,
 }
 
 const StaticPage = ({ data: { mdx } }) => {
   const intl = useIntl()
   const isRightToLeft = isLangRightToLeft(intl.locale)
   const tocItems = mdx.tableOfContents.items
-  const isContributors = mdx.frontmatter.contributors
 
   // TODO some `gitLogLatestDate` are `null` - why?
   const lastUpdatedDate = mdx.parent.fields
@@ -154,41 +140,33 @@ const StaticPage = ({ data: { mdx } }) => {
     : mdx.parent.mtime
 
   return (
-    <PageContainer>
-      <StyledBannerNotification shouldShow={isContributors}>
-        {/* TODO move to common.json */}
-        Claim your POAP token! If you contributed to ethereum.org in 2020,
-        there's a unique POAP waiting for you.{" "}
-        <Link to="#poap">How to claim</Link>
-      </StyledBannerNotification>
-      <Page dir={isRightToLeft ? "rtl" : "ltr"}>
-        <PageMetadata
-          title={mdx.frontmatter.title}
-          description={mdx.frontmatter.description}
+    <Page dir={isRightToLeft ? "rtl" : "ltr"}>
+      <PageMetadata
+        title={mdx.frontmatter.title}
+        description={mdx.frontmatter.description}
+      />
+      <ContentContainer>
+        <Breadcrumbs slug={mdx.fields.slug} />
+        <LastUpdated>
+          <Translation id="page-last-updated" />:{" "}
+          {getLocaleTimestamp(intl.locale, lastUpdatedDate)}
+        </LastUpdated>
+        <MobileTableOfContents
+          items={tocItems}
+          maxDepth={mdx.frontmatter.sidebarDepth}
+          isMobile={true}
         />
-        <ContentContainer>
-          <Breadcrumbs slug={mdx.fields.slug} />
-          <LastUpdated>
-            <Translation id="page-last-updated" />:{" "}
-            {getLocaleTimestamp(intl.locale, lastUpdatedDate)}
-          </LastUpdated>
-          <MobileTableOfContents
-            items={tocItems}
-            maxDepth={mdx.frontmatter.sidebarDepth}
-            isMobile={true}
-          />
-          <MDXProvider components={components}>
-            <MDXRenderer>{mdx.body}</MDXRenderer>
-          </MDXProvider>
-        </ContentContainer>
-        {mdx.frontmatter.sidebar && tocItems && (
-          <TableOfContents
-            items={tocItems}
-            maxDepth={mdx.frontmatter.sidebarDepth}
-          />
-        )}
-      </Page>
-    </PageContainer>
+        <MDXProvider components={components}>
+          <MDXRenderer>{mdx.body}</MDXRenderer>
+        </MDXProvider>
+      </ContentContainer>
+      {mdx.frontmatter.sidebar && tocItems && (
+        <TableOfContents
+          items={tocItems}
+          maxDepth={mdx.frontmatter.sidebarDepth}
+        />
+      )}
+    </Page>
   )
 }
 
@@ -203,7 +181,6 @@ export const staticPageQuery = graphql`
         description
         sidebar
         sidebarDepth
-        contributors
       }
       body
       tableOfContents

--- a/src/templates/static.js
+++ b/src/templates/static.js
@@ -10,6 +10,7 @@ import Breadcrumbs from "../components/Breadcrumbs"
 import Card from "../components/Card"
 import Contributors from "../components/Contributors"
 import InfoBanner from "../components/InfoBanner"
+import BannerNotification from "../components/BannerNotification"
 import Link from "../components/Link"
 import MarkdownTable from "../components/MarkdownTable"
 import Logo from "../components/Logo"
@@ -24,6 +25,7 @@ import Translation from "../components/Translation"
 import TranslationsInProgress from "../components/TranslationsInProgress"
 import SectionNav from "../components/SectionNav"
 import DocLink from "../components/DocLink"
+import DismissibleCard from "../components/DismissibleCard"
 import GhostCard from "../components/GhostCard"
 import { getLocaleTimestamp } from "../utils/time"
 import { isLangRightToLeft } from "../utils/translations"
@@ -50,6 +52,10 @@ const Page = styled.div`
   @media (min-width: ${(props) => props.theme.breakpoints.l}) {
     padding-top: 4rem;
   }
+`
+
+const PageContainer = styled.div`
+  width: 100%;
 `
 
 // Apply styles for classes within markdown here
@@ -128,12 +134,15 @@ const components = {
   ExpandableCard,
   CardContainer,
   GhostCard,
+  DismissibleCard,
+  BannerNotification,
 }
 
 const StaticPage = ({ data: { mdx } }) => {
   const intl = useIntl()
   const isRightToLeft = isLangRightToLeft(intl.locale)
   const tocItems = mdx.tableOfContents.items
+  const isContributors = mdx.frontmatter.contributors
 
   // TODO some `gitLogLatestDate` are `null` - why?
   const lastUpdatedDate = mdx.parent.fields
@@ -141,33 +150,39 @@ const StaticPage = ({ data: { mdx } }) => {
     : mdx.parent.mtime
 
   return (
-    <Page dir={isRightToLeft ? "rtl" : "ltr"}>
-      <PageMetadata
-        title={mdx.frontmatter.title}
-        description={mdx.frontmatter.description}
-      />
-      <ContentContainer>
-        <Breadcrumbs slug={mdx.fields.slug} />
-        <LastUpdated>
-          <Translation id="page-last-updated" />:{" "}
-          {getLocaleTimestamp(intl.locale, lastUpdatedDate)}
-        </LastUpdated>
-        <MobileTableOfContents
-          items={tocItems}
-          maxDepth={mdx.frontmatter.sidebarDepth}
-          isMobile={true}
+    <PageContainer>
+      <BannerNotification shouldShow={isContributors}>
+        {/* TODO move to common.json */}
+        Claim your POAP
+      </BannerNotification>
+      <Page dir={isRightToLeft ? "rtl" : "ltr"}>
+        <PageMetadata
+          title={mdx.frontmatter.title}
+          description={mdx.frontmatter.description}
         />
-        <MDXProvider components={components}>
-          <MDXRenderer>{mdx.body}</MDXRenderer>
-        </MDXProvider>
-      </ContentContainer>
-      {mdx.frontmatter.sidebar && tocItems && (
-        <TableOfContents
-          items={tocItems}
-          maxDepth={mdx.frontmatter.sidebarDepth}
-        />
-      )}
-    </Page>
+        <ContentContainer>
+          <Breadcrumbs slug={mdx.fields.slug} />
+          <LastUpdated>
+            <Translation id="page-last-updated" />:{" "}
+            {getLocaleTimestamp(intl.locale, lastUpdatedDate)}
+          </LastUpdated>
+          <MobileTableOfContents
+            items={tocItems}
+            maxDepth={mdx.frontmatter.sidebarDepth}
+            isMobile={true}
+          />
+          <MDXProvider components={components}>
+            <MDXRenderer>{mdx.body}</MDXRenderer>
+          </MDXProvider>
+        </ContentContainer>
+        {mdx.frontmatter.sidebar && tocItems && (
+          <TableOfContents
+            items={tocItems}
+            maxDepth={mdx.frontmatter.sidebarDepth}
+          />
+        )}
+      </Page>
+    </PageContainer>
   )
 }
 
@@ -182,6 +197,7 @@ export const staticPageQuery = graphql`
         description
         sidebar
         sidebarDepth
+        contributors
       }
       body
       tableOfContents


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR includes a couple options for how we might want to advertise 2020 POAPS on our contributing page.

Option 1: page banner on contributing page
Option 2: InfoBanner on contributing page

I wonder whether we also include a tout on the new homepage that advertises this as I doubt past contributors would be checking the contributors page as it's largely instructions for people who haven't contribute before.
