### PR TITLE
Fixes #4621 rasberry-pi tutorial typo

### DIFF
--- a/src/content/developers/tutorials/run-node-raspberry-pi/index.md
+++ b/src/content/developers/tutorials/run-node-raspberry-pi/index.md
@@ -64,7 +64,7 @@ Both images include the same packages, the only difference between them is that 
 ### Recommended hardware and setup {#recommended-hardware-and-setup}
 
 - Raspberry 4 (model B) - 4GB
-- MicroSD Card (16 GB Class 10 minimun)
+- MicroSD Card (16 GB Class 10 minimum)
 - SSD USB 3.0 disk (see storage section)
 - Power supply
 - Ethernet cable


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes issue #4621 -- Small Typo in the run-node-rasberry-pi tutorial 

<!--- Describe your changes in detail -->
Hardware and Setup section had "- MicroSD Card (16 GB Class 10 minimun)"
Changed "minimun" to minimum

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
