### PR TITLE
Update ecosystem grants link for The Graph 

### DIFF
--- a/src/content/community/grants/index.md
+++ b/src/content/community/grants/index.md
@@ -26,7 +26,7 @@ These programs support the broad Ethereum ecosystem by offering grants to a wide
 
 These projects have created their own grants for projects aimed at developing and experimenting with their own technology.
 
-- [TheGraph](https://airtable.com/shreX09LazIhsg0bU) – _[The Graph](https://thegraph.com/) ecosystem_
+- [TheGraph](https://airtable.com/shrdfvnFvVch3IOVm) – _[The Graph](https://thegraph.com/) ecosystem_
 - [Uniswap](https://airtable.com/shrEXXxXB1humz7VS) – _[Uniswap](https://uniswap.org/) community_
 - [Balancer](https://forms.gle/c68e4fM7JHCQkPkN7) – _[Balancer](https://balancer.fi/) Ecosystem Fund_
 


### PR DESCRIPTION
Updated TheGraph Grants Apply Link As The Old Link is no longer valid.
How to check the authenticity of the updated link.


I recently checked their latest procedure for the grants in their official Discord Channel.
https://discord.gg/9fZZFn2f
And After that I Got The Link
https://www.notion.so/The-Graph-Foundation-e822e66d7b614fdd899a647f5db51a68
Then 
https://airtable.com/shrdfvnFvVch3IOVm



I have mentioned so much details because airtable link can be created by anybody so authenticity needs to be verified.


@minimalsm @corwintines 

Please Take A Look

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
