### PR TITLE
Sidechain glossary link bug fix

### DIFF
--- a/src/content/glossary/index.md
+++ b/src/content/glossary/index.md
@@ -541,9 +541,9 @@ A [proof-of-stake](#proof-of-stake) chain that is coordinated by the [Beacon Cha
 
 <DocLink to="/eth2/shard-chains" title="Shard chains" />
 
-### Sidechain {#sidechain}
+### sidechain {#sidechain}
 
-A scaling solution that uses a separate chain with different, often faster, [consensus rules]{#consensus-rules}. A bridge is needed to connect these sidechains to [mainnet](#mainnet). [Rollups](#rollups) also use sidechains, but they operate in collaboration with [mainnet](#mainnet) instead.
+A scaling solution that uses a separate chain with different, often faster, [consensus rules](#consensus-rules). A bridge is needed to connect these sidechains to [mainnet](#mainnet). [Rollups](#rollups) also use sidechains, but they operate in collaboration with [mainnet](#mainnet) instead.
 
 <DocLink to="/developers/docs/layer-2-scaling/#sidechains" title="Sidechains" />
 


### PR DESCRIPTION
## Description
- Fixed typo in link syntax within "sidechain" glossary entry
- Lowercased "sidechain" for consistency

## Related Issue
![image](https://user-images.githubusercontent.com/54227730/107609988-527cc400-6bf5-11eb-97e0-28c5889ef63f.png)
