### PR TITLE
Fix grammatical error in ERC-721 documentation

### DIFF
--- a/src/content/developers/docs/standards/tokens/erc-721/index.md
+++ b/src/content/developers/docs/standards/tokens/erc-721/index.md
@@ -21,7 +21,7 @@ than another Token from the same Smart Contract, maybe due to its age, rarity or
 Wait, visual?
 
 Yes! All NFTs have a `uint256` variable called `tokenId`, so for any ERC-721 Contract, the pair
-`contract address, uint256 tokenId` must be globally unique. Said that a dApp can have a "converter" that
+`contract address, uint256 tokenId` must be globally unique. That said, a dApp can have a "converter" that
 uses the `tokenId` as input and outputs an image of something cool, like zombies, weapons, skills or amazing kitties!
 
 ## Prerequisites {#prerequisites}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
"Said that" doesn't make grammatical sense in English, it should be "That said", or "In saying that".

## Description
Fixed grammatical error.

## Related Issue
N/A
