### PR TITLE
Fix punctuation in smart contracts developer doc

### DIFF
--- a/src/content/developers/docs/smart-contracts/index.md
+++ b/src/content/developers/docs/smart-contracts/index.md
@@ -9,7 +9,7 @@ sidebar: true
 
 A "smart contract" is simply a program that runs on the Ethereum blockchain. It's a collection of code (its functions) and data (its state) that resides at a specific address on the Ethereum blockchain.
 
-Smart contracts are a type of [Ethereum account](/developers/docs/accounts/). This means they have a balance and they can send transactions over the network. However they're not controlled by a user, instead they are deployed to the network and run as programmed. User accounts can then interact with a smart contract by submitting transactions that execute a function defined on the smart contract. Smart contracts can define rules, like a regular contract, and automatically enforce them via the code. Smart contracts can not be deleted by default, and interactions with them are irreversible.
+Smart contracts are a type of [Ethereum account](/developers/docs/accounts/). This means they have a balance and they can send transactions over the network. However they're not controlled by a user, instead they are deployed to the network and run as programmed. User accounts can then interact with a smart contract by submitting transactions that execute a function defined on the smart contract. Smart contracts can define rules, like a regular contract, and automatically enforce them via the code. Smart contracts cannot be deleted by default, and interactions with them are irreversible.
 
 ## Prerequisites {#prerequisites}
 


### PR DESCRIPTION
Fixed punctuation 

<!--- Provide a general summary of your changes in the Title above -->

## Description
Added space for the word 'cannot' on line number 12
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
