### PR TITLE
Add more explicit font families for monospace fonts

### DIFF
--- a/src/components/BugBountyPoints.js
+++ b/src/components/BugBountyPoints.js
@@ -29,7 +29,8 @@ const PointsExchangeLabel = styled.div`
 `
 
 const PointsExchangeTitle = styled.h2`
-  font-family: "SFMono-Regular", monospace;
+  font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
+    "Liberation Mono", Menlo, Courier, monospace;
   font-size: 24px;
   font-weight: 700;
   text-transform: uppercase;

--- a/src/components/CallToContribute.js
+++ b/src/components/CallToContribute.js
@@ -60,7 +60,6 @@ const GithubIcon = styled(Icon)`
 const Description = styled.p`
   line-height: 140%;
   color: ${(props) => props.theme.colors.text};
-  font-family: "SFMono-Regular", monospace;
   font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
     "Liberation Mono", Menlo, Courier, monospace;
 `

--- a/src/components/CallToContribute.js
+++ b/src/components/CallToContribute.js
@@ -61,10 +61,13 @@ const Description = styled.p`
   line-height: 140%;
   color: ${(props) => props.theme.colors.text};
   font-family: "SFMono-Regular", monospace;
+  font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
+    "Liberation Mono", Menlo, Courier, monospace;
 `
 
 const Title = styled.h2`
-  font-family: "SFMono-Regular", monospace;
+  font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
+    "Liberation Mono", Menlo, Courier, monospace;
   text-transform: uppercase;
   background: ${(props) => props.theme.colors.border};
   padding: 0.25rem;

--- a/src/components/CodeModal.js
+++ b/src/components/CodeModal.js
@@ -66,7 +66,8 @@ const ModalClose = styled.div`
 const Title = styled.div`
   margin-left: 1.5rem;
   text-transform: uppercase;
-  font-family: "SFMono-Regular", monospace;
+  font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
+    "Liberation Mono", Menlo, Courier, monospace;
 `
 
 const ModalCloseIcon = styled(Icon)`

--- a/src/components/StatsBoxGrid.js
+++ b/src/components/StatsBoxGrid.js
@@ -29,7 +29,8 @@ const Title = styled.p`
   margin-bottom: 0.5rem;
   color: ${({ theme }) => theme.colors.text};
   text-transform: uppercase;
-  font-family: "SFMono-Regular", monospace;
+  font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
+    "Liberation Mono", Menlo, Courier, monospace;
 `
 
 const Grid = styled.div`

--- a/src/components/TutorialMetadata.js
+++ b/src/components/TutorialMetadata.js
@@ -63,7 +63,8 @@ const AddressContainer = styled.div`
 const Code = styled.div`
   overflow: hidden;
   text-overflow: ellipsis;
-  font-family: "SFMono-Regular", monospace;
+  font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
+    "Liberation Mono", Menlo, Courier, monospace;
   background: ${(props) => props.theme.colors.ednBackground};
   padding-left: 0.25rem;
   padding-right: 0.25rem;

--- a/src/pages/developers/index.js
+++ b/src/pages/developers/index.js
@@ -69,7 +69,8 @@ const HeroCopy = styled.div`
 const H1 = styled.h1`
   font-style: normal;
   font-weight: normal;
-  font-family: "SFMono-Regular", monospace;
+  font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
+    "Liberation Mono", Menlo, Courier, monospace;
   text-transform: uppercase;
   font-weight: 500;
   font-size: 32px;

--- a/src/pages/developers/learning-tools.js
+++ b/src/pages/developers/learning-tools.js
@@ -33,7 +33,8 @@ const H1 = styled.h1`
   margin-top: 0;
   color: ${(props) => props.theme.colors.text};
   font-style: normal;
-  font-family: "SFMono-Regular", monospace;
+  font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
+    "Liberation Mono", Menlo, Courier, monospace;
   text-transform: uppercase;
   font-weight: 600;
   font-size: 2rem;

--- a/src/pages/developers/local-environment.js
+++ b/src/pages/developers/local-environment.js
@@ -38,7 +38,8 @@ const HeroContent = styled(Content)`
 const Slogan = styled.h1`
   font-style: normal;
   font-weight: normal;
-  font-family: "SFMono-Regular", monospace;
+  font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
+    "Liberation Mono", Menlo, Courier, monospace;
   text-transform: uppercase;
   font-weight: 600;
   font-size: 32px;

--- a/src/pages/developers/tutorials.js
+++ b/src/pages/developers/tutorials.js
@@ -98,7 +98,8 @@ const Title = styled.p`
 const PageTitle = styled.h1`
   font-style: normal;
   font-weight: normal;
-  font-family: "SFMono-Regular", monospace;
+  font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
+    "Liberation Mono", Menlo, Courier, monospace;
   text-transform: uppercase;
   font-weight: 600;
   font-size: 32px;

--- a/src/pages/eth2/deposit-contract.js
+++ b/src/pages/eth2/deposit-contract.js
@@ -111,7 +111,8 @@ const AddressCard = styled.div`
 `
 
 const Address = styled.div`
