### PR TITLE
Update link to geth installation instructions

### DIFF
--- a/src/content/developers/tutorials/run-light-node-geth/index.md
+++ b/src/content/developers/tutorials/run-light-node-geth/index.md
@@ -11,7 +11,7 @@ published: 2020-06-14
 
 You may be interested in running an [Ethereum node](/developers/docs/nodes-and-clients/). One of the easiest ways to do so is by downloading, installing, and running Geth. With Geth, we can have a light node up and running in minutes.
 
-First, you’ll want to [install Geth](https://github.com/ethereum/go-ethereum/wiki/Building-Ethereum).
+First, you’ll want to [install Geth](https://geth.ethereum.org/docs/install-and-build/installing-geth).
 
 Once you’ve installed Geth, running an Ethereum full node is as simple as typing
 

--- a/src/content/translations/pl/developers/tutorials/run-light-node-geth/index.md
+++ b/src/content/translations/pl/developers/tutorials/run-light-node-geth/index.md
@@ -14,7 +14,7 @@ published: 2020-06-14
 
 Możesz być zainteresowany uruchomieniem [węzła Ethereum](/developers/docs/nodes-and-clients/). Jednym z najprostszych sposobów jest pobieranie, instalowanie i uruchamianie Geth. Dzięki Geth możemy uruchomić lekki węzeł w ciągu kilku minut.
 
-Najpierw musisz [zainstalować Geth](https://github.com/ethereum/go-ethereum/wiki/Building-Ethereum).
+Najpierw musisz [zainstalować Geth](https://geth.ethereum.org/docs/install-and-build/installing-geth).
 
 Po zainstalowaniu Getha uruchomienie pełnego węzła Ethereum jest tak proste, jak pisanie
 

--- a/src/content/translations/ro/developers/tutorials/run-light-node-geth/index.md
+++ b/src/content/translations/ro/developers/tutorials/run-light-node-geth/index.md
@@ -11,7 +11,7 @@ published: 2020-06-14
 
 Probabil ești interesat să rulezi un [nod Ethereum](/developers/docs/noses-and-clients/). Unul dintre cele mai simple moduri de a face acest lucru este prin descărcarea, instalarea și rularea Geth. Cu Geth, putem avea un nod ușor gata și funcțional în câteva minute.
 
-Mai întâi, trebuie să [instalezi Geth](https://github.com/ethereum/go-ethereum/wiki/Building-Ethereum).
+Mai întâi, trebuie să [instalezi Geth](https://geth.ethereum.org/docs/install-and-build/installing-geth).
 
 După ce ai instalat Geth, rularea unui nod complet Ethereum este la fel de simplă ca tastarea
 

--- a/src/content/translations/zh/developers/tutorials/run-light-node-geth/index.md
+++ b/src/content/translations/zh/developers/tutorials/run-light-node-geth/index.md
@@ -14,7 +14,7 @@ published: 2020-06-14
 
 您可能会对运行[以太坊节点](/developers/docs/nodes-and-clients/)感兴趣。 最简单的实现方式就是下载、安装和运行 Geth。 通过 Geth，我们只需数分钟便能设置并运行一个轻节点。
 
-首先，您将需要[安装 Geth](https://github.com/ethereum/go-ethereum/wiki/Building-Ethereum)。
+首先，您将需要[安装 Geth](https://geth.ethereum.org/docs/install-and-build/installing-geth)。
 
 安装 Geth 之后，只需在命令行中键入
 


### PR DESCRIPTION
## Description
Updates link on "How to run a light node with Geth" tutorial to https://github.com/ethereum/go-ethereum/wiki/Building-Ethereum from https://github.com/ethereum/go-ethereum/wiki/Building-Ethereum. Avoids extra navigation step for users. 

![image](https://user-images.githubusercontent.com/54227730/139731360-d9312695-5b57-440b-a2ea-660c6f3d2a6c.png)