### PR TITLE
Storj Spelling Mistake Fix

### DIFF
--- a/src/content/developers/docs/storage/index.md
+++ b/src/content/developers/docs/storage/index.md
@@ -49,7 +49,7 @@ Platforms with contract based persistence:
 
 - [Filecoin](https://docs.filecoin.io/about-filecoin/what-is-filecoin/)
 - [Skynet](https://siasky.net/)
-- [Stroj](https://storj.io/)
+- [Storj](https://storj.io/)
 
 ### Additional considerations {#additional-considertion}
 


### PR DESCRIPTION
The document spelled the Storj link label incorrectly, so this is the fix for it. 

<!--- Describe your changes in detail -->
Incorrect spelling fix. 

Previously -- "Stroj" 
Updated to -- "Storj"
