### PR TITLE
Allows hash linking alongside queryParams [Fixes #2465]

### DIFF
--- a/src/pages-conditional/dapps.js
+++ b/src/pages-conditional/dapps.js
@@ -367,7 +367,7 @@ const DappsPage = ({ data, location }) => {
     } else if (window && queryParamCategories && explore.current) {
       window.scrollTo({
         top: explore.current.offsetTop - 76,
-        behavior: "auto",
+        behavior: "smooth",
       })
     }
   }, [location.search])

--- a/src/pages-conditional/dapps.js
+++ b/src/pages-conditional/dapps.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react"
+import React, { useRef, useState, useEffect } from "react"
 import styled from "styled-components"
 import Img from "gatsby-image"
 import { graphql } from "gatsby"
@@ -347,6 +347,7 @@ const GAMING = "gaming"
 const DappsPage = ({ data, location }) => {
   const intl = useIntl()
   const [selectedCategory, setCategory] = useState(FINANCE)
+  const explore = useRef(null)
 
   useEffect(() => {
     // Fetch category on load
@@ -361,6 +362,14 @@ const DappsPage = ({ data, location }) => {
         ? selectedCategory
         : FINANCE
     )
+    if (location.hash.length > 0 && location.hash[0] === "#") {
+      navigate(location.hash)
+    } else if (window && queryParamCategories && explore.current) {
+      window.scrollTo({
+        top: explore.current.offsetTop - 76,
+        behavior: "auto",
+      })
+    }
   }, [location.search])
 
   const updatePath = (selectedCategory, isMobile) => {
@@ -1154,7 +1163,7 @@ const DappsPage = ({ data, location }) => {
           })}
         </StyledCardGrid>
       </Content>
-      <FullWidthContainer>
+      <FullWidthContainer ref={explore}>
         <H2 id="explore">
           <Translation id="page-dapps-explore-dapps-title" />
         </H2>


### PR DESCRIPTION
## Description
- If hash link provided, will navigate to it
- If "category" queryParam provided, this will be set before navigating to any hash link, and will automatically scroll to "explore" section to provide context for queryParam if no overriding hash link is provided

examples:
`/en/dapps` -> No pre-filtering (defaults to Finance), user stays at top of page
`/en/dapps#explore` -> No pre-filtering (defaults to Finance), user is taken to `explore` section
`/en/dapps?category=gaming` ->  Pre-filters to Gaming, user is taken to `explore` section
`/en/dapps?category=gaming#what-are-dapps` -> Pre-filters to Gaming, user is taken to `what-are-dapps` section

## Related Issue #2465 


@ryancreatescopy I defaulted this to an automatic scroll (no animation), but this can be switched to a "smooth" scroll if you wanted to consider adding some more context for the user (ie, they go to `/en/dapps?category=gaming` and it animates the scroll to that section so the user knows where they are, instead of it just jumping there). Personally prefer the `auto` option over `scroll`.