### PR TITLE
Update tutorial with complete steps to get tests working

### DIFF
--- a/src/content/developers/tutorials/waffle-test-simple-smart-contract/index.md
+++ b/src/content/developers/tutorials/waffle-test-simple-smart-contract/index.md
@@ -26,12 +26,12 @@ published: 2021-02-26
 
 The tutorial demonstrates test setup and run using yarn, but there is no problem if you prefer npm - I will provide proper references to the official Waffle [documentation](https://ethereum-waffle.readthedocs.io/en/latest/index.html).
 
-## Install Waffle
+## Install Dependencies
 
-[Add](https://ethereum-waffle.readthedocs.io/en/latest/getting-started.html#installation) ethereum-waffle package to the dev dependencies of your project.
+[Add](https://ethereum-waffle.readthedocs.io/en/latest/getting-started.html#installation) ethereum-waffle and typescript dependencies to the dev dependencies of your project.
 
 ```bash
-yarn add --dev ethereum-waffle
+yarn add --dev ethereum-waffle ts-node typescript @types/jest
 ```
 
 ## Example smart contract
@@ -95,7 +95,7 @@ Testing with Waffle requires using Chai matchers and Mocha, so you need to [add]
 ```json
 "scripts": {
     "build": "waffle",
-    "test": "export NODE_ENV=test && mocha 'test/**/*.test.ts'"
+    "test": "export NODE_ENV=test && mocha -r ts-node/register 'test/**/*.test.ts'"
   }
 ```
 


### PR DESCRIPTION
The tutorial [Testing Simple Smart Contract with Waffle Library](https://ethereum.org/en/developers/tutorials/waffle-test-simple-smart-contract/) is missing some small details to get the tests running smoothly. This PR update the test command and required dependencies so that the tutorial can be run seamlessly.

## Description
Converts Install Waffle step to Install Dependency and adds missing deps `ts-node`, `typescript`, `@types/jest`
Updates the test command to require `ts-node/register` so that typescript files can be run without a build step.

## Related Issue
Closes Issue #3441
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
