### PR TITLE
[Smart Contract Lang Page] Remove Turkish Docs Link in Solidity Section

### DIFF
--- a/src/content/developers/docs/smart-contracts/languages/index.md
+++ b/src/content/developers/docs/smart-contracts/languages/index.md
@@ -30,7 +30,6 @@ Previous knowledge of programming languages, especially of JavaScript or Python,
 ### Important links {#important-links}
 
 - [Documentation](https://docs.soliditylang.org/en/latest/)
-- [Documentation (Türkçe)](https://sol.eyystudio.com/)
 - [Solidity Language Portal](https://soliditylang.org/)
 - [Solidity by Example](https://docs.soliditylang.org/en/latest/solidity-by-example.html)
 - [GitHub](https://github.com/ethereum/solidity/)


### PR DESCRIPTION
Hi there! 

I propose removing the link to the "Turkish Solidity Documentation". 

A few reasons and some context:
- There are plenty of efforts for community translations of the Solidity documentation (e.g. in French, Korean, Chinese, Italian, Spanish, Japanese, and more), not only the Turkish one. Some of them are in a more up-to-date state and some of them are in a somewhat unfinished / out-of-date state. (See https://docs.soliditylang.org/en/latest/index.html#translations.)
- Linking to unfinished or out-of-date translations in this section is not helpful.
- We recently set up a new translation process which should help streamline the translation efforts and give translations the chance to be featured in the "official" Solidity documentation once they reach a certain state of completeness and quality.
- The process and all details about it can be found here https://github.com/ethereum/solidity/issues/10119#issuecomment-802714891 and here https://github.com/solidity-docs/translation-guide.
- The Turkish community translation does not follow any of these guidelines, is nowhere near a complete translation, does not include versioning (or any info on from which date this translation is) and can clearly not be seen as an "important link" (I personally think none of the translations should be featured there, it would crowd the link section too much).

In general, the Solidity team would highly appreciate tagging one of us in the review before merging stuff into the Solidity section! In most cases, we do have a bit more of context on things that can help make a reasonable decision. Thanks :)