### PR TITLE
Updating title of this tutorial to indicate pt.1 of larger tutorial series

### DIFF
--- a/src/content/developers/tutorials/hello-world-smart-contract/index.md
+++ b/src/content/developers/tutorials/hello-world-smart-contract/index.md
@@ -1,5 +1,5 @@
 ---
-title: Hello World Smart Contract for Beginners
+title: Hello World Smart Contract for Beginners (Part 1/4 of Hello World dApp Series)
 description: Introductory tutorial on writing and deploying a simple smart contract on Ethereum.
 author: "elanh"
 tags:


### PR DESCRIPTION
As a Go-To-Market engineer at Alchemy, I will be adding part two to this tutorial as a PR to the Ethereum foundation. Thus, I wanted to signal that this is only part 1 via the title change "Hello World Smart Contract for Beginners" to "Hello World Smart Contract for Beginners (Part 1/4 of Hello World dApp Series)".

Thank you and let's go builders!!!

## Description

As a Go-To-Market engineer at Alchemy, I will be adding part two to this tutorial as a PR to the Ethereum foundation. Thus, I wanted to signal that this is only part 1 via the title change "Hello World Smart Contract for Beginners" to "Hello World Smart Contract for Beginners (Part 1/4 of Hello World dApp Series)".

## Related Issue
