### PR TITLE
Restores waffle say hello world tutorial

### DIFF
--- a/src/content/developers/tutorials/waffle-say-hello-world-with-hardhat-and-ethers/index.md
+++ b/src/content/developers/tutorials/waffle-say-hello-world-with-hardhat-and-ethers/index.md
@@ -1,0 +1,198 @@
+---
+title: "Waffle say hello world tutorial with hardhat and ethers"
+description: Make your first Waffle project with hardhat and ethers.js
+author: "MiZiet"
+tags:
+  ["waffle", "smart contracts", "solidity", "testing", "hardhat", "ethers.js"]
+skill: basic
+lang: en
+sidebar: true
+published: 2020-10-16
+---
+
+In this [Waffle](https://ethereum-waffle.readthedocs.io) tutorial, we will learn how to set up a simple "Hello world" smart contract project, using [hardhat](https://hardhat.org/) and [ethers.js](https://docs.ethers.io/v5/). Then we will learn how to add a new functionality to our smart contract and how to test it with Waffle.
+
+Let's start with creating new project:
+
+```bash
+yarn init
+```
+
+or
+
+```bash
+npm init
+```
+
+and installing required packages:
+
+```bash
+yarn add -D hardhat @nomiclabs/hardhat-ethers ethers @nomiclabs/hardhat-waffle ethereum-waffle chai
+```
+
+or
+
+```bash
+npm install -D hardhat @nomiclabs/hardhat-ethers ethers @nomiclabs/hardhat-waffle ethereum-waffle chai
+```
+
+Next step is creating a sample hardhat project by running `npx hardhat`.
+
+```bash
+888    888                      888 888               888
+888    888                      888 888               888
+888    888                      888 888               888
+8888888888  8888b.  888d888 .d88888 88888b.   8888b.  888888
+888    888     "88b 888P"  d88" 888 888 "88b     "88b 888
+888    888 .d888888 888    888  888 888  888 .d888888 888
+888    888 888  888 888    Y88b 888 888  888 888  888 Y88b.
+888    888 "Y888888 888     "Y88888 888  888 "Y888888  "Y888
+
+👷 Welcome to Hardhat v2.0.3 👷‍
+
+? What do you want to do? …
+❯ Create a sample project
+Create an empty hardhat.config.js
+Quit
+```
+
+Select `Create a sample project`
+
+Our project's structure should look like this:
+
+```
+MyWaffleProject
+├── contracts
+│   └── Greeter.sol
+├── node_modules
+├── scripts
+│   └── sample-script.js
+├── test
+│   └── sample-test.js
+├── .gitattributs
+├── .gitignore
+├── hardhat.config.js
+└── package.json
+```
+
+### Now let's talk about some of these files: {#now-lets-talk}
+
+- Greeter.sol - our smart contract writen in solidity;
+
+```solidity
+contract Greeter {
+string greeting;
+
+constructor(string memory _greeting) public {
+console.log("Deploying a Greeter with greeting:", _greeting);
+greeting = _greeting;
+}
+
+function greet() public view returns (string memory) {
+return greeting;
+}
+
+function setGreeting(string memory _greeting) public {
+console.log("Changing greeting from '%s' to '%s'", greeting, _greeting);
+greeting = _greeting;
+}
+}
+```
+
+Our smart contract can be divided into three parts:
+
+1. constructor - where we declare a string type variable called `greeting`,
+2. function greet - a function that will return the `greeting` when called,
+3. function setGreeting - a function that allows us to change the `greeting` value.
+
+- sample-test.js - our tests file
+
+```js
+describe("Greeter", function () {
+  it("Should return the new greeting once it's changed", async function () {
+    const Greeter = await ethers.getContractFactory("Greeter")
+    const greeter = await Greeter.deploy("Hello, world!")
+
+    await greeter.deployed()
+    expect(await greeter.greet()).to.equal("Hello, world!")
+
+    await greeter.setGreeting("Hola, mundo!")
+    expect(await greeter.greet()).to.equal("Hola, mundo!")
+  })
+})
+```
+
+### Next step consists of compiling our contract and running tests: {#compiling-and-testing}
+
+Waffle tests use Mocha (a test framework) with Chai (an assertion library). All you have to do is run `npx hardhat test` and wait for the following message to appear.
+
+```bash
+✓ Should return the new greeting once it's changed
+```
+
+### Everything looks great so far, let's add some more complexity to our project <emoji text=":slightly_smiling_face:" size={1}/> {#adding-complexity}
+
+Imagine a situation where someone adds an empty string as a greeting. It wouldn't be a warm greeting, right?  
+Let's make sure that doesn't happen:
+
+We want to use solidity's `revert` when someone passes an empty string. A good thing is that we can easily test this functionality with Waffle's chai matcher `to.be.revertedWith()`.
+
+```js
+it("Should revert when passing an empty string", async () => {
+  const Greeter = await ethers.getContractFactory("Greeter")
+  const greeter = await Greeter.deploy("Hello, world!")
+
+  await greeter.deployed()
+  await expect(greeter.setGreeting("")).to.be.revertedWith(
+    "Greeting should not be empty"
+  )
+})
+```
+
+Looks like our new test didn't pass:
+
+```bash
+Deploying a Greeter with greeting: Hello, world!
+Changing greeting from 'Hello, world!' to 'Hola, mundo!'
+    ✓ Should return the new greeting once it's changed (1514ms)
+Deploying a Greeter with greeting: Hello, world!
+Changing greeting from 'Hello, world!' to ''
+    1) Should revert when passing an empty string
+
+
+  1 passing (2s)
+  1 failing
+```
+
+Let's implement this functionality into our smart contract:
+
+```solidity
+require(bytes(_greeting).length > 0, "Greeting message is empty");
+```
+
+Now, our setGreeting function looks like this:
+
+```solidity
+function setGreeting(string memory _greeting) public {
+require(bytes(_greeting).length > 0, "Greeting should not be empty");
+console.log("Changing greeting from '%s' to '%s'", greeting, _greeting);
+greeting = _greeting;
+}
+```
+
+Let's run tests again:
+
+```bash
+✓ Should return the new greeting once it's changed (1467ms)
+✓ Should revert when passing an empty string (276ms)
+
+2 passing (2s)
+```
+
+Congrats! You made it :)
+
+### Conclusion {#conclusion}
+
+We made a simple project with Waffle, Hardhat and ethers.js. We learned how to set up a project, add a test and implement new functionality.
+
+For more great chai matchers to test your smart contracts, check [official Waffle's docs](https://ethereum-waffle.readthedocs.io/en/latest/matchers.html).

--- a/src/content/translations/ro/developers/tutorials/waffle-say-hello-world-with-hardhat-and-ethers/index.md
+++ b/src/content/translations/ro/developers/tutorials/waffle-say-hello-world-with-hardhat-and-ethers/index.md
@@ -1,0 +1,198 @@
+---
+title: "Waffle spune „Salut, lume”; tutorial cu Hardhat și eteri"
+description: Realizează primul tău proiect Waffle cu hardhat și ethers.js
+author: "MiZiet"
+tags:
+  ["waffle", "contracte inteligente", "solidity", "testare", "hardhat", "ethers.js"]
+skill: de bază
+lang: ro
+sidebar: true
+published: 2020-10-16
+---
+
+În acest tutorial [Waffle](https://ethereum-waffle.readthedocs.io), vei învăța cum să configurezi un proiect simplu de contract inteligent „Salut, lume”, utilizând [hardhat](https://hardhat.org/) și [ethers.js](https://docs.ethers.io/v5/). Apoi vei învăța cum să adaugi o nouă funcționalitate la contractul tău inteligent și cum să-l testezi cu Waffle.
+
+Să începem cu crearea unui nou proiect:
+
+```bash
+yarn init
+```
+
+sau
+
+```bash
+npm init
+```
+
+și instalează pachetele necesare:
+
+```bash
+yarn add -D hardhat @nomiclabs/hardhat-ethers ethers @nomiclabs/hardhat-waffle ethereum-waffle chai
+```
+
+sau
+
+```bash
+npm install -D hardhat @nomiclabs/hardhat-ethers ethers @nomiclabs/hardhat-waffle ethereum-waffle chai
+```
+
+Următorul pas este crearea unui exemplu de proiect hardhat executând `npx hardhat`.
+
+```bash
+888    888                      888 888               888
+888    888                      888 888               888
+888    888                      888 888               888
+8888888888  8888b.  888d888 .d88888 88888b.   8888b.  888888
+888    888     "88b 888P"  d88" 888 888 "88b     "88b 888
+888    888 .d888888 888    888  888 888  888 .d888888 888
+888    888 888  888 888    Y88b 888 888  888 888  888 Y88b.
+888    888 "Y888888 888     "Y88888 888  888 "Y888888  "Y888
+
+👷 Bun venit la Hardhat v2.0.3 👷‍
+
+? What do you want to do ? (Ce vrei să faci?) …
+Create a sample project (Să creez un exemplu de proiect)
+Create an empty hardhat.config.js
+Quit
+```
+
+Selectează `Creează un exemplu de proiect`
+
+Structura proiectelor noastre ar trebui să arate astfel:
+
+```
+MyWaffleProject
+├── contracts
+│   └── Greeter.sol
+├── node_modules
+├── scripts
+│   └── sample-script.js
+├── test
+│   └── sample-test.js
+├── .gitattributs
+├── .gitignore
+├── hardhat.config.js
+└── package.json
+```
+
+### Acum să vorbim despre unele dintre aceste fișiere: {#now-lets-talk}
+
+- Greeter.sol - contractul nostru inteligent scris în solidity;
+
+```solidity
+contract Greeter {
+string greeting;
+
+constructor(string memory _greeting) public {
+console.log("Implementare program Greeter cu salutări:", _greeting);
+greeting = _greeting;
+}
+
+function greet() public view returns (string memory) {
+return greeting;
+}
+
+function setGreeting(string memory _greeting) public {
+console.log("Schimbare salut din '%s' în '%s'", greeting, _greeting);
+greeting = _greeting;
+}
+}
+```
+
+Contractul nostru inteligent poate fi împărțit în trei părți:
+
+1. „constructor” - unde declarăm o variabilă de tip string numită `greeting`,
+2. funcția „greet” -o funcție care va returna `greeting` atunci când este apelată,
+3. funcția „setGreeting” - o funcție care ne permite să schimbăm valoarea `greeting`.
+
+- sample-test.js - fișierul nostru de teste
+
+```js
+describe("Greeter", function () {
+  it("Trebuie să returneze noul mesaj de salut odată ce a fost schimbat", async function () {
+    const Greeter = await ethers.getContractFactory("Greeter")
+    const greeter = await Greeter.deploy("Hello, world!")
+
+    await greeter.deployed()
+    expect(await greeter.greet()).to.equal("Hello, world!")
+
+    await greeter.setGreeting("Salut, lume!")
+    expect(await greeter.greet()).to.equal("Salut, lume!")
+  })
+})
+```
+
+### Pasul următor constă în compilarea contractelor și a testelor de execuție: {#compiling-and-testing}
+
+Testele Waffle folosesc Mocha (un cadru de testare) cu Chai (o bibliotecă de afirmații). Tot ce trebuie să faci este să rulezi `npx hardhat test` și să aștepți să apară următorul mesaj.
+
+```bash
+✓ Trebuie să returneze noul mesaj de salut odată ce a fost schimbat
+```
+
+### Totul arată bine până acum, hai să adăugăm ceva mai multă complexitate proiectului nostru <emoji text=":slightly_smiling_face:" size={1}/> {#adding-complexity}
+
+Imaginează-ți o situație când cineva adaugă un string gol ca salut. Nu ar fi un salut călduros, nu?  
+Să ne asigurăm că acest lucru nu se întâmplă:
+
+Vrem să folosim funcția solidity `revert` atunci când cineva transmite un string gol. Un lucru bun este că putem testa cu ușurință această funcționalitate cu validatorul matcher chai `to.bo.revertedWith()` a lui Waffle..
+
+```js
+it("Trebuie să se schimbe când se transmite un string gol", async () => {
+  const Greeter = await ethers.getContractFactory("Greeter")
+  const greeter = await Greeter.deploy("Hello, world!")
+
+  await greeter.deployed()
+  await expect(greeter.setGreeting("")).to.be.revertedWith(
+    "Salutul nu trebuie să rămână gol"
+  )
+})
+```
+
+Se pare că noul nostru test nu a trecut:
+
+```bash
+Implementarea unui Greeter cu salut: Hello, world!
+Schimbarea salutului din „Hello, world!” în „Salut, lume!”
+    ✓ Trebuie să returneze noul mesaj de salut odată ce a fost schimbat (1514 ms)
+Implementarea unui Greeter cu salut: Salut, lume!
+Schimbarea salutului din „Salut, lume!” în „
+    1) Trebuie să se schimbe când se transmite un string gol
+
+
+  1 transmitere (2 s)
+  1 nereușită
+```
+
+Să implementăm această funcționalitate în contractul nostru inteligent:
+
+```solidity
+require(bytes(_greeting).length > 0, "Mesajul de salut este gol");
+```
+
+Acum, funcția noastră „setGreeting” arată astfel:
+
+```solidity
+function setGreeting(string memory _greeting) public {
+require(bytes(_greeting).length > 0, "Salutul nu trebuie să fie gol");
+console.log("Changing greeting from '%s' to '%s'", greeting, _greeting);
+greeting = _greeting;
+}
+```
+
+Să rulăm din nou testele:
+
+```bash
+✓ Trebuie să returneze noul mesaj de salut odată ce a fost schimbat (1467 ms)
+✓ Trebuie să se schimbe când se transmite un string gol (276 ms)
+
+2 transmiteri (2 secunde)
+```
+
+Felicitări! Ai reușit :)
+
+### Concluzie {#conclusion}
+
+Am făcut un proiect simplu cu Waffle, Hardhat și ethers.js. Am învățat cum să configurăm un proiect, să adăugăm un test și să implementăm noi funcționalități.
+
+Pentru mai mulți validatori matcher chai de mare valoare pentru testarea contractelor inteligente consultă [documentele oficiale Waffle](https://ethereum-waffle.readthedocs.io/en/latest/matchers.html).


### PR DESCRIPTION
## Description
 - Restores the tutorial with title "Waffle say hello world tutorial with hardhat and ethers" 
 - Retrieved from repo history per [comment](https://github.com/ethereum/ethereum-org-website/issues/2766#issuecomment-852435490).
 - While here, updated path to replace "buidler" with "hardhat"
 - Includes Romanian translation

## Related Issue
[Fixes #2766]