### PR TITLE
Added margin between FeedbackCard and BackToTop sections. [Fixes #2974]

### DIFF
--- a/src/components/FeedbackCard.js
+++ b/src/components/FeedbackCard.js
@@ -11,9 +11,7 @@ const Card = styled.div`
   display: flex;
   flex-direction: column;
   margin-bottom: 1rem;
-  @media (max-width: ${(props) => props.theme.breakpoints.l}) {
-    margin-top: 2rem;
-  }
+  margin-top: 2rem;
 `
 
 const Content = styled.div`


### PR DESCRIPTION
[Fixes #2974]

## Description

Deleted media-query in the FeedbackCard file to add top margin between the FeedbackCard element and the previous one.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
