### PR TITLE
Tutorials filter by language [Fixes #2584]

### DIFF
--- a/src/content/developers/tutorials/erc20-annotated-code/index.md
+++ b/src/content/developers/tutorials/erc20-annotated-code/index.md
@@ -6,28 +6,26 @@ lang: en
 sidebar: true
 tags: ["solidity", "erc-20"]
 skill: beginner
-published: 2021-<month>-<day>
+published: 2021-02-11
 ---
 
 ## Introduction {#introduction}
 
-One of the most common uses for Ethereum is for a group to create a tradable token, in a sense their own currency. These tokens typically follow a standard, 
+One of the most common uses for Ethereum is for a group to create a tradable token, in a sense their own currency. These tokens typically follow a standard,
 [ERC-20](/developers/docs/standards/tokens/erc-20/). This standard makes it possible to write tools, such as liquidity pools and wallets, that work with all ERC-20
-tokens. In this article we will analyze the 
+tokens. In this article we will analyze the
 [OpenZeppelin Solidity ERC20 implementation](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/ERC20.sol), as well as the
 [interface definition](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/IERC20.sol).
 
-This is annotated source code. If you want to implement ERC-20, 
+This is annotated source code. If you want to implement ERC-20,
 [read this tutorial](https://docs.openzeppelin.com/contracts/2.x/erc20-supply).
-
 
 ## The Interface {#the-interface}
 
-The purpose of a standard like ERC-20 is to allow many tokens implementations that are interoperable across applications, like wallets and decentralized exchanges. To achieve that, we create an 
+The purpose of a standard like ERC-20 is to allow many tokens implementations that are interoperable across applications, like wallets and decentralized exchanges. To achieve that, we create an
 [interface](https://www.geeksforgeeks.org/solidity-basics-of-interface/). Any code that needs to use the token contract
-can use the same definitions in the interface and be compatible with all token contracts that use it, whether it is a wallet such as 
+can use the same definitions in the interface and be compatible with all token contracts that use it, whether it is a wallet such as
 MetaMask, a dapp such as etherscan.io, or a different contract such as liquidity pool.
-
 
 ![Illustration of the ERC-20 interface](erc20_interface.png)
 
@@ -35,8 +33,8 @@ If you are an experienced programmer, you probably remember seeing similar const
 or even in [C header files](https://gcc.gnu.org/onlinedocs/cpp/Header-Files.html).
 
 This is a definition of the [ERC-20 Interface](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/IERC20.sol)
-from OpenZeppelin. It is a translation of the [human readable standard](https://eips.ethereum.org/EIPS/eip-20) into Solidity code. Of course, the 
-interface itself does not define *how* to do anything. That is explained in the contract source code below.
+from OpenZeppelin. It is a translation of the [human readable standard](https://eips.ethereum.org/EIPS/eip-20) into Solidity code. Of course, the
+interface itself does not define _how_ to do anything. That is explained in the contract source code below.
 
 &nbsp;
 
@@ -47,22 +45,17 @@ interface itself does not define *how* to do anything. That is explained in the 
 Solidity files are supposed to includes a license identifier. [You can see the list of licenses here](https://spdx.org/licenses/). If you need a different
 license, just explain it in the comments.
 
-
-
 &nbsp;
 
 ```solidity
 pragma solidity >=0.6.0 <0.8.0;
 ```
 
-
-The Solidity language is still evolving quickly, and new versions may not be compatible with old code 
-([see here](https://docs.soliditylang.org/en/v0.7.0/070-breaking-changes.html)). Therefore, it is a goood idea to specify not just a minimum 
+The Solidity language is still evolving quickly, and new versions may not be compatible with old code
+([see here](https://docs.soliditylang.org/en/v0.7.0/070-breaking-changes.html)). Therefore, it is a goood idea to specify not just a minimum
 version of the language, but also a maximum version, the latest with which you tested the code.
 
-
 &nbsp;
-
 
 ```solidity
 /**
@@ -70,12 +63,10 @@ version of the language, but also a maximum version, the latest with which you t
  */
 ```
 
-
-The `@dev` in the comment is part of the [NatSpec format](https://docs.soliditylang.org/en/develop/natspec-format.html), used to produce 
+The `@dev` in the comment is part of the [NatSpec format](https://docs.soliditylang.org/en/develop/natspec-format.html), used to produce
 documentation from the source code.
 
 &nbsp;
-
 
 ```solidity
 interface IERC20 {
@@ -93,18 +84,16 @@ By convention, interface names start with `I`.
 ```
 
 This function is `external`, meaning [it can only be called from outside the contract](https://docs.soliditylang.org/en/v0.7.0/cheatsheet.html#index-2).
-It returns the total supply of tokens in the contract. This value is returned using the most common type in Ethereum, unsigned 256 bits (256 bits is the 
-native word size of the EVM). This function is also a `view`, which means that it does not change the state, so it can be executed on a single node instead of having 
+It returns the total supply of tokens in the contract. This value is returned using the most common type in Ethereum, unsigned 256 bits (256 bits is the
+native word size of the EVM). This function is also a `view`, which means that it does not change the state, so it can be executed on a single node instead of having
 every node in the blockchain run it. This kind of function does not generate a transaction and does not cost [gas](https://ethereum.org/en/developers/docs/gas/).
 
 **Note:** In theory it might appear that a contract's creator could cheat by returning a smaller total supply than the real value, making each token appear
 more valuable than it actually is. However, that fear ignores the true nature of the blockchain. Everything that happens on the blockchain can be verified by
 every node. To achieve this, every contract's machine language code and storage is available on every node. While you are not required to publish the Solidity
 code for your contract, nobody would take you seriously unless you publish the source code and the version of Solidity with which it was complied, so it can
-be verified against the machine language code you provided. 
+be verified against the machine language code you provided.
 For example, see [this contract](https://etherscan.io/address/0xa530F85085C6FE2f866E7FdB716849714a89f4CD#code).
-
-
 
 &nbsp;
 
@@ -115,10 +104,8 @@ For example, see [this contract](https://etherscan.io/address/0xa530F85085C6FE2f
     function balanceOf(address account) external view returns (uint256);
 ```
 
-
 As the name says, `balanceOf` returns the balance of an account. Ethereum accounts are identified in Solidity using the `address` type, which holds 160 bits.
 It is also `external` and `view`.
-
 
 &nbsp;
 
@@ -133,22 +120,20 @@ It is also `external` and `view`.
     function transfer(address recipient, uint256 amount) external returns (bool);
 ```
 
-The `transfer` function transfers a tokens from the caller to a different address. This involves a change of state, so it isn't a `view`. 
-When a user calls this function it creates a transaction and costs gas. It also emits an event, `Transfer`, to inform everybody on 
+The `transfer` function transfers a tokens from the caller to a different address. This involves a change of state, so it isn't a `view`.
+When a user calls this function it creates a transaction and costs gas. It also emits an event, `Transfer`, to inform everybody on
 the blockchain of the event.
 
 The function has two types of output for two different types of callers:
 
 - Users that call the function directly from a user interface. Typically the user submits a transaction
   and does not wait for a response, which could take an indefinite amount of time. The user can see what happened
-  by looking for the transaction receipt (which is identified by the transaction hash) or by looking for the 
+  by looking for the transaction receipt (which is identified by the transaction hash) or by looking for the
   `Transfer` event.
 - Other contracts, which call the function as part of an overall transaction. Those contracts get the result immediately,
   because they run in the same transaction, so they can use the function return value.
 
 The same type of output is created by the other functions that change the contract's state.
-
-
 
 &nbsp;
 
@@ -174,8 +159,6 @@ can know if it was successful.
 The `allowance` function lets anybody query to see what is the allowance that one
 address (`owner`) lets another address (`spender`) spend.
 
-
-
 &nbsp;
 
 ```solidity
@@ -196,13 +179,11 @@ address (`owner`) lets another address (`spender`) spend.
     function approve(address spender, uint256 amount) external returns (bool);
 ```
 
-
-The `approve` function creates an allowance. Make sure to read the message about 
+The `approve` function creates an allowance. Make sure to read the message about
 how it can be abused. In Ethereum you control the order of your own transactions,
-but you cannot control the order in which other people's transactions will 
+but you cannot control the order in which other people's transactions will
 be executed, unless you don't submit your own transaction until you see the
 other side's transaction had happened.
-
 
 &nbsp;
 
@@ -219,12 +200,9 @@ other side's transaction had happened.
     function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
 ```
 
-
 Finally, `transferFrom` is used by the spender to actually spend the allowance.
 
-
 &nbsp;
-
 
 ```solidity
 
@@ -246,13 +224,11 @@ Finally, `transferFrom` is used by the spender to actually spend the allowance.
 
 These events are emitted when the state of the ERC-20 contract changes.
 
-
-
 ## The Actual Contract {#the-actual-contract}
 
-This is the actual contract that implements the ERC-20 standard, 
-[taken from here](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/ERC20.sol). 
-It is not meant to be used as-is, but you can 
+This is the actual contract that implements the ERC-20 standard,
+[taken from here](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/ERC20.sol).
+It is not meant to be used as-is, but you can
 [inherit](https://www.tutorialspoint.com/solidity/solidity_inheritance.htm) from it to extend it to something usable.
 
 ```solidity
@@ -261,7 +237,6 @@ pragma solidity >=0.6.0 <0.8.0;
 ```
 
 &nbsp;
-
 
 ### Import Statements {#import-statements}
 
@@ -274,14 +249,12 @@ import "./IERC20.sol";
 import "../../math/SafeMath.sol";
 ```
 
-
--  `GSN/Context.sol` is the definitions required to use [OpenGSN](https://www.opengsn.org/), a system that allows users without ether
-   to use the blockchain. Note that this is an old version, if you want to integrate with OpenGSN 
-   [use this tutorial](https://docs.opengsn.org/tutorials/integration.html).
--  [The SafeMath library](https://ethereumdev.io/using-safe-math-library-to-prevent-from-overflows/), which is used to make 
-   addition and subtraction without overflows. This is necessary because otherwise a person might somehow have one token, spend
-   two tokens, and then have 2^256-1 tokens.
-
+- `GSN/Context.sol` is the definitions required to use [OpenGSN](https://www.opengsn.org/), a system that allows users without ether
+  to use the blockchain. Note that this is an old version, if you want to integrate with OpenGSN
+  [use this tutorial](https://docs.opengsn.org/tutorials/integration.html).
+- [The SafeMath library](https://ethereumdev.io/using-safe-math-library-to-prevent-from-overflows/), which is used to make
+  addition and subtraction without overflows. This is necessary because otherwise a person might somehow have one token, spend
+  two tokens, and then have 2^256-1 tokens.
 
 &nbsp;
 
@@ -312,17 +285,16 @@ This comment explains the purpose of the contract.
  * functions have been added to mitigate the well-known issues around setting
  * allowances. See {IERC20-approve}.
  */
- 
+
 ```
- 
-### Contract Definition   {#contract-definition}
- 
+
+### Contract Definition {#contract-definition}
+
 ```solidity
 contract ERC20 is Context, IERC20 {
 ```
 
 This line specifies the inheritence, in this case from `IERC20` from above and `Context`, for OpenGSN.
-
 
 &nbsp;
 
@@ -335,17 +307,16 @@ This line specifies the inheritence, in this case from `IERC20` from above and `
 This line attaches the `SafeMath` library to the `uint256` type. You can find this library
 [here](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/math/SafeMath.sol).
 
-
-### Variable Definitions  {#variable-definitions}
+### Variable Definitions {#variable-definitions}
 
 These definitions specify the contract's state variables. There variables are declared `private`, but
-that only means that other contracts on the blockchain can't read them. *There are no
-secrets on the blockchain*, the software on every node has the state of every contract
+that only means that other contracts on the blockchain can't read them. _There are no
+secrets on the blockchain_, the software on every node has the state of every contract
 at every block. By convention, state variables are named `_<something>`.
 
 The first two variables are [mappings](https://www.tutorialspoint.com/solidity/solidity_mappings.htm),
 meaning they behave roughly the same as [associative arrays](https://en.wikipedia.org/wiki/Associative_array),
-except that the keys are numeric values. In contrast to normal arrays, which have storage for all cells, 
+except that the keys are numeric values. In contrast to normal arrays, which have storage for all cells,
 
 ```solidity
     mapping (address => uint256) private _balances;
@@ -353,7 +324,6 @@ except that the keys are numeric values. In contrast to normal arrays, which hav
 
 The first mapping, `_balances`, is addresses and their respective balances of this token. To access
 the balance, use this syntax: `_balances[<address>]`.
-
 
 &nbsp;
 
@@ -365,7 +335,6 @@ This variable, `_allowances`, stores the allowances explained earlier. The first
 of the tokens, and the second is the contract with the allowance. To access the amount address A can
 spend from address B's account, use `_allowances[B][A]`.
 
-
 &nbsp;
 
 ```solidity
@@ -373,8 +342,6 @@ spend from address B's account, use `_allowances[B][A]`.
 ```
 
 As the name suggests, this variable keeps track of the total supply of tokens.
-
-
 
 &nbsp;
 
@@ -385,10 +352,10 @@ As the name suggests, this variable keeps track of the total supply of tokens.
 ```
 
 These three variables are used to impprove readability. The first two are self-explanatory, but `_decimals`
-isn't. 
+isn't.
 
 On one hand, ethereum does not have floating point or fractional variables. On the other hand,
-humans like being able to divide tokens. One reason people settled on gold for currency was that 
+humans like being able to divide tokens. One reason people settled on gold for currency was that
 it was hard to make change when somebody wanted to buy a duck's worth of cow.
 
 The solution is to keep track of integers, but count instead of the real token a fractional token that is
@@ -397,11 +364,10 @@ ETH. At writing, 10,000,000,000,000 wei is approximately one US or Euro cent.
 
 Applications need to know how to display the token balance. If a user has 3,141,000,000,000,000,000 wei, is that
 3.14 ETH? 31.41 ETH? 3,141 ETH? In the case of ether it is defined 10^18 wei to the ETH, but for your
-token you can select a different value. If dividing the token doesn't make sense, you can use a 
+token you can select a different value. If dividing the token doesn't make sense, you can use a
 `_decimals` value of zero. If you want to use the same standard as ETH, use the value **18**.
 
-
-### The Constructor  {#the-constructor}
+### The Constructor {#the-constructor}
 
 ```solidity
     /**
@@ -420,10 +386,9 @@ token you can select a different value. If dividing the token doesn't make sense
     }
 ```
 
-The constructor is called when the contract is first created. By convention, function parameters are named `<something>_`. 
+The constructor is called when the contract is first created. By convention, function parameters are named `<something>_`.
 
-
-### User Interface Functions  {#user-interface-functions}
+### User Interface Functions {#user-interface-functions}
 
 ```solidity
     /**
@@ -459,22 +424,20 @@ The constructor is called when the contract is first created. By convention, fun
     }
 ```
 
-
 These functions, `name`, `symbol`, and `decimals` help user interfaces know about your contract so they'll be able to display it properly.
 
 The return type is `string memory`, meaning return a string that is stored in memory. Variables, such as
 strings, can be stored in three locations:
 
-|           | Lifetime      | Contract Access | Gas Cost |
-| --------- | ------------- | --------------- | -------- |
-| Memory    | Function call | Read/Write      | Tens or hundreds (higher for higher locations) |
-| Calldata  | Function call | Read Only       | Very low (paid by the caller, not the callee)  | 
-| Storage   | Until changed | Read/Write      | High (800 for read, 20k for write)             |
+|          | Lifetime      | Contract Access | Gas Cost                                       |
+| -------- | ------------- | --------------- | ---------------------------------------------- |
+| Memory   | Function call | Read/Write      | Tens or hundreds (higher for higher locations) |
+| Calldata | Function call | Read Only       | Very low (paid by the caller, not the callee)  |
+| Storage  | Until changed | Read/Write      | High (800 for read, 20k for write)             |
 
 In this case, `memory` is the best choice.
 
-
-### Read Token Information  {#read-token-information}
+### Read Token Information {#read-token-information}
 
 These are functions that provide information about the token, either the total supply or an
 account's balance.
@@ -488,8 +451,7 @@ account's balance.
     }
 ```
 
-The `totalSupply` function returns the total supply of tokens. 
-
+The `totalSupply` function returns the total supply of tokens.
 
 &nbsp;
 
@@ -500,15 +462,13 @@ The `totalSupply` function returns the total supply of tokens.
     function balanceOf(address account) public view override returns (uint256) {
         return _balances[account];
     }
-```   
+```
 
-Read an account's balance. Note that anybody is allowed to get anybody else's account 
+Read an account's balance. Note that anybody is allowed to get anybody else's account
 balance. There is no point in trying to hide this information, because it is available on every
-node anyway. *There are no secrets on the blockchain.*
+node anyway. _There are no secrets on the blockchain._
 
-
-### Transfer Tokens   {#transfer-tokens}
-
+### Transfer Tokens {#transfer-tokens}
 
 ```solidity
     /**
@@ -526,7 +486,6 @@ The `transfer` function is called to transfer tokens from the sender's account t
 that even though it returns a boolean value, that value is always **true**. If the transfer
 fails the contract reverts the call.
 
-
 &nbsp;
 
 ```solidity
@@ -539,17 +498,16 @@ The `_transfer` function does the actual work. It is a private function that can
 other contract functions. By convention private functions are named `_<something>`, same as state
 variables.
 
-Normally in Solidity we use `msg.sender` for the message sender. However, that breaks 
+Normally in Solidity we use `msg.sender` for the message sender. However, that breaks
 [OpenGSN](http://opengsn.org/). If we want to allow etherless transactions with our token, we
 need to use `_msgSender()`. It returns `msg.sender` for normal transactions, but for etherless ones
 return the original signer and not the contract that relayed the message.
 
-
-### Allowance Functions    {#allowance-functions}
+### Allowance Functions {#allowance-functions}
 
 These are the functions that implement the allowance functionality: `allowance`, `approve`, `transferFrom`,
-and `_approve`. Additionally, the OpenZeppelin implementation goes beyond the basic standard to include some features that improve 
-security: `increaseAllowance`, and `decreaseAllowance`. 
+and `_approve`. Additionally, the OpenZeppelin implementation goes beyond the basic standard to include some features that improve
+security: `increaseAllowance`, and `decreaseAllowance`.
 
 #### The allowance function {#allowance}
 
@@ -563,7 +521,6 @@ security: `increaseAllowance`, and `decreaseAllowance`.
 ```
 
 The `allowance` function allows everybody to check any allowance.
-
 
 #### The approve function {#approve}
 
@@ -583,7 +540,6 @@ This function is called to create an allowance. It is similar to the `transfer` 
 - The function just calls an internal function (in this case, `_approve`) that does the real work.
 - The function either returns `true` (if successful) or reverts (if not).
 
-
 &nbsp;
 
 ```solidity
@@ -592,9 +548,8 @@ This function is called to create an allowance. It is similar to the `transfer` 
     }
 ```
 
-We use internal functions to minimize the number of places where state changes happen. *Any* function that changes the
+We use internal functions to minimize the number of places where state changes happen. _Any_ function that changes the
 state is a potential security risk that needs to be audited for security. This way we have less chances to get it wrong.
-
 
 #### The transferFrom function {#transferFrom}
 
@@ -615,7 +570,7 @@ being spent and reduce the allowance by that amount.
      * - the caller must have allowance for ``sender``'s tokens of at least
      * `amount`.
      */
-    function transferFrom(address sender, address recipient, uint256 amount) public virtual 
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual
                                                 override returns (bool) {
         _transfer(sender, recipient, amount);
 ```
@@ -625,17 +580,16 @@ being spent and reduce the allowance by that amount.
 The `a.sub(b, "message")` function call does two things. First, it calculates `a-b`, which is the new allowance.
 Second, it checks that this result is not negative. If it is negative the call reverts with the provided message.
 
-
 ```solidity
-        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, 
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount,
              "ERC20: transfer amount exceeds allowance"));
         return true;
     }
 ```
 
-#### OpenZeppelin safety additions {#openzeppelin-safety-additions} 
+#### OpenZeppelin safety additions {#openzeppelin-safety-additions}
 
-It is dangerous to set a non-zero allowance to another non-zero value, 
+It is dangerous to set a non-zero allowance to another non-zero value,
 because you only control the order of your own transactions, not anybody else's. Imagine you
 have two users, Alice who is naive and Bill who is dishonest. Alice wants some service from
 Bill, which she things costs five tokens - so she gives Bill an allowance of five tokens.
@@ -645,39 +599,37 @@ sends a transaction that sets Bill's allowance to ten. The moment Bill sees this
 in the transaction pool he sends a transaction that spends Alice's five tokens and has a much
 higher gas price so it will be mined faster. That way Bill can spend first five tokens and then,
 once Alice's new allowance is mined, spend ten more for a total price of fifteen tokens, more than
-Alice meant to authorize. This technique is called 
+Alice meant to authorize. This technique is called
 [front-running](https://consensys.github.io/smart-contract-best-practices/known_attacks/#front-running)
 
-| Alice Transaction | Alice Nonce | Bill Transaction               | Bill Nonce | Bill's Allowance | Bill Total Income from Alice |
-| ------------------| ----------- | ------------------------------ | ---------- | ---------------- | ---------------------------- |
-| approve(Bill, 5)  |          10 |                                |            |                5 |                            0 |
-|                   |             | transferFrom(Alice, Bill, 5)   |     10,123 |                0 |                            5 |
-| approve(Bill, 10) |          11 |                                |            |               10 |                            5 |
-|                   |             | transferFrom(Alice, Bill, 10)  |     10,124 |                0 |                           15 |
+| Alice Transaction | Alice Nonce | Bill Transaction              | Bill Nonce | Bill's Allowance | Bill Total Income from Alice |
+| ----------------- | ----------- | ----------------------------- | ---------- | ---------------- | ---------------------------- |
+| approve(Bill, 5)  | 10          |                               |            | 5                | 0                            |
+|                   |             | transferFrom(Alice, Bill, 5)  | 10,123     | 0                | 5                            |
+| approve(Bill, 10) | 11          |                               |            | 10               | 5                            |
+|                   |             | transferFrom(Alice, Bill, 10) | 10,124     | 0                | 15                           |
 
 To avoid this problem, these two functions (`increaseAllowance` and `decreaseAllowance`) allow you
 to modify the allowance by a specific amount. So if Bill had already spent five tokens, he'll just
-be able to spend five more. Depending on the timing, there are two ways ways this can work, both of 
+be able to spend five more. Depending on the timing, there are two ways ways this can work, both of
 which end with Bill only getting ten tokens:
 
 A:
 
-| Alice Transaction | Alice Nonce | Bill Transaction               | Bill Nonce | Bill's Allowance | Bill Total Income from Alice |
-| ------------------| ----------: | ------------------------------ | ---------: | ---------------: | ---------------------------- |
-| approve(Bill, 5)  |          10 |                                |            |                5 |                            0 |
-|                   |             | transferFrom(Alice, Bill, 5)   |     10,123 |                0 |                            5 |
-| increaseAllowance(Bill, 5) |          11 |                       |            |          0+5 = 5 |                            5 |
-|                   |             | transferFrom(Alice, Bill, 5)  |     10,124 |                 0 |                           10 |
+| Alice Transaction          | Alice Nonce | Bill Transaction             | Bill Nonce | Bill's Allowance | Bill Total Income from Alice |
+| -------------------------- | ----------: | ---------------------------- | ---------: | ---------------: | ---------------------------- |
+| approve(Bill, 5)           |          10 |                              |            |                5 | 0                            |
+|                            |             | transferFrom(Alice, Bill, 5) |     10,123 |                0 | 5                            |
+| increaseAllowance(Bill, 5) |          11 |                              |            |          0+5 = 5 | 5                            |
+|                            |             | transferFrom(Alice, Bill, 5) |     10,124 |                0 | 10                           |
 
+B:
 
-B: 
-
-| Alice Transaction | Alice Nonce | Bill Transaction               | Bill Nonce | Bill's Allowance | Bill Total Income from Alice |
-| ------------------| ----------: | ------------------------------ | ---------: | ---------------: | ---------------------------: |
-| approve(Bill, 5)  |          10 |                                |            |                5 |                            0 |
-| increaseAllowance(Bill, 5) |          11 |                                |            |        5+5 = 10 |                            0 |
-|                   |             | transferFrom(Alice, Bill, 10)  |     10,124 |                0 |                           10 |
-
+| Alice Transaction          | Alice Nonce | Bill Transaction              | Bill Nonce | Bill's Allowance | Bill Total Income from Alice |
+| -------------------------- | ----------: | ----------------------------- | ---------: | ---------------: | ---------------------------: |
+| approve(Bill, 5)           |          10 |                               |            |                5 |                            0 |
+| increaseAllowance(Bill, 5) |          11 |                               |            |         5+5 = 10 |                            0 |
+|                            |             | transferFrom(Alice, Bill, 10) |     10,124 |                0 |                           10 |
 
 ```solidity
     /**
@@ -693,14 +645,13 @@ B:
      * - `spender` cannot be the zero address.
      */
     function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
-        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));        
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
         return true;
     }
-````
+```
 
 The `a.add(b)` function is a safe add. In the unlikely case that `a`+`b`>=`2^256` it does not wrap around
 the way normal addition does.
-
 
 ```solidity
 
@@ -719,17 +670,18 @@ the way normal addition does.
      * `subtractedValue`.
      */
     function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
-        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, 
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue,
                 "ERC20: decreased allowance below zero"));
         return true;
     }
-```    
+```
 
-### Functions that Modify Token Information  {#functions-that-modify-token-information}
+### Functions that Modify Token Information {#functions-that-modify-token-information}
 
 These are the four functions that do the actual work: `_transfer`, `_mint`, `_burn`, and `_approve`.
 
-#### The \_transfer function  {#_transfer}
+#### The \_transfer function {#\_transfer}
+
 ```solidity
     /**
      * @dev Moves tokens `amount` from `sender` to `recipient`.
@@ -752,7 +704,6 @@ This function, `_transfer`, transfers tokens from one account to another. It is 
 `transfer` (for transfers from the sender's own account) and `transferFrom` (for using allowances
 to transfer from somebody else's account).
 
-
 &nbsp;
 
 ```solidity
@@ -761,17 +712,15 @@ to transfer from somebody else's account).
 ```
 
 Nobody actually owns address zero in Ethereum (that is, nobody knows a private key whose matching public key
-is transformed to the zero address). When people use that address, it is usually a software bug - so we 
+is transformed to the zero address). When people use that address, it is usually a software bug - so we
 fail if the zero address is used as the sender or the recipient.
-
 
 &nbsp;
 
 ```solidity
         _beforeTokenTransfer(sender, recipient, amount);
-        
-```
 
+```
 
 There are two ways to use this contract:
 
@@ -782,9 +731,8 @@ The second method is much better because the OpenZeppelin ERC-20 code has alread
 it is clear what are the functions you modify, and to trust your contract people only need to audit those specific functions.
 
 It is often useful to perform a function each time tokens change hands. However,`_transfer` is a very important function and it is
-possible to write it insecurely (see below), so it is best not to override it. The solution is `_beforeTokenTransfer`, a 
+possible to write it insecurely (see below), so it is best not to override it. The solution is `_beforeTokenTransfer`, a
 [hook function](https://en.wikipedia.org/wiki/Hooking). You can override this function, and it will be called on each transfer.
-
 
 &nbsp;
 
@@ -794,10 +742,9 @@ possible to write it insecurely (see below), so it is best not to override it. T
 ```
 
 These are the lines that actually do the transfer. Note that there is **nothing** between them, and that we subtract
-the transferred amount from the sender before adding it to the recipient. This is important because if there was a 
+the transferred amount from the sender before adding it to the recipient. This is important because if there was a
 call to a different contract in the middle, it could have been used to cheat this contract. This way the transfer
 is atomic, nothing can happen in the middle of it.
-
 
 &nbsp;
 
@@ -809,22 +756,19 @@ is atomic, nothing can happen in the middle of it.
 Finally, emit a `Transfer` event. Events are not accessible to smart contracts, but code running outside the blockchain
 can listen for events and react to them. For example, a wallet can keep track of when the owner gets more tokens.
 
+#### The \_mint and \_burn functions {#\_mint-and-\_burn}
 
-#### The \_mint and \_burn functions {#_mint-and-_burn}
-
-These two functions (`_mint` and `_burn`) modify the total supply of tokens. 
+These two functions (`_mint` and `_burn`) modify the total supply of tokens.
 They are internal and there is no function that calls them in this contract,
 so they are only useful if you inherit from the contract and add your own
 logic to decide under what conditions to mint new tokens or burn existing
 ones.
-
 
 **NOTE:** every ERC-20 token has its own business logic that dictates
 token management. For example, a fixed supply contract might only call `_mint`
 in the constructor and never call `_burn`. A contract that sells tokens
 will call `_mint` when it is paid, and presumably call `_burn` at some point
 to avoid runaway inflation.
-
 
 ```solidity
     /** @dev Creates `amount` tokens and assigns them to `account`, increasing
@@ -843,10 +787,9 @@ to avoid runaway inflation.
         _balances[account] = _balances[account].add(amount);
         emit Transfer(address(0), account, amount);
     }
-```    
-    
-Make sure to update `_totalSupply` when the total number of tokens changes.
+```
 
+Make sure to update `_totalSupply` when the total number of tokens changes.
 
 &nbsp;
 
@@ -875,10 +818,10 @@ Make sure to update `_totalSupply` when the total number of tokens changes.
 
 The `_burn` function is almost identical to `_emit`, except it goes in the other direction.
 
-#### The \_approve function {#_approve}
+#### The \_approve function {#\_approve}
 
 This is the function that actually specifies allowances. Note that it allows an owner to specify
-an allowance that is higher than the owner's current balance. This is OK because the balance is 
+an allowance that is higher than the owner's current balance. This is OK because the balance is
 checked at the time of transfer, when it could be different from the balance when the allowance is
 created.
 
@@ -914,7 +857,7 @@ approval either by the owner or by a server that listens to these events.
 
 ```
 
-### Modify The Decimals Variable  {#modify-the-decimals-variable}
+### Modify The Decimals Variable {#modify-the-decimals-variable}
 
 ```solidity
 
@@ -931,12 +874,11 @@ approval either by the owner or by a server that listens to these events.
     }
 ```
 
-This function modifies the `_decimals` variable which is used to tell user interfaces how to interpret the amount. 
+This function modifies the `_decimals` variable which is used to tell user interfaces how to interpret the amount.
 You should call it from the constructor. It would be dishonest to call it at any subsequent point, and applications
 are not designed to handle it.
 
-
-### Hooks  {#hooks}
+### Hooks {#hooks}
 
 ```solidity
 
@@ -965,23 +907,22 @@ it to do something you just override it.
 
 For review, here are some of the most important ideas in this contract (in my opinion, yours is likely to vary):
 
-* *There are no secrets on the blockchain*. Any information that a smart contract can access 
+- _There are no secrets on the blockchain_. Any information that a smart contract can access
   is available to the whole world.
-* You can control the order of your own transactions, but not when other people's transaction
+- You can control the order of your own transactions, but not when other people's transaction
   happen. This is the reason that changing an allowance can be dangerous, because it lets
   the spender spend the sum of both allowances.
-* Values of type `uint256` wrap around. In other words, *0-1=2^256-1*. If that is not desired 
+- Values of type `uint256` wrap around. In other words, _0-1=2^256-1_. If that is not desired
   behavior, you have to check for it (or use the SafeMath library that does it for you). Note that this changed in
   [Solidity 0.8.0](https://docs.soliditylang.org/en/breaking/080-breaking-changes.html).
-* Do all state changes of a specific type in a specific place, because it makes auditing easier. 
+- Do all state changes of a specific type in a specific place, because it makes auditing easier.
   This is the reason that we have, for example, `_approve`, which is called by `approve`, `transferFrom`,
   `increaseAllowance`, and `decreaseAllowance`
-* State changes should be atomic, without any other action in their middle (as you can see
+- State changes should be atomic, without any other action in their middle (as you can see
   in `_transfer`). This is because during the state change you have an inconsistent state. For example,
-  between the time you deduct from the balance of the sender and the time you add to the balance of the 
+  between the time you deduct from the balance of the sender and the time you add to the balance of the
   recipient there are less token in existence than there should be. This could be potentially abused if there
   are operations between them, especially calls to a different contract.
-  
 
-Now that you've seen how the OpenZeppelin ERC-20 contract is written, and especially how it is 
-made more secure, go and write your own secure contracts and applications. 
+Now that you've seen how the OpenZeppelin ERC-20 contract is written, and especially how it is
+made more secure, go and write your own secure contracts and applications.

--- a/src/content/developers/tutorials/waffle-test-simple-smart-contract/index.md
+++ b/src/content/developers/tutorials/waffle-test-simple-smart-contract/index.md
@@ -6,7 +6,7 @@ tags: ["smart contracts", "solidity", "Waffle", "testing"]
 skill: beginner
 lang: en
 sidebar: true
-published: 2021-26-02
+published: 2021-02-26
 ---
 
 ## In this tutorial you'll learn how to

--- a/src/data/translations.json
+++ b/src/data/translations.json
@@ -1,172 +1,138 @@
 {
   "en": {
     "version": 2.4,
-    "language": "English",
-    "hasTutorials": true
+    "language": "English"
   },
   "ar": {
     "version": 1.1,
-    "language": "العربية",
-    "hasTutorials": false
+    "language": "العربية"
   },
   "bn": {
     "version": 1.1,
-    "language": "বাংলা",
-    "hasTutorials": false
+    "language": "বাংলা"
   },
   "cs": {
     "version": 1.1,
-    "language": "čeština",
-    "hasTutorials": false
+    "language": "čeština"
   },
   "de": {
     "version": 1.1,
-    "language": "Deutsch",
-    "hasTutorials": false
+    "language": "Deutsch"
   },
   "el": {
     "version": 1.0,
-    "language": "Ελληνικά",
-    "hasTutorials": false
+    "language": "Ελληνικά"
   },
   "es": {
     "version": 2.0,
-    "language": "Español",
-    "hasTutorials": false
+    "language": "Español"
   },
   "fa": {
     "version": 1.0,
-    "language": "فارسی",
-    "hasTutorials": false
+    "language": "فارسی"
   },
   "fi": {
     "version": 1.1,
-    "language": "Suomi",
-    "hasTutorials": false
+    "language": "Suomi"
   },
   "fr": {
     "version": 1.1,
-    "language": "Français",
-    "hasTutorials": false
+    "language": "Français"
   },
   "hi": {
     "version": 2.0,
-    "language": "हिन्दी",
-    "hasTutorials": false
+    "language": "हिन्दी"
   },
   "hu": {
     "version": 1.1,
-    "language": "Magyar",
-    "hasTutorials": false
+    "language": "Magyar"
   },
   "id": {
     "version": 1.1,
-    "language": "Bahasa Indonesia",
-    "hasTutorials": false
+    "language": "Bahasa Indonesia"
   },
   "ig": {
     "version": 1.0,
-    "language": "Ibo",
-    "hasTutorials": false
+    "language": "Ibo"
   },
   "it": {
     "version": 1.1,
-    "language": "Italiano",
-    "hasTutorials": false
+    "language": "Italiano"
   },
   "ja": {
     "version": 1.1,
-    "language": "日本語",
-    "hasTutorials": false
+    "language": "日本語"
   },
   "ko": {
     "version": 1.1,
-    "language": "한국어",
-    "hasTutorials": false
+    "language": "한국어"
   },
   "lt": {
     "version": 1.1,
-    "language": "Lietuvis",
-    "hasTutorials": false
+    "language": "Lietuvis"
   },
   "ml": {
     "version": 1.1,
-    "language": "മലയാളം",
-    "hasTutorials": false
+    "language": "മലയാളം"
   },
   "nl": {
     "version": 1.0,
-    "language": "Nederlands",
-    "hasTutorials": false
+    "language": "Nederlands"
   },
   "nb": {
     "version": 1.1,
-    "language": "norsk",
-    "hasTutorials": false
+    "language": "norsk"
   },
   "pl": {
     "version": 1.0,
-    "language": "Polski",
-    "hasTutorials": false
+    "language": "Polski"
   },
   "pt": {
     "version": 1.0,
-    "language": "Português",
-    "hasTutorials": false
+    "language": "Português"
   },
   "pt-br": {
     "version": 1.1,
-    "language": "Português",
-    "hasTutorials": false
+    "language": "Português"
   },
   "ro": {
     "version": 2.2,
-    "language": "Română",
-    "hasTutorials": true
+    "language": "Română"
   },
   "ru": {
     "version": 1.0,
-    "language": "Pусский",
-    "hasTutorials": false
+    "language": "Pусский"
   },
   "se": {
     "version": 1.1,
-    "language": "Svenska",
-    "hasTutorials": false
+    "language": "Svenska"
   },
   "sk": {
     "version": 1.1,
-    "language": "Slovenský",
-    "hasTutorials": false
+    "language": "Slovenský"
   },
   "sl": {
     "version": 1.0,
-    "language": "Slovenija",
-    "hasTutorials": false
+    "language": "Slovenija"
   },
   "tr": {
     "version": 1.1,
-    "language": "Türkçe",
-    "hasTutorials": false
+    "language": "Türkçe"
   },
   "uk": {
     "version": 1.1,
-    "language": "Українська",
-    "hasTutorials": false
+    "language": "Українська"
   },
   "vi": {
     "version": 1.1,
-    "language": "Tiếng Việt",
-    "hasTutorials": false
+    "language": "Tiếng Việt"
   },
   "zh": {
     "version": 1.1,
-    "language": "简体中文",
-    "hasTutorials": false
+    "language": "简体中文"
   },
   "zh-tw": {
     "version": 1.1,
-    "language": "繁體中文",
-    "hasTutorials": false
+    "language": "繁體中文"
   }
 }

--- a/src/data/translations.json
+++ b/src/data/translations.json
@@ -1,138 +1,172 @@
 {
   "en": {
     "version": 2.4,
-    "language": "English"
+    "language": "English",
+    "hasTutorials": true
   },
   "ar": {
     "version": 1.1,
-    "language": "العربية"
+    "language": "العربية",
+    "hasTutorials": false
   },
   "bn": {
     "version": 1.1,
-    "language": "বাংলা"
+    "language": "বাংলা",
+    "hasTutorials": false
   },
   "cs": {
     "version": 1.1,
-    "language": "čeština"
+    "language": "čeština",
+    "hasTutorials": false
   },
   "de": {
     "version": 1.1,
-    "language": "Deutsch"
+    "language": "Deutsch",
+    "hasTutorials": false
   },
   "el": {
     "version": 1.0,
-    "language": "Ελληνικά"
+    "language": "Ελληνικά",
+    "hasTutorials": false
   },
   "es": {
     "version": 2.0,
-    "language": "Español"
+    "language": "Español",
+    "hasTutorials": false
   },
   "fa": {
     "version": 1.0,
-    "language": "فارسی"
+    "language": "فارسی",
+    "hasTutorials": false
   },
   "fi": {
     "version": 1.1,
-    "language": "Suomi"
+    "language": "Suomi",
+    "hasTutorials": false
   },
   "fr": {
     "version": 1.1,
-    "language": "Français"
+    "language": "Français",
+    "hasTutorials": false
   },
   "hi": {
     "version": 2.0,
-    "language": "हिन्दी"
+    "language": "हिन्दी",
+    "hasTutorials": false
   },
   "hu": {
     "version": 1.1,
-    "language": "Magyar"
+    "language": "Magyar",
+    "hasTutorials": false
   },
   "id": {
     "version": 1.1,
-    "language": "Bahasa Indonesia"
+    "language": "Bahasa Indonesia",
+    "hasTutorials": false
   },
   "ig": {
     "version": 1.0,
-    "language": "Ibo"
+    "language": "Ibo",
+    "hasTutorials": false
   },
   "it": {
     "version": 1.1,
-    "language": "Italiano"
+    "language": "Italiano",
+    "hasTutorials": false
   },
   "ja": {
     "version": 1.1,
-    "language": "日本語"
+    "language": "日本語",
+    "hasTutorials": false
   },
   "ko": {
     "version": 1.1,
-    "language": "한국어"
+    "language": "한국어",
+    "hasTutorials": false
   },
   "lt": {
     "version": 1.1,
-    "language": "Lietuvis"
+    "language": "Lietuvis",
+    "hasTutorials": false
   },
   "ml": {
     "version": 1.1,
-    "language": "മലയാളം"
+    "language": "മലയാളം",
+    "hasTutorials": false
   },
   "nl": {
     "version": 1.0,
-    "language": "Nederlands"
+    "language": "Nederlands",
+    "hasTutorials": false
   },
   "nb": {
     "version": 1.1,
-    "language": "norsk"
+    "language": "norsk",
+    "hasTutorials": false
   },
   "pl": {
     "version": 1.0,
-    "language": "Polski"
+    "language": "Polski",
+    "hasTutorials": false
   },
   "pt": {
     "version": 1.0,
-    "language": "Português"
+    "language": "Português",
+    "hasTutorials": false
   },
   "pt-br": {
     "version": 1.1,
-    "language": "Português"
+    "language": "Português",
+    "hasTutorials": false
   },
   "ro": {
     "version": 2.2,
-    "language": "Română"
+    "language": "Română",
+    "hasTutorials": true
   },
   "ru": {
     "version": 1.0,
-    "language": "Pусский"
+    "language": "Pусский",
+    "hasTutorials": false
   },
   "se": {
     "version": 1.1,
-    "language": "Svenska"
+    "language": "Svenska",
+    "hasTutorials": false
   },
   "sk": {
     "version": 1.1,
-    "language": "Slovenský"
+    "language": "Slovenský",
+    "hasTutorials": false
   },
   "sl": {
     "version": 1.0,
-    "language": "Slovenija"
+    "language": "Slovenija",
+    "hasTutorials": false
   },
   "tr": {
     "version": 1.1,
-    "language": "Türkçe"
+    "language": "Türkçe",
+    "hasTutorials": false
   },
   "uk": {
     "version": 1.1,
-    "language": "Українська"
+    "language": "Українська",
+    "hasTutorials": false
   },
   "vi": {
     "version": 1.1,
-    "language": "Tiếng Việt"
+    "language": "Tiếng Việt",
+    "hasTutorials": false
   },
   "zh": {
     "version": 1.1,
-    "language": "简体中文"
+    "language": "简体中文",
+    "hasTutorials": false
   },
   "zh-tw": {
     "version": 1.1,
-    "language": "繁體中文"
+    "language": "繁體中文",
+    "hasTutorials": false
   }
 }

--- a/src/intl/en/page-developers-tutorials.json
+++ b/src/intl/en/page-developers-tutorials.json
@@ -15,7 +15,7 @@
   "page-tutorial-submit-btn": "Submit a tutorial",
   "page-tutorial-submit-tutorial": "To submit a tutorial, you'll need to use GitHub. We welcome you to create an issue or a pull request.",
   "page-tutorial-subtitle": "Welcome to our curated list of community tutorials.",
-  "page-tutorial-tags-error": "No tutorials has all of these tags",
+  "page-tutorial-tags-error": "There are no tutorials with all your chosen tags yet",
   "page-tutorial-title": "Ethereum Development Tutorials",
   "page-tutorials-meta-description": "Browse and filter vetted Ethereum community tutorials by topic.",
   "page-tutorials-meta-title": "Ethereum Development Tutorials"

--- a/src/pages/developers/tutorials.js
+++ b/src/pages/developers/tutorials.js
@@ -16,7 +16,7 @@ import TutorialTags from "../../components/TutorialTags"
 import Emoji from "../../components/Emoji"
 import { Page, ButtonSecondary } from "../../components/SharedStyledComponents"
 
-import { getLocaleTimestamp } from "../../utils/time"
+import { getLocaleTimestamp, INVALID_DATETIME } from "../../utils/time"
 
 const SubSlogan = styled.p`
   font-size: 20px;
@@ -186,12 +186,22 @@ const ModalTitle = styled.h2`
   margin-bottom: 1rem;
 `
 
-const TutorialsPage = ({ data }) => {
-  const intl = useIntl()
+const published = (locale, published) => {
+  const localeTimestamp = getLocaleTimestamp(locale, published)
+  return localeTimestamp !== INVALID_DATETIME ? (
+    <span>
+      <Emoji text=":calendar:" size={1} ml={`0.5em`} mr={`0.5em`} />{" "}
+      {localeTimestamp} •
+    </span>
+  ) : null
+}
 
+const TutorialsPage = ({ data, pageContext }) => {
+  const intl = useIntl()
+  console.log({ pageContext })
   // Filter tutorials by language and map to object
   const allTutorials = data.allTutorials.nodes
-    .filter((tutorial) => tutorial.frontmatter.lang === intl.locale)
+    .filter((tutorial) => tutorial.frontmatter.lang === pageContext.language)
     .map((tutorial) => ({
       to:
         tutorial.fields.slug.substr(0, 3) === "/en"
@@ -376,26 +386,28 @@ const TutorialsPage = ({ data }) => {
             </p>
           </ResultsContainer>
         )}
-        {state.filteredTutorials.map((tutorial) => (
-          <TutorialCard key={tutorial.to} to={tutorial.to}>
-            <TitleContainer>
-              <Title>{tutorial.title}</Title>
-              <Pill isSecondary={true}>{tutorial.skill}</Pill>
-            </TitleContainer>
-            <Author>
-              <Emoji text=":writing_hand:" size={1} mr={`0.5em`} />
-              {tutorial.author} •
-              <Emoji text=":calendar:" size={1} ml={`0.5em`} mr={`0.5em`} />
-              {getLocaleTimestamp(intl.locale, tutorial.published)} •
-              <Emoji text=":stopwatch:" size={1} ml={`0.5em`} mr={`0.5em`} />
-              {tutorial.timeToRead} <Translation id="page-tutorial-read-time" />
-            </Author>
-            <About>{tutorial.description}</About>
-            <PillContainer>
-              <TutorialTags tags={tutorial.tags} />
-            </PillContainer>
-          </TutorialCard>
-        ))}
+        {state.filteredTutorials.map((tutorial) => {
+          console.log(tutorial.published)
+          return (
+            <TutorialCard key={tutorial.to} to={tutorial.to}>
+              <TitleContainer>
+                <Title>{tutorial.title}</Title>
+                <Pill isSecondary={true}>{tutorial.skill}</Pill>
+              </TitleContainer>
+              <Author>
+                <Emoji text=":writing_hand:" size={1} mr={`0.5em`} />
+                {tutorial.author} •{published(intl.locale, tutorial.published)}
+                <Emoji text=":stopwatch:" size={1} ml={`0.5em`} mr={`0.5em`} />
+                {tutorial.timeToRead}{" "}
+                <Translation id="page-tutorial-read-time" />
+              </Author>
+              <About>{tutorial.description}</About>
+              <PillContainer>
+                <TutorialTags tags={tutorial.tags} />
+              </PillContainer>
+            </TutorialCard>
+          )
+        })}
       </TutorialContainer>
     </StyledPage>
   )

--- a/src/pages/developers/tutorials.js
+++ b/src/pages/developers/tutorials.js
@@ -17,6 +17,7 @@ import Emoji from "../../components/Emoji"
 import { Page, ButtonSecondary } from "../../components/SharedStyledComponents"
 
 import { getLocaleTimestamp, INVALID_DATETIME } from "../../utils/time"
+import { hasTutorials } from "../../utils/translations"
 
 const SubSlogan = styled.p`
   font-size: 20px;
@@ -201,7 +202,11 @@ const TutorialsPage = ({ data, pageContext }) => {
   console.log({ pageContext })
   // Filter tutorials by language and map to object
   const allTutorials = data.allTutorials.nodes
-    .filter((tutorial) => tutorial.frontmatter.lang === pageContext.language)
+    .filter((tutorial) =>
+      hasTutorials(pageContext.language)
+        ? tutorial.frontmatter.lang === pageContext.language
+        : tutorial.frontmatter.lang === "en"
+    )
     .map((tutorial) => ({
       to:
         tutorial.fields.slug.substr(0, 3) === "/en"

--- a/src/pages/developers/tutorials.js
+++ b/src/pages/developers/tutorials.js
@@ -199,7 +199,6 @@ const published = (locale, published) => {
 
 const TutorialsPage = ({ data, pageContext }) => {
   const intl = useIntl()
-  console.log({ pageContext })
   // Filter tutorials by language and map to object
   const allTutorials = data.allTutorials.nodes
     .filter((tutorial) =>
@@ -392,7 +391,6 @@ const TutorialsPage = ({ data, pageContext }) => {
           </ResultsContainer>
         )}
         {state.filteredTutorials.map((tutorial) => {
-          console.log(tutorial.published)
           return (
             <TutorialCard key={tutorial.to} to={tutorial.to}>
               <TitleContainer>

--- a/src/pages/developers/tutorials.js
+++ b/src/pages/developers/tutorials.js
@@ -189,8 +189,10 @@ const ModalTitle = styled.h2`
 const TutorialsPage = ({ data }) => {
   const intl = useIntl()
 
-  const allTutorials = data.allTutorials.nodes.map((tutorial) => {
-    return {
+  // Filter tutorials by language and map to object
+  const allTutorials = data.allTutorials.nodes
+    .filter((tutorial) => tutorial.frontmatter.lang === intl.locale)
+    .map((tutorial) => ({
       to:
         tutorial.fields.slug.substr(0, 3) === "/en"
           ? tutorial.fields.slug.substr(3)
@@ -202,9 +204,14 @@ const TutorialsPage = ({ data }) => {
       skill: tutorial.frontmatter.skill,
       timeToRead: tutorial.timeToRead,
       published: tutorial.frontmatter.published,
-    }
-  })
-  const allTags = data.allTags.group
+    }))
+
+  // Tally all subject tag counts
+  const tagsConcatenated = []
+  for (const tutorial of allTutorials) {
+    tagsConcatenated.push(...tutorial.tags)
+  }
+  const allTags = tagsConcatenated.map((tag) => ({ name: tag, totalCount: 1 }))
   const sanitizedAllTags = Array.from(
     allTags.reduce(
       (m, { name, totalCount }) =>
@@ -412,14 +419,9 @@ export const query = graphql`
           author
           skill
           published
+          lang
         }
         timeToRead
-      }
-    }
-    allTags: allMdx {
-      group(field: frontmatter___tags) {
-        name: fieldValue
-        totalCount
       }
     }
   }

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -1,12 +1,14 @@
 import { DateTime } from "luxon"
 
+export const INVALID_DATETIME = "Invalid DateTime"
+
 export const getLocaleTimestamp = (locale, timestamp) => {
   let localeTimestamp = DateTime.fromSQL(timestamp)
     .setLocale(locale)
     .toLocaleString(DateTime.DATE_FULL)
 
   // Fallback to ISO
-  if (localeTimestamp === "Invalid DateTime") {
+  if (localeTimestamp === INVALID_DATETIME) {
     localeTimestamp = DateTime.fromISO(timestamp)
       .setLocale(locale)
       .toLocaleString(DateTime.DATE_FULL)

--- a/src/utils/translations.js
+++ b/src/utils/translations.js
@@ -3,6 +3,15 @@ const languageMetadata = require("../data/translations.json")
 
 const supportedLanguages = Object.keys(languageMetadata)
 
+const hasTutorials = (lang) => {
+  const metadata = languageMetadata[lang]
+  if (!metadata) {
+    consoleError(`No metadata found for language: ${lang}`)
+    return
+  }
+  return metadata.hasTutorials
+}
+
 const consoleError = (message) => {
   const { NODE_ENV } = process.env
   if (NODE_ENV === "development") {
@@ -66,6 +75,7 @@ const translateMessageId = (id, intl) => {
 // Must export using ES5 to import in gatsby-node.js
 module.exports.languageMetadata = languageMetadata
 module.exports.supportedLanguages = supportedLanguages
+module.exports.hasTutorials = hasTutorials
 module.exports.getLangContentVersion = getLangContentVersion
 module.exports.getDefaultMessage = getDefaultMessage
 module.exports.isLangRightToLeft = isLangRightToLeft

--- a/src/utils/translations.js
+++ b/src/utils/translations.js
@@ -9,7 +9,8 @@ const hasTutorials = (lang) => {
     consoleError(`No metadata found for language: ${lang}`)
     return
   }
-  return metadata.hasTutorials
+  // Tutorials are included in v2.2: https://crowdin.com/project/ethereumfoundation/settings#files
+  return metadata.version >= 2.2
 }
 
 const consoleError = (message) => {


### PR DESCRIPTION
## Description
- Filters `allTutorials` by lang locale when going to `/{lang}/developers/tutorials` 
- Added work-around to create `allTags` object from the above filtered tutorials list, as pulling via graphql did not allow differentiating tags coming from tutorials of foreign languages.

## Related Issue
#2584