### PR TITLE
Fix small grammatical error in accounts docs

### DIFF
--- a/src/content/developers/docs/accounts/index.md
+++ b/src/content/developers/docs/accounts/index.md
@@ -126,7 +126,7 @@ For dapp development, you'll want access to dummy accounts with test ETH so you 
 
 ## A note on wallets {#a-note-on-wallets}
 
-An account is not a wallet. A wallet is the keypair associated with a user-owned account, which allow a user to make transactions from or manage the account.
+An account is not a wallet. A wallet is the keypair associated with a user-owned account, which allows a user to make transactions from or manage the account.
 
 ## A visual demo {#a-visual-demo}
 


### PR DESCRIPTION
## Description

This PR fixes a very small grammatical error in the "A note on wallets" section of the "Ethereum accounts" documentation. See the extremely brief diff. 

## Related Issue

There is no related issue to this PR. It seems silly to open an issue for such a small modification.