### PR TITLE
Rearrange order of gas page links

### DIFF
--- a/src/content/developers/docs/gas/index.md
+++ b/src/content/developers/docs/gas/index.md
@@ -154,7 +154,14 @@ If you are looking to reduce gas costs for your ETH you are able to set a tip to
 
 If you want to monitor gas prices so you are able to send your ETH for less you can use many different tools such as:
 
-- [Etherscan](https://etherscan.io/gastracker)
+- [Etherscan](https://etherscan.io/gastracker) _Transaction gas price estimator_
+- [GasNow](https://www.gasnow.org) _ETH Gas Price forecast system_
+- [ETH Gas Station](https://ethgasstation.info/) _Consumer oriented metrics for the Ethereum gas market_
+
+## Related Tools {#related-tools}
+
+- [Bloxy Gas Analytics](https://stat.bloxy.info/superset/dashboard/gas/?standalone=true) _Ethereum network gas stats_
+- [Blocknative's Gas Platform](https://www.blocknative.com/gas) _Gas estimation API powered by Blocknative's global mempool data platform_
 
 ## Further Reading {#further-reading}
 
@@ -162,13 +169,6 @@ If you want to monitor gas prices so you are able to send your ETH for less you 
 - [Is Ethereum more expensive to use as price rises?](https://docs.ethhub.io/questions-about-ethereum/is-ethereum-more-expensive-to-use-as-price-rises/)
 - [Reducing the gas consumption of your Smart Contracts](https://medium.com/coinmonks/8-ways-of-reducing-the-gas-consumption-of-your-smart-contracts-9a506b339c0a)
 - [Proof of Stake versus Proof of Work](https://blockgeeks.com/guides/proof-of-work-vs-proof-of-stake/)
-
-## Related Tools {#related-tools}
-
-- [ETH Gas Station](https://ethgasstation.info/) _Consumer oriented metrics for the Ethereum gas market_
-- [Etherscan Gas Tracker](https://etherscan.io/gastracker) _Transaction gas price estimator_
-- [Bloxy Gas Analytics](https://stat.bloxy.info/superset/dashboard/gas/?standalone=true) _Ethereum network gas stats_
-- [Blocknative's Gas Platform](https://www.blocknative.com/gas) _Gas estimation API powered by Blocknative's global mempool data platform_
 
 ## Related Topics {#related-topics}
 

--- a/src/content/developers/docs/gas/index.md
+++ b/src/content/developers/docs/gas/index.md
@@ -155,7 +155,6 @@ If you are looking to reduce gas costs for your ETH you are able to set a tip to
 If you want to monitor gas prices so you are able to send your ETH for less you can use many different tools such as:
 
 - [Etherscan](https://etherscan.io/gastracker) _Transaction gas price estimator_
-- [GasNow](https://www.gasnow.org) _ETH Gas Price forecast system_
 - [ETH Gas Station](https://ethgasstation.info/) _Consumer oriented metrics for the Ethereum gas market_
 
 ## Related Tools {#related-tools}


### PR DESCRIPTION
Since it said many different tools, I put the gas trackers right next to Etherscan and added GasNow. Pulled ETH Gas Station up to that list as well. Kept the related tools for analytics and apis.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
