### PR TITLE
Added mobile navbar fix [Fixes #3329]

### DIFF
--- a/src/components/Nav/Mobile.js
+++ b/src/components/Nav/Mobile.js
@@ -51,7 +51,7 @@ const MenuContainer = styled(motion.div)`
   position: fixed;
   left: 0;
   top: 0;
-  height: 100vh;
+  height: 100%;
   overflow: hidden;
   width: 100%;
   max-width: 450px;
@@ -127,7 +127,7 @@ const CloseIconContainer = styled.span`
 
 const MenuItems = styled.ul`
   margin: 0;
-  height: 100vh;
+  height: 100%;
   overflow-y: scroll;
   overflow-x: hidden;
   padding: 3rem 1rem 8rem;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The bottom bar was hidden under chrome address bar because of using viewport heights. Changed the height values to use percentage values as recommended in the chrome documentation.

## Related Issue
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This fixes issue #3329 
