### PR TITLE
SafeMath removal from Solidity 0.8.0

### DIFF
--- a/src/content/developers/tutorials/create-and-deploy-a-defi-app/index.md
+++ b/src/content/developers/tutorials/create-and-deploy-a-defi-app/index.md
@@ -192,7 +192,12 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract FarmToken is ERC20 {
     using Address for address;
-    using SafeMath for uint256;
+    using SafeMath for uint256; /* This is not required for Solidity ^0.8.0
+                                   
+                                   Everyone who wanted to write a SafeMath function for exponentiation probably noticed that it is rather expensive to do that because the EVM does not provide overflow signalling. Essentially you have to implement your own exp routine without using the exp opcode for the general case.
+                                   
+                                   More info here: https://blog.soliditylang.org/2020/12/16/solidity-v0.8.0-release-announcement/
+                                */
     using SafeERC20 for IERC20;
 
     IERC20 public token;


### PR DESCRIPTION
While implementing the steps on this page, happened to know that Solidity 0.8.0 has an improvement [documented here](https://blog.soliditylang.org/2020/12/16/solidity-v0.8.0-release-announcement/).

<!--- Provide a general summary of your changes in the Title above -->

## Description

The [documentation](https://ethereum.org/en/developers/tutorials/create-and-deploy-a-defi-app/) to create and deploy Dapps has the source codes with Solidity ^0.6.2. 

The developers who would use a later compiler might face an issue with the usage of SafeMath.

```
using SafeMath for uint256;
```
A comment about the new changes for Solidity 0.8.0 would help the developers to learn the improvement.

Something like "As of Solidity v0.8.0, mathematical operations can be done safely without the need for SafeMath. More info here: https://blog.soliditylang.org/2020/12/16/solidity-v0.8.0-release-announcement", or how it suits better.