### PR TITLE
fix typo of raspberry pi 4 node tutorial [Fixes #3924]

### DIFF
--- a/src/content/developers/tutorials/run-node-raspberry-pi/index.md
+++ b/src/content/developers/tutorials/run-node-raspberry-pi/index.md
@@ -74,7 +74,7 @@ Both images include the same packages, the only difference between them is that 
 
 ## Storage {#storage}
 
-You will need and SSD to run the Ethereum clients (without an SSD drive there’s absolutely no chance of syncing the Ethereum blockchain). There are 2 options:
+You will need an SSD to run the Ethereum clients (without an SSD drive there’s absolutely no chance of syncing the Ethereum blockchain). There are 2 options:
 
 - Use a USB portable SSD disk such as the Samsung T5 Portable SSD.
 - Use a USB 3.0 External Hard Drive Case with a SSD Disk. In our case we used a Inateck 2.5 Hard Drive Enclosure FE2011. Make sure to buy a case with an UAS compliant chip, particularly, one of these: JMicron (JMS567 or JMS578) or ASMedia (ASM1153E).


### PR DESCRIPTION
Fix Typo

## Description

fix typo of raspberry pi 4 node tutorial at https://ethereum.org/en/developers/tutorials/run-node-raspberry-pi/#storage

## Related Issue
#3924

