### PR TITLE
Added missing JSON-RPC API methods [Fixes #3209]

### DIFF
--- a/src/content/developers/docs/apis/json-rpc/index.md
+++ b/src/content/developers/docs/apis/json-rpc/index.md
@@ -831,6 +831,127 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getCode","params":["0xa94f53
 
 <Divider />
 
+### eth_sign {#eth_sign}
+
+The sign method calculates an Ethereum specific signature with: `sign(keccak256("\x19Ethereum Signed Message:\n" + len(message) + message)))`.
+
+By adding a prefix to the message makes the calculated signature recognisable as an Ethereum specific signature. This prevents misuse where a malicious DApp can sign arbitrary data (e.g. transaction) and use the signature to impersonate the victim.
+
+Note: the address to sign with must be unlocked.
+
+**Parameters**
+
+1. `DATA`, 20 Bytes - address
+2. `DATA`, N Bytes - message to sign
+
+**Returns**
+
+`DATA`: Signature
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_sign","params":["0x9b2055d370f73ec7d8a03e965129118dc8f5bf83", "0xdeadbeaf"],"id":1}'
+
+// Result
+{
+  "id":1,
+  "jsonrpc": "2.0",
+  "result": "0xa3f20717a250c2b0b729b7e5becbff67fdaef7e0699da4de7ca5895b02a170a12d887fd3b17bfdce3481f10bea41f45ba9f709d39ce8325427b57afcfc994cee1b"
+}
+```
+
+<Divider />
+
+### eth_signTransaction {#eth_signtransaction}
+
+Signs a transaction that can be submitted to the network at a later time using with [eth_sendRawTransaction](#eth_sendrawtransaction).
+
+**Parameters**
+
+1. `Object` - The transaction object
+
+- `from`: `DATA`, 20 Bytes - The address the transaction is sent from.
+- `to`: `DATA`, 20 Bytes - (optional when creating new contract) The address the transaction is directed to.
+- `gas`: `QUANTITY` - (optional, default: 90000) Integer of the gas provided for the transaction execution. It will return unused gas.
+- `gasPrice`: `QUANTITY` - (optional, default: To-Be-Determined) Integer of the gasPrice used for each paid gas, in Wei.
+- `value`: `QUANTITY` - (optional) Integer of the value sent with this transaction, in Wei.
+- `data`: `DATA` - The compiled code of a contract OR the hash of the invoked method signature and encoded parameters.
+- `nonce`: `QUANTITY` - (optional) Integer of a nonce. This allows to overwrite your own pending transactions that use the same nonce.
+
+**Returns**
+
+`DATA`, The signed transaction object.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"id": 1,"jsonrpc": "2.0","method": "eth_signTransaction","params": [{"data":"0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675","from": "0xb60e8dd61c5d32be8058bb8eb970870f07233155","gas": "0x76c0","gasPrice": "0x9184e72a000","to": "0xd46e8dd67c5d32be8058bb8eb970870f07244567","value": "0x9184e72a"}]}'
+
+// Result
+{
+    "id": 1,
+    "jsonrpc": "2.0",
+    "result": "0xa3f20717a250c2b0b729b7e5becbff67fdaef7e0699da4de7ca5895b02a170a12d887fd3b17bfdce3481f10bea41f45ba9f709d39ce8325427b57afcfc994cee1b"
+}
+```
+
+<Divider />
+
+### eth_sendTransaction {#eth_sendtransaction}
+
+Creates new message call transaction or a contract creation, if the data field contains code.
+
+**Parameters**
+
+1. `Object` - The transaction object
+
+- `from`: `DATA`, 20 Bytes - The address the transaction is sent from.
+- `to`: `DATA`, 20 Bytes - (optional when creating new contract) The address the transaction is directed to.
+- `gas`: `QUANTITY` - (optional, default: 90000) Integer of the gas provided for the transaction execution. It will return unused gas.
+- `gasPrice`: `QUANTITY` - (optional, default: To-Be-Determined) Integer of the gasPrice used for each paid gas.
+- `value`: `QUANTITY` - (optional) Integer of the value sent with this transaction.
+- `data`: `DATA` - The compiled code of a contract OR the hash of the invoked method signature and encoded parameters.
+- `nonce`: `QUANTITY` - (optional) Integer of a nonce. This allows to overwrite your own pending transactions that use the same nonce.
+
+```js
+params: [
+  {
+    from: "0xb60e8dd61c5d32be8058bb8eb970870f07233155",
+    to: "0xd46e8dd67c5d32be8058bb8eb970870f07244567",
+    gas: "0x76c0", // 30400
+    gasPrice: "0x9184e72a000", // 10000000000000
+    value: "0x9184e72a", // 2441406250
+    data:
+      "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675",
+  },
+]
+```
+
+**Returns**
+
+`DATA`, 32 Bytes - the transaction hash, or the zero hash if the transaction is not yet available.
+
+Use [eth_getTransactionReceipt](#eth_gettransactionreceipt) to get the contract address, after the transaction was mined, when you created a contract.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{see above}],"id":1}'
+
+// Result
+{
+  "id":1,
+  "jsonrpc": "2.0",
+  "result": "0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331"
+}
+```
+
+<Divider />
+
 ### eth_sendRawTransaction {#eth_sendrawtransaction}
 
 Creates new message call transaction or a contract creation for signed transactions.


### PR DESCRIPTION
JSON-RPC API METHODS section of https://ethereum.org/en/developers/docs/apis/json-rpc/ had some methods missing.

## Description

Added:

- eth_sign
- eth_signTransaction
- eth_sendTransaction

## Related Issue

https://github.com/ethereum/ethereum-org-website/issues/3209
