### PR TITLE
Added aria-labels to icon links in footer

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -101,18 +101,22 @@ const socialLinks = [
   {
     icon: "github",
     to: "https://github.com/ethereum/ethereum-org-website",
+    ariaLabel: "GitHub",
   },
   {
     icon: "twitter",
     to: "https://twitter.com/ethdotorg",
+    ariaLabel: "Twitter",
   },
   {
     icon: "youtube",
     to: "https://youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g",
+    ariaLabel: "Youtube",
   },
   {
     icon: "discord",
     to: "https://discord.gg/CetY6Y4",
+    ariaLabel: "Discord",
   },
 ]
 
@@ -327,7 +331,12 @@ const Footer = () => {
             <SocialIcons>
               {socialLinks.map((link, idx) => {
                 return (
-                  <Link to={link.to} hideArrow={true} key={idx}>
+                  <Link
+                    to={link.to}
+                    hideArrow={true}
+                    key={idx}
+                    ariaLabel={link.ariaLabel}
+                  >
                     <SocialIcon name={link.icon} size="36" />
                   </Link>
                 )

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -69,6 +69,7 @@ const Link = ({
   hideArrow = false,
   className,
   isPartiallyActive = true,
+  ariaLabel,
 }) => {
   // markdown pages pass `href`, not `to`
   to = to || href
@@ -83,7 +84,7 @@ const Link = ({
   // See https://github.com/gatsbyjs/gatsby/issues/21909
   if (isHash) {
     return (
-      <a className={className} href={to}>
+      <a className={className} href={to} aria-label={ariaLabel}>
         {children}
       </a>
     )
@@ -98,6 +99,7 @@ const Link = ({
         href={to}
         target="_blank"
         rel="noopener noreferrer"
+        aria-label={ariaLabel}
       >
         {children}
       </a>
@@ -118,6 +120,7 @@ const Link = ({
         target="_blank"
         rel="noopener noreferrer"
         onClick={() => trackCustomEvent(eventOptions)}
+        aria-label={ariaLabel}
       >
         {children}
       </a>
@@ -128,6 +131,7 @@ const Link = ({
         target="_blank"
         rel="noopener noreferrer"
         onClick={() => trackCustomEvent(eventOptions)}
+        aria-label={ariaLabel}
       >
         {children}
       </ExternalLink>


### PR DESCRIPTION
## Description

Added an ariaLabel property to the Link component and supplied it with values in the Footer component to improve accessibility.

Couple of things to note:

- I haven't added translations for the aria labels as they are brand names and will be read out by a screen reader.
- To resolve the scenario mentioned in the linked issue I would only need to update the link where isExternal is true and hide arrow is true (line 123 Link.js). In this PR I've updated all links with the aria-label in case people need to use it elsewhere.

Let me know your thoughts

## Related Issue

[Fixes #2770]
