### PR TITLE
Update to include link to Storj DCS Documentation

### DIFF
--- a/src/content/developers/docs/storage/index.md
+++ b/src/content/developers/docs/storage/index.md
@@ -109,6 +109,10 @@ PoS based:
 - [Documentation](https://docs.ipfs.io/)
 - [GitHub](https://github.com/ipfs/ipfs)
 
+**Storj DCS -** **_Secure, private, and S3-compatible decentralized cloud object storage for developers._**
+- [Storj](https://storj.io/)
+- [Documentation](https://docs.storj.io/)
+
 **Skynet -** **_Skynet is a decentralized PoW chain dedicated to a decentralized web._**
 
 - [Skynet](https://siasky.net/)


### PR DESCRIPTION
Updated to include new link to Storj DCS website and developer documentation

## Description

Added link to Storj DCS documentation for S3-compatible decentralized storage.

## Related Issue

Related to issue #2929 – https://github.com/ethereum/ethereum-org-website/issues/2929
