### PR TITLE
Modified Crytic Link To Its Github URL

### DIFF
--- a/src/content/developers/tutorials/how-to-use-slither-to-find-smart-contract-bugs/index.md
+++ b/src/content/developers/tutorials/how-to-use-slither-to-find-smart-contract-bugs/index.md
@@ -64,7 +64,7 @@ slither project_paths
 
 In addition to detectors, Slither has code review capabilities through its [printers](https://github.com/crytic/slither#printers) and [tools](https://github.com/crytic/slither#tools).
 
-Use [crytic.io](https://crytic.io) to get access to private detectors and GitHub integration.
+Use [crytic.io](https://github.com/crytic) to get access to private detectors and GitHub integration.
 
 ## Static analysis {#static-analysis}
 


### PR DESCRIPTION
Modified Crytic Link To Its Github URL.
It seems that the website is not entertaining users.
@samajammin @minimalsm @wackerow 
Thoughts on these

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
