### PR TITLE
contributors modal shows duplicates [Fixes #3468]

### DIFF
--- a/src/components/FileContributors.js
+++ b/src/components/FileContributors.js
@@ -241,6 +241,9 @@ const FileContributors = ({ relativePath, className, editPath }) => {
   const uniqueContributors =
     commits?.reduce(
       (res, cur) => {
+        if (cur.author.user === null) {
+          return res
+        }
         for (const contributor of res) {
           const hasAuthorInfo = !!contributor.user && !!cur.author.user
           if (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Contributors shows duplicate users in https://ethereum.org/en/developers/docs/ (every docs page)

## Description
The issue is previously the check to detect duplicates only worked when the _author.user_ is not null. Somehow one specific user shows up in contributors for all docs even though there are no contributions i.e with author.user null. 
example- https://ethereum.org/en/developers/docs/web2-vs-web3/ (Click see contributors)
Actual contributors- https://github.com/ethereum/ethereum-org-website/blob/dev/src/content/developers/docs/web2-vs-web3/index.md
![Screenshot from 2021-07-26 02-51-18](https://user-images.githubusercontent.com/55653617/126913863-66dfbccf-ece0-4744-b7bf-800b4247f808.png)

<!--- Describe your changes in detail -->

https://user-images.githubusercontent.com/55653617/126914133-613c270b-a01c-4428-aaa2-bba28a543318.mp4

I added a check to not add any such user in the contributors list. 

## Related Issue
Fixes #3468 
cc @samajammin 
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
