### PR TITLE
Fix ethers documentation links

### DIFF
--- a/src/content/developers/docs/apis/javascript/index.md
+++ b/src/content/developers/docs/apis/javascript/index.md
@@ -253,7 +253,7 @@ ethers.utils.formatEther(balance)
 
 **Ethers.js -** **_Complete Ethereum wallet implementation and utilities in JavaScript and TypeScript._**
 
-- [Documentation](https://docs.ethers.io/ethers.js/html/)
+- [Documentation](https://docs.ethers.io/)
 - [GitHub](https://github.com/ethers-io/ethers.js/)
 
 **The Graph -** **_A protocol for indexing Ethereum and IPFS data and querying it using GraphQL._**

--- a/src/content/developers/tutorials/kickstart-your-dapp-frontend-development-wth-create-eth-app/index.md
+++ b/src/content/developers/tutorials/kickstart-your-dapp-frontend-development-wth-create-eth-app/index.md
@@ -57,7 +57,7 @@ The _create-eth-app_ in particular is making use of the new [hooks effects](http
 
 ### ethers.js {#ethersjs}
 
-While [Web3](https://web3js.readthedocs.io/en/v1.2.7/) is still mostly used, [ethers.js](https://docs.ethers.io/ethers.js/html/) has been getting a lot more traction as an alternative in the last year and is the one integrated into _create-eth-app_. You can work with this one, change it to Web3 or consider upgrading to [ethers.js v5](https://docs-beta.ethers.io/) which is almost out of beta.
+While [Web3](https://web3js.readthedocs.io/en/v1.2.7/) is still mostly used, [ethers.js](https://docs.ethers.io/) has been getting a lot more traction as an alternative in the last year and is the one integrated into _create-eth-app_. You can work with this one, change it to Web3 or consider upgrading to [ethers.js v5](https://docs-beta.ethers.io/) which is almost out of beta.
 
 ### The Graph {#the-graph}
 

--- a/src/content/developers/tutorials/set-up-web3js-to-use-ethereum-in-javascript/index.md
+++ b/src/content/developers/tutorials/set-up-web3js-to-use-ethereum-in-javascript/index.md
@@ -90,4 +90,4 @@ if (window.ethereum != null) {
 }
 ```
 
-Alternatives to web3.js like [Ethers.js](https://docs.ethers.io/ethers.js/html/) do exist but we’ll focus all our JavaScript tutorials on web3.js as it is the official library to interact with Ethereum in the browser. In the next tutorial we’ll see [how to easily listen to new incoming blocks on the blockchain and see what they contains](https://ethereumdev.io/listening-to-new-transactions-happening-on-the-blockchain/).
+Alternatives to web3.js like [Ethers.js](https://docs.ethers.io/) do exist but we’ll focus all our JavaScript tutorials on web3.js as it is the official library to interact with Ethereum in the browser. In the next tutorial we’ll see [how to easily listen to new incoming blocks on the blockchain and see what they contains](https://ethereumdev.io/listening-to-new-transactions-happening-on-the-blockchain/).

--- a/src/content/translations/ar/javascript/index.md
+++ b/src/content/translations/ar/javascript/index.md
@@ -44,7 +44,7 @@ sidebar: true
 
 **Ethers.js -** **_تطبيق محفظة إيثريوم مكتملة مع الأدوات المساعدة باستخدام JavaScript و TypeScript._**
 
-- [التوثيق](https://docs.ethers.io/ethers.js/html/)
+- [التوثيق](https://docs.ethers.io/)
 - [GitHub](https://github.com/ethers-io/ethers.js/)
 
 **ethereumjs-vm -** **_VM الخاص بإيثريوم المنفذ في JavaScript_**

--- a/src/content/translations/bn/javascript/index.md
+++ b/src/content/translations/bn/javascript/index.md
@@ -44,7 +44,7 @@ sidebar: true
 
 **Ethers.js -** **_সম্পূর্ণ ইথেরিয়াম ওয়ালেট বাস্তবায়ন এবং জাভাস্ক্রিপ্ট ও টাইপস্ক্রিপ্ট-এ ইউটিলিটি।_**
 
-- [নথিপত্র](https://docs.ethers.io/ethers.js/html/)
+- [নথিপত্র](https://docs.ethers.io/)
 - [GitHub](https://github.com/ethers-io/ethers.js/)
 
 **ethereumjs-vm -** **_জাভাস্ক্রিপ্টে বাস্তবায়িত এথেরিয়াম ভিএম_**

--- a/src/content/translations/cs/javascript/index.md
+++ b/src/content/translations/cs/javascript/index.md
@@ -45,7 +45,7 @@ Potřebujete nejdříve úplně základní informace? Podívejte se na [ethereum
 
 **Ethers.js -** **_kompletní implementace peněženky pro Ethereum a nástrojů v JavaScriptu a v TypeScriptu_**
 
-- [Dokumentace](https://docs.ethers.io/ethers.js/html/)
+- [Dokumentace](https://docs.ethers.io/)
 - [GitHub](https://github.com/ethers-io/ethers.js/)
 
 **ethereumjs-vm -** **_Ethereum virtuální stroj (VM) implementovaný v JavaScriptu_**

--- a/src/content/translations/de/javascript/index.md
+++ b/src/content/translations/de/javascript/index.md
@@ -44,7 +44,7 @@ Brauchst du zuerst einen grundsätzlichen Einstieg? Schaue dir [ethereum.org/lea
 
 **Ethers.js -** **_Eine vollständige Ethereum-Wallet-Implementierung und Utilities in JavaScript und TypeScript._**
 
-- [Dokumentation](https://docs.ethers.io/ethers.js/html/)
+- [Dokumentation](https://docs.ethers.io/)
 - [GitHub](https://github.com/ethers-io/ethers.js/)
 
 **Web3.js -** **_Ethereum JavaScript API._**

--- a/src/content/translations/es/javascript/index.md
+++ b/src/content/translations/es/javascript/index.md
@@ -45,7 +45,7 @@ Usa Ethereum para crear aplicaciones descentralizadas (o "dapps") mediante los b
 
 **Ethers.js:** **_completa implementación de la cartera de Ethereum y utilidades en JavaScript y TypeScript._**
 
-- [Documentación](https://docs.ethers.io/ethers.js/html/)
+- [Documentación](https://docs.ethers.io/)
 - [GitHub](https://github.com/ethers-io/ethers.js/)
 
 **ethereumjs-vm: ** **_la máquina virtual de Ethereum implementada en JavaScript_**

--- a/src/content/translations/fi/javascript/index.md
+++ b/src/content/translations/fi/javascript/index.md
@@ -45,7 +45,7 @@ Tarvitsetko perusteellisempaa aloitusta? Katso [ethereum.org/fi/learn](/learn/) 
 
 **Ethers.js -** **_Kokonainen Ethereum-lompakkototeutus ja työkalut JavaScriptillä ja TypeScriptillä._**
 
-- [Dokumentaatio](https://docs.ethers.io/ethers.js/html/)
+- [Dokumentaatio](https://docs.ethers.io/)
 - [GitHub](https://github.com/ethers-io/ethers.js/)
 
 **ethereumjs-vm -** **_Ethereum VM toteutettu JavaScriptillä_**

--- a/src/content/translations/fr/javascript/index.md
+++ b/src/content/translations/fr/javascript/index.md
@@ -44,7 +44,7 @@ Besoin d’une approche plus élémentaire&nbsp;? Jetez un oeil à [ethereum.org
 
 **Ethers.js -** **_Complete Ethereum wallet implementation and utilities in JavaScript and TypeScript._**
 
-- [Documentation](https://docs.ethers.io/ethers.js/html/)
+- [Documentation](https://docs.ethers.io/)
 - [GitHub](https://github.com/ethers-io/ethers.js/)
 
 **ethereumjs-vm -** **_The Ethereum VM implemented in JavaScript_**

--- a/src/content/translations/hu/javascript/index.md
+++ b/src/content/translations/hu/javascript/index.md
@@ -45,7 +45,7 @@ Szűkséged van egy még kezdetlegesebb alapozóra? Tekintsd meg a [ethereum.org
 
 **Ethers.js -** **_Teljes Ethereum tárca implementáció és segédprogramok JavaScript-ben és TypeScript-ben._**
 
-- [Dokumentáció](https://docs.ethers.io/ethers.js/html/)
+- [Dokumentáció](https://docs.ethers.io/)
 - [GitHub](https://github.com/ethers-io/ethers.js/)
 
 **ethereumjs-vm -** **_Az Ethereum VM JavaScript-ben implementálva_**

--- a/src/content/translations/id/javascript/index.md
+++ b/src/content/translations/id/javascript/index.md
@@ -44,7 +44,7 @@ Perlu penjelasan yang lebih mendasar? Kunjungi [ethereum.org/learn](/id/learn/) 
 
 **Ethers.js -** **_Implementasi wallet Ethereum secara lengkap dengan JavaScript and TypeScript._**
 
-- [Dokumentasi](https://docs.ethers.io/ethers.js/html/)
+- [Dokumentasi](https://docs.ethers.io/)
 - [GitHub](https://github.com/ethers-io/ethers.js/)
 
 **ethereumjs-vm -** **_Implementasi Ethereum Virtual Machine (EVM) di JavaScript_**

--- a/src/content/translations/it/javascript/index.md
+++ b/src/content/translations/it/javascript/index.md
@@ -45,7 +45,7 @@ Ti servono prima le nozioni di base? Dai un'occhiata a [ethereum.org/learn](/it/
 
 **Ethers.js -** **_Implementazione completa del portafoglio di Ethereum e utilità in JavaScript e TypeScript_**
 
-- [Documentazione](https://docs.ethers.io/ethers.js/html/)
+- [Documentazione](https://docs.ethers.io/)
 - [GitHub](https://github.com/ethers-io/ethers.js/)
 
 **ethereumjs-vm -** **_La VM di Ethereum implementata in JavaScript_**

--- a/src/content/translations/ja/javascript/index.md
+++ b/src/content/translations/ja/javascript/index.md
@@ -45,7 +45,7 @@ sidebarDepth: 1
 
 **Ethers.js -** **_JavaScript と TypeScript による完全なイーサリアムウォレットの実装とユーティリティ。_**
 
-- [ドキュメント](https://docs.ethers.io/ethers.js/html/)
+- [ドキュメント](https://docs.ethers.io/)
 - [GitHub](https://github.com/ethers-io/ethers.js/)
 
 **ethereumjs-vm -** **_JavaScript で実装されたイーサリアム VM_**

--- a/src/content/translations/ko/javascript/index.md
+++ b/src/content/translations/ko/javascript/index.md
@@ -45,7 +45,7 @@ sidebarDepth: 1
 
 **Ethers.js -** **_JavaScript와 TypeScript로 작성된 완전한 이더리움 지갑 구현체 및 각종 유틸리티_**
 
-- [개발 문서](https://docs.ethers.io/ethers.js/html/)
+- [개발 문서](https://docs.ethers.io/)
 - [GitHub](https://github.com/ethers-io/ethers.js/)
 
 **ethereumjs-vm -** **_JavaScript로 구현된 이더리움 VM_**

--- a/src/content/translations/lt/javascript/index.md
+++ b/src/content/translations/lt/javascript/index.md
@@ -45,7 +45,7 @@ Norėtumėte pradėti nuo ko nors paprastesnio? Apsilankykite [ethereum.org/lear
 
 **Ethers.js –** **_visiškas Ethereum piniginės įdiegimas ir parankinės priemonės, skirtos JavaScript ir TypeScript._**
 
-- [Dokumentacija](https://docs.ethers.io/ethers.js/html/)
+- [Dokumentacija](https://docs.ethers.io/)
 - [GitHub](https://github.com/ethers-io/ethers.js/)
 
 **ethereumjs-vm -** **_Ethereum VM įdiegta JavaScript_**

--- a/src/content/translations/ml/javascript/index.md
+++ b/src/content/translations/ml/javascript/index.md
@@ -44,7 +44,7 @@ sidebar: true
 
 ** Ethers.js - ** ** _ ജാവാസ്ക്രിപ്റ്റിലും ടൈപ്പ്സ്ക്രിപ്റ്റിലും Ethereum Wallet നടപ്പിലാക്കലും യൂട്ടിലിറ്റികളും പൂർത്തിയാക്കുക. _ **
 
-- [പ്രമാണീകരണം](https://docs.ethers.io/ethers.js/html/)
+- [പ്രമാണീകരണം](https://docs.ethers.io/)
 - [Github](https://github.com/ethers-io/ethers.js/)
 
 ** ethereumjs-vm - ** ** _ ജാവാസ്ക്രിപ്റ്റിൽ നടപ്പിലാക്കിയ Ethereum VM _ **

--- a/src/content/translations/nb/javascript/index.md
+++ b/src/content/translations/nb/javascript/index.md
@@ -44,7 +44,7 @@ Trenger du en mer grunnleggende informasjon først? Sjekk ut [ethereum.org/learn
 
 **Ethers.js -** **_Komplett Ethereum wallet implementering og verktøyer i JavaScript og TypeScript._**
 
-- [Dokumentasjon](https://docs.ethers.io/ethers.js/html/)
+- [Dokumentasjon](https://docs.ethers.io/)
 - [GitHub](https://github.com/ethers-io/ethers.js/)
 
 **ethereumjs-vm -** **_Ethereum VM implementert i JavaScript_**

--- a/src/content/translations/pt-br/javascript/index.md
+++ b/src/content/translations/pt-br/javascript/index.md
@@ -45,7 +45,7 @@ Precisa de uma introdução geral? Confira [ethereum.org/learn](/learn/) ou [eth
 
 **Ethers.js -** **_Implementação completa de uma carteira Ethereum e utilidades em JavaScript e TypeScript._**
 
-- [Documentação](https://docs.ethers.io/ethers.js/html/)
+- [Documentação](https://docs.ethers.io/)
 - [GitHub](https://github.com/ethers-io/ethers.js/)
 
 **ethereumjs-vm -** **_A Máquina Virtual de Ethereum implementada em JavaScript_**

--- a/src/content/translations/ro/developers/docs/apis/javascript/index.md
+++ b/src/content/translations/ro/developers/docs/apis/javascript/index.md
@@ -253,7 +253,7 @@ ethers.utils.formatEther(balance)
 
 **Ethers.js -** **_Implementare completă de portofel Ethereum și utilitare, în JavaScript și TypeScript._**
 
-- [Documentație](https://docs.ethers.io/ethers.js/html/)
+- [Documentație](https://docs.ethers.io/)
 - [GitHub](https://github.com/ethers-io/ethers.js/)
 
 **The Graph -** **_Un protocol de indexare a datelor Ethereum și IPFS și interogarea acestora folosind GraphQL._**

--- a/src/content/translations/ro/javascript/index.md
+++ b/src/content/translations/ro/javascript/index.md
@@ -44,7 +44,7 @@ Ai nevoie de o scurtă introducere? Accesează [ethereum.org/learn](/ro/learn/) 
 
 **Ethers.js -** **_Implementare completă de portofel Ethereum și utilitare, în JavaScript și TypeScript._**
 
-- [Documentație](https://docs.ethers.io/ethers.js/html/)
+- [Documentație](https://docs.ethers.io/)
 - [GitHub](https://github.com/ethers-io/ethers.js/)
 
 **ethereumjs-vm -** **_Implementare Ethereum VM în JavaScript_**

--- a/src/content/translations/se/javascript/index.md
+++ b/src/content/translations/se/javascript/index.md
@@ -44,7 +44,7 @@ Behöver du en mer grundläggande introduktion först? Kolla in [ethereum.org/se
 
 **Ethers.js -** **_Fullständig Ethereum-plånboksimplementering och verktyg i JavaScript och TypeScript_**
 
-- [Dokumentation](https://docs.ethers.io/ethers.js/html/)
+- [Dokumentation](https://docs.ethers.io/)
 - [GitHub](https://github.com/ethers-io/ethers.js/)
 
 **ethereumjs-vm -** **_Ethereum VM implementerad i JavaScript_**

--- a/src/content/translations/sk/javascript/index.md
+++ b/src/content/translations/sk/javascript/index.md
@@ -44,7 +44,7 @@ Potrebujete ďalšie základné informácie o Ethereu? Pozrite si [ethereum.org/
 
 **Ethers.js -** **_kompletná implementácia peňaženky Ethereum a pomôcky vytvorené v jazykoch JavaScript a TypeScript_**
 
-- [Dokumentácia](https://docs.ethers.io/ethers.js/html/)
+- [Dokumentácia](https://docs.ethers.io/)
 - [GitHub](https://github.com/ethers-io/ethers.js/)
 
 **ethereumjs-vm -** **_implementácia virtuálneho počítača Ethereum v JavaScripte_**

--- a/src/content/translations/tr/javascript/index.md
+++ b/src/content/translations/tr/javascript/index.md
@@ -44,7 +44,7 @@ Başlamadan önce daha fazla bilgiye mi ihtiyacın var? Bu adrese giderek [ether
 
 **Ethers.js -** **_Complete Ethereum wallet implementation and utilities in JavaScript and TypeScript._**
 
-- [Dökümanlar](https://docs.ethers.io/ethers.js/html/)
+- [Dökümanlar](https://docs.ethers.io/)
 - [GitHub](https://github.com/ethers-io/ethers.js/)
 
 **ethereumjs-vm -** **_The Ethereum VM implemented in JavaScript_**

--- a/src/content/translations/uk/javascript/index.md
+++ b/src/content/translations/uk/javascript/index.md
@@ -45,7 +45,7 @@ sidebarDepth: 1
 
 **Ethers.js —** **_повна реалізація гаманця Ethereum та інших службових програм на JavaScript і TypeScript._**
 
-- [Документація](https://docs.ethers.io/ethers.js/html/)
+- [Документація](https://docs.ethers.io/)
 - [GitHub](https://github.com/ethers-io/ethers.js/)
 
 **ethereumjs-vm —** **_ВМ Ethereum, реалізована на JavaScript_**

--- a/src/content/translations/vi/javascript/index.md
+++ b/src/content/translations/vi/javascript/index.md
@@ -45,7 +45,7 @@ Cần một hướng dẫn cơ bản hơn? Tham khảo [ethereum.org/learn](/vi/
 
 **Ethers.js -** **_Công cụ thiết lập và các tiện ích ví Ethereum toàn diện bằng ngôn ngữ JavaScript và TypeScript._**
 
-- [Tài liệu tham khảo](https://docs.ethers.io/ethers.js/html/)
+- [Tài liệu tham khảo](https://docs.ethers.io/)
 - [GitHub](https://github.com/ethers-io/ethers.js/)
 
 **ethereumjs-vm -** **_Máy ảo Ethereum được triển khai bằng JavaScript_**

--- a/src/content/translations/zh-tw/javascript/index.md
+++ b/src/content/translations/zh-tw/javascript/index.md
@@ -44,7 +44,7 @@ sidebar: true
 
 **Ethers.js -** **_JavaScript 和 TypeScript 中完整的以太坊錢包實現和實用工具。 _**
 
-- [文件](https://docs.ethers.io/ethers.js/html/)
+- [文件](https://docs.ethers.io/)
 - [GitHub](https://github.com/ethers-io/ethers.js/)
 
 **ethereumjs-vm -** **_在 JavaScript 中實現以太坊虛擬機（VM）_**

--- a/src/content/translations/zh/javascript/index.md
+++ b/src/content/translations/zh/javascript/index.md
@@ -44,7 +44,7 @@ sidebar: true
 
 **Ethers.js -** **_JavaScript 和 TypeScript 中完整的以太坊钱包实现和实用工具。_**
 
-- [相关文档](https://docs.ethers.io/ethers.js/html/)
+- [相关文档](https://docs.ethers.io/)
 - [GitHub](https://github.com/ethers-io/ethers.js/)
 
 **ethereumjs-vm -** **_在 JavaScript 中实现以太坊虚拟机（VM）_**


### PR DESCRIPTION
The current ethers documentation links go to an outdated page which gives the message: 'This link is out-of-date and has moved.'

This PR fixes those links to go to the correct documentation page.
