### PR TITLE
Fix list item color in markdown files [Fixes #4495]

### DIFF
--- a/src/templates/job.js
+++ b/src/templates/job.js
@@ -12,6 +12,7 @@ import {
   Paragraph,
   Header1,
   Header4,
+  ListItem,
 } from "../components/SharedStyledComponents"
 
 const Page = styled.div`
@@ -232,6 +233,7 @@ const components = {
   h3: H3,
   h4: Header4,
   p: Paragraph,
+  li: ListItem,
   pre: Pre,
   ButtonLink,
   Emoji,


### PR DESCRIPTION
## Description
This PR fixes the issue where the `<p>` and `<li>` tags have different colors.

The `ListItem` component needed to be imported into the `job.js` template and passed to the MDXProvider.
## Related Issue
#4495

