### PR TITLE
Ignore queryParams on canonical URLs

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -176,6 +176,7 @@ module.exports = {
       resolve: `gatsby-plugin-react-helmet-canonical-urls`,
       options: {
         siteUrl,
+        noQueryString: true,
       },
     },
     // Needed for `gatsby-image`

--- a/src/components/Search/index.js
+++ b/src/components/Search/index.js
@@ -154,7 +154,7 @@ const indices = [
   { name: `prod-ethereum-org`, title: `Pages`, hitComp: `PageHit` },
 ]
 
-// Validate agaisnt basic requirements of an ETH address
+// Validate against basic requirements of an ETH address
 const isValidAddress = (address) => {
   return /^(0x)?[0-9a-f]{40}$/i.test(address)
 }


### PR DESCRIPTION
## Description
Adds `noQueryString: true` to `gatsby-plugin-react-helmet-canonical-urls` with goal to eliminate duplicate Algolia search results for pages with query params. 

ie: `https://ethereum.org/en/dapps/?category=gaming` and `https://ethereum.org/en/dapps/?category=technology` would both have a canonical URL of `https://ethereum.org/en/dapps/`
Reached out to Algolia on how to test this, as I believe it should require the new pages to be indexed.

## Related Issue
#2764