### PR TITLE
Remove RimbleUI from dapp tools section [Fixes #3734]

### DIFF
--- a/src/content/developers/docs/dapps/index.md
+++ b/src/content/developers/docs/dapps/index.md
@@ -69,7 +69,6 @@ Tokens must be generated in order to prove the value nodes that contribute to th
 
 ## Dapp tools {#dapp-tools}
 
-
 **One Click Dapp** **_- FOSS tool for generating dapp frontends from an [ABI](/glossary/#abi)._**
 
 - [oneclickdapp.com](https://oneclickdapp.com)

--- a/src/content/developers/docs/dapps/index.md
+++ b/src/content/developers/docs/dapps/index.md
@@ -69,10 +69,6 @@ Tokens must be generated in order to prove the value nodes that contribute to th
 
 ## Dapp tools {#dapp-tools}
 
-**Rimble UI** **_- Adaptable components and design standards for decentralized applications._**
-
-- [GitHub](https://github.com/ConsenSys/rimble-ui)
-- [Example dapp](https://consensys.github.io/rimble-app-demo/)
 
 **One Click Dapp** **_- FOSS tool for generating dapp frontends from an [ABI](/glossary/#abi)._**
 

--- a/src/content/translations/es/developers/docs/dapps/index.md
+++ b/src/content/translations/es/developers/docs/dapps/index.md
@@ -66,7 +66,6 @@ Tokens must be generated in order to prove the value nodes that contribute to th
 ---==crwdHRulesLBB_2_BBsuleRHdwrc==
 -->## Las herramientas de las dapps {#dapp-tools}
 
-
 **One Click Dapp\*\***_: Herramienta FOSS para generar front-ends de dapps desde una ABI._\*\*
 
 - [oneclickdapp.com](https://oneclickdapp.com)

--- a/src/content/translations/es/developers/docs/dapps/index.md
+++ b/src/content/translations/es/developers/docs/dapps/index.md
@@ -66,10 +66,6 @@ Tokens must be generated in order to prove the value nodes that contribute to th
 ---==crwdHRulesLBB_2_BBsuleRHdwrc==
 -->## Las herramientas de las dapps {#dapp-tools}
 
-**Interfaz de usuario Rimble\*\***_: Componentes adaptables y estándares de diseño para aplicaciones descentralizadas._\*\*
-
-- [rimble.consensys.design](https://rimble.consensys.design)
-- [GitHub](https://github.com/ConsenSys/rimble-ui)
 
 **One Click Dapp\*\***_: Herramienta FOSS para generar front-ends de dapps desde una ABI._\*\*
 

--- a/src/content/translations/fr/developers/docs/dapps/index.md
+++ b/src/content/translations/fr/developers/docs/dapps/index.md
@@ -66,10 +66,6 @@ Tokens must be generated in order to prove the value nodes that contribute to th
 ---==crwdHRulesLBB_2_BBsuleRHdwrc==
 -->## Outils pour DApp {#dapp-tools}
 
-**Rimble UI -** **_Composants adaptables et standards de conception pour les applications décentralisées_**
-
-- [rimble.consensys.design](https://rimble.consensys.design)
-- [GitHub](https://github.com/ConsenSys/rimble-ui)
 
 **One Click Dapp** **_- Outil FOSS pour générer des interfaces DApp à partir d'une ABI_**
 

--- a/src/content/translations/fr/developers/docs/dapps/index.md
+++ b/src/content/translations/fr/developers/docs/dapps/index.md
@@ -66,7 +66,6 @@ Tokens must be generated in order to prove the value nodes that contribute to th
 ---==crwdHRulesLBB_2_BBsuleRHdwrc==
 -->## Outils pour DApp {#dapp-tools}
 
-
 **One Click Dapp** **_- Outil FOSS pour générer des interfaces DApp à partir d'une ABI_**
 
 - [oneclickdapp.com](https://oneclickdapp.com)

--- a/src/content/translations/hu/developers/docs/dapps/index.md
+++ b/src/content/translations/hu/developers/docs/dapps/index.md
@@ -66,10 +66,6 @@ Tokens must be generated in order to prove the value nodes that contribute to th
 ---==crwdHRulesLBB_2_BBsuleRHdwrc==
 -->## Dapp eszközök {#dapp-tools}
 
-**Rimble UI** **_- Decentralizált alkalmazások alkalmazkodó komponensei és tervezési szabványai._**
-
-- [rimble.consensys.design](https://rimble.consensys.design)
-- [GitHub](https://github.com/ConsenSys/rimble-ui)
 
 **One Click Dapp** **_- FOSS eszköz, mely egy dapp frontendet generál egy ABI-ból._**
 

--- a/src/content/translations/hu/developers/docs/dapps/index.md
+++ b/src/content/translations/hu/developers/docs/dapps/index.md
@@ -66,7 +66,6 @@ Tokens must be generated in order to prove the value nodes that contribute to th
 ---==crwdHRulesLBB_2_BBsuleRHdwrc==
 -->## Dapp eszközök {#dapp-tools}
 
-
 **One Click Dapp** **_- FOSS eszköz, mely egy dapp frontendet generál egy ABI-ból._**
 
 - [oneclickdapp.com](https://oneclickdapp.com)

--- a/src/content/translations/it/developers/docs/dapps/index.md
+++ b/src/content/translations/it/developers/docs/dapps/index.md
@@ -66,7 +66,6 @@ Tokens must be generated in order to prove the value nodes that contribute to th
 ---==crwdHRulesLBB_2_BBsuleRHdwrc==
 -->## Strumenti per le dapp {#dapp-tools}
 
-
 **One Click Dapp** **_: strumento FOSS per generare frontend di dapp da un'ABI._**
 
 - [oneclickdapp.com](https://oneclickdapp.com)

--- a/src/content/translations/it/developers/docs/dapps/index.md
+++ b/src/content/translations/it/developers/docs/dapps/index.md
@@ -66,10 +66,6 @@ Tokens must be generated in order to prove the value nodes that contribute to th
 ---==crwdHRulesLBB_2_BBsuleRHdwrc==
 -->## Strumenti per le dapp {#dapp-tools}
 
-**Rimble UI** **_: componenti adattabili e con progettazione standard di progettazione per applicazioni decentralizzate_**
-
-- [rimble.consensys.design](https://rimble.consensys.design)
-- [GitHub](https://github.com/ConsenSys/rimble-ui)
 
 **One Click Dapp** **_: strumento FOSS per generare frontend di dapp da un'ABI._**
 

--- a/src/content/translations/pl/developers/docs/dapps/index.md
+++ b/src/content/translations/pl/developers/docs/dapps/index.md
@@ -66,10 +66,6 @@ Tokens must be generated in order to prove the value nodes that contribute to th
 ---==crwdHRulesLBB_2_BBsuleRHdwrc==
 -->## Narzędzia aplikacji zdecentralizowanych {#dapp-tools}
 
-**Interfejs użytkownika Rimble** **_– komponenty z możliwością dostosowania i standardy projektowe dla aplikacji zdecentralizowanych._ **
-
-- [projekt rimble.consensus](https://rimble.consensys.design)
-- [GitHub](https://github.com/ConsenSys/rimble-ui)
 
 **One ​​Click Dapp** **_– narzędzie FOSS do generowania frontendów dapp z ABI._**
 

--- a/src/content/translations/pl/developers/docs/dapps/index.md
+++ b/src/content/translations/pl/developers/docs/dapps/index.md
@@ -66,7 +66,6 @@ Tokens must be generated in order to prove the value nodes that contribute to th
 ---==crwdHRulesLBB_2_BBsuleRHdwrc==
 -->## Narzędzia aplikacji zdecentralizowanych {#dapp-tools}
 
-
 **One ​​Click Dapp** **_– narzędzie FOSS do generowania frontendów dapp z ABI._**
 
 - [oneclickdapp.com](https://oneclickdapp.com)

--- a/src/content/translations/ro/developers/docs/dapps/index.md
+++ b/src/content/translations/ro/developers/docs/dapps/index.md
@@ -66,7 +66,6 @@ Tokens must be generated in order to prove the value nodes that contribute to th
 ---==crwdHRulesLBB_2_BBsuleRHdwrc==
 -->## Instrumente Dapp {#dapp-tools}
 
-
 **One Click Dapp** **_- Instrument FOSS pentru a genera front-end-uri aplicației dapp dintr-un ABI._**
 
 - [oneclickdapp.com](https://oneclickdapp.com)

--- a/src/content/translations/ro/developers/docs/dapps/index.md
+++ b/src/content/translations/ro/developers/docs/dapps/index.md
@@ -66,10 +66,6 @@ Tokens must be generated in order to prove the value nodes that contribute to th
 ---==crwdHRulesLBB_2_BBsuleRHdwrc==
 -->## Instrumente Dapp {#dapp-tools}
 
-**Rimble UI** **_- Componente adaptabile și standarde de design pentru aplicații descentralizate._**
-
-- [rimble.consensys.design](https://rimble.consensys.design)
-- [GitHub](https://github.com/ConsenSys/rimble-ui)
 
 **One Click Dapp** **_- Instrument FOSS pentru a genera front-end-uri aplicației dapp dintr-un ABI._**
 

--- a/src/content/translations/zh/developers/docs/dapps/index.md
+++ b/src/content/translations/zh/developers/docs/dapps/index.md
@@ -66,7 +66,6 @@ Tokens must be generated in order to prove the value nodes that contribute to th
 ---==crwdHRulesLBB_2_BBsuleRHdwrc==
 -->## Dapp 工具 {#dapp-tools}
 
-
 **One Click Dapp** **_- FOSS 工具，用于从 ABI 生成 dapp 前端_**。
 
 - [oneclickdapp.com](https://oneclickdapp.com)

--- a/src/content/translations/zh/developers/docs/dapps/index.md
+++ b/src/content/translations/zh/developers/docs/dapps/index.md
@@ -66,10 +66,6 @@ Tokens must be generated in order to prove the value nodes that contribute to th
 ---==crwdHRulesLBB_2_BBsuleRHdwrc==
 -->## Dapp 工具 {#dapp-tools}
 
-**Rimble UI** **_- 去中心化应用程序的自适应组件和设计标准。_**
-
-- [rimble.consensys.design](https://rimble.consensys.design)
-- [GitHub](https://github.com/ConsenSys/rimble-ui)
 
 **One Click Dapp** **_- FOSS 工具，用于从 ABI 生成 dapp 前端_**。
 


### PR DESCRIPTION
Remove the RimbleUI from the dapp-tools sections in all pages(including the translations).
## Related Issue
#3734 

## Related Discussion
#3740 
