### PR TITLE
add css rule to Aside component to address vertical height bug #2583…

### DIFF
--- a/src/components/Eth2TableOfContents.js
+++ b/src/components/Eth2TableOfContents.js
@@ -9,7 +9,7 @@ const Aside = styled.aside`
   padding: 0rem;
   text-align: right;
   margin-bottom: 2rem;
-  overflow: scroll;
+  overflow-y: auto;
 `
 
 const OuterList = styled(motion.ul)`

--- a/src/components/Eth2TableOfContents.js
+++ b/src/components/Eth2TableOfContents.js
@@ -9,6 +9,7 @@ const Aside = styled.aside`
   padding: 0rem;
   text-align: right;
   margin-bottom: 2rem;
+  overflow: scroll;
 `
 
 const OuterList = styled(motion.ul)`


### PR DESCRIPTION
Added 'overflow-y: auto' CSS rule to the Styled Aside component in Eth2TableOfContents.js to attempt to address the vertical height bug flagged in #2583 

## Description

Unsure if this is what you guys had in mind. Saw this open issue a few days ago and decided to give it a go. Rather simple fix, but on sufficiently short screens, a scrollbar is now visible on the left-hand Aside component, and disappears on taller viewports. I only saw today prior to this PR that it had been assigned to @NilsKaden ... apologies if we doubled work, or if someone else had a different/better fix.

https://user-images.githubusercontent.com/4992682/111256600-d01a6200-85ef-11eb-9d40-fb1e9df25de0.mp4

## Related Issue

#2583
