### PR TITLE
Fix docs h4 anchor covered by navbar [Fixes #3892]

### DIFF
--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -127,13 +127,14 @@ const H3 = styled(Header3)`
   }
 `
 
-const StyledH4 = styled(Header4)`
+const H4 = styled(Header4)`
+  @media (max-width: ${(props) => props.theme.breakpoints.m}) {
+    font-size: 1rem;
+    font-weight: 600;
+  }
   &:before {
     height: 160px;
     margin-top: -160px;
-  }
-  a.header-anchor {
-    vertical-align: baseline;
   }
 `
 
@@ -154,7 +155,7 @@ const components = {
   h1: H1,
   h2: H2,
   h3: H3,
-  h4: StyledH4,
+  h4: H4,
   p: Paragraph,
   li: ListItem,
   pre: Codeblock,

--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -27,6 +27,7 @@ import {
   Header1,
   Header2,
   Header3,
+  Header4,
   ListItem,
 } from "../components/SharedStyledComponents"
 import Emoji from "../components/Emoji"
@@ -126,19 +127,13 @@ const H3 = styled(Header3)`
   }
 `
 
-const StyledH4 = styled.h4`
-  /* Anchor tag styles */
-  a {
-    position: relative;
-    display: none;
-    margin-left: 0rem;
-    padding-right: 0.5rem;
-    font-size: 1rem;
-    vertical-align: middle;
-    &:hover {
-      display: initial;
-      fill: ${(props) => props.theme.colors.primary};
-    }
+const StyledH4 = styled(Header4)`
+  &:before {
+    height: 160px;
+    margin-top: -160px;
+  }
+  a.header-anchor {
+    vertical-align: baseline;
   }
 `
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Inherited `Header4` from `SharedStyledComponents` and copied styling for same headers from the tutorials template. Everything appears to work as intended.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This closes #3892.
