### PR TITLE
Moved Lodestar from experimental to production-ready ETH2 client 

### DIFF
--- a/src/pages/eth2/get-involved/index.js
+++ b/src/pages/eth2/get-involved/index.js
@@ -228,7 +228,7 @@ const GetInvolvedPage = ({ data, location }) => {
         url: "https://chainsafe.io/",
         image: data.lodestar.childImageSharp.fixed,
         githubUrl: "https://github.com/ChainSafe/lodestar",
-        isProductionReady: false,
+        isProductionReady: true,
       },
       {
         name: "Nimbus",

--- a/src/pages/eth2/get-involved/index.js
+++ b/src/pages/eth2/get-involved/index.js
@@ -225,7 +225,7 @@ const GetInvolvedPage = ({ data, location }) => {
           <Translation id="page-eth2-get-involved-written-javascript" />
         ),
         alt: "eth2-client-lodestar-logo-alt",
-        url: "https://chainsafe.io/",
+        url: "https://lodestar.chainsafe.io/",
         image: data.lodestar.childImageSharp.fixed,
         githubUrl: "https://github.com/ChainSafe/lodestar",
         isProductionReady: true,


### PR DESCRIPTION
Moved Lodestar from experimental to production-ready ETH2 client 
Fixes #4098 
<!--- Provide a general summary of your changes in the Title above -->

## Description
That is pretty much it 

<!--- Describe your changes in detail -->
under `src\pages\eth2\get-involved\index.js` 
from `randomizedClients`
I changed `isProductionReady` for Lodestar to `true`
## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
