### PR TITLE
Docsearch Config Updates

### DIFF
--- a/.github/workflows/docsearchConfig.json
+++ b/.github/workflows/docsearchConfig.json
@@ -2,6 +2,48 @@
   "index_name": "prod-ethereum-org",
   "start_urls": [
     {
+      "url": "https://ethereum.org/(?P<lang>.*?)/developers/tutorials/",
+      "variables": {
+        "lang": [
+          "en",
+          "ar",
+          "bn",
+          "cs",
+          "de",
+          "el",
+          "es",
+          "fa",
+          "fi",
+          "fr",
+          "hi",
+          "hu",
+          "id",
+          "ig",
+          "it",
+          "ja",
+          "ko",
+          "lt",
+          "ml",
+          "nb",
+          "nl",
+          "pl",
+          "pt",
+          "pt-br",
+          "ru",
+          "sk",
+          "sl",
+          "ro",
+          "se",
+          "tr",
+          "uk",
+          "vi",
+          "zh",
+          "zh-tw"
+        ]
+      },
+      "page_rank": 1
+    },
+    {
       "url": "https://ethereum.org/(?P<lang>.*?)/",
       "variables": {
         "lang": [
@@ -40,10 +82,11 @@
           "zh",
           "zh-tw"
         ]
-      }
+      },
+      "page_rank": 10
     }
   ],
-  "stop_urls": [],
+  "stop_urls": [".*(?<!/)$"],
   "selectors": {
     "lvl0": {
       "selector": "title",


### PR DESCRIPTION
## Description
Changed the docsearchConfig file to now use stop_urls that filter out query parameters. The filtering out of query parameters will remove the duplicate search queries that were coming in. Added a page_rank to tutorial pages to rank them lower than our other pages. There were many situations where the tutorial pages had similar weight due to fitting the same criteria for ranking, so introduced a way to weight those lower. 

## Related Issue

Fixes: https://github.com/ethereum/ethereum-org-website/issues/3842 https://github.com/ethereum/ethereum-org-website/issues/2764
