### PR TITLE
Update merge date in eth/merge

### DIFF
--- a/src/content/eth2/merge/index.md
+++ b/src/content/eth2/merge/index.md
@@ -14,7 +14,7 @@ summaryPoints:
   ]
 ---
 
-<UpgradeStatus date="~2021/22">
+<UpgradeStatus date="~Q1/Q2 2022">
   This upgrade represents the official switch to proof-of-stake consensus. This eliminates the need for energy-intensive mining, and instead secures the network using staked ether. A truly exciting step in realizing the <a href="/eth2/vision/">Eth2 vision</a> – more scalability, security, and sustainability.
 </UpgradeStatus>
 


### PR DESCRIPTION
## Description
Updates the merge date on [eth/merge](https://ethereum.org/en/eth2/merge) to more accurately reflect the current roadmap