### PR TITLE
Update the solidity version in Create and Deploy Defi App tutorial

### DIFF
--- a/src/content/developers/tutorials/create-and-deploy-a-defi-app/index.md
+++ b/src/content/developers/tutorials/create-and-deploy-a-defi-app/index.md
@@ -50,7 +50,7 @@ npm install @openzeppelin/contracts
 Using the OpenZeppelin library we can create our ERC20 token by writing to `contracts/MyToken.sol` with the following solidity code:
 
 ```solidity
-pragma solidity ^0.6.2;
+pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
@@ -99,7 +99,7 @@ The default version is the `Solidity v0.5.16`. Since our token is written using 
 // Configure your compilers
 compilers: {
   solc: {
-    version: "0.6.2",    // Fetch exact version from solc-bin (default: truffle's version)
+    version: "^0.8.0",    // Fetch exact version from solc-bin (default: truffle's version)
     // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
     // settings: {          // See the solidity docs for advice about optimization and evmVersion
     //  optimizer: {


### PR DESCRIPTION
The latest version of @openzeppelin/contracts requires solidity version ^0.8.0. This PR updates the tutorial to use this version of solidity

<!--- Provide a general summary of your changes in the Title above -->

## Description
Updates Solidity version to be ^0.8.0 in tutorial contract and truffle config
<!--- Describe your changes in detail -->

## Related Issue
Closes Issue #3161 
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
