### PR TITLE
Remove Eth2 announcement banner [Fixes #3806]

### DIFF
--- a/src/pages/eth2/index.js
+++ b/src/pages/eth2/index.js
@@ -282,16 +282,6 @@ const Eth2IndexPage = ({ data }) => {
         title={translateMessageId("page-eth2-meta-title", intl)}
         description={translateMessageId("page-eth2-meta-desc", intl)}
       />
-      <StyledBannerNotification shouldShow>
-        <StyledEmoji text=":megaphone:" />
-        <div>
-          <b>Latest:</b> Eth2 researchers are working on ways to accelerate the
-          merge. It will probably happen earlier than expected. More soon.{" "}
-          <Link to="https://blog.ethereum.org/category/research-and-development/">
-            Follow updates
-          </Link>
-        </div>
-      </StyledBannerNotification>
       <PageHero content={heroContent} />
       <Divider />
       <Content>

--- a/src/pages/eth2/vision.js
+++ b/src/pages/eth2/vision.js
@@ -146,16 +146,6 @@ const VisionPage = ({ data, location }) => {
         title={translateMessageId("page-eth2-vision-meta-title", intl)}
         description={translateMessageId("page-eth2-vision-meta-desc", intl)}
       />
-      <StyledBannerNotification shouldShow>
-        <StyledEmoji text=":megaphone:" />
-        <div>
-          <b>Latest:</b> Eth2 researchers are working on ways to accelerate the
-          merge. It will probably happen earlier than expected. More soon.{" "}
-          <Link to="https://blog.ethereum.org/category/research-and-development/">
-            Follow updates
-          </Link>
-        </div>
-      </StyledBannerNotification>
       <PageHero content={heroContent} />
       <Divider />
       <Content>

--- a/src/templates/eth2.js
+++ b/src/templates/eth2.js
@@ -384,16 +384,6 @@ const Eth2Page = ({ data, data: { mdx } }) => {
 
   return (
     <Container>
-      <StyledBannerNotification shouldShow>
-        <StyledEmoji text=":megaphone:" />
-        <div>
-          <b>Latest:</b> Eth2 researchers are working on ways to accelerate the
-          merge. It will probably happen earlier than expected. More soon.{" "}
-          <Link to="https://blog.ethereum.org/category/research-and-development/">
-            Follow updates
-          </Link>
-        </div>
-      </StyledBannerNotification>
       <HeroContainer>
         <TitleCard>
           <DesktopBreadcrumbs slug={mdx.fields.slug} startDepth={1} />


### PR DESCRIPTION
## Description
- Removes announcement banner regarding prioritizing the merge from eth2 pages.

## Related Issue
[Fixes #3806]