### PR TITLE
Remove non-existent attack vector for ORUs

### DIFF
--- a/src/content/developers/docs/layer-2-scaling/index.md
+++ b/src/content/developers/docs/layer-2-scaling/index.md
@@ -103,7 +103,7 @@ So you get reimbursed for proving fraud.
 | Pros                                                                                                             | Cons                                                                                                             |
 | ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
 | Anything you can do on Ethereum layer 1, you can do with Optimistic rollups as it's EVM and Solidity compatible. | Long wait times for on-chain transaction due to potential fraud challenges.                                      |
-| All transaction data is stored on the layer 1 chain, meaning it's secure and decentralized.                      | Potentially vulnerable to attacks if the value in an Optimistic rollup exceeds the amount in an operator's bond. |
+| All transaction data is stored on the layer 1 chain, meaning it's secure and decentralized.                      |  |
 
 #### Use Optimistic rollups {#use-optimistic-rollups}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Remove a point describing a non-existent attack vector for ORUs.

<!--- Describe your changes in detail -->

ORU block producers bonds are meant to refund fraud provers for gas costs and disincentivize producing bad blocks. They're not related to the TLV in the rollup at all, including as a potential attack vector.

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
