### PR TITLE
Asterisk in markdown fix

### DIFF
--- a/src/content/developers/docs/gas/index.md
+++ b/src/content/developers/docs/gas/index.md
@@ -26,8 +26,8 @@ In essence, gas fees are paid in Ethereum's native currency, ether (ETH). Gas pr
 Let's say Alice has to pay Bob 1ETH.
 In the transaction the gas limit is 21000 units and the gas price is 200 GWei. 
 
-Total fee will be: Gas units * Gas price per unit 
-i.e 21000 * 200 = 4,200,000 Gwei or 0.0042 ETH
+Total fee will be: Gas units &#42; Gas price per unit 
+i.e 21000 &#42; 200 = 4,200,000 Gwei or 0.0042 ETH
 
 Now, when Alice sends the money, 1.0042 ETH will be deducted from Alice's account.
 Bob will be credited 1.0000 ETH.


### PR DESCRIPTION
Changed * into &#42; because * is not visible on webpage

<!--- Provide a general summary of your changes in the Title above -->

## Description
On line 29 and 30 on the webpage https://ethereum.org/en/developers/docs/gas/
the * are not visible even not in de HTML code. 
I asume that the change from * to &#42; makes the differrence.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
