### PR TITLE
fix(locales): typos in "Eth for .NET developers"

### DIFF
--- a/src/content/translations/de/dot-net/index.md
+++ b/src/content/translations/de/dot-net/index.md
@@ -11,7 +11,7 @@ sidebar: true
 
 Verwende Ethereum, um dezentralen Anwendungen (oder „dApps“) zu erschaffen, die von den kryptografischen Begebenheiten von Kryptowährungen und der Blockchain-Technologie profitieren. Sie sind vertrauenswürdig, was bedeutet, dass dApps nach dem Hochladen auf Ethereum immer exakt wie programmiert ausgeführt werden. Sie können digitale Vermögenswerte verwalten und dadurch neuartige Finanzanwendungen erschaffen. Sie können dezentralisiert sein, was bedeutet, dass keine einzelne Einheit oder Person sie kontrollieren kann und sie so fast unmöglich zu zensieren ist.
 
-Erstelle dezentrale Anwendungen auf Ethereum und interagiere mit Smart Contracts unter Verwendung von Tools und Sprachen aus dem Microsoft-Technologie-Stack - Unterstützt C#, # Visual Basic . ET, F#, über Werkzeuge wie VSCode und Visual Studio, mit dem .NET Framework/.NET Core/.NET Standard. Starte eine Ethereum-Blockchain mit Microsoft Azure Blockchain in wenigen Minuten. Bring die Liebe von .NET zu Ethereum!
+Erstelle dezentrale Anwendungen auf Ethereum und interagiere mit Smart Contracts unter Verwendung von Tools und Sprachen aus dem Microsoft-Technologie-Stack - Unterstützt C#, Visual Basic .NET, F#, über Werkzeuge wie VSCode und Visual Studio, mit dem .NET Framework/.NET Core/.NET Standard. Starte eine Ethereum-Blockchain mit Microsoft Azure Blockchain in wenigen Minuten. Bring die Liebe von .NET zu Ethereum!
 
 <img src="https://raw.githubusercontent.com/Nethereum/Nethereum/master/logos/logo192x192t.png" />
 

--- a/src/content/translations/it/dot-net/index.md
+++ b/src/content/translations/it/dot-net/index.md
@@ -12,7 +12,7 @@ sidebarDepth: 1
 
 Usa Ethereum per creare applicazioni decentralizzate (dette "dapp") che sfruttano i vantaggi delle criptovalute e della tecnologia blockchain. Queste dapp sono attendibili perché, una volta distribuite su Ethereum, vengono eseguite sempre come programmato. Possono controllare beni digitali per creare nuovi tipi di applicazioni finanziarie. Possono essere decentralizzate, pertanto nessuna entità singola o individuo le controlla e sono quasi impossibili da censurare.
 
-Crea applicazioni decentralizzate su Ethereum e interagisci con Smart Contract utilizzando strumenti e linguaggi Microsoft. Supporta C#, # Visual Basic . ET, F#, con strumenti come VSCode e Visual Studio, in .NET Framework/.NET Core/.NET Standard. Distribuisci una blockchain Ethereum su Azure usando Microsoft Azure Blockchain in pochi minuti. Porta .NET su Ethereum!
+Crea applicazioni decentralizzate su Ethereum e interagisci con Smart Contract utilizzando strumenti e linguaggi Microsoft. Supporta C#, Visual Basic .NET, F#, con strumenti come VSCode e Visual Studio, in .NET Framework/.NET Core/.NET Standard. Distribuisci una blockchain Ethereum su Azure usando Microsoft Azure Blockchain in pochi minuti. Porta .NET su Ethereum!
 
 <img src="https://raw.githubusercontent.com/Nethereum/Nethereum/master/logos/logo192x192t.png" />
 

--- a/src/content/translations/nb/dot-net/index.md
+++ b/src/content/translations/nb/dot-net/index.md
@@ -11,7 +11,7 @@ sidebar: true
 
 Bruk Ethereum til å utvikle desentraliserte applikasjoner (eller "dapps") som utnytter fordelene med kryptovaluta og blokkjedeknologi. De er pålitelige. Det vil si at når de er utrullet på Ethereum, vil de alltid kjøre som programmert. Det kan styre digitale eiendeler for å skape nye typer finansielle applikasjoner. De kan være desentraliserte, det betyr at ingen enkeltenhet eller person styrer dem, og er nesten umulig å sensurere.
 
-Bygg desentraliserte applikasjoner oppå Ethereum og samhandle med smarte kontrakter ved hjelp av verktøy og språk fra Microsofts technology stack - Supporting C#, # Visual Basic . ET, F#, verktøy som for eksempel VSCode og Visual Studio, gjennom .NET Framework/.NET Core/.NET Standard. Distribuer en Ethereum-blokkjede på Azure med Microsoft Azure Blockchain på få minutter. Bring nyttigheten av .NET til Ethereum!
+Bygg desentraliserte applikasjoner oppå Ethereum og samhandle med smarte kontrakter ved hjelp av verktøy og språk fra Microsofts technology stack - Supporting C#, Visual Basic .NET, F#, verktøy som for eksempel VSCode og Visual Studio, gjennom .NET Framework/.NET Core/.NET Standard. Distribuer en Ethereum-blokkjede på Azure med Microsoft Azure Blockchain på få minutter. Bring nyttigheten av .NET til Ethereum!
 
 <img src="https://raw.githubusercontent.com/Nethereum/Nethereum/master/logos/logo192x192t.png" />
 


### PR DESCRIPTION
Typos in "Ethereum for .NET developers" section in Italian, German and Norwegian.

## Related Issue
#4150 
