### PR TITLE
Prevent the page to scroll when modal search/menu is open [Fixes #4194]

### DIFF
--- a/src/components/Nav/index.js
+++ b/src/components/Nav/index.js
@@ -321,6 +321,12 @@ const Nav = ({ handleThemeChange, isDarkTheme, path }) => {
       setIsMenuOpen(false)
       setIsSearchOpen(false)
     }
+
+    if (isMenuOpen || isSearchOpen) {
+      document.documentElement.style.overflowY = "scroll"
+    } else {
+      document.documentElement.style.overflowY = "hidden"
+    }
   }
 
   const shouldShowSubNav = path.includes("/developers/")


### PR DESCRIPTION
## Description

Prevent the page to scroll when the screen is below 1025px wide and the navigation modal are open

Done by just stopping gatsby to force `overflow-y: scroll` when the hamburger menu or the search bar are open.

Done with @vluna
## Related Issue

 #https://github.com/ethereum/ethereum-org-website/issues/4194#event-5581859174
