### PR TITLE
Update Serenity glossary term

### DIFF
--- a/src/content/glossary/index.md
+++ b/src/content/glossary/index.md
@@ -532,7 +532,7 @@ A type of [layer 2](#layer-2) scaling solution that batches multiple transaction
 
 ### Serenity {#serenity}
 
-The fourth and final development stage of Ethereum.
+The fourth and final development stage of Ethereum, otherwise known as Ethereum 2.0.
 
 <DocLink to="/eth2/" title="Ethereum 2.0 (Eth2)" />
 


### PR DESCRIPTION
Update Serenity glossary term to make it obvious that Eth2 and Serenity are the same thing.

Related Issue #2872
