### PR TITLE
Policy updates, adds Matomo opt-out option

### DIFF
--- a/src/components/MatomoOptOut.js
+++ b/src/components/MatomoOptOut.js
@@ -1,0 +1,80 @@
+import React, { useState, useEffect } from "react"
+import styled from "styled-components"
+import { MATOMO_LS_KEY } from "../utils/matomo"
+
+const Container = styled.div`
+  border: 1px solid ${({ theme }) => theme.colors.border};
+  background-color: ${({ theme }) => theme.colors.background};
+  border-radius: 4px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+  margin-top: 2rem;
+  align-items: flex-start;
+  justify-content: space-between;
+  p {
+    color: ${({ theme }) => theme.colors.fail};
+  }
+  form {
+    margin: 0;
+  }
+  input {
+    margin-right: 0.5rem;
+  }
+`
+
+const MatomoOptOut = () => {
+  const [loading, setLoading] = useState(true)
+  const [isOptedOut, setIsOptedOut] = useState(false)
+
+  useEffect(() => {
+    // Load user choice for Matomo tracking from localStorage
+    const savedOptOut = JSON.parse(localStorage.getItem(MATOMO_LS_KEY))
+    // If saved opt-out selection is `true` then set this as local checkbox state
+    // Else, instantiate localStorage value to `false`
+    if (savedOptOut) {
+      setIsOptedOut(true)
+    } else {
+      localStorage.setItem(MATOMO_LS_KEY, false)
+    }
+    setLoading(false)
+  }, [])
+
+  const handleCheckbox = ({ target: { checked } }) => {
+    // Set local opt-out state based on check mark
+    // Note: `checked` in the UI refers to being opted-in
+    setIsOptedOut(!checked)
+    // Save selection to localStorage
+    localStorage.setItem(MATOMO_LS_KEY, !checked)
+  }
+  return (
+    <Container>
+      <p>
+        You can opt out of being tracked by Matomo Analytics and prevent the
+        website from analysing the actions you take using the website. This will
+        prevent us from learning from your actions and creating a better website
+        experience for you and other users.
+      </p>
+      {loading ? (
+        "Loading preferences..."
+      ) : (
+        <form>
+          <input
+            type="checkbox"
+            id="matomo"
+            checked={!isOptedOut}
+            onChange={handleCheckbox}
+          />
+          <label for="matomo">
+            {isOptedOut
+              ? "You are opted out. Check this box to opt-in."
+              : "You are not opted out. Uncheck this box to opt-out."}
+          </label>
+        </form>
+      )}
+    </Container>
+  )
+}
+
+export default MatomoOptOut

--- a/src/content/cookie-policy/index.md
+++ b/src/content/cookie-policy/index.md
@@ -32,6 +32,8 @@ transferred to your computer's hard drive. We use the following cookies:
   websites, the pages you have visited and the links you have
   followed.
 
+<MatomoOptOut />
+
 You can find more information about the individual cookies we use and
 the purposes for which we use them in the table below:
 

--- a/src/content/privacy-policy/index.md
+++ b/src/content/privacy-policy/index.md
@@ -7,39 +7,28 @@ lang: en
 
 **1. General information**
 
-Stiftung Ethereum, a Swiss Stiftung, located at Zeughausgasse 7a, 6300
-Zug, Switzerland (the "Foundation," "we" or "us") is the operator
-of this website, together with ethereum.org, ethereum.foundation, devcon.org or
-blog.ethereum.org (each a "website" and together, our "websites"). As
-the operator of the sites, we take the protection of your personal data
-very seriously. We collect, process and use your personal data in
-accordance with this privacy policy and in compliance with the Swiss
-Federal Act on Data Protection ("FADP"), the Swiss Ordinance to the
-Federal Act on Data Protection ("OFADP") and the General European Data
-Protection Regulation ("GDPR").
+Stiftung Ethereum, a Swiss Stiftung, located at Zeughausgasse 7a, 6300 Zug, Switzerland (the "Foundation," "we" or "us") is the operator of this website, together with ethereum.org, ethereumfoundation.org or blog.ethereum.org (each a "website" and together, our "websites"). As the operator of the sites, we take the protection of your personal data very seriously. We collect, process and use your personal data in accordance with this privacy policy and in compliance with the Swiss Federal Act on Data Protection ("FADP"), the Swiss Ordinance to the Federal Act on Data Protection ("OFADP") and the General European Data Protection Regulation ("GDPR").
 
-This privacy policy ("Privacy Policy") will provide you with information
-about the collection, processing and use of your personal data when
-using our websites.
+This privacy policy ("Privacy Policy") will provide you with information about the collection, processing and use of your personal data when using our website.
 
-In case you provide us with the personal data of third persons (such as
-family members, work colleagues) you should make sure that these persons
-are familiar with this Privacy Policy and you should only share their
-personal data if you have permission to do so and ensure that his
-personal data is correct.
+In case you provide us with the personal data of third persons (such as family members, work colleagues) you should make sure that these persons are familiar with this Privacy Policy and you should only share their personal data if you have permission to do so and ensure that his personal data is correct.
 
 **2. Responsible Person**
+
+For any matters, relating to data protection you may contact <notices@ethereum.org> in writing by e-mail or letter to the following address:
 
 For any matters, relating to data protection you may contact
 <notices@ethereum.org> in writing by e-mail or letter to the following
 address:
 
-       Zeughausgasse 7A,
-       6302 Zug, Switzerland
-       Email: notices@ethereum.org
+    Ethereum Foundation
+    Zeughausgasse 7A,
+    6302 Zug, Switzerland
+    Email: notices@ethereum.org
 
 Our representative in the EU according to article 27 GDPR is:
 
+    Ethereum Dev GmbH
     Oranienstrasse 6, 10997 Berlin
     Email: notices@ethereum.org
 
@@ -47,121 +36,55 @@ Our representative in the EU according to article 27 GDPR is:
 
 **3.1 Visiting our websites**
 
-When you visit our website, the hosting provider of our website, Amazon
-Web Services (AWS) automatically collects and stores various information
-in so-called server log files that your browser transmits to us. The
-information/data mentioned is neither assigned to specific persons nor
-linked to data from other sources. The following technical data will be
-recorded by us, as usual with every connection with a web server,
-without your intervention, and stored by us until automatic deletion
-after no later than two days:
+When you visit our website, the hosting provider of our website, Amazon Web Services (AWS) automatically collects and stores various information in so-called server log files that your browser transmits to us. The information/data mentioned is neither assigned to specific persons nor linked to data from other sources. The following technical data will be recorded by us, as usual with every connection with a web server, without your intervention, and stored by us until automatic deletion after no later than two days:
 
 - Woocommerce cart data
 - Unique identification code for Woocommerce customer
+- Anonymized IP addresses
 
-The collection and processing of this technical data is for the purpose
-of enabling the use of our website, continuously ensuring system security
-and stability, optimising our website, and for internal statistical
-purposes. This is our legitimate interest in the processing of data in
-the sense of Art. 6 Par. 1 lit. f GDPR.
+The collection and processing of this technical data is for the purpose of enabling the use of our website, continuously ensuring system security and stability, optimising our website, and for internal statistical purposes. This is our legitimate interest in the processing of data in the sense of Art. 6 Par. 1 lit. f GDPR.
 
-Furthermore, the IP addresses will be evaluated, together with other
-data, in case of attacks on the network infrastructure or other
-unauthorised use or misuse of the website, for the purpose of
-intelligence and protection, and if appropriate, used in criminal
-proceedings for identification and civil and criminal proceedings
-against the relevant users. This is our legitimate interest in the
-processing of data in the sense of Art. 6 Par. 1 lit. f GDPR.
+Furthermore, the IP addresses will be evaluated, together with other data, in case of attacks on the network infrastructure or other unauthorised use or misuse of the website, for the purpose of intelligence and protection, and if appropriate, used in criminal proceedings for identification and civil and criminal proceedings against the relevant users. This is our legitimate interest in the processing of data in the sense of Art. 6 Par. 1 lit. f GDPR.
 
 **3.2 Use of Websites Cookies**
 
