### PR TITLE
Update broken URL in hello-world-smart-contract tutorial

### DIFF
--- a/src/content/developers/tutorials/hello-world-smart-contract/index.md
+++ b/src/content/developers/tutorials/hello-world-smart-contract/index.md
@@ -207,7 +207,7 @@ We’ve created a Metamask wallet, Alchemy account, and written our smart contra
 
 Every transaction sent from your virtual wallet requires a signature using your unique private key. To provide our program with this permission, we can safely store our private key (and Alchemy API key) in an environment file.
 
-> To learn more about sending transactions, check out [this tutorial](https://ethereum.org/en/developers/tutorials/sending-transactions-using-web3-and-alchemy/) on sending transactions using web3.
+> To learn more about sending transactions, check out [this tutorial](/developers/tutorials/sending-transactions-using-web3-and-alchemy/) on sending transactions using web3.
 
 First, install the dotenv package in your project directory:
 


### PR DESCRIPTION
Updated Broken URL To Absolute URL FOR SENDING TRANSACTIONS USING WEB3 

[THIS](https://ethereum.org/en/developers/tutorials/sending-transactions-using-web3-and-alchemy/)

@wackerow  We Can Put Relative URL Also.

Help Me In Putting The Relative URL
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
