### PR TITLE
Markdown syntax fix for whitepaper tables

### DIFF
--- a/src/content/translations/fr/whitepaper/index.md
+++ b/src/content/translations/fr/whitepaper/index.md
@@ -418,11 +418,13 @@ Le modèle d'émission sera le suivant :
 - 0,099 x le montant total vendu sera conservé comme réserve à long terme.
 - 0,26 x le montant total vendu sera alloué aux mineurs chaque année indéfiniment après ce point.
 
-Groupe Au lancement Après 1 an Après 5 ans
-
----
-
-Unités monétaires 1,198 X 1,458 X 2,498 X Acheteurs 83,5 % 68,6 % 40,0 % Réserve dépensée avant vente 8,26 % 6,79 % 3,96 % Réserve utilisée après vente 8,26 % 6,79 % 3,96 % Mineurs 0 % 17,8 % 52,0 %
+| Groupe                       | Au lancement | Après 1 an | Après 5 ans |
+| ---------------------------- | ------------ | ---------- | ----------- |
+| Unités monétaires            | 1,198 X      | 1,458 X    | 2,498 X     |
+| Acheteurs                    | 83,5 %       | 68,6 %     | 40,0 %      |
+| Réserve dépensée avant vente | 8,26 %       | 6,79 %     | 3,96 %      |
+| Réserve utilisée après vente | 8,26 %       | 6,79 %     | 3,96 %      |
+| Mineurs                      | 0 %          | 17,8 %     | 52,0 %      |
 
 **Taux de croissance de l'offre à long terme (en pourcentage)**
 

--- a/src/content/translations/hu/whitepaper/index.md
+++ b/src/content/translations/hu/whitepaper/index.md
@@ -418,11 +418,13 @@ A kiadási modell a következő:
 - A teljes értékesített összeg 0,099x részét hosszú távú tartalékba helyezik.
 - A teljes értékesített összeg 0,26x része a bányászokhoz kerül évente, örökre ezután a pont után.
 
-Csoport induláskor 1 év után 5 év után
-
----
-
-Valuta egység 1,198X 1,458X 2,498X Vásárlók 83,5% 68,6% 40,0% Értékesítés előtt elköltött tartalék 8,26% 6,79% 3,96% Értékesítés után felhasznált tartalék 8,26% 6,79% 3,96% Bányászok 0% 17,8% 52,0%
+| Csoport                               | induláskor | 1 év után | 5 év után |
+| ------------------------------------- | ---------- | --------- | --------- |
+| Valuta egység                         | 1,198X     | 1,458X    | 2,498X    |
+| Vásárlók                              | 83,5%      | 68,6%     | 40,0%     |
+| Értékesítés előtt elköltött tartalék  | 8,26%      | 6,79%     | 3,96%     |
+| Értékesítés után felhasznált tartalék | 8,26%      | 6,79%     | 3,96%     |
+| Bányászok                             | 0%         | 17,8%     | 52,0%     |
 
 **Hosszú távú kínálati növekedési ütem (százalék)**
 

--- a/src/content/translations/ro/whitepaper/index.md
+++ b/src/content/translations/ro/whitepaper/index.md
@@ -418,11 +418,13 @@ Modelul de emisiune va fi după cum urmează:
 - 0,099x suma totală vândută va fi menținută pe termen lung ca rezervă.
 - 0,26x suma totală vândută va fi alocată minerilor pe an pentru totdeauna după acel moment.
 
-Grup La lansare După 1 an După 5 ani
-
----
-
-Unități valutare 1,198X 1,458X 2,498X Cumpărători 83,5% 68,6% 40,0% Rezervă cheltuită pre-vânzare 8,26% 6,79% 3,96% Rezervă folosite post-vânzare 8,26% 6,79% 3,96% Mineri 0% 17,8% 52,0%
+| Grup                          | La lansare | După 1 an | După 5 ani |
+| ----------------------------- | ---------- | --------- | ---------- |
+| Unități valutare              | 1,198X     | 1,458X    | 2,498X     |
+| Cumpărători                   | 83,5%      | 68,6%     | 40,0%      |
+| Rezervă cheltuită pre-vânzare | 8,26%      | 6,79%     | 3,96%      |
+| Rezervă folosite post-vânzare | 8,26%      | 6,79%     | 3,96%      |
+| Mineri                        | 0%         | 17,8%     | 52,0%      |
 
 **Rata de creștere a aprovizionării pe termen lung (procente)**
 


### PR DESCRIPTION
## Description
The `/whitepaper` page has a markdown table in it that required the syntax to be corrected on the English page, and this carried over into the translated pages.
This fixes the instances outstanding (`fr`, `hu`, `ro`)

## Related Issue
None filed, noticed issue while preparing #3592