### PR TITLE
Remove the word 'dapp' from intro to ether description

### DIFF
--- a/src/content/developers/docs/intro-to-ether/index.md
+++ b/src/content/developers/docs/intro-to-ether/index.md
@@ -1,6 +1,6 @@
 ---
 title: Intro to ether
-description: A dapp developer's introduction to the ether cryptocurrency.
+description: A developer's introduction to the ether cryptocurrency.
 lang: en
 sidebar: true
 ---


### PR DESCRIPTION
Removes the word 'dapp' from intro to ether description. Users hitting a intro to ether page probably aren't dapp developers just yet :)

<img width="425" alt="Screenshot 2021-09-01 at 09 51 43" src="https://user-images.githubusercontent.com/62268199/131642871-ef9cd2a3-7d0b-4408-99c4-14f18f614399.png">