-  font-family: "SFMono-Regular", monospace;
+  font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
+    "Liberation Mono", Menlo, Courier, monospace;
   border-radius: 2px;
   font-size: 2rem;
   flex-wrap: wrap;

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -99,7 +99,8 @@ code,
 kbd,
 pre,
 samp {
-  font-family: "SFMono-Regular", monospace;
+  font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
+    "Liberation Mono", Menlo, Courier, monospace;
   font-size: 1em;
 }
 figure {

--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -83,7 +83,8 @@ const Content = styled.article`
 
 const H1 = styled(Header1)`
   font-size: 2.5rem;
-  font-family: "SFMono-Regular", monospace;
+  font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
+    "Liberation Mono", Menlo, Courier, monospace;
   text-transform: uppercase;
   @media (max-width: ${(props) => props.theme.breakpoints.m}) {
     font-size: 2rem;
@@ -102,7 +103,8 @@ const H1 = styled(Header1)`
 `
 
 const H2 = styled(Header2)`
-  font-family: "SFMono-Regular", monospace;
+  font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
+    "Liberation Mono", Menlo, Courier, monospace;
   text-transform: uppercase;
 
   font-size: 1.5rem;

--- a/src/templates/tutorial.js
+++ b/src/templates/tutorial.js
@@ -84,7 +84,8 @@ const ContentContainer = styled.article`
 
 const H1 = styled(Header1)`
   font-size: 2.5rem;
-  font-family: "SFMono-Regular", monospace;
+  font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
+    "Liberation Mono", Menlo, Courier, monospace;
   text-transform: uppercase;
   @media (max-width: ${(props) => props.theme.breakpoints.m}) {
     font-size: 1.75rem;
@@ -96,7 +97,8 @@ const H1 = styled(Header1)`
 `
 
 const H2 = styled(Header2)`
-  font-family: "SFMono-Regular", monospace;
+  font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
+    "Liberation Mono", Menlo, Courier, monospace;
   text-transform: uppercase;
 
   &:before {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We are not declaring explicit font families for most things using a monospace typeface unless the user has `SFMono-Regular` installed. Even on my iMac, the H2 was defaulting to `monospace` instead of `SFMono-Regular`

This was causing pages using monospace to 1. look a bit disconnected on most devices and 2. created issues with typographical hierarchy in some cases as H2s appeared to be smaller in height than H3s.

On this before screenshot notice how 'Development Modules' looks smaller than 'Foundational Topics' despite being the same font-size:
<img width="941" alt="Screenshot 2021-09-16 at 11 58 36" src="https://user-images.githubusercontent.com/62268199/133603999-55b7bd73-0b73-4a32-ad09-b497050884b0.png">

See after screenshot to see how this change fixes this.
<img width="904" alt="Screenshot 2021-09-16 at 11 58 25" src="https://user-images.githubusercontent.com/62268199/133604160-ba1c87ea-88e9-4e46-9d85-ab3d96656863.png">

Using BrowserStack I've tested this across windows and a few mobile devices and the change seems to be an improvement across all devices.

I re-used the monospace font-stack already used in our [layout CSS](https://github.com/ethereum/ethereum-org-website/search?q=Roboto+Mono)

Pretty sure this is the intended design as this is how it appears on @samajammin's screenshots [here](https://github.com/ethereum/ethereum-org-website/pull/2671#pullrequestreview-615891877).

*Should probably refactor this at some point so we aren't declaring the same fonts everywhere.*
