### PR TITLE
Fix m.killed states in Manticore tutorial

### DIFF
--- a/src/content/developers/tutorials/how-to-use-manticore-to-find-smart-contract-bugs/index.md
+++ b/src/content/developers/tutorials/how-to-use-manticore-to-find-smart-contract-bugs/index.md
@@ -341,7 +341,7 @@ contract Simple {
 Each path executed has its state of the blockchain. A state is either ready or it is killed, meaning that it reaches a THROW or REVERT instruction:
 
 - [m.ready_states](https://manticore.readthedocs.io/en/latest/states.html#accessing): the list of states that are ready (they did not execute a REVERT/INVALID)
-- [m.killed_states](https://manticore.readthedocs.io/en/latest/states.html#accessings): the list of states that are ready (they did not execute a REVERT/INVALID)
+- [m.killed_states](https://manticore.readthedocs.io/en/latest/states.html#accessings): the list of states that are killed
 - [m.all_states](https://manticore.readthedocs.io/en/latest/states.html#accessings): all the states
 
 ```python


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
m.killed states changed in developer tutorials

## Description

[Here](https://github.com/ethereum/ethereum-org-website/blob/dev/src/content/developers/tutorials/how-to-use-manticore-to-find-smart-contract-bugs/index.md) the description of m.ready states and m.killed states was the same.
<!--- Describe your changes in detail -->
I changed the description of m.killed states to 'the list of states that are killed' 

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #3698 