### PR TITLE
Filter Spam/Abandoned issues from Implemented section of the Roadmap on About page

### DIFF
--- a/src/components/Roadmap.js
+++ b/src/components/Roadmap.js
@@ -57,6 +57,10 @@ const Roadmap = () => {
     implemented: blankIssues,
   })
 
+  // Checks if any of the label objects in the array of labels associated with an issue have the spam label
+  const issueIsSpam = ({ labels }) =>
+    labels.some((label) => label.name === "Status: Spam")
+
   // TODO update to pull PRs & issues separately
   useEffect(() => {
     axios
@@ -98,7 +102,8 @@ const Roadmap = () => {
               (issue) =>
                 issue.state === "closed" &&
                 "allcontributors[bot]" !== issue.user.login &&
-                !!issue.pull_request
+                !!issue.pull_request &&
+                !issueIsSpam(issue)
             )
             .slice(0, 6)
           setIssues({

--- a/src/components/Roadmap.js
+++ b/src/components/Roadmap.js
@@ -59,7 +59,10 @@ const Roadmap = () => {
 
   // Checks if any of the label objects in the array of labels associated with an issue have the spam label
   const issueIsSpam = ({ labels }) =>
-    labels.some((label) => label.name === "Status: Spam")
+    labels.some((label) => label.name === "Type: Spam")
+
+  const issueIsAbandoned = ({ labels }) =>
+    labels.some((label) => label.name === "Status: Abandoned")
 
   // TODO update to pull PRs & issues separately
   useEffect(() => {
@@ -103,7 +106,8 @@ const Roadmap = () => {
                 issue.state === "closed" &&
                 "allcontributors[bot]" !== issue.user.login &&
                 !!issue.pull_request &&
-                !issueIsSpam(issue)
+                !issueIsSpam(issue) &&
+                !issueIsAbandoned(issue)
             )
             .slice(0, 6)
           setIssues({


### PR DESCRIPTION
## Description
Didn't have access to Netlify function to test but I think this works if we just use labels...

_Edit: this works._ Filters out any PRs that have been given the 'Status: Spam' label. 

## Screenshots
On ethereum.org
<img width="841" alt="Screenshot 2021-09-06 at 10 40 20" src="https://user-images.githubusercontent.com/62268199/132196331-661b3be4-6939-422a-abf6-60137c254138.png">

On branch deploy preview
<img width="841" alt="Screenshot 2021-09-06 at 10 41 14" src="https://user-images.githubusercontent.com/62268199/132196468-15d9ea07-68e1-4b30-8c27-748b902e3df6.png">

## Link
https://deploy-preview-3822--ethereumorg.netlify.app/en/about/#roadmap

## Next Steps

We could generalise this to 'Not Merged' and automate it using GitHub actions. [Event received](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request) contains info on whether the PR has been merged or not. 

## Related Issue
#3047
#3808
