### PR TITLE
stablecoins: set the correct URLs for all DEXs

### DIFF
--- a/src/components/StablecoinAccordion.js
+++ b/src/components/StablecoinAccordion.js
@@ -353,25 +353,25 @@ const StablecoinAccordion = () => {
     {
       title: "DyDx",
       image: data.dydx.childImageSharp.fixed,
-      link: "https://beaconcha.in",
+      link: "https://dydx.exchange",
       alt: translateMessageId("dydx-logo", intl),
     },
     {
       title: "Loopring",
       image: data.loopring.childImageSharp.fixed,
-      link: "https://beaconcha.in",
+      link: "https://loopring.org",
       alt: translateMessageId("loopring-logo", intl),
     },
     {
       title: "1inch",
       image: data.oneinch.childImageSharp.fixed,
-      link: "https://beaconcha.in",
+      link: "https://app.1inch.io",
       alt: translateMessageId("1inch-logo", intl),
     },
     {
       title: "Matcha",
       image: data.matcha.childImageSharp.fixed,
-      link: "https://beaconcha.in",
+      link: "https://matcha.xyz",
       alt: translateMessageId("matcha-logo", intl),
     },
   ]
@@ -386,7 +386,7 @@ const StablecoinAccordion = () => {
     {
       title: "DyDx",
       image: data.dydx.childImageSharp.fixed,
-      link: "https://beaconcha.in",
+      link: "https://dydx.exchange",
       alt: translateMessageId("dydx-logo", intl),
     },
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The DEX links on the stablecoin section contain wrong URLs. This change uses the correct URL for each DEX.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
