### PR TITLE
Fix link to the glossary and corrected the translation

### DIFF
--- a/src/content/translations/it/enterprise/index.md
+++ b/src/content/translations/it/enterprise/index.md
@@ -14,7 +14,8 @@ La applicazioni della blockchain aiutano le imprese nei seguenti ambiti:
 - Instaurare nuovi modelli di business e offrire opportunità per la creazione di valore
 - Creare organizzazioni a prova di futuro
 
-Le applicazioni della blockchain aziendali possono essere basate sulla [rete principale](/glossary/#rete principale) pubblica Ethereum senza permessi o sulle blockchain private basate su tecnologia Ethereum. Consulta maggiori informazioni sulle [catene Ethereum aziendali private](/enterprise/private-ethereum/).
+Le applicazioni blockchain aziendali possono essere create sulla [rete principale](/glossary/#mainnet) pubblica Ethereum senza permessi o su blockchain private basate sulla
+tecnologia Ethereum. Consulta maggiori informazioni sulle [catene Ethereum aziendali private](/enterprise/private-ethereum/).
 
 ## Ethereum pubblica e privata {#private-vs-public}
 

--- a/src/content/translations/it/enterprise/index.md
+++ b/src/content/translations/it/enterprise/index.md
@@ -14,8 +14,7 @@ La applicazioni della blockchain aiutano le imprese nei seguenti ambiti:
 - Instaurare nuovi modelli di business e offrire opportunità per la creazione di valore
 - Creare organizzazioni a prova di futuro
 
-Le applicazioni blockchain aziendali possono essere create sulla [rete principale](/glossary/#mainnet) pubblica Ethereum senza permessi o su blockchain private basate sulla
-tecnologia Ethereum. Consulta maggiori informazioni sulle [catene Ethereum aziendali private](/enterprise/private-ethereum/).
+Le applicazioni blockchain aziendali possono essere create sulla [rete principale](/glossary/#mainnet) pubblica Ethereum senza permessi o su blockchain private basate sulla tecnologia Ethereum. Consulta maggiori informazioni sulle [catene Ethereum aziendali private](/enterprise/private-ethereum/).
 
 ## Ethereum pubblica e privata {#private-vs-public}
 


### PR DESCRIPTION
## Fix link to the glossary and corrected the translation

The link to the glossary was incorrect and consequently the page does not display the word with the link style, but the word with the .md syntax

" [rete principale](/glossary/#rete principale) "
