### PR TITLE
Fix typo in glossary for 'ether' description

### DIFF
--- a/src/content/glossary/index.md
+++ b/src/content/glossary/index.md
@@ -215,7 +215,7 @@ A [proof-of-work](#pow) algorithm for Ethereum 1.0.
 
 ### ether {#ether}
 
-The native cryptocurrency used by the Ethereum ecosystem, which covers [gas](#gas) costs when executing transactions. Also writen as ETH or its symbol Ξ, the Greek uppercase Xi character.
+The native cryptocurrency used by the Ethereum ecosystem, which covers [gas](#gas) costs when executing transactions. Also written as ETH or its symbol Ξ, the Greek uppercase Xi character.
 
 <DocLink to="/eth/" title="Currency for our digital future" />
 


### PR DESCRIPTION
A typo

<!--- Provide a general summary of your changes in the Title above -->

## Description
Typo for a word on line number 218
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
