### PR TITLE
Remove Edit Button for Whitepaper

### DIFF
--- a/src/templates/static.js
+++ b/src/templates/static.js
@@ -143,7 +143,9 @@ const StaticPage = ({ data: { siteData, pageData: mdx }, pageContext }) => {
   const tocItems = mdx.tableOfContents.items
   const { editContentUrl } = siteData.siteMetadata
   const { relativePath } = pageContext
-  const absoluteEditPath = `${editContentUrl}${relativePath}`
+  const absoluteEditPath = relativePath.split("/").includes("whitepaper")
+    ? ""
+    : `${editContentUrl}${relativePath}`
 
   return (
     <Page dir={isRightToLeft ? "rtl" : "ltr"}>


### PR DESCRIPTION
## Description
Since we arent editing the whitepaper moving forward, this PR removes the Edit Button for the whitepaper.

