### PR TITLE
Update Python programming language developer doc

### DIFF
--- a/src/content/developers/docs/programming-languages/python/index.md
+++ b/src/content/developers/docs/programming-languages/python/index.md
@@ -46,26 +46,29 @@ Need a more basic primer first? Check out [ethereum.org/learn](/learn/) or [ethe
 
 ## Python Projects and Tools {#python-projects-and-tools}
 
+### Active:
+
+- [Web3.py](https://github.com/ethereum/web3.py) - _Python library for interacting with Ethereum_
 - [Brownie](https://github.com/eth-brownie/brownie) - _Python framework for deploying, testing and interacting with Ethereum smart contracts_
-- [eth-utils](https://github.com/ethereum/eth-utils/) - _utility functions for working with Ethereum related codebases_
+- [Vyper](https://github.com/ethereum/vyper/) - _Pythonic Smart Contract Language for the EVM_
 - [py-evm](https://github.com/ethereum/py-evm) - _implementation of the Ethereum Virtual Machine_
+- [Mamba](https://mamba.black) - _framework to write, compile, and deploy smart contracts written in Vyper language_
+- [eth-tester](https://github.com/ethereum/eth-tester) - _tools for testing Ethereum-based applications_
+- [eth-utils](https://github.com/ethereum/eth-utils/) - _utility functions for working with Ethereum related codebases_
 - [py-solc-x](https://pypi.org/project/py-solc-x/) - _Python wrapper around the solc solidity compiler with 0.5.x support_
 - [py-wasm](https://github.com/ethereum/py-wasm) - _Python implementation of the web assembly interpreter_
-- [pydevp2p](https://github.com/ethereum/pydevp2p) - _Implementation of the Ethereum P2P stack_
+- [pydevp2p](https://github.com/ethereum/pydevp2p) - _implementation of the Ethereum P2P stack_
 - [pymaker](https://github.com/makerdao/pymaker) - _Python API for Maker contracts_
-- [Mamba](https://mamba.black) - _framework to write, compile, and deploy smart contracts written in Vyper language_
-- [Trinity](https://github.com/ethereum/trinity) - _Ethereum Python client_
-- [Vyper](https://github.com/ethereum/vyper/) - _Pythonic Smart Contract Language for the EVM_
-- [Web3.py](https://github.com/ethereum/web3.py) - _Python library for interacting with Ethereum_
 
-Looking for more resources? Check out [ethereum.org/developers.](/developers/)
+
+### Archived / No Longer Maintained:
+
+- [Trinity](https://github.com/ethereum/trinity) - _Ethereum Python client_
+
+Looking for more resources? Check out [ethereum.org/developers](/developers/).
 
 ## Python Community Contributors {#python-community-contributors}
 
-- [Py-EVM Gitter](https://gitter.im/ethereum/py-evm)
-- [Trinity Gitter](https://gitter.im/ethereum/trinity)
-- [Vyper Gitter](https://gitter.im/ethereum/vyper)
-- [Webpy Gitter](https://gitter.im/ethereum/web3.py)
 - [Ethereum Python Community Discord](https://discord.gg/9zk7snTfWe)
 
 ## Other Aggregated Lists {#other-aggregated-lists}

--- a/src/content/developers/docs/programming-languages/python/index.md
+++ b/src/content/developers/docs/programming-languages/python/index.md
@@ -23,6 +23,7 @@ Need a more basic primer first? Check out [ethereum.org/learn](/learn/) or [ethe
 
 ## Beginner articles {#beginner-articles}
 
+- [A (Python) Developer's Guide to Ethereum](https://snakecharmers.ethereum.org/a-developers-guide-to-ethereum-pt-1/)
 - [An Introduction to Smart Contracts with Vyper](https://kauri.io/#collections/Getting%20Started/an-introduction-to-smart-contracts-with-vyper/)
 - [Deploy your own ERC20 Token with Python and Brownie](https://betterprogramming.pub/python-blockchain-token-deployment-tutorial-create-an-erc20-77a5fd2e1a58)
 - [How to develop Ethereum contract using Python Flask?](https://medium.com/coinmonks/how-to-develop-ethereum-contract-using-python-flask-9758fe65976e)

--- a/src/content/developers/docs/programming-languages/python/index.md
+++ b/src/content/developers/docs/programming-languages/python/index.md
@@ -35,7 +35,6 @@ Need a more basic primer first? Check out [ethereum.org/learn](/learn/) or [ethe
 - [Dapp Development for Python Programmers](https://levelup.gitconnected.com/dapps-development-for-python-developers-f52b32b54f28)
 - [Creating a Python Ethereum Interface: Part 1](https://hackernoon.com/creating-a-python-ethereum-interface-part-1-4d2e47ea0f4d)
 - [Ethereum Smart Contracts in Python: a comprehensive(ish) guide](https://hackernoon.com/ethereum-smart-contracts-in-python-a-comprehensive-ish-guide-771b03990988)
-- [Everything you need to know about the Trinity Ethereum client](https://medium.com/@pipermerriam/everything-you-need-to-know-about-the-trinity-ethereum-client-b093c756d1de)
 - [Using Brownie and Python to deploy Smart Contracts](https://dev.to/patrickalphac/using-brownie-for-to-deploy-smart-contracts-1kkp)
 - [Creating NFTs on OpenSea with Brownie](https://www.freecodecamp.org/news/how-to-make-an-nft-and-render-on-opensea-marketplace/)
 


### PR DESCRIPTION
- Remove gitters in favor of the discord, where all the conversation takes place today.
- Add eth-tester to the projects list.
- Add archived list of projects that may still be interesting. Add Trinity to this list.
- Re-roganize list based on traffic / usage / foundation + somewhat alphabetically sorted after that.


## Description

- gitter channels are a space to have the same conversations that are present in the discord which is very active. Removing these channels will be an efficient way of directing all traffic to one spot (the python community discord)
- Added eth-tester to the projects list in case it is of interest to anyone perusing
- Separated active vs archived projects (not tied to how this was implemented but important to make the distinction for Trinity)
- Re-organized the list based on utility / usage / traffic + somewhat alphabetical after that. (Not tied to this particular order either but makes more sense having `web3.py`, for example, (heavily used) above libraries like `eth-utils`).

## Related Issue

It was asked in the Ethereum Python Community discord that maintainers take a peek and update this page.
