### PR TITLE
Fix typos in security learn page

### DIFF
--- a/src/content/security/index.md
+++ b/src/content/security/index.md
@@ -25,7 +25,7 @@ Example of a weak password: CuteFluffyKittens!
 Example of a strong password: ymv\*azu.EAC8eyp8umf
 ```
 
-Another common mistake is using passwords that can be easily guessed or found out through [social engineering](<https://en.wikipedia.org/wiki/Social_engineering_(security)>). Including your mother's maiden name, the name's of your children or pets, or dates of birth in your password is not secure and will increase the risk of your password getting hacked.
+Another common mistake is using passwords that can be easily guessed or found out through [social engineering](<https://en.wikipedia.org/wiki/Social_engineering_(security)>). Including your mother's maiden name, the names of your children or pets, or dates of birth in your password is not secure and will increase the risk of your password getting hacked.
 
 #### Good password practices: {#good-password-practices}
 
@@ -91,11 +91,11 @@ Watch more on the 2FA:
 
 <iframe width="100%" height="315px" src="https://www.youtube.com/embed/m8jlnZuV1i4?start=3479&end=3875" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-### Uninstall browser extentions {#uninstall-browser-extentions}
+### Uninstall browser extensions {#uninstall-browser-extensions}
 
 Browser extensions like Chrome extensions or Add-ons for Firefox can augment useful browser functionality and improve user experience, but they come with risks. By default, most browser extensions ask for access to 'read and change site data', allowing them to do almost anything with your data. Chrome extensions are always automatically updated, so a previously safe extension may update later to include malicious code. Most browser extensions are not trying to steal your data, but you should be aware that they can.
 
-#### Stay safe by: {#browser-extention-safety}
+#### Stay safe by: {#browser-extension-safety}
 
 - Only install browser extensions from trusted sources
 - Removing unused browser extensions


### PR DESCRIPTION
Fix typos in security doc
<!--- Provide a general summary of your changes in the Title above -->

## Description
Corrected typos on line number 28, 94 and 98., however I am quite skeptical about it, because some of them might be used as 'CSS Selectors' for webpage, so these changes might affect

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
