### PR TITLE
Remove EEA links [Fixes #3121]

### DIFF
--- a/src/content/enterprise/index.md
+++ b/src/content/enterprise/index.md
@@ -44,9 +44,6 @@ The Baseline Protocol is one key project which is defining a protocol that enabl
 
 Some collaborative efforts to make Ethereum enterprise friendly have been made by different organizations:
 
-- [Enterprise Ethereum Alliance (EEA)](https://entethalliance.org/)
-  The EEA enables organizations to adopt and use Ethereum technology in their daily business operations. It empowers the Ethereum ecosystem to develop new business opportunities, drive industry adoption, and learn and collaborate with one another.
-  The EEA’s mainnet working group is a focal point for representatives from businesses who are interested in building on the public Ethereum mainnet, as well as members of the Ethereum community who would like to support them.
 - [Ethereum OASIS Open Project](https://github.com/ethereum-oasis/oasis-open-project)
   The Ethereum OASIS Open Project is an OASIS Open Project that exists to provide a neutral forum for diverse stakeholders to create high-quality specifications that facilitate Ethereum’s longevity, interoperability, and ease of integration. The project intends to develop clear, open standards, high-quality documentation, and shared test suites that facilitate new features and enhancements to the Ethereum protocol.
 - [Baseline Project](https://www.baseline-protocol.org/)

--- a/src/content/enterprise/private-ethereum/index.md
+++ b/src/content/enterprise/private-ethereum/index.md
@@ -13,10 +13,6 @@ Enterprise blockchain applications can be built on the public permissionless Eth
 
 ### Organizations {#organisations}
 
-Some collaborative efforts to make Ethereum enterprise friendly have been put together by different organizations:
-
-- [Enterprise Ethereum Alliance](https://entethalliance.org/)
-  The EEA enables organizations to adopt and use Ethereum technology in their daily business operations. We empower the Ethereum ecosystem to develop new business opportunities, drive industry adoption, and learn and collaborate with one another.
 - [Hyperledger](https://hyperledger.org)
   _Hyperledger is an open source collaborative effort created to advance cross-industry blockchain technologies. It is a global collaboration, hosted by The Linux Foundation, including leaders in finance, banking, Internet of Things, supply chains, manufacturing and Technology. The foundation has some projects in it that work with the Ethereum stack:, including [Besu](https://www.hyperledger.org/use/besu) and [Burrow](https://www.hyperledger.org/projects/hyperledger-burrow)._
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Remove untrustworthy organisation links from /enterprise and /enterprise/private-ethereum/

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
#3121 
