### PR TITLE
Fix broken link to RimbleUI in dapps docs page

### DIFF
--- a/src/content/developers/docs/dapps/index.md
+++ b/src/content/developers/docs/dapps/index.md
@@ -71,7 +71,7 @@ Tokens must be generated in order to prove the value nodes that contribute to th
 
 **Rimble UI** **_- Adaptable components and design standards for decentralized applications._**
 
-- [rimble.consensys.design](https://rimble.consensys.design)
+- [consensys.github.io](https://consensys.github.io/rimble-app-demo/)
 - [GitHub](https://github.com/ConsenSys/rimble-ui)
 
 **One Click Dapp** **_- FOSS tool for generating dapp frontends from an [ABI](/glossary/#abi)._**

--- a/src/content/developers/docs/dapps/index.md
+++ b/src/content/developers/docs/dapps/index.md
@@ -71,8 +71,8 @@ Tokens must be generated in order to prove the value nodes that contribute to th
 
 **Rimble UI** **_- Adaptable components and design standards for decentralized applications._**
 
-- [consensys.github.io](https://consensys.github.io/rimble-app-demo/)
 - [GitHub](https://github.com/ConsenSys/rimble-ui)
+- [Example dapp](https://consensys.github.io/rimble-app-demo/)
 
 **One Click Dapp** **_- FOSS tool for generating dapp frontends from an [ABI](/glossary/#abi)._**
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed old broken link from "https://rimble.consensys.design" to "https://consensys.github.io/rimble-app-demo/"

## Related Issue
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Related [#3734](https://github.com/ethereum/ethereum-org-website/issues/3734)
