### PR TITLE
Add width property to static template container [Fixes #4142]

### DIFF
--- a/src/templates/static.js
+++ b/src/templates/static.js
@@ -54,6 +54,7 @@ const Page = styled.div`
 // Apply styles for classes within markdown here
 const ContentContainer = styled.article`
   max-width: ${(props) => props.theme.breakpoints.m};
+  width: 100%;
 
   .featured {
     padding-left: 1rem;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Whitepaper is rendered by `static` layout and it is missing width property on `ContentContainer`. Table is too wide and the whole page displays with horizontal scrolling on mobile viewports. Fixed by adding 100% width to `ContentContainer` as in the other templates(`docs`).