### PR TITLE
Finalize London numbers on history page

### DIFF
--- a/src/content/history/index.md
+++ b/src/content/history/index.md
@@ -37,7 +37,7 @@ The Altair upgrade is the first scheduled upgrade for the [Beacon Chain](/eth2/b
 <Emoji text=":calendar:" size={1} mr={"0.5rem"} mb={"0.5rem"} /> <code>Aug-05-2021 12:33:42 PM +UTC</code><br />
 <Emoji text=":bricks:" size={1} mr={"0.5rem"} mb={"0.5rem"} /> Block number: <a href="https://etherscan.io/block/12965000">12,965,000</a><br />
 <Emoji text=":money_bag:" size={1} mr={"0.5rem"} mb={"0.5rem"} /> ETH price: $2627 USD<br />
-<Emoji text=":desktop_computer:" size={1} mr={"0.5rem"} mb={"0.5rem"} /> <a href="https://web.archive.org/web/20210804044709/https://ethereum.org/">ethereum.org on waybackmachine</a>
+<Emoji text=":desktop_computer:" size={1} mr={"0.5rem"} mb={"0.5rem"} /> <a href="https://web.archive.org/web/20210805124609/https://ethereum.org/en/">ethereum.org on waybackmachine</a>
 
 #### Summary {#london-summary}
 

--- a/src/content/history/index.md
+++ b/src/content/history/index.md
@@ -34,9 +34,9 @@ The Altair upgrade is the first scheduled upgrade for the [Beacon Chain](/eth2/b
 
 ### London {#london}
 
-<Emoji text=":calendar:" size={1} mr={"0.5rem"} mb={"0.5rem"} /> <code>Aug-05-2021 12:11:34 PM +UTC</code><br />
+<Emoji text=":calendar:" size={1} mr={"0.5rem"} mb={"0.5rem"} /> <code>Aug-05-2021 12:33:42 PM +UTC</code><br />
 <Emoji text=":bricks:" size={1} mr={"0.5rem"} mb={"0.5rem"} /> Block number: <a href="https://etherscan.io/block/12965000">12,965,000</a><br />
-<Emoji text=":money_bag:" size={1} mr={"0.5rem"} mb={"0.5rem"} /> ETH price: $2710 USD<br />
+<Emoji text=":money_bag:" size={1} mr={"0.5rem"} mb={"0.5rem"} /> ETH price: $2627 USD<br />
 <Emoji text=":desktop_computer:" size={1} mr={"0.5rem"} mb={"0.5rem"} /> <a href="https://web.archive.org/web/20210804044709/https://ethereum.org/">ethereum.org on waybackmachine</a>
 
 #### Summary {#london-summary}


### PR DESCRIPTION
## Description
🇬🇧 🔥 🎉  London is live! Updates history page with official timestamp and CoinGecko reported ETH price at time of upgrade
