### PR TITLE
Fix typo in layer-2 developer docs

### DIFF
--- a/src/content/developers/docs/scaling/layer-2-rollups/index.md
+++ b/src/content/developers/docs/scaling/layer-2-rollups/index.md
@@ -101,7 +101,7 @@ Being on layer 2, ZK-rollups can be optimised to reduce transaction size further
 | ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
 | Faster finality time since the state is instantly verified once the proofs are sent to the main chain.            | Some don't have EVM support.                                                                          |
 | Not vulnerable to the economic attacks that [Optimistic rollups](#optimistic-pros-and-cons) can be vulnerable to. | Validity proofs are intense to compute – not worth it for applications with little on-chain activity. |
-| Secure and decentralized, since the data that is needed to recover the state is stored on the layer 1 chain.      | An operator can influence transaction. ordering                                                       |
+| Secure and decentralized, since the data that is needed to recover the state is stored on the layer 1 chain.      | An operator can influence transaction ordering                                                       |
 
 #### A visual explanation of ZK-rollups {#zk-video}
 


### PR DESCRIPTION
The dot between transaction and ordering should be deleted.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
