### PR TITLE
Use-cases banner/hero mobile fixes

### DIFF
--- a/src/templates/use-cases.js
+++ b/src/templates/use-cases.js
@@ -305,6 +305,8 @@ const Image = styled(Img)`
     width: 100%;
     height: 100%;
     overflow: initial;
+    align-self: center;
+    margin: 0;
   }
 `
 

--- a/src/templates/use-cases.js
+++ b/src/templates/use-cases.js
@@ -330,6 +330,9 @@ const MobileTableOfContents = styled(TableOfContents)`
 const StyledBannerNotification = styled(BannerNotification)`
   display: flex;
   justify-content: center;
+  @media (max-width: ${({ theme }) => theme.breakpoints.l}) {
+    display: none;
+  }
 `
 
 const TitleCard = styled.div`


### PR DESCRIPTION
## Description
- Hides "edit" banner for use-cases on mobile
- Centers hero image on mobile

cc: @samajammin @ryancreatescopy 