### PR TITLE
doc: updating the gas limit to April 2021

### DIFF
--- a/src/content/developers/docs/blocks/index.md
+++ b/src/content/developers/docs/blocks/index.md
@@ -55,7 +55,7 @@ Proof of work means the following:
 
 ## Block size {#block-size}
 
-A final important note is that blocks themselves are bounded in size. Each block has a block gas limit which is set by the network and the miners collectively: the total amount of gas expended by all transactions in the block must be less than the block gas limit. This is important because it ensures that blocks can’t be arbitrarily large. If blocks could be arbitrarily large, then less performant full nodes would gradually stop being able to keep up with the network due to space and speed requirements. The block gas limit at block 0 was initialized to 5,000; any miner who mines a new block can alter the gas limit by up to about 0.1% in either direction from the parent block gas limit. The gas limit as of November 2018 currently hovers around 8,000,000.
+A final important note is that blocks themselves are bounded in size. Each block has a block gas limit which is set by the network and the miners collectively: the total amount of gas expended by all transactions in the block must be less than the block gas limit. This is important because it ensures that blocks can’t be arbitrarily large. If blocks could be arbitrarily large, then less performant full nodes would gradually stop being able to keep up with the network due to space and speed requirements. The block gas limit at block 0 was initialized to 5,000; any miner who mines a new block can alter the gas limit by up to about 0.1% in either direction from the parent block gas limit. The gas limit as of April 2021 currently hovers around 15,000,000.
 
 ## Further reading {#further-reading}
 


### PR DESCRIPTION
#### Description

https://www.coindesk.com/ethereum-gas-limit-eth-price-soars

Was reading up on this and realized the gas limit was outdated and right now is ~15M as oppose to ~8M back in 2018
