### PR TITLE
Fix typo in merge/index.md

### DIFF
--- a/src/content/eth2/merge/index.md
+++ b/src/content/eth2/merge/index.md
@@ -9,7 +9,7 @@ summaryPoints:
   [
     'Eventually the current Ethereum mainnet will "merge" with the beacon chain proof-of-stake system.',
     "This will mark the end of proof-of-work for Ethereum, and the full transition to proof-of-stake.",
-    "This is planned to preceed the roll out of shard chains.",
+    "This is planned to precede the roll out of shard chains.",
     'We formerly referred to this as "the docking."',
   ]
 ---


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed typo.
```
preceed -> precede
```

<!--- Describe your changes in detail -->
