### PR TITLE
InfoBanner / DocLink bug fix [Fixes #2718]

### DIFF
--- a/src/components/DocLink.js
+++ b/src/components/DocLink.js
@@ -5,6 +5,8 @@ import Link from "./Link"
 import Emoji from "./Emoji"
 
 const Container = styled(Link)`
+  position: relative;
+  z-index: 1;
   text-decoration: none;
   display: flex;
   flex-direction: row;

--- a/src/components/InfoBanner.js
+++ b/src/components/InfoBanner.js
@@ -9,6 +9,8 @@ const Container = styled.div`
 `
 
 const Banner = styled.div`
+  position: relative;
+  z-index: 1;
   display: flex;
   align-items: center;
   padding: 1.5rem;


### PR DESCRIPTION
## Description
- Headers in markdown have a false top margin so hash links load with the header nudged down (to prevent being buried by the nav bar)
- Custom components that precede these headers as a sibling element can be blocked from clicking on them because of this false margin
- Adding relative positioning with a z-index of 1 to the components will give them precedence.  (Tried just doing this to the header with z-index -1 but this didn't work)
- The two notable components that were encountering this bug were `DocLink.js` and `InfoBanner.js`, and this styling was added to these two components. 

Mousing-over these components will now behave appropriately, and the hash links correctly bring the header to just below the nav bar. 

## Related Issue #2718