### PR TITLE
Add term Oracle to the Ethereum Glossary

### DIFF
--- a/src/content/glossary/index.md
+++ b/src/content/glossary/index.md
@@ -473,6 +473,12 @@ A [rollup](#rollups) of transactions that use [fraud proofs](#fraud-proof) to of
 
 <DocLink to="/developers/docs/scaling/layer-2-rollups/#optimistic-rollups" title="Optimistic Rollups" />
 
+### Oracle {#oracle}
+
+An oracle is a bridge between the [blockchain](#blockchain) and the real world. They act as on-chain [APIs](#api) that can be queried for information and used in [smart contracts](#smart-contract). This could be anything from price information to weather reports. Oracles can also be bi-directional, used to "send" data out to the real world.
+
+<DocLink to="/developers/docs/oracles/" title="Oracles" />
+
 <Divider />
 
 ## P {#section-p}

--- a/src/content/glossary/index.md
+++ b/src/content/glossary/index.md
@@ -475,7 +475,7 @@ A [rollup](#rollups) of transactions that use [fraud proofs](#fraud-proof) to of
 
 ### Oracle {#oracle}
 
-An oracle is a bridge between the [blockchain](#blockchain) and the real world. They act as on-chain [APIs](#api) that can be queried for information and used in [smart contracts](#smart-contract). This could be anything from price information to weather reports. Oracles can also be bi-directional, used to "send" data out to the real world.
+An oracle is a bridge between the [blockchain](#blockchain) and the real world. They act as on-chain [APIs](#api) that can be queried for information and used in [smart contracts](#smart-contract).
 
 <DocLink to="/developers/docs/oracles/" title="Oracles" />
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added the term "Oracle" to the Ethereum Glossary which was previously missing but was directly relevant to Ethereum.
The term was already extensively described here: https://ethereum.org/en/developers/docs/oracles/, but never actually added to the Glossary.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/ethereum/ethereum-org-website/issues/4309