### PR TITLE
Fix Alchemy website link

### DIFF
--- a/src/content/developers/docs/frameworks/index.md
+++ b/src/content/developers/docs/frameworks/index.md
@@ -79,7 +79,7 @@ Before diving into frameworks, we recommend you first read through our introduct
 
 **Alchemy -** **_Ethereum Development Platform._**
 
-- [alchemyapi.io](https://alchemyapi.io/)
+- [alchemy.com](https://www.alchemy.com/)
 - [GitHub](https://github.com/alchemyplatform)
 - [Discord](https://discord.gg/kwqVnrA)
 


### PR DESCRIPTION
Corrected Alchemy Website :: alchemyapi.io is redirecting to alchemy.com

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
