### PR TITLE
Add redirect from APIs page to Javascript APIs page

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -302,9 +302,6 @@
 [[redirects]]
   from = "/*/developers/docs/layer-2-scaling"
   to = "/:splat/developers/docs/scaling"
-[[redirects]]
-  from = "/*/developers/docs/api"
-  to = "/:splat/developers/docs/javascript/"
 
 # Jobs
 [[redirects]]

--- a/src/components/DeveloperDocsLinks.js
+++ b/src/components/DeveloperDocsLinks.js
@@ -12,9 +12,13 @@ const DeveloperDocsLinks = ({ headerId }) =>
         {items &&
           items.map(({ id, to, path, description, items }) => (
             <ListItem>
-              <Link to={to || path}>
+              {to || path ? (
+                <Link to={to || path}>
+                  <Translation id={id} />
+                </Link>
+              ) : (
                 <Translation id={id} />
-              </Link>
+              )}
               <i>
                 {" – "}
                 <Translation id={description} />

--- a/src/data/developer-docs-links.yaml
+++ b/src/data/developer-docs-links.yaml
@@ -88,7 +88,6 @@
       to: /developers/docs/frameworks/
       description: docs-nav-development-frameworks-description
     - id: docs-nav-ethereum-client-apis
-      path: /developers/docs/apis/
       description: docs-nav-ethereum-client-apis-description
       items:
         - id: docs-nav-java-script-apis


### PR DESCRIPTION
## Description
On our [Overview page](https://ethereum.org/en/developers/docs/) of the developer docs, we show the top-level links in the Docs sidebar.  

The 'Ethereum APIs' sidebar link is a dropdown for the other API pages (does not have a page itself) which causes us to link to a page that does not exist.

This PR re-directs to the first link in the dropdown (Javascript API page)

## Related Issue
Fixes #4250
