### PR TITLE
Eth2 merge banner

### DIFF
--- a/src/content/eth2/docking/index.md
+++ b/src/content/eth2/docking/index.md
@@ -1,16 +1,16 @@
 ---
-title: Docking mainnet with Eth2
-description: Learn about the docking - when mainnet Ethereum joins the Beacon Chain coordinated proof-of-stake system.
+title: The merge
+description: Learn about the merge - when mainnet Ethereum joins the Beacon Chain coordinated proof-of-stake system.
 lang: en
 template: eth2
 sidebar: true
 image: ../../../assets/eth2/docking.png
 summaryPoints:
   [
-    'Eventually the current Ethereum mainnet will "dock" with the rest of the Eth2 upgrades.',
-    'The docking will merge "Eth1" mainnet with the Eth2 beacon chain and sharding system.',
+    'Eventually the current Ethereum mainnet will "merge" with the beacon chain proof-of-stake system.',
     "This will mark the end of proof-of-work for Ethereum, and the full transition to proof of stake.",
     'You might know this as "Phase 1.5" on technical roadmaps.',
+    'We formerly referred to this as "the docking.',
   ]
 ---
 
@@ -18,15 +18,15 @@ summaryPoints:
     This upgrade will follow the arrival of shard chains. But it’s the moment where the <a href="/eth2/vision/">Eth2 vision</a> becomes fully realised – more scalability, security, and sustainability with staking supporting the whole network.
 </UpgradeStatus>
 
-## What is the docking? {#what-is-the-docking}
+## What is the merge? {#what-is-the-docking}
 
-It's important to remember that initially, the other Eth2 upgrades are being shipped separately from [mainnet](/glossary/#mainnet) - the chain we use today. Ethereum mainnet will continue to be secured by [proof-of-work](/developers/docs/consensus-mechanisms/pow/), even while [the Beacon Chain](/eth2/beacon-chain/) and its [shard chains](/eth2/shard-chains/) run in parallel using [proof of stake](/developers/docs/consensus-mechanisms/pos/). The docking is when these two systems are merged together.
+It's important to remember that initially, the other Eth2 upgrades are being shipped separately from [mainnet](/glossary/#mainnet) - the chain we use today. Ethereum mainnet will continue to be secured by [proof-of-work](/developers/docs/consensus-mechanisms/pow/), even while [the Beacon Chain](/eth2/beacon-chain/) and its [shard chains](/eth2/shard-chains/) run in parallel using [proof of stake](/developers/docs/consensus-mechanisms/pos/). The merge is when these two systems dock together.
 
-Imagine Ethereum is a space ship that isn’t quite ready for an interstellar voyage. With the Beacon Chain and the shard chains the community has built a new engine and a hardened hull. When it’s time, the current ship will dock with this new system so it can become one ship, ready to put in some serious lightyears and take on the universe.
+Imagine Ethereum is a space ship that isn’t quite ready for an interstellar voyage. With the Beacon Chain and the shard chains the community has built a new engine and a hardened hull. When it’s time, the current ship will dock with this new system, merging into one ship, ready to put in some serious lightyears and take on the universe.
 
-## Docking mainnet {#docking-mainnet}
+## Merging with mainnet {#docking-mainnet}
 
-When ready, Ethereum mainnet will "dock" with the Beacon Chain, becoming its own shard which uses proof-of-stake instead of [proof of work](/developers/docs/consensus-mechanisms/pow/).
+When ready, Ethereum mainnet will "merge" with the Beacon Chain, becoming its own shard which uses proof-of-stake instead of [proof of work](/developers/docs/consensus-mechanisms/pow/).
 
 Mainnet will bring the ability to run smart contracts into the proof-of-stake system, plus the full history and current state of Ethereum, to ensure that the transition is smooth for all ETH holders and users.
 
@@ -46,21 +46,21 @@ Plus many more.
 
 These improvements all have a place in Eth2 so it’s likely that their progress may affect the timing of the docking. -->
 
