### PR TITLE
Fixes Issue #3489

### DIFF
--- a/src/components/WalletCard.js
+++ b/src/components/WalletCard.js
@@ -139,7 +139,7 @@ const Description = styled.p`
   margin-bottom: 0.5rem;
   line-height: 140%;
   max-height: 100px;
-  overflow-y: auto;
+  overflow-y: inherit;
 `
 
 const StyledButtonLink = styled(ButtonLink)`


### PR DESCRIPTION
The problem with the WallETH description was that, it had a property of `overflow-y:auto` on line number 142 in the file `ethereum-org-website\src\components\WalletCard.js` which was the reason that it had a scroll bar. All I did was change the value of overflow-y from `auto` to `inherit`.