### PR TITLE
Removed Kauri From The List

### DIFF
--- a/src/content/learn/index.md
+++ b/src/content/learn/index.md
@@ -22,7 +22,6 @@ In addition to the information on this page, there are many community-built reso
 - [EthHub](https://docs.ethhub.io) _Comprehensive knowledge base for all things Ethereum_
 - [District0x](https://education.district0x.io/general-topics/understanding-ethereum/) _An educational resource about Ethereum targeted at beginners_
 - [Ethereum.wiki](https://eth.wiki) _A community-built wiki about Ethereum’s technology_
-- [Kauri](https://kauri.io) _Technical articles and tutorials for Ethereum and related projects_
 - [Ethereum Foundation YouTube](https://www.youtube.com/channel/UCNOfzGXD_C9YMYmnefmPH0g) _Videos and talks about Ethereum_
 - [Week in Ethereum News](https://weekinethereumnews.com/) _A weekly newsletter covering key developments across the ecosystem_
 - [What’s new in ETH 2.0](https://eth2.news) _A regular newsletter about Eth2 development_


### PR DESCRIPTION
Removed Kauri From The List of Community Built Resources.
All the Materials Provided By Them is almost already available in other list items other than Kauri.
Reason :  Last Updated Dec 2020, URL : https://github.com/kauri-io/archive
Community Report : Community is No Longer managing The WebSite. They have just hosted it.
@samajammin @minimalsm Take a look

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
