### PR TITLE
Fix typo in uniswap-v2-annotated-code

### DIFF
--- a/src/content/developers/tutorials/uniswap-v2-annotated-code/index.md
+++ b/src/content/developers/tutorials/uniswap-v2-annotated-code/index.md
@@ -106,7 +106,7 @@ This is most common flow, used by traders:
 #### Caller
 
 1. Provide the periphery account with an allowance of liquidity tokens to be burned in exchange for the underlying tokens.
-2. Call one of the periphery contract's addLiquidity functions.
+2. Call one of the periphery contract's removeLiquidity functions.
 
 #### In the periphery contract (UniswapV2Router02.sol)
 


### PR DESCRIPTION
It should be `removeLiquidity` function in  remove liquidity flow instead of `addLiquidity`.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
