### PR TITLE
fix: isPartiallyActive set to false for NavDropdown & FooterLink

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -337,10 +337,7 @@ const Footer = () => {
                     {section.links.map((link, linkIdx) => {
                       return (
                         <ListItem key={linkIdx}>
-                          <FooterLink
-                            to={link.to}
-                            isPartiallyActive={link.isPartiallyActive}
-                          >
+                          <FooterLink to={link.to} isPartiallyActive={false}>
                             <Translation id={link.text} />
                           </FooterLink>
                         </ListItem>

--- a/src/components/Nav/Dropdown.js
+++ b/src/components/Nav/Dropdown.js
@@ -133,7 +133,7 @@ const NavDropdown = ({ section, hasSubNav }) => {
         {section.items.map((item, idx) => {
           return (
             <DropdownItem key={idx} onClick={() => setIsOpen(false)}>
-              <NavLink to={item.to} tabIndex="-1">
+              <NavLink to={item.to} tabIndex="-1" isPartiallyActive={false}>
                 <Translation id={item.text} />
               </NavLink>
             </DropdownItem>


### PR DESCRIPTION
## Description

Removed of the partiallyActive behaviour on Navigation Dropdown & Footer links by setting `isPartiallyActive` props to false for those links.

## Related Issue

#2515 
