### PR TITLE
Updates the invalid "ERC 20 Annotated Code" OpenGSN link

### DIFF
--- a/src/content/developers/tutorials/erc20-annotated-code/index.md
+++ b/src/content/developers/tutorials/erc20-annotated-code/index.md
@@ -251,7 +251,7 @@ import "../../math/SafeMath.sol";
 
 - `GSN/Context.sol` is the definitions required to use [OpenGSN](https://www.opengsn.org/), a system that allows users without ether
   to use the blockchain. Note that this is an old version, if you want to integrate with OpenGSN
-  [use this tutorial](https://docs.opengsn.org/tutorials/integration.html).
+  [use this tutorial](https://docs.opengsn.org/javascript-client/tutorial.html).
 - [The SafeMath library](https://ethereumdev.io/using-safe-math-library-to-prevent-from-overflows/), which is used to make
   addition and subtraction without overflows. This is necessary because otherwise a person might somehow have one token, spend
   two tokens, and then have 2^256-1 tokens.


### PR DESCRIPTION
Updates index.md to have the OpenGSN link point to the new implementation webpage.
Currently, the reader is redirected to a 404 page.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
