### PR TITLE
Explicitly types frontmatter schema

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -306,6 +306,11 @@ exports.createSchemaCustomization = ({ actions }) => {
       incomplete: Boolean
       template: String
       summaryPoints: [String!]!
+      position: String
+      compensation: String
+      location: String
+      type: String
+      link: String
     }
     type Eth2BountyHuntersCsv implements Node {
       username: String,

--- a/netlify.toml
+++ b/netlify.toml
@@ -293,6 +293,9 @@
 [[redirects]]
   from = "/*/about/web-developer"
   to = "/:splat/about/#open-jobs"
+[[redirects]]
+  from = "/*/about/community-lead"
+  to = "/:splat/about/#open-jobs"
 
 # A redirect rule with all the supported properties
 # [[redirects]]


### PR DESCRIPTION
## Description
- Adds fields exclusively used in `job.js` template to frontmatter schema. 
- Fixes build error caused by 1d7c5181 after removal of the only markdown file that populated these fields. Solution suggested within logs
```
It is recommended to explicitly type your GraphQL schema if you want to use optional fields. This way you don't have to add the mentioned "dummy content". Visit our docs to learn how you can define the schema for "Frontmatter":
```
- Leaves `job.js` template available for future use
- Adds Netlify redirect from old page to /about/#open-jobs