### PR TITLE
removed extra divider [fixes #3264]

### DIFF
--- a/src/content/developers/docs/apis/json-rpc/index.md
+++ b/src/content/developers/docs/apis/json-rpc/index.md
@@ -1053,8 +1053,6 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_estimateGas","params":[{see 
 
 <Divider />
 
-<Divider />
-
 ### eth_getBlockByHash {#eth_getblockbyhash}
 
 Returns information about a block by hash.


### PR DESCRIPTION
removed extra divider after https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_estimategas section

## Related Issue

https://github.com/ethereum/ethereum-org-website/issues/3264