### PR TITLE
Fixes related tutorials links

### DIFF
--- a/src/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
+++ b/src/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
@@ -97,7 +97,7 @@ Here is a list of some of the most popular Ethereum node providers, feel free to
   - Features
     - Free shared nodes
     - Free shared archive nodes
-    - Privacy focused (no logs policy) 
+    - Privacy focused (no logs policy)
     - Cross chain support
     - Scale as you go
     - Dashboard
@@ -127,5 +127,5 @@ Here is a list of some of the most popular Ethereum node providers, feel free to
 
 ## Related tutorials {#related-tutorials}
 
-- [Getting started with Ethereum development using Alchemy](/developers/tutorials/sending-transactions-using-web3-and-alchemy/)
-- [Guide to sending transactions using web3 and Alchemy](/developers/tutorials/getting-started-with-ethereum-development-using-alchemy/)
+- [Getting started with Ethereum development using Alchemy](/developers/tutorials/getting-started-with-ethereum-development-using-alchemy/)
+- [Guide to sending transactions using web3 and Alchemy](/developers/tutorials/sending-transactions-using-web3-and-alchemy/)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Swaps the previously incorrect links in the related tutorials section of nodes as a service in the developer docs. 

Addresses issue #3340 [here](https://github.com/ethereum/ethereum-org-website/issues/3340).

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
