### PR TITLE
fix incorrect login credentials for first login

### DIFF
--- a/src/content/developers/tutorials/run-node-raspberry-pi/index.md
+++ b/src/content/developers/tutorials/run-node-raspberry-pi/index.md
@@ -134,8 +134,8 @@ Depending on the image, you will be running:
 You can log in through SSH or using the console (if you have a monitor and keyboard attached)
 
 ```bash
-User: ethereum
-Password: ethereum
+User: ubuntu
+Password: ubuntu
 ```
 
 You will be prompted to change the password on first login, so you will need to login twice.


### PR DESCRIPTION
Edit: nevermind, it was just that initial 10 minutes waiting time until the setup script ist finished and the login with the ethereum:ethereum credendtials was enabled was way to optimistic, it took almost an hour on my raspberry pi 4 4GB..

I was just trying to setup a node on my raspberry pi following this guide: https://ethereum.org/en/developers/tutorials/run-node-raspberry-pi/

But was not able to login via ssh. (even after more than 10 minutes)
This was because default username and password are wrong in this guide are incorrect. 

I inspected the image and found this config in the `user-data` file:

```
# On first boot, set the (default) ubuntu user's password to "ubuntu" and
# expire user passwords
chpasswd:
  expire: true
  list:
  - ubuntu:ubuntu
```

The actual username/password combo ubuntu:ubuntu.

## Description

I changed the username and password from `ethereum` to `ubuntu`