-The websites uses cookies. Cookies are text files that are stored in a
-computer system via an Internet browser. More detailed information on
-cookies and how they work can be found at:
-<http://www.allaboutcookies.org>.
+The website uses cookies. Cookies are text files that are stored in a computer system via an Internet browser. More detailed information on cookies and how they work can be found at: <http://www.allaboutcookies.org>.
 
-Many Internet sites and servers use cookies. Many cookies contain a
-so-called cookie ID. A cookie ID is a unique identifier of the cookie.
-It consists of a character string through which Internet pages and
-servers can be assigned to the specific Internet browser in which the
-cookie was stored. This allows visited Internet sites and servers to
-differentiate the individual browser of the data subject from other
-Internet browsers that contain other cookies. A specific Internet
-browser can be recognized and identified using the unique cookie ID.
+Many Internet sites and servers use cookies. Many cookies contain a so-called cookie ID. A cookie ID is a unique identifier of the cookie. It consists of a character string through which Internet pages and servers can be assigned to the specific Internet browser in which the cookie was stored. This allows visited Internet sites and servers to differentiate the individual browser of the data subject from other Internet browsers that contain other cookies. A specific Internet browser can be recognized and identified using the unique cookie ID.
 
-Through the use of cookies, the Foundation can provide the users of this
-website with more user-friendly services that would not be possible
-without the cookie setting.
+Through the use of cookies, the Foundation can provide the users of this website with more user-friendly services that would not be possible without the cookie setting.
 
-Cookies allow us, as previously mentioned, to recognize our websites
-users. The purpose of this recognition is to make it easier for users to
-utilize our websites. The websites user that uses cookies, e.g. does not
-have to enter access data each time the websites is accessed, because
-this is taken over by the website, and the cookie is thus stored on the
-user's computer system.
+Cookies allow us, as previously mentioned, to recognize our website users. The purpose of this recognition is to make it easier for users to utilize our website. The website user that uses cookies, e.g. does not have to enter access data each time the website is accessed, because this is taken over by the website, and the cookie is thus stored on the user's computer system.
 
-You may, at any time, prevent the setting of cookies through our
-websites by means of a corresponding setting of the Internet browser
-used, and may thus permanently deny the setting of cookies. Furthermore,
-previously set cookies may be deleted at any time via an Internet
-browser or other software programs. This is possible in all popular
-Internet browsers. If the data subject deactivates the setting of
-cookies in the Internet browser used, it may not be possible to use all
-the functions of our websites.
+You may, at any time, prevent the setting of cookies through our website by means of a corresponding setting of the Internet browser used, and may thus permanently deny the setting of cookies. Furthermore, previously set cookies may be deleted at any time via an Internet browser or other software programs. This is possible in all popular Internet browsers. If the data subject deactivates the setting of cookies in the Internet browser used, it may not be possible to use all the functions of our website.
 
-For detailed information on the cookies we use and the purposes for
-which we use them, see our Cookie Policy.
+For detailed information on the cookies we use and the purposes for which we use them, see our Cookie Policy.
 
-**3.3 Google Analytics**
+**3.3 Matomo Analytics**
 
-This websites also uses Google Analytics, a web analysis service
-provided by Google Inc. ("Google"). Google Inc. is an enterprise of
-the holding company Alphabet Inc., domiciled in the USA. The information
-generated by the cookie about your use of the websites (including your
-IP address) will be transmitted to and stored by Google on servers in
-the United States. Google will use this information for the purpose of
-evaluating your use of the website, compiling reports on websites
-activity and providing other services relating to websites activity and
-internet usage. Google may also transfer this information to third
-parties if this is required by law or if third parties process this data
-on behalf of Google.
+This website also uses Matomo, an open source web analytics platform ("Matomo Analytics"). The information generated by the cookie about your use of the website (including your automatically anonymized IP address) will be stored on the servers of our hosting provider Amazon Web Services (AWS) in the United States. For more information about Matomo Analytics, you can access a demo version at: https://demo.matomo.cloud.
 
