### PR TITLE
Fixes broken intl tutorial images [#2585]

### DIFF
--- a/src/content/developers/tutorials/how-to-use-slither-to-find-smart-contract-bugs/index.md
+++ b/src/content/developers/tutorials/how-to-use-slither-to-find-smart-contract-bugs/index.md
@@ -232,7 +232,3 @@ A `Function` or a `Modifier` object has:
 - `variables_written (list(Variable))`: List of variables written
 - `state_variables_read (list(StateVariable))`: List of state variables read (subset of variables`read)
 - `state_variables_written (list(StateVariable))`: List of state variables written (subset of variables`written)
-
-### Example: Print Basic Information {#example-print-basic-information}
-
-[print_basic_information.py](./examples/print_basic_information.py) shows how to print basic information about a project.

--- a/src/content/translations/ro/developers/docs/accounts/index.md
+++ b/src/content/translations/ro/developers/docs/accounts/index.md
@@ -47,7 +47,7 @@ Conturile Ethereum au patru câmpuri:
 <!--this hash refers to the code of this account on the Ethereum virtual machine (EVM). This EVM code gets executed if the account gets a message call. It cannot be changed unlike the other account fields.  -->
 - `storageRoot` – Uneori cunoscut sub numele de hash de stocare. Un hash de 256 biți al nodului rădăcină al unui arbore Merkle Patricia, care codează conținutul stocării contului (o mapare între valori întregi de 256 biți). Acesta schimbă formatul hash al cheilor de codificare din trie de la Keccat la RLP (Recursive Length Prefix), ambele 256 biți valori întregi. Acest arbore codifică hash-ul conținutului stocării acestui cont și este gol în mod implicit.
 
-![O diagramă care arată structura unui cont](./accounts.png) _Diagramă adaptată din [Ethereum EVM ilustrat](https://takenobu-hs.github.io/downloads/ethereum_evm_illustrated.pdf)_
+![O diagramă care arată structura unui cont](../../../../../developers/docs/accounts/accounts.png) _Diagramă adaptată din [Ethereum EVM ilustrat](https://takenobu-hs.github.io/downloads/ethereum_evm_illustrated.pdf)_
 
 ## Conturi deținute extern și perechi de chei {#externally-owned-accounts-and-key-pairs}
 

--- a/src/content/translations/ro/developers/docs/blocks/index.md
+++ b/src/content/translations/ro/developers/docs/blocks/index.md
@@ -17,7 +17,7 @@ Blocurile sunt un subiect foarte prietenos pentru începători. Dar pentru a te 
 
 Pentru a ne asigura că toți participanții din rețeaua Ethereum mențin o stare sincronizată și convin asupra istoricului precis al tranzacțiilor pe care le grupăm în blocuri. Aceasta înseamnă că zeci (sau sute) de tranzacții sunt comise, convenite și sincronizate simultan.
 
-![O diagramă care arată tranzacția într-un bloc care provoacă modificări de stare](./tx-block.png) _Diagramă adaptată din [Ethereum EVM ilustrat](https://takenobu-hs.github.io/downloads/ethereum_evm_illustrated.pdf)_
+![O diagramă care arată tranzacția într-un bloc care provoacă modificări de stare](../../../../../developers/docs/blocks/tx-block.png) _Diagramă adaptată din [Ethereum EVM ilustrat](https://takenobu-hs.github.io/downloads/ethereum_evm_illustrated.pdf)_
 
 Crescând perioada dintre comiteri, acordăm tuturor participanților la rețea suficient timp pentru a ajunge la consens: chiar dacă solicitările de tranzacții apar de zeci de ori pe secundă, blocurile Ethereum sunt executate aproximativ o dată la cincisprezece secunde.
 

--- a/src/content/translations/ro/developers/docs/evm/index.md
+++ b/src/content/translations/ro/developers/docs/evm/index.md
@@ -19,7 +19,7 @@ Analogia unui „registru distribuit” este adesea folosită pentru a descrie u
 
 În timp ce Ethereum are propria criptomonedă nativă (Ether) care urmează aproape exact aceleași reguli intuitive, permite, de asemenea, o funcție mult mai puternică: [contracte inteligente](/en/developers/docs/smart-contracts/). Pentru această caracteristică mai complexă, este necesară o analogie mai sofisticată. În loc de un registru distribuit, Ethereum este o [mașină de stare](https://en.wikipedia.org/wiki/Finite-state_machine) distribuită. Starea Ethereum este o structură mare de date care deține nu numai toate conturile și soldurile, ci și o _mașină de stare_, care se poate schimba din bloc în bloc în conformitate cu un set predefinit de reguli și care poate executa aleatoriu codul mașinii. Regulile specifice de schimbare a stării de la bloc la bloc sunt definite de EVM.
 
-![O diagramă care prezintă alcătuirea EVM](./evm.png) _Diagramă adaptată după [Ethereum EVM ilustrat](https://takenobu-hs.github.io/downloads/ethereum_evm_illustrated.pdf)_
+![O diagramă care prezintă alcătuirea EVM](../../../../../developers/docs/evm/evm.png) _Diagramă adaptată după [Ethereum EVM ilustrat](https://takenobu-hs.github.io/downloads/ethereum_evm_illustrated.pdf)_
 
 ## Funcția de tranziție a stării Ethereum {#the-ethereum-state-transition-function}
 
@@ -51,7 +51,7 @@ Contractele, cu toate acestea, conțin un _spațiu de stocare_ Merkle Patricia t
 
 Bytecode-ul compilat al contractului inteligent se execută ca un număr de [opcoduri](https://www.ethervm.io/) EVM, care efectuează operațiuni de stivă standard cum ar fi `XOR`, `AND`, `ADD`, `SUB` etc. EVM implementează, de asemenea, o serie de operațiuni de stivă specifice blockchain, cum ar fi `ADDRESS`, `BALANCE`, `SHA3`, `BLOCKHASH` etc.
 
-![O diagramă care arată unde este necesar gaz pentru operațiunile EVM](../gas/gas.png) _Diagrame adaptate din[ Ethereum EVM ilustrat](https://takenobu-hs.github.io/downloads/ethereum_evm_illustrated.pdf)_
+![O diagramă care arată unde este necesar gaz pentru operațiunile EVM](../../../../../developers/docs/gas/gas.png) _Diagrame adaptate din[ Ethereum EVM ilustrat](https://takenobu-hs.github.io/downloads/ethereum_evm_illustrated.pdf)_
 
 <!-- TODO add full list from  https://eth.wiki/concepts/evm/implementations -->
 

--- a/src/content/translations/ro/developers/docs/gas/index.md
+++ b/src/content/translations/ro/developers/docs/gas/index.md
@@ -18,7 +18,7 @@ Gazul este unitatea care măsoară cantitatea de efort de calcul necesar pentru 
 
 Deoarece fiecare tranzacție Ethereum necesită resurse de calcul pentru executare, fiecare tranzacție necesită o taxă. Gazul se referă la taxa necesară pentru a efectua cu succes o tranzacție pe Ethereum.
 
-![O diagramă care arată unde este nevoie de gaz în operațiunile EVM](./gas.png) _Diagramă adaptată după [Ethereum EVM ilustrat](https://takenobu-hs.github.io/downloads/ethereum_evm_illustrated.pdf)_
+![O diagramă care arată unde este nevoie de gaz în operațiunile EVM](../../../../../developers/docs/gas/gas.png) _Diagramă adaptată după [Ethereum EVM ilustrat](https://takenobu-hs.github.io/downloads/ethereum_evm_illustrated.pdf)_
 
 În esență, taxele pe gaz sunt plătite în moneda nativă a Ethereum, eterul (ETH). Prețurile gazului sunt indicate în Gwei, care este o denominație a ETH - fiecare Gwei este egal cu 0,000000001 ETH (10<sup>-9</sup> ETH). De exemplu, în loc să spui că gazul tău costă 0,000000001 eter, poți spune că el costă 1 Gwei.
 
@@ -30,7 +30,7 @@ Pe scurt, taxele pe gaz contribuie la menținerea securității rețelei Ethereu
 
 Deși o tranzacție include o limită, orice gaz neutilizat într-o tranzacție este returnat utilizatorului.
 
-![Diagrama care arată modul în care este rambursat gazul neutilizat](../transactions/gas-tx.png) _Diagramă adaptată după [Ethereum EVM ilustrat](https://takenobu-hs.github.io/downloads/ethereum_evm_illustrated.pdf)_
+![Diagrama care arată modul în care este rambursat gazul neutilizat](../../../../../developers/docs/transactions/gas-tx.png) _Diagramă adaptată după [Ethereum EVM ilustrat](https://takenobu-hs.github.io/downloads/ethereum_evm_illustrated.pdf)_
 
 ## Referințe suplimentare {#further-reading}
 

--- a/src/content/translations/ro/developers/docs/layer-2-scaling/index.md
+++ b/src/content/translations/ro/developers/docs/layer-2-scaling/index.md
@@ -90,7 +90,7 @@ Deoarece calculul este partea lentă și costisitoare a utilizării Ethereum, ro
 
 Rollup-urile Optimistic nu calculează de fapt tranzacția, deci trebuie să existe un mecanism care să asigure că tranzacțiile sunt legitime și nu frauduloase. Aici intervin dovezile de fraudă. Dacă cineva observă o tranzacție frauduloasă, rollup-ul va executa o dovadă de fraudă și va rula calculul tranzacției, utilizând datele de stare disponibile. Aceasta înseamnă că este posibil să ai timpi de așteptare mai lungi pentru confirmarea tranzacției decât un rollup-ZK, deoarece ar putea fi contestat.
 
-![Diagramă care arată ce se întâmplă atunci când are loc o tranzacție frauduloasă într-un rollup Optimist pe Ethereum](./optimistic-rollups.png)
+![Diagramă care arată ce se întâmplă atunci când are loc o tranzacție frauduloasă într-un rollup Optimist pe Ethereum](../../../../../developers/docs/layer-2-scaling/optimistic-rollups.png)
 
 Gazul de care ai nevoie pentru a calcula dovada fraudelor este chiar rambursat. Ben Jones, de la Optimism, descrie sistemul de legături în loc:
 

--- a/src/content/translations/ro/developers/docs/nodes-and-clients/index.md
+++ b/src/content/translations/ro/developers/docs/nodes-and-clients/index.md
@@ -20,7 +20,7 @@ Poți vizualiza în timp real rețeaua Ethereum uitându-te la această [hartă 
 
 Multe [implementări ale clienților Ethereum](/developers/docs/nodes-and-clients/#clients) există într-o varietate de limbaje. Ceea ce au în comun aceste implementări ale clienților este că toate respectă o specificație formală. Această specificație dictează modul în care funcționează rețeaua Ethereum și blockchain-ul.
 
-![Client Eth1x](./client-diagram.png) Diagramă simplificată a caracteristicilor clientului Ethereum.
+![Client Eth1x](../../../../../developers/docs/nodes-and-clients/client-diagram.png) Diagramă simplificată a caracteristicilor clientului Ethereum.
 
 ## Tipuri de noduri {#node-types}
 
@@ -58,7 +58,7 @@ Rularea propriul nod îți permite să utilizezi Ethereum într-un mod cu adevă
 - Nu va trebui să-ți dezvălui adresele și soldurile către noduri aleatorii. Totul poate fi verificat cu propriul client.
 - Aplicația ta dapp poate fi mai sigură și mai privată dacă folosești propriul nod. [Metamask](https://metamask.io), [MyEtherWallet](https://myetherwallet.com) și alte portofele pot fi ușor direcționate către propriul nod local.
 
-![Cum să accesezi Ethereum prin intermediul aplicației și nodurilor](./nodes.png)
+![Cum să accesezi Ethereum prin intermediul aplicației și nodurilor](../../../../../developers/docs/nodes-and-clients/nodes.png)
 
 ### Beneficiile rețelei {#network-benefits}
 
@@ -197,9 +197,9 @@ O modalitate ușoară de a rula propriul nod este utilizarea casetelor „plug a
 | Nethermind   | Minimum 200 GB             | Minimum 3 TB                  |
 | Besu         | Minimum 750 GB             | Minimum 4 TB                  |
 
-![O diagramă care arată că numărul de GB necesari la o sincronizare completă este în creștere](./full-sync.png)
+![O diagramă care arată că numărul de GB necesari la o sincronizare completă este în creștere](../../../../../developers/docs/nodes-and-clients/full-sync.png)
 
-![O diagramă care arată că numărul de GB necesari la o sincronizare arhivă este în creștere](./archive-sync.png)
+![O diagramă care arată că numărul de GB necesari la o sincronizare arhivă este în creștere](../../../../../developers/docs/nodes-and-clients/archive-sync.png)
 
 Aceste diagrame arată cum cerințele de stocare sunt mereu în schimbare. Pentru cele mai recente date ale Geth și Parity, consultă [datele de sincronizare completă](https://etherscan.io/chartsync/chaindefault) și [arhivarea datelor de sincronizare](https://etherscan.io/chartsync/chainarchive).
 

--- a/src/content/translations/ro/developers/docs/transactions/index.md
+++ b/src/content/translations/ro/developers/docs/transactions/index.md
@@ -19,7 +19,7 @@ Pentru a te ajuta să înțelegi mai bine această pagină, îți recomandăm s�
 
 O tranzacție Ethereum se referă la o acțiune inițiată de un cont deținut din exterior, cu alte cuvinte un cont gestionat de o persoană, nu de un contract. De exemplu, dacă Bob trimite lui Alice 1 ETH, contul lui Bob, trebuie debitat, iar cel al lui Alice trebuie creditat. Această acțiune care schimbă starea, are loc în cadrul unei tranzacții.
 
-![Diagramă care arată o tranzacție care cauzează modificarea stării](./tx.png) _Diagrama adaptată din [EVM Ethereum ilustrată](https://takenobu-hs.github.io/downloads/ethereum_evm_illustrated.pdf)_
+![Diagramă care arată o tranzacție care cauzează modificarea stării](../../../../../developers/docs/nodes-and-clients/tx.png) _Diagrama adaptată din [EVM Ethereum ilustrată](https://takenobu-hs.github.io/downloads/ethereum_evm_illustrated.pdf)_
 
 Tranzacțiile, care schimbă starea EVM, trebuie difuzate către întreaga rețea. Orice nod poate difuza o cerere, pentru ca o tranzacție să fie executată pe EVM; după aceasta, un miner va executa tranzacția și va propaga modificarea stării rezultate către restul rețelei.
 
@@ -123,7 +123,7 @@ Minerul care procesează tranzacția va primi ** + 0,0042 ETH**
 
 Gazul este necesar și pentru orice interacțiune cu contractul inteligent.
 
-![Diagramă care arată modul în care este rambursat gazul neutilizat](./gas-tx.png) _Diagramă adaptată din [EVM Ethereum ilustrat ](https://takenobu-hs.github.io/downloads/ethereum_evm_illustrated.pdf)_
+![Diagramă care arată modul în care este rambursat gazul neutilizat](../../../../../developers/docs/nodes-and-clients/gas-tx.png) _Diagramă adaptată din [EVM Ethereum ilustrat ](https://takenobu-hs.github.io/downloads/ethereum_evm_illustrated.pdf)_
 
 Orice gaz neutilizat într-o tranzacție este rambursat în contul utilizatorului.
 

--- a/src/content/translations/ro/developers/tutorials/deploying-your-first-smart-contract/index.md
+++ b/src/content/translations/ro/developers/tutorials/deploying-your-first-smart-contract/index.md
@@ -27,7 +27,7 @@ Nu-ți face griji, deoarece este primul nostru contract inteligent, îl vom impl
 
 Primul pas este să vizitezi [Remix](https://remix.ethereum.org/) și să creezi un fișier nou. În partea din stânga de sus a interfeței Remix, adaugă un nou fișier și introdu numele fișierului dorit.
 
-![Adăugarea unui fișier nou în interfața Remix](./remix.png)
+![Adăugarea unui fișier nou în interfața Remix](../../../../../developers/tutorials/deploying-your-first-smart-contract/remix.png)
 
 În noul fișier, vom lipi următorul cod.
 
@@ -69,34 +69,34 @@ După ce am scris primul nostru contract inteligent, îl implementăm în blockc
 
 Mai întâi vom [compila contractul](/developers/docs/smart-contracts/compiling/) făcând clic pe pictograma compilare din partea stângă:
 
-![Pictograma de compilare din bara de instrumente Remix](./remix-compile-button.png)
+![Pictograma de compilare din bara de instrumente Remix](../../../../../developers/tutorials/deploying-your-first-smart-contract/remix-compile-button.png)
 
 Apoi facem clic pe butonul compilare:
 
-![Butonul de compilare din compilatorul Remix solidity](./remix-compile.png)
+![Butonul de compilare din compilatorul Remix solidity](../../../../../developers/tutorials/deploying-your-first-smart-contract/remix-compile.png)
 
 Poți alege opțiunea „Compilare automată”, astfel încât contractul să fie întotdeauna compilat când salvezi conținutul pe editorul de text.
 
 Apoi navighează la „deploy” și rulează ecranul de tranzacții:
 
-![Pictograma de implementare din bara de instrumente Remix](./remix-deploy.png)
+![Pictograma de implementare din bara de instrumente Remix](../../../../../developers/tutorials/deploying-your-first-smart-contract/remix-deploy.png)
 
 Odată ce te afli în ecranul de tranzacții „implementare și executare”, verifică din nou dacă numele contractului tău apare și fă clic pe „Deploy”. După cum poți vedea în partea de sus a paginii, mediul actual este „JavaScript VM”, ceea ce înseamnă că vom implementa și interacționa cu contractul nostru inteligent pe un blockchain de test local pentru a putea testa mai rapid și fără taxe.
 
-![Butonul de implementare din compilatorul Remix solidity](./remix-deploy.png)
+![Butonul de implementare din compilatorul Remix solidity](../../../../../developers/tutorials/deploying-your-first-smart-contract/remix-deploy.png)
 
 După ce ai făcut clic pe butonul „Deploy”, vei vedea contractul tău în partea de jos. Fă clic pe săgeata din stânga pentru a o extinde, astfel încât să vedem conținutul contractului nostru. Aceasta este variabila `counter`, funcția noastră `increment()` și getter-ul `getCounter()`.
 
 Dacă faci clic pe butonul `count` sau `getCount`, acesta va prelua conținutul variabilei `count` a contractului și o va afișa. Deoarece nu am apelat încă funcția `increment`, ar trebui să afișeze 0.
 
-![Butonul funcție din compilatorul Remix solidity](./remix-function-button.png)
+![Butonul funcție din compilatorul Remix solidity](../../../../../developers/tutorials/deploying-your-first-smart-contract/remix-function-button.png)
 
 Să apelăm acum funcția `increment` făcând clic pe buton. Vei vedea jurnalele tranzacțiilor efectuate care apar în partea de jos a ferestrei. Vei vedea că jurnalele sunt diferite atunci când apeși butonul pentru a prelua datele în loc de butonul `increment`. Acest lucru se datorează faptului că citirea datelor pe blockchain nu are nevoie de tranzacții (scriere) sau taxe. Deoarece doar modificarea stării blockchain-ului necesită efectuarea unei tranzacții:
 
-![Un jurnal al tranzacțiilor](./transaction-log.png)
+![Un jurnal al tranzacțiilor](../../../../../developers/tutorials/deploying-your-first-smart-contract/transaction-log.png)
 
 După apăsarea butonului de incrementare, care va genera o tranzacție pentru a apela funcția noastră `increment()`, dacă facem clic din nou pe butoanele count sau getCount, vom citi noua stare actualizată a contractului nostru inteligent, cu variabila count mai mare de 0.
 
-![Starea nouă actualizată a contractului inteligent](./updated-state.png)
+![Starea nouă actualizată a contractului inteligent](../../../../../developers/tutorials/deploying-your-first-smart-contract/updated-state.png)
 
 În tutorialul următor, vom acoperi [cum poți adăuga evenimente la contractele tale inteligente](/developers/tutorials/logging-events-smart-contracts/). Înregistrarea evenimentelor este o modalitate convenabilă de a depana contractul inteligent și de a înțelege ce se întâmplă în timp ce apelezi o funcție.

--- a/src/content/translations/ro/developers/tutorials/getting-started-with-ethereum-development-using-alchemy/index.md
+++ b/src/content/translations/ro/developers/tutorials/getting-started-with-ethereum-development-using-alchemy/index.md
@@ -19,7 +19,7 @@ source: Mediu
 sourceUrl: https://medium.com/alchemy-api/getting-started-with-ethereum-development-using-alchemy-c3d6a45c567f
 ---
 
-![Logouri Ethereum și Alchemy](./ethereum-alchemy.png)
+![Logouri Ethereum și Alchemy](../../../../../developers/tutorials/getting-started-with-ethereum-development-using-alchemy/ethereum-alchemy.png)
 
 Acesta este un ghid pentru începători pentru a demara cu dezvoltarea Ethereum folosind [Alchemy](https://alchemyapi.io/), cea mai importantă platformă de programator blockchain alimentând milioane de utilizatori din 70% din aplicațiile blockchain de top, inclusiv Maker, 0x, MyEtherWallet, Dharma și Kyber.
 
@@ -37,15 +37,15 @@ Poți [crea chei API din tabloul de bord](http://dashboard.alchemyapi.io/). Pent
 
 Mulțumiri speciale site-ului [_ShapeShift_](https://shapeshift.com/) _pentru că ne permite să arătăm tabloul de bord!_
 
-![Tabloul de bord Alchemy](./alchemy-dashboard.png)
+![Tabloul de bord Alchemy](../../../../../developers/tutorials/getting-started-with-ethereum-development-using-alchemy/alchemy-dashboard.png)
 
 Completează detaliile sub „Creare aplicație” pentru a obține noua cheie. De easemenea, aici poți să vezi aplicațiile pe care le-ai făcut anterior și cele făcute de echipa ta. Trage cheile existente făcând clic pe „Vizualizare cheie” pentru orice aplicație.
 
-![Creează aplicații cu captura de ecran Alchemy](./create-app.png)
+![Creează aplicații cu captura de ecran Alchemy](../../../../../developers/tutorials/getting-started-with-ethereum-development-using-alchemy/create-app.png)
 
 Poți trage, de asemenea, cheile API existente prin trecerea peste „Apps” și selectând una. Poți „Vizualiza cheia” aici, precum și „Edita aplicația” pentru a lista în alb anumite domenii, pentru a vedea mai multe instrumente pentru programatori și pentru a vizualiza analizele.
 
-![Gif care arată unui utilizator să tragă cheile API](./pull-api-keys.gif)
+![Gif care arată unui utilizator să tragă cheile API](../../../../../developers/tutorials/getting-started-with-ethereum-development-using-alchemy/pull-api-keys.gif)
 
 ## 3\. Efectuarea unei solicitări din linia de comandă {#make-a-request-from-the-command-line}
 

--- a/src/content/translations/ro/developers/tutorials/how-to-use-slither-to-find-smart-contract-bugs/index.md
+++ b/src/content/translations/ro/developers/tutorials/how-to-use-slither-to-find-smart-contract-bugs/index.md
@@ -106,7 +106,7 @@ function safeAdd(uint a, uint b) pure internal returns(uint){
 
 AST-ul corespunzător este indicat în:
 
-![AST](./ast.png)
+![AST](../../../../../developers/tutorials/how-to-use-slither-to-find-smart-contract-bugs/ast.png)
 
 Slither utilizează AST-ul exportat de solc.
 
@@ -135,7 +135,7 @@ print(f'Expresia {expression} are o adunare: {visitor.result()}')
 
 Cea de-a doua reprezentare a codurilor este graficul fluxului de control (CFG). După cum sugerează și numele, este o reprezentare pe bază de grafic care expune toate căile de execuție. Fiecare nod conține una sau mai multe instrucțiuni. Marginile din grafic reprezintă operațiunile fluxului de control (dacă/atunci/altfel, buclă etc.). CFG-ul exemplului nostru anterior este:
 
-![CFG](./cfg.png)
+![CFG](../../../../../developers/tutorials/how-to-use-slither-to-find-smart-contract-bugs/cfg.png)
 
 CFG este reprezentarea pe baza căreia sunt construite cele mai multe analize.
 
@@ -239,7 +239,3 @@ Un obiect `Function` sau un obiect `Modifier` are:
 - `variables_written (list(Variable))`: Lista variabilelor scrise
 - `state_variables_read (list(StateVariable))`: Lista variabilelor de stare citite (subset de variabile`read)
 - `state_variables_written (list(StateVariable))`: Lista variabilelor de stare scrise (subset de variabile`scris)
-
-### Exemplu: Imprimare de informații de bază {#example-print-basic-information}
-
-[print_basic_information.py](./exemple/print_basic_information.py) arată cum să tipărești informații de bază despre un proiect.

--- a/src/content/translations/ro/developers/tutorials/interact-with-other-contracts-from-solidity/index.md
+++ b/src/content/translations/ro/developers/tutorials/interact-with-other-contracts-from-solidity/index.md
@@ -176,6 +176,6 @@ contract CounterFactory {
 
 După compilare, în secțiunea Remix Deploy vei selecta fabrica ce va fi implementată:
 
-![Selectarea fabricii care va fi implementată în Remix](./counterfactory-deploy.png)
+![Selectarea fabricii care va fi implementată în Remix](../../../../../developers/tutorials/interact-with-other-contracts-from-solidity/counterfactory-deploy.png)
 
 După aceea, poți să te joci cu fabrica de contract și să verifici cum se modifică valorile. Dacă dorești să apelezi contractul inteligent de la o adresă diferență va trebui să modifici adresa din „Selectare cont” din Remix.

--- a/src/content/translations/ro/developers/tutorials/logging-events-smart-contracts/index.md
+++ b/src/content/translations/ro/developers/tutorials/logging-events-smart-contracts/index.md
@@ -56,6 +56,6 @@ Observă că:
 
 Dacă implementăm acum contractul și apelăm funcția increment, vom vedea că Remix îl va afișa automat când faci clic pe noua tranzacție din interiorul unei matrice numite „logs".
 
-![Captură ecran Remix](./remix-screenshot.png)
+![Captură ecran Remix](../../../../../developers/tutorials/logging-events-smart-contracts/remix-screenshot.png)
 
 Jurnalele sunt foarte utile pentru depanarea contractelor inteligente, dar sunt, de asemenea, importante atunci când construiești aplicații utilizate de diferite persoane și faci mai ușoară analiza pentru a urmări și a înțelege modul în care este utilizat contractul inteligent. Jurnalele generate de tranzacții sunt afișate în exploratoarele de bloc populare și, de asemenea, le poți utiliza, de exemplu, pentru a crea scripturi off-chain pentru a asculta evenimente specifice și de a lua măsuri atunci când acestea apar.

--- a/src/content/translations/ro/developers/tutorials/the-graph-fixing-web3-data-querying/index.md
+++ b/src/content/translations/ro/developers/tutorials/the-graph-fixing-web3-data-querying/index.md
@@ -74,7 +74,7 @@ GameContract.events.BetPlaced({
 
 Acum, acest lucru este încă destul de bun pentru exemplul nostru simplu. Dar să presupunem că vrem să afișăm numai câte pariuri a pierdut/câștigat doar jucătorul actual. Ei bine, nu avem noroc, ar fi bine să implementezi un nou contract care stochează valorile respective și să le afișeze. Și acum să ne imaginăm un contract inteligent și o aplicație dapp mult mai complicate, lucrurile pot deveni repede foarte confuze.
 
-![Nu faci interogări pur și simplu](./one-does-not-simply-query.jpg)
+![Nu faci interogări pur și simplu](../../../../../developers/tutorials/the-graph-fixing-web3-data-querying/one-does-not-simply-query.jpg)
 
 Putem vedea de ce acest lucru nu este optim:
 
@@ -82,7 +82,7 @@ Putem vedea de ce acest lucru nu este optim:
 - Costuri suplimentare de gaz pentru stocarea acestor valori.
 - Necesită un alt apel pentru a prelua datele pentru un nod Ethereum.
 
-![Asta nu e suficient de bine](./not-good-enough.jpg)
+![Asta nu e suficient de bine](../../../../../developers/tutorials/the-graph-fixing-web3-data-querying/not-good-enough.jpg)
 
 Acum să analizăm o soluție mai bună.
 
@@ -90,7 +90,7 @@ Acum să analizăm o soluție mai bună.
 
 În primul rând, să vorbim despre GraphQL, inițial proiectat și implementat de Facebook. Este posibil să fii familiarizat cu modelul tradițional API Rest. Acum imaginează-ți că ai putea scrie o interogare pentru exact datele pe care le-ai dorit:
 
-![GraphQL API față de REST API](./graphql.jpg)
+![GraphQL API față de REST API](../../../../../developers/tutorials/the-graph-fixing-web3-data-querying/graphql.jpg)
 
 <!-- TODO gif embed not working: -->
 <!-- Need additional plugin? https://github.com/gatsbyjs/gatsby/issues/7317#issuecomment-412984851 -->
@@ -104,7 +104,7 @@ Acum, cu aceste cunoștințe, să sărim în cele din urmă în spațiul blockch
 
 Un blockchain este o bază de date descentralizată, dar spre deosebire de ceea ce se întâmplă de obicei, nu avem un limbaj de interogare pentru această bază de date. Soluțiile pentru obținerea datelor sunt dureroase sau complet imposibile. „The Graph” este un protocol descentralizat pentru indexarea și interogarea datelor blockchain. Și s-ar putea să fi ghicit, se utilizează GraphQL ca limbaj de interogare.
 
-![The Graph](./thegraph.png)
+![The Graph](../../../../../developers/tutorials/the-graph-fixing-web3-data-querying/thegraph.png)
 
 Exemplele sunt cele mai bune ca să înțelegem ceva, așa că hai să folosim „The Graph” pentru exemplul nostru „GameContract”
 
@@ -290,7 +290,7 @@ React.useEffect(() => {
 }, [loading, error, data])
 ```
 
-![Magic](./magic.jpg)
+![Magic](../../../../../developers/tutorials/the-graph-fixing-web3-data-querying/magic.jpg)
 
 Dar ne lipsește o ultimă piesă din puzzle și acesta este serverul. Îl poți rula singur sau poți utiliza serviciul găzduit.
 
@@ -300,7 +300,7 @@ Dar ne lipsește o ultimă piesă din puzzle și acesta este serverul. Îl poți
 
 Cel mai simplu mod de a utiliza serviciul găzduit. Urmează instrucțiunile [aici](https://thegraph.com/docs/deploy-a-subgraph) pentru a implementa un subgraph. Pentru multe proiecte, poți găsi de fapt, „subgraph”-uri deja realizate în explorer la https://thegraph.com/explorer/.
 
-![Exploratorul - The Graph](./thegraph-explorer.png)
+![Exploratorul - The Graph](../../../../../developers/tutorials/the-graph-fixing-web3-data-querying/thegraph-explorer.png)
 
 ### Rularea propriului tău nod {#running-your-own-node}
 

--- a/src/content/translations/ro/developers/tutorials/transfers-and-approval-of-erc-20-tokens-from-a-solidity-smart-contract/index.md
+++ b/src/content/translations/ro/developers/tutorials/transfers-and-approval-of-erc-20-tokens-from-a-solidity-smart-contract/index.md
@@ -169,7 +169,7 @@ function buy() payable public {
 
 În cazul în care cumpărarea are succes, ar trebui să vedem două evenimente în tranzacție: `Transfer`-ul de token și evenimentul `Bought`.
 
-![Două evenimente în tranzacție: „Transfer” și „Bought”](./transfer-and-bought-events.png)
+![Două evenimente în tranzacție: „Transfer” și „Bought”](../../../../../developers/tutorials/transfers-and-approval-of-erc-20-tokens-from-a-solidity-smart-contract/transfer-and-bought-events.png)
 
 ## Funcția de vânzare {#the-sell-function}
 
@@ -188,7 +188,7 @@ function sell(uint256 amount) public {
 
 Dacă totul merge bine ar trebui să ai 2 evenimente (un `„Transfer”` și un `„Sold”`) în tranzacție și soldul tokenului și al Ethereum actualizate.
 
-![Două evenimente în tranzacție: „Transfer” și „Sold”](./transfer-and-bought-events.png)
+![Două evenimente în tranzacție: „Transfer” și „Sold”](../../../../../developers/tutorials/transfers-and-approval-of-erc-20-tokens-from-a-solidity-smart-contract/transfer-and-bought-events.png)
 
 <Divider />
 

--- a/src/content/translations/ro/developers/tutorials/using-websockets/index.md
+++ b/src/content/translations/ro/developers/tutorials/using-websockets/index.md
@@ -47,7 +47,7 @@ $ wscat -c wss://eth-mainnet.ws.alchemyapi.io/ws/demo
 
 Pentru început, deschide un WebSocket folosind adresa URL WebSocket a aplicației tale. Poți găsi adresa URL a aplicației tale WebSocket deschizând pagina aplicației în [tabloul de bord](https://dashboard.alchemyapi.io/) și făcând clic pe „View Key” (Vizualizare cheie). Reține că URL-ul aplicației pentru WebSockets este diferit de URL-ul său pentru cererile HTTP, dar ambele pot fi găsite dacă facem clic pe „View Key”(Vizualizare cheie).
 
-![Unde să găsești URL-ul WebSocket în panoul tău Alchimy](./use-websockets.gif)
+![Unde să găsești URL-ul WebSocket în panoul tău Alchimy](../../../../../developers/tutorials/using-websockets/use-websockets.gif)
 
 Oricare dintre API-urile enumerate în [Alchemy API de referință](https://docs.alchemyapi.io/documentation/alchemy-api-reference/) poate fi folosit prin intermediul WebSocket. Pentru aceasta, folosește aceleași elemente care ar fi trimise prin metoda de cereri POST suportată de HTTP, dar trimite-le prin WebSocket.
 

--- a/src/content/translations/ro/developers/tutorials/waffle-dynamic-mocking-and-testing-calls/index.md
+++ b/src/content/translations/ro/developers/tutorials/waffle-dynamic-mocking-and-testing-calls/index.md
@@ -219,7 +219,7 @@ Să descompunem acest test în părți:
 
 Suntem gata să dăm drumul fiarei:
 
-![Un test care trece](test-one.png)
+![Un test care trece](../../../../../developers/tutorials/waffle-dynamic-mocking-and-testing-calls/test-one.png)
 
 Deci, testul funcționează, dar... mai este loc pentru îmbunătățiri. Funcția `balanceOf()` va returna întotdeauna 99999. Putem îmbunătăți acest lucru prin specificarea unui portofel pentru care funcția ar trebui să returneze ceva - la del ca un contract real:
 
@@ -245,7 +245,7 @@ it("returnează true dacă portofelul are cel puțin 1000001 tokenuri", async ()
 
 Rulează testele...
 
-![Două teste care trec](test-two.png)
+![Două teste care trec](../../../../../developers/tutorials/waffle-dynamic-mocking-and-testing-calls/test-two.png)
 
 ...și iată! Contractul nostru pare să funcționeze conform scopului :)
 
@@ -275,7 +275,7 @@ it("contractul nostru este verificat dacă a apelat balanceOf cu un anumit porto
 
 Să verificăm dacă testele sunt corecte:
 
-![Trei teste care trec](test-three.png)
+![Trei teste care trec](../../../../../developers/tutorials/waffle-dynamic-mocking-and-testing-calls/test-three.png)
 
 Super, toate testele sunt verzi.
 


### PR DESCRIPTION
## Description
Updates image references in new foreign language markdown to use appropriate relative link.

@samajammin This was a quick patch to fix the Romanian dev docs and tutorials so all the images weren't broken anymore. Will look into a better way to solve this as we move forward with more translations. Although this one was relatively quick, I agree this should be automated as much as possible. 

## Related Issue
#2585