### PR TITLE
Remove serif font from home page

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -379,7 +379,6 @@ const H2 = styled.h2`
 
 const StyledH2 = styled.h2`
   margin-bottom: 0.5rem;
-  font-family: serif;
   @media (max-width: ${(props) => props.theme.breakpoints.s}) {
     font-size: 24px;
   }


### PR DESCRIPTION
## Description

Currently the `h2` elements on the home page (e.g. `What is Ethereum?`, `A fairer financial system`) have the CSS property `font-family: serif` applied. I thought this was a little strange as this font is not used anywhere else throughout the site and all other headings use the system-ui font (which is applied on the body). 

This PR removes this CSS property to keep all heading font families consistent.

## Related Issue

https://github.com/ethereum/ethereum-org-website/issues/2636