### PR TITLE
Change dead Discord invitation link for Eth Staker

### DIFF
--- a/src/content/community/index.md
+++ b/src/content/community/index.md
@@ -33,6 +33,7 @@ Hundreds of thousands of Ethereum enthusiasts gather in these online forums to s
   - [Ethereum Cat Herders](https://discord.gg/tzYmDmF) - _community oriented around offering project management support to Ethereum development_
   - [Ethereum Hackers](https://ethglobal.co/discord) - _Discord chat run by [ETHGlobal](https://www.ethglobal.co/): an online community for Ethereum hackers all over the world_
   - [CryptoDevs Discord](https://discord.gg/5W5tVb3) - _Ethereum development focused Discord community_
+  - [EthStaker Discord](https://discord.io/ethstaker) - _Support for the [Beacon Chain](/eth2/beacon-chain/) staking community_
   - [ethereum.org Website Team](https://discord.gg/CetY6Y4) - _Stop by and chat ethereum.org web design with the team and folks from the community_
 - Twitter
   - The Ethereum community is very active on Twitter - not sure where to start?


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

The Discord invitation is dead: https://discord.gg/NvCxbCu

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
