### PR TITLE
Add MT section to Translation Program page

### DIFF
--- a/src/content/contributing/translation-program/index.md
+++ b/src/content/contributing/translation-program/index.md
@@ -91,8 +91,9 @@ The ethereum.org Translation Program aims to make Ethereum accessible to everyon
 4. **Review process**  
    Once you've completed the translation (i.e. all files for a content version display 100%), our professional translation service will review (and potentially edit) the content. Once the review is complete (i.e. review progress is 100%), we will add it to the website.
    
-   ❗ Please do not use machine translation to translate the project. All the translations will be reviewed before being added to the website.
-If your suggested translations are found to be machine translated, they will be dismissed and contributors who use machine translation often will be removed from the project.
+<InfoBanner shouldCenter emoji=":warning:">
+Please do not use machine translation to translate the project. All the translations will be reviewed before being added to the website. If your suggested translations are found to be machine translated, they will be dismissed and contributors who use machine translation often will be removed from the project.
+</InfoBanner>
 
 Do you have any questions? Or want to collaborate with our team and other translators? Please post in the #translations channel of our [ethereum.org Discord server](https://discord.gg/6WX7E97)
 


### PR DESCRIPTION
## Description

Add section about machine translation and potential consequences of using MT to suggest translations to the review section of the Translation Program page in order to discourage contributors from using machine translation.

## Related Issue

Closes #4199
