### PR TITLE
Fix typo in shard chains page

### DIFF
--- a/src/content/eth2/shard-chains/index.md
+++ b/src/content/eth2/shard-chains/index.md
@@ -98,7 +98,7 @@ The Beacon Chain contains all the logic for keeping shards secure and synced up.
 
 By the time additional shards are added, Ethereum Mainnet will already be secured by the Beacon Chain using proof of stake. This enables a fertile mainnet to build shard chains off of, powered by layer 2 solutions that supercharge the scalability.
 
-It remains to be seen whether mainnet will exist as the only “smart” shard that can handle code execution – but either way, the decision to expand shards can be revisted as needed.
+It remains to be seen whether mainnet will exist as the only “smart” shard that can handle code execution – but either way, the decision to expand shards can be revisited as needed.
 
 <ButtonLink to="/eth2/merge/">The merge</ButtonLink>
 


### PR DESCRIPTION
There is a typo in the page that I fixed. I just happened to notice this as I was actually reading the page to learn about shard chains and Ethereum 2.0 in general.

## Description

The word "revisited" was misspelled, but it is no longer with this PR.