### PR TITLE
improve example gas calculation in transactions topic

### DIFF
--- a/src/content/developers/docs/transactions/index.md
+++ b/src/content/developers/docs/transactions/index.md
@@ -131,9 +131,9 @@ Bob's account will be debited **-1.0042 ETH**
 
 Alice's account will be credited **+1.0 ETH**
 
-The base fee will be burned **-0.003735 ETH**
+The base fee will be burned **-0.00399 ETH**
 
-Miner keeps the tip **+0.000197 ETH**
+Miner keeps the tip **+0.000210 ETH**
 
 Gas is required for any smart contract interaction too.
 


### PR DESCRIPTION
The example numbers are no consistent in the gas fee example on the _Transactions_ page of the _Fundament topics_ in the the Docs section of the website, making for a confusing experience to a reader new to gas or new to the EIP-1559 base fee.

## Description

This PR proposes a simple change to the explanation of the gas components in the gas fee example, which now reflects behavior after EIP-1559, but the numbers are not consistent.

## Related Issue

#3951 _Docs / Transactions / improve gas fee accounting example_