-Generally, before the data is transmitted to the provider, the IP
-address will be abbreviated by activating IP anonymization (anonymizeIP)
-on this website, within the member states of the European Union or in
-other contracting states of the agreement on the European Economic Area.
-Only in exceptional cases will the full IP address be sent to a Google
-server in the USA and abbreviated there. In these cases, we provide
-contractual guarantees to ensure that Google Inc. maintains a sufficient
-level of data protection. According to Google Inc., under no
-circumstances will the IP address be associated with any other
-user-related data. More information about the web analytics service used
-is available at the websites of Google Analytics:
-<https://www.google.ch/policies/privacy/partners>
+Before the data is stored, the IP address will be abbreviated by activating IP anonymization (anonymizeIP) on this website.
 
-In addition to the data listed in section 3.1, we may receive the
-following information of Google Analytics:
+In addition to the data listed in section 3.1, we may receive the following information because of Matomo Analytics:
 
 - Navigation path
 - Length of stay on the website
 - Returning or new user
 - End device
 
-We do not use the information and personal data collected by Google
-Analytics to identify individuals unless we become aware of specific
-indications of illegal use.
+We will use this technical data to analyse your use of the website by compiling reports on website activity for the understanding and optimizing our website and for internal statistical purposes. We do not use the information and personal data collected by Matomo to identify individuals unless we become aware of specific indications of illegal use.
+
+The processing of this technical personal data is helping us identify what is working and what is not on our website and how we may improve our website. Without the data so received, we would not be able to provide you the service we are currently offering to you. Your data will be used only to improve the user experience on our website and help you find the information you are looking for.
+This is our legitimate interest in the processing of data in the sense of Art. 6 Par. 1 lit. f GDPR.
+
+<MatomoOptOut />
 
 **3.4 Opening an account for the Ethereum Web Forum**
 
-To access our forums at <https://forum.ethereum.org/> you must set up an
-account and provide us with your username, e-mail address, skype name,
-and password.
+To access our forums at <https://forum.ethereum.org/> you must set up an account and provide us with your username, e-mail address, skype name, and password.
 
-The collected data, which you have voluntarily provided is used for the
-purpose of providing your password-protected access to your base data we
-have stored. The legal basis for processing the data for this purpose
-lies in the consent you have provided in accordance with Art. 6 Par. 1
-lit. a GDPR.
+The collected data, which you have voluntarily provided is used for the purpose of providing your password-protected access to your base data we have stored. The legal basis for processing the data for this purpose lies in the consent you have provided in accordance with Art. 6 Par. 1 lit. a GDPR.
 
 **3.5 Contact possibility via the website**
 

--- a/src/templates/static.js
+++ b/src/templates/static.js
@@ -24,6 +24,7 @@ import TranslationsInProgress from "../components/TranslationsInProgress"
 import SectionNav from "../components/SectionNav"
 import DocLink from "../components/DocLink"
 import GhostCard from "../components/GhostCard"
+import MatomoOptOut from "../components/MatomoOptOut"
 import { getLocaleTimestamp } from "../utils/time"
 import { isLangRightToLeft } from "../utils/translations"
 import {
@@ -128,6 +129,7 @@ const components = {
   CardContainer,
   GhostCard,
   UpcomingEventsList,
+  MatomoOptOut,
 }
 
 const StaticPage = ({ data: { siteData, pageData: mdx }, pageContext }) => {

--- a/src/utils/matomo.js
+++ b/src/utils/matomo.js
@@ -1,3 +1,5 @@
+export const MATOMO_LS_KEY = "ethereum-org.matomo-opt-out"
+
 export const trackCustomEvent = ({
   eventCategory,
   eventAction,
@@ -5,7 +7,8 @@ export const trackCustomEvent = ({
   eventValue,
 }) => {
   if (process.env.NODE_ENV === "production" || window.dev === true) {
-    if (!window._paq) return
+    const isOptedOut = JSON.parse(localStorage.getItem(MATOMO_LS_KEY))
+    if (!window._paq || isOptedOut) return
 
     const { _paq, dev } = window
 


### PR DESCRIPTION
## Description
- Adds component that offers user the ability to opt-out of Matomo tracking. (`MatomoOptOut.js`)
- Uses `localStorage` to store this preference, and `utils/matomo.js` will check this before submitting an event, returning early if set to `true`
- Updated the cookie and privacy policies per legal team, adding the above component
