### PR TITLE
Update StatBoxGrid development fallback figures 

### DIFF
--- a/src/components/StatsBoxGrid.js
+++ b/src/components/StatsBoxGrid.js
@@ -197,19 +197,19 @@ const StatsBoxGrid = () => {
     // Skip APIs when not in production
     if (process.env.NODE_ENV !== "production") {
       setEthPrice({
-        value: formatPrice(1330),
+        value: formatPrice(2265),
         hasError: false,
       })
       setValueLocked({
-        value: formatTVL(23456789000),
+        value: formatTVL(57141111000),
         hasError: false,
       })
       setTxs({
-        value: formatTxs(1234567),
+        value: formatTxs(1305167),
         hasError: false,
       })
       setNodes({
-        value: formatNodes(8040),
+        value: formatNodes(5472),
         hasError: false,
       })
     } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In development the StatBoxGrid component doesn't fetch from coingecko/etherscan/defipulse but the fallback figures were way off. I updated the fallbacks figures to reflect todays figures.

## Development Figures
![Screenshot 2021-05-29 at 21 42 53](https://user-images.githubusercontent.com/62268199/120084405-d1740a80-c0c7-11eb-873e-078161094850.png)

## Production Figures (5-29-2021) && Proposed New Development Figures
![Screenshot 2021-05-29 at 21 42 43](https://user-images.githubusercontent.com/62268199/120084400-ccaf5680-c0c7-11eb-89d9-eecf1abd10f4.png)