### PR TITLE
Temporarily remove Blocktribe.com from Ethereum jobs section

### DIFF
--- a/src/content/community/index.md
+++ b/src/content/community/index.md
@@ -131,8 +131,8 @@ If you’re not a developer, it can be hard to know where to start in Ethereum. 
 ## Ethereum Jobs {#ethereum-jobs}
 
 **Want to find a job working in Ethereum?**
+
 - [Cryptocurrency Jobs](https://cryptocurrencyjobs.co/ethereum/)
 - [Crypto.jobs](https://crypto.jobs/)
 - [Careers at ConsenSys](https://consensys.net/careers/)
-- [Blocktribe](https://blocktribe.com/)
 - [Crypto Jobs List](https://cryptojobslist.com/ethereum-jobs)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

[Blocktribe's](https://blocktribe.com/) URL was not working for the last few days....I removed it from the Jobs section as it was directing to Job Board is Unavailable page.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #3720
