### PR TITLE
Update stablecoins editors' choice cards to be responsive

### DIFF
--- a/src/pages/stablecoins.js
+++ b/src/pages/stablecoins.js
@@ -51,8 +51,8 @@ const Image = styled(Img)`
   background-repeat: repeat;
   align-self: center;
   width: 100%;
-  min-width: 240px;
   max-width: 240px;
+  flex: 1;
   @media (max-width: ${(props) => props.theme.breakpoints.m}) {
     margin: 2rem 2rem;
     min-width: 160px;
@@ -80,7 +80,7 @@ const StyledGhostCard = styled(GhostCard)`
 const Row = styled.div`
   display: flex;
   width: 100%;
-  align-items: flex-start;
+  align-items: stretch;
   @media (max-width: ${(props) => props.theme.breakpoints.l}) {
     flex-direction: column;
   }


### PR DESCRIPTION
## Description
- Remove `min-width` for Image on desktop so it can resize with the card before changing layout to columns
- Add `flex: 1` to `Image` to keep even ratios for cards
- Update `align-items` to `stretch` in `Row` to keep the cards with the same height

## Related Issue

#4598 