### PR TITLE
fix whitespace issue (missing newline) in code snippet

### DIFF
--- a/src/content/developers/tutorials/getting-started-with-ethereum-development-using-alchemy/index.md
+++ b/src/content/developers/tutorials/getting-started-with-ethereum-development-using-alchemy/index.md
@@ -123,7 +123,7 @@ npm install @alch/alchemy-web3
 ```js
 async function main() {
   const { createAlchemyWeb3 } = require("@alch/alchemy-web3")
-  const web3 = createAlchemyWeb3("https://eth-   mainnet.alchemyapi.io/v2/demo")
+  const web3 = createAlchemyWeb3("https://eth-mainnet.alchemyapi.io/v2/demo")
   const blockNumber = await web3.eth.getBlockNumber()
   console.log("The latest block number is " + blockNumber)
 }

--- a/src/content/developers/tutorials/getting-started-with-ethereum-development-using-alchemy/index.md
+++ b/src/content/developers/tutorials/getting-started-with-ethereum-development-using-alchemy/index.md
@@ -106,7 +106,8 @@ Now to get our hands dirty with a little web3 programming we’ll write a simple
 1.  **If you haven’t already, in your terminal create a new project directory and cd into it:**
 
 ```
-mkdir web3-examplecd web3-example
+mkdir web3-example
+cd web3-example
 ```
 
 **2\. Install the Alchemy web3 (or any web3) dependency into your project if you have not already:**

--- a/src/content/translations/ro/developers/tutorials/getting-started-with-ethereum-development-using-alchemy/index.md
+++ b/src/content/translations/ro/developers/tutorials/getting-started-with-ethereum-development-using-alchemy/index.md
@@ -130,7 +130,7 @@ npm install @alch/alchemy-web3
 ```js
 async function main() {
   const { createAlchemyWeb3 } = require("@alch/alchemy-web3")
-  const web3 = createAlchemyWeb3("https://eth-   mainnet.alchemyapi.io/v2/demo")
+  const web3 = createAlchemyWeb3("https://eth-mainnet.alchemyapi.io/v2/demo")
   const blockNumber = await web3.eth.getBlockNumber()
   console.log("The latest block number is " + blockNumber)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There was a code snippet in this [guide](https://ethereum.org/en/developers/tutorials/getting-started-with-ethereum-development-using-alchemy/) missing a whitespace, it was:
```
mkdir web3-examplecd web3-example
```
It should be:
```
mkdir web3-example
cd web3-example
```
or:
```
mkdir web3-example && cd web3-example
```

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
