### PR TITLE
Update `/merge` with post-merge cleanup note

### DIFF
--- a/src/content/eth2/merge/index.md
+++ b/src/content/eth2/merge/index.md
@@ -48,8 +48,11 @@ These improvements all have a place in Eth2 so it’s likely that their progress
 
 ## After the merge {#after-the-merge}
 
-This will signal the end of proof-of-work for Ethereum and start the era of a more sustainable, eco-friendly Ethereum. 
-At this point Ethereum will be one step closer to achieving the full scale, security and sustainability outlined in its [Eth2 vision](/eth2/vision/).
+This will signal the end of proof-of-work for Ethereum and start the era of a more sustainable, eco-friendly Ethereum. At this point Ethereum will be one step closer to achieving the full scale, security and sustainability outlined in its [Eth2 vision](/eth2/vision/).
+
+It is important to note that an implementation goal of the merge is simplicity in order to expedite the transition from proof-of-work to proof-of-stake. Developers are focusing their efforts on this transition, and minimizing additional features that could delay this goal. 
+
+**This means a few features, such as the ability to withdraw staked ETH, will have to wait a little longer after the merge is complete.** Plans include a post-merge "cleanup" upgrade to address these features, which is expected to happen very soon after the merge is completed.
 
 ## Relationship between upgrades {#relationship-between-upgrades}
 
@@ -60,6 +63,12 @@ The Eth2 upgrades are all somewhat interrelated. So let’s recap how the merge 
 Once the merge happens, stakers will be assigned to validate the Ethereum mainnet. [Mining](/developers/docs/consensus-mechanisms/pow/mining/) will no longer be required so miners will likely invest their earnings into staking in the new proof-of-stake system.
 
 <ButtonLink to="/eth2/beacon-chain/">The Beacon Chain</ButtonLink>
+
+### The merge and the post-merge cleanup {#merge-and-post-merge-cleanup}
+
+Immediately after the merge, some features such as withdrawing staked ETH, will not yet be supported. These are planned for a separate upgrade to follow shortly after the merge.
+
+Stay up-to-date with the [EF Research and Development Blog](https://blog.ethereum.org/category/research-and-development/). For those curious, learn more about [What Happens After the Merge](https://youtu.be/7ggwLccuN5s?t=101), presented by Vitalik at the April 2021 ETHGlobal event. 
 
 ### The merge and shard chains {#docking-and-shard-chains}
 

--- a/src/intl/en/page-eth2-staking.json
+++ b/src/intl/en/page-eth2-staking.json
@@ -57,6 +57,6 @@
   "page-eth2-staking-upgrades-title": "Proof-of-stake and Eth2 upgrades",
   "page-eth2-staking-validators": "More validators, more security",
   "page-eth2-staking-validators-desc": "In a blockchain like Ethereum it is possible to censor and reorder transactions to suit you if you control a majority of the network. But, to control a majority of the network, you need a majority of validators, and for this you’d need to control a majority of the ETH in the system – that’s a lot! This amount of ETH grows every time a new validator enters the system, bolstering the security of the network. Proof-of-work, the security model proof-of-stake will replace, requires the validators (miners) to have specialist hardware and lots of physical space – entering the system as a miner is difficult so security against majority attacks doesn't increase as much. Proof-of-stake doesn't have these requirements, which should grow the network (and its resistance to majority attacks) to sizes that aren't possible with proof of work.",
-  "page-eth2-staking-withdrawals": "Withdrawals won't be live right away",
-  "page-eth2-staking-withdrawals-desc": "You won't be able to withdraw your stake until future upgrades are deployed. Withdraws will be available in a miner upgrade following the merge of mainnet with the Beacon Chain."
+  "page-eth2-staking-withdrawals": "Withdraws won't be live right away",
+  "page-eth2-staking-withdrawals-desc": "You won't be able to withdraw your stake until future upgrades are deployed. Withdraws will be available in a minor upgrade following the merge of mainnet with the Beacon Chain."
 }


### PR DESCRIPTION
## Description
- Adds some information regarding the nuance that there will be a post-merge cleanup fork. 
- Focused on the key point that withdraws will not be capable until then, not immediately after the merge.
- Couple spelling corrections