### PR TITLE
Switches tx count to etherscan API [Fixes #2362]

### DIFF
--- a/src/components/StatsBoxGrid.js
+++ b/src/components/StatsBoxGrid.js
@@ -303,8 +303,8 @@ const StatsBoxGrid = () => {
       state: ethPrice,
     },
     {
-      apiProvider: "Coin Metrics",
-      apiUrl: "https://coinmetrics.io/",
+      apiProvider: "Etherscan",
+      apiUrl: "https://etherscan.io/",
       title: <Translation id="page-index-network-stats-tx-day-description" />,
       description: (
         <Translation id="page-index-network-stats-tx-day-explainer" />

--- a/src/components/StatsBoxGrid.js
+++ b/src/components/StatsBoxGrid.js
@@ -269,11 +269,11 @@ const StatsBoxGrid = () => {
       }
       fetchTotalValueLocked()
 
-      const fetchTxnCount = async () => {
+      const fetchTxCount = async () => {
         try {
-          const data = await getData("/.netlify/functions/coinmetrics")
-          const { series } = data.metricData
-          const count = +series[series.length - 1].values[0]
+          const { result } = await getData("/.netlify/functions/txs")
+          // result: [{UTCDate: string, unixTimeStamp: string, transactionCount: number}, {...}]
+          const count = result[0].transactionCount
           const value = formatTxs(count)
           setTxs({
             value,
@@ -286,7 +286,7 @@ const StatsBoxGrid = () => {
           })
         }
       }
-      fetchTxnCount()
+      fetchTxCount()
     }
   }, [])
 

--- a/src/lambda/txs.js
+++ b/src/lambda/txs.js
@@ -2,8 +2,8 @@ const axios = require("axios")
 
 const handler = async () => {
   try {
-    const dayToFetch = 30
-    const milliseconds = dayToFetch * 24 * 60 * 60 * 1000
+    const daysToFetch = 30
+    const milliseconds = daysToFetch * 24 * 60 * 60 * 1000
     const now = new Date()
     // startdate and enddate format: YYYY-MM-DD
     const to = now.toISOString().split("T")[0]

--- a/src/lambda/txs.js
+++ b/src/lambda/txs.js
@@ -1,0 +1,31 @@
+const axios = require("axios")
+
+const handler = async () => {
+  try {
+    const dayToFetch = 30
+    const milliseconds = dayToFetch * 24 * 60 * 60 * 1000
+    const now = new Date()
+    // startdate and enddate format: YYYY-MM-DD
+    const to = now.toISOString().split("T")[0]
+    const from = new Date(now.getTime() - milliseconds)
+      .toISOString()
+      .split("T")[0]
+    const response = await axios.get(
+      `https://api.etherscan.io/api?module=stats&action=dailytx&startdate=${from}&enddate=${to}&sort=desc&apikey=${process.env.ETHERSCAN_API_KEY}`
+    )
+    if (response.status < 200 || response.status >= 300) {
+      return { statusCode: response.status, body: response.statusText }
+    }
+
+    const { data } = response
+    return {
+      statusCode: 200,
+      body: JSON.stringify(data),
+    }
+  } catch (error) {
+    console.error(error)
+    return { statusCode: 500, body: JSON.stringify({ msg: error.message }) }
+  }
+}
+
+module.exports = { handler }


### PR DESCRIPTION
## Description
- Added new lambda function for call to Etherscan API to pull transaction counts
- Created second lambda for Etherscan in the event one endpoint fails, this will not block the other from potentially displaying
- Pulling 30-days of data in anticipation of charting, but currently only displaying current

## Related Issue 
#2362
