### PR TITLE
Single quote issue in npm install [Fixes #4268]

### DIFF
--- a/src/content/developers/tutorials/how-to-write-and-deploy-an-nft/index.md
+++ b/src/content/developers/tutorials/how-to-write-and-deploy-an-nft/index.md
@@ -244,7 +244,7 @@ Hardhat makes it super easy to integrate [Plugins](https://hardhat.org/plugins/)
 
 In your project directory type:
 
-    npm install --save-dev @nomiclabs/hardhat-ethers 'ethers@^5.0.0'
+    npm install --save-dev @nomiclabs/hardhat-ethers ethers@^5.0.0
 
 We’ll also require ethers in our hardhat.config.js in the next step.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Single quotes for ethers.js is creating issue in npm install as it converts single quote to %27 when search in npm repo.
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/ethereum/ethereum-org-website/issues/4268
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
