### PR TITLE
Remove Matic Network link

### DIFF
--- a/src/content/developers/docs/scaling/plasma/index.md
+++ b/src/content/developers/docs/scaling/plasma/index.md
@@ -27,7 +27,7 @@ You should have a good understanding of all the foundational topics and a high-l
 Multiple projects provide implementations of Plasma that you can integrate into your dapps:
 
 - [OMG Network](https://omg.network/)
-- [Polygon](https://polygon.technology/)[previously Matic Network](https://matic.network/)
+- [Polygon](https://polygon.technology/) (previously Matic Network)
 - [Gluon](https://gluon.network/)
 - [Gazelle](https://gzle.io/)
 - [LeapDAO](https://ipfs.leapdao.org/)


### PR DESCRIPTION
## Description
The Matic Network page has been changed (https://matic.network/) to re-direct to Polygon's homepage so we had two adjacent links landing on the same page. This PR removes the second link. 

## Other solutions
Not opposed to removing reference to Matic altogether (Polygon have now removed reference to Matic on their homepage) if anyone has any opinions on that.