### PR TITLE
Fix asterisk escape

### DIFF
--- a/src/content/developers/docs/blocks/index.md
+++ b/src/content/developers/docs/blocks/index.md
@@ -36,9 +36,9 @@ Once a block is put together (mined) by some miner on the network, it is propaga
 
 Proof of work means the following:
 
-- Mining nodes have to spend a variable but substantial amount of energy, time, and computational power to produce a “certificate of legitimacy” for a block they propose to the network. This helps protect the network from spam/denial-of-service attacks, among other things\*, since certificates are expensive to produce.
-- Other miners who hear about a new block with a valid certificate of legitimacy must\* accept the new block as the canonical next block on the blockchain.
-- The exact amount of time needed for any given miner to produce this certificate is a random variable with high variance. This ensures that it is unlikely* that two miners produce validations for a proposed next block simultaneously; when a miner produces and propagates a certified new block, they can be almost certain that the block will be accepted by the network as the canonical next block on the blockchain, without conflict* (though there is a protocol for dealing with conflicts as well in the case that two chains of certified blocks are produced almost simultaneously).
+- Mining nodes have to spend a variable but substantial amount of energy, time, and computational power to produce a “certificate of legitimacy” for a block they propose to the network. This helps protect the network from spam/denial-of-service attacks, among other things, since certificates are expensive to produce.
+- Other miners who hear about a new block with a valid certificate of legitimacy must accept the new block as the canonical next block on the blockchain.
+- The exact amount of time needed for any given miner to produce this certificate is a random variable with high variance. This ensures that it is unlikely that two miners produce validations for a proposed next block simultaneously; when a miner produces and propagates a certified new block, they can be almost certain that the block will be accepted by the network as the canonical next block on the blockchain, without conflict (though there is a protocol for dealing with conflicts as well in the case that two chains of certified blocks are produced almost simultaneously).
 
 [More on mining](/developers/docs/consensus-mechanisms/pow/mining/)
 

--- a/src/content/developers/docs/gas/index.md
+++ b/src/content/developers/docs/gas/index.md
@@ -26,8 +26,8 @@ In essence, gas fees are paid in Ethereum's native currency, ether (ETH). Gas pr
 Let's say Alice has to pay Bob 1ETH.
 In the transaction the gas limit is 21000 units and the gas price is 200 GWei. 
 
-Total fee will be: Gas units * Gas price per unit 
-i.e 21000 * 200 = 4,200,000 Gwei or 0.0042 ETH
+Total fee will be: `Gas units * Gas price per unit`
+i.e `21000 * 200 = 4,200,000` Gwei or 0.0042 ETH
 
 Now, when Alice sends the money, 1.0042 ETH will be deducted from Alice's account.
 Bob will be credited 1.0000 ETH.

--- a/src/content/developers/docs/transactions/index.md
+++ b/src/content/developers/docs/transactions/index.md
@@ -108,10 +108,10 @@ With the signature hash, the transaction can be cryptographically proven that it
 
 As mentioned, transactions cost [gas](/developers/docs/gas/) to execute. Simple transfer transactions require 21000 units of Gas.
 
-So for Bob to send Alice 1ETH at a `gasPrice` of 200 Gwei, Bob will need to pay the following fee:
+So for Bob to send Alice 1 ETH at a `gasPrice` of 200 gwei, Bob will need to pay the following fee:
 
 ```
-200*21000 = 4,200,000 GWEI
+200 * 21000 = 4,200,000 gwei
 --or--
 0.0042 ETH
 ```

--- a/src/content/developers/docs/transactions/index.md
+++ b/src/content/developers/docs/transactions/index.md
@@ -108,7 +108,7 @@ With the signature hash, the transaction can be cryptographically proven that it
 
 As mentioned, transactions cost [gas](/developers/docs/gas/) to execute. Simple transfer transactions require 21000 units of Gas.
 
-So for Bob to send Alice 1ETH at a `gasPrice` of 200 Gwei, he'll need to pay the following fee:
+So for Bob to send Alice 1ETH at a `gasPrice` of 200 Gwei, Bob will need to pay the following fee:
 
 ```
 200*21000 = 4,200,000 GWEI


### PR DESCRIPTION
Fix unescaped asterisks as described in issue. Remove some gendered language. Remove some unnecessary asterisks.

## Description
Asterisks on the blocks page are unnecessary as they don't refer to any footnote. The italics aren't necessary either.

## Related Issue

https://github.com/ethereum/ethereum-org-website/issues/3202
