### PR TITLE
Add product ordering instructions to adding products page

### DIFF
--- a/src/content/contributing/adding-developer-tools/index.md
+++ b/src/content/contributing/adding-developer-tools/index.md
@@ -47,6 +47,12 @@ Many projects in the Ethereum space are open source. We are more likely to list 
 
 ---
 
+## Product Ordering {#product-ordering}
+
+Unless products are specifically ordered otherwise, such as alphabetically, products will be displayed from most to least recently added to the page. In other words, the newest products get added to the bottom of the list. 
+
+---
+
 ## Add your developer tool {#how-decisions-about-the-site-are-made}
 
 If you want to add a developer tool to ethereum.org and it meets the criteria, create an issue on GitHub.

--- a/src/content/contributing/adding-products/index.md
+++ b/src/content/contributing/adding-products/index.md
@@ -79,6 +79,10 @@ This is a design decision that ethereum.org is responsible for.
 
 But rest assured, **there will be links to other websites that rank more dapps/wallets**
 
+### Product Ordering {#product-ordering}
+
+Unless products are specifically ordered otherwise, such as alphabetically, products will be displayed from most to least recently added to the page. In other words, the newest products get added to the bottom of the list. 
+
 ### Terms of use {#terms-of-use}
 
 Please also refer to our [terms of use](/terms-of-use/). Information on ethereum.org is provided solely for general information purposes.


### PR DESCRIPTION
## Description
The previous instructions that new product entries on the site should be added to the bottom are no longer visible on the site. This re-adds those instructions to avoid confusion or perceived favouritism between products. 