### PR TITLE
Add Chainstack in the range of Enterprise infrastructure providers

### DIFF
--- a/src/content/enterprise/index.md
+++ b/src/content/enterprise/index.md
@@ -56,6 +56,7 @@ Some collaborative efforts to make Ethereum enterprise friendly have been made b
 
 - [Alchemy](https://alchemyapi.io/) _provides API services and tools for building and monitoring applications on Ethereum_
 - [Blockapps](https://blockapps.net/) _implementation of the Enterprise Ethereum protocol, tooling and APIs that form the STRATO platform_
+- [Chainstack](https://chainstack.com/) _mainnet and testnet Ethereum infrastructure hosted in public & isolated customer clouds_
 - [ConsenSys](https://consensys.net/) _provides a range of products and tools for building on Ethereum, as well as consulting and custom development services_
 - [Envision Blockchain](https://envisionblockchain.com/) _provides enterprise focused consulting and development services specializing in Ethereum mainnet_
 - [EY OpsChain](https://blockchain.ey.com/products/procurement) _provides a procurement workflow by issuing RFQ’s, contracts, purchase orders, and invoices across your network of trusted business partners_


### PR DESCRIPTION
## Description

Added chainstack.com as an infrastructure provider of Enterprise Ethereum nodes. 
