### PR TITLE
typo in docs, intenal -> internal

### DIFF
--- a/src/content/developers/docs/smart-contracts/anatomy/index.md
+++ b/src/content/developers/docs/smart-contracts/anatomy/index.md
@@ -84,7 +84,7 @@ In the most simplistic terms, functions can get information or set information i
 There are two types of function calls:
 
 - `internal` – these don't create an EVM call
-  - Intenal functions and state variables can only be accessed internally (i.e. from within the current contract or contracts deriving from it)
+  - Internal functions and state variables can only be accessed internally (i.e. from within the current contract or contracts deriving from it)
 - `external` – these do create an EVM call
   - External functions are part of the contract interface, which means they can be called from other contracts and via transactions. An external function `f` cannot be called internally (i.e. `f()` does not work, but `this.f()` works).
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There is a typo in official ethereum documentation. 
I currently learning ethereum and going through the docs and found this small typo

