### PR TITLE
fix(Nav): NavContainer width fixed to avoid horizontal scroll #2411

### DIFF
--- a/src/components/Nav/index.js
+++ b/src/components/Nav/index.js
@@ -19,9 +19,7 @@ const NavContainer = styled.div`
   position: sticky;
   top: 0;
   z-index: 1000;
-  width: 100vw;
-  /* xl breakpoint (1440px) + 72px (2rem padding on each side) */
-  max-width: 1504px;
+  width: 100%;
 `
 
 const StyledNav = styled.nav`


### PR DESCRIPTION
## Description

The NavContainer width set to **100vw** causes a horizontal scroll bar to appear on a 13-inch laptop screen. In fact, the vertical scroll width is included using the *vw* viewport unit.

Setting width at **100%** solve this bug. Moreover I removed the useless max-width rule. It is already set on the `ContentContainer` component who is wrapping `Nav` (in *src/components/Layout.js*).

## Related Issue

#2411
