### PR TITLE
Update language names

### DIFF
--- a/src/data/translations.json
+++ b/src/data/translations.json
@@ -21,7 +21,7 @@
   },
   "cs": {
     "version": 1.1,
-    "language": "čeština"
+    "language": "Čeština"
   },
   "de": {
     "version": 2.0,
@@ -93,7 +93,7 @@
   },
   "nb": {
     "version": 1.1,
-    "language": "norsk"
+    "language": "Norsk"
   },
   "pl": {
     "version": 2.2,
@@ -125,7 +125,7 @@
   },
   "sl": {
     "version": 2.0,
-    "language": "Slovenija"
+    "language": "Slovenščina"
   },
   "tr": {
     "version": 2.0,


### PR DESCRIPTION
## Description

Changed the capitalization for 'čeština' and 'norsk' to ensure consistency with the capitalization throughout the language list.
Changed 'Slovenija' to 'Slovenščina', since all the remaining languages include the language name (Slovenščina), instead of the country name (Slovenija).

## Related Issue

#3788