### PR TITLE
Non-english pages link to English pages in footer navigation

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -135,11 +135,6 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
       template = `docs`
     }
 
-    const isLegal =
-      slug.includes(`/cookie-policy/`) ||
-      slug.includes(`/privacy-policy/`) ||
-      slug.includes(`/terms-of-use/`) ||
-      slug.includes(`/contributing/`)
     const language = node.frontmatter.lang
     if (!language) {
       throw `Missing 'lang' frontmatter property. All markdown pages must have a lang property. Page slug: ${slug}`
@@ -149,7 +144,7 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
     // If markdown file is English, check for corresponding file in each language.
     // e.g. English file: "src/content/community/index.md"
     // e.g. corresponding German file: "src/content/translations/de/community/index.md"
-    if (language === defaultLanguage && !isLegal) {
+    if (language === defaultLanguage) {
       for (const lang of supportedLanguages) {
         const splitPath = relativePath.split("/")
         splitPath.splice(2, 0, `translations/${lang}`)

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -135,6 +135,11 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
       template = `docs`
     }
 
+    const isLegal =
+      slug.includes(`/cookie-policy/`) ||
+      slug.includes(`/privacy-policy/`) ||
+      slug.includes(`/terms-of-use/`) ||
+      slug.includes(`/contributing/`)
     const language = node.frontmatter.lang
     if (!language) {
       throw `Missing 'lang' frontmatter property. All markdown pages must have a lang property. Page slug: ${slug}`
@@ -159,6 +164,7 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
             component: path.resolve(`./src/templates/${template}.js`),
             context: {
               slug: langSlug,
+              ignoreTranslationBanner: isLegal,
               isOutdated: false,
               isContentEnglish: true,
               relativePath: relativePath, // Use English path for template MDX query

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -286,7 +286,7 @@ const Footer = () => {
           text: "jobs",
         },
         {
-          to: "/en/contributing/",
+          to: "/contributing/",
           text: "contributing",
         },
         {
@@ -294,15 +294,15 @@ const Footer = () => {
           text: "language-support",
         },
         {
-          to: "/en/privacy-policy/",
+          to: "/privacy-policy/",
           text: "privacy-policy",
         },
         {
-          to: "/en/terms-of-use/",
+          to: "/terms-of-use/",
           text: "terms-of-use",
         },
         {
-          to: "/en/cookie-policy/",
+          to: "/cookie-policy/",
           text: "cookie-policy",
         },
         {

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -82,6 +82,7 @@ const Layout = (props) => {
 
   const isPageLanguageEnglish = intl.language === intl.defaultLanguage
   const isPageContentEnglish = !!props.pageContext.isContentEnglish
+  const isTranslationBannerIgnored = !props.pageContext.ignoreTranslationBanner
   const isPageTranslationOutdated =
     !!props.pageContext.isOutdated ||
     !!props.data?.pageData?.frontmatter?.isOutdated
@@ -90,7 +91,7 @@ const Layout = (props) => {
   const shouldShowTranslationBanner =
     (isPageTranslationOutdated ||
       (isPageContentEnglish && !isPageLanguageEnglish)) &&
-    !props.pageContext.ignoreTranslationBanner
+    isTranslationBannerIgnored
 
   const path = props.path
 

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -88,8 +88,9 @@ const Layout = (props) => {
   const isPageRightToLeft = isLangRightToLeft(intl.language)
 
   const shouldShowTranslationBanner =
-    isPageTranslationOutdated ||
-    (isPageContentEnglish && !isPageLanguageEnglish)
+    (isPageTranslationOutdated ||
+      (isPageContentEnglish && !isPageLanguageEnglish)) &&
+    !props.pageContext.ignoreTranslationBanner
 
   const path = props.path
 


### PR DESCRIPTION
## Description
- Removed isLegal check as we want to produce these pages for the lang in english
- removed the /en/ in the footer to keep user on their lang

## Related Issue
Fixes: https://github.com/ethereum/ethereum-org-website/issues/4001
