### PR TITLE
Distinguish production-ready Eth2 clients [Fixes #3422]

### DIFF
--- a/src/intl/en/page-eth2-get-involved.json
+++ b/src/intl/en/page-eth2-get-involved.json
@@ -27,6 +27,8 @@
   "page-eth2-get-involved-more": "More info",
   "page-eth2-get-involved-run-clients": "Run beacon chain clients",
   "page-eth2-get-involved-run-clients-desc": "Key to Ethereum's long term security is a strong distribution of clients. A client is software that runs the blockchain, checking transactions and the creation of new blocks. Each client has its own features, so choose one based on what you're comfortable with.",
+  "page-eth2-get-involved-run-clients-production": "Production-ready Eth2 clients",
+  "page-eth2-get-involved-run-clients-experimental": "Experimental Eth2 clients",
   "page-eth2-get-involved-stake": "Stake your ETH",
   "page-eth2-get-involved-stake-desc": "You can now stake your ETH to help secure the beacon chain.",
   "page-eth2-get-involved-stake-eth": "Stake ETH",

--- a/src/pages/eth2/get-involved/index.js
+++ b/src/pages/eth2/get-involved/index.js
@@ -97,12 +97,6 @@ const ReverseRow = styled.div`
   }
 `
 
-const Status = styled.div`
-  display: flex;
-  align-items: center;
-  margin-top: 2rem;
-`
-
 const StyledCardContainer = styled(CardContainer)`
   margin-top: 2rem;
   margin-bottom: 3rem;
@@ -113,32 +107,8 @@ const StyledCardGrid = styled(CardGrid)`
   margin-bottom: 3rem;
 `
 
-const H2 = styled.h2`
-  font-size: 24px;
-  font-style: normal;
-  font-weight: 700;
-  line-height: 22px;
-  letter-spacing: 0px;
-  text-align: left;
-`
-
-const On = styled.div`
-  width: 8px;
-  height: 8px;
-  background: ${(props) => props.theme.colors.success400};
-  border-radius: 64px;
-`
-
 const StyledCardList = styled(CardList)`
   margin-right: 2rem;
-`
-
-const Title = styled.p`
-  text-transform: uppercase;
-  font-size: 14px;
-  color: ${(props) => props.theme.colors.text};
-  margin-bottom: 0rem;
-  margin-left: 0.5rem;
 `
 
 const Staking = styled.div`
@@ -190,13 +160,6 @@ const StyledCalloutBanner = styled(CalloutBanner)`
   }
 `
 
-const TemporaryCallout = styled(CalloutBanner)`
-  background: transparent;
-  border: 1px solid ${(props) => props.theme.colors.border};
-  border-radius: 4px;
-  box-shadow: ${(props) => props.theme.colors.tableBoxShadow};
-`
-
 const GetInvolvedPage = ({ data, location }) => {
   const intl = useIntl()
   const themeContext = useContext(ThemeContext)
@@ -215,6 +178,7 @@ const GetInvolvedPage = ({ data, location }) => {
       url: "https://prylabs.net/",
       image: data.prysm.childImageSharp.fixed,
       githubUrl: "https://github.com/prysmaticlabs/prysm",
+      isProductionReady: true,
     },
     {
       name: "Lighthouse",
@@ -226,6 +190,7 @@ const GetInvolvedPage = ({ data, location }) => {
         ? data.lighthouseDark.childImageSharp.fixed
         : data.lighthouseLight.childImageSharp.fixed,
       githubUrl: "https://github.com/sigp/lighthouse",
+      isProductionReady: true,
     },
     {
       name: "Teku",
@@ -237,6 +202,7 @@ const GetInvolvedPage = ({ data, location }) => {
         ? data.tekuLight.childImageSharp.fixed
         : data.tekuDark.childImageSharp.fixed,
       githubUrl: "https://github.com/ConsenSys/teku",
+      isProductionReady: true,
     },
     {
       name: "Cortex",
@@ -246,6 +212,7 @@ const GetInvolvedPage = ({ data, location }) => {
       url: "https://nethermind.io/",
       image: data.cortex.childImageSharp.fixed,
       githubUrl: "https://github.com/NethermindEth/nethermind",
+      isProductionReady: false,
     },
     {
       name: "Lodestar",
@@ -257,6 +224,7 @@ const GetInvolvedPage = ({ data, location }) => {
       url: "https://chainsafe.io/",
       image: data.lodestar.childImageSharp.fixed,
       githubUrl: "https://github.com/ChainSafe/lodestar",
+      isProductionReady: false,
     },
     {
       name: "Nimbus",
@@ -266,6 +234,7 @@ const GetInvolvedPage = ({ data, location }) => {
       url: "https://nimbus.team/",
       image: data.nimbus.childImageSharp.fixed,
       githubUrl: "https://github.com/status-im/nimbus-eth1",
+      isProductionReady: true,
     },
     {
       name: "Trinity",
@@ -275,6 +244,7 @@ const GetInvolvedPage = ({ data, location }) => {
       url: "https://trinity.ethereum.org/",
       image: data.trinity.childImageSharp.fixed,
       githubUrl: "https://github.com/ethereum/trinity",
+      isProductionReady: false,
     },
   ]
 
@@ -347,9 +317,9 @@ const GetInvolvedPage = ({ data, location }) => {
             </Subtitle>
           </HeroContainer>
         </HeroCard>
-        <H2>
+        <h2>
           <Translation id="page-eth2-get-involved-how" />
-        </H2>
+        </h2>
         <p>
           <Translation id="page-eth2-get-involved-how-desc" />
         </p>
@@ -368,25 +338,49 @@ const GetInvolvedPage = ({ data, location }) => {
       </Content>
       <Divider id="clients" />
       <Content>
-        <H2>
+        <h2>
           <Translation id="page-eth2-get-involved-run-clients" />
-        </H2>
+        </h2>
         <p>
           <Translation id="page-eth2-get-involved-run-clients-desc" />
         </p>
+        <h3>
+          <Translation id="page-eth2-get-involved-run-clients-production" />
+        </h3>
         <StyledCardGrid>
-          {clients.map((client, idx) => (
-            <ProductCard
-              key={idx}
-              url={client.url}
-              background={client.background}
-              image={client.image}
-              name={client.name}
-              description={client.description}
-              alt={translateMessageId(client.alt, intl)}
-              githubUrl={client.githubUrl}
-            />
-          ))}
+          {clients
+            .filter((client) => client.isProductionReady)
+            .map((client, idx) => (
+              <ProductCard
+                key={idx}
+                url={client.url}
+                background={client.background}
+                image={client.image}
+                name={client.name}
+                description={client.description}
+                alt={translateMessageId(client.alt, intl)}
+                githubUrl={client.githubUrl}
+              />
+            ))}
+        </StyledCardGrid>
+        <h3>
+          <Translation id="page-eth2-get-involved-run-clients-experimental" />
+        </h3>
+        <StyledCardGrid>
+          {clients
+            .filter((client) => !client.isProductionReady)
+            .map((client, idx) => (
+              <ProductCard
+                key={idx}
+                url={client.url}
+                background={client.background}
+                image={client.image}
+                name={client.name}
+                description={client.description}
+                alt={translateMessageId(client.alt, intl)}
+                githubUrl={client.githubUrl}
+              />
+            ))}
         </StyledCardGrid>
       </Content>
       <Staking>
@@ -410,9 +404,9 @@ const GetInvolvedPage = ({ data, location }) => {
         <Content>
           <Row>
             <LeftColumn>
-              <H2 id="#bug-bounty">
+              <h2 id="#bug-bounty">
                 <Translation id="page-eth2-get-involved-bug-hunting" />
-              </H2>
+              </h2>
               <p>
                 <Translation id="page-eth2-get-involved-bug-hunting-desc" />
               </p>
@@ -449,9 +443,9 @@ const GetInvolvedPage = ({ data, location }) => {
             <StyledCardList content={ethresearch} />
           </LeftColumn>
           <RightColumn>
-            <H2>
+            <h2>
               <Translation id="page-eth2-get-involved-join" />
-            </H2>
+            </h2>
             <p>
               <Translation id="page-eth2-get-involved-join-desc" />
             </p>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Re-org Eth2 client list into 2 sections, "production-ready" & "experimental":
![Image 2021-07-15 at 10 39 41 AM](https://user-images.githubusercontent.com/8097623/125832999-29abb564-af49-46b0-9ae3-5170300a185f.jpg)

## Related Issue
#3422