### PR TITLE
Use American English on Transaction Lifecycle

### DIFF
--- a/src/content/developers/docs/transactions/index.md
+++ b/src/content/developers/docs/transactions/index.md
@@ -151,9 +151,9 @@ Once the transaction has been submitted the following happens:
 2. The transaction is then broadcast to the network and included in a pool with lots of other transactions.
 3. A miner must pick your transaction and include it in a block in order to verify the transaction and consider it "successful".
    - You may end up waiting at this stage if the network is busy and miners aren't able to keep up.
-4. Your transaction will receive "confirmations". The number of confirmations is the number of blocks created since the block that included your transaction. The higher the number, the greater the certainty that the network processed and recognised the transaction.
-   - Recent blocks may get re-organised, giving the impression the transaction was unsuccessful; however, the transaction may still be valid but included in a different block.
-   - The probability of a re-organisation diminishes with every subsequent block mined, i.e. the greater the number of confirmations, the more immutable the transaction is.
+4. Your transaction will receive "confirmations". The number of confirmations is the number of blocks created since the block that included your transaction. The higher the number, the greater the certainty that the network processed and recognized the transaction.
+   - Recent blocks may get re-organized, giving the impression the transaction was unsuccessful; however, the transaction may still be valid but included in a different block.
+   - The probability of a re-organization diminishes with every subsequent block mined, i.e. the greater the number of confirmations, the more immutable the transaction is.
 
 <!-- **State change**
 


### PR DESCRIPTION
## Description

Fixed a couple more typos in the Transaction Section

