### PR TITLE
Show header ID chain on hover for docs/static templates

### DIFF
--- a/src/components/SharedStyledComponents.js
+++ b/src/components/SharedStyledComponents.js
@@ -299,7 +299,8 @@ export const Header2 = styled.h2`
   /* Selected specifically for mdx rendered side icon link */
   a.header-anchor {
     position: relative;
-    display: none;
+    display: initial;
+    opacity: 0;
     margin-left: -1.5em;
     padding-right: 0.5rem;
     font-size: 1rem;
@@ -307,6 +308,7 @@ export const Header2 = styled.h2`
     &:hover {
       display: initial;
       fill: ${(props) => props.theme.colors.primary};
+      opacity: 1;
     }
   }
 
@@ -314,6 +316,7 @@ export const Header2 = styled.h2`
     a.header-anchor {
       display: initial;
       fill: ${(props) => props.theme.colors.primary};
+      opacity: 1;
     }
   }
 `
@@ -336,7 +339,8 @@ export const Header3 = styled.h3`
   /* Selected specifically for mdx rendered side icon link */
   a.header-anchor {
     position: relative;
-    display: none;
+    display: initial;
+    opacity: 0;
     margin-left: -1.5em;
     padding-right: 0.5rem;
     font-size: 1rem;
@@ -344,6 +348,7 @@ export const Header3 = styled.h3`
     &:hover {
       display: initial;
       fill: ${(props) => props.theme.colors.primary};
+      opacity: 1;
     }
   }
 
@@ -351,6 +356,7 @@ export const Header3 = styled.h3`
     a.header-anchor {
       display: initial;
       fill: ${(props) => props.theme.colors.primary};
+      opacity: 1;
     }
   }
 `


### PR DESCRIPTION
## Description
#4491 fixed an issue where the chain for anchor links was not showing correctly on hover for the eth2, use-cases and jobs templates. 

This PR adds the same functionality to the SharedStyledComponents which the `static` and `docs` templates inherit from.

![Screenshot 2021-11-26 at 11 27 28](https://user-images.githubusercontent.com/62268199/143574183-e04dd9b8-5f19-4069-b206-431b1c2c8cd3.png)

## Related Issue
#4487
