### PR TITLE
Eth2 client randomization and GH star removal [Fixes #4059]

### DIFF
--- a/src/components/GitStars.js
+++ b/src/components/GitStars.js
@@ -24,6 +24,10 @@ const Pill = styled.div`
   text-align: center;
 `
 
+const StyledIcon = styled(Icon)`
+  margin: 0.25rem;
+`
+
 const GlyphPill = styled(Pill)`
   display: flex;
   align-items: center;
@@ -43,12 +47,19 @@ const Text = styled.div`
   background: ${(props) => props.theme.colors.searchBackgroundEmpty};
 `
 
-const GitStars = ({ gitHubRepo, className }) => {
+const GitStars = ({ gitHubRepo, className, hideStars }) => {
   // Stringify with commas
   let starsString = gitHubRepo.stargazerCount.toString()
   const rgx = /(\d+)(\d{3})/
   while (rgx.test(starsString)) {
     starsString = starsString.replace(rgx, "$1,$2")
+  }
+  if (hideStars) {
+    return (
+      <Container className={className} to={gitHubRepo.url} hideArrow={true}>
+        <StyledIcon name="github" size="16px" />
+      </Container>
+    )
   }
   return (
     <Container className={className} to={gitHubRepo.url} hideArrow={true}>

--- a/src/components/ProductCard.js
+++ b/src/components/ProductCard.js
@@ -144,6 +144,7 @@ const ProductCard = ({
   githubUrl = "",
   repoLangCount = 1,
   subjects,
+  hideStars = false,
 }) => {
   const split = githubUrl.split("/")
   const repoOwner = split[split.length - 2]
@@ -168,7 +169,9 @@ const ProductCard = ({
       </ImageWrapper>
       <Content className="hover">
         <div>
-          {hasRepoData && <GitStars gitHubRepo={data.repository} />}
+          {hasRepoData && (
+            <GitStars gitHubRepo={data.repository} hideStars={hideStars} />
+          )}
           <Title gitHidden={!hasRepoData}>{name}</Title>
           <Description>{description}</Description>
         </div>

--- a/src/pages/eth2/get-involved/index.js
+++ b/src/pages/eth2/get-involved/index.js
@@ -1,4 +1,4 @@
-import React, { useContext } from "react"
+import React, { useContext, useState, useEffect } from "react"
 import { ThemeContext } from "styled-components"
 import styled from "styled-components"
 import { graphql } from "gatsby"
@@ -169,84 +169,90 @@ const GetInvolvedPage = ({ data, location }) => {
   const bountyHunters = data.bountyHunters.nodes.sort(
     (a, b) => b.score - a.score
   )
-  const clients = [
-    {
-      name: "Prysm",
-      background: "#23292E",
-      description: <Translation id="page-eth2-get-involved-written-go" />,
-      alt: "eth2-client-prysm-logo-alt",
-      url: "https://docs.prylabs.network/docs/getting-started/",
-      image: data.prysm.childImageSharp.fixed,
-      githubUrl: "https://github.com/prysmaticlabs/prysm",
-      isProductionReady: true,
-    },
-    {
-      name: "Lighthouse",
-      background: "",
-      description: <Translation id="page-eth2-get-involved-written-rust" />,
-      alt: "eth2-client-lighthouse-logo-alt",
-      url: "https://lighthouse-book.sigmaprime.io/",
-      image: isDarkTheme
-        ? data.lighthouseDark.childImageSharp.fixed
-        : data.lighthouseLight.childImageSharp.fixed,
-      githubUrl: "https://github.com/sigp/lighthouse",
-      isProductionReady: true,
-    },
-    {
-      name: "Teku",
-      background: "#3359D5",
-      description: <Translation id="page-eth2-get-involved-written-java" />,
-      alt: "eth2-client-teku-logo-alt",
-      url: "https://pegasys.tech/teku",
-      image: isDarkTheme
-        ? data.tekuLight.childImageSharp.fixed
-        : data.tekuDark.childImageSharp.fixed,
-      githubUrl: "https://github.com/ConsenSys/teku",
-      isProductionReady: true,
-    },
-    {
-      name: "Cortex",
-      background: "#4CAEE5",
-      description: <Translation id="page-eth2-get-involved-written-net" />,
-      alt: "eth2-client-cortex-logo-alt",
-      url: "https://nethermind.io/",
-      image: data.cortex.childImageSharp.fixed,
-      githubUrl: "https://github.com/NethermindEth/nethermind",
-      isProductionReady: false,
-    },
-    {
-      name: "Lodestar",
-      background: "#14140B",
-      description: (
-        <Translation id="page-eth2-get-involved-written-javascript" />
-      ),
-      alt: "eth2-client-lodestar-logo-alt",
-      url: "https://chainsafe.io/",
-      image: data.lodestar.childImageSharp.fixed,
-      githubUrl: "https://github.com/ChainSafe/lodestar",
-      isProductionReady: false,
-    },
-    {
-      name: "Nimbus",
-      background: "#DC8600",
-      description: <Translation id="page-eth2-get-involved-written-nim" />,
-      alt: "eth2-client-nimbus-logo-alt",
-      url: "https://nimbus.team/",
-      image: data.nimbus.childImageSharp.fixed,
-      githubUrl: "https://github.com/status-im/nimbus-eth2",
-      isProductionReady: true,
-    },
-    {
-      name: "Trinity",
-      background: "#0B131E",
-      description: <Translation id="page-eth2-get-involved-written-python" />,
-      alt: "eth2-client-trinity-logo-alt",
-      url: "https://trinity.ethereum.org/",
-      image: data.trinity.childImageSharp.fixed,
-      githubUrl: "https://github.com/ethereum/trinity",
-      isProductionReady: false,
-    },
-  ]
+
+  const [clients, setClients] = useState([])
+
+  useEffect(() => {
+    const randomizedClients = [
+      {
+        name: "Prysm",
+        background: "#23292E",
+        description: <Translation id="page-eth2-get-involved-written-go" />,
+        alt: "eth2-client-prysm-logo-alt",
+        url: "https://docs.prylabs.network/docs/getting-started/",
+        image: data.prysm.childImageSharp.fixed,
+        githubUrl: "https://github.com/prysmaticlabs/prysm",
+        isProductionReady: true,
+      },
+      {
+        name: "Lighthouse",
+        background: "",
+        description: <Translation id="page-eth2-get-involved-written-rust" />,
+        alt: "eth2-client-lighthouse-logo-alt",
+        url: "https://lighthouse-book.sigmaprime.io/",
+        image: isDarkTheme
+          ? data.lighthouseDark.childImageSharp.fixed
+          : data.lighthouseLight.childImageSharp.fixed,
+        githubUrl: "https://github.com/sigp/lighthouse",
+        isProductionReady: true,
+      },
+      {
+        name: "Teku",
+        background: "#3359D5",
+        description: <Translation id="page-eth2-get-involved-written-java" />,
+        alt: "eth2-client-teku-logo-alt",
+        url: "https://pegasys.tech/teku",
+        image: isDarkTheme
+          ? data.tekuLight.childImageSharp.fixed
+          : data.tekuDark.childImageSharp.fixed,
+        githubUrl: "https://github.com/ConsenSys/teku",
+        isProductionReady: true,
+      },
+      {
+        name: "Cortex",
+        background: "#4CAEE5",
+        description: <Translation id="page-eth2-get-involved-written-net" />,
+        alt: "eth2-client-cortex-logo-alt",
+        url: "https://nethermind.io/",
+        image: data.cortex.childImageSharp.fixed,
+        githubUrl: "https://github.com/NethermindEth/nethermind",
+        isProductionReady: false,
+      },
+      {
+        name: "Lodestar",
+        background: "#14140B",
+        description: (
+          <Translation id="page-eth2-get-involved-written-javascript" />
+        ),
+        alt: "eth2-client-lodestar-logo-alt",
+        url: "https://chainsafe.io/",
+        image: data.lodestar.childImageSharp.fixed,
+        githubUrl: "https://github.com/ChainSafe/lodestar",
+        isProductionReady: false,
+      },
+      {
+        name: "Nimbus",
+        background: "#DC8600",
+        description: <Translation id="page-eth2-get-involved-written-nim" />,
+        alt: "eth2-client-nimbus-logo-alt",
+        url: "https://nimbus.team/",
+        image: data.nimbus.childImageSharp.fixed,
+        githubUrl: "https://github.com/status-im/nimbus-eth2",
+        isProductionReady: true,
+      },
+      {
+        name: "Trinity",
+        background: "#0B131E",
+        description: <Translation id="page-eth2-get-involved-written-python" />,
+        alt: "eth2-client-trinity-logo-alt",
+        url: "https://trinity.ethereum.org/",
+        image: data.trinity.childImageSharp.fixed,
+        githubUrl: "https://github.com/ethereum/trinity",
+        isProductionReady: false,
+      },
+    ].sort(() => Math.random() - 0.5)
+    setClients(randomizedClients)
+  }, [])
 
   const ethresearch = [
     {

--- a/src/pages/eth2/get-involved/index.js
+++ b/src/pages/eth2/get-involved/index.js
@@ -366,6 +366,7 @@ const GetInvolvedPage = ({ data, location }) => {
                 description={client.description}
                 alt={translateMessageId(client.alt, intl)}
                 githubUrl={client.githubUrl}
+                hideStars={true}
               />
             ))}
         </StyledCardGrid>
@@ -385,6 +386,7 @@ const GetInvolvedPage = ({ data, location }) => {
                 description={client.description}
                 alt={translateMessageId(client.alt, intl)}
                 githubUrl={client.githubUrl}
+                hideStars={true}
               />
             ))}
         </StyledCardGrid>


### PR DESCRIPTION
## Description
- Removes star count from eth2 client listings
- Randomizes order of these clients with each load (Went with this approach given how we fetch the star count on a component level, and the parent that is sorting it doesn't easily have this data.)
- Adjusted the `GitStars.js` component to accept hiding the stars with prop `hideStars`, which preserves the link to GitHub with a GH icon, but does not show star count. 

## Related Issue
#4059 