### PR TITLE
Typo corrections

### DIFF
--- a/src/content/developers/docs/accounts/index.md
+++ b/src/content/developers/docs/accounts/index.md
@@ -67,7 +67,7 @@ Example:
 
 `fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036415f`
 
-The public key is generated from the private key using the [Elliptic Curve Digital Signature Algorithm](https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm). You get a public address for your account by taking the last 20 bytes of the SHA3 hash of the public key and adding `0x` to the beginning.
+The public key is generated from the private key using the [Elliptic Curve Digital Signature Algorithm](https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm). You get a public address for your account by taking the last 20 bytes of the SHA3 hash of the private key and adding `0x` to the beginning.
 
 Here's an example of creating an account in the console using GETH's `personal_newAccount`
 

--- a/src/content/developers/docs/scaling/index.md
+++ b/src/content/developers/docs/scaling/index.md
@@ -52,7 +52,7 @@ Learn more about [rollups](/developers/docs/scaling/layer-2-rollups/).
 
 #### State Channels {#channels}
 
-State channels utilize multisig contracts to enable participants to transact quickly and freely off-chain, then settle finality with mainnet. This minimizies network congestion, fees, and delays. The two types of channels are currently state channels and payment channels.
+State channels utilize multisig contracts to enable participants to transact quickly and freely off-chain, then settle finality with mainnet. This minimizes network congestion, fees, and delays. The two types of channels are currently state channels and payment channels.
 
 Learn more about [state channels](/developers/docs/scaling/state-channels/).
 


### PR DESCRIPTION
## Description
Two typos noted in Deploy 2.29.1 changes:
- "minimizies"
- Fixing statement about hashing your public key to get your public key. 
