### PR TITLE
Hid overflow of wallet descriptions

### DIFF
--- a/src/components/WalletCard.js
+++ b/src/components/WalletCard.js
@@ -139,7 +139,7 @@ const Description = styled.p`
   margin-bottom: 0.5rem;
   line-height: 140%;
   max-height: 100px;
-  overflow-y: auto;
+  overflow-y: hidden;
 `
 
 const StyledButtonLink = styled(ButtonLink)`


### PR DESCRIPTION
WallETH wallet card description overflowed and needed a scrollbar to view. It was the only card that needed this. Setting overflow-y to hidden limits description length so we're not redesigning every time the new max description length is exceeded, per issue #3489 .