### PR TITLE
Fix typo in ERC-20 tutorial

### DIFF
--- a/src/content/developers/tutorials/transfers-and-approval-of-erc-20-tokens-from-a-solidity-smart-contract/index.md
+++ b/src/content/developers/tutorials/transfers-and-approval-of-erc-20-tokens-from-a-solidity-smart-contract/index.md
@@ -142,7 +142,7 @@ contract DEX {
 }
 ```
 
-So we know have our DEX and it has all the token reserve available. The contract has two functions:
+So we now have our DEX and it has all the token reserve available. The contract has two functions:
 
 - `buy`: The user can send ether and get tokens in exchange
 - `sell`: The user can decide to send tokens to get ether back


### PR DESCRIPTION
## Description

Changed "know" to "now" for better readability.

## Related Issue

https://github.com/ethereum/ethereum-org-website/issues/3231
