### PR TITLE
Typo correction

### DIFF
--- a/src/content/developers/docs/apis/json-rpc/index.md
+++ b/src/content/developers/docs/apis/json-rpc/index.md
@@ -1831,7 +1831,7 @@ params: [
 
 **Returns**
 
-`Boolean` - returns `true` if submitting went through succesfully and `false` otherwise.
+`Boolean` - returns `true` if submitting went through successfully and `false` otherwise.
 
 **Example**
 

--- a/src/content/developers/tutorials/transfers-and-approval-of-erc-20-tokens-from-a-solidity-smart-contract/index.md
+++ b/src/content/developers/tutorials/transfers-and-approval-of-erc-20-tokens-from-a-solidity-smart-contract/index.md
@@ -172,7 +172,7 @@ In the case where the buy is successful we should see two events in the transact
 
 ## The sell function {#the-sell-function}
 
-The function responsible for the sell will first require the user to have approved the amount by calling the approve function beforehand. Then when the sell function is called, we’ll check if the transfer from the caller address to the contract address was succesful and then send the Ethers back to the caller address.
+The function responsible for the sell will first require the user to have approved the amount by calling the approve function beforehand. Then when the sell function is called, we’ll check if the transfer from the caller address to the contract address was successful and then send the Ethers back to the caller address.
 
 ```solidity
 function sell(uint256 amount) public {

--- a/src/intl/en/page-index.json
+++ b/src/intl/en/page-index.json
@@ -50,7 +50,7 @@
   "page-index-network-stats-eth-price-description": "ETH price (USD)",
   "page-index-network-stats-eth-price-explainer": "The latest price for 1 ether. You can buy as little as 0.000000000000000001 – you don't need to buy 1 whole ETH.",
   "page-index-network-stats-tx-day-description": "Transactions today",
-  "page-index-network-stats-tx-day-explainer": "The number of transactions succesfully processed on the network in the last 24 hours.",
+  "page-index-network-stats-tx-day-explainer": "The number of transactions successfully processed on the network in the last 24 hours.",
   "page-index-network-stats-value-defi-description": "Value locked in DeFi (USD)",
   "page-index-network-stats-value-defi-explainer": "The amount of money in decentralized finance (DeFi) applications, the Ethereum digital economy.",
   "page-index-network-stats-nodes-description": "Nodes",


### PR DESCRIPTION
## Description
- "succesful" and "succesfully" typos fixed

## Related Issue
Reported by user via email (thanks!):
![image](https://user-images.githubusercontent.com/54227730/117726906-20e7aa80-b19c-11eb-90e5-63917df81901.png)

Found a couple other instances while fixing. 