### PR TITLE
Fix repo URL for Nimbus on ETH2 page

### DIFF
--- a/src/pages/eth2/get-involved/index.js
+++ b/src/pages/eth2/get-involved/index.js
@@ -233,7 +233,7 @@ const GetInvolvedPage = ({ data, location }) => {
       alt: "eth2-client-nimbus-logo-alt",
       url: "https://nimbus.team/",
       image: data.nimbus.childImageSharp.fixed,
-      githubUrl: "https://github.com/status-im/nimbus-eth1",
+      githubUrl: "https://github.com/status-im/nimbus-eth2",
       isProductionReady: true,
     },
     {


### PR DESCRIPTION
URL used to point to Eth1 execution client...

<!--- Provide a general summary of your changes in the Title above -->

## Description

The URL for the Nimbus eth2 client currently points to their eth1 client repo.

<!--- Describe your changes in detail -->

## Related Issue

N/A
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
