### PR TITLE
Updated instances of "tree" to "trie" in docs.

### DIFF
--- a/src/content/developers/docs/accounts/index.md
+++ b/src/content/developers/docs/accounts/index.md
@@ -45,7 +45,7 @@ Ethereum accounts have four fields:
 - `balance` – the number of Wei owned by this address. Wei is a denomination of ETH and there are 1e+18 Wei per ETH.
 - `codeHash` – All such code fragments are contained in the state database under their corresponding hashes for later retrieval. For contract accounts, this is the code that gets hashed and stored as the codeHash. For externally owned accounts, the codeHash field is the hash of the empty string.
 <!--this hash refers to the code of this account on the Ethereum virtual machine (EVM). This EVM code gets executed if the account gets a message call. It cannot be changed unlike the other account fields.  -->
-- `storageRoot` – Sometimes known as a storage hash. A 256-bit hash of the root node of a Merkle Patricia tree that encodes the storage contents of the account (a mapping between 256-bit integer values), encoded into the trie as a mapping from the Keccak 256-bit hash of the 256-bit integer keys to the RLP-encoded 256-bit integer values. This tree encodes the hash of the storage contents of this account, and is empty by default.
+- `storageRoot` – Sometimes known as a storage hash. A 256-bit hash of the root node of a Merkle Patricia trie that encodes the storage contents of the account (a mapping between 256-bit integer values), encoded into the trie as a mapping from the Keccak 256-bit hash of the 256-bit integer keys to the RLP-encoded 256-bit integer values. This trie encodes the hash of the storage contents of this account, and is empty by default.
 
 ![A diagram showing the make up of an account](./accounts.png)
 _Diagram adapted from [Ethereum EVM illustrated](https://takenobu-hs.github.io/downloads/ethereum_evm_illustrated.pdf)_

--- a/src/content/developers/docs/data-and-analytics/block-explorers/index.md
+++ b/src/content/developers/docs/data-and-analytics/block-explorers/index.md
@@ -49,7 +49,7 @@ New blocks are added to Ethereum every ~12 seconds (this can fluctuate) so there
 - Hash – The cryptographic hash that represents the block header (the unique identifier of the block).
 - Parent hash – The hash of the block that came before the current block.
 - Sha3Uncles – The combined hash of all uncles for a given parent.
-- StateRoot – The root hash of Merkle tree which stores the entire state of the system.
+- StateRoot – The root hash of Merkle trie which stores the entire state of the system.
 - Nonce – A value used to demonstrate proof-of-work for a block by the miner.
 
 **Uncle blocks**

--- a/src/content/glossary/index.md
+++ b/src/content/glossary/index.md
@@ -395,7 +395,7 @@ An Ethereum client that does not store a local copy of the [blockchain](#blockch
 
 Short for "main network," this is the main public Ethereum [blockchain](#blockchain). Real ETH, real value, and real consequences. Also known as layer 1 when discussing [layer 2](#layer-2) scaling solutions. (Also, see [testnet](#testnet))
 
-### Merkle Patricia tree {#merkle-patricia-tree}
+### Merkle Patricia trie {#merkle-patricia-tree}
 
 A data structure used in Ethereum to efficiently store key-value pairs.
 


### PR DESCRIPTION
Changed "tree" to "trie" as discussed in https://github.com/ethereum/ethereum-org-website/pull/2397