### PR TITLE
Link ETH terminology to "Intro to ether"

### DIFF
--- a/src/content/developers/docs/intro-to-ethereum/index.md
+++ b/src/content/developers/docs/intro-to-ethereum/index.md
@@ -67,6 +67,8 @@ The sequence of all blocks that have been committed to the Ethereum network in t
 
 The native cryptocurrency of Ethereum. Users pay ether to other users to have their code execution requests fulfilled.
 
+[More on ETH](/developers/docs/intro-to-ether/)
+
 ### EVM {#evm}
 
 The Ethereum Virtual Machine is the global virtual computer whose state every participant on the Ethereum network stores and agrees on. Any participant can request the execution of arbitrary code on the EVM; code execution changes the state of the EVM.


### PR DESCRIPTION
## Description

Add a link to the "Intro to ether" doc page from the terminology section of "Intro to ethereum". Similar to other titles (blocks, transactions, accounts, etc.).

## Related Issue
https://github.com/ethereum/ethereum-org-website/issues/4505