### PR TITLE
Remove smartcontracts.code (broken app) from security page

### DIFF
--- a/src/content/developers/docs/security/index.md
+++ b/src/content/developers/docs/security/index.md
@@ -242,11 +242,6 @@ While there is no substitute for understanding Ethereum security basics and enga
 - [mythril](https://github.com/ConsenSys/mythril)
 - [Documentation](https://mythril-classic.readthedocs.io/en/master/about.html)
 
-**SmartContract.Codes -** **_Search engine for verified solidity source codes._**
-
-- [smartcontract.codes (alpha)](https://smartcontract.codes/)
-- [Documentation](https://github.com/playproject-io/smartcontract.codes)
-
 **Manticore -** **_A command line interface that uses a symbolic execution tool on smart contracts and binaries._**
 
 - [GitHub](https://github.com/trailofbits/manticore)

--- a/src/content/developers/docs/security/index.md
+++ b/src/content/developers/docs/security/index.md
@@ -245,7 +245,7 @@ While there is no substitute for understanding Ethereum security basics and enga
 **SmartContract.Codes -** **_Search engine for verified solidity source codes._**
 
 - [smartcontract.codes (alpha)](https://smartcontract.codes/)
-- [Documentation](https://github.com/ethereum-play/smartcontract.codes/blob/master/README.md)
+- [Documentation](https://github.com/playproject-io/smartcontract.codes)
 
 **Manticore -** **_A command line interface that uses a symbolic execution tool on smart contracts and binaries._**
 

--- a/src/content/translations/es/developers/docs/security/index.md
+++ b/src/content/translations/es/developers/docs/security/index.md
@@ -245,7 +245,7 @@ Aunque no hay sustituto para entender los conceptos básicos de seguridad de Eth
 **SmartContract.Codes: ** **_Motor de búsqueda para códigos fuente verificados de Solidity._**
 
 - [smartcontract.codes (alpha)](https://smartcontract.codes/)
-- [Documentación](https://github.com/ethereum-play/smartcontract.codes/blob/master/README.md)
+- [Documentación](https://github.com/playproject-io/smartcontract.codes)
 
 **Manticore:** **_ Una interfaz de línea de comandos que utiliza una herramienta de ejecución simbólica en contratos inteligentes y binarios._**
 

--- a/src/content/translations/es/developers/docs/security/index.md
+++ b/src/content/translations/es/developers/docs/security/index.md
@@ -242,11 +242,6 @@ Aunque no hay sustituto para entender los conceptos básicos de seguridad de Eth
 - [mythril](https://github.com/ConsenSys/mythril)
 - [Documentación](https://mythril-classic.readthedocs.io/en/master/about.html)
 
-**SmartContract.Codes: ** **_Motor de búsqueda para códigos fuente verificados de Solidity._**
-
-- [smartcontract.codes (alpha)](https://smartcontract.codes/)
-- [Documentación](https://github.com/playproject-io/smartcontract.codes)
-
 **Manticore:** **_ Una interfaz de línea de comandos que utiliza una herramienta de ejecución simbólica en contratos inteligentes y binarios._**
 
 - [GitHub](https://github.com/trailofbits/manticore)

--- a/src/content/translations/fr/developers/docs/security/index.md
+++ b/src/content/translations/fr/developers/docs/security/index.md
@@ -245,7 +245,7 @@ Bien qu'il n'y ait pas de substitut à la compréhension des bases de sécurité
 **SmartContract.Codes -** **_Moteur de recherche pour les codes sources Solidity vérifiés_**
 
 - [smartcontract.codes (alpha)](https://smartcontract.codes/)
-- [Documentation](https://github.com/ethereum-play/smartcontract.codes/blob/master/README.md)
+- [Documentation](https://github.com/playproject-io/smartcontract.codes)
 
 **Manticore -** **_Interface en ligne de commande qui utilise un outil d'exécution symbolique sur les contrats intelligents et les fichiers binaires_**
 

--- a/src/content/translations/fr/developers/docs/security/index.md
+++ b/src/content/translations/fr/developers/docs/security/index.md
@@ -242,11 +242,6 @@ Bien qu'il n'y ait pas de substitut à la compréhension des bases de sécurité
 - [mythril](https://github.com/ConsenSys/mythril)
 - [Documentation](https://mythril-classic.readthedocs.io/en/master/about.html)
 
-**SmartContract.Codes -** **_Moteur de recherche pour les codes sources Solidity vérifiés_**
-
-- [smartcontract.codes (alpha)](https://smartcontract.codes/)
-- [Documentation](https://github.com/playproject-io/smartcontract.codes)
-
 **Manticore -** **_Interface en ligne de commande qui utilise un outil d'exécution symbolique sur les contrats intelligents et les fichiers binaires_**
 
 - [GitHub](https://github.com/trailofbits/manticore)

--- a/src/content/translations/hu/developers/docs/security/index.md
+++ b/src/content/translations/hu/developers/docs/security/index.md
@@ -245,7 +245,7 @@ Bár nem helyettesítheti az Ethereum biztonsági alapismereteinek megértését
 **SmartContract.Codes -** **_Ellenőrzött Solidity forráskódok keresőmotora_**
 
 - [smartcontract.codes (alpha)](https://smartcontract.codes/)
-- [Dokumentáció](https://github.com/ethereum-play/smartcontract.codes/blob/master/README.md)
+- [Dokumentáció](https://github.com/playproject-io/smartcontract.codes)
 
 **Manticore -** **_Egy Cli, ami egy szimbolikus futtató eszközt használ okosszerződésekre és binary-kre._**
 

--- a/src/content/translations/hu/developers/docs/security/index.md
+++ b/src/content/translations/hu/developers/docs/security/index.md
@@ -242,11 +242,6 @@ Bár nem helyettesítheti az Ethereum biztonsági alapismereteinek megértését
 - [mythril](https://github.com/ConsenSys/mythril)
 - [Dokumentáció](https://mythril-classic.readthedocs.io/en/master/about.html)
 
-**SmartContract.Codes -** **_Ellenőrzött Solidity forráskódok keresőmotora_**
-
-- [smartcontract.codes (alpha)](https://smartcontract.codes/)
-- [Dokumentáció](https://github.com/playproject-io/smartcontract.codes)
-
 **Manticore -** **_Egy Cli, ami egy szimbolikus futtató eszközt használ okosszerződésekre és binary-kre._**
 
 - [GitHub](https://github.com/trailofbits/manticore)

--- a/src/content/translations/it/developers/docs/security/index.md
+++ b/src/content/translations/it/developers/docs/security/index.md
@@ -242,11 +242,6 @@ Niente può sostituire la conoscenza dei principi di base della sicurezza di Eth
 - [mythril](https://github.com/ConsenSys/mythril)
 - [Documentazione](https://mythril-classic.readthedocs.io/en/master/about.html)
 
-**SmartContract.Codes -** **_Motore di ricerca per codice sorgente Solidity verificato_**
-
-- [smartcontract.codes (alpha)](https://smartcontract.codes/)
-- [Documentazione](https://github.com/playproject-io/smartcontract.codes)
-
 **Manticore -** **_Interfaccia da riga di comando che usa uno strumento di esecuzione simbolica su Smart Contract e file binari_**
 
 - [GitHub](https://github.com/trailofbits/manticore)

--- a/src/content/translations/it/developers/docs/security/index.md
+++ b/src/content/translations/it/developers/docs/security/index.md
@@ -245,7 +245,7 @@ Niente può sostituire la conoscenza dei principi di base della sicurezza di Eth
 **SmartContract.Codes -** **_Motore di ricerca per codice sorgente Solidity verificato_**
 
 - [smartcontract.codes (alpha)](https://smartcontract.codes/)
-- [Documentazione](https://github.com/ethereum-play/smartcontract.codes/blob/master/README.md)
+- [Documentazione](https://github.com/playproject-io/smartcontract.codes)
 
 **Manticore -** **_Interfaccia da riga di comando che usa uno strumento di esecuzione simbolica su Smart Contract e file binari_**
 

--- a/src/content/translations/pl/developers/docs/security/index.md
+++ b/src/content/translations/pl/developers/docs/security/index.md
@@ -242,11 +242,6 @@ Chociaż nic nie zastąpi zrozumienia podstaw bezpieczeństwa Ethereum i zaanga�
 - [mithril](https://github.com/ConsenSys/mythril)
 - [Dokumentacja](https://mythril-classic.readthedocs.io/en/master/about.html)
 
-**SmartContract.Codes —** **_wyszukiwarka sprawdzonych kodów źródłowych Solidity._**
-
-- [smartcontract.codes (alfa)](https://smartcontract.codes/)
-- [Dokumentacja](https://github.com/playproject-io/smartcontract.codes)
-
 **Manticore —** **_interfejs wiersza poleceń, który wykorzystuje symboliczne narzędzie do wykonywania inteligentnych kontraktów i plików binarnych._**
 
 - [GitHub](https://github.com/trailofbits/manticore)

--- a/src/content/translations/pl/developers/docs/security/index.md
+++ b/src/content/translations/pl/developers/docs/security/index.md
@@ -245,7 +245,7 @@ Chociaż nic nie zastąpi zrozumienia podstaw bezpieczeństwa Ethereum i zaanga�
 **SmartContract.Codes —** **_wyszukiwarka sprawdzonych kodów źródłowych Solidity._**
 
 - [smartcontract.codes (alfa)](https://smartcontract.codes/)
-- [Dokumentacja](https://github.com/ethereum-play/smartcontract.codes/blob/master/README.md)
+- [Dokumentacja](https://github.com/playproject-io/smartcontract.codes)
 
 **Manticore —** **_interfejs wiersza poleceń, który wykorzystuje symboliczne narzędzie do wykonywania inteligentnych kontraktów i plików binarnych._**
 

--- a/src/content/translations/ro/developers/docs/security/index.md
+++ b/src/content/translations/ro/developers/docs/security/index.md
@@ -242,11 +242,6 @@ Deși nu există nici un substitut pentru înțelegerea elementelor de bază ale
 - [mythril](https://github.com/ConsenSys/mythril)
 - [Documentație](https://mythril-classic.readthedocs.io/en/master/about.html)
 
-**SmartContract.Codes -** **_motor de căutare pentru coduri sursă Solidity verificate._**
-
-- [smartcontract.codes (alpha)](https://smartcontract.codes/)
-- [Documentație](https://github.com/playproject-io/smartcontract.codes)
-
 **Manticore -** **_o interfață tip linie de comandă care utilizează un instrument de execuție simbolică pe contracte inteligente și binare._**
 
 - [GitHub](https://github.com/trailofbits/manticore)

--- a/src/content/translations/ro/developers/docs/security/index.md
+++ b/src/content/translations/ro/developers/docs/security/index.md
@@ -245,7 +245,7 @@ Deși nu există nici un substitut pentru înțelegerea elementelor de bază ale
 **SmartContract.Codes -** **_motor de căutare pentru coduri sursă Solidity verificate._**
 
 - [smartcontract.codes (alpha)](https://smartcontract.codes/)
-- [Documentație](https://github.com/ethereum-play/smartcontract.codes/blob/master/README.md)
+- [Documentație](https://github.com/playproject-io/smartcontract.codes)
 
 **Manticore -** **_o interfață tip linie de comandă care utilizează un instrument de execuție simbolică pe contracte inteligente și binare._**
 

--- a/src/content/translations/zh/developers/docs/security/index.md
+++ b/src/content/translations/zh/developers/docs/security/index.md
@@ -244,7 +244,7 @@ contract NoLongerAVictim {
 **SmartContract.codes -** **_用于搜索经过验证的 Solidity 源代码的搜索引擎。_**
 
 - [smartcontract.codes (alpha)](https://smartcontract.codes/)
-- [相关文档](https://github.com/ethereum-play/smartcontract.codes/blob/master/README.md)
+- [相关文档](https://github.com/playproject-io/smartcontract.codes)
 
 **Manticore -** **_在智能合约和二进制文件上使用符号执行工具的命令行界面。_**
 

--- a/src/content/translations/zh/developers/docs/security/index.md
+++ b/src/content/translations/zh/developers/docs/security/index.md
@@ -241,11 +241,6 @@ contract NoLongerAVictim {
 - [mythril](https://github.com/ConsenSys/mythril)
 - [相关文档](https://mythril-classic.readthedocs.io/en/master/about.html)
 
-**SmartContract.codes -** **_用于搜索经过验证的 Solidity 源代码的搜索引擎。_**
-
-- [smartcontract.codes (alpha)](https://smartcontract.codes/)
-- [相关文档](https://github.com/playproject-io/smartcontract.codes)
-
 **Manticore -** **_在智能合约和二进制文件上使用符号执行工具的命令行界面。_**
 
 - [GitHub](https://github.com/trailofbits/manticore)


### PR DESCRIPTION
## Description
Ethereum-play has rebranded as Playproject-io and this broke a few of the GitHub links in our docs. This PR fixes the links across all effected translated languages.

## Related Issue
Closes #4013 