### PR TITLE
Fix Translation Banner Logic

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -288,7 +288,7 @@ exports.onCreatePage = ({ page, actions }) => {
         ...page.context,
         isOutdated,
         //display TranslationBanner for translation-component pages that are still in English
-        isContentEnglish: langVersion < 2 && !page.component.includes('/developers/index.js')
+        isContentEnglish: langVersion < 1.0 && !page.component.includes('/developers/index.js')
       },
     })
   }


### PR DESCRIPTION
## Description
The translation banner was saying that the content was in English if the translation version was less than 2, causing translation for 1.0 and 1.1 translations to display the wrong banner.

## Related Issue
Closes #3213

## New Logic Screenshots

An outdated translation page
<img width="617" alt="Screenshot 2021-06-08 at 21 36 39" src="https://user-images.githubusercontent.com/62268199/121253998-ae084700-c8a1-11eb-843e-d1b0490a266c.png">

An untranslated page
<img width="628" alt="Screenshot 2021-06-08 at 21 36 52" src="https://user-images.githubusercontent.com/62268199/121254001-af397400-c8a1-11eb-999c-5eb7a34c3055.png">
