### PR TITLE
Corrected typo in EVM: State. Trie -> Tree.

### DIFF
--- a/src/content/developers/docs/evm/index.md
+++ b/src/content/developers/docs/evm/index.md
@@ -34,7 +34,7 @@ Given an old valid state `(S)` and a new set of valid transactions `(T)`, the Et
 
 ### State {#state}
 
-In the context of Ethereum, the state is an enormous data structure called a [modified Merkle Patricia Trie](https://eth.wiki/en/fundamentals/patricia-tree), which keeps all [accounts](/developers/docs/accounts/) linked by hashes and reducible to a single root hash stored on the blockchain.
+In the context of Ethereum, the state is an enormous data structure called a [modified Merkle Patricia Tree](https://eth.wiki/en/fundamentals/patricia-tree), which keeps all [accounts](/developers/docs/accounts/) linked by hashes and reducible to a single root hash stored on the blockchain.
 
 ### Transactions {#transactions}
 


### PR DESCRIPTION
There was a typo in the link to the Patricia Tree website. The typo was corrected from "modified Merkle Patricia Trie" -> "modified Merkle Patricia Tree".

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
