### PR TITLE
Fix broken link on DeFi page

### DIFF
--- a/src/content/defi/index.md
+++ b/src/content/defi/index.md
@@ -79,7 +79,7 @@ There's a decentralized alternative to most financial services. But Ethereum als
 - [Access stable currencies](#stablecoins)
 - [Borrow funds with collateral](#lending)
 - [Borrow without collateral](#flash-loans)
-- [Start crypto savings](#savings)
+- [Start crypto savings](#saving)
 - [Trade tokens](#swaps)
 - [Grow your portfolio](#investing)
 - [Fund your ideas](#crowdfunding)
@@ -166,7 +166,7 @@ To be able to do the above example in the traditional finance world, you'd need 
 
 <Divider />
 
-### Start saving with crypto {#savings}
+### Start saving with crypto {#saving}
 
 #### Lending {#lending}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

fix crypto savings link error on defi page

## Related Issue

https://github.com/ethereum/ethereum-org-website/issues/4183