### PR TITLE
Fix typo in erc-20 tutorial

### DIFF
--- a/src/content/developers/tutorials/understand-the-erc-20-token-smart-contract/index.md
+++ b/src/content/developers/tutorials/understand-the-erc-20-token-smart-contract/index.md
@@ -37,7 +37,7 @@ interface IERC20 {
 }
 ```
 
-Here is a line-by-line explainer of what every function is for. After this we’ll present a simple implementation of the a ERC-20 token.
+Here is a line-by-line explainer of what every function is for. After this we’ll present a simple implementation of the ERC-20 token.
 
 ## Getters {#getters}
 


### PR DESCRIPTION
Corrected a sentence

<!--- Provide a general summary of your changes in the Title above -->

## Description
Removed letter 'a' to correct the sentence on line number 40
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
