### PR TITLE
Change a word in definition of difficulty bomb

### DIFF
--- a/src/content/glossary/index.md
+++ b/src/content/glossary/index.md
@@ -150,7 +150,7 @@ A network-wide setting that controls how much computation is required to produce
 
 ### difficulty bomb {#difficulty-bomb}
 
-Planned exponential increase in [proof-of-work](#pow) [difficulty](#difficulty) setting designed to motivate the transition to [proof-of-stake](#pos), reducing the changes of a [fork](#hard-fork)
+Planned exponential increase in [proof-of-work](#pow) [difficulty](#difficulty) setting designed to motivate the transition to [proof-of-stake](#pos), reducing the chances of a [fork](#hard-fork)
 
 ### digital signature {#digital-signatures}
 


### PR DESCRIPTION
Changes the word 'changes' to 'chances' for the sentence to make sense.

## Related Issue
Closes #3043
