### PR TITLE
Align labels in code logic with GitHub labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ""
-labels: "Type: Bug"
+labels: "bug :bug:"
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ""
-labels: "Type: Feature"
+labels: "feature :sparkles:"
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/suggest_dapp.md
+++ b/.github/ISSUE_TEMPLATE/suggest_dapp.md
@@ -2,7 +2,7 @@
 name: Suggest a dapp
 about: Suggest a new dapp to list on ethereum.org
 title: ""
-labels: "Type: Feature, Type: Content"
+labels: "feature :sparkles:, content :fountain_pen:"
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/suggest_dev_tool.md
+++ b/.github/ISSUE_TEMPLATE/suggest_dev_tool.md
@@ -2,7 +2,7 @@
 name: Suggest a developer tool
 about: Anything a developer can use when building with Ethereum
 title: ""
-labels: "Type: Feature, Type: Content"
+labels: "feature :sparkles:, content :fountain_pen:"
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/suggest_exchange.md
+++ b/.github/ISSUE_TEMPLATE/suggest_exchange.md
@@ -2,7 +2,7 @@
 name: Suggest an exchange
 about: Suggest a new exchange to list on ethereum.org
 title: ""
-labels: "Type: Feature, Type: Content"
+labels: "feature :sparkles:, content :fountain_pen:"
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/suggest_glossary_term.md
+++ b/.github/ISSUE_TEMPLATE/suggest_glossary_term.md
@@ -2,7 +2,7 @@
 name: Suggest a glossary term
 about: Suggest a new ethereum.org glossary term
 title: ""
-labels: "Type: Feature, Type: Content"
+labels: "feature :sparkles:, content :fountain_pen:"
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/suggest_tutorial.md
+++ b/.github/ISSUE_TEMPLATE/suggest_tutorial.md
@@ -2,7 +2,7 @@
 name: Suggest a tutorial
 about: Suggest a tutorial to our developers platform
 title: ""
-labels: "Type: Feature, Type: Content"
+labels: "feature :sparkles:, content :fountain_pen:"
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/suggest_wallet.md
+++ b/.github/ISSUE_TEMPLATE/suggest_wallet.md
@@ -2,7 +2,7 @@
 name: Suggest a wallet
 about: Suggest a new wallet to list on ethereum.org
 title: ""
-labels: "Type: Feature, Type: Content"
+labels: "feature :sparkles:, content :fountain_pen:"
 assignees: ""
 ---
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,31 +1,31 @@
-"Status: Review Needed":
+"review needed :eyes:":
   - src/**/*
 
-"Type: Documentation":
+"documentation :book:":
   - README.md
 
-"Type: Tooling":
+"tooling :wrench:":
   - .github/**/*
   - src/scripts/*
   - netlify.toml
 
-"Type: Dependencies":
+"dependencies :package:":
   - package.json
   - yarn.lock
 
-"Type: Internal":
+"internal :house:":
   - gatsby-browser.js
   - gatsby-config.js
   - gatsby-node.js
   - gatsby-ssr.js
   - .all-contributorsrc
 
-"Type: Translation":
+"translation :earth_africa:":
   - src/content/translations/**/*
   - src/intl/*
   - src/utils/translations.js
 
-"Type: Content":
+"content :fountain_pen:":
   - src/pages/*
   - src/pages-conditional/*
   - src/content/**/*

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -4,28 +4,28 @@ name-template: v$NEXT_PATCH_VERSION
 tag-template: v$NEXT_PATCH_VERSION
 categories:
   - title: ":rocket: Enhancement"
-    label: "Type: Feature"
+    label: "feature :sparkles:"
 
   - title: ":globe_with_meridians: Translations"
-    label: "Type: Translation"
+    label: "translation :earth_africa:"
 
   - title: ":bug: Bug Fix"
-    label: "Type: Bug"
+    label: "bug :bug:"
 
   - title: ":memo: Documentation"
-    label: "Type: Documentation"
+    label: "documentation :book:"
 
   - title: ":nail_care: Refactor"
-    label: "Type: Refactor"
+    label: "refactor :recycle:"
 
   - title: ":house: Internal"
-    label: "Type: Internal"
+    label: "internal :house:"
 
   - title: ":wrench: Tooling"
-    label: "Type: Tooling"
+    label: "tooling :wrench:"
 
   - title: ":package: Dependencies"
-    label: "Type: Dependencies"
+    label: "dependencies :package:"
 
 change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
 no-changes-template: "- No changes"

--- a/.github/workflows/on-pr-close.yml
+++ b/.github/workflows/on-pr-close.yml
@@ -17,5 +17,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: ['Status: Abandoned']
+              labels: ['abandoned']
             })


### PR DESCRIPTION
## Description

The [GitHub labels have been updated](https://github.com/ethereum/ethereum-org-website/labels/). These changes fix the code that interacts with labeling, aligning them with our new labels.

## Additional Info

Will need to change the labels below at the time of a deploy or the [roadmap on the about page](https://ethereum.org/en/about/) will break:

- `Status: In Progress`
- `Status: Up Next`
- `Status: Abandoned`
- `Type: Spam`

## Related Issue
None
