### PR TITLE
Add focus state to Card [Fixes #4230]

### DIFF
--- a/src/components/ActionCard.js
+++ b/src/components/ActionCard.js
@@ -52,7 +52,8 @@ const Card = styled(Link)`
     0px 10px 17px rgba(0, 0, 0, 0.03), 0px 4px 7px rgba(0, 0, 0, 0.05);
   margin: 1rem;
 
-  &:hover {
+  &:hover,
+  &:focus {
     border-radius: 4px;
     box-shadow: 0px 8px 17px rgba(0, 0, 0, 0.15);
     background: ${(props) => props.theme.colors.tableBackgroundHover};


### PR DESCRIPTION
## Description

I've added a focus state to the Card styled-component in ActionCard.js. You can
now tab through the cards and they will appear the same as when you mouse hover on them. This fixes #4230.

However, on smaller screens (at a size where the burger button appears), tabbing will move through each item in the burger menu (even when closed) before getting to the cards. I'm not sure if that should be treated as a separate issue but I haven't attempted to fix that.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
