### PR TITLE
feat: 'Typed Transaction Envelope' added to transaction page

### DIFF
--- a/src/content/developers/docs/transactions/index.md
+++ b/src/content/developers/docs/transactions/index.md
@@ -307,19 +307,22 @@ Watch Austin walk you through transactions, gas, and mining.
 
 ## Typed Transaction Envelope {#typed-transaction-envelope}
 
-Over time, Ethereum has evolved to support multiple types of transactions. This allows new features like access lists and EIP-1559 to be implemented without affecting legacy transaction formats.  
-[EIP-2718: Typed Transaction Envelope](https://eips.ethereum.org/EIPS/eip-2718) defines a transaction type that is an envelope for future transaction types.
+Ethereum originally had one format for transactions. Each transaction consists of a nonce, gas price, gas limit, to address, value, data, v, r, and s. These fields are RLP-encoded, to look something like this:  
 
-Previously, Ethereum had one format for transactions. Each transaction consists of a nonce, gas price, gas limit, to address, value, data, v, r, and s. These fields are RLP-encoded, to look something like this:  
 `RLP([nonce, gasPrice, gasLimit, to, value, data, v, r, s])`
 
+Ethereum has evolved to support multiple types of transactions to allow for new features such as access lists and [EIP-1559](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md) to be implemented without affecting legacy transaction formats.  
+
+[EIP-2718: Typed Transaction Envelope](https://eips.ethereum.org/EIPS/eip-2718) defines a transaction type that is an envelope for future transaction types.
+
 EIP-2718 is a new generalised envelope for typed transactions. In the new standard, transactions are interpreted as:  
+
 `TransactionType || TransactionPayload`
 
 Where the fields are defined as:
 
-- TransactionType: a number between 0 and 0x7f, for a total of 128 possible transaction types.
-- TransactionPayload: an arbitrary byte array, defined by the transaction type.
+- `TransactionType` - a number between 0 and 0x7f, for a total of 128 possible transaction types.
+- `TransactionPayload` an arbitrary byte array defined by the transaction type.
 
 ## Further reading {#further-reading}
 

--- a/src/content/developers/docs/transactions/index.md
+++ b/src/content/developers/docs/transactions/index.md
@@ -322,7 +322,7 @@ EIP-2718 is a new generalised envelope for typed transactions. In the new standa
 Where the fields are defined as:
 
 - `TransactionType` - a number between 0 and 0x7f, for a total of 128 possible transaction types.
-- `TransactionPayload` an arbitrary byte array defined by the transaction type.
+- `TransactionPayload` - an arbitrary byte array defined by the transaction type.
 
 ## Further reading {#further-reading}
 

--- a/src/content/developers/docs/transactions/index.md
+++ b/src/content/developers/docs/transactions/index.md
@@ -323,6 +323,8 @@ Where the fields are defined as:
 
 ## Further reading {#further-reading}
 
+- [EIP-2718: Typed Transaction Envelope](https://eips.ethereum.org/EIPS/eip-2718) 
+
 _Know of a community resource that helped you? Edit this page and add it!_
 
 ## Related topics {#related-topics}

--- a/src/content/developers/docs/transactions/index.md
+++ b/src/content/developers/docs/transactions/index.md
@@ -305,15 +305,14 @@ Watch Austin walk you through transactions, gas, and mining.
 
 <iframe width="100%" height="315" src="https://www.youtube.com/embed/er-0ihqFQB0" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-## Typed Transaction Envelope
+## Typed Transaction Envelope {#typed-transaction-envelope}
 
-Ethereum has different transaction types that specify what a transaction should do. For example, sending Ether to an address, deploying a contract, etc.  
-Ethereum now has a new transaction standard that was defined and created by Micah Zoltu in [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718): Typed Transaction Envelope, which forms the basis for some new and other yet-to-be-developed features on Ethereum.
+[EIP-2718: Typed Transaction Envelope](https://eips.ethereum.org/EIPS/eip-2718) defines a transaction type that is an envelope for future transaction types.
 
 Previously, Ethereum had one format for transactions. Each transaction consists of a nonce, gas price, gas limit, to address, value, data, v, r, and s. These fields are RLP-encoded, to look something like this:  
 `RLP([nonce, gasPrice, gasLimit, to, value, data, v, r, s])`
 
-EIP-2718 defines a new generalised envelope for typed transactions. In the new standard, transactions look like this:  
+EIP-2718 is a new generalised envelope for typed transactions. In the new standard, transactions are interpreted as:  
 `TransactionType || TransactionPayload`
 
 Where the fields are defined as:

--- a/src/content/developers/docs/transactions/index.md
+++ b/src/content/developers/docs/transactions/index.md
@@ -307,6 +307,7 @@ Watch Austin walk you through transactions, gas, and mining.
 
 ## Typed Transaction Envelope {#typed-transaction-envelope}
 
+Over time, Ethereum has evolved to support multiple types of transactions. This allows new features like access lists and EIP-1559 to be implemented without affecting legacy transaction formats.  
 [EIP-2718: Typed Transaction Envelope](https://eips.ethereum.org/EIPS/eip-2718) defines a transaction type that is an envelope for future transaction types.
 
 Previously, Ethereum had one format for transactions. Each transaction consists of a nonce, gas price, gas limit, to address, value, data, v, r, and s. These fields are RLP-encoded, to look something like this:  

--- a/src/content/developers/docs/transactions/index.md
+++ b/src/content/developers/docs/transactions/index.md
@@ -111,7 +111,7 @@ With the signature hash, the transaction can be cryptographically proven that it
 ## Types of transactions {#types-of-transactions}
 
 On Ethereum there are a few different types of transactions:
- 
+
 - Regular transactions: a transaction from one wallet to another.
 - Contract deployment transactions: a transaction without a 'to' address, where the data field is used for the contract code.
 
@@ -304,6 +304,22 @@ Ethers
 Watch Austin walk you through transactions, gas, and mining.
 
 <iframe width="100%" height="315" src="https://www.youtube.com/embed/er-0ihqFQB0" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+## Typed Transaction Envelope
+
+Ethereum has different transaction types that specify what a transaction should do. For example, sending Ether to an address, deploying a contract, etc.  
+Ethereum now has a new transaction standard that was defined and created by Micah Zoltu in [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718): Typed Transaction Envelope, which forms the basis for some new and other yet-to-be-developed features on Ethereum.
+
+Previously, Ethereum had one format for transactions. Each transaction consists of a nonce, gas price, gas limit, to address, value, data, v, r, and s. These fields are RLP-encoded, to look something like this:  
+`RLP([nonce, gasPrice, gasLimit, to, value, data, v, r, s])`
+
+EIP-2718 defines a new generalised envelope for typed transactions. In the new standard, transactions look like this:  
+`TransactionType || TransactionPayload`
+
+Where the fields are defined as:
+
+- TransactionType: a number between 0 and 0x7f, for a total of 128 possible transaction types.
+- TransactionPayload: an arbitrary byte array, defined by the transaction type.
 
 ## Further reading {#further-reading}
 

--- a/src/content/developers/docs/transactions/index.md
+++ b/src/content/developers/docs/transactions/index.md
@@ -307,7 +307,7 @@ Watch Austin walk you through transactions, gas, and mining.
 
 ## Typed Transaction Envelope {#typed-transaction-envelope}
 
-Ethereum originally had one format for transactions. Each transaction consists of a nonce, gas price, gas limit, to address, value, data, v, r, and s. These fields are RLP-encoded, to look something like this:  
+Ethereum originally had one format for transactions. Each transaction contained a nonce, gas price, gas limit, to address, value, data, v, r, and s. These fields are RLP-encoded, to look something like this:  
 
 `RLP([nonce, gasPrice, gasLimit, to, value, data, v, r, s])`
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added 'Typed Transaction Envelope' on the transaction page

References used:-
- https://eips.ethereum.org/EIPS/eip-2718
- https://blog.mycrypto.com/new-transaction-types-on-ethereum/
<!--- Describe your changes in detail -->

## Link to deploy preview

https://deploy-preview-3836--ethereumorg.netlify.app/en/developers/docs/transactions/

## Related Issue

Fixes #3807 

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
