### PR TITLE
Remove ''minted'' from the POAP instuctions

### DIFF
--- a/src/content/contributing/index.md
+++ b/src/content/contributing/index.md
@@ -78,7 +78,7 @@ If your contribution gets merged into ethereum.org, we'll mint you a unique cont
 
 1. Join our [Discord server](https://discord.gg/E8dET2ux8y).
 2. Paste a link to your contribution in the #poaps-🏆 channel.
-3. Wait for a member of our team to send you a link to your minted POAP.
+3. Wait for a member of our team to send you a link to your POAP.
 4. Claim your POAP!
 
 ## Contributors {#contributors}


### PR DESCRIPTION
## Description

The instructions to claim the ethereum.org POAP contain the following sentence: 
''Wait for a member of our team to send you a link to your minted POAP.''

As the POAP doesn't get minted until claimed, the word ''minted'' should be removed.

## Related Issue

