### PR TITLE
missing code snippet in tutorial

### DIFF
--- a/src/content/developers/tutorials/sending-transactions-using-web3-and-alchemy/index.md
+++ b/src/content/developers/tutorials/sending-transactions-using-web3-and-alchemy/index.md
@@ -117,6 +117,38 @@ Create a `sendTx.js` file, which is where we will configure and send our example
 
 Be sure to replace the address on **line 6** with your own public address.
 
+```
+async function main() {
+    require('dotenv').config();
+    const { API_URL, PRIVATE_KEY } = process.env;
+    const { createAlchemyWeb3 } = require("@alch/alchemy-web3");
+    const web3 = createAlchemyWeb3(API_URL);
+    const myAddress = '0x610Ae88399fc1687FA7530Aac28eC2539c7d6d63' //TODO: replace this address with your own public address
+   
+    const nonce = await web3.eth.getTransactionCount(myAddress, 'latest'); // nonce starts counting from 0
+
+    const transaction = {
+     'to': '0x31B98D14007bDEe637298086988A0bBd31184523', // faucet address to return eth
+     'value': 1000000000000000000, // 1 ETH
+     'gas': 30000, 
+     'nonce': nonce,
+     // optional data field to send message or execute smart contract
+    };
+   
+    const signedTx = await web3.eth.accounts.signTransaction(transaction, PRIVATE_KEY);
+    
+    web3.eth.sendSignedTransaction(signedTx.rawTransaction, function(error, hash) {
+    if (!error) {
+      console.log("🎉 The hash of your transaction is: ", hash, "\n Check Alchemy's Mempool to view the status of your transaction!");
+    } else {
+      console.log("❗Something went wrong while submitting your transaction:", error)
+    }
+   });
+}
+
+main();
+```
+
 Now, before we jump into running this code, let's talk about some of the components here.
 
 - `nonce` : The nonce specification is used to keep track of the number of transactions sent from your address. We need this for security purposes and to prevent [replay attacks](https://docs.alchemyapi.io/resources/blockchain-glossary#account-nonce). To get the number of transactions sent from your address we use [getTransactionCount](https://docs.alchemyapi.io/documentation/alchemy-api-reference/json-rpc#eth_gettransactioncount).

--- a/src/content/developers/tutorials/sending-transactions-using-web3-and-alchemy/index.md
+++ b/src/content/developers/tutorials/sending-transactions-using-web3-and-alchemy/index.md
@@ -115,8 +115,6 @@ Great, now that we have our sensitive data protected in a .env file, let’s sta
 
 Create a `sendTx.js` file, which is where we will configure and send our example transaction, and add the following lines of code to it:
 
-Be sure to replace the address on **line 6** with your own public address.
-
 ```
 async function main() {
     require('dotenv').config();
@@ -148,6 +146,8 @@ async function main() {
 
 main();
 ```
+
+Be sure to replace the address on **line 6** with your own public address.
 
 Now, before we jump into running this code, let's talk about some of the components here.
 


### PR DESCRIPTION
Tutorial was missing a code snippet as the line above it suggested to refer the code written below

## Description

Add the code snippet as the same tutorial can be found on [alchemy website](https://docs.alchemyapi.io/alchemy/tutorials/sending-transactions-using-web3-and-alchemy) 
