### PR TITLE
Limit Netlify builds to relevant diffs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -16,6 +16,9 @@
   # Directory with the serverless Lambda functions to deploy to AWS.
   functions = "public/lambda"
 
+  # Only build on changes to src/ OR changes to .js and .json files outside src/
+  ignore="git diff --quiet --exit-code HEAD^ HEAD ./src || if [[ $(git diff --name-only HEAD^ HEAD .) == *[.](js|json)* ]]; then exit 1; else exit 0; fi"
+
 # Production context: all deploys from the Production branch set in your site's
 # deploy contexts will inherit these settings.
 # [context.production]

--- a/netlify.toml
+++ b/netlify.toml
@@ -17,7 +17,7 @@
   functions = "public/lambda"
 
   # Only build on changes to src/ OR changes to .js and .json files outside src/
-  ignore="git diff --quiet --exit-code HEAD^ HEAD ./src || if [[ $(git diff --name-only HEAD^ HEAD .) == *[.](js|json)* ]]; then exit 1; else exit 0; fi"
+  ignore="git diff --quiet --exit-code dev ./src || if [[ $(git diff --name-only dev .) == *[.](js|json)* ]]; then exit 1; else exit 0; fi"
 
 # Production context: all deploys from the Production branch set in your site's
 # deploy contexts will inherit these settings.


### PR DESCRIPTION
## Description

> EDIT: Having put this out I now realize Netlify asks for permission to build, so not sure it even is relevant anymore

Adds a shell script to ignore builds based on what files have been changed (rather than the author). 

The idea here is to provide the foundation for not running builds on certain commits that can of course be changed by the maintainers as you need.

Currently, it makes it so that Netlify will build if:

- Something changed in `/src` **OR**
- `.js` or `.json` files were changed elsewhere

Happy to update the pattern if anyone has suggestions. 

## Related Issue

#1148 

## Further explanation

The first part of the script: 

```
git diff --quiet --exit-code HEAD^ HEAD ./src
```

Will exit with code 1 if files changed in `/src`, triggering a build as per [Netlify's docs](https://docs.netlify.com/configure-builds/file-based-configuration/#ignore-builds).

If it exits with code 0 (no files changed in that dir), it will then run the second part:

```
if [[ $(git diff --name-only HEAD^ HEAD .) == *[.](js|json)* ]]; then exit 1; else exit 0; fi
```

Here we are getting only the names of the files changed elsewhere (since there were no changes in `/src`) and seeing if they match a given pattern, which essentially checks if there's an extension `.js` or `.json` somewhere. Here are some examples to try:

**No build**

```
diff="test.foo\nhey.bar"
if [[ $diff == *[.](js|json)* ]]; then echo build; else echo dont build; fi
```

**Build**

```
diff="test.js\nhey.bar"
if [[ $diff == *[.](js|json)* ]]; then echo build; else echo dont build; fi
```

**Build**

```
diff="test.foo\nhey.json"
if [[ $diff == *[.](js|json)* ]]; then echo build; else echo dont build; fi
```

## Limitations

There is a problem here though. While this should catch all PRs from the allcontributors bot for example, the script currently only checks the latest commit against its parent. In the case of most bots, the parent will be a commit in `dev` anyway, which is fine, but if one submits a PR with multiple commits, this check won't actually be referring to `dev`, but rather to the commit's parent in that branch.

One might then think that `git diff dev` might be better, since it will compare branch HEADs. Problem is that then it will trigger on useless commits if even one commit in that branch matches the pattern against `dev`.

Happy to explore other avenues here but thought the best approach was to open a PR to spark discussion :smiley: 