### PR TITLE
Translates missing string on eth2/beacon-chain

### DIFF
--- a/src/content/translations/bg/eth2/beacon-chain/index.md
+++ b/src/content/translations/bg/eth2/beacon-chain/index.md
@@ -14,7 +14,7 @@ summaryPoints:
   ]
 ---
 
-<UpgradeStatus isShipped date="Shipped!">
+<UpgradeStatus isShipped date="Изпратено!">
     Сигналната верига беше пусната на 1 декември по обяд UTC. За да научите повече, <a href="https://beaconscan.com/">вижте данните</a>. Ако желаете да помогнете при валидирането на веригата, може да <a href="/eth2/staking/">заложите своя ETH</a>.
 </UpgradeStatus>
 

--- a/src/content/translations/ca/eth2/beacon-chain/index.md
+++ b/src/content/translations/ca/eth2/beacon-chain/index.md
@@ -14,7 +14,7 @@ summaryPoints:
   ]
 ---
 
-<UpgradeStatus isShipped date="Shipped!">
+<UpgradeStatus isShipped date="Enviat!">
     La Cadena de Balisa es va posar en marxa l'1 de desembre al migdia (UTC). Per saber-ne més <a href="https://beaconscan.com/">explora les dades</a>. Si vols ajudar a validar la cadena, pots <a href="/eth2/staking/">"apostar" els teus ETH</a>.
 </UpgradeStatus>
 

--- a/src/content/translations/de/eth2/beacon-chain/index.md
+++ b/src/content/translations/de/eth2/beacon-chain/index.md
@@ -14,7 +14,7 @@ summaryPoints:
   ]
 ---
 
-<UpgradeStatus isShipped date="Shipped!">
+<UpgradeStatus isShipped date="Versandt!">
     Die Beacon Chain wurde am 1. Dezember um 12:00 UTC eingeführt. Um mehr zu erfahren, schau dir die <a href="https://beaconscan.com/">Daten</a> an. Wenn Du auch beim Validieren von Transaktionen auf der Beacon Chain helfen möchtest, kannst Du <a href="/eth2/staking/">Deine ETH staken</a>.
 </UpgradeStatus>
 

--- a/src/content/translations/el/eth2/beacon-chain/index.md
+++ b/src/content/translations/el/eth2/beacon-chain/index.md
@@ -14,7 +14,7 @@ summaryPoints:
   ]
 ---
 
-<UpgradeStatus isShipped date="Shipped!">
+<UpgradeStatus isShipped date="Αποστολή!">
     Η κύρια αλυσίδα ανακοινώθηκε στις 1 Δεκεμβρίου το μεσημέρι UTC. Για να μάθετε περισσότερα, <a href="https://beaconscan.com/">εξερευνήστε τα δεδομένα</a>. Αν θέλετε να βοηθήσετε στην επικύρωση της αλυσίδας "chain", μπορείτε να <a href="/eth2/staking/">δεσμεύσετε (stake) τα ETH σας</a>.
 </UpgradeStatus>
 

--- a/src/content/translations/fr/eth2/beacon-chain/index.md
+++ b/src/content/translations/fr/eth2/beacon-chain/index.md
@@ -14,7 +14,7 @@ summaryPoints:
   ]
 ---
 
-<UpgradeStatus isShipped date="Shipped!">
+<UpgradeStatus isShipped date="Expédié!">
     La chaîne phare a démarré le 1er décembre à midi UTC. Pour en savoir plus, <a href="https://beaconscan.com/">explorez les données</a>. Si vous voulez aider à valider la chaîne, vous pouvez <a href="/eth2/staking/">miser vos ETH</a>.
 </UpgradeStatus>
 

--- a/src/content/translations/hi/eth2/beacon-chain/index.md
+++ b/src/content/translations/hi/eth2/beacon-chain/index.md
@@ -14,7 +14,7 @@ summaryPoints:
   ]
 ---
 
-<UpgradeStatus isShipped date="Shipped!">
+<UpgradeStatus isShipped date="लादा गया!">
     बीकन चेन को 1 दिसंबर को दोपहर UTC पर शिप किया जाता है। अधिक जानने के लिए, <a href="https://beaconscan.com/"> डेटा का अन्वेषण करें </a>। यदि आप चेन को मान्य करने में मदद चाहते हैं, तो आप <a href="/eth2/staking/"> अपने ETH को स्टेक</a> कर सकते हैं।
 </UpgradeStatus>
 

--- a/src/content/translations/hr/eth2/beacon-chain/index.md
+++ b/src/content/translations/hr/eth2/beacon-chain/index.md
@@ -14,7 +14,7 @@ summaryPoints:
   ]
 ---
 
-<UpgradeStatus isShipped date="Shipped!">
+<UpgradeStatus isShipped date="Dostavljeno!">
     Beacon Chain poslan je 1. prosinca u podne (UTC). Za više informacija <a href="https://beaconscan.com/">proučite podatke</a>. Ako želite pomoći u validaciji lanca, možete <a href="/eth2/staking/"> uložiti svoj ETH </a>.
 </UpgradeStatus>
 

--- a/src/content/translations/hu/eth2/beacon-chain/index.md
+++ b/src/content/translations/hu/eth2/beacon-chain/index.md
@@ -14,7 +14,7 @@ summaryPoints:
   ]
 ---
 
