### PR TITLE
improve keyboard accessibility (a11y)

### DIFF
--- a/src/components/Nav/Mobile.js
+++ b/src/components/Nav/Mobile.js
@@ -3,6 +3,7 @@ import styled from "styled-components"
 import { useIntl } from "gatsby-plugin-intl"
 import { motion } from "framer-motion"
 
+import NakedButton from "../NakedButton"
 import Translation from "../Translation"
 import Icon from "../Icon"
 import Link from "../Link"
@@ -10,6 +11,25 @@ import Search from "../Search"
 import Emoji from "../Emoji"
 import { NavLink } from "../../components/SharedStyledComponents"
 import { translateMessageId } from "../../utils/translations"
+
+const Container = styled.div`
+  display: none;
+  @media (max-width: ${(props) => props.theme.breakpoints.l}) {
+    display: flex;
+  }
+`
+
+const MenuIcon = styled(Icon)`
+  fill: ${(props) => props.theme.colors.text};
+`
+
+const MenuButton = styled(NakedButton)`
+  margin-left: 1rem;
+`
+
+const SearchIcon = styled(MenuIcon)`
+  margin-right: 1rem;
+`
 
 const MobileModal = styled(motion.div)`
   position: fixed;
@@ -179,10 +199,6 @@ const BottomItemText = styled.div`
   }
 `
 
-const MenuIcon = styled(Icon)`
-  fill: ${(props) => props.theme.colors.text};
-`
-
 const BlankSearchState = styled.div`
   color: ${(props) => props.theme.colors.text};
   background: ${(props) => props.theme.colors.searchBackgroundEmpty};
@@ -211,7 +227,19 @@ const MobileNavMenu = ({
 
   const isOpen = isMenuOpen || isSearchOpen
   return (
-    <>
+    <Container>
+      <MenuButton
+        onClick={() => toggleMenu("search")}
+        aria-label={translateMessageId("aria-toggle-search-button", intl)}
+      >
+        <SearchIcon name="search" />
+      </MenuButton>
+      <MenuButton
+        onClick={() => toggleMenu("menu")}
+        aria-label={translateMessageId("aria-toggle-menu-button", intl)}
+      >
+        <MenuIcon name="menu" />
+      </MenuButton>
       <MobileModal
         animate={isOpen ? "open" : "closed"}
         variants={mobileModalVariants}
@@ -219,6 +247,7 @@ const MobileNavMenu = ({
         onClick={toggleMenu}
       />
       <MenuContainer
+        aria-hidden={isMenuOpen ? false : true}
         animate={isMenuOpen ? "open" : "closed"}
         variants={mobileMenuVariants}
         initial="closed"
@@ -301,7 +330,7 @@ const MobileNavMenu = ({
           <Translation id="search-box-blank-state-text" />
         </BlankSearchState>
       </SearchContainer>
-    </>
+    </Container>
   )
 }
 

--- a/src/components/Nav/index.js
+++ b/src/components/Nav/index.js
@@ -54,9 +54,6 @@ const NavContent = styled.div`
     justify-content: space-between;
   }
 `
-const NavMobileButton = styled(NakedButton)`
-  margin-left: 1rem;
-`
 
 const InnerContent = styled.div`
   display: flex;
@@ -129,26 +126,6 @@ const ThemeToggle = styled(NakedButton)`
 
 const NavIcon = styled(Icon)`
   fill: ${(props) => props.theme.colors.text};
-`
-
-const MenuIcon = styled(Icon)`
-  fill: ${(props) => props.theme.colors.text};
-  display: none;
-  @media (max-width: ${(props) => props.theme.breakpoints.l}) {
-    display: block;
-    cursor: pointer;
-  }
-`
-
-const MobileIcons = styled.div`
-  display: none;
-  @media (max-width: ${(props) => props.theme.breakpoints.l}) {
-    display: flex;
-  }
-`
-
-const SearchIcon = styled(MenuIcon)`
-  margin-right: 1rem;
 `
 
 // TODO display page title on mobile
@@ -393,24 +370,8 @@ const Nav = ({ handleThemeChange, isDarkTheme, path }) => {
             toggleTheme={handleThemeChange}
             linkSections={mobileLinkSections}
           />
-          <MobileIcons>
-            <NavMobileButton
-              onClick={() => handleMenuToggle("search")}
-              aria-label={translateMessageId("aria-toggle-search-button", intl)}
-            >
-              <SearchIcon name="search" />
-            </NavMobileButton>
-
-            <NavMobileButton
-              onClick={() => handleMenuToggle("menu")}
-              aria-label={translateMessageId("aria-toggle-menu-button", intl)}
-            >
-              <MenuIcon name="menu" />
-            </NavMobileButton>
-          </MobileIcons>
         </NavContent>
       </StyledNav>
-
       {shouldShowSubNav && (
         <SubNav>
           {ednLinks.map((link, idx) => (


### PR DESCRIPTION
## Description

The mobile navigation isn't hidden correctly and therefor is rendered in the accessibility tree. This means a keyboard user has to tab through all of these hidden nav items before reaching any content.

## Related Issue

Issue #2648 

Related PR: #2649 