### PR TITLE
Merge Translations fix on Windows [Fixes #2582]

### DIFF
--- a/src/scripts/merge-translations.js
+++ b/src/scripts/merge-translations.js
@@ -19,7 +19,10 @@ const supportedLanguages = Object.keys(languageMetadata)
 for (const lang of supportedLanguages) {
   try {
     const currentTranslation = lang
-    const pathToProjectSrc = __dirname.split("/").slice(0, -1).join("/")
+    const pathToProjectSrc = __dirname
+      .split(process.platform === "win32" ? "\\" : "/")
+      .slice(0, -1)
+      .join("/")
     const pathToTranslations = path.join(
       pathToProjectSrc,
       "intl",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

`yarn merge-translations` was failing on Windows with no file found error. This was happening because Windows uses backslash for file paths whereas the code was only spiliting __dirname on "/" only which was creating an empty string for pathToDirectory. I added code that replaces forward-slash with backslash on Windows environments.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This will close #2582 