### PR TITLE
Update MakerDAO grants link [fixes #3255]

### DIFF
--- a/src/content/community/grants/index.md
+++ b/src/content/community/grants/index.md
@@ -26,8 +26,7 @@ These programs support the broad Ethereum ecosystem by offering grants to a wide
 
 These projects have created their own grants for projects aimed at developing and experimenting with their own technology.
 
-<!-- This grants program seems to be down - [Maker](https://grants.makerdao.com/) - _Risk, governance, core development, ecosystem, tools, MakerDAO community, security_  
-  Grants ranging from 5K - 50K Dai. -->
+- [MakerDAO](https://community-development.makerdao.com/en/programs/development-grants/) – _[MakerDAO](https://makerdao.com/en/) development_
 - [TheGraph](https://airtable.com/shreX09LazIhsg0bU) – _[The Graph](https://thegraph.com/) ecosystem_
 - [Uniswap](https://airtable.com/shrEXXxXB1humz7VS) – _[Uniswap](https://uniswap.org/) community_
 - [Balancer](https://forms.gle/c68e4fM7JHCQkPkN7) – _[Balancer](https://balancer.fi/) Ecosystem Fund_


### PR DESCRIPTION
Description 

I have updated the link to the MakerDAO grants page, since the previous link is no longer valid.

Additional information

Ideally, I would have preferred to replace the link with a link to the grant form, similarly to the other listed grants, however there are currently no open grants on MakerDAO, therefore the form is not accessible.

Related issue

#3255
