### PR TITLE
Remove duplicate link in 'node' glossary definition. [Fixes #3846]

### DIFF
--- a/src/content/glossary/index.md
+++ b/src/content/glossary/index.md
@@ -451,8 +451,6 @@ A software client that participates in the network.
 
 <DocLink to="/developers/docs/nodes-and-clients/" title="Nodes and Clients" />
 
-<DocLink to="/developers/docs/nodes-and-clients/" title="Nodes and Clients" />
-
 ### nonce {#nonce}
 
 In cryptography, a value that can only be used once. There are two types of nonce used in Ethereum- an account nonce is a transaction counter in each account, which is used to prevent replay attacks; a [proof-of-work](#pow) nonce is the random value in a block that was used to satisfy the [proof-of-work](#pow).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

removed repeated 'Nodes and Clients' link in the 'node' glossary definition. [Fixes #3846]

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
