### PR TITLE
Switches banner to "flex" [Fixes #2940]

### DIFF
--- a/src/components/BannerNotification.js
+++ b/src/components/BannerNotification.js
@@ -2,7 +2,7 @@ import React from "react"
 import styled from "styled-components"
 
 const Banner = styled.div`
-  display: ${(props) => (props.shouldShow ? `block` : `none`)};
+  display: ${(props) => (props.shouldShow ? `flex` : `none`)};
   width: 100%;
   background-color: ${(props) => props.theme.colors.primary};
   color: ${(props) => props.theme.colors.background};


### PR DESCRIPTION
Changes display styling for banner to "flex" instead of "block"
Fixes #2940