### PR TITLE
Fixed the link to the JSON RPC interface

### DIFF
--- a/src/content/developers/docs/programming-languages/index.md
+++ b/src/content/developers/docs/programming-languages/index.md
@@ -29,5 +29,5 @@ Select your language of choice to find projects, resources, and virtual communit
 If you want to link to resources or point to a virtual community for an additional programming language you can request a new page by [opening an issue](https://github.com/ethereum/ethereum-org-website/issues/new/choose).
 
 If you just want to write code to interface with the blockchain using a currently unsupported language
-you can use the [JSON-RPC interface](/en/developers/docs/apis/json-rpc/) to connect to the Ethereum network. Any programming 
+you can use the [JSON-RPC interface](/developers/docs/apis/json-rpc/) to connect to the Ethereum network. Any programming 
 language that can use TCP/IP can use this interface.

--- a/src/content/developers/docs/programming-languages/index.md
+++ b/src/content/developers/docs/programming-languages/index.md
@@ -29,5 +29,5 @@ Select your language of choice to find projects, resources, and virtual communit
 If you want to link to resources or point to a virtual community for an additional programming language you can request a new page by [opening an issue](https://github.com/ethereum/ethereum-org-website/issues/new/choose).
 
 If you just want to write code to interface with the blockchain using a currently unsupported language
-you can use the [JSON-RPC interface](/developers/docs/apis/json-rpc/endpoints/) to connect to the Ethereum network. Any programming 
+you can use the [JSON-RPC interface](/en/developers/docs/apis/json-rpc/) to connect to the Ethereum network. Any programming 
 language that can use TCP/IP can use this interface.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The link in the page led to a 404 error instead of https://ethereum.org/en/developers/docs/apis/json-rpc/

## Related Issue

#2222 