### PR TITLE
Fixed double scrollbar bug [fixes #3253]

### DIFF
--- a/src/components/Codeblock.js
+++ b/src/components/Codeblock.js
@@ -28,6 +28,9 @@ const StyledPre = styled.pre`
   padding-top: ${({ hasTopBar }) => (hasTopBar ? "2.75rem" : "1.5rem")};
   margin: 0;
   padding-left: 1rem;
+  overflow: visible;
+  min-width: 100%;
+  width: fit-content;
 `
 
 const Line = styled.div`


### PR DESCRIPTION
## Description

added the following css instructions to the codeblock pre tag styles:
overflow: visible;
min-width: 100%;
width: fit-content;

## Related Issue

https://github.com/ethereum/ethereum-org-website/issues/3253
