### PR TITLE
Update Intro to Ether developer doc

### DIFF
--- a/src/content/developers/docs/intro-to-ether/index.md
+++ b/src/content/developers/docs/intro-to-ether/index.md
@@ -13,9 +13,9 @@ To help you better understand this page, we recommend you first read [Introducti
 
 A cryptocurrency is a medium of exchange secured by a blockchain-based ledger.
 
-A medium of exchange is anything that is widely accepted as payment for goods and services, and a ledger is a data store that keeps track of transactions. Blockchain technology allows users to make transactions on the ledger without reliance upon a trusted third party to maintain the ledger.
+A medium of exchange is anything widely accepted as payment for goods and services, and a ledger is a data store that keeps track of transactions. Blockchain technology allows users to make transactions on the ledger without reliance upon a trusted third party to maintain the ledger.
 
-The first-ever cryptocurrency was Bitcoin, created by Satoshi Nakamoto. Since Bitcoin's release in 2009, people have made thousands of cryptocurrencies across many different types of blockchains.
+The first cryptocurrency was Bitcoin, created by Satoshi Nakamoto. Since Bitcoin's release in 2009, people have made thousands of cryptocurrencies across many different blockchains.
 
 ## What is ether? {#what-is-ether}
 

--- a/src/content/developers/docs/intro-to-ether/index.md
+++ b/src/content/developers/docs/intro-to-ether/index.md
@@ -37,11 +37,9 @@ Ether is minted when a miner creates a block on the Ethereum blockchain. As an i
 
 ## Burning ether {#burning-ether}
 
-Just as ether can be created by minting, ether can be destroyed by a process called burning. When burn occurs, ether is removed from the Ethereum ledger.
+As well as creating ether through minting, ether can get destroyed by a process called 'burning'. When ether gets burned, it gets removed from circulation permanently.
 
-Ether burn occurs in every transaction on Ethereum. When a user pays for their transaction, their base gas fee is automatically destroyed by the Ethereum protocol. [In some blocks](https://etherscan.io/block/12965263), more ether are burned than minted due to base fee burn.
-
-[More on gas base-fees](/developers/docs/gas/#base-fee)
+Ether burn occurs in every transaction on Ethereum. When users pay for their transactions, their base gas fee gets destroyed by the protocol. Depending on network demand, [some blocks](https://etherscan.io/block/12965263) burn more ether than they mint.
 
 ## Denominations of ether {#denominations}
 

--- a/src/content/developers/docs/intro-to-ether/index.md
+++ b/src/content/developers/docs/intro-to-ether/index.md
@@ -56,7 +56,7 @@ Gwei, short for giga-Wei, is often used to describe gas costs on Ethereum.
 
 ## Transferring ether {#transferring-ether}
 
-Each transaction on Ethereum contains a `value` field, which specifies the amonunt of ether to be transferred, denominated in Wei, to send from the sender's address to the recipient address.
+Each transaction on Ethereum contains a `value` field, which specifies the amount of ether to be transferred, denominated in Wei, to send from the sender's address to the recipient address.
 
 When the recipient address is a [smart contract](/developers/docs/smart-contracts/), this transferred ether may be used to pay for gas when the smart contract executes its code.
 

--- a/src/content/developers/docs/intro-to-ether/index.md
+++ b/src/content/developers/docs/intro-to-ether/index.md
@@ -70,7 +70,7 @@ Users can query the ether balance of any [account](/developers/docs/accounts/) b
 
 ## Further reading {#further-reading}
 
+- [Defining Ether and Ethereum](https://www.cmegroup.com/education/courses/introduction-to-ether/defining-ether-and-ethereum.html) – _CME Group_
 - [Ethereum Whitepaper](/whitepaper/): The original proposal for Ethereum. This document includes a description of ether and the motivations behind its creation.
-- [Ethereum Yellowpaper](https://ethereum.github.io/yellowpaper/paper.pdf): A technical description of Ethereum's implementation. This document describes the underlying logic of the Ethereum blockchain and ether cryptocurrency.
 
 _Know of a community resource that helped you? Edit this page and add it!_

--- a/src/content/developers/docs/intro-to-ether/index.md
+++ b/src/content/developers/docs/intro-to-ether/index.md
@@ -19,21 +19,19 @@ The first cryptocurrency was Bitcoin, created by Satoshi Nakamoto. Since Bitcoin
 
 ## What is ether? {#what-is-ether}
 
-Ether (ETH) is the cryptocurrency used to pay for computing services on the [Ethereum blockchain](/developers/docs/intro-to-ethereum).
+**Ether (ETH)** is the cryptocurrency used to pay for computing resources on the Ethereum blockchain.
 
-It is [common](https://www.reuters.com/article/us-crypto-currencies-lending-insight-idUSKBN25M0GP#:~:text=price%20of%20ethereum) [to](https://abcnews.go.com/Business/bitcoin-slumps-week-low-amid-renewed-worries-chinese/story?id=78399845#:~:text=cryptocurrencies%20including%20ethereum) [conflate](https://www.cnn.com/2021/03/14/tech/nft-art-buying/index.html#:~:text=price%20of%20ethereum) Ethereum and ether — when people reference the "price of Ethereum," they are almost always describing the price of ether.
+Ethereum allows developers to create [**decentralized applications (dapps)**](/developers/docs/dapps), which all share a pool of computing power. This shared pool is finite, so Ethereum needs to determine who gets access to the computing power. Otherwise, a dapp could accidentally or maliciously consume the entire network.
 
-The Ethereum blockchain allows developers to create [decentralized applications (dapps)](/developers/docs/dapps), which all share a pool of computing power. This shared pool is finite, so Ethereum needs to determine who gets access to the computing power. Otherwise, a dapp with an accidental infinite loop or another malicious program could consume the entire network.
+The ether cryptocurrency supports a pricing mechanism for Ethereum's computing power. When users want to make a transaction, they must pay ether to have their transaction recognized on the blockchain. These usage costs are known as [gas fees](/developers/docs/gas/), and the gas fee depends on the amount of computing power required to execute the transaction and the network-wide demand for computing power at the time.
 
-The ether cryptocurrency supports a pricing mechanism for Ethereum's computing power. When users want to make a transaction, they must pay ether to have their transaction recognized on the blockchain. These usage costs are called gas fees, and they depend on the total amount of computing required by a transaction, as well as the network-wide demand for computing when the transaction is submitted.
+Therefore, even if a malicious dapp submitted an infinite loop, the transaction would eventually run out of ether and terminate, allowing the network to return to normal.
 
-Thus, even if a malicious dapp submitted an infinite loop, the transaction would eventually run out of ether and terminate, allowing the network to return to normal.
-
-[More on gas](/developers/docs/gas/)
+It is [common](https://www.reuters.com/article/us-crypto-currencies-lending-insight-idUSKBN25M0GP#:~:text=price%20of%20ethereum) [to](https://abcnews.go.com/Business/bitcoin-slumps-week-low-amid-renewed-worries-chinese/story?id=78399845#:~:text=cryptocurrencies%20including%20ethereum) [conflate](https://www.cnn.com/2021/03/14/tech/nft-art-buying/index.html#:~:text=price%20of%20ethereum) Ethereum and ether — when people reference the "price of Ethereum," they are describing the price of ether.
 
 ## Minting ether {#minting-ether}
 
-Minting is a process in which new ether is created on the Ethereum ledger. The new ether is created by the underlying Ethereum protocol, and it is not possible for a user to create new ether.
+Minting is the process in which new ether gets created on the Ethereum ledger. The underlying Ethereum protocol creates the new ether, and it is not possible for a user to create ether.
 
 Ether is minted when a miner creates a block on the Ethereum blockchain. As an incentive to miners, the protocol grants a reward in each block, incrementing the balance of an address set by the block's miner. The block reward has changed over time, and today it is 2 ETH per block.
 

--- a/src/content/developers/docs/intro-to-ether/index.md
+++ b/src/content/developers/docs/intro-to-ether/index.md
@@ -47,7 +47,7 @@ Since many transactions on Ethereum are small, ether has several denominations w
 
 Wei is the smallest possible amount of ether, and as a result, many technical implementations, such as the [Ethereum Yellowpaper](https://ethereum.github.io/yellowpaper/paper.pdf), will base all calculations in Wei.
 
-Gwei, short for giga-Wei, is often used to describe gas costs on the Ethereum network.
+Gwei, short for giga-Wei, is often used to describe gas costs on Ethereum.
 
 | Denomination | Value in ether   | Common Usage              |
 | ------------ | ---------------- | ------------------------- |
@@ -56,7 +56,7 @@ Gwei, short for giga-Wei, is often used to describe gas costs on the Ethereum ne
 
 ## Transferring ether {#transferring-ether}
 
-Each transaction in the Ethereum blockchain contains a `value` field, which transfers a specified amount of ether, denominated in Wei, to send from the sender's address to the recipient address.
+Each transaction on Ethereum contains a `value` field, which specifies the amonunt of ether to be transferred, denominated in Wei, to send from the sender's address to the recipient address.
 
 When the recipient address is a [smart contract](/developers/docs/smart-contracts/), this transferred ether may be used to pay for gas when the smart contract executes its code.
 

--- a/src/content/developers/docs/intro-to-ether/index.md
+++ b/src/content/developers/docs/intro-to-ether/index.md
@@ -37,7 +37,7 @@ Ether is minted when a miner creates a block on the Ethereum blockchain. As an i
 
 ## Burning ether {#burning-ether}
 
-As well as creating ether through minting, ether can get destroyed by a process called 'burning'. When ether gets burned, it gets removed from circulation permanently.
+As well as creating ether through block rewards, ether can get destroyed by a process called 'burning'. When ether gets burned, it gets removed from circulation permanently.
 
 Ether burn occurs in every transaction on Ethereum. When users pay for their transactions, their base gas fee gets destroyed by the protocol. Depending on network demand, [some blocks](https://etherscan.io/block/12965263) burn more ether than they mint.
 

--- a/src/content/developers/docs/intro-to-ether/index.md
+++ b/src/content/developers/docs/intro-to-ether/index.md
@@ -21,7 +21,7 @@ The first cryptocurrency was Bitcoin, created by Satoshi Nakamoto. Since Bitcoin
 
 **Ether (ETH)** is the cryptocurrency used to pay for computing resources on the Ethereum blockchain.
 
-Ethereum allows developers to create [**decentralized applications (dapps)**](/developers/docs/dapps), which all share a pool of computing power. This shared pool is finite, so Ethereum needs to determine who gets access to the computing power. Otherwise, a dapp could accidentally or maliciously consume the entire network.
+Ethereum allows developers to create [**decentralized applications (dapps)**](/developers/docs/dapps), which all share a pool of computing power. This shared pool is finite, so Ethereum needs to determine who gets access to use it. Otherwise, a dapp could accidentally or maliciously consume all network resources, which would block others from accessing it.
 
 The ether cryptocurrency supports a pricing mechanism for Ethereum's computing power. When users want to make a transaction, they must pay ether to have their transaction recognized on the blockchain. These usage costs are known as [gas fees](/developers/docs/gas/), and the gas fee depends on the amount of computing power required to execute the transaction and the network-wide demand for computing power at the time.
 

--- a/src/content/developers/docs/intro-to-ether/index.md
+++ b/src/content/developers/docs/intro-to-ether/index.md
@@ -47,7 +47,7 @@ Since many transactions on Ethereum are small, ether has several denominations w
 
 Wei is the smallest possible amount of ether, and as a result, many technical implementations, such as the [Ethereum Yellowpaper](https://ethereum.github.io/yellowpaper/paper.pdf), will base all calculations in Wei.
 
-Gwei, short for giga-Wei, is often used to describe gas costs on Ethereum.
+Gwei, short for giga-wei, is often used to describe gas costs on Ethereum.
 
 | Denomination | Value in ether   | Common Usage              |
 | ------------ | ---------------- | ------------------------- |

--- a/src/content/developers/docs/intro-to-ether/index.md
+++ b/src/content/developers/docs/intro-to-ether/index.md
@@ -19,7 +19,7 @@ The first cryptocurrency was Bitcoin, created by Satoshi Nakamoto. Since Bitcoin
 
 ## What is ether? {#what-is-ether}
 
-**Ether (ETH)** is the cryptocurrency used to pay for computing resources on the Ethereum blockchain.
+**Ether (ETH)** is the cryptocurrency used for many things on the Ethereum network. Fundamentally, it is the only acceptable form of payment for transaction fees, and after [the merge](/eth2/merge) is also required in order to validate and propose blocks on Mainnet. Ether is also used as a primary form of collateral in the [DeFi](/defi) lending markets, as a unit of account in NFT marketplaces, as payment earned for performing services or selling real-world goods, and more. 
 
 Ethereum allows developers to create [**decentralized applications (dapps)**](/developers/docs/dapps), which all share a pool of computing power. This shared pool is finite, so Ethereum needs a mechanism to determine who gets to use it. Otherwise, a dapp could accidentally or maliciously consume all network resources, which would block others from accessing it.
 

--- a/src/content/developers/docs/intro-to-ether/index.md
+++ b/src/content/developers/docs/intro-to-ether/index.md
@@ -21,7 +21,7 @@ The first cryptocurrency was Bitcoin, created by Satoshi Nakamoto. Since Bitcoin
 
 **Ether (ETH)** is the cryptocurrency used to pay for computing resources on the Ethereum blockchain.
 
-Ethereum allows developers to create [**decentralized applications (dapps)**](/developers/docs/dapps), which all share a pool of computing power. This shared pool is finite, so Ethereum needs to determine who gets access to use it. Otherwise, a dapp could accidentally or maliciously consume all network resources, which would block others from accessing it.
+Ethereum allows developers to create [**decentralized applications (dapps)**](/developers/docs/dapps), which all share a pool of computing power. This shared pool is finite, so Ethereum needs a mechanism to determine who gets to use it. Otherwise, a dapp could accidentally or maliciously consume all network resources, which would block others from accessing it.
 
 The ether cryptocurrency supports a pricing mechanism for Ethereum's computing power. When users want to make a transaction, they must pay ether to have their transaction recognized on the blockchain. These usage costs are known as [gas fees](/developers/docs/gas/), and the gas fee depends on the amount of computing power required to execute the transaction and the network-wide demand for computing power at the time.
 

--- a/src/content/developers/docs/intro-to-ether/index.md
+++ b/src/content/developers/docs/intro-to-ether/index.md
@@ -56,7 +56,7 @@ Gwei, short for giga-wei, is often used to describe gas costs on Ethereum.
 
 ## Transferring ether {#transferring-ether}
 
-Each transaction on Ethereum contains a `value` field, which specifies the amount of ether to be transferred, denominated in Wei, to send from the sender's address to the recipient address.
+Each transaction on Ethereum contains a `value` field, which specifies the amount of ether to be transferred, denominated in wei, to send from the sender's address to the recipient address.
 
 When the recipient address is a [smart contract](/developers/docs/smart-contracts/), this transferred ether may be used to pay for gas when the smart contract executes its code.
 


### PR DESCRIPTION
## Description

This PR is part of a series to [audit the developer docs](https://github.com/ethereum/ethereum-org-website/issues/3908) in preparation for upgrades to our translation program.

## Notes from the changes I've suggested:

### intro
reword

### what-is-ether
computing services sounds inaccurate -> computing resources?
bold definitions as per style guide
removed link. it's a prerequisite
simplify network consumption explanation
reword gas fee explanation
move section 
remove link, add it as inline link above

### minting-ether
sentence clarity

### burning-ether 
simplify language
explaining base fee too complicated at this stage in users journey


### demonations
Ethereum or 'the network' not 'the Ethereum network'

### transferring
incorrect the value field doesn't transfer ether, it specifies how much ether to transfer if the transaction is successful

### reading
added resource
removed yellowpaper
