### PR TITLE
make Antonio code owner of eth2-bounty-hunters.csv

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,4 +8,4 @@
 *       @samajammin @jjmstark @GeorgeTrotter @wackerow @corwintines @pettinarip
 
 # Owners of specific files
-/src/data/eth2-bounty-hunters.csv @lsankar4033 @djrtwo @JustinDrake
+/src/data/eth2-bounty-hunters.csv @lsankar4033 @djrtwo @JustinDrake @asanso


### PR DESCRIPTION
For context, Antonio (@asanso) is part of the EF Eth2 security team and is now actively involved in the management of the Eth2 bounty program :) cc @djrtwo

(Related PR: https://github.com/ethereum/ethereum-org-website/pull/3379.)