### PR TITLE
Add year to Beacon Chain ship date

### DIFF
--- a/src/content/eth2/beacon-chain/index.md
+++ b/src/content/eth2/beacon-chain/index.md
@@ -15,7 +15,7 @@ summaryPoints:
 ---
 
 <UpgradeStatus isShipped date="Shipped!">
-    The Beacon Chain shipped on December 1 at noon UTC. To learn more, <a href="https://beaconscan.com/">explore the data</a>. If you want to help validate the chain, you can <a href="/eth2/staking/">stake your ETH</a>.
+    The Beacon Chain shipped on December 1, 2020 at noon UTC. To learn more, <a href="https://beaconscan.com/">explore the data</a>. If you want to help validate the chain, you can <a href="/eth2/staking/">stake your ETH</a>.
 </UpgradeStatus>
 
 ## What does the Beacon Chain do? {#what-does-the-beacon-chain-do}


### PR DESCRIPTION
The Beacon Chain shipped over a year ago! This adds the year so that it is clear which December 1 the Beacon Chain shipped on.
