### PR TITLE
Adds new Defi hero image [Fixes #2651]

### DIFF
--- a/src/content/defi/index.md
+++ b/src/content/defi/index.md
@@ -5,7 +5,7 @@ lang: en
 template: use-cases
 emoji: ":money_with_wings:"
 sidebar: true
-image: ../../assets/finance_transparent.png
+image: ../../assets/use-cases/defi.png
 alt: "An Eth logo made of lego bricks."
 sidebarDepth: 2
 summaryPoints:

--- a/src/templates/use-cases.js
+++ b/src/templates/use-cases.js
@@ -232,25 +232,7 @@ const SummaryPoint = styled.li`
   line-height: auto;
 `
 
-const SummaryBox = styled.div`
-  /* border: 1px solid ${(props) => props.theme.colors.border};
-  padding: 1.5rem;
-  padding-bottom: 0rem;
-  border-radius: 4px; */
-`
-
-const DesktopBreadcrumbs = styled(Breadcrumbs)`
-  margin-top: 0.5rem;
-  @media (max-width: ${(props) => props.theme.breakpoints.l}) {
-    display: none;
-  }
-`
-const MobileBreadcrumbs = styled(Breadcrumbs)`
-  margin-top: 0.5rem;
-  @media (min-width: ${(props) => props.theme.breakpoints.l}) {
-    display: none;
-  }
-`
+const SummaryBox = styled.div``
 
 const StyledButtonDropdown = styled(ButtonDropdown)`
   margin-bottom: 2rem;

--- a/src/templates/use-cases.js
+++ b/src/templates/use-cases.js
@@ -299,17 +299,17 @@ const Image = styled(Img)`
   right: 0;
   bottom: 0;
   background-size: cover;
-  max-width: ${(props) => (props.useCase === "dao" ? `572px` : `640px`)};
+  max-width: ${({ useCase }) =>
+    useCase === `dao` ? `572px` : useCase === `defi` ? `80%` : `640px`};
   @media (max-width: ${({ theme }) => theme.breakpoints.l}) {
     width: 100%;
     height: 100%;
+    max-height: 340px;
+    max-width: ${({ useCase }) =>
+      useCase === "defi" ? "100%" : "min(405px, 98%)"};
     overflow: initial;
     align-self: center;
     margin: 0;
-  }
-  @media (max-width: ${({ theme }) => theme.breakpoints.m}) {
-    transform: scale(0.8);
-    margin: -1rem 0;
   }
 `
 


### PR DESCRIPTION
## Description
- Added logic of `use-cases` template to show Defi hero nicely given that it has a top/right/bottom edge unlike the other. 
- Adjusted logic of smaller screens for all use-cases, @ryancreatescopy Lemme know what you think
- Cleaned up unused components

## Netlify Previews
[defi](https://deploy-preview-2663--ethereumorg.netlify.app/en/defi/) | [nft](https://deploy-preview-2663--ethereumorg.netlify.app/en/nft/) | [dao](https://deploy-preview-2663--ethereumorg.netlify.app/en/dao/)

## Related Issue
#2651