### PR TITLE
Add styling to links where the language is explicitly stated

### DIFF
--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -50,13 +50,6 @@ const ExplicitLangInternalLink = styled(GatsbyLink)`
   &.active {
     color: ${(props) => props.theme.colors.primary};
   }
-  &:hover {
-    svg {
-      fill: ${(props) => props.theme.colors.primary};
-      transition: transform 0.1s;
-      transform: scale(1.2);
-    }
-  }
 `
 
 const GlossaryIcon = styled(Icon)`

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -46,6 +46,22 @@ const InternalLink = styled(IntlLink)`
   }
 `
 
+const ExplicitLangInternalLink = styled(GatsbyLink)`
+  .is-glossary {
+    white-space: nowrap;
+  }
+  &.active {
+    color: ${(props) => props.theme.colors.primary};
+  }
+  &:hover {
+    svg {
+      fill: ${(props) => props.theme.colors.primary};
+      transition: transform 0.1s;
+      transform: scale(1.2);
+    }
+  }
+`
+
 const GlossaryIcon = styled(Icon)`
   margin: 0 0.25rem 0 0.35rem;
   fill: ${(props) => props.theme.colors.primary400};
@@ -132,14 +148,14 @@ const Link = ({
   const langPath = to.split("/")[1]
   if (Object.keys(languageMetadata).includes(langPath)) {
     return (
-      <GatsbyLink
+      <ExplicitLangInternalLink
         className={className}
         to={to}
         activeClassName="active"
         partiallyActive={isPartiallyActive}
       >
         {children}
-      </GatsbyLink>
+      </ExplicitLangInternalLink>
     )
   }
 

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -47,9 +47,6 @@ const InternalLink = styled(IntlLink)`
 `
 
 const ExplicitLangInternalLink = styled(GatsbyLink)`
-  .is-glossary {
-    white-space: nowrap;
-  }
   &.active {
     color: ${(props) => props.theme.colors.primary};
   }


### PR DESCRIPTION
## Description

Fixes an issue with lack of styling on footer links that have their language set explicity (#2815).
Wraps the GatsbyLink in a styled component. I couldn't find a similar use cases in the codebase so I hope the naming convention is okay 😃.

One thought -- the styling is the same as the InternalLink, this could maybe be refactored to be more DRY?

## Related Issue 
Closes #2815