-<UpgradeStatus isShipped date="Shipped!">
+<UpgradeStatus isShipped date="Kiszállított!">
     A Beacon Chain december 1.-jén központi idő szerint délben indult el. További információért <a href="https://beaconscan.com/">nézd meg az adatokat</a>. Ha szeretnél segíteni a lánc érvényesítésében, akkor <a href="/eth2/staking/">letétbe tudod helyezni az ETH-edet</a>.
 </UpgradeStatus>
 

--- a/src/content/translations/it/eth2/beacon-chain/index.md
+++ b/src/content/translations/it/eth2/beacon-chain/index.md
@@ -14,7 +14,7 @@ summaryPoints:
   ]
 ---
 
-<UpgradeStatus isShipped date="Shipped!">
+<UpgradeStatus isShipped date="Spedito!">
     La beacon chain è stata resa disponibile il primo dicembre a mezzogiorno (UTC). Per saperne di più, <a href="https://beaconscan.com/">esplora i dati</a>. Se vuoi contribuire a convalidare la catena, puoi <a href="/eth2/staking/">fare staking con i tuoi ETH</a>.
 </UpgradeStatus>
 

--- a/src/content/translations/ja/eth2/beacon-chain/index.md
+++ b/src/content/translations/ja/eth2/beacon-chain/index.md
@@ -14,7 +14,7 @@ summaryPoints:
   ]
 ---
 
-<UpgradeStatus isShipped date="Shipped!">
+<UpgradeStatus isShipped date="発送しました！">
     ビーコンチェーンは12月1日正午UTCにリリースされました。 詳細については、 <a href="https://beaconscan.com/">データ</a> を参照してください。 このビーコンチェーンの正当性は、 <a href="/eth2/staking/">ETHを投資</a>することで援助できます。
 </UpgradeStatus>
 

--- a/src/content/translations/ro/eth2/beacon-chain/index.md
+++ b/src/content/translations/ro/eth2/beacon-chain/index.md
@@ -14,7 +14,7 @@ summaryPoints:
   ]
 ---
 
-<UpgradeStatus isShipped date="Shipped!">
+<UpgradeStatus isShipped date="Expediat!">
     Lanțul Beacon a fost lansat pe 1 decembrie la prânz, UTC. Pentru informații suplimentare, <a href="https://beaconscan.com/">explorează datele</a>. Dacă vrei să ajuți la validarea lanțului, poți <a href="/eth2/staking/">să mizezi ETH</a>.
 </UpgradeStatus>
 

--- a/src/content/translations/ru/eth2/beacon-chain/index.md
+++ b/src/content/translations/ru/eth2/beacon-chain/index.md
@@ -14,7 +14,7 @@ summaryPoints:
   ]
 ---
 
-<UpgradeStatus isShipped date="Shipped!">
+<UpgradeStatus isShipped date="Отправленный!">
     Beacon Chain запущена 1 декабря в полдень по UTC. Чтобы узнать больше, <a href="https://beaconscan. com/">ознакомьтесь с данными</a>. Если вы хотите помочь с проверкой цепочки, вы можете <a href="/eth2/staking/">вложить свои ETH</a>.
 </UpgradeStatus>
 

--- a/src/content/translations/sl/eth2/beacon-chain/index.md
+++ b/src/content/translations/sl/eth2/beacon-chain/index.md
@@ -14,7 +14,7 @@ summaryPoints:
   ]
 ---
 
-<UpgradeStatus isShipped date="Shipped!">
+<UpgradeStatus isShipped date="Odpremljeno!">
     Oddajniška veriga je začela delovati 1. decembra ob 12.00 UTC. Če želite več informacij, <a href="https://beaconscan.com/">raziščite podatke</a>. Če želite pomagati potrjevati verigo, lahko <a href="/eth2/staking/">zastavite svoj ETH</a>.
 </UpgradeStatus>
 

--- a/src/content/translations/tr/eth2/beacon-chain/index.md
+++ b/src/content/translations/tr/eth2/beacon-chain/index.md
@@ -13,7 +13,7 @@ summaryPoints:
   ]
 ---
 
-<UpgradeStatus isShipped date="Shipped!">
+<UpgradeStatus isShipped date="Sevk edildi!">
     İşaret (Beacon) Zinciri 1 Aralık saat 12:00'de (UTC) başlatılmıştır. Daha fazla bilgi için, bk. <a href="https://beaconscan.com/">verileri keşfet</a>. Zincirin doğrulanmasını isterseniz, <a href="/eth2/staking/">ETH'nizi stake edebilirsiniz</a>.
 </UpgradeStatus>
 

--- a/src/content/translations/uk/eth2/beacon-chain/index.md
+++ b/src/content/translations/uk/eth2/beacon-chain/index.md
@@ -14,7 +14,7 @@ summaryPoints:
   ]
 ---
 
-<UpgradeStatus isShipped date="Shipped!">
+<UpgradeStatus isShipped date="Відправлено!">
     Оновлення Beacon Chain запущено 1 грудня о 12:00 UTC. Щоб дізнатися більше, перейдіть на <a href="https://beaconscan.com/">цю сторінку</a>. Якщо ви хочете допомогти підтвердити ланцюг, то можете <a href="/eth2/staking/">отримати частку ETH</a>.
 </UpgradeStatus>
 


### PR DESCRIPTION
## Description
The string "Shipped!" is embedded as a prop within a component in the `/eth2/beacon-chain/` markdown pages, and has not been getting translated. This utilized Google Translate to quickly translate this single word for the current v2 pages