-## After the docking {#after-the-docking}
+## After the merge {#after-the-merge}
 
 This will signal the end of proof-of-work for Ethereum and start the era of a more sustainable, eco-friendly Ethereum. At this point Ethereum will have the scale, security and sustainability outlined in its [Eth2 vision](/eth2/vision/).
 
 ## Relationship between upgrades {#relationship-between-upgrades}
 
-The Eth2 upgrades are all somewhat interrelated. So let’s recap how the docking relates to the other upgrades.
+The Eth2 upgrades are all somewhat interrelated. So let’s recap how the merge relates to the other upgrades.
 
-### Docking and the Beacon Chain {#docking-and-beacon-chain}
+### The merge and the Beacon Chain {#docking-and-beacon-chain}
 
-Once the docking happens, stakers will be assigned to validate the Ethereum mainnet. Just like with the shard chains. [Mining](/developers/docs/consensus-mechanisms/pow/mining/) will no longer be required so miners will likely invest their earnings into staking in the new proof-of-stake system.
+Once the merge happens, stakers will be assigned to validate the Ethereum mainnet. Just like with the shard chains. [Mining](/developers/docs/consensus-mechanisms/pow/mining/) will no longer be required so miners will likely invest their earnings into staking in the new proof-of-stake system.
 
 <ButtonLink to="/eth2/beacon-chain/">The Beacon Chain</ButtonLink>
 
-### Docking and shard chains {#docking-and-shard-chains}
+### The merge and shard chains {#docking-and-shard-chains}
 
 With mainnet becoming a shard, the successful implementation of the shard chains is critical to this upgrade. It’s likely that the transition will play an important role in helping the community to decide whether to roll out a second upgrade to sharding. This upgrade will make the other shards like mainnet: they’ll be able to handle transactions and smart contracts and not just provide more data.
 

--- a/src/intl/en/page-eth2-index.json
+++ b/src/intl/en/page-eth2-index.json
@@ -164,7 +164,7 @@
   "page-eth2-upgrades": "The Eth2 Upgrades",
   "page-eth2-upgrades-aria-label": "Eth2 upgrades menu",
   "page-eth2-upgrades-beacon-chain": "The Beacon Chain",
-  "page-eth2-upgrades-docking": "Docking mainnet and Eth2",
+  "page-eth2-upgrades-docking": "The merge",
   "page-eth2-upgrades-guide": "Guide to Eth2 upgrades",
   "page-eth2-upgrades-shard-chains": "The shard chains",
   "page-eth2-upgrading": "Upgrading Ethereum to radical new heights",

--- a/src/pages/eth2/index.js
+++ b/src/pages/eth2/index.js
@@ -16,6 +16,7 @@ import GhostCard from "../../components/GhostCard"
 import InfoBanner from "../../components/InfoBanner"
 import Link from "../../components/Link"
 import PageMetadata from "../../components/PageMetadata"
