### PR TITLE
Increase Trilemma viewBox width to fit text on Linux

### DIFF
--- a/src/components/Trilemma.js
+++ b/src/components/Trilemma.js
@@ -282,7 +282,7 @@ const Trilemma = () => {
       <Triangle
         width="540"
         height="620"
-        viewBox="-100 100 810 915"
+        viewBox="-100 100 850 915"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
       >


### PR DESCRIPTION
## Description
In Brave Browser on Linux, some text in the Trilemma diagram is cut off (see #3434).

This PR increases the width of the viewBox for the Trilemma diagram SVG, so that the text does not get cut off, as seen in these screenshots:
![image](https://user-images.githubusercontent.com/25834218/131409281-bd7f204c-04a8-4abb-88f2-886239177d9d.png)
![image](https://user-images.githubusercontent.com/25834218/131409312-48c7bfcd-5b9f-4e6a-a5ac-c6171868fe7a.png)

## Related Issue
Fixes: #3434. 

## Other
I'll need a hand with testing on Mac and Windows (and perhaps other browsers) to ensure that it still looks reasonable on those platforms/browsers :slightly_smiling_face: 