### PR TITLE
Community tout link patch [Fixes #2413]

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -468,7 +468,7 @@ const HomePage = ({ data }) => {
         "page-index-tout-community-description",
         intl
       ),
-      to: "/enterprise/",
+      to: "/community/",
     },
   ]
 


### PR DESCRIPTION
## Description
- Fixes link for Community "tout" card on homepage. (was pointing to `/enterprise/`)

## Related Issue #2413