### PR TITLE
Update title tag of security docs page

### DIFF
--- a/src/content/developers/docs/security/index.md
+++ b/src/content/developers/docs/security/index.md
@@ -1,5 +1,5 @@
 ---
-title: Security
+title: Smart contract security
 description: Security considerations for Ethereum developers
 lang: en
 sidebar: true


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Updating to a more specific title.
<!--- Describe your changes in detail -->

I noticed this showed up as the 1st result when Googling "Ethereum security". I think a more relevant result is this new Security page:
https://ethereum.org/en/security/

We should optimize accordingly.

One other thought - should this page be nested under https://ethereum.org/en/developers/docs/smart-contracts/ ? At least in its current form, it's entirely about smart contract security.

## Related Issue
None

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
