### PR TITLE
Added dapp-tool resources -  scaffold-eth, create-eth-app [Fixes #3782]

### DIFF
--- a/src/content/developers/docs/dapps/index.md
+++ b/src/content/developers/docs/dapps/index.md
@@ -69,14 +69,14 @@ Tokens must be generated in order to prove the value nodes that contribute to th
 
 ## Dapp tools {#dapp-tools}
 
+**Scaffold-ETH** **_- Quickly experiment with Solidity using a frontend that adapts to your smart contract._**
+
+- [GitHub](https://github.com/austintgriffith/scaffold-eth)
+- [Example dapp](https://punkwallet.io/)
+
 **Create Eth App** **_- Create Ethereum-powered apps with one command._**
 
 - [GitHub](https://github.com/paulrberg/create-eth-app)
-
-**Scaffold-ETH** **_- Quickly experiment with Solidity using a frontend that adapts to your smart contract._**
-
-- [Example dapp](https://punkwallet.io/)
-- [GitHub](https://github.com/austintgriffith/scaffold-eth)
 
 **One Click Dapp** **_- FOSS tool for generating dapp frontends from an [ABI](/glossary/#abi)._**
 

--- a/src/content/developers/docs/dapps/index.md
+++ b/src/content/developers/docs/dapps/index.md
@@ -69,6 +69,15 @@ Tokens must be generated in order to prove the value nodes that contribute to th
 
 ## Dapp tools {#dapp-tools}
 
+**Create Eth App** **_- Create Ethereum-powered apps with one command._**
+
+- [GitHub](https://github.com/paulrberg/create-eth-app)
+
+**Scaffold-ETH** **_- Quickly experiment with Solidity using a frontend that adapts to your smart contract._**
+
+- [Example dapp](https://punkwallet.io/)
+- [GitHub](https://github.com/austintgriffith/scaffold-eth)
+
 **One Click Dapp** **_- FOSS tool for generating dapp frontends from an [ABI](/glossary/#abi)._**
 
 - [oneclickdapp.com](https://oneclickdapp.com)


### PR DESCRIPTION
Added resources in dapp-tool section.
## Description
Adding below resources and example dapps-
1. [scaffold-eth](https://github.com/austintgriffith/scaffold-eth) & [Example Dapp](https://punkwallet.io/)
2. [Create Eth App](https://github.com/paulrberg/create-eth-app) & Example Dapp is not available.

## Related Issue
#3782 

