### PR TITLE
fix a typo

### DIFF
--- a/src/content/developers/tutorials/erc20-annotated-code/index.md
+++ b/src/content/developers/tutorials/erc20-annotated-code/index.md
@@ -819,7 +819,7 @@ Make sure to update `_totalSupply` when the total number of tokens changes.
     }
 ```
 
-The `_burn` function is almost identical to `_emit`, except it goes in the other direction.
+The `_burn` function is almost identical to `_mint`, except it goes in the other direction.
 
 #### The \_approve function {#\_approve}
 


### PR DESCRIPTION
I believe the correct function name here is `_mint` and not `_emit`. I can't even find a definition of the function `_emit` anywhere.