### PR TITLE
Add article to web2 vs web3 developer doc (Spanish)

### DIFF
--- a/src/content/translations/es/developers/docs/web2-vs-web3/index.md
+++ b/src/content/translations/es/developers/docs/web2-vs-web3/index.md
@@ -56,3 +56,4 @@ Ten en cuenta que estos son patrones generales que pueden no mantenerse auténti
 
 - [El significado de la descentralización ](https://medium.com/@VitalikButerin/the-meaning-of-decentralization-a0c92b76a274) _ 6 de Febrero de 2017 - Vitalik Buterin_
 - [Por qué la descentralización importa](https://medium.com/s/story/why-decentralization-matters-5e3f79f7638e) _18 de Febrero de 2018, Chris Dixon_
+- [Qué es Web3 y por qué importa](https://medium.com/fabric-ventures/what-is-web-3-0-why-it-matters-934eb07f3d2b) _31 de Diciembre de 2019 - Max Mersch and Richard Muirhead_


### PR DESCRIPTION
Link missing in Web2 vs Web3 article in spanish version

## Description
A link from the section Further reading was missing on the spanish version of the article

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
