### PR TITLE
Fix typo in web2-vs-web3 developer docs

### DIFF
--- a/src/content/developers/docs/web2-vs-web3/index.md
+++ b/src/content/developers/docs/web2-vs-web3/index.md
@@ -55,4 +55,4 @@ Note that these are general patterns that may not hold true in every network. Fu
 
 - [The Meaning of Decentralization](https://medium.com/@VitalikButerin/the-meaning-of-decentralization-a0c92b76a274) _Feb 6, 2017 - Vitalik Buterin_
 - [Why Decentralization Matters](https://medium.com/s/story/why-decentralization-matters-5e3f79f7638e) _Feb 18, 2018 - Chris Dixon_
-- [What Is Web 3.0 & Why It Matters](https://medium.com/fabric-ventures/what-is-web-3-0-why-it-matters-934eb07f3d2b) _Dec 31, 2019 - Max Mersch_ and Richard Muirhead\_
+- [What Is Web 3.0 & Why It Matters](https://medium.com/fabric-ventures/what-is-web-3-0-why-it-matters-934eb07f3d2b) _Dec 31, 2019 - Max Mersch and Richard Muirhead_


### PR DESCRIPTION
Looks like a typo to me.

## Description

Formatting only.

## Related Issue

Sorry, no related issue.  I hope this is useful nevertheless.