### PR TITLE
docs: fix typos

### DIFF
--- a/src/content/developers/docs/ethereum-stack/index.md
+++ b/src/content/developers/docs/ethereum-stack/index.md
@@ -35,7 +35,7 @@ In order for an application to interact with the Ethereum blockchain (i.e. read 
 
 Ethereum nodes are computers running software - an Ethereum client. A client is an implementation of Ethereum that verifies all transactions in each block, keeping the network secure and the data accurate. Ethereum nodes ARE the Ethereum blockchain. They collectively store the state of the Ethereum blockchain and reach consensus on transactions to mutate the blockchain state.
 
-By connecting your application to an Ethereum node (via a JSON RPC spec), your application is able to read data from the blockchain (such as user account balances) as well as broadcast new transactions to the network (such as transfering ETH between user accounts or executing functions of smart contracts).
+By connecting your application to an Ethereum node (via a JSON RPC spec), your application is able to read data from the blockchain (such as user account balances) as well as broadcast new transactions to the network (such as transferring ETH between user accounts or executing functions of smart contracts).
 
 ## Level 4: Ethereum Client APIs {#ethereum-client-apis}
 

--- a/src/content/developers/docs/oracles/index.md
+++ b/src/content/developers/docs/oracles/index.md
@@ -114,7 +114,7 @@ Chainlink VRF (Verifiable Random Function) is a provably-fair and verifiable sou
 Random numbers are difficult because blockchains are deterministic.
 
 Working with Chainlink Oracles outside of data feeds follows the [request and receive cycle](https://docs.chain.link/docs/architecture-request-model) of working with Chainlink. They use the LINK token to send oracle providers oracle gas for returning responses. The LINK token is specifically designed to work with oracles and are based on the upgraded ERC-677 token, which is backwards compatible with [ERC-20](/developers/docs/standards/tokens/erc-20/).
-The following code, if deployed on the Kovan testnet will retreive a cryptographically proven random number. To make the request, fund the contract with some testnet LINK token that you can get from the [Kovan LINK Faucet](https://kovan.chain.link/).
+The following code, if deployed on the Kovan testnet will retrieve a cryptographically proven random number. To make the request, fund the contract with some testnet LINK token that you can get from the [Kovan LINK Faucet](https://kovan.chain.link/).
 
 ```javascript
 

--- a/src/content/developers/docs/standards/tokens/erc-721/index.md
+++ b/src/content/developers/docs/standards/tokens/erc-721/index.md
@@ -242,7 +242,7 @@ recent_births = [get_event_data(ck_extra_events_abi[1], log)["args"] for log in 
 
 ## Popular NFTs {#popular-nfts}
 
-- [Etherscan NFT Tracker](https://etherscan.io/tokens-nft) list the top NFT on Ethereum by tranfers volume.
+- [Etherscan NFT Tracker](https://etherscan.io/tokens-nft) list the top NFT on Ethereum by transfers volume.
 - [CryptoKitties](https://www.cryptokitties.co/) is a game centered around breedable, collectible, and oh-so-adorable
   creatures we call CryptoKitties.
 - [Sorare](https://sorare.com/) is a global fantasy football game where you can collect limited editions collectibles,

--- a/src/content/developers/tutorials/create-and-deploy-a-defi-app/index.md
+++ b/src/content/developers/tutorials/create-and-deploy-a-defi-app/index.md
@@ -471,6 +471,6 @@ _output of withdrawMyTokenFromTokenFarm.js_
 
 [Ganache | Truffle Suite](https://www.trufflesuite.com/ganache)
 
-[What is DeFi? A Begginer's Guide (2021 Updated) (99bitcoins.com)](https://99bitcoins.com/what-is-defi/)
+[What is DeFi? A Beginner's Guide (2021 Updated) (99bitcoins.com)](https://99bitcoins.com/what-is-defi/)
 
 [DeFi - The Decentralized Finance Leaderboard at DeFi Pulse](https://defipulse.com/)

--- a/src/content/developers/tutorials/the-graph-fixing-web3-data-querying/index.md
+++ b/src/content/developers/tutorials/the-graph-fixing-web3-data-querying/index.md
@@ -299,7 +299,7 @@ But we're missing one last piece of the puzzle and that's the server. You can ei
 
 ### Graph Explorer: The hosted service {#graph-explorer-the-hosted-service}
 
-The easiest way is to use the hosted service. Follow the instructions [here](https://thegraph.com/docs/deploy-a-subgraph) to deploy a subgraph. For many projects you can actually find exisiting subgraphs in the explorer at https://thegraph.com/explorer/.
+The easiest way is to use the hosted service. Follow the instructions [here](https://thegraph.com/docs/deploy-a-subgraph) to deploy a subgraph. For many projects you can actually find existing subgraphs in the explorer at https://thegraph.com/explorer/.
 
 ![The Graph-Explorer](./thegraph-explorer.png)
 

--- a/src/content/glossary/index.md
+++ b/src/content/glossary/index.md
@@ -620,7 +620,7 @@ Short for "test network," a network used to simulate the behavior of the main Et
 
 ### token standard {#token-standard}
 
-Introduced by ERC-20 proposal, this provides a standardized [smart contract](#smart-contract) structure for fungible tokens. Tokens from the same contract can be tracked, traded, and are interchangable, unlike [NFTs](#nft).
+Introduced by ERC-20 proposal, this provides a standardized [smart contract](#smart-contract) structure for fungible tokens. Tokens from the same contract can be tracked, traded, and are interchangeable, unlike [NFTs](#nft).
 
 <DocLink to="/developers/docs/standards/tokens/erc-20/" title="ERC-20 Token Standard" />
 
@@ -661,7 +661,7 @@ A security model for certain [layer 2](#layer-2) solutions where, to increase sp
 
 ### Validium {#validium}
 
-A [layer 2](#layer-2) solution that uses [validity proofs](#validity-proof) to improve transaction throughput. Unlike [Zero-knowlege rollups](#zk-rollup), Validium data isn't stored on layer 1 [mainnet](#mainnet).
+A [layer 2](#layer-2) solution that uses [validity proofs](#validity-proof) to improve transaction throughput. Unlike [Zero-knowledge rollups](#zk-rollup), Validium data isn't stored on layer 1 [mainnet](#mainnet).
 
 <DocLink to="/developers/docs/layer-2-scaling/#validium" title="Validium" />
 

--- a/src/content/history/index.md
+++ b/src/content/history/index.md
@@ -268,7 +268,7 @@ The Tangerine Whistle fork was the first response to the denial of service (DoS)
 
 #### Summary {#dao-fork-summary}
 
-The DAO fork was in response to the [2016 DAO attack](https://www.coindesk.com/understanding-dao-hack-journalists) where an insecure [DAO](/glossary/#dao) contract was drained of over 3.6 million ETH in a hack. The fork moved the funds from the faulty contract to a [new contract](https://etherscan.io/address/0xbf4ed7b27f1d666546e30d74d50d173d20bca754) with a single funtion: withdraw. Anyone who lost funds could withdraw 1 ETH for every 100 DAO tokens in their wallets.
+The DAO fork was in response to the [2016 DAO attack](https://www.coindesk.com/understanding-dao-hack-journalists) where an insecure [DAO](/glossary/#dao) contract was drained of over 3.6 million ETH in a hack. The fork moved the funds from the faulty contract to a [new contract](https://etherscan.io/address/0xbf4ed7b27f1d666546e30d74d50d173d20bca754) with a single function: withdraw. Anyone who lost funds could withdraw 1 ETH for every 100 DAO tokens in their wallets.
 
 This course of action was voted on by the Ethereum community. Any ETH holder was able to vote via a transaction on [a voting platform](http://v1.carbonvote.com/). The decision to fork reached over 85% of the votes.
 

--- a/src/content/nft/index.md
+++ b/src/content/nft/index.md
@@ -202,7 +202,7 @@ The NFT world and the [decentralized finance (DeFi)](/defi/) world are starting 
 
 #### NFT-backed loans {#nft-backed-loans}
 
-There are DeFi applications that let you borrow money by using collateral. For example you collateralise 10 ETH so you can borrow 5000 DAI ([a stablecoin](/stablecoins/)). This guarantees that the lender gets paid back – if the borrower does't pay back the DAI, the collateral is sent to the lender. However not everyone has enough crypto to use as collateral.
+There are DeFi applications that let you borrow money by using collateral. For example you collateralise 10 ETH so you can borrow 5000 DAI ([a stablecoin](/stablecoins/)). This guarantees that the lender gets paid back – if the borrower doesn't pay back the DAI, the collateral is sent to the lender. However not everyone has enough crypto to use as collateral.
 
 Projects are beginning to explore using NFTs as collateral instead. Imagine you bought a rare CryptoPunk NFT back in the day – they can fetch $1000s at today's prices. By putting this up as collateral, you can access a loan with the same rule set. If you don't pay back the DAI, your CryptoPunk will be sent to the lender as collateral. This could eventually work with anything you tokenise as an NFT.
 


### PR DESCRIPTION
Hello,

This PR will fix : 

- 1 typo in `src/content/developers/docs/ethereum-stack/index.md`
- 1 typo in `src/content/developers/docs/oracles/index.md`
- 1 typo in `src/content/developers/docs/standards/tokens/erc-721/index.md`
- 1 typo in `src/content/developers/tutorials/create-and-deploy-a-defi-app/index.md`
- 1 typo in `src/content/developers/tutorials/the-graph-fixing-web3-data-querying/index.md`
- 2 typos in `src/content/glossary/index.md`
- 1 typo in `src/content/history/index.md`
- 1 typo in `src/content/nft/index.md`



Bye! :robot: