### PR TITLE
Fix typo in proof-of-work description in the consensus mechanisms developer docs

### DIFF
--- a/src/content/developers/docs/consensus-mechanisms/pow/index.md
+++ b/src/content/developers/docs/consensus-mechanisms/pow/index.md
@@ -62,7 +62,7 @@ Miners who successfully create a block get rewarded with two freshly minted ETH 
 
 A transaction has "finality" on Ethereum when it's part of a block that can't change.
 
-Because miners work in a decentralized way, two valid blocks can get mined at the same time. This creates a temporary fork. Eventually, one of these chains will become the accepted chained after a subsequent block has been mined and added, making it longer.
+Because miners work in a decentralized way, two valid blocks can get mined at the same time. This creates a temporary fork. Eventually, one of these chains will become the accepted chain after a subsequent block has been mined and added, making it longer.
 
 But to complicate things further, transactions rejected on the temporary fork may have been included in the accepted chain. This means it could get reversed. So finality refers to the time you should wait before considering a transaction irreversible. For Ethereum, the recommended time is six blocks or just over 1 minute. After six blocks, you can say with relative confidence that the transaction was successful. You can wait longer for even greater assurances.
 


### PR DESCRIPTION
## Description

Tiny typo I found while cruising the documentation.
