### PR TITLE
Fix all-contributors badge to autoupdate

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -3,7 +3,6 @@
     "README.md"
   ],
   "imageSize": 100,
-  "badgeTemplate": "[![All Contributors](https://img.shields.io/badge/all_contributors-<%= contributors.length %>-orange.svg?style=flat-square)](#contributors)",
   "commit": false,
   "contributors": [
     {

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Netlify Status](https://api.netlify.com/api/v1/badges/e8f2e766-888b-4954-8500-1b647d84db99/deploy-status)](https://app.netlify.com/sites/ethereumorg/deploys)
-[![All Contributors](https://img.shields.io/badge/all_contributors-258-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/github/all-contributors/ethereum/ethereum-org-website)](#contributors-)
 [![Discord](https://img.shields.io/discord/714888181740339261?color=1C1CE1&label=ethereum.org%20%7C%20Discord%20%F0%9F%91%8B%20&style=flat-square)](https://discord.gg/CetY6Y4)
 [![Twitter Follow](https://img.shields.io/twitter/follow/ethdotorg.svg?style=social)](https://twitter.com/ethdotorg)
 [![Crowdin](https://badges.crowdin.net/ethereum-org/localized.svg)](https://crowdin.com/project/ethereumfoundation)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Netlify Status](https://api.netlify.com/api/v1/badges/e8f2e766-888b-4954-8500-1b647d84db99/deploy-status)](https://app.netlify.com/sites/ethereumorg/deploys)
-[![All Contributors](https://img.shields.io/github/all-contributors/ethereum/ethereum-org-website)](#contributors-)
+[![All Contributors](https://img.shields.io/github/all-contributors/ethereum/ethereum-org-website?color=orange&style=flat-square)](#contributors-)
 [![Discord](https://img.shields.io/discord/714888181740339261?color=1C1CE1&label=ethereum.org%20%7C%20Discord%20%F0%9F%91%8B%20&style=flat-square)](https://discord.gg/CetY6Y4)
 [![Twitter Follow](https://img.shields.io/twitter/follow/ethdotorg.svg?style=social)](https://twitter.com/ethdotorg)
 [![Crowdin](https://badges.crowdin.net/ethereum-org/localized.svg)](https://crowdin.com/project/ethereumfoundation)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The all-contributors badge in our README wasn't updating automatically (it was showing 258 contributors when we've got 508 contributors).

### Fix

- Added new dynamic badge (see [this issue for context](https://github.com/all-contributors/all-contributors/issues/406)) that will calculate number of contributors to the repo on shields.io rather being reliant on the script inside `.all-contributorsrc`
- I've removed the badge template in `.all-contributorsrc` as the above change made it redundant  

### Screenshots

**Old badge**
<img width="135" alt="Screenshot 2021-09-11 at 13 01 38" src="https://user-images.githubusercontent.com/62268199/132948501-33698725-8a7a-497a-b396-e9a4bf60e2e3.png">

**Actual contributors** 
<img width="201" alt="Screenshot 2021-09-11 at 13 01 43" src="https://user-images.githubusercontent.com/62268199/132948502-0e851114-3f24-406a-821a-452c6ebf8a88.png">

**New badge**
<img width="130" alt="Screenshot 2021-09-11 at 14 00 40" src="https://user-images.githubusercontent.com/62268199/132948686-c526ce57-e711-47b5-b995-97a8724e3583.png">

## Related Issue
[Related discord discussion](https://discord.com/channels/714888181740339261/727898649006309377/886219891290566686)
