### PR TITLE
Moved 0chain from "blockchain based" to "contract based"

### DIFF
--- a/src/content/developers/docs/storage/index.md
+++ b/src/content/developers/docs/storage/index.md
@@ -37,7 +37,6 @@ Platforms with blockchain based persistence:
 
 - Ethereum
 - [Arweave](https://www.arweave.org/)
-- [0Chain](https://0chain.net/)
 
 ### Contract Based {#contract-based}
 
@@ -50,6 +49,7 @@ Platforms with contract based persistence:
 - [Filecoin](https://docs.filecoin.io/about-filecoin/what-is-filecoin/)
 - [Skynet](https://siasky.net/)
 - [Storj](https://storj.io/)
+- [0Chain](https://0chain.net/)
 
 ### Additional considerations {#additional-considertion}
 


### PR DESCRIPTION
## Description
0chain does not store the actual data within the blockchain itself.
Instead the concept of spreading data in allocations (contracts) across multiple 'blobbers' using user-configurable erasure-coding is used.

## Related Issue
https://github.com/ethereum/ethereum-org-website/issues/3293