### PR TITLE
Adds link to Turkish docs

### DIFF
--- a/src/content/developers/docs/smart-contracts/languages/index.md
+++ b/src/content/developers/docs/smart-contracts/languages/index.md
@@ -30,6 +30,7 @@ Previous knowledge of programming languages, especially of JavaScript or Python,
 ### Important links {#important-links}
 
 - [Documentation](https://docs.soliditylang.org/en/latest/)
+- [Documentation (Türkçe)](https://sol.eyystudio.com/)
 - [Solidity Language Portal](https://soliditylang.org/)
 - [Solidity by Example](https://docs.soliditylang.org/en/latest/solidity-by-example.html)
 - [GitHub](https://github.com/ethereum/solidity/)


### PR DESCRIPTION
## Description
As discussed in Discord, added link to https://ethereum.org/en/developers/docs/smart-contracts/languages/#solidity
for Turkish Documentation
