### PR TITLE
Add redirect for old docking URL

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -269,6 +269,9 @@
 [[redirects]]
   from = "/*/build"
   to = "/:splat/developers/learning-tools/"
+[[redirects]]
+  from = "/*/eth2/the-docking"
+  to = "/:splat/eth2/the-docking/"
 
 # A redirect rule with all the supported properties
 # [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -271,7 +271,7 @@
   to = "/:splat/developers/learning-tools/"
 [[redirects]]
   from = "/*/eth2/the-docking"
-  to = "/:splat/eth2/the-docking/"
+  to = "/:splat/eth2/docking/"
 
 # A redirect rule with all the supported properties
 # [[redirects]]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
URL used to be e.g. https://ethereum.org/en/eth2/the-docking/ but it's not https://ethereum.org/en/eth2/docking/

Add 301 redirect for all languages to the updated URL.

## Related Issue
https://github.com/ethereum/eth2.0-deposit/pull/405
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
