### PR TITLE
Add description/purpose to Eth R&D Discord link

### DIFF
--- a/src/content/community/index.md
+++ b/src/content/community/index.md
@@ -33,7 +33,7 @@ Hundreds of thousands of Ethereum enthusiasts gather in these online forums to s
   - [Ethereum Hackers](https://ethglobal.co/discord) - _Discord chat run by [ETHGlobal](https://www.ethglobal.co/): an online community for Ethereum hackers all over the world_
   - [CryptoDevs Discord](https://discord.gg/5W5tVb3) - _Ethereum development focused Discord community_
   - [EthStaker Discord](https://discord.io/ethstaker) - _Support for the [Beacon Chain](/eth2/beacon-chain/) staking community_
-  - [Eth R&D Discord](https://discord.gg/qGpsxSA) - _Not for individual support or assistance. Strictly for focused discussions around core protocol development_
+  - [Eth R&D Discord](https://discord.gg/qGpsxSA) - _Strictly for focused discussions around core protocol development (Not for individual support or assistance)_
   - [ethereum.org Website Team](https://discord.gg/CetY6Y4) - _Stop by and chat ethereum.org web design with the team and folks from the community_
 - Twitter
   - The Ethereum community is very active on Twitter - not sure where to start?

--- a/src/content/community/index.md
+++ b/src/content/community/index.md
@@ -28,12 +28,12 @@ Hundreds of thousands of Ethereum enthusiasts gather in these online forums to s
   - [Ethereum Stackexchange](https://ethereum.stackexchange.com) - _discussion and help for Ethereum developers_
   - [Ethereum Research](https://ethresear.ch) - _the most influential messageboard for cryptoeconomic research_
 - Chat rooms
-  - [Eth R&D Discord server](https://discord.gg/qGpsxSA)
   - [Ethereum Gitter](https://gitter.im/ethereum/home) - _chat room for the Ethereum GitHub repo_
   - [Ethereum Cat Herders](https://discord.gg/tzYmDmF) - _community oriented around offering project management support to Ethereum development_
   - [Ethereum Hackers](https://ethglobal.co/discord) - _Discord chat run by [ETHGlobal](https://www.ethglobal.co/): an online community for Ethereum hackers all over the world_
   - [CryptoDevs Discord](https://discord.gg/5W5tVb3) - _Ethereum development focused Discord community_
   - [EthStaker Discord](https://discord.io/ethstaker) - _Support for the [Beacon Chain](/eth2/beacon-chain/) staking community_
+  - [Eth R&D Discord](https://discord.gg/qGpsxSA) - _Not for individual support or assistance. Strictly for focused discussions around core protocol development_
   - [ethereum.org Website Team](https://discord.gg/CetY6Y4) - _Stop by and chat ethereum.org web design with the team and folks from the community_
 - Twitter
   - The Ethereum community is very active on Twitter - not sure where to start?


### PR DESCRIPTION
Quite a few people seem to come to the Eth R&D Discord asking support
questions, even though that is explicitly not allowed in that server
according to its #welcome message.

One possible reason this happens is that it is the first Discord/chat
entry they see on the "community" page. To redirect users to a more
appropriate chat room/server we:

- Elaborate that the Eth R&D Discord is _not_ for support questions, and
  only for focused technical discussions.

- move it down on the list, such that it is not the first link people
  see if they are looking for a chat room to ask for support in.
