### PR TITLE
Translation banner patch [Fixes #3213]

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -290,9 +290,7 @@ exports.onCreatePage = ({ page, actions }) => {
         isOutdated,
         //display TranslationBanner for translation-component pages that are still in English
         isContentEnglish:
-          langVersion < 2 &&
-          !page.component.includes("/developers/index.js") &&
-          !page.component.includes("/index.js"),
+          langVersion < 2 && !page.component.includes("/index.js"),
       },
     })
   }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -50,6 +50,7 @@ const outdatedMarkdownPages = [
   "/wallets/",
   "/what-is-ethereum/",
 ]
+
 exports.onCreateNode = ({ node, getNode, actions }) => {
   const { createNodeField } = actions
 
@@ -289,7 +290,9 @@ exports.onCreatePage = ({ page, actions }) => {
         isOutdated,
         //display TranslationBanner for translation-component pages that are still in English
         isContentEnglish:
-          langVersion < 2 && !page.component.includes("/developers/index.js"),
+          langVersion < 2 &&
+          !page.component.includes("/developers/index.js") &&
+          !page.component.includes("/index.js"),
       },
     })
   }


### PR DESCRIPTION
## Description
- Adjusts logic to exclude homepage from being flagged as `isContentEnglish === true` for v1/v1.1 languages.
- This switches the banner that is being displayed on the v1/v1.1 homepages to the "content out-of-date" banner.

Did some checking and wasn't able to find any other pages that were affected this way, but please comment if you know of any. 

## Related Issue
#3213