### PR TITLE
Update "use-case" page redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -79,9 +79,6 @@
   from = "/crowdsale"
   to = "/en/developers/"
 [[redirects]]
-  from = "/dao"
-  to = "/en/developers/"
-[[redirects]]
   from = "/cli"
   to = "/en/developers/"
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -226,6 +226,23 @@
   to = "/en/developers/docs/programming-languages/dart/"
   force = true
 
+# Use-cases
+[[redirects]]
+  from = "/nft/"
+  to = "/en/nft/"
+[[redirects]]
+  from = "/nfts/"
+  to = "/en/nft/"
+[[redirects]]
+  from = "/dao/"
+  to = "/en/dao/"
+[[redirects]]
+  from = "/daos/"
+  to = "/en/dao/"
+[[redirects]]
+  from = "/defi/"
+  to = "/en/defi/"
+
 # Norwegian update
 ## All translations
 [[redirects]]


### PR DESCRIPTION
## Description
Removed the redirect from `ethereum.org/dao` to `ethereum.org/en/developers`. This was added to account for the missing DAO page from the original ethereum.org website (before we added the DAO learn page).