### PR TITLE
Updating broken link for eth2 news (intl versions)

### DIFF
--- a/src/content/translations/ar/learn/index.md
+++ b/src/content/translations/ar/learn/index.md
@@ -24,7 +24,7 @@ sidebar: true
 - [Kauri](https://kauri.io) _المقالات الفنية والدروس الخاصة بإيثريوم والمشاريع ذات الصلة_
 - [ Ethereum Foundation YouTub](https://www.youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g)_مقاطع فيديو ونقاشات حول إيثريوم _
 - [Week in Ethereum News ](https://weekinethereumnews.com/)_نشرة إخبارية أسبوعية تغطي التطورات الرئيسية في النظام البيئي لإيثريوم_
-- [ما الجديد في ETH 2.0](https://notes.ethereum.org/c/Sk8Zs--CQ)_ نشرة إخبارية منتظمة حول تطور ETH 2.0_
+- [ما الجديد في ETH 2.0](https://eth2.news)_ نشرة إخبارية منتظمة حول تطور ETH 2.0_
 - [ethresear.ch forum](https://ethresear.ch/) _نقاشات فنية أعمق عن إيثريوم لـ ETH 2.0 وما بعده_
 - [ ETHGlobal](https://ethglobal.co)_ سلسلة مسابقات " هاكثون" خاصه بإيثريوم - شارك بالقريب منك_
 

--- a/src/content/translations/bn/learn/index.md
+++ b/src/content/translations/bn/learn/index.md
@@ -24,7 +24,7 @@ sidebar: true
 - [Kauri](https://kauri.io) _ইথেরিয়াম এবং সম্পর্কিত প্রকল্পগুলির জন্য প্রযুক্তিগত নিবন্ধ এবং টিউটোরিয়াল।_
 - [Ethereum Foundation YouTube](https://www.youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g) _ইথেরিয়াম সম্পর্কে ভিডিও এবং আলোচনা।_
 - [Week in Ethereum News](https://weekinethereumnews.com/) _ একটি সাপ্তাহিক নিউজলেটার যা ইকোসিস্টেম ব্যাপী প্রধান উন্নয়নগুলি সম্বন্ধে আলোচনা করে_
-- [What’s new in ETH 2.0](https://notes.ethereum.org/c/Sk8Zs--CQ)_ ETH 2.0 ডেভেলপমেন্ট সম্পর্কে একটি নিয়মিত নিউজলেটার_
+- [What’s new in ETH 2.0](https://eth2.news)_ ETH 2.0 ডেভেলপমেন্ট সম্পর্কে একটি নিয়মিত নিউজলেটার_
 - [ethresear.ch forum](https://ethresear.ch/) _ETH 2.0 এবং এর বাইরেও ইথেরিয়ামের উপর গভীর প্রযুক্তিগত আলোচনা_
 - [ETHGlobal](https://ethglobal.co) _একটি ইথেরিয়াম হ্যাকাথন সিরিজ - আপনার কাছের সিরিজে উপস্থিত থাকুন!_
 

--- a/src/content/translations/cs/learn/index.md
+++ b/src/content/translations/cs/learn/index.md
@@ -25,7 +25,7 @@ Kromě zdrojů uvedených na této stránce stojí za pozornost řada dalších 
 - [Kauri](https://kauri.io) _Technické články a návody pro Ethereum a související projekty_
 - [Ethereum Foundation YouTube](https://www.youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g) _Videa a rozhovory o Ethereu_
 - [Week in Ethereum News](https://weekinethereumnews.com/) _Týdenní newsletter o stěžejních novinkách ve vývoji Etherea_
-- [What’s new in ETH 2.0](https://notes.ethereum.org/c/Sk8Zs--CQ) _Pravidelný newsletter o vývoji ETH 2.0_
+- [What’s new in ETH 2.0](https://eth2.news) _Pravidelný newsletter o vývoji ETH 2.0_
 - [ethresear.ch forum](https://ethresear.ch/) _Hlubší technické diskuze o Ethereu pro ETH 2.0 a dále_
 - [ETHGlobal](https://ethglobal.co) _Ethereum hackathon – zúčastněte se ve vašem okolí!_
 

--- a/src/content/translations/de/learn/index.md
+++ b/src/content/translations/de/learn/index.md
@@ -24,7 +24,7 @@ Neben den Informationen auf dieser Seite gibt es viele von der Community erstell
 - [Kauri](https://kauri.io): _technische Artikel und Tutorials für Ethereum und verwandte Projekte_
 - [Ethereum Foundation YouTube](https://www.youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g): _Videos und Vorträge über Ethereum_
 - [Week in Ethereum News](https://weekinethereumnews.com/): _ein wöchentlicher Newsletter zu wichtigen Entwicklungen im gesamten Ökosystem_
-- [What’s new in ETH 2.0](https://notes.ethereum.org/c/Sk8Zs--CQ): _ein regelmäßiger Newsletter über ETH 2.0-Entwicklungsfortschritte_
+- [What’s new in ETH 2.0](https://eth2.news): _ein regelmäßiger Newsletter über ETH 2.0-Entwicklungsfortschritte_
 - [ethresear.ch forum](https://ethresear.ch/) _Tiefergehende technische Diskussionen über Ethereum für ETH 2.0 und darüber hinaus_
 - [ETHGlobal](https://ethglobal.co): _eine Ethereum-Hackkathon-Serie – besuche einen Hackkathon in deiner Nähe!_
 

--- a/src/content/translations/el/learn/index.md
+++ b/src/content/translations/el/learn/index.md
@@ -22,7 +22,7 @@ sidebar: true
 - [Kauri](https://kauri.io) _Τεχνικά άρθρα και σεμινάρια για το Ethereum και σχετικά projects_
 - [Ethereum Foundation YouTube](https://www.youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g) _Βίντεο και συνομιλίες για το Ethereum_
 - [Week in Ethereum News](https://weekinethereumnews.com/) _Ένα εβδομαδιαίο ενημερωτικό δελτίο που καλύπτει τις βασικές εξελίξεις σε ολόκληρο το οικοσύστημα_
-- [What’s new in ETH 2.0](https://notes.ethereum.org/c/Sk8Zs--CQ) _Ένα τακτικό ενημερωτικό δελτίο για την ανάπτυξη του ETH 2.0_
+- [What’s new in ETH 2.0](https://eth2.news) _Ένα τακτικό ενημερωτικό δελτίο για την ανάπτυξη του ETH 2.0_
 - [ETHGlobal](https://ethglobal.co) _Μία σειρά Ethereum hackathon - παρακολουθήστε ένα κοντά σας!_
 
 ## Τα βασικά του Ethereum {#ethereum-basics}

--- a/src/content/translations/es/learn/index.md
+++ b/src/content/translations/es/learn/index.md
@@ -25,7 +25,7 @@ Además de la información en esta página, hay muchos recursos creados por la c
 - [Kauri](https://kauri.io) _Artículos técnicos y tutoriales para Ethereum y proyectos relacionados_
 - [YouTube de Ethereum Foundation](https://www.youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g) _Charlas y vídeos sobre Ethereum_
 - [Week in Ethereum News](https://weekinethereumnews.com/) _Un boletín semanal que cubre los desarrollos clave en todo el ecosistema_
-- [What’s new in ETH 2.0](https://notes.ethereum.org/c/Sk8Zs--CQ) _Un boletín regular sobre el desarrollo de ETH 2.0_
+- [What’s new in ETH 2.0](https://eth2.news) _Un boletín regular sobre el desarrollo de ETH 2.0_
 - [ethresear.ch forum](https://ethresear.ch/) _Discusiones más técnicas sobre Ethereum para ETH 2.0 y versiones más recientes._
 - [ETHGlobal](https://ethglobal.co) _Una serie de hackatones de Ethereum: ¡participa en el más cercano!_
 

--- a/src/content/translations/fa/learn/index.md
+++ b/src/content/translations/fa/learn/index.md
@@ -28,7 +28,7 @@ sidebar: true
   _گفتگو‌ها و ویدیو‌ها درباره اتریوم_
 - [Week in Ethereum News](https://weekinethereumnews.com/)
   _یک خبرنامه هفتگی درباره توسعه‌های اکوسیستم_
-- [What’s new in ETH 2.0](https://notes.ethereum.org/c/Sk8Zs--CQ)
+- [What’s new in ETH 2.0](https://eth2.news)
   _یک خبرنامه درباره توسعه ETH 2.0_
 - [ethresear.ch forum](https://ethresear.ch/)
   _مباحث فنی عمیق‌تر در اتریوم برای ETH 2.0 و ماورای آن_

--- a/src/content/translations/fi/learn/index.md
+++ b/src/content/translations/fi/learn/index.md
@@ -25,7 +25,7 @@ Tämän sivun lisäksi saatavilla on useita yhteisön luomia resursseja, jotka o
 - [Kauri](https://kauri.io) _Teknillisiä artikkeleja ja oppaita Ethereumiin ja siihen liittyviin projekteihin_
 - [Ethereum Foundation YouTube](https://www.youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g) _Videoita ja esityksiä Ethereumista_
 - [Week in Ethereum News](https://weekinethereumnews.com/) _Viikottainen uutiskirje, joka käsittelee ekosysteemin avainkehityksiä_
-- [What’s new in ETH 2.0](https://notes.ethereum.org/c/Sk8Zs--CQ) _Säännöllinen uutiskirje ETH 2.0:n kehityksestä_
+- [What’s new in ETH 2.0](https://eth2.news) _Säännöllinen uutiskirje ETH 2.0:n kehityksestä_
 - [ethresear.ch forum](https://ethresear.ch/) _Syvempiä teknisiä keskusteluja Ethereumista, ETH 2.0:sta ja muusta aiheeseen liittyvästä_
 - [ETHGlobal](https://ethglobal.co) _Ethereumin hackathon-sarja - liity itsekin lähimpään!_
 

--- a/src/content/translations/fr/learn/index.md
+++ b/src/content/translations/fr/learn/index.md
@@ -24,7 +24,7 @@ En plus des informations figurant sur cette page, de nombreuses ressources déve
 - [Kauri](https://kauri.io) _Articles techniques et tutoriels pour Ethereum et les projets connexes_
 - [Ethereum Foundation YouTube](https://www.youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g) _Vidéos et discussions à propos d'Ethereum_
 - [Actualité hebdomadaire d'Ethereum](https://weekinethereumnews.com/) _Un bulletin hebdomadaire couvrant les principaux développements sur l'écosystème _
-- [Quoi de neuf pour ETH 2.0](https://notes.ethereum.org/c/Sk8Zs--CQ) _Une lettre d'information régulière concernant l'évolution d'ETH 2.0_
+- [Quoi de neuf pour ETH 2.0](https://eth2.news) _Une lettre d'information régulière concernant l'évolution d'ETH 2.0_
 - [ethresear.ch forum](https://ethresear.ch/) _Des discussions techniques approfondies sur Ethereum pour ETH 2.0 et au-delà_
 - [ETHGlobal](https://ethglobal.co) _Une série de hackathons Ethereum - près de chez vous&nbsp;!_
 

--- a/src/content/translations/hu/learn/index.md
+++ b/src/content/translations/hu/learn/index.md
@@ -25,7 +25,7 @@ Ezen az oldalon található információk mellett számos, közösség által k�
 - [Kauri](https://kauri.io) _Technikai cikkek és útmutatók Ethereumról és kapcsolódó projektekről_
 - [Ethereum Foundation YouTube](https://www.youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g) _Videók és beszélgetések Ethereumról_
 - [Week in Ethereum News](https://weekinethereumnews.com/) _Egy heti rendszerességű hírlevél, mely összefoglalja a legfontosabb fejlesztéseket az ökoszisztémán keresztül_
-- [What’s new in ETH 2.0](https://notes.ethereum.org/c/Sk8Zs--CQ) _Egy rendszeres hírlevél az ETH 2.0 fejlesztéséről_
+- [What’s new in ETH 2.0](https://eth2.news) _Egy rendszeres hírlevél az ETH 2.0 fejlesztéséről_
 - [ethresear.ch forum](https://ethresear.ch/) _Mélyebb technikai beszélgetések Ethereumról az ETH 2.0 szempontjából és azontúl_
 - [ETHGlobal](https://ethglobal.co) _Egy Ethereum hackathon sorozat - vegyél részt a hozzád legközelebb eső helyen!_
 

--- a/src/content/translations/id/learn/index.md
+++ b/src/content/translations/id/learn/index.md
@@ -24,7 +24,7 @@ Selain informasi yang tersedia di halaman ini, masih banyak lagi sumber informas
 - [Kauri](https://kauri.io) _Artikel teknis dan tutorial untuk Ethereum dan proyek terkait_
 - [Kanal Youtube Ethereum Foundation YouTube](https://www.youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g) _Video informasi dan seminar tentang Ethereum_
 - [Week in Ethereum News](https://weekinethereumnews.com/) _Sebuah newsletter yang memberitakan tentang perkembangan inti yang terjadi di ekosistem Ethereum_
-- [What’s new in ETH 2.0](https://notes.ethereum.org/c/Sk8Zs--CQ) _Sebuah newsletter yang memberitakan tentang perkembangan ETH 2.0_
+- [What’s new in ETH 2.0](https://eth2.news) _Sebuah newsletter yang memberitakan tentang perkembangan ETH 2.0_
 - [ethresear.ch forum](https://ethresear.ch/) _Diskusi teknis yang lebih dalam mengenai Ethereum untuk ETH 2.0 dan rencana di masa depan_
 - [ETHGlobal](https://ethglobal.co) _Hackathon bertema Ethereum yang diadakan di berbagai kota di seluruh dunia - kunjungi yang paling dekat dengan kotamu!_
 

--- a/src/content/translations/ig/learn/index.md
+++ b/src/content/translations/ig/learn/index.md
@@ -22,7 +22,7 @@ Na mgbakwunye na ozi dị na peeji a, enwere ọtụtụ ihe enyere obodo aka kw
 - [Kauri](https://kauri.io) _Ederede nka na ụzụ na nkuzi maka Ethereum na arụmaoru metụtara ya_
 - [Mmepe Ethereum na YouTube](https://www.youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g) _Vidio na okwu banyere Ethereum_
 - [Izu uka na Akụkọ uwa Ethereum ](https://weekinethereumnews.com/)_Akwụkwọ akụkọ uwa izu nke na-ekpuchi mmepe di mkpa gafere ihe di ndu n' ebe obibi_
-- [Kedu ihe dị ọhụrụ na ETH 2.0](https://notes.ethereum.org/c/Sk8Zs--CQ) _Akwụkwọ akụkọ uwa mgbe niile gbasara mmepe ETH 2.0_
+- [Kedu ihe dị ọhụrụ na ETH 2.0](https://eth2.news) _Akwụkwọ akụkọ uwa mgbe niile gbasara mmepe ETH 2.0_
 - [ETHGlobal](https://ethglobal.co) _Usoro Ethereum hackathon -gaa otu nke dị gị nso!_
 
   ## Ethereum kachasi mkpa {#ethereum-basics}

--- a/src/content/translations/it/learn/index.md
+++ b/src/content/translations/it/learn/index.md
@@ -25,7 +25,7 @@ Oltre alle informazioni su questa pagina, le seguenti risorse realizzate da memb
 - [Kauri](https://kauri.io) _Articoli tecnici e tutorial per Ethereum e progetti correlati_
 - [Canale Youtube della Fondazione Ethereum](https://www.youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g) _Raccolta di video e interviste su Ethereum_
 - [Week in Ethereum News](https://weekinethereumnews.com/) _Newsletter settimanale che copre le principali novità dell'ecosistema_
-- [What’s new in ETH 2.0](https://notes.ethereum.org/c/Sk8Zs--CQ) _Newsletter a frequenza regolare sui nuovi sviluppi di ETH 2.0_
+- [What’s new in ETH 2.0](https://eth2.news) _Newsletter a frequenza regolare sui nuovi sviluppi di ETH 2.0_
 - [ethresear.ch forum](https://ethresear.ch/) _Discussioni tecniche approfondite su Ethereum per ETH 2.0 e non solo_
 - [ETHGlobal](https://ethglobal.co) _Serie di hackathon. Partecipa a uno nella tua zona!_
 

--- a/src/content/translations/ja/learn/index.md
+++ b/src/content/translations/ja/learn/index.md
@@ -25,7 +25,7 @@ sidebarDepth: 1
 - [Kauri](https://kauri.io) _イーサリアムと関連プロジェクトに関する技術記事とチュートリアル_
 - [Ethereum Foundation YouTube](https://www.youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g) _イーサリアムに関するビデオとプレゼンテーション_
 - [Week in Ethereum News](https://weekinethereumnews.com/) _エコシステム全体の開発を取り扱うウィークリーニュースレター_
-- [What’s new in ETH 2.0](https://notes.ethereum.org/c/Sk8Zs--CQ) _ETH 2.0 の開発状況に関する定期ニュースレター_
+- [What’s new in ETH 2.0](https://eth2.news) _ETH 2.0 の開発状況に関する定期ニュースレター_
 - [ethresear.ch forum](https://ethresear.ch/) _ETH 2.0 以降の Ethereum に関する深い技術的なディスカッション_
 - [ETHGlobal](https://ethglobal.co) _イーサリアムハッカソン - 近くで開催されるハッカソンに出場してみては?!_
 

--- a/src/content/translations/ko/learn/index.md
+++ b/src/content/translations/ko/learn/index.md
@@ -25,7 +25,7 @@ sidebarDepth: 1
 - [Kauri](https://kauri.io) _이더리움과 관련 프로젝트에 대한 기술적 자료와 튜토리얼 제공_
 - [Ethereum Foundation YouTube](https://www.youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g) _이더리움에 대한 영상 자료 제공_
 - [Week in Ethereum News](https://weekinethereumnews.com/) _이더리움 생태계의 주요 발전 사항을 전해주는 주간 뉴스레터 서비스 제공_
-- [What’s new in ETH 2.0](https://notes.ethereum.org/c/Sk8Zs--CQ) _ETH 2.0의 개발 사항에 대해 주기적인 뉴스레터 제공_
+- [What’s new in ETH 2.0](https://eth2.news) _ETH 2.0의 개발 사항에 대해 주기적인 뉴스레터 제공_
 - [ethresear.ch forum](https://ethresear.ch/) _ETH 2.0 이상에 대한 상세한 기술적 논의_
 - [ETHGlobal](https://ethglobal.co) _이더리움 해커톤 시리즈 - 가까운 곳에서 진행되는 해커톤에 참여해보세요!_
 

--- a/src/content/translations/lt/learn/index.md
+++ b/src/content/translations/lt/learn/index.md
@@ -25,7 +25,7 @@ Be šiame puslapyje pateikiamos informacijos yra kitų bendruomenės sukurtų i�
 - [Kauri](https://kauri.io) _Techniniai straipsniai ir mokymo programos Ethereum ir susijusiems projektams_
 - [Ethereum Foundation YouTube](https://www.youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g) _Vaizdo įrašai ir paskaitos apie Ethereum_
 - [Week in Ethereum News](https://weekinethereumnews.com/) _Savaitinis informacinis biuletenis, apimantis pagrindinius ekosistemos pokyčius_
-- [What’s new in ETH 2.0](https://notes.ethereum.org/c/Sk8Zs--CQ) _Reguliarusis informacinis biuletenis apie ETH 2.0 vystymą_
+- [What’s new in ETH 2.0](https://eth2.news) _Reguliarusis informacinis biuletenis apie ETH 2.0 vystymą_
 - [ethresear.ch forum](https://ethresear.ch/) _Gilesnės techninės diskusijos apie Ethereum, skirtą ETH 2.0 ir vėlesnėms versijoms_
 - [ETHGlobal](https://ethglobal.co) _Ethereum hakatonai – apsilankyk viename iš jų netoli savo namų!_
 

--- a/src/content/translations/ml/learn/index.md
+++ b/src/content/translations/ml/learn/index.md
@@ -24,7 +24,7 @@ sidebar: true
 - [Kauri](https://kauri.io) _ Ethereum-നും അനുബന്ധ പ്രോജക്റ്റുകൾക്കുമായുള്ള സാങ്കേതിക ലേഖനങ്ങളും ട്യൂട്ടോറിയലുകളും _
 - [ Ethereum Foundation YouTube ](https://www.youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g) _ വീഡിയോകളും Ethereum-നെ കുറിച്ചുള്ള സംസാരവും _
 - [ Ethereum വാർത്തയിലെ ആഴ്ച ](https://weekinethereumnews.com/) ആവാസവ്യവസ്ഥയിലുടനീളമുള്ള പ്രധാന സംഭവവികാസങ്ങൾ ഉൾക്കൊള്ളുന്ന പ്രതിവാര വാർത്താക്കുറിപ്പ്
-- [ ETH 2.0- ൽ പുതിയതെന്താണ് ](https://notes.ethereum.org/c/Sk8Zs--CQ) ETH 2.0 വികസനത്തെക്കുറിച്ചുള്ള ഒരു പതിവ് വാർത്താക്കുറിപ്പ്
+- [ ETH 2.0- ൽ പുതിയതെന്താണ് ](https://eth2.news) ETH 2.0 വികസനത്തെക്കുറിച്ചുള്ള ഒരു പതിവ് വാർത്താക്കുറിപ്പ്
 - [ ethresear.ch ഫോറം ](https://ethresear.ch/) _ ETH 2.0 നും അതിനുമുകളിലുള്ള Ethereum നെക്കുറിച്ചും ആഴത്തിലുള്ള സാങ്കേതിക ചർച്ചകൾ _
 - [ ETHGlobal ](https://ethglobal.co) _ ഒരു Ethereum hackathon series - നിങ്ങളുടെ അടുത്തുള്ള ഒരെണ്ണത്തിൽ പങ്കെടുക്കുക! _
 

--- a/src/content/translations/nb/learn/index.md
+++ b/src/content/translations/nb/learn/index.md
@@ -24,7 +24,7 @@ I tillegg til informasjonen på denne siden er det mange samfunnsutviklede ressu
 - [Kauri](https://kauri.io) _Tekniske artikler og opplæringsprogrammer for Ethereum og relaterte prosjekter _
 - [Ethereum Foundation YouTube](https://www.youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g) _Videoer og samtaler om Ethereum _
 - [Week in Ethereum News](https://weekinethereumnews.com/) _ukentlig nyhetsbrev som dekker viktige utviklinger i økosystemet _
-- [What’s new in ETH 2.0](https://notes.ethereum.org/c/Sk8Zs--CQ) _Et vanlig nyhetsbrev om ETH 2.0-utvikling _
+- [What’s new in ETH 2.0](https://eth2.news) _Et vanlig nyhetsbrev om ETH 2.0-utvikling _
 - [ethresear.ch forum](https://ethresear.ch/) _Dypere tekniske diskusjoner om Ethereum for ETH 2.0 og utover _
 - [ETHGlobal](https://ethglobal.co) _En Ethereum hackathon-serie - delta på en i nærheten! _
 

--- a/src/content/translations/nl/learn/index.md
+++ b/src/content/translations/nl/learn/index.md
@@ -22,7 +22,7 @@ Naast de informatie op deze pagina zijn er bronnen uit de community die het verk
 - [Kauri](https://kauri.io) _Technische artikelen en tutorials voor Ethereum en gerelateerde projecten_
 - [Ethereum Foundation YouTube](https://www.youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g) _Video's and presentaties over Ethereum_
 - [Week in Ethereum News](https://weekinethereumnews.com/) _Een wekelijkse nieuwsbrief over belangrijke ontwikkelingen in het ecosysteem_
-- [What’s new in ETH 2.0](https://notes.ethereum.org/c/Sk8Zs--CQ) _Een periodieke nieuwsbrief over de ontwikkeling van ETH 2.0_
+- [What’s new in ETH 2.0](https://eth2.news) _Een periodieke nieuwsbrief over de ontwikkeling van ETH 2.0_
 - [ETHGlobal](https://ethglobal.co) _Ethereum-hackathons: bezoek er eentje in je buurt!_
 
 ## De basisprincipes van Ethereum {#ethereum-basics}

--- a/src/content/translations/pl/learn/index.md
+++ b/src/content/translations/pl/learn/index.md
@@ -22,7 +22,7 @@ Oprócz informacji zawartych na tej stronie istnieje wiele zasobów stworzonych 
 - [Kauri](https://kauri.io) _Technical articles and tutorials for Ethereum and related projects_
 - [Ethereum Foundation YouTube](https://www.youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g) _Videos and talks about Ethereum_
 - [Week in Ethereum News](https://weekinethereumnews.com/) _A weekly newsletter covering key developments across the ecosystem_
-- [What’s new in ETH 2.0](https://notes.ethereum.org/c/Sk8Zs--CQ) _A regular newsletter about ETH 2.0 development_
+- [What’s new in ETH 2.0](https://eth2.news) _A regular newsletter about ETH 2.0 development_
 - [ETHGlobal](https://ethglobal.co) _An Ethereum hackathon series - attend one near you!_
 
 ## Podstawy Ethereum {#ethereum-basics}

--- a/src/content/translations/pt-br/learn/index.md
+++ b/src/content/translations/pt-br/learn/index.md
@@ -25,7 +25,7 @@ Além das informações nesta página, há muitos recursos construídos pela com
 - [Kauri](https://kauri.io) _Artigos técnicos e tutoriais para Ethereum e projetos relacionados_
 - [Fundação Ethereum YouTube](https://www.youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g) _Vídeos e palestras sobre Ethereum_
 - [Week in Ethereum News](https://weekinethereumnews.com/) _Uma newsletter semanal cobrindo os principais desenvolvimentos do ecossistema como um todo_
-- [What’s new in ETH 2.0](https://notes.ethereum.org/c/Sk8Zs--CQ) _Um boletim de notícias regular sobre o desenvolvimento do ETH 2.0_
+- [What’s new in ETH 2.0](https://eth2.news) _Um boletim de notícias regular sobre o desenvolvimento do ETH 2.0_
 - [ethresear.ch forum](https://ethresear.ch/) _Discussões mais profundas sobre Ethereum para ETH 2.0 e além_
 - [ETHGlobal](https://ethglobal.co) _Uma série global de hackathons sobre Ethereum - Veja uma perto de você!_
 

--- a/src/content/translations/pt/learn/index.md
+++ b/src/content/translations/pt/learn/index.md
@@ -23,7 +23,7 @@ Além das informações nesta página, há muitos recursos construídos pela com
 - [Kauri](https://kauri.io) _Artigos técnicos e tutoriais para Ethereum e projetos relacionados_
 - [Youtube da Fundação Ethereum](https://www.youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g) _Vídeos e palestras sobre o Ethereum_
 - [Semanário de Notícias sobre o Ethereum](https://weekinethereumnews.com/) _Newsletter semanal sobre desenvolvimentos fundamentais em todo o ecossistema_
-- [O que há de novo no ETH 2.0](https://notes.ethereum.org/c/Sk8Zs--CQ) _Newsletter regular sobre o desenvolvimento em ETH 2.0_
+- [O que há de novo no ETH 2.0](https://eth2.news) _Newsletter regular sobre o desenvolvimento em ETH 2.0_
 - [ethresear.ch forum](https://ethresear.ch/) _Disussões mais profundas sobre Ethereum para ETH 2.0 e além_
 - [ETHGlobal](https://ethglobal.co) _Uma série de hackathons do Ethereum - participe num perto de si!_
 

--- a/src/content/translations/ro/learn/index.md
+++ b/src/content/translations/ro/learn/index.md
@@ -24,7 +24,7 @@ Pe lângă informațiile din această pagină, există multe resurse generate de
 - [Kauri](https://kauri.io) _Articole tehnice și tutoriale despre Ethereum și proiecte conexe_
 - [Ethereum Foundation YouTube](https://www.youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g) _Videoclipuri și prezentări despre Ethereum_
 - [Week in Ethereum News](https://weekinethereumnews.com/) _Un newsletter săptămânal ce acoperă principalele evoluții din ecosistem_
-- [What's new in ETH 2.0](https://notes.ethereum.org/c/Sk8Zs--CQ) _Un newsletter periodic despre dezvoltarea ETH 2.0_
+- [What's new in ETH 2.0](https://eth2.news) _Un newsletter periodic despre dezvoltarea ETH 2.0_
 - [ethresear.ch forum](https://ethresear.ch/) _Discuții tehnice avansate despre Ethereum în perspectiva ETH 2.0 și mai departe_
 - [ETHGlobal](https://ethglobal.co) _O serie de hackathoane Ethereum - participă la unul din zona ta!_
 

--- a/src/content/translations/ru/learn/index.md
+++ b/src/content/translations/ru/learn/index.md
@@ -22,7 +22,7 @@ sidebar: true
 - [Kauri](https://kauri.io) _Технические статьи и руководства по Ethereum и связанным с ним проектам_
 - [YouTube Ethereum Foundation](https://www.youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g) _Видео и выступления о Ethereum_
 - [Week in Ethereum News](https://weekinethereumnews.com/) _Еженедельный бюллетень, охватывающий ключевые события в экосистеме_
-- [What’s new in ETH 2.0](https://notes.ethereum.org/c/Sk8Zs--CQ) _Периодический информационный бюллетень о разработке ETH 2.0_
+- [What’s new in ETH 2.0](https://eth2.news) _Периодический информационный бюллетень о разработке ETH 2.0_
 - [ETHGlobal](https://ethglobal.co) _Перечень хакатонов по Ethereum – посетите один из них рядом с вами!_
 
 ## Основы Ethereum {#ethereum-basics}

--- a/src/content/translations/se/learn/index.md
+++ b/src/content/translations/se/learn/index.md
@@ -24,7 +24,7 @@ Dessutom finns det många gemenskapsbyggda resurser som är värda att utforska:
 - [Kauri](https://kauri.io) _Tekniska artiklar och handledningar för Ethereum och närliggande projekt_
 - [Ethereum Foundation YouTube](https://www.youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g) _Videor och presentationer om Ethereum_
 - [Week in Ethereum News](https://weekinethereumnews.com/) _Ett veckovis nyhetsbrev angående viktiga utvecklingar vad gäller ekosystemet_
-- [What’s new in ETH 2.0](https://notes.ethereum.org/c/Sk8Zs--CQ) _Ett regelbundet nyhetsbrev om ETH 2.0-utvecklingen_
+- [What’s new in ETH 2.0](https://eth2.news) _Ett regelbundet nyhetsbrev om ETH 2.0-utvecklingen_
 - [ethresear.ch forum](https://ethresear.ch/) _Tekniska diskussioner om Ethereum för ETH 2.0 och mer_
 - [ETHGlobal](https://ethglobal.co) _An Ethereum-backad hackatonserie - delta i en nära dig!_
 

--- a/src/content/translations/sk/learn/index.md
+++ b/src/content/translations/sk/learn/index.md
@@ -24,7 +24,7 @@ Okrem informácií uvedených na tejto stránke existuje množstvo zaujímavých
 - [Kauri](https://kauri.io) _Technické články a návody pre Ethereum a súvisiace projekty_
 - [Ethereum Foundation YouTube](https://www.youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g) _Videá, prednášky a rozhovory o Ethereu_
 - [Week in Ethereum News](https://weekinethereumnews.com/) _Týždenný newsletter o kľúčových novinkách vo vývoji Etherea_
-- [What’s new in ETH 2.0](https://notes.ethereum.org/c/Sk8Zs--CQ) _Pravidelný newsletter o vývoji Etherea 2.0_
+- [What’s new in ETH 2.0](https://eth2.news) _Pravidelný newsletter o vývoji Etherea 2.0_
 - [ethresear.ch forum](https://ethresear.ch/) _Hlbšie technické diskusie o Ethereu pre ETH 2.0 a ďalšie roky_
 - [ETHGlobal](https://ethglobal.co) _Séria hackathonov Etherea - zúčastnite sa jedného vo vašom okolí!_
 

--- a/src/content/translations/sl/learn/index.md
+++ b/src/content/translations/sl/learn/index.md
@@ -22,7 +22,7 @@ Poleg informacij na tej strani je še veliko virov, ki jih je pripravila skupnos
 - [Kauri](https://kauri.io) _Tehnični članki in vodiči za Ethereum in sorodne projekte_
 - [Ethereum Foundation YouTube](https://www.youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g) _Videoposnetki in predavanja o Ethereumu_
 - [Week in Ethereum News](https://weekinethereumnews.com/) _Tedenski novičnik, ki pokriva ključne dogodke v ekosistemu Ethereum_
-- [What’s new in ETH 2.0](https://notes.ethereum.org/c/Sk8Zs--CQ) _Reden novičnik o razvoju ETH 2.0_
+- [What’s new in ETH 2.0](https://eth2.news) _Reden novičnik o razvoju ETH 2.0_
 - [ETHGlobal](https://ethglobal.co) _Serija hackathonov za Ethereum – udeležite se kakšnega v bližini!_
 
 ## Osnove Ethereuma {#ethereum-basics}

--- a/src/content/translations/tr/learn/index.md
+++ b/src/content/translations/tr/learn/index.md
@@ -24,7 +24,7 @@ Bu sayfadaki bilgilere ek olarak, araştırılmaya değer birçok topluluk taraf
 - [Kauri](https://kauri.io)_Ethereum ve ilgili projeler için teknik makaleler ve öğretici bilgiler_
 - [Ethereum Foundation YouTube kanalı ](https://www.youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g) _Videolar ve Ethereum hakkında konuşuyor_
 - [Haftalık Ethereum hakkında yeni haberler](https://weekinethereumnews.com/) _ Ekosistemdeki önemli gelişmeleri içeren haftalık bir bülten_
-- [ETH 2.0'daki yenilikler](https://notes.ethereum.org/c/Sk8Zs--CQ) _ETH 2.0 gelişimi hakkında bir bülten_
+- [ETH 2.0'daki yenilikler](https://eth2.news) _ETH 2.0 gelişimi hakkında bir bülten_
 - [ethresear.ch forum](https://ethresear.ch/) _ETH 2.0 ve sonrası için Ethereum hakkında daha derin teknik tartışmalar_
 - [ETHGlobal](https://ethglobal.co) _Bir Ethereum hackathon serisi - yakınınızdaki birine katılın!_
 

--- a/src/content/translations/uk/learn/index.md
+++ b/src/content/translations/uk/learn/index.md
@@ -25,7 +25,7 @@ sidebarDepth: 1
 - [Kauri](https://kauri.io) _Технічні статті та навчальні посібники з Ethereum і пов'язані проекти_
 - [Ethereum Foundation YouTube](https://www.youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g) _Відеоматеріали та дискусії про Ethereum_
 - [Щотижневі новини Ethereum](https://weekinethereumnews.com/) _Щотижневий інформаційний бюлетень, що висвітлює ключові події в екосистемі_
-- [Що нового у ETH 2.0](https://notes.ethereum.org/c/Sk8Zs--CQ) _Регулярний інформаційний бюлетень про розробку ETH 2.0_
+- [Що нового у ETH 2.0](https://eth2.news) _Регулярний інформаційний бюлетень про розробку ETH 2.0_
 - [ethresear.ch forum](https://ethresear.ch/) _Глибокі технічні дискусії з Ethereum для ETH 2.0 і не тільки_
 - [ETHGlobal](https://ethglobal.co) _Серія мозкових штурмів з Ethereum — завітайте на один із них поруч з вами!_
 

--- a/src/content/translations/vi/learn/index.md
+++ b/src/content/translations/vi/learn/index.md
@@ -25,7 +25,7 @@ Ngoài thông tin trên trang này, còn có nhiều tài nguyên do cộng đ�
 - [Kauri](https://kauri.io) _Các bài viết và hướng dẫn kỹ thuật cho Ethereum và các dự án liên quan_
 - [Video trên YouTube về Nền tảng Ethereum](https://www.youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g) _và thảo luận về Ethereum_
 - [Tin tức về Ethereum trong tuần](https://weekinethereumnews.com/) _Một bản tin hằng tuần bao gồm các phát triển quan trọng trong hệ sinh thái_
-- [Những tính năng mới trong ETH 2.0](https://notes.ethereum.org/c/Sk8Zs--CQ) _Bản tin định kỳ xuyên về sự phát triển ETH 2.0_
+- [Những tính năng mới trong ETH 2.0](https://eth2.news) _Bản tin định kỳ xuyên về sự phát triển ETH 2.0_
 - [Diễn đàn ethresear.ch](https://ethresear.ch/) _Thảo luận kỹ thuật sâu hơn về Ethereum cho ETH 2.0 và hơn thế nữa_
 - [ETHGlobal](https://ethglobal.co) _Một loạt hackathon Ethereum - tham dự một nơi gần bạn!_
 

--- a/src/content/translations/zh-tw/learn/index.md
+++ b/src/content/translations/zh-tw/learn/index.md
@@ -24,7 +24,7 @@ sidebar: true
 - [Kauri](https://kauri.io) _Technical articles and tutorials for Ethereum and related projects_
 - [Ethereum Foundation YouTube](https://www.youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g) _Videos and talks about Ethereum_
 - [Week in Ethereum News](https://weekinethereumnews.com/) _A weekly newsletter covering key developments across the ecosystem_
-- [What’s new in ETH 2.0](https://notes.ethereum.org/c/Sk8Zs--CQ) _A regular newsletter about ETH 2.0 development_
+- [What’s new in ETH 2.0](https://eth2.news) _A regular newsletter about ETH 2.0 development_
 - [ethresear.ch forum](https://ethresear.ch/) _Deeper technical discussions on Ethereum for ETH 2.0 and beyond_
 - [ETHGlobal](https://ethglobal.co) _An Ethereum hackathon series - attend one near you!_
 

--- a/src/content/translations/zh/learn/index.md
+++ b/src/content/translations/zh/learn/index.md
@@ -24,7 +24,7 @@ sidebar: true
 - [Kauri](https://kauri.io) _以太坊技术文章、教程、相关项目_
 - [以太坊基金会 YouTube 频道](https://www.youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g) _与以太坊相关的视频、演讲_
 - [以太坊周报](https://weekinethereumnews.com/) _包含过去一周以太坊生态中各个方面的重要进展_
-- [ETH 2.0 最新进度](https://notes.ethereum.org/c/Sk8Zs--CQ) _ETH 2.0 开发进度的定期通报_
+- [ETH 2.0 最新进度](https://eth2.news) _ETH 2.0 开发进度的定期通报_
 - [ethresearch 论坛](https://ethresear.ch/) _以太坊上关于 ETH2.0 和后续版本更深入的技术讨论_
 - [ETHGlobal](https://ethglobal.co) _以太坊黑客马拉松活动——赶快参与您周边的黑客松吧！_
 


### PR DESCRIPTION
## Description
Extends PR #2606 which updates a link for Eth2 News. Applies same patch to all translated versions of the same page.
