### PR TITLE
Update NFT tutorial: add quotes around NPM package `ethers.js`

### DIFF
--- a/src/content/developers/tutorials/how-to-write-and-deploy-an-nft/index.md
+++ b/src/content/developers/tutorials/how-to-write-and-deploy-an-nft/index.md
@@ -244,7 +244,7 @@ Hardhat makes it super easy to integrate [Plugins](https://hardhat.org/plugins/)
 
 In your project directory type:
 
-    npm install --save-dev @nomiclabs/hardhat-ethers ethers@^5.0.0
+    npm install --save-dev @nomiclabs/hardhat-ethers 'ethers@^5.0.0'
 
 We’ll also require ethers in our hardhat.config.js in the next step.
 


### PR DESCRIPTION




<!--- Provide a general summary of your changes in the Title above -->

## Description

Added single quotes to the package name in an instruction that didn't work on zsh/mac in order to make the command work correctly.

As currently written, the command returns `zsh: no matches found: ethers@^5.0.0`

This change is consistent with the instructions at https://hardhat.org/plugins/nomiclabs-hardhat-ethers.html , which is reference in this same page.


