### PR TITLE
remove a word for better grammar

### DIFF
--- a/src/content/dao/index.md
+++ b/src/content/dao/index.md
@@ -54,7 +54,7 @@ There are different models for DAO membership. Membership can determine how voti
 
 ### Token-based membership {#token-based-membership}
 
-Usually fully permissionless, depending on the token used. Mostly these governance tokens can be traded for permissionlessly on a decentralized exchange. Others must be earned through providing liquidity or some other ‘proof of work’. Either way, simply holding the token grants access to voting.
+Usually fully permissionless, depending on the token used. Mostly these governance tokens can be traded permissionlessly on a decentralized exchange. Others must be earned through providing liquidity or some other ‘proof of work’. Either way, simply holding the token grants access to voting.
 
 _Typically used to govern broad decentralized protocols and/or tokens themselves._
 


### PR DESCRIPTION
content of post remains the same

<!--- Provide a general summary of your changes in the Title above -->

## Sentence read: "Mostly these governance tokens can be traded for permissionlessly on a decentralized exchange."

Sentence now reads: 
Mostly these governance tokens can be traded permissionlessly on a decentralized exchange.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
