### PR TITLE
Card style updated, created a single shared component [Fixes #2251]

### DIFF
--- a/src/components/Roadmap.js
+++ b/src/components/Roadmap.js
@@ -9,7 +9,6 @@ import { FakeLinkExternal, H2, H3 } from "./SharedStyledComponents"
 
 import { translateMessageId } from "../utils/translations"
 
-//Import for Item / Card
 import { CardItem as Item } from "./SharedStyledComponents"
 
 const Section = styled.div`

--- a/src/components/Roadmap.js
+++ b/src/components/Roadmap.js
@@ -9,34 +9,15 @@ import { FakeLinkExternal, H2, H3 } from "./SharedStyledComponents"
 
 import { translateMessageId } from "../utils/translations"
 
+//Import for Item / Card
+import { CardItem as Item } from "./SharedStyledComponents"
+
 const Section = styled.div`
   display: flex;
   flex-wrap: wrap;
   margin-top: 2rem;
   margin-bottom: 2rem;
   width: 100%;
-`
-
-const Item = styled(Link)`
-  text-decoration: none;
-  margin: 1rem 1rem 1rem 0;
-  padding: 1rem;
-  width: 240px;
-  list-style: none;
-  border-radius: 2px;
-  border: 1px solid ${(props) => props.theme.colors.lightBorder};
-  /*   box-shadow: ${(props) => props.theme.colors.tableBoxShadow};
- */ /* transition: all 0.5s cubic-bezier(0.25, 0.8, 0.25, 1); */
-  color: ${(props) => props.theme.colors.text};
-
-  &:hover {
-    box-shadow: ${(props) => props.theme.colors.cardBoxShadow};
-    border: 1px solid ${(props) => props.theme.colors.black300};
-  }
-
-  @media (max-width: ${(props) => props.theme.breakpoints.m}) {
-    width: 100%;
-  }
 `
 
 const ErrorMsg = styled.div`

--- a/src/components/SharedStyledComponents.js
+++ b/src/components/SharedStyledComponents.js
@@ -462,4 +462,7 @@ export const CardItem = styled(Link)`
     box-shadow: ${(props) => props.theme.colors.cardBoxShadow};
     border: 1px solid ${(props) => props.theme.colors.black300};
   }
+  @media (max-width: ${(props) => props.theme.breakpoints.s}) {
+    flex: 1 1 240px;
+  }
 `

--- a/src/components/SharedStyledComponents.js
+++ b/src/components/SharedStyledComponents.js
@@ -450,7 +450,7 @@ export const CardItem = styled(Link)`
   text-decoration: none;
   margin: 1rem 1rem 1rem 0;
   padding: 1rem;
-  flex: 1 1 240px;
+  flex: 0 1 240px;
   list-style: none;
   border-radius: 2px;
   width: 100%;
@@ -461,9 +461,5 @@ export const CardItem = styled(Link)`
   &:hover {
     box-shadow: ${(props) => props.theme.colors.cardBoxShadow};
     border: 1px solid ${(props) => props.theme.colors.black300};
-  }
-
-  @media (max-width: ${(props) => props.theme.breakpoints.m}) {
-    width: 100%;
   }
 `

--- a/src/components/SharedStyledComponents.js
+++ b/src/components/SharedStyledComponents.js
@@ -464,5 +464,6 @@ export const CardItem = styled(Link)`
   }
   @media (max-width: ${(props) => props.theme.breakpoints.s}) {
     flex: 1 1 240px;
+    margin: 1rem 0;
   }
 `

--- a/src/components/SharedStyledComponents.js
+++ b/src/components/SharedStyledComponents.js
@@ -3,8 +3,6 @@ import styled from "styled-components"
 import { Mixins } from "../theme"
 import Card from "./Card"
 import Link from "./Link"
-//Imported for LangItem
-import { Link as GatsbyLink } from "gatsby"
 
 export const Page = styled.div`
   display: flex;
