### PR TITLE
Remove accidental contribution attributions

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -4790,8 +4790,6 @@
       "avatar_url": "https://avatars.githubusercontent.com/u/20266893?v=4",
       "profile": "http://www.technobunnies.com",
       "contributions": [
-        "projectManagement",
-        "question",
         "doc"
       ]
     }


### PR DESCRIPTION
Removes `projectManagement` and `question` accidentally assigned to a user by @all_contributors bot in #3909
