### PR TITLE
Added Ethereum Studio to Deprecated Software

### DIFF
--- a/src/content/deprecated-software/index.md
+++ b/src/content/deprecated-software/index.md
@@ -28,12 +28,11 @@ Deprecated on December 10, 2020
 
 **Summary**
 
-Grid was a Javascript-based desktop application that allowed you to securely access Ethereum, IPFS, and other decentralized networks. It provided a user-friendly interface to assist a less technical audience in safely interacting with dapps, which increased accessibility for everyone. 
+Grid was a Javascript-based desktop application that allowed you to securely access Ethereum, IPFS, and other decentralized networks. It provided a user-friendly interface to assist a less technical audience in safely interacting with dapps, which increased accessibility for everyone.
 
 **Archives**
 
 [Archived GitHub repo](https://github.com/ethereum/grid)
-
 
 **History**
 
@@ -43,6 +42,31 @@ Grid could be seen as a successor to Mist, also a standalone, Javascript-based d
 
 [DappNode](https://dappnode.io/) is a platform for deploying and hosting DApps, P2P clients, and blockchain nodes.
 
+### Ethereum Studio {#grid}
+
+<p align="center">
+  <img width="500" height="350" 
+  	style="background-color:#fff; padding:0px 10px 0px 10px;"
+  	src="https://user-images.githubusercontent.com/7814134/78335917-d0f8e600-758e-11ea-91e1-2433eaaef6f4.png" />
+</p>
+
+Deprecated on December 7, 2020
+
+**Summary**
+
+Ethereum Studio was a web-based IDE which allowed users to create and test smart contracts, as well as build front-ends for them.
+
+**Archives**
+
+[Archived GitHub repo](https://github.com/SuperblocksHQ/ethereum-studio)
+
+**History**
+
+Ethereum Studio was developed to provide users with an IDE that had a built-in Ethereum blockchain and Solidity compiler. In addition to this it provided the ability to live edit code and export full DApps without the need for a terminal.
+
+**Alternatives**
+
+[Remix](https://remix.ethereum.org/) is an alternative web IDE for Solidity development. Additionally, the [Developer Portal](https://ethereum.org/en/developers/) has tools for web and local development, documentation, and more.
 
 ### Meteor Dapp Wallet {#meteor-dapp-wallet}
 
@@ -56,7 +80,7 @@ Deprecated on March 27, 2019
 
 **Summary**
 
-Meteor Dapp Wallet was a component of Mist, an Ethereum wallet for managing Ethereum accounts and interacting with smart contracts. For many years the Meteor Dapp Wallet web UI was hosted as a subdomain "wallet.ethereum.org". 
+Meteor Dapp Wallet was a component of Mist, an Ethereum wallet for managing Ethereum accounts and interacting with smart contracts. For many years the Meteor Dapp Wallet web UI was hosted as a subdomain "wallet.ethereum.org".
 
 The Mist Multisig Contract (solidity code) was also included, and Meteor Dapp Wallet featured a user interface for configuring and deploying it.
 
@@ -75,7 +99,6 @@ See Mist below.
 **Alternatives**
 
 See the [Ethereum Wallets](/wallets/) page on ethereum.org.
-
 
 ### Mist {#mist}
 
@@ -102,7 +125,6 @@ Mist was an important early experiment because it explored how to manage Ethereu
 **Alternatives**
 
 [Metamask](https://metamask.io/) is an in-browser wallet enabling you to manage Ethereum keys and interact with dapps. It is available as an extension for Google Chrome and Firefox, and is included in [Brave Browser](https://brave.com/).
-
 
 ### Mix {#mix}
 
@@ -152,7 +174,6 @@ The successor project to Parity Ethereum client is [Open Ethereum](https://githu
 
 The ["Spin up your own Ethereum node"](/developers/docs/nodes-and-clients/run-a-node/#getting-the-client) resource on ethereum.org includes a section for downloading, installing, and running an Ethereum client.
 
-
 ### Trinity {#trinity}
 
 <p align="center">
@@ -179,12 +200,11 @@ Trinity was the successor project to [pyethereum](https://github.com/ethereum/py
 
 The ["Spin up your own Ethereum node"](/developers/docs/nodes-and-clients/run-a-node/#getting-the-client) resource on ethereum.org includes a section for downloading, installing, and running an Ethereum client.
 
-The [EthereumJS](https://github.com/ethereumjs) project has a similar research and educational use-case as Trinity did. 
+The [EthereumJS](https://github.com/ethereumjs) project has a similar research and educational use-case as Trinity did.
 
 ## Dapps and Services {#dapps-and-services}
 
 This section is for services deployed to Ethereum mainnet and other EVM-based networks. Be aware that the dapps and services here may include DeFi applications which have been hacked or may suffer security vulnerabilities due to lack of maintenance, changes in the protocol, etc.
-
 
 ### Cover Protocol {#cover-protocol}
 
@@ -210,7 +230,6 @@ Cover was an DeFi insurance protocol running on Ethereum and other EVM-based net
 
 [Documentation](https://wayback.archive-it.org/17679/20211004074634/https://docs.coverprotocol.com/)
 
-
 ### The DAO {#the-dao}
 
 Hacked and shut down in Summer 2016
@@ -229,7 +248,7 @@ While The DAO failed, the concept endured. The basic technical, social, and gove
 
 ["DAO Fork" on ethereum.org](/history/#dao-fork)
 
-[Wikipedia entry for "The DAO"](https://en.wikipedia.org/wiki/The_DAO_(organization))
+[Wikipedia entry for "The DAO"](<https://en.wikipedia.org/wiki/The_DAO_(organization)>)
 
 **Alternatives**
 
@@ -238,7 +257,6 @@ While The DAO failed, the concept endured. The basic technical, social, and gove
 [MolochDAO](https://www.molochdao.com/)
 
 [Gitcoin Grants](https://gitcoin.co/grants/)
-
 
 ### SparkPool {#sparkpool}
 
@@ -252,18 +270,17 @@ Shut down in Fall 2021
 
 **Summary**
 
-Headquartered in Hangzhou, the SparkPool service and community was one of the largest Ethereum-centered mining pools in the world.  
+Headquartered in Hangzhou, the SparkPool service and community was one of the largest Ethereum-centered mining pools in the world.
 
 **Archives**
 
 **History**
 
-Associated with the EthFans community, the service was launched in 2015. SparkPool was disbanded  in Fall, 2021 as a result of stricter legal regulations.
+Associated with the EthFans community, the service was launched in 2015. SparkPool was disbanded in Fall, 2021 as a result of stricter legal regulations.
 
 **Alternatives**
 
 [Ethermine](https://ethermine.org/)
-
 
 ## Documentation and Information Sources {#documentation-and-information-sources}
 
@@ -283,7 +300,7 @@ Legacy Wiki and eth.wiki were wikis maintained by the Ethereum Foundation for th
 
 **History**
 
-Legacy Wiki was a GitHub wiki and a very early locus of technical content (including the original Ethereum White Paper). Over time, Ethereum developers migrated their documentation, specifications, and technical description work to other platforms like [Read the Docs](https://readthedocs.org/) and GitHub-hosted content. 
+Legacy Wiki was a GitHub wiki and a very early locus of technical content (including the original Ethereum White Paper). Over time, Ethereum developers migrated their documentation, specifications, and technical description work to other platforms like [Read the Docs](https://readthedocs.org/) and GitHub-hosted content.
 
 In 2019 and 2020, eth.wiki became the successor to Legacy Wiki, but an enduring community of contributors did not materialize.
 
@@ -294,7 +311,6 @@ Community-driven content: [Ethereum.org Website](/), [EthHub Docs](https://docs.
 Ethereum software projects often host their documentation on [Read the Docs](https://readthedocs.org/)
 
 GitHub-hosted technical specifications: [EIPs](https://github.com/ethereum/eips), [Execution Specs](https://github.com/ethereum/execution-specs), [Consensus Specs](https://github.com/ethereum/consensus-specs)
-
 
 ### forum.ethereum.org {#forum-ethereum-org}
 
@@ -314,7 +330,6 @@ This Forum was an early, "official" discussion board for the Ethereum community.
 
 [/r/ethereum](https://reddit.com/r/ethereum), and a large number of DAO Forums and Discord servers.
 
-
 ## Gitter Channels {#gitter-channels}
 
 ### AllCoreDevs {#allcorewdevs-gitter}
@@ -330,7 +345,6 @@ AllCoreDevs Gitter was the main public coordination comms channel for [Ethereum 
 **Alternatives**
 
 Please use the "allcoredevs" channel on the [EthR&D Discord Server](https://discord.gg/qHv7AjTDuK)
-
 
 ### EthereumJS {#ethereumjs-gitter}
 


### PR DESCRIPTION
## Description
Ethereum Studio was listed as being deprecated on https://ethereum.org/en/studio/ but not on the Deprecated Software page https://ethereum.org/en/deprecated-software/

Information about it has now been added to the Deprecated Software page.
The date for when it was deprecated was taken from https://blog.ethereum.org/2020/12/07/we-are-sunsetting-studio/

The information provided in this change follows the same format as other the other deprecated software that are listed on the page.

## Related Issue
#4433 