### PR TITLE
refactor monospace font family into the theme [Fixes #3967]

### DIFF
--- a/src/components/BugBountyPoints.js
+++ b/src/components/BugBountyPoints.js
@@ -29,8 +29,7 @@ const PointsExchangeLabel = styled.div`
 `
 
 const PointsExchangeTitle = styled.h2`
-  font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
-    "Liberation Mono", Menlo, Courier, monospace;
+  font-family: ${(props) => props.theme.fonts.monospace};
   font-size: 24px;
   font-weight: 700;
   text-transform: uppercase;

--- a/src/components/CallToContribute.js
+++ b/src/components/CallToContribute.js
@@ -60,13 +60,11 @@ const GithubIcon = styled(Icon)`
 const Description = styled.p`
   line-height: 140%;
   color: ${(props) => props.theme.colors.text};
-  font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
-    "Liberation Mono", Menlo, Courier, monospace;
+  font-family: ${(props) => props.theme.fonts.monospace};
 `
 
 const Title = styled.h2`
-  font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
-    "Liberation Mono", Menlo, Courier, monospace;
+  font-family: ${(props) => props.theme.fonts.monospace};
   text-transform: uppercase;
   background: ${(props) => props.theme.colors.border};
   padding: 0.25rem;

--- a/src/components/CodeModal.js
+++ b/src/components/CodeModal.js
@@ -66,8 +66,7 @@ const ModalClose = styled.div`
 const Title = styled.div`
   margin-left: 1.5rem;
   text-transform: uppercase;
-  font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
-    "Liberation Mono", Menlo, Courier, monospace;
+  font-family: ${(props) => props.theme.fonts.monospace};
 `
 
 const ModalCloseIcon = styled(Icon)`

--- a/src/components/StatsBoxGrid.js
+++ b/src/components/StatsBoxGrid.js
@@ -31,8 +31,7 @@ const Title = styled.p`
   margin-bottom: 0.5rem;
   color: ${({ theme }) => theme.colors.text};
   text-transform: uppercase;
-  font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
-    "Liberation Mono", Menlo, Courier, monospace;
+  font-family: ${(props) => props.theme.fonts.monospace};
 `
 
 const Grid = styled.div`
@@ -116,14 +115,12 @@ const ButtonContainer = styled.div`
   position: absolute;
   right: 20px;
   bottom: 20px;
-  font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
-    "Liberation Mono", Menlo, Courier, monospace;
+  font-family: ${(props) => props.theme.fonts.monospace};
 `
 
 const Button = styled.button`
   background: ${(props) => props.theme.colors.background};
-  font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
-    "Liberation Mono", Menlo, Courier, monospace;
+  font-family: ${(props) => props.theme.fonts.monospace};
   font-size: 20px;
   color: ${({ theme }) => theme.colors.text};
   padding: 2px 15px;

--- a/src/components/TutorialMetadata.js
+++ b/src/components/TutorialMetadata.js
@@ -63,8 +63,7 @@ const AddressContainer = styled.div`
 const Code = styled.div`
   overflow: hidden;
   text-overflow: ellipsis;
-  font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
-    "Liberation Mono", Menlo, Courier, monospace;
+  font-family: ${(props) => props.theme.fonts.monospace};
   background: ${(props) => props.theme.colors.ednBackground};
   padding-left: 0.25rem;
   padding-right: 0.25rem;

--- a/src/pages/developers/index.js
+++ b/src/pages/developers/index.js
@@ -69,8 +69,7 @@ const HeroCopy = styled.div`
 const H1 = styled.h1`
   font-style: normal;
   font-weight: normal;
-  font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
-    "Liberation Mono", Menlo, Courier, monospace;
+  font-family: ${(props) => props.theme.fonts.monospace};
   text-transform: uppercase;
   font-weight: 500;
   font-size: 32px;

--- a/src/pages/developers/learning-tools.js
+++ b/src/pages/developers/learning-tools.js
@@ -33,8 +33,7 @@ const H1 = styled.h1`
   margin-top: 0;
   color: ${(props) => props.theme.colors.text};
   font-style: normal;
-  font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
-    "Liberation Mono", Menlo, Courier, monospace;
+  font-family: ${(props) => props.theme.fonts.monospace};
   text-transform: uppercase;
   font-weight: 600;
   font-size: 2rem;

--- a/src/pages/developers/local-environment.js
+++ b/src/pages/developers/local-environment.js
@@ -38,8 +38,7 @@ const HeroContent = styled(Content)`
 const Slogan = styled.h1`
   font-style: normal;
   font-weight: normal;
-  font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
-    "Liberation Mono", Menlo, Courier, monospace;
+  font-family: ${(props) => props.theme.fonts.monospace};
   text-transform: uppercase;
   font-weight: 600;
   font-size: 32px;

--- a/src/pages/developers/tutorials.js
+++ b/src/pages/developers/tutorials.js
@@ -98,8 +98,7 @@ const Title = styled.p`
 const PageTitle = styled.h1`
   font-style: normal;
   font-weight: normal;
-  font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
-    "Liberation Mono", Menlo, Courier, monospace;
+  font-family: ${(props) => props.theme.fonts.monospace};
   text-transform: uppercase;
   font-weight: 600;
   font-size: 32px;

--- a/src/pages/eth2/deposit-contract.js
+++ b/src/pages/eth2/deposit-contract.js
@@ -111,8 +111,7 @@ const AddressCard = styled.div`
 `
 
 const Address = styled.div`
-  font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
-    "Liberation Mono", Menlo, Courier, monospace;
+  font-family: ${(props) => props.theme.fonts.monospace};
   border-radius: 2px;
   font-size: 2rem;
   flex-wrap: wrap;

--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -83,8 +83,7 @@ const Content = styled.article`
 
 const H1 = styled(Header1)`
   font-size: 2.5rem;
-  font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
-    "Liberation Mono", Menlo, Courier, monospace;
+  font-family: ${(props) => props.theme.fonts.monospace};
   text-transform: uppercase;
   @media (max-width: ${(props) => props.theme.breakpoints.m}) {
     font-size: 2rem;
@@ -103,8 +102,7 @@ const H1 = styled(Header1)`
 `
 
 const H2 = styled(Header2)`
-  font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
-    "Liberation Mono", Menlo, Courier, monospace;
+  font-family: ${(props) => props.theme.fonts.monospace};
   text-transform: uppercase;
 
   font-size: 1.5rem;

--- a/src/templates/tutorial.js
+++ b/src/templates/tutorial.js
@@ -84,8 +84,7 @@ const ContentContainer = styled.article`
 
 const H1 = styled(Header1)`
   font-size: 2.5rem;
-  font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
-    "Liberation Mono", Menlo, Courier, monospace;
+  font-family: ${(props) => props.theme.fonts.monospace};
   text-transform: uppercase;
   @media (max-width: ${(props) => props.theme.breakpoints.m}) {
     font-size: 1.75rem;
@@ -97,8 +96,7 @@ const H1 = styled(Header1)`
 `
 
 const H2 = styled(Header2)`
-  font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
-    "Liberation Mono", Menlo, Courier, monospace;
+  font-family: ${(props) => props.theme.fonts.monospace};
   text-transform: uppercase;
 
   &:before {

--- a/src/theme.js
+++ b/src/theme.js
@@ -324,6 +324,10 @@ const darkThemeColors = Object.assign({}, baseColors, darkColors)
 const theme = {
   isDark: false, // Overwritten in Object.assign
   colors: {}, // Overwritten in Object.assign
+  fonts: {
+    monospace:
+      '"SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono", "Liberation Mono", Menlo, Courier, monospace',
+  },
   fontSizes: {
     // based on typical browser default font size of 16px
     xs: "0.75rem", // 12px


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Refactors hard-coded monospace font into the base theme object - adding a new `fonts.monospace` key. This allows easier re-use of monospace font families.

## Related Issue

https://github.com/ethereum/ethereum-org-website/issues/3967

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
