### PR TITLE
Update index.md: Broken link for Ethereum Grants page

### DIFF
--- a/src/content/community/index.md
+++ b/src/content/community/index.md
@@ -123,7 +123,7 @@ If you’re not a developer, it can be hard to know where to start in Ethereum. 
 
 ## Ethereum Grants {#ethereum-grants}
 
-[View open Ethereum grants](/grants/)
+[View open Ethereum grants](/community/grants/)
 
 ## Ethereum Jobs {#ethereum-jobs}
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
broken link: ethereum grants link going to a 404 page 
Change: changing url to /community/grants because the url https://ethereum.org/en/community/grants/ works

