### PR TITLE
Typo fix in english stablecoin copy

### DIFF
--- a/src/intl/en/page-stablecoins.json
+++ b/src/intl/en/page-stablecoins.json
@@ -81,7 +81,7 @@
   "page-stablecoins-explore-dapps": "Explore dapps",
   "page-stablecoins-fiat-backed": "Fiat backed",
   "page-stablecoins-fiat-backed-con-1": "Centralized – someone must issue the tokens.",
-  "page-stablecoins-fiat-backed-con-2": "Requires auditing to ensure company has suffficient reserves.",
+  "page-stablecoins-fiat-backed-con-2": "Requires auditing to ensure company has sufficient reserves.",
   "page-stablecoins-fiat-backed-description": "Basically an IOU (I owe you) for a traditional fiat currency (usually dollars). You use your fiat currency to purchase a stablecoin that you can later cash-in and redeem for your original currency.",
   "page-stablecoins-fiat-backed-pro-1": "Safe against crypto volatility.",
   "page-stablecoins-fiat-backed-pro-2": "Changes in price are minimal.",


### PR DESCRIPTION
## Description
`suffficient` -> `sufficient`

## Related Issue
Issue raised by user offline (thanks!)