### PR TITLE
Updates critical bug bounty copy

### DIFF
--- a/src/intl/en/page-eth2-get-involved-bug-bounty.json
+++ b/src/intl/en/page-eth2-get-involved-bug-bounty.json
@@ -81,7 +81,7 @@
   "page-eth2-bug-bountycard-li-3": "High impact, low likelihood",
   "page-eth2-bug-bountycard-li-4": "Medium impact, medium likelihood",
   "page-eth2-bug-bountycard-li-5": "Low impact, high likelihood",
-  "page-eth2-bug-bountycard-li-6": "High impact, medium likelihood",
+  "page-eth2-bug-bountycard-li-6": "High impact, high likelihood",
   "page-eth2-bug-bountycard-li-7": "Medium impact, high likelihood",
   "page-eth2-bug-bountycard-low": "Low",
   "page-eth2-bug-bountycard-low-risk": "Submit low risk bug",


### PR DESCRIPTION
## Description
Per @JustinDrake changing copy of Critical bugs to read "high likelihood"

## Related Issue 
[Fixes #2895]