### PR TITLE
Stop refresh on 'Enter' key press while searching

### DIFF
--- a/src/components/Search/Input.js
+++ b/src/components/Search/Input.js
@@ -40,12 +40,16 @@ const Input = ({ query, setQuery, refine, ...rest }) => {
     refine(value)
     setQuery(value)
   }
+  
+  const handleSubmit = (event) => {
+    event.preventDefault()
+  }
 
   const intl = useIntl()
   const searchString = translateMessageId("search", intl)
 
   return (
-    <Form>
+    <Form onSubmit={handleSubmit}>
       <StyledInput
         type="text"
         placeholder={searchString}


### PR DESCRIPTION
## Description

Hitting <kbd>Enter</kbd> whilst in the search box refreshed the page. Added onSubmit handler to override this behaviour. Now it simply does nothing.. I think this is probably the only thing that can be done for now unless there are plans to implement a search results page?

Open to ideas on this one because I don't think simply breaking the form submission is optimal.

## Related Issue
Closes #3059
