### PR TITLE
Remove Duplicated Index Coop Description Text [Fixes #2959]

### DIFF
--- a/src/intl/en/page-dapps.json
+++ b/src/intl/en/page-dapps.json
@@ -70,7 +70,7 @@
   "page-dapps-dapp-description-opera": "Send crypto from your browser to merchants, other users and apps.",
   "page-dapps-dapp-description-polymarket": "Bet on outcomes. Trade on information markets.",
   "page-dapps-dapp-description-pooltogether": "A lottery you can't lose. Prizes every week.",
-  "page-dapps-dapp-description-index-coop": "A crypto index fund that gives your portfolio exposure to top DeFi tokens.A crypto index fund that gives your portfolio exposure to top DeFi tokens.",
+  "page-dapps-dapp-description-index-coop": "A crypto index fund that gives your portfolio exposure to top DeFi tokens.",
   "page-dapps-dapp-description-nexus-mutual": "Coverage without the insurance company. Get protected against smart contract bugs and hacks.",
   "page-dapps-dapp-description-etherisc": "A decentralized insurance template anyone can use to create their own insurance coverage.",
   "page-dapps-dapp-description-zapper": "Track your portfolio and use a range of DeFi products from one interface.",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There is duplicated text in the description of the Index Coop on the dapps page: https://ethereum.org/en/dapps/?category=finance

This PR removes the duplicated "A crypto index fund that gives your portfolio exposure to top DeFi tokens." text

## Related Issue

https://github.com/ethereum/ethereum-org-website/issues/2959