### PR TITLE
Fix typo in Gas developer doc 

### DIFF
--- a/src/content/developers/docs/gas/index.md
+++ b/src/content/developers/docs/gas/index.md
@@ -104,7 +104,7 @@ With the new base fee getting burned, the London Upgrade introduced a priority f
 
 To execute a transaction on the network users are able to specify a maximum limit they are willing to pay for their transaction to be executed. This optional parameter is known as the `maxFeePerGas`. In order for a transaction to be executed the max fee must exceed the sum of the base fee and the tip. The transaction sender is refunded the difference between the max fee and the sum of the base fee and tip.
 
-### Calcuating fees {#calculating-fees}
+### Calculating fees {#calculating-fees}
 
 One of the main benefits achieved with the London upgrade is improving the user's experience when setting transaction fees. For wallets that support the upgrade, instead of explicitly stating how much you are willing to pay to get your transaction through, wallet providers will automatically set a recommended transaction fee (base fee + recommended priority fee) to reduce the amount of complexity burdened onto their users.
 


### PR DESCRIPTION
## Description
Fix typo of "Calculation" in Gas and fees page in doc.

## Related Issue
No
