### PR TITLE
fix: ZK-rollups link on validium page

### DIFF
--- a/src/content/developers/docs/scaling/validium/index.md
+++ b/src/content/developers/docs/scaling/validium/index.md
@@ -7,7 +7,7 @@ incomplete: true
 sidebarDepth: 3
 ---
 
-Uses validity proofs like [ZK-rollups](#zk-rollups) but data is not stored on the main layer 1 Ethereum chain. This can lead to 10k transactions per second per validium chain and multiple chains can be run in parallel.
+Uses validity proofs like [ZK-rollups](/developers/docs/scaling/layer-2-rollups#zk-rollups) but data is not stored on the main layer 1 Ethereum chain. This can lead to 10k transactions per second per validium chain and multiple chains can be run in parallel.
 
 ## Prerequisites {#prerequisites}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
The link anchor did not exist in the scope of "validium" page. I changed the link to reference the L2 page that contains the "zk-rollup" section.

I was not sure whether I should use the relative path or the absolute path, but I saw an absolute example on one of the pages and did the same here.

## Related Issue

N/A
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
