### PR TITLE
Adds calculating fees section on Gas Page to explain wallet UX changes

### DIFF
--- a/src/content/developers/docs/gas/index.md
+++ b/src/content/developers/docs/gas/index.md
@@ -117,6 +117,10 @@ If you are interested you can read the exact
 
 Continue down the rabbit hole with these [EIP-1559 Resources](https://hackmd.io/@timbeiko/1559-resources).
 
+## Calcuating fees {#calculating-fees}
+
+One of the main benefits got through EIP-1559 is improving the user's experience when setting transaction fees. Instead of explicitly stating how much you are willing to pay to get your transaction through, wallet providers will automatically set a recommended transaction fee to reduce the amount of complexity burdened onto their users.
+
 ## Why do gas fees exist? {#why-do-gas-fees-exist}
 
 In short, gas fees help keep the Ethereum network secure. By requiring a fee for every computation executed on the network, we prevent bad actors from spamming the network. In order to prevent accidental or hostile infinite loops or other computational wastage in code, each transaction is required to set a limit to how many computational steps of code execution it can use. The fundamental unit of computation is "gas".

--- a/src/content/developers/docs/gas/index.md
+++ b/src/content/developers/docs/gas/index.md
@@ -104,6 +104,10 @@ With the new base fee getting burned, the London Upgrade introduced a priority f
 
 To execute a transaction on the network users are able to specify a maximum limit they are willing to pay for their transaction to be executed. This optional parameter is known as the `maxFeePerGas`. In order for a transaction to be executed the max fee must exceed the sum of the base fee and the tip. The transaction sender is refunded the difference between the max fee and the sum of the base fee and tip.
 
+### Calcuating fees {#calculating-fees}
+
+One of the main benefits achieved with the London upgrade is improving the user's experience when setting transaction fees. For wallets that support the upgrade, instead of explicitly stating how much you are willing to pay to get your transaction through, wallet providers will automatically set a recommended transaction fee to reduce the amount of complexity burdened onto their users.
+
 ## EIP-1559 {#eip-1559}
 
 The implementation of [EIP-1559](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md) in the London Upgrade made the transaction fee mechanism more complex than the previous gas price auction, but it has the advantage of making gas fees more predictable, resulting in a more efficient transaction fee market. Users can submit transactions with a `maxFeePerGas` corresponding to how much they are willing to pay for the transaction to be executing, knowing that they will not pay more than the market price for gas (`baseFeePerGas`), and get any extra, minus their tip, refunded.
@@ -116,10 +120,6 @@ If you are interested you can read the exact
 [EIP-1559 specifications](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md).
 
 Continue down the rabbit hole with these [EIP-1559 Resources](https://hackmd.io/@timbeiko/1559-resources).
-
-## Calcuating fees {#calculating-fees}
-
-One of the main benefits got through EIP-1559 is improving the user's experience when setting transaction fees. Instead of explicitly stating how much you are willing to pay to get your transaction through, wallet providers will automatically set a recommended transaction fee to reduce the amount of complexity burdened onto their users.
 
 ## Why do gas fees exist? {#why-do-gas-fees-exist}
 

--- a/src/content/developers/docs/gas/index.md
+++ b/src/content/developers/docs/gas/index.md
@@ -106,7 +106,7 @@ To execute a transaction on the network users are able to specify a maximum limi
 
 ### Calcuating fees {#calculating-fees}
 
-One of the main benefits achieved with the London upgrade is improving the user's experience when setting transaction fees. For wallets that support the upgrade, instead of explicitly stating how much you are willing to pay to get your transaction through, wallet providers will automatically set a recommended transaction fee to reduce the amount of complexity burdened onto their users.
+One of the main benefits achieved with the London upgrade is improving the user's experience when setting transaction fees. For wallets that support the upgrade, instead of explicitly stating how much you are willing to pay to get your transaction through, wallet providers will automatically set a recommended transaction fee (base fee + recommended priority fee) to reduce the amount of complexity burdened onto their users.
 
 ## EIP-1559 {#eip-1559}
 


### PR DESCRIPTION
## Description
Adds a section explaining that wallets supporting the 1559 upgrade will automatically set fees for you to the EIP-1559 section

## Related Issue
Closes #3588
