### PR TITLE
Adds ethereum.org discord to community section [Closes #3083]

### DIFF
--- a/src/content/community/index.md
+++ b/src/content/community/index.md
@@ -34,6 +34,7 @@ Hundreds of thousands of Ethereum enthusiasts gather in these online forums to s
   - [Ethereum Hackers](https://ethglobal.co/discord) - _Discord chat run by [ETHGlobal](https://www.ethglobal.co/): an online community for Ethereum hackers all over the world_
   - [CryptoDevs Discord](https://discord.gg/5W5tVb3) - _Ethereum development focused Discord community_
   - [EthStaker Discord](https://discord.gg/NvCxbCu) - _Support for the [Beacon Chain](/eth2/beacon-chain/) staking community_
+  - [ethereum.org Website Team](https://discord.gg/CetY6Y4) - _Stop by and chat ethereum.org web design with the team and folks from the community_
 - Twitter
   - The Ethereum community is very active on Twitter - not sure where to start?
     - [List of influential Ethereum twitter accounts](https://hive.one/ethereum/)


### PR DESCRIPTION
## Description
Adds ethereum.org discord to list of chat rooms on community page. 

Possible answer to #3083, but would appreciate feedback before merging... @samajammin @ryancreatescopy Any thoughts on placing this here? Or should we consider waiting until our community role is expanded and re-address then? 

## Related Issue
[Closes #3083]