### PR TITLE
feat: add "data availiability" con to Validium page

### DIFF
--- a/src/content/developers/docs/scaling/validium/index.md
+++ b/src/content/developers/docs/scaling/validium/index.md
@@ -20,6 +20,7 @@ You should have a good understanding of all the foundational topics and a high-l
 | No withdrawal delay (no latency to on-chain/cross-chain tx); consequent greater capital efficiency.       | Limited support for general computation/smart contracts; specialized languages required.                                                 |
 | Not vulnerable to certain economic attacks faced by fraud-proof based systems in high-value applications. | High computational power required to generate ZK proofs; not cost effective for low throughput applications.                             |
 |                                                                                                           | Slower subjective finality time (10-30 min to generate a ZK proof) (but faster to full finality because there is no dispute time delay). |
+|                                                                                                           | Generating a proof requires off-chain data (it must be available at all times)                                                           |
 
 ### Use Validium {#use-validium}
 

--- a/src/content/developers/docs/scaling/validium/index.md
+++ b/src/content/developers/docs/scaling/validium/index.md
@@ -20,7 +20,7 @@ You should have a good understanding of all the foundational topics and a high-l
 | No withdrawal delay (no latency to on-chain/cross-chain tx); consequent greater capital efficiency.       | Limited support for general computation/smart contracts; specialized languages required.                                                 |
 | Not vulnerable to certain economic attacks faced by fraud-proof based systems in high-value applications. | High computational power required to generate ZK proofs; not cost effective for low throughput applications.                             |
 |                                                                                                           | Slower subjective finality time (10-30 min to generate a ZK proof) (but faster to full finality because there is no dispute time delay). |
-|                                                                                                           | Generating a proof requires off-chain data (it must be available at all times)                                                           |
+|                                                                                                           | Generating a proof requires off-chain data to be available at all times                                                                  |
 
 ### Use Validium {#use-validium}
 

--- a/src/content/developers/docs/scaling/validium/index.md
+++ b/src/content/developers/docs/scaling/validium/index.md
@@ -20,7 +20,7 @@ You should have a good understanding of all the foundational topics and a high-l
 | No withdrawal delay (no latency to on-chain/cross-chain tx); consequent greater capital efficiency.       | Limited support for general computation/smart contracts; specialized languages required.                                                 |
 | Not vulnerable to certain economic attacks faced by fraud-proof based systems in high-value applications. | High computational power required to generate ZK proofs; not cost effective for low throughput applications.                             |
 |                                                                                                           | Slower subjective finality time (10-30 min to generate a ZK proof) (but faster to full finality because there is no dispute time delay). |
-|                                                                                                           | Generating a proof requires off-chain data to be available at all times                                                                  |
+|                                                                                                           | Generating a proof requires off-chain data to be available at all times.                                                                 |
 
 ### Use Validium {#use-validium}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
From what I understand it's essential for the Validium to have the off-chain data available at all times. Otherwise the users cannot recreate the state, because the data posted on L1 is not sufficient.

If that's correct, then I believe this is a con that should be added to the list.

## Related Issue

N/A
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
