### PR TITLE
Fix tutorial: 1 token is equal to 1 Wei, not 1 Ether in the buy() method

### DIFF
--- a/src/content/developers/tutorials/transfers-and-approval-of-erc-20-tokens-from-a-solidity-smart-contract/index.md
+++ b/src/content/developers/tutorials/transfers-and-approval-of-erc-20-tokens-from-a-solidity-smart-contract/index.md
@@ -153,7 +153,7 @@ Let’s code the buy function. We’ll first need to check the amount of ether t
 
 Note that if we call the require function in the case of an error the ether sent will directly be reverted and given back to the user.
 
-To keep things simple, we just exchange 1 token for 1 ether.
+To keep things simple, we just exchange 1 token for 1 Wei.
 
 ```solidity
 function buy() payable public {


### PR DESCRIPTION
## Description

The way the code for the `buy()` in this tutorial is written, 1 token is equal to 1 Wei, not 1 Ether. If I send one Ether (1000000000000000000 Wei) to the `buy()` method, I would recieve 1000000000000000000 tokens, not 1 token.

The wording of the sentence confused me and made me think there was a bug somewhere in the code or in my local development environment.