### PR TITLE
Checks for "undefined" lastCommit

### DIFF
--- a/src/components/FileContributors.js
+++ b/src/components/FileContributors.js
@@ -158,6 +158,7 @@ const FileContributors = ({ relativePath, className, editPath }) => {
   )
 
   const lastCommit = commits[0]
+  if (typeof lastCommit === "undefined") return null
   const lastContributor = lastCommit.author
   const uniqueContributors = commits.reduce(
     (res, cur) => {


### PR DESCRIPTION
### Bug noted:
`FileContributors` errors out when loading a page without commit history. Surfaced from PR #2785 where new page errors out on load, since this component is trying to fetch the commit history on something that is not included in the master branch yet.

### Fix Description:
This component already conditionally returns `null` while in a `loading` or `error` state. I added another guard clause to also return `null` if `lastCommit` is undefined.
This allows pages without commit history yet to still load remainder of page correctly.