### PR TITLE
Removes Altair notification banner

### DIFF
--- a/src/components/UpgradeBannerNotification.js
+++ b/src/components/UpgradeBannerNotification.js
@@ -14,7 +14,7 @@ const StyledEmoji = styled(Emoji)`
   flex-shrink: 0;
 `
 
-export default () => (
+export default UpgradeBannerNotification = () => (
   <StyledBannerNotification shouldShow>
     <StyledEmoji text=":megaphone:" />
     <div>

--- a/src/pages/eth2/index.js
+++ b/src/pages/eth2/index.js
@@ -15,7 +15,6 @@ import GhostCard from "../../components/GhostCard"
 import InfoBanner from "../../components/InfoBanner"
 import Link from "../../components/Link"
 import PageMetadata from "../../components/PageMetadata"
-import UpgradeBannerNotification from "../../components/UpgradeBannerNotification"
 import Translation from "../../components/Translation"
 import PageHero from "../../components/PageHero"
 import {
@@ -272,7 +271,6 @@ const Eth2IndexPage = ({ data }) => {
         title={translateMessageId("page-eth2-meta-title", intl)}
         description={translateMessageId("page-eth2-meta-desc", intl)}
       />
-      <UpgradeBannerNotification />
       <PageHero content={heroContent} />
       <Divider />
       <Content>

--- a/src/pages/eth2/vision.js
+++ b/src/pages/eth2/vision.js
@@ -14,7 +14,6 @@ import PageHero from "../../components/PageHero"
 import Breadcrumbs from "../../components/Breadcrumbs"
 import ButtonLink from "../../components/ButtonLink"
 import PageMetadata from "../../components/PageMetadata"
-import UpgradeBannerNotification from "../../components/UpgradeBannerNotification"
 import {
   CardContainer,
   Content,
@@ -126,7 +125,6 @@ const VisionPage = ({ data, location }) => {
         title={translateMessageId("page-eth2-vision-meta-title", intl)}
         description={translateMessageId("page-eth2-vision-meta-desc", intl)}
       />
-      <UpgradeBannerNotification />
       <PageHero content={heroContent} />
       <Divider />
       <Content>

--- a/src/templates/eth2.js
+++ b/src/templates/eth2.js
@@ -7,7 +7,6 @@ import styled from "styled-components"
 import Img from "gatsby-image"
 import ButtonLink from "../components/ButtonLink"
 import ButtonDropdown from "../components/ButtonDropdown"
-import UpgradeBannerNotification from "../components/UpgradeBannerNotification"
 import Breadcrumbs from "../components/Breadcrumbs"
 import Card from "../components/Card"
 import Icon from "../components/Icon"
@@ -382,7 +381,6 @@ const Eth2Page = ({ data, data: { mdx } }) => {
 
   return (
     <Container>
-      <UpgradeBannerNotification />
       <HeroContainer>
         <TitleCard>
           <DesktopBreadcrumbs slug={mdx.fields.slug} startDepth={1} />


### PR DESCRIPTION
## Description
Altair is live and participation has been over 98%. This removes the call-to-action for node operators from the `/eth2` pages. Well done everyone!
