### PR TITLE
Fixed translation bug on Chinese simplified wallets page [Fixes #4145]

### DIFF
--- a/src/intl/zh/page-wallets-find-wallet.json
+++ b/src/intl/zh/page-wallets-find-wallet.json
@@ -90,7 +90,7 @@
   "page-find-wallet-we-found": "我们发现",
   "page-find-wallet-withdraw": "变现至银行",
   "page-find-wallet-withdraw-desc": "无需交易所，您就可以将您的ETH直接变现并存入您的银行账户。",
-  "page-find-wallet-yet": "没有",
+  "page-find-wallet-yet": "",
   "page-find-wallet-zengo-logo-alt": "ZenGo徽标",
   "page-stake-eth": "质押ETH"
 }


### PR DESCRIPTION
# Fixed Bug/mistranslation on Chinese tutorials/find wallets page 

## Description

I changed:
- "page-find-wallet-yet": "no need to translate here",

to:
-  "page-find-wallet-yet": "",

yet is already on the beggining of the sentence, so there is no need to translate at the end.

## Related Issue

Bug/mistranslation, please see issue:
ref: #4145
