### PR TITLE
Update POAP section Discord link to go to #poaps channel

### DIFF
--- a/src/content/contributing/index.md
+++ b/src/content/contributing/index.md
@@ -76,7 +76,7 @@ If your contribution gets merged into ethereum.org, we'll mint you a unique cont
 
 ### How to claim {#how-to-claim}
 
-1. Join our [Discord server](https://discord.gg/CetY6Y4).
+1. Join our [Discord server](https://discord.gg/Gnz2jWHw6t).
 2. Paste a link to your contribution in the #poaps-🏆 channel.
 3. Wait for a member of our team to send you a link to your minted POAP.
 4. Claim your POAP!


### PR DESCRIPTION
Updated Discord Link Explicitly For #poap channel.
I think It is good Idea To redirect the user to #poap channel rather than #ethereum-org-development channel of discord Server Because We are Talking About POAP
Note : The Link Attached is of the following type [The Link Will Never Expire, There is No Limit To the Number Of Users]

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
