### PR TITLE
resolve width overflow on mobile [Fixes #2553]

### DIFF
--- a/src/templates/use-cases.js
+++ b/src/templates/use-cases.js
@@ -296,11 +296,13 @@ const Image = styled(Img)`
   flex: 1 1 100%;
   background-size: cover;
   background-repeat: no-repeat;
-  margin-left: 2rem;
   right: 0;
   bottom: 0;
   background-size: cover;
   max-width: ${(props) => (props.useCase === "dao" ? `572px` : `640px`)};
+  @media (min-width: ${(props) => props.theme.breakpoints.m}) {
+    margin-left: 2rem;
+  }
   @media (max-width: ${(props) => props.theme.breakpoints.l}) {
     width: 100%;
     height: 100%;


### PR DESCRIPTION
The NFT, DeFi and DAO pages were overflowing horizontally on mobile. The previous styles applied a margin to the hero image, which led to the bug. Added a media query to resolve the issue.

## Related Issue

https://github.com/ethereum/ethereum-org-website/issues/2553