### PR TITLE
Fixed duplicate tutorial images

### DIFF
--- a/src/content/developers/tutorials/transfers-and-approval-of-erc-20-tokens-from-a-solidity-smart-contract/index.md
+++ b/src/content/developers/tutorials/transfers-and-approval-of-erc-20-tokens-from-a-solidity-smart-contract/index.md
@@ -187,7 +187,7 @@ function sell(uint256 amount) public {
 
 If everything works you should see 2 events (a `Transfer` and `Sold`) in the transaction and your token balance and Ethereum balance updated.
 
-![Two events in the transaction: Transfer and Sold](./transfer-and-bought-events.png)
+![Two events in the transaction: Transfer and Sold](./transfer-and-sold-events.png)
 
 <Divider />
 


### PR DESCRIPTION
Tutorial incorrectly displayed ./transfer-and-bought-events.png image twice rather than the correct ./transfer-and-sold-events.png image corresponding to the second sell() function tx data being described.