### PR TITLE
Update Ethereum JSON-RPC Specification direct link

### DIFF
--- a/src/content/developers/docs/apis/json-rpc/index.md
+++ b/src/content/developers/docs/apis/json-rpc/index.md
@@ -13,7 +13,7 @@ JSON-RPC is a stateless, light-weight remote procedure call (RPC) protocol. Prim
 
 ## JSON-RPC resources {#json-rpc-resources}
 
-- [Ethereum JSON-RPC Specification](https://playground.open-rpc.org/)
+- [Ethereum JSON-RPC Specification](https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/ethereum/eth1.0-apis/assembled-spec/openrpc.json&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:input]=false&uiSchema[appBar][ui:examplesDropdown]=false)
 - [Ethereum JSON-RPC Specification GitHub repo](https://github.com/ethereum/eth1.0-apis)
 
 ## Client implementations {#client-implementations}


### PR DESCRIPTION

## Description
This fixes the direct to link to the ethereum specification, not directly to playground.open-rpc.org (this would bring up an example OpenRPC spec by default, or your last open spec)

