### PR TITLE
Add GitHub action to label unmerged PRs

### DIFF
--- a/.github/workflows/on-pr-close.yml
+++ b/.github/workflows/on-pr-close.yml
@@ -1,0 +1,21 @@
+name: Close Pull Request
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  close_job:
+    # this job will only run if the PR has been closed without being merged
+    if: github.event.pull_request.merged == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v4
+        with:
+          script: |
+            github.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['Status: Abandoned']
+            })


### PR DESCRIPTION
## Description

Adds a GitHub action to add the `Status: Abandoned` label to PRs that have been closed without being merged. This stops these issues from appearing on the [Implemented section of our roadmap](https://ethereum.org/en/about/#roadmap). 

## Additional Context

Seems [events received](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request) is the only way to access the 'merged' property on a GitHub issue. 

## Related Issue

Extends #3822