### PR TITLE
Fix incorrect translation ID in intro to ether developer doc [Fixes #3826]

### DIFF
--- a/src/pages/developers/index.js
+++ b/src/pages/developers/index.js
@@ -333,7 +333,7 @@ const DevelopersPage = ({ data }) => {
               <Translation id="page-developers-intro-ether-link" />
             </Link>
             <p>
-              <Translation id="page-developers-into-ether-desc" />
+              <Translation id="page-developers-intro-ether-desc" />
             </p>
 
             <Link to="/developers/docs/dapps/">


### PR DESCRIPTION
## Description

Fixes the translation ID on the [developers resource](https://ethereum.org/en/developers/) page, so that the **Intro to Ether** description shows up properly.

Matching translation here: https://github.com/ethereum/ethereum-org-website/blob/dev/src/intl/en/page-developers-index.json#L35

## Related Issue

Closes #3826 