### PR TITLE
Fix typo in README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ $ git push
 
 There may be times where you develop features that make external API requests to other services. For these we write lambda functions to obfuscate API keys. In order to test these locally, you will need to do the following:
 
-1. Download a CORS enabling browswer extension (ex: https://chrome.google.com/webstore/search/cors).
+1. Download a CORS enabling browser extension (ex: https://chrome.google.com/webstore/search/cors).
 2. Enable CORS in the downloaded browser extension.
 3. Add the relevant API key to the `.env` file.
 4. After you have started your development server for ethereum.org (above), start up a netlify lambda server using:


### PR DESCRIPTION
Typo in Readme file

<!--- Provide a general summary of your changes in the Title above -->

## Description
There was a typo in line number 142, corrected it to 'browser'
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
