### PR TITLE
add conditional logic to onCreatePage hook to address TranslationBanner bug #2757

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -272,12 +272,10 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
 exports.onCreatePage = ({ page, actions }) => {
   const { createPage, deletePage } = actions
 
-// Actually we might be able to fix this in the onCreatePage hook... if content version is <2, for most pages (I think anything other than /developers/index.js we should set page.context.isContentEnglish to true.
-
   const isTranslated = page.context.language !== defaultLanguage
   const hasNoContext = page.context.isOutdated === undefined
   const langVersion = getLangContentVersion(page.context.language)
-  console.log(langVersion)
+  console.log(`component: ${page.component}`)
 
   if (isTranslated && hasNoContext) {
     let isOutdated = false
@@ -290,7 +288,8 @@ exports.onCreatePage = ({ page, actions }) => {
       context: {
         ...page.context,
         isOutdated,
-        isContentEnglish: langVersion < 2
+        //to display TranslationBanner for translation component pages that are still in English
+        isContentEnglish: langVersion < 2 && !page.component.includes('/developers/index.js')
       },
     })
   }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -272,8 +272,13 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
 exports.onCreatePage = ({ page, actions }) => {
   const { createPage, deletePage } = actions
 
+// Actually we might be able to fix this in the onCreatePage hook... if content version is <2, for most pages (I think anything other than /developers/index.js we should set page.context.isContentEnglish to true.
+
   const isTranslated = page.context.language !== defaultLanguage
   const hasNoContext = page.context.isOutdated === undefined
+  const langVersion = getLangContentVersion(page.context.language)
+  console.log(langVersion)
+
   if (isTranslated && hasNoContext) {
     let isOutdated = false
     if (page.component.includes("src/pages/index.js")) {
@@ -285,6 +290,7 @@ exports.onCreatePage = ({ page, actions }) => {
       context: {
         ...page.context,
         isOutdated,
+        isContentEnglish: langVersion < 2
       },
     })
   }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -275,7 +275,6 @@ exports.onCreatePage = ({ page, actions }) => {
   const isTranslated = page.context.language !== defaultLanguage
   const hasNoContext = page.context.isOutdated === undefined
   const langVersion = getLangContentVersion(page.context.language)
-  console.log(`component: ${page.component}`)
 
   if (isTranslated && hasNoContext) {
     let isOutdated = false
@@ -288,7 +287,7 @@ exports.onCreatePage = ({ page, actions }) => {
       context: {
         ...page.context,
         isOutdated,
-        //to display TranslationBanner for translation component pages that are still in English
+        //display TranslationBanner for translation-component pages that are still in English
         isContentEnglish: langVersion < 2 && !page.component.includes('/developers/index.js')
       },
     })


### PR DESCRIPTION
## Description

Attempted to address issue #2757 by doing some research and following @samajammin's suggestion on where to start looking. Added some conditional logic to the ```onCreatePage``` hook to auto set ```page.context.isContentEnglish``` to ```true``` for pages with a language content version < 2 that isn't /developers/index.js ... had some time to look into it and decided to give it a go, though commented on the issue first and made sure there was no other assignee before doing so. 

Did not test all languages pages, but did a few, and on the ones that the issue had flagged, the fix seems to work locally both on desktop and mobile screens. See attachments below. Comments and change requests welcome.

> Desktop screenshot

<img width="1277" alt="Screen Shot 2021-03-31 at 1 31 16 AM" src="https://user-images.githubusercontent.com/4992682/113181371-ada75c00-921f-11eb-9aef-6effa9ca2cf0.png">

> Mobile screenshot

<img width="291" alt="Screen Shot 2021-03-31 at 12 36 19 PM" src="https://user-images.githubusercontent.com/4992682/113181425-bf88ff00-921f-11eb-877f-1271cf64bfa7.png">

## Related Issue

#2757 
