### PR TITLE
Fix inconsistencies on proof-of-work page

### DIFF
--- a/src/content/developers/docs/consensus-mechanisms/pow/index.md
+++ b/src/content/developers/docs/consensus-mechanisms/pow/index.md
@@ -8,15 +8,15 @@ incomplete: true
 
 Ethereum, like Bitcoin, currently uses a consensus protocol called [Proof-of-work (PoW)](https://en.wikipedia.org/wiki/Proof_of_work). This allows the nodes of the Ethereum network to agree on the state of all information recorded on the Ethereum blockchain, and prevents certain kinds of economic attacks.
 
-Over the next few years, proof-of-work will be phased out in favour of [proof of stake](/developers/docs/consensus-mechanisms/pos). This will also phase out mining from Ethereum. For more details on timing, check the progress of the [Eth2 merge upgrade](/eth2/merge/).
+Over the next few years, proof-of-work will be phased out in favour of [Proof-of-stake (PoS)](/developers/docs/consensus-mechanisms/pos). This will also phase out mining from Ethereum. For more details on timing, check the progress of the [Eth2 merge upgrade](/eth2/merge/).
 
 ## Prerequisites {#prerequisites}
 
 To better understand this page, we recommend you first read up on [transactions](/developers/docs/transactions/) and [blocks](/developers/docs/blocks/).
 
-## What is proof-of-Work (PoW)? {#what-is-pow}
+## What is Proof-of-work (PoW)? {#what-is-pow}
 
-Proof of Work (PoW) is the mechanism that allows the decentralized Ethereum network to come to consensus, or agree on things like account balances and the order of transactions. This prevents users "double spending" their coins and ensures that the Ethereum chain is incredibly difficult to attack or overwrite.
+Proof-of-work is the mechanism that allows the decentralized Ethereum network to come to consensus, or agree on things like account balances and the order of transactions. This prevents users "double spending" their coins and ensures that the Ethereum chain is incredibly difficult to attack or overwrite.
 
 ## Proof-of-work and mining {#pow-and-mining}
 
@@ -34,7 +34,7 @@ Ethereum transactions are processed into blocks. Each block has a:
 
 This block data is directly related to PoW.
 
-### The work in proof of work {#the-work}
+### The work in proof-of-work {#the-work}
 
 The proof-of-work protocol, known as Ethash, requires miners to go through an intense race of trial and error to find the nonce for a block. Only blocks with a valid nonce can be added to the chain.
 
@@ -42,19 +42,19 @@ When racing to create a block, a miner will repeatedly put a dataset, that you c
 
 The difficulty determines the target for the hash. The lower the target, the smaller the set of valid hashes. Once generated, this is incredibly easy for other miners and clients to verify. Even if one transaction was to change, the hash would be completely different, signalling fraud.
 
-Hashing makes fraud easy to spot. But PoW as a process is also a big deterrent to attacking the chain.
+Hashing makes fraud easy to spot. But proof-of-work as a process is also a big deterrent to attacking the chain.
 
 ### Proof-of-work and security {#security}
 
 Miners are incentivised to do this work on the main Ethereum chain. There is little incentive for a subset of miners to start their own chain – it undermines the system. Blockchains rely on having a single state as a source of truth. And users will always choose the longest or "heaviest" chain.
 
-The objective of PoW is to extend the chain. The longest chain is most believable as the valid one because it's had the most computational work done on it. Within Ethereum's PoW system it's nearly impossible to create new blocks that erase transactions or create fake ones, or maintain a second chain. That's because a malicious miner would need to always be solving the block nonce faster than everyone else.
+The objective of proof-of-work is to extend the chain. The longest chain is most believable as the valid one because it's had the most computational work done on it. Within Ethereum's PoW system it's nearly impossible to create new blocks that erase transactions or create fake ones, or maintain a second chain. That's because a malicious miner would need to always be solving the block nonce faster than everyone else.
 
 To consistently create malicious, yet valid, blocks, you'd need over 51% of the network mining power to beat everyone else. You'd need a lot of computing power to be able to do this amount of "work". And the energy spend might even outweigh the gains you'd make in an attack.
 
 ### Proof-of-work economics {#economics}
 
-PoW is also responsible for issuing new currency into the system and incentivising miners to do the work.
+Proof-of-work is also responsible for issuing new currency into the system and incentivising miners to do the work.
 
 Miners who successfully create a block are rewarded in 2 freshly minted ETH and all the transaction fees within the block. A miner may also get 1.75ETH for an uncle block. This is a valid block, created simultaneously to the successful block, by another miner. This usually happens due to network latency.
 
@@ -74,20 +74,20 @@ Remember, this timing doesn't include the wait times for having a transaction pi
 
 | Pros                                                                                                                                                                                                               | Cons                                                                                                                                         |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| PoW is neutral. You don't need ETH to get started and block rewards allow you to go from 0ETH to a positive balance. With [proof of stake](/developers/docs/consensus-mechanisms/pos/) you need ETH to start with. | PoW uses up so much energy that it's bad for the environment.                                                                                |
-| PoW is a tried and tested consensus mechanism that has kept Bitcoin and Ethereum secure and decentralized for many years.                                                                                          | If you want to mine, you need such specialized equipment that it's a big investment to start.                                                |
+| Proof-of-work is neutral. You don't need ETH to get started and block rewards allow you to go from 0ETH to a positive balance. With [proof-of-stake](/developers/docs/consensus-mechanisms/pos/) you need ETH to start with. | Proof-of-work uses up so much energy that it's bad for the environment.                                                                                |
+| Proof-of-work is a tried and tested consensus mechanism that has kept Bitcoin and Ethereum secure and decentralized for many years.                                                                                          | If you want to mine, you need such specialized equipment that it's a big investment to start.                                                |
 | Compared to proof-of-stake it's relatively easy to implement.                                                                                                                                                      | Due to increasing computation needed, mining pools could potentially dominate the mining game, leading to centralization and security risks. |
 
 ## Compared to proof of stake {#compared-to-pos}
 
 At a high level, proof-of-stake has the same end goal as proof-of-work: to help the decentralized network reach consensus, securely. But it has some differences in process and personnel:
 
-- PoS switches out the importance of computational power for staked ETH.
-- PoS replaces miners with validators. Validators stake their ETH to activate the ability to create new blocks.
+- Proof-of-stake switches out the importance of computational power for staked ETH.
+- Proof-of-stake replaces miners with validators. Validators stake their ETH to activate the ability to create new blocks.
 - Validators don't compete to create blocks, instead they are chosen at random by an algorithm.
 - Finality is clearer: at certain checkpoints, if 2/3 validators agree on the state of the block it is considered final. Validators must bet their entire stake on this, so if they try to collude down the line, they'll lose their entire stake.
 
-[More on proof of stake](/developers/docs/consensus-mechanisms/pos/)
+[More on proof-of-stake](/developers/docs/consensus-mechanisms/pos/)
 
 ## Further Reading {#further-reading}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed inconsistencies with cycling back-and-forth between terms: Proof of work, proof-of-work, PoW, etc...