### PR TITLE
Remove/comment out ReleaseBanner in Layout after London Release

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -114,7 +114,6 @@ const Layout = (props) => {
                 path={path}
               />
               {shouldShowSideNav && <SideNavMobile path={path} />}
-              <ReleaseBanner storageKey={"london-release-banner"} />
               <MainContainer>
                 {shouldShowSideNav && <SideNav path={path} />}
                 <MainContent>


### PR DESCRIPTION
## Description
Removes the London Release Banner

## Related Issue
Fixes: https://github.com/ethereum/ethereum-org-website/issues/3541#issuecomment-892815821

