### PR TITLE
Update README developer doc

### DIFF
--- a/src/content/developers/docs/index.md
+++ b/src/content/developers/docs/index.md
@@ -7,7 +7,7 @@ sidebar: true
 
 This documentation is designed to help you build with Ethereum. It covers Ethereum as a concept, explains the Ethereum tech stack, and documents advanced topics for more complex applications and use cases.
 
-This is an open-source community effort, so feel free to suggest new topics, add new content, and provide examples wherever you think it might be helpful. All documentation can be eddited via GitHub – if you're unsure how, [follow these instructions](https://github.com/ethereum/ethereum-org-website/blob/dev/README.md).
+This is an open-source community effort, so feel free to suggest new topics, add new content, and provide examples wherever you think it might be helpful. All documentation can be edited via GitHub – if you're unsure how, [follow these instructions](https://github.com/ethereum/ethereum-org-website/blob/dev/README.md).
 
 ## Development modules {#development-modules}
 

--- a/src/content/developers/docs/index.md
+++ b/src/content/developers/docs/index.md
@@ -7,7 +7,7 @@ sidebar: true
 
 This documentation is designed to help you build with Ethereum. It covers Ethereum as a concept, explains the Ethereum tech stack, and documents advanced topics for more complex applications and use cases.
 
-This is an open-source community effort, so feel free to suggest new topics, add new content, and provide examples wherever you think it might be helpful. All documentation is editable via GitHub – if you're unsure how, [follow these instructions](https://github.com/ethereum/ethereum-org-website/blob/dev/README.md).
+This is an open-source community effort, so feel free to suggest new topics, add new content, and provide examples wherever you think it might be helpful. All documentation can be eddited via GitHub – if you're unsure how, [follow these instructions](https://github.com/ethereum/ethereum-org-website/blob/dev/README.md).
 
 ## Development modules {#development-modules}
 

--- a/src/intl/en/page-developers-docs.json
+++ b/src/intl/en/page-developers-docs.json
@@ -62,7 +62,7 @@
   "docs-nav-proof-of-stake": "Proof of stake",
   "docs-nav-proof-of-work": "Proof of work",
   "docs-nav-python": "Python",
-  "docs-nav-readme": "README",
+  "docs-nav-readme": "Overview",
   "docs-nav-rust": "Rust",
   "docs-nav-scaling": "Scaling",
   "docs-nav-scaling-description": "Methods for preserving decentralization and security as Ethereum grows",


### PR DESCRIPTION
## Description

This PR is part of a series to [audit the developer docs](https://github.com/ethereum/ethereum-org-website/issues/3908) in preparation for upgrades to our translation program.

## Notes from the changes I've suggested:
Sam and I discussed changing the README title in the introduction doc to something more semantic. Currently, we're translating 'README' which seems very confusing to me.

<img width="375" alt="Screenshot 2021-09-30 at 15 32 20" src="https://user-images.githubusercontent.com/62268199/135475705-c7546549-6299-4ad3-b538-b3bcef9b8227.png">

I've proposed changing this to `Overview` (taking inspiration from [Gatsby documentation](https://www.gatsbyjs.com/docs/)). 

<img width="366" alt="Screenshot 2021-09-30 at 16 13 49" src="https://user-images.githubusercontent.com/62268199/135482825-d08926df-dd20-498e-ba6f-9a86e606699d.png">

- If we agree on this I'll make this change consistent throughout the docs. 
- If we don't we can remove the change.

## Link
Deploy preview - https://deploy-preview-4095--ethereumorg.netlify.app/en/developers/docs/