### PR TITLE
English TimeToRead for Chinese Tutorials #4083

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -125,6 +125,8 @@ module.exports = {
     // Image support in markdown
     `gatsby-remark-images`,
     `gatsby-remark-copy-linked-files`,
+    // READING time
+    "gatsby-remark-reading-time",
     // MDX support
     {
       resolve: `gatsby-plugin-mdx`,

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "gatsby-remark-images": "^6.0.0",
     "gatsby-source-filesystem": "^4.0.0",
     "gatsby-transformer-csv": "^4.0.0",
+    "gatsby-remark-reading-time": "^1.1.0",
     "gatsby-transformer-gitinfo": "^1.1.0",
     "gatsby-transformer-remark": "^3.0.0",
     "gatsby-transformer-sharp": "^4.0.0",

--- a/src/components/TutorialMetadata.js
+++ b/src/components/TutorialMetadata.js
@@ -115,7 +115,7 @@ const TutorialMetadata = ({ tutorial, data }) => {
         )}
         <DataContainer>
           <Emoji size={1} mr={`0.5em`} text=":stopwatch:" />
-          {tutorial.timeToRead}{" "}
+          {Math.round(tutorial.fields.readingTime.minutes)}{" "}
           <Translation id="comp-tutorial-metadata-minute-read" />
         </DataContainer>
       </HorizontalContainer>

--- a/src/pages/developers/tutorials.js
+++ b/src/pages/developers/tutorials.js
@@ -223,7 +223,7 @@ const TutorialsPage = ({ data, pageContext }) => {
     author: tutorial.frontmatter.author,
     tags: tutorial.frontmatter.tags.map((tag) => tag.toLowerCase().trim()),
     skill: tutorial.frontmatter.skill,
-    timeToRead: tutorial.fields.readingTime.minutes,
+    timeToRead: Math.round(tutorial.fields.readingTime.minutes),
     published: tutorial.frontmatter.published,
     lang: tutorial.frontmatter.lang || "en",
     isExternal: false,

--- a/src/pages/developers/tutorials.js
+++ b/src/pages/developers/tutorials.js
@@ -223,7 +223,7 @@ const TutorialsPage = ({ data, pageContext }) => {
     author: tutorial.frontmatter.author,
     tags: tutorial.frontmatter.tags.map((tag) => tag.toLowerCase().trim()),
     skill: tutorial.frontmatter.skill,
-    timeToRead: tutorial.timeToRead,
+    timeToRead: tutorial.fields.readingTime.minutes,
     published: tutorial.frontmatter.published,
     lang: tutorial.frontmatter.lang || "en",
     isExternal: false,
@@ -487,6 +487,9 @@ export const query = graphql`
       nodes {
         fields {
           slug
+          readingTime {
+            minutes
+          }
         }
         frontmatter {
           title
@@ -497,7 +500,6 @@ export const query = graphql`
           published
           lang
         }
-        timeToRead
       }
     }
   }

--- a/src/templates/tutorial.js
+++ b/src/templates/tutorial.js
@@ -210,6 +210,9 @@ export const query = graphql`
     pageData: mdx(fields: { relativePath: { eq: $relativePath } }) {
       fields {
         slug
+        readingTime {
+          minutes
+        }
       }
       frontmatter {
         title
@@ -228,7 +231,6 @@ export const query = graphql`
       }
       body
       tableOfContents
-      timeToRead
     }
   }
 `

--- a/yarn.lock
+++ b/yarn.lock
@@ -8106,6 +8106,13 @@ gatsby-source-filesystem@^4.0.0:
     valid-url "^1.0.9"
     xstate "^4.25.0"
 
+gatsby-remark-reading-time@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/gatsby-remark-reading-time/-/gatsby-remark-reading-time-1.1.0.tgz#f23590ae34233c3625e656e0368ad0e0e84761a1"
+  integrity sha512-J2I/Aerw6iEcYUs9MH5r7Ky5PIe7Aiq7+M3sDWdRa0ddWYIOZGxPq8U1xYsIBwQjVtPovk8N4aMTau9kjQQLQA==
+  dependencies:
+    reading-time "^1.1.3"
+
 gatsby-telemetry@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/gatsby-telemetry/-/gatsby-telemetry-3.3.0.tgz#7658093996a50055218443374c3f570ba134f2ba"
@@ -13596,6 +13603,11 @@ readdirp@~3.6.0:
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
+
+reading-time@^1.1.3:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/reading-time/-/reading-time-1.5.0.tgz#d2a7f1b6057cb2e169beaf87113cc3411b5bc5bb"
+  integrity sha512-onYyVhBNr4CmAxFsKS7bz+uTLRakypIe4R+5A824vBSkQy/hB3fZepoVEf8OVAxzLvK+H/jm9TzpI3ETSm64Kg==
 
 recharts-scale@^0.4.2:
   version "0.4.5"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Make the Chinese developer Tutorials Page use English TimeToRead till [this PR](https://github.com/gatsbyjs/gatsby/pull/25533) is merged.

Please, keep in mind that this is just a temporary fix.

<!--- Describe your changes in detail -->

## Related Issue

- #4083 
- https://github.com/gatsbyjs/gatsby/issues/25532
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
