### PR TITLE
Fix WalletCard component layout issues and errors in Safari

### DIFF
--- a/src/components/WalletCard.js
+++ b/src/components/WalletCard.js
@@ -311,7 +311,7 @@ const WalletCard = ({ wallet }) => {
           >
             <FlipIcon>
               <Translation id="page-find-wallet-card-more-info" />
-              <StyledIcon name="flip" ml="1rem" size="1.25rem" />
+              <StyledIcon name="flip" ml="1rem" size="20px" />
             </FlipIcon>
           </StyledButtonSecondary>
           <StyledButtonLink to={wallet.url} hideArrow={true}>
@@ -335,7 +335,7 @@ const WalletCard = ({ wallet }) => {
                 </ImageWrapper>
                 <Title>{wallet.name}</Title>
               </BackHeaderRow>
-              <Icon name="flip" ml="1rem" size="1.5rem" />
+              <Icon name="flip" ml="1rem" size="24px" />
             </FlipTitle>
             <FeaturesHeader>
               <Translation id="page-find-wallet-card-features" />

--- a/src/components/WalletCard.js
+++ b/src/components/WalletCard.js
@@ -36,7 +36,6 @@ const StyledIcon = styled(Icon)`
 const CardFace = styled(motion.div)`
   position: absolute;
   backface-visibility: hidden;
-  height: 100%;
   width: 100%;
   color: ${({ theme }) => theme.colors.text};
   box-shadow: 0px 14px 66px rgba(0, 0, 0, 0.07),
@@ -46,8 +45,8 @@ const CardFace = styled(motion.div)`
 
 const CardFront = styled(CardFace)`
   display: flex;
-  height: 100%;
   width: 100%;
+  min-height: 400px;
   flex-direction: column;
   justify-content: space-between;
   border-radius: 4px;
@@ -166,8 +165,7 @@ const FeatureRow = styled.div`
 `
 
 const StyledButtonSecondary = styled(ButtonSecondary)`
-  margin: 1rem;
-  margin-bottom: 0rem;
+  margin: auto 1rem 0 1rem;
 `
 
 const HeaderRow = styled.div`


### PR DESCRIPTION
## Description

Switch size of Icons from rem to px because Safari was throw errors related to setting width and height on svgs.
Replaced height: 100% with min-height and adjusted margin to fix layout issues in safari

## Related Issue

[Fixes #2971]
