### PR TITLE
Remove DC blockchain developers meetup

### DIFF
--- a/src/components/MeetupList.js
+++ b/src/components/MeetupList.js
@@ -252,12 +252,6 @@ const meetups = [
     link: "https://www.meetup.com/Seattle-Ethereum-Meetup/",
   },
   {
-    title: "DC Blockchain Developers",
-    emoji: ":us:",
-    location: "Washington D.C.",
-    link: "https://www.meetup.com/DC-Blockchain-Developers/",
-  },
-  {
     title: "Chiang Mai Dapps",
     emoji: ":thailand:",
     location: "Chiang Mai",


### PR DESCRIPTION
## Description
Removed DC blockchain meetup as the group [no longer exists](https://www.meetup.com/DC-Blockchain-Developers/). Couldn't find the alternative (i.e. if they had renamed/hosted elsewhere).
