### PR TITLE
Fix broken glossary link (Italian)

### DIFF
--- a/src/content/translations/it/eth2/merge/index.md
+++ b/src/content/translations/it/eth2/merge/index.md
@@ -20,7 +20,7 @@ summaryPoints:
 
 ## Che cos'è il docking? {#what-is-the-docking}
 
-È importante ricordare che inizialmente gli altri aggiornamenti Eth2 vengono rilasciati separatamente dalla [rete principale](/glossary/#rete principale), cioè la catena che usiamo oggi. Il funzionamento della rete principale Ethereum continuerà ad essere assicurato dal [proof of work](/developers/docs/consensus-mechanisms/pow/), anche mentre la [beacon chain](/eth2/beacon-chain/) e le sue [shard chain](/eth2/shard-chains/) funzioneranno in parallelo utilizzando il [proof of stake](/developers/docs/consensus-mechanisms/pos/). Per docking si intende il momento in cui questi due sistemi si fonderanno.
+È importante ricordare che inizialmente gli altri aggiornamenti Eth2 vengono rilasciati separatamente dalla [rete principale](/glossary/#mainnet), cioè la catena che usiamo oggi. Il funzionamento della rete principale Ethereum continuerà ad essere assicurato dal [proof of work](/developers/docs/consensus-mechanisms/pow/), anche mentre la [beacon chain](/eth2/beacon-chain/) e le sue [shard chain](/eth2/shard-chains/) funzioneranno in parallelo utilizzando il [proof of stake](/developers/docs/consensus-mechanisms/pos/). Per docking si intende il momento in cui questi due sistemi si fonderanno.
 
 Immagina Ethereum come una nave spaziale che non è ancora pronta per un viaggio interstellare. Con la beacon chain e le shard chain la community ha costruito un nuovo motore e uno scafo più resistente. Quando sarà il momento, l'attuale navicella aggancerà questo nuovo sistema diventando un'unica astronave, pronta a percorrere diversi anni luce e conquistare l'universo.
 


### PR DESCRIPTION
## Description
Fixes another instance of a broken, accidentally translated, link highlighted in #4589

I have checked CrowdIn and no issues found.

## Related Issue
#4589