### PR TITLE
Adds Altair release information, node operator cta [Fixes #4137]

### DIFF
--- a/src/components/UpgradeBannerNotification.js
+++ b/src/components/UpgradeBannerNotification.js
@@ -1,0 +1,30 @@
+import React from "react"
+import BannerNotification from "./BannerNotification"
+import Emoji from "./Emoji"
+import Link from "./Link"
+import styled from "styled-components"
+
+const StyledBannerNotification = styled(BannerNotification)`
+  display: flex;
+  justify-content: center;
+`
+
+const StyledEmoji = styled(Emoji)`
+  margin-right: 1rem;
+  flex-shrink: 0;
+`
+
+export default () => (
+  <StyledBannerNotification shouldShow>
+    <StyledEmoji text=":megaphone:" />
+    <div>
+      <b>Calling all Beacon Chain node operators!</b> Time to upgrade your
+      client to support the Altair upgrade set for{" "}
+      <Link to="/history#altair">Oct 27</Link>. See communications from your
+      client developer team for further details.{" "}
+      <Link to="https://blog.ethereum.org/category/research-and-development/">
+        Follow updates
+      </Link>
+    </div>
+  </StyledBannerNotification>
+)

--- a/src/content/history/index.md
+++ b/src/content/history/index.md
@@ -26,9 +26,19 @@ These rule changes may create a temporary split in the network. New blocks could
 
 ### (_In Progress_) Altair {#altair}
 
-The Altair upgrade is the first scheduled upgrade for the [Beacon Chain](/eth2/beacon-chain). It is expected to go live in 2021. It will add support for "sync committees", which can enable light clients, and will bring inactivity and slashing penalties up to their full values.
+<Emoji text=":calendar:" size={1} mr={"0.5rem"} mb={"0.5rem"} />Planned: <code>Oct-27-2021 10:56:23 AM +UTC</code><br />
+<Emoji text=":bricks:" size={1} mr={"0.5rem"} mb={"0.5rem"} />Planned epoch number: 74,240<br />
+<Emoji text=":money_bag:" size={1} mr={"0.5rem"} mb={"0.5rem"} />ETH price: <em>to be determined</em><br />
+
+#### Summary {#altair-summary}
+
+The Altair upgrade is the first scheduled upgrade for the [Beacon Chain](/eth2/beacon-chain). It will add support for "sync committees", which can enable light clients, and will bring inactivity and slashing penalties up to their full values.
 
 - [Read the Altair upgrade specification](https://github.com/ethereum/eth2.0-specs/tree/dev/specs/altair)
+
+#### <Emoji text="🚨" size={1} mr="0.5rem" /> Beacon Chain node operators {#altair-cta}
+
+The date for this upgrade has been set for Wednesday, October 27. If you are operating a beacon chain node, _it's time to upgrade_ to a version that supports the Altair upgrade. Check with your clients communication channels for latest information and details on compatible versions.
 
 ---
 

--- a/src/pages/eth2/index.js
+++ b/src/pages/eth2/index.js
@@ -15,7 +15,7 @@ import GhostCard from "../../components/GhostCard"
 import InfoBanner from "../../components/InfoBanner"
 import Link from "../../components/Link"
 import PageMetadata from "../../components/PageMetadata"
-import BannerNotification from "../../components/BannerNotification"
+import UpgradeBannerNotification from "../../components/UpgradeBannerNotification"
 import Translation from "../../components/Translation"
 import PageHero from "../../components/PageHero"
 import {
@@ -202,16 +202,6 @@ const ResearchContainer = styled.div`
   margin-top: 2rem;
 `
 
-const StyledBannerNotification = styled(BannerNotification)`
-  display: flex;
-  justify-content: center;
-`
-
-const StyledEmoji = styled(Emoji)`
-  margin-right: 1rem;
-  flex-shrink: 0;
-`
-
 const paths = [
   {
     emoji: ":rocket:",
@@ -282,6 +272,7 @@ const Eth2IndexPage = ({ data }) => {
         title={translateMessageId("page-eth2-meta-title", intl)}
         description={translateMessageId("page-eth2-meta-desc", intl)}
       />
+      <UpgradeBannerNotification />
       <PageHero content={heroContent} />
       <Divider />
       <Content>

--- a/src/pages/eth2/vision.js
+++ b/src/pages/eth2/vision.js
@@ -14,7 +14,7 @@ import PageHero from "../../components/PageHero"
 import Breadcrumbs from "../../components/Breadcrumbs"
 import ButtonLink from "../../components/ButtonLink"
 import PageMetadata from "../../components/PageMetadata"
-import BannerNotification from "../../components/BannerNotification"
+import UpgradeBannerNotification from "../../components/UpgradeBannerNotification"
 import {
   CardContainer,
   Content,
@@ -48,16 +48,6 @@ const CentreCard = styled(Card)`
   }
 `
 
-const StyledCard = styled(Card)`
-  flex: 1 1 30%;
-  min-width: 240px;
-  margin: 1rem;
-  padding: 1.5rem;
-  @media (max-width: ${(props) => props.theme.breakpoints.l}) {
-    flex: 1 1 30%;
-  }
-`
-
 const CentralContent = styled.div`
   margin: 0rem 12rem;
   justify-content: center;
@@ -75,16 +65,6 @@ const TrilemmaContent = styled.div`
 
 const StyledBreadcrumbs = styled(Breadcrumbs)`
   justify-content: center;
-`
-
-const StyledBannerNotification = styled(BannerNotification)`
-  display: flex;
-  justify-content: center;
-`
-
-const StyledEmoji = styled(Emoji)`
-  margin-right: 1rem;
-  flex-shrink: 0;
 `
 
 const paths = [
@@ -146,6 +126,7 @@ const VisionPage = ({ data, location }) => {
         title={translateMessageId("page-eth2-vision-meta-title", intl)}
         description={translateMessageId("page-eth2-vision-meta-desc", intl)}
       />
+      <UpgradeBannerNotification />
       <PageHero content={heroContent} />
       <Divider />
       <Content>

--- a/src/templates/eth2.js
+++ b/src/templates/eth2.js
@@ -7,7 +7,7 @@ import styled from "styled-components"
 import Img from "gatsby-image"
 import ButtonLink from "../components/ButtonLink"
 import ButtonDropdown from "../components/ButtonDropdown"
-import BannerNotification from "../components/BannerNotification"
+import UpgradeBannerNotification from "../components/UpgradeBannerNotification"
 import Breadcrumbs from "../components/Breadcrumbs"
 import Card from "../components/Card"
 import Icon from "../components/Icon"
@@ -351,16 +351,6 @@ const TitleCard = styled.div`
   }
 `
 
-const StyledBannerNotification = styled(BannerNotification)`
-  display: flex;
-  justify-content: center;
-`
-
-const StyledEmoji = styled(Emoji)`
-  margin-right: 1rem;
-  flex-shrink: 0;
-`
-
 const dropdownLinks = {
   text: "page-eth2-upgrades-guide",
   ariaLabel: "page-eth2-upgrades-aria-label",
@@ -392,6 +382,7 @@ const Eth2Page = ({ data, data: { mdx } }) => {
 
   return (
     <Container>
+      <UpgradeBannerNotification />
       <HeroContainer>
         <TitleCard>
           <DesktopBreadcrumbs slug={mdx.fields.slug} startDepth={1} />


### PR DESCRIPTION
## Description
- Places a banner similar to previous notice about the merge being expedited, located on the eth2 pages.
- Stated as a call-to-action for Beacon Chain node operators to make sure they update their clients.
- Adds Altair upgrade time information to history page
- (Refactored this into a new component to avoid code duplication)

Went with this approach over how we drew attention to the London upgrade, as this is targeted more to node operators. Left it off the homepage, but welcome feedback on this (as well as on the copy used).

## Related Issue
[Fixes #4137]