### PR TITLE
removed deprecated ETH2 clien -(trinity) [Fixes #4097]

### DIFF
--- a/src/pages/eth2/get-involved/index.js
+++ b/src/pages/eth2/get-involved/index.js
@@ -240,16 +240,16 @@ const GetInvolvedPage = ({ data, location }) => {
         githubUrl: "https://github.com/status-im/nimbus-eth2",
         isProductionReady: true,
       },
-      {
-        name: "Trinity",
-        background: "#0B131E",
-        description: <Translation id="page-eth2-get-involved-written-python" />,
-        alt: "eth2-client-trinity-logo-alt",
-        url: "https://trinity.ethereum.org/",
-        image: data.trinity.childImageSharp.fixed,
-        githubUrl: "https://github.com/ethereum/trinity",
-        isProductionReady: false,
-      },
+      // {
+      //   name: "Trinity",
+      //   background: "#0B131E",
+      //   description: <Translation id="page-eth2-get-involved-written-python" />,
+      //   alt: "eth2-client-trinity-logo-alt",
+      //   url: "https://trinity.ethereum.org/",
+      //   image: data.trinity.childImageSharp.fixed,
+      //   githubUrl: "https://github.com/ethereum/trinity",
+      //   isProductionReady: false,
+      // },
     ].sort(() => Math.random() - 0.5)
     setClients(randomizedClients)
   }, [])
@@ -513,9 +513,6 @@ export const query = graphql`
       ...Clients
     }
     lodestar: file(relativePath: { eq: "eth2/lodestar.png" }) {
-      ...Clients
-    }
-    trinity: file(relativePath: { eq: "eth2/trinity.png" }) {
       ...Clients
     }
     nimbus: file(relativePath: { eq: "eth2/nimbus.png" }) {

--- a/src/pages/eth2/get-involved/index.js
+++ b/src/pages/eth2/get-involved/index.js
@@ -240,16 +240,6 @@ const GetInvolvedPage = ({ data, location }) => {
         githubUrl: "https://github.com/status-im/nimbus-eth2",
         isProductionReady: true,
       },
-      // {
-      //   name: "Trinity",
-      //   background: "#0B131E",
-      //   description: <Translation id="page-eth2-get-involved-written-python" />,
-      //   alt: "eth2-client-trinity-logo-alt",
-      //   url: "https://trinity.ethereum.org/",
-      //   image: data.trinity.childImageSharp.fixed,
-      //   githubUrl: "https://github.com/ethereum/trinity",
-      //   isProductionReady: false,
-      // },
     ].sort(() => Math.random() - 0.5)
     setClients(randomizedClients)
   }, [])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Removed the deprecated Experimental Eth2 client - Trinity
## Description

<!--- Describe your changes in detail -->
in `src\pages\eth2\get-involved\index.js`
from `randomizedClients`
I deleted the `object` with `name: Trinity`
and from `graphql` query `deleted` the `query part for Trinity` 
## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
