### PR TITLE
Fix base fee rounding in gas developer doc

### DIFF
--- a/src/content/developers/docs/gas/index.md
+++ b/src/content/developers/docs/gas/index.md
@@ -73,8 +73,8 @@ The base fee is calculated by a formula that compares the size of the previous b
 
 | Block Number | Included Gas | Fee Increase | Current Base Fee |
 | ------------ | -----------: | -----------: | ---------------: |
-| 1            |          15M |           0% |       100.0 gwei |
-| 2            |          30M |           0% |       100.0 gwei |
+| 1            |          15M |           0% |         100 gwei |
+| 2            |          30M |           0% |         100 gwei |
 | 3            |          30M |        12.5% |       112.5 gwei |
 | 4            |          30M |        12.5% |       126.6 gwei |
 | 5            |          30M |        12.5% |       142.4 gwei |

--- a/src/content/developers/docs/gas/index.md
+++ b/src/content/developers/docs/gas/index.md
@@ -77,7 +77,7 @@ The base fee is calculated by a formula that compares the size of the previous b
 | 2            |          30M |           0% |       100.0 gwei |
 | 3            |          30M |        12.5% |       112.5 gwei |
 | 4            |          30M |        12.5% |       126.6 gwei |
-| 5            |          30M |        12.5% |       142.3 gwei |
+| 5            |          30M |        12.5% |       142.4 gwei |
 | 6            |          30M |        12.5% |       160.2 gwei |
 | 7            |          30M |        12.5% |       180.2 gwei |
 | 8            |          30M |        12.5% |       202.8 gwei |

--- a/src/content/developers/docs/gas/index.md
+++ b/src/content/developers/docs/gas/index.md
@@ -80,7 +80,7 @@ The base fee is calculated by a formula that compares the size of the previous b
 | 5            |          30M |        12.5% |       142.4 gwei |
 | 6            |          30M |        12.5% |       160.2 gwei |
 | 7            |          30M |        12.5% |       180.2 gwei |
-| 8            |          30M |        12.5% |       202.8 gwei |
+| 8            |          30M |        12.5% |       202.7 gwei |
 
 Relative to the pre-London gas auction market, this transaction-fee-mechanism change causes fee prediction to be more reliable. Following the table above - to create a transaction on block number 9, a wallet will let the user know with certainty that the **maximum base fee** to be added to the next block is `current base fee * 112.5%` or `202.8 gwei * 112.5% = 228.1 gwei`.
 

--- a/src/content/developers/docs/gas/index.md
+++ b/src/content/developers/docs/gas/index.md
@@ -73,11 +73,11 @@ The base fee is calculated by a formula that compares the size of the previous b
 
 | Block Number | Included Gas | Fee Increase | Current Base Fee |
 | ------------ | -----------: | -----------: | ---------------: |
-| 1            |          15M |           0% |         100 gwei |
-| 2            |          30M |           0% |         100 gwei |
+| 1            |          15M |           0% |       100.0 gwei |
+| 2            |          30M |           0% |       100.0 gwei |
 | 3            |          30M |        12.5% |       112.5 gwei |
-| 4            |          30M |        12.5% |       126.5 gwei |
-| 5            |          30M |        12.5% |       142.4 gwei |
+| 4            |          30M |        12.5% |       126.6 gwei |
+| 5            |          30M |        12.5% |       142.3 gwei |
 | 6            |          30M |        12.5% |       160.2 gwei |
 | 7            |          30M |        12.5% |       180.2 gwei |
 | 8            |          30M |        12.5% |       202.8 gwei |
@@ -92,7 +92,7 @@ It's also important to note it is unlikely we will see extended spikes of full b
 | ...          |          ... |        12.5% |              ... |
 | 50           |          30M |        12.5% |     28531.3 gwei |
 | ...          |          ... |        12.5% |              ... |
-| 100          |          30M |        12.5% | 10302608.57 gwei |
+| 100          |          30M |        12.5% |  10302608.6 gwei |
 
 ### Priority Fee (Tips) {#priority-fee}
 


### PR DESCRIPTION
Some values in the Gas page of the Docs section of the website are not consistently rounded and formatted.

## Description

The change in numbers uses conventional rounding and rounds to the nearest 0.1 ETH, consistently.

## Related Issue

#3964 
