### PR TITLE
Fix mobile side navigation rendering issue [Fixes #2301]

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -58,7 +58,7 @@ const StyledBannerNotification = styled(BannerNotification)`
 // TODO `Layout` renders twice on page load - why?
 const Layout = (props) => {
   const [isDarkTheme, setIsDarkTheme] = useState(false)
-
+  const [shouldShowSideNav, setShouldShowSideNav] = useState(false)
   // set isDarkTheme based on browser/app user preferences
   useEffect(() => {
     if (localStorage && localStorage.getItem("dark-theme") !== null) {
@@ -67,6 +67,10 @@ const Layout = (props) => {
       setIsDarkTheme(window.matchMedia("(prefers-color-scheme: dark)").matches)
     }
   }, [])
+
+  useEffect(() => {
+    setShouldShowSideNav(props.path.includes("/docs/"))
+  }, [props.path])
 
   const handleThemeChange = () => {
     setIsDarkTheme(!isDarkTheme)
@@ -87,7 +91,6 @@ const Layout = (props) => {
   const shouldShowTranslationBanner = isPageOutdated || isPageTranslated
 
   const path = props.path
-  const shouldShowSideNav = path.includes("/docs/")
   const shouldShowBanner =
     path.includes("/eth2/") && !path.includes("/eth2/deposit-contract/")
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail --> 

* When you access a page under ```/doc``` on **light mode**, mobile navigation is rendered in a broken way (see screenshot below)  _This only happens on light mode, (works fine on dark mode)_  
<img width="1498" alt="Screen Shot 2021-03-08 at 11 39 16 AM" src="https://user-images.githubusercontent.com/12257412/110332487-b6af6e00-8063-11eb-81a7-d7993d970d2d.png">


 

### Why is this happening  

After some research into this issue, it appears to behave such due to rehydration - where ```shouldShowBanner``` is ```false``` in server side, but ```true``` on client side. 
https://github.com/ethereum/ethereum-org-website/blob/41744cc49ebc9b6be762f85912f9378fc4be1dd6/src/components/Layout.js#L93
I'm suggesting to hold off rendering of ```SideNavMobile``` component until we know the ```path``` of the page being rendered. I wrapped this logic using ```useEffect``` hook to check when ```path``` changes. 


### How to reproduce 
* Turn on light mode
* Open up any page under /Docs 
* Refresh


## Related Issue
#2301 
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
