### PR TITLE
Correction to externally-owned accounts section in developer docs

### DIFF
--- a/src/content/developers/docs/accounts/index.md
+++ b/src/content/developers/docs/accounts/index.md
@@ -29,7 +29,7 @@ Both account types have the ability to:
 
 - Creating an account costs nothing
 - Can initiate transactions
-- Transactions between externally-owned accounts can only be ETH transfers
+- Transactions between externally-owned accounts can only be ETH/token transfers
 
 **Contract**
 


### PR DESCRIPTION
The key differences mentions that externally-owned can only send ETH between them. But they can send tokens as well, of course.