### PR TITLE
Fix "Majority attack" link in PoW article

### DIFF
--- a/src/content/developers/docs/consensus-mechanisms/pow/index.md
+++ b/src/content/developers/docs/consensus-mechanisms/pow/index.md
@@ -99,7 +99,7 @@ At a high level, proof-of-stake has the same end goal as proof-of-work: to help 
 
 ## Further Reading {#further-reading}
 
-- [Majority attack](https://en.bitcoin.it/wiki/Majority_attack/)
+- [Majority attack](https://en.bitcoin.it/wiki/Majority_attack)
 - [On settlement finality](https://blog.ethereum.org/2016/05/09/on-settlement-finality/)
 
 ### Videos {#videos}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes the link to https://en.bitcoin.it/wiki/Majority_attack. Original link is https://en.bitcoin.it/wiki/Majority_attack/ (with an extra slash at the end)

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