@@ -448,16 +446,15 @@ export const dropdownIconContainerVariant = {
 
 // Common styled item card for languages/about
 
-export const CardItem = styled(GatsbyLink)`
+export const CardItem = styled(Link)`
   text-decoration: none;
   margin: 1rem 1rem 1rem 0;
   padding: 1rem;
-  flex: 1 1 200px;
+  flex: 1 1 240px;
   list-style: none;
   border-radius: 2px;
   width: 100%;
   border: 1px solid ${(props) => props.theme.colors.lightBorder};
-  ${"" /* box-shadow: ${(props) => props.theme.colors.tableBoxShadow}; */}
   transition: all 0.5s cubic-bezier(0.25, 0.8, 0.25, 1);
   color: ${(props) => props.theme.colors.text};
 

--- a/src/components/SharedStyledComponents.js
+++ b/src/components/SharedStyledComponents.js
@@ -3,6 +3,8 @@ import styled from "styled-components"
 import { Mixins } from "../theme"
 import Card from "./Card"
 import Link from "./Link"
+//Imported for LangItem
+import { Link as GatsbyLink } from "gatsby"
 
 export const Page = styled.div`
   display: flex;
@@ -443,3 +445,28 @@ export const dropdownIconContainerVariant = {
   },
   closed: { rotate: -90, y: 0 },
 }
+
+// Common Language item card
+
+export const CardItem = styled(GatsbyLink)`
+  text-decoration: none;
+  margin: 1rem 1rem 1rem 0;
+  padding: 1rem;
+  flex: 1 1 200px;
+  list-style: none;
+  border-radius: 2px;
+  width: 100%;
+  border: 1px solid ${(props) => props.theme.colors.lightBorder};
+  ${"" /* box-shadow: ${(props) => props.theme.colors.tableBoxShadow}; */}
+  transition: all 0.5s cubic-bezier(0.25, 0.8, 0.25, 1);
+  color: ${(props) => props.theme.colors.text};
+
+  &:hover {
+    box-shadow: ${(props) => props.theme.colors.cardBoxShadow};
+    border: 1px solid ${(props) => props.theme.colors.black300};
+  }
+
+  @media (max-width: ${(props) => props.theme.breakpoints.m}) {
+    width: 100%;
+  }
+`

--- a/src/components/SharedStyledComponents.js
+++ b/src/components/SharedStyledComponents.js
@@ -446,7 +446,7 @@ export const dropdownIconContainerVariant = {
   closed: { rotate: -90, y: 0 },
 }
 
-// Common Language item card
+// Common styled item card for languages/about
 
 export const CardItem = styled(GatsbyLink)`
   text-decoration: none;

--- a/src/components/TranslationsInProgress.js
+++ b/src/components/TranslationsInProgress.js
@@ -3,12 +3,15 @@ import styled from "styled-components"
 import axios from "axios"
 import { FakeLinkExternal } from "./SharedStyledComponents"
 import Translation from "./Translation"
-import { CardItem as LangItem } from "./SharedStyledComponents"
+import { CardItem } from "./SharedStyledComponents"
 
 const LangContainer = styled.div`
   margin-bottom: 2rem;
   display: flex;
   flex-wrap: wrap;
+`
+const LangItem = styled(CardItem)`
+  flex: 1 1 200px;
 `
 
 const TranslationsInProgress = () => {

--- a/src/components/TranslationsInProgress.js
+++ b/src/components/TranslationsInProgress.js
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from "react"
-import { Link as GatsbyLink } from "gatsby"
 import styled from "styled-components"
 import axios from "axios"
 import { FakeLinkExternal } from "./SharedStyledComponents"

--- a/src/components/TranslationsInProgress.js
+++ b/src/components/TranslationsInProgress.js
@@ -4,30 +4,12 @@ import styled from "styled-components"
 import axios from "axios"
 import { FakeLinkExternal } from "./SharedStyledComponents"
 import Translation from "./Translation"
+import { CardItem as LangItem } from "./SharedStyledComponents"
 
 const LangContainer = styled.div`
   margin-bottom: 2rem;
   display: flex;
   flex-wrap: wrap;
-`
-
-const LangItem = styled(GatsbyLink)`
-  text-decoration: none;
-  margin: 1rem 1rem 1rem 0;
-  padding: 1rem;
-  flex: 1 1 200px;
-  list-style: none;
-  border-radius: 0.5rem;
-  width: 100%;
-  border: 1px dotted ${(props) => props.theme.colors.lightBorder};
-  box-shadow: 0 1px 4px ${(props) => props.theme.colors.boxShadow};
-  transition: all 0.5s cubic-bezier(0.25, 0.8, 0.25, 1);
-  color: ${(props) => props.theme.colors.text};
-
-  &:hover {
-    box-shadow: 0 4px 8px ${(props) => props.theme.colors.boxShadowHover};
-    border: 1px dotted ${(props) => props.theme.colors.primary};
-  }
 `
 
 const TranslationsInProgress = () => {

--- a/src/components/TranslationsInProgress.js
+++ b/src/components/TranslationsInProgress.js
@@ -39,7 +39,7 @@ const TranslationsInProgress = () => {
       {translationsInProgress.map((lang) => {
         const url = `https://crowdin.com/project/ethereumfoundation/${lang.code}`
         return (
-          <LangItem to={url} key={lang.code}>
+          <LangItem to={url} key={lang.code} hideArrow>
             <h4>{lang.name}</h4>
             <div>
               <Translation id="translation-progress" />:{" "}

--- a/src/pages/languages.js
+++ b/src/pages/languages.js
@@ -1,5 +1,4 @@
 import React from "react"
-import { Link as GatsbyLink } from "gatsby"
 import styled from "styled-components"
 import { useIntl } from "gatsby-plugin-intl"
 
@@ -11,6 +10,7 @@ import { Mixins } from "../theme"
 
 import languageMetadata from "../data/translations"
 import { translateMessageId } from "../utils/translations"
+import { CardItem as LangItem } from "../components/SharedStyledComponents"
 
 const StyledPage = styled(Page)`
   margin-top: 4rem;
@@ -24,28 +24,6 @@ const LangContainer = styled.div`
   display: flex;
   flex-wrap: wrap;
   width: 100%;
-`
-
-const LangItem = styled(GatsbyLink)`
-  text-decoration: none;
-  margin: 1rem 1rem 1rem 0;
-  padding: 1rem;
-  width: 240px;
-  list-style: none;
-  border-radius: 2px;
-  border: 1px solid ${(props) => props.theme.colors.lightBorder};
-  /* box-shadow: ${(props) => props.theme.colors.tableBoxShadow};
-  transition: all 0.5s cubic-bezier(0.25, 0.8, 0.25, 1); */
-  color: ${(props) => props.theme.colors.text};
-
-  &:hover {
-    box-shadow: ${(props) => props.theme.colors.cardBoxShadow};
-    border: 1px solid ${(props) => props.theme.colors.black300};
-  }
-
-  @media (max-width: ${(props) => props.theme.breakpoints.m}) {
-    width: 100%;
-  }
 `
 
 const LangTitle = styled.div`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- [x] Updated card style on https://ethereum.org/en/contributing/translation-program/ to match the one on the Languages page: https://ethereum.org/en/languages/
- [x]  Created a single shared component in SharedStyledComponents.js
<!--- Describe your changes in detail -->

Created a single shared component CardItem in SharedStyledComponents and replaced the cards on `/languages` and `/about` ( #2076 & #2195 ) with the new shared component. Doing this also unified card hover transition.

## Related Issue #2251
These card styles were outdated:
https://ethereum.org/en/contributing/translation-program/#in-progress so @samajammin I updated them to similar ones like on `/languages` and `/about`.
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
