### PR TITLE
Add simple caching for homepage queries

### DIFF
--- a/src/components/StatsBoxGrid.js
+++ b/src/components/StatsBoxGrid.js
@@ -1,12 +1,13 @@
 import React, { useState, useEffect } from "react"
 import styled from "styled-components"
 import { useIntl } from "gatsby-plugin-intl"
-import axios from "axios"
 
 import Translation from "./Translation"
 import Tooltip from "./Tooltip"
 import Link from "./Link"
 import Icon from "./Icon"
+
+import { getData } from "../utils/cache"
 
 const Value = styled.h3`
   font-size: min(4.4vw, 64px);
@@ -213,10 +214,10 @@ const StatsBoxGrid = () => {
     } else {
       const fetchPrice = async () => {
         try {
-          const response = await axios.get(
+          const data = await getData(
             "https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd&include_24hr_change=true"
           )
-          const { usd } = response.data.ethereum
+          const { usd } = data.ethereum
           const value = formatPrice(usd)
           setEthPrice({
             value,
@@ -233,8 +234,7 @@ const StatsBoxGrid = () => {
 
       const fetchNodes = async () => {
         try {
-          const response = await axios.get("/.netlify/functions/etherscan")
-          const { data } = response
+          const data = await getData("/.netlify/functions/etherscan")
           const total = data.result.TotalNodeCount
           const value = formatNodes(total)
           setNodes({
@@ -252,8 +252,8 @@ const StatsBoxGrid = () => {
 
       const fetchTotalValueLocked = async () => {
         try {
-          const response = await axios.get("/.netlify/functions/defipulse")
-          const ethereumTVL = response.data.ethereumTVL
+          const data = await getData("/.netlify/functions/defipulse")
+          const ethereumTVL = data.ethereumTVL
           const value = formatTVL(ethereumTVL)
           setValueLocked({
             value,
@@ -270,8 +270,8 @@ const StatsBoxGrid = () => {
 
       const fetchTxnCount = async () => {
         try {
-          const response = await axios.get("/.netlify/functions/coinmetrics")
-          const { series } = response.data.metricData
+          const data = await getData("/.netlify/functions/coinmetrics")
+          const { series } = data.metricData
           const count = +series[series.length - 1].values[0]
           const value = formatTxs(count)
           setTxs({

--- a/src/components/StatsBoxGrid.js
+++ b/src/components/StatsBoxGrid.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react"
 import styled from "styled-components"
 import { useIntl } from "gatsby-plugin-intl"
+import axios from "axios"
 
 import Translation from "./Translation"
 import Tooltip from "./Tooltip"
@@ -214,10 +215,10 @@ const StatsBoxGrid = () => {
     } else {
       const fetchPrice = async () => {
         try {
-          const data = await getData(
+          const response = await axios.get(
             "https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd&include_24hr_change=true"
           )
-          const { usd } = data.ethereum
+          const { usd } = response.data.ethereum
           const value = formatPrice(usd)
           setEthPrice({
             value,

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -1,0 +1,30 @@
+import axios from "axios"
+
+const ONE_HOUR = 1000 * 60 * 60
+
+const writeToCache = (key, value) => {
+  localStorage.setItem(
+    key,
+    JSON.stringify({ value, timestamp: new Date().getTime() })
+  )
+}
+
+const readFromCache = (key) => JSON.parse(localStorage.getItem(key)) || null
+
+const getFreshData = async (url, cacheResponse = false) => {
+  const { data } = await axios.get(url)
+  cacheResponse && writeToCache(url, data)
+  return data
+}
+
+const getCachedData = (url) => readFromCache(url)
+
+export const getData = async (url) => {
+  const cachedData = getCachedData(url)
+  const now = new Date().getTime()
+  if (cachedData && now - cachedData.timestamp < ONE_HOUR) {
+    return cachedData.value
+  } else {
+    return getFreshData(url, true)
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Store API data in browser local storage & on fetch data source if >1 hour stale.

## Related Issue
None
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
