### PR TITLE
Add Aleth to deprecated software list

### DIFF
--- a/src/content/deprecated-software/index.md
+++ b/src/content/deprecated-software/index.md
@@ -146,6 +146,26 @@ Mix was of the earliest Ethereum-related applications. See this [presentation by
 
 [Remix](https://remix.ethereum.org/) is a browser-hosted IDE for Solidity / smart contract development, testing, and deployment. It also has a desktop option.
 
+### Aleth {#aleth}
+
+Deprecated on October 6, 2021
+
+**Summary**
+
+Aleth was an Ethereum client written in C++.
+
+**Archives**
+
+[Archived GitHub repo](https://github.com/ethereum/aleth)
+
+**History**
+
+Aleth was the third most popular client for Ethereum before being deprecated on October 6, 2021.
+
+**Alternatives**
+
+[Geth](https://geth.ethereum.org/) is a well-known altenative Ethereum client.
+
 ### Parity {#parity}
 
 <p align="center">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This adds Aleth to the deprecated software list. The date referenced for deprecation is not the earliest reference of deprecation I could find, but rather the date of pull request [5937](https://github.com/ethereum/aleth/pull/5937), where the change to archive was proposed.

If anyone has a logo/image for Aleth, that would be great. I could not find one.

<!--- Describe your changes in detail -->

## Related Issue
[Add Aleth to deprecated software page #4432 ](https://github.com/ethereum/ethereum-org-website/issues/4432)

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
