### PR TITLE
Stop stale issues closing

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,3 +15,4 @@ jobs:
           stale-issue-label: "Status: Stale"
           stale-issue-message: "This issue is stale because it has been open 45 days with no activity."
           days-before-stale: 45
+          days-before-close: -1

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,6 +13,5 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-label: "Status: Stale"
-          stale-issue-message: "This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days"
+          stale-issue-message: "This issue is stale because it has been open 45 days with no activity."
           days-before-stale: 45
-          days-before-close: 7


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Stops stale GitHub issues from closing automatically

- Removed option to close stale PRs after 7 days
- Updated stale message to reflect changes
- Stale bot will still mark issues as stale which receive no activity.

## Related Issue #3523

