### PR TITLE
fix: change absolute path to relative in governance

### DIFF
--- a/src/content/governance/index.md
+++ b/src/content/governance/index.md
@@ -168,7 +168,7 @@ When the Beacon Chain merges with the Ethereum execution layer, the governance p
 - [Get involved in R&D discussion](https://ethresear.ch/)
 - [Join the Ethereum R&D discord](https://discord.gg/mncqtgVSVw)
 - [Run a node](/developers/docs/nodes-and-clients/run-a-node/)
-- [Contribute to client development](https://ethereum.org/en/developers/docs/nodes-and-clients/#clients)
+- [Contribute to client development](/developers/docs/nodes-and-clients/#clients)
 - [Core Developer Apprenticeship Program](https://blog.ethereum.org/2021/09/06/core-dev-apprenticeship-second-cohort/)
 
 ## Further reading {#further-reading}


### PR DESCRIPTION
Change absolute path of a link to relative path in governance page.

## Related Issue
Resolves #3893
