### PR TITLE
Remove "inspired by Python" in Solidity's description

### DIFF
--- a/src/content/developers/docs/smart-contracts/languages/index.md
+++ b/src/content/developers/docs/smart-contracts/languages/index.md
@@ -20,7 +20,7 @@ Previous knowledge of programming languages, especially of JavaScript or Python,
 
 ## Solidity {#solidity}
 
-- Influenced by C++, Python and JavaScript.
+- Influenced by C++ and JavaScript.
 - Statically typed (the type of a variable is known at compile time).
 - Supports:
   - Inheritance (you can extend other contracts).


### PR DESCRIPTION
## Description
Every time I look at this page, I see "Solidity is inspired by C++, *Python* and JavaScript" and think to myself "where's the Python influence?"

Thinking about it further, it also seems kind of weird to have that there, and then mention another language that is also "Pythonic" (aka Vyper) right below it. It really just seems confusing to me. "Which language should I try if I really like Python?", the natural answer should be Vyper I would think.

Feel free to accept or reject this PR, but I just finally decided to do something about my cognitive dissonance.