### PR TITLE
feat: highlight table of content on scroll

### DIFF
--- a/src/hooks/useActiveHash.js
+++ b/src/hooks/useActiveHash.js
@@ -1,0 +1,40 @@
+import { useState, useEffect } from "react"
+
+/**
+ * A hook to determine which section of the page is currently in the viewport.
+ * @param {*} itemIds Array of document ids to observe
+ * @param {*} rootMargin
+ * @returns id of the element currently in viewport
+ */
+export const useActiveHash = (itemIds, rootMargin = undefined) => {
+  const [activeHash, setActiveHash] = useState(``)
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setActiveHash(`#${entry.target.id}`)
+          }
+        })
+      },
+      { rootMargin: rootMargin || `0% 0% -80% 0%` }
+    )
+
+    itemIds?.forEach((id) => {
+      if (document.getElementById(id) !== null) {
+        observer.observe(document.getElementById(id))
+      }
+    })
+
+    return () => {
+      itemIds?.forEach((id) => {
+        if (document.getElementById(id) !== null) {
+          observer.unobserve(document.getElementById(id))
+        }
+      })
+    }
+  }, [])
+
+  return activeHash
+}

--- a/src/hooks/useActiveHash.js
+++ b/src/hooks/useActiveHash.js
@@ -6,7 +6,7 @@ import { useState, useEffect } from "react"
  * @param {*} rootMargin
  * @returns id of the element currently in viewport
  */
-export const useActiveHash = (itemIds, rootMargin = undefined) => {
+export const useActiveHash = (itemIds, rootMargin = `0% 0% -80% 0%`) => {
   const [activeHash, setActiveHash] = useState(``)
 
   useEffect(() => {
@@ -18,7 +18,7 @@ export const useActiveHash = (itemIds, rootMargin = undefined) => {
           }
         })
       },
-      { rootMargin: rootMargin || `0% 0% -80% 0%` }
+      { rootMargin: rootMargin}
     )
 
     itemIds?.forEach((id) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Highlight the link in table of content that is currently in viewport.

## Description
https://user-images.githubusercontent.com/4337699/126549847-ab397df6-41aa-4ff1-98c3-1c14682bb7ab.mp4

Created an useActiveHash hook. It changes the state to the id of the element that scrolled into the viewport.

## Related Issue

Resolves #3235

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