+import BannerNotification from "../../components/BannerNotification"
 import Translation from "../../components/Translation"
 import PageHero from "../../components/PageHero"
 import {
@@ -209,6 +210,16 @@ const ResearchContainer = styled.div`
   margin-top: 2rem;
 `
 
+const StyledBannerNotification = styled(BannerNotification)`
+  display: flex;
+  justify-content: center;
+`
+
+const StyledEmoji = styled(Emoji)`
+  margin-right: 1rem;
+  flex-shrink: 0;
+`
+
 const paths = [
   {
     emoji: ":rocket:",
@@ -279,6 +290,16 @@ const Eth2IndexPage = ({ data }) => {
         title={translateMessageId("page-eth2-meta-title", intl)}
         description={translateMessageId("page-eth2-meta-desc", intl)}
       />
+      <StyledBannerNotification shouldShow>
+        <StyledEmoji text=":megaphone:" />
+        <div>
+          <b>Latest:</b> Eth2 researchers are working on ways to accelerate the
+          merge. It will probably happen earlier than expected. More soon.{" "}
+          <Link to="https://blog.ethereum.org/category/research-and-development/">
+            Follow updates
+          </Link>
+        </div>
+      </StyledBannerNotification>
       <PageHero content={heroContent} />
       <Divider />
       <Content>

--- a/src/pages/eth2/vision.js
+++ b/src/pages/eth2/vision.js
@@ -14,6 +14,7 @@ import PageHero from "../../components/PageHero"
 import Breadcrumbs from "../../components/Breadcrumbs"
 import ButtonLink from "../../components/ButtonLink"
 import PageMetadata from "../../components/PageMetadata"
+import BannerNotification from "../../components/BannerNotification"
 import {
   CardContainer,
   Content,
@@ -76,6 +77,16 @@ const StyledBreadcrumbs = styled(Breadcrumbs)`
   justify-content: center;
 `
 
+const StyledBannerNotification = styled(BannerNotification)`
+  display: flex;
+  justify-content: center;
+`
+
+const StyledEmoji = styled(Emoji)`
+  margin-right: 1rem;
+  flex-shrink: 0;
+`
+
 const paths = [
   {
     emoji: ":vertical_traffic_light:",
@@ -135,6 +146,16 @@ const VisionPage = ({ data, location }) => {
         title={translateMessageId("page-eth2-vision-meta-title", intl)}
         description={translateMessageId("page-eth2-vision-meta-desc", intl)}
       />
+      <StyledBannerNotification shouldShow>
+        <StyledEmoji text=":megaphone:" />
+        <div>
+          <b>Latest:</b> Eth2 researchers are working on ways to accelerate the
+          merge. It will probably happen earlier than expected. More soon.{" "}
+          <Link to="https://blog.ethereum.org/category/research-and-development/">
+            Follow updates
+          </Link>
+        </div>
+      </StyledBannerNotification>
       <PageHero content={heroContent} />
       <Divider />
       <Content>

--- a/src/templates/eth2.js
+++ b/src/templates/eth2.js
@@ -7,6 +7,7 @@ import styled from "styled-components"
 import Img from "gatsby-image"
 import ButtonLink from "../components/ButtonLink"
 import ButtonDropdown from "../components/ButtonDropdown"
+import BannerNotification from "../components/BannerNotification"
 import Breadcrumbs from "../components/Breadcrumbs"
 import Card from "../components/Card"
 import Icon from "../components/Icon"
@@ -342,6 +343,16 @@ const TitleCard = styled.div`
   }
 `
 
+const StyledBannerNotification = styled(BannerNotification)`
+  display: flex;
+  justify-content: center;
+`
+
+const StyledEmoji = styled(Emoji)`
+  margin-right: 1rem;
+  flex-shrink: 0;
+`
+
 const dropdownLinks = {
   text: "page-eth2-upgrades-guide",
   ariaLabel: "page-eth2-upgrades-aria-label",
@@ -373,6 +384,16 @@ const Eth2Page = ({ data, data: { mdx } }) => {
 
   return (
     <Container>
+      <StyledBannerNotification shouldShow>
+        <StyledEmoji text=":megaphone:" />
+        <div>
+          <b>Latest:</b> Eth2 researchers are working on ways to accelerate the
+          merge. It will probably happen earlier than expected. More soon.{" "}
+          <Link to="https://blog.ethereum.org/category/research-and-development/">
+            Follow updates
+          </Link>
+        </div>
+      </StyledBannerNotification>
       <HeroContainer>
         <TitleCard>
           <DesktopBreadcrumbs slug={mdx.fields.slug} startDepth={1} />


### PR DESCRIPTION
Created a banner that addresses latest talk of the merge happening earlier than expected.

Also updated terminology from "docking" to "merge" on the merge upgrade page. **I haven't** updated links or updated any other content at this point. I want to confirm what our plan is here and wonder if there's an efficient way to update all this at once and inform translators etc.