### PR TITLE
Throw error if MDX page is missing "lang" prop

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -141,7 +141,7 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
       slug.includes(`/terms-of-use/`) ||
       slug.includes(`/contributing/`)
     const language = node.frontmatter.lang
-    if (!!language) {
+    if (!language) {
       throw `Missing 'lang' frontmatter property. All markdown pages must have a lang property. Page slug: ${slug}`
     }
     const relativePath = node.fields.relativePath


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Checks that `lang` property exists & throws error if not.

## Related Issue
This should help us catch issues like #4251 more easily.
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
