### PR TITLE
Update local dev instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,18 @@ We recommend setting this up when running the project locally, as we use the Git
 GATSBY_GITHUB_TOKEN_READ_ONLY=48f84de812090000demo00000000697cf6e6a059
 ```
 
+5. Add Etherscan API token (free)
+
+> - [Create an account](https://etherscan.io/) on Etherscan
+> - Navigate to your Account Settings page
+> - In the sidebar, click on 'API-KEYs' and add a new token
+> - Copy & paste your Etherscan Api-Key Token in `.env`
+
+```
+// .env Example:
+ETHERSCAN_API_KEY=K6NUTARFJZJCIXHF1F1E1YGJZ8RQ29BE4U
+```
+
 6. Add DeFiPulse API token (free)
 
 > - [Follow this guide](https://docs.defipulse.com/quick-start-guide) to create an account and get your DeFiPulse API token

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ We recommend setting this up when running the project locally, as we use the Git
 > - [Follow these instructions](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) to create a personal GitHub API token
 >   - When selecting scopes in step 7, leave everything unchecked (the data we fetch doesn't require any [scope](https://docs.github.com/en/developers/apps/scopes-for-oauth-apps#available-scopes))
 > - In local repo root directory: Make a copy of `.env.example` and name it `.env`
-> - Copy & paste your new GitHub API token in `.env`
+> - Copy & paste your new GitHub API token into `.env`
 
 ```
 // .env Example:
@@ -88,7 +88,7 @@ GATSBY_GITHUB_TOKEN_READ_ONLY=48f84de812090000demo00000000697cf6e6a059
 > - [Create an account](https://etherscan.io/) on Etherscan
 > - Navigate to your Account Settings page
 > - In the sidebar, click on 'API-KEYs' and add a new token
-> - Copy & paste your Etherscan Api-Key Token in `.env`
+> - Copy & paste your Etherscan Api-Key Token into `.env`
 
 ```
 // .env Example:
@@ -98,7 +98,7 @@ ETHERSCAN_API_KEY=K6NUTARFJZJCIXHF1F1E1YGJZ8RQ29BE4U
 6. Add DeFiPulse API token (free)
 
 > - [Follow this guide](https://docs.defipulse.com/quick-start-guide) to create an account and get your DeFiPulse API token
-> - Copy & paste your DeFiPulse API token in `.env`
+> - Copy & paste your DeFiPulse API token into `.env`
 
 ```
 // .env Example:

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ GATSBY_GITHUB_TOKEN_READ_ONLY=48f84de812090000demo00000000697cf6e6a059
 > - [Create an account](https://etherscan.io/) on Etherscan
 > - Navigate to your Account Settings page
 > - In the sidebar, click on 'API-KEYs' and add a new token
-> - Copy & paste your Etherscan Api-Key Token into `.env`
+> - Copy & paste your Api-Key Token from Etherscan into `.env`
 
 ```
 // .env Example:
@@ -98,7 +98,7 @@ ETHERSCAN_API_KEY=K6NUTARFJZJCIXHF1F1E1YGJZ8RQ29BE4U
 6. Add DeFiPulse API token (free)
 
 > - [Follow this guide](https://docs.defipulse.com/quick-start-guide) to create an account and get your DeFiPulse API token
-> - Copy & paste your DeFiPulse API token into `.env`
+> - Copy & paste your Active API Key from DeFiPulse into `.env`
 
 ```
 // .env Example:

--- a/README.md
+++ b/README.md
@@ -83,6 +83,16 @@ We recommend setting this up when running the project locally, as we use the Git
 GATSBY_GITHUB_TOKEN_READ_ONLY=48f84de812090000demo00000000697cf6e6a059
 ```
 
+6. Add DeFiPulse API token (free)
+
+> - [Follow this guide](https://docs.defipulse.com/quick-start-guide) to create an account and get your DeFiPulse API token
+> - Copy & paste your DeFiPulse API token in `.env`
+
+```
+// .env Example:
+DEFI_PULSE_API_KEY=4953aaf7966dad9c129397e197a0630ed0594f66962dd5fb058972b250da
+```
+
 ### Make awesome changes!
 
 1. Create new branch for your changes


### PR DESCRIPTION
Added Instructions for setting up Etherscan and DeFiPulse API keys.

Should we preface these instructions as being optional/less important than the GitHub API token. I think having the instructions available is important but we don't really want people to be bogged down by configuration if it is unnecessary for the majority of PRs.

## Related Issue
Closes #3123
