### PR TITLE
Fix Fallback Language Direction #4028

### DIFF
--- a/src/components/Breadcrumbs.js
+++ b/src/components/Breadcrumbs.js
@@ -37,9 +37,11 @@ const Slash = styled.span`
 const CrumbLink = styled(Link)`
   text-decoration: none;
   color: ${(props) => props.theme.colors.textTableOfContents};
+
   &:hover {
     color: ${(props) => props.theme.colors.primary};
   }
+
   &.active {
     color: ${(props) => props.theme.colors.primary};
   }
@@ -77,7 +79,7 @@ const Breadcrumbs = ({ slug, startDepth = 0, className }) => {
   })
 
   return (
-    <List className={className}>
+    <List className={className} dir={"auto"}>
       {crumbs.map((crumb, idx) => (
         <ListItem key={idx}>
           <Crumb>

--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -124,6 +124,7 @@ const H3 = styled(Header3)`
     font-size: 1rem;
     font-weight: 600;
   }
+
   &:before {
     height: 160px;
     margin-top: -160px;
@@ -135,6 +136,7 @@ const H4 = styled(Header4)`
     font-size: 1rem;
     font-weight: 600;
   }
+
   &:before {
     height: 160px;
     margin-top: -160px;
@@ -181,10 +183,10 @@ const Contributors = styled(FileContributors)`
 `
 
 const DocsPage = ({ data, pageContext }) => {
-  const { locale } = useIntl()
-  const isRightToLeft = isLangRightToLeft(locale)
-
   const mdx = data.pageData
+  const { locale } = useIntl()
+  const isRightToLeft = isLangRightToLeft(mdx.frontmatter.lang)
+
   const tocItems = mdx.tableOfContents.items
   const isPageIncomplete = mdx.frontmatter.incomplete
 
@@ -254,6 +256,7 @@ export const query = graphql`
       frontmatter {
         title
         description
+        lang
         incomplete
         sidebar
         sidebarDepth

--- a/src/templates/eth2.js
+++ b/src/templates/eth2.js
@@ -135,11 +135,13 @@ const H2 = styled.h2`
   font-size: 32px;
   font-weight: 700;
   margin-top: 4rem;
+
   a {
     display: none;
   }
 
   /* Anchor tag styles */
+
   a {
     position: relative;
     display: none;
@@ -147,6 +149,7 @@ const H2 = styled.h2`
     padding-right: 0.5rem;
     font-size: 1rem;
     vertical-align: middle;
+
     &:hover {
       display: initial;
       fill: ${(props) => props.theme.colors.primary};
@@ -164,11 +167,13 @@ const H2 = styled.h2`
 const H3 = styled.h3`
   font-size: 24px;
   font-weight: 700;
+
   a {
     display: none;
   }
 
   /* Anchor tag styles */
+
   a {
     position: relative;
     display: none;
@@ -176,6 +181,7 @@ const H3 = styled.h3`
     padding-right: 0.5rem;
     font-size: 1rem;
     vertical-align: middle;
+
     &:hover {
       display: initial;
       fill: ${(props) => props.theme.colors.primary};
@@ -311,9 +317,11 @@ const MoreContent = styled(Link)`
   padding: 1rem;
   display: flex;
   justify-content: center;
+
   &:hover {
     background: ${(props) => props.theme.colors.background};
   }
+
   @media (max-width: ${(props) => props.theme.breakpoints.l}) {
     display: none;
   }
@@ -374,7 +382,7 @@ const dropdownLinks = {
 
 const Eth2Page = ({ data, data: { mdx } }) => {
   const intl = useIntl()
-  const isRightToLeft = isLangRightToLeft(intl.locale)
+  const isRightToLeft = isLangRightToLeft(mdx.frontmatter.lang)
   const tocItems = mdx.tableOfContents.items
 
   // TODO some `gitLogLatestDate` are `null` - why?
@@ -464,6 +472,7 @@ export const eth2PageQuery = graphql`
       frontmatter {
         title
         description
+        lang
         sidebar
         sidebarDepth
         summaryPoints

--- a/src/templates/static.js
+++ b/src/templates/static.js
@@ -131,7 +131,7 @@ const components = {
 
 const StaticPage = ({ data: { siteData, mdx }, pageContext }) => {
   const intl = useIntl()
-  const isRightToLeft = isLangRightToLeft(intl.locale)
+  const isRightToLeft = isLangRightToLeft(mdx.frontmatter.lang)
 
   const lastUpdatedDate = mdx.parent.fields
     ? mdx.parent.fields.gitLogLatestDate
@@ -150,7 +150,7 @@ const StaticPage = ({ data: { siteData, mdx }, pageContext }) => {
       />
       <ContentContainer>
         <Breadcrumbs slug={mdx.fields.slug} />
-        <LastUpdated>
+        <LastUpdated dir={isLangRightToLeft(intl.locale) ? "rtl" : "ltr"}>
           <Translation id="page-last-updated" />:{" "}
           {getLocaleTimestamp(intl.locale, lastUpdatedDate)}
         </LastUpdated>
@@ -189,6 +189,7 @@ export const staticPageQuery = graphql`
       frontmatter {
         title
         description
+        lang
         sidebar
         sidebarDepth
       }

--- a/src/templates/tutorial.js
+++ b/src/templates/tutorial.js
@@ -159,10 +159,9 @@ const Contributors = styled(FileContributors)`
 `
 
 const TutorialPage = ({ data, pageContext }) => {
-  const intl = useIntl()
-  const isRightToLeft = isLangRightToLeft(intl.locale)
-
   const pageData = data.pageData
+  const isRightToLeft = isLangRightToLeft(pageData.frontmatter.lang)
+
   const tocItems = pageData.tableOfContents.items
 
   const { editContentUrl } = data.siteData.siteMetadata
@@ -217,6 +216,7 @@ export const query = graphql`
       frontmatter {
         title
         description
+        lang
         tags
         author
         source

--- a/src/templates/use-cases.js
+++ b/src/templates/use-cases.js
@@ -348,9 +348,8 @@ const TitleCard = styled.div`
 `
 
 const UseCasePage = ({ data, pageContext }) => {
-  const intl = useIntl()
-  const isRightToLeft = isLangRightToLeft(intl.locale)
   const mdx = data.pageData
+  const isRightToLeft = isLangRightToLeft(mdx.frontmatter.lang)
   const tocItems = mdx.tableOfContents.items
 
   const { editContentUrl } = data.siteData.siteMetadata
@@ -464,6 +463,7 @@ export const useCasePageQuery = graphql`
       frontmatter {
         title
         description
+        lang
         sidebar
         emoji
         sidebarDepth


### PR DESCRIPTION
## Description

This merge will fix the issue with Fallback Language (English).
The issue existed for every page generated using the 5 templates.

Rather than basing the direction off the language selected by the user, now the direction will be based on the `lang` in which the document is written (The `lang` field inside the content markdowns is being used to detect the same).
![image](https://user-images.githubusercontent.com/51415616/134813659-e3b745f4-a32f-4a88-a047-9e3274e71710.png)


## Related Issue

- #4028 