### PR TITLE
Fix GitHub instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ $ yarn
 We recommend setting this up when running the project locally, as we use the GitHub API to fetch repository data for many projects & files.
 
 > - [Follow these instructions](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) to create a personal GitHub API token
->   - When selecting scopes in step 7, leave everything unchecked (the data we fetch doesn't require any [scope](https://docs.github.com/en/developers/apps/scopes-for-oauth-apps#available-scopes))
+>   - When selecting scopes in step 8, leave everything unchecked (the data we fetch doesn't require any [scope](https://docs.github.com/en/developers/apps/scopes-for-oauth-apps#available-scopes))
 > - In local repo root directory: Make a copy of `.env.example` and name it `.env`
 > - Copy & paste your new GitHub API token into `.env`
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
For Github API Token instructions, it mentions selecting scopes in step 7, but it is in step 8. (https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
<!--- Describe your changes in detail -->

## Related Issue
None
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
