### PR TITLE
Remove broken links in Rust developer docs (all languages)

### DIFF
--- a/src/content/developers/docs/programming-languages/rust/index.md
+++ b/src/content/developers/docs/programming-languages/rust/index.md
@@ -34,7 +34,6 @@ Need a more basic primer first? Check out [ethereum.org/learn](/learn/) or [ethe
 
 - [Rust-Web3 Documentation](https://tomusdrw.github.io/rust-web3/web3/index.html)
 - [Rust-Web3 Working Examples](https://github.com/tomusdrw/rust-web3/blob/master/examples)
-- [Creating a Private Chat Server with OASIS SDK](https://docs.oasis.dev/tutorials/messaging.html#prerequisites)
 
 ## Advanced use patterns {#advanced-use-patterns}
 

--- a/src/content/translations/ar/rust/index.md
+++ b/src/content/translations/ar/rust/index.md
@@ -35,8 +35,6 @@ sidebar: true
 
 - [توثيق Rust-Web3](https://tomusdrw.github.io/rust-web3/web3/index.html)
 - [أمثلة عمل Rust-Web3](https://github.com/tomusdrw/rust-web3/blob/master/examples)
-- [إنشاء Secret Ballot باستخدام OASIS SDK](https://docs.oasis.dev/tutorials/ballot.html#prerequisites)
-- [إنشاء خادم دردشة خاص باستخدام OASIS SDK](https://docs.oasis.dev/tutorials/messaging.html#prerequisites)
 
 ## أنماط الاستخدام المتقدم {#advanced-use-patterns}
 

--- a/src/content/translations/bn/rust/index.md
+++ b/src/content/translations/bn/rust/index.md
@@ -35,8 +35,6 @@ sidebar: true
 
 - [রাস্ট-ওয়েব3 ডকুমেন্টেশন](https://tomusdrw.github.io/rust-web3/web3/index.html)
 - [রাস্ট-ওয়েব3 কাজের উদাহরণ](https://github.com/tomusdrw/rust-web3/blob/master/examples)
-- [ওয়েসিস SDK এর সাহায্যে একটি গোপন ব্যালট তৈরি করা](https://docs.oasis.dev/tutorials/ballot.html#prerequisites)
-- [ওয়েসিস SDK এর সাহায্যে একটি ব্যক্তিগত চ্যাট সার্ভার তৈরি করা](https://docs.oasis.dev/tutorials/messaging.html#prerequisites)
 
 ## উন্নত ইউজ প্যাটার্ন {#advanced-use-patterns}
 

--- a/src/content/translations/cs/rust/index.md
+++ b/src/content/translations/cs/rust/index.md
@@ -36,8 +36,6 @@ Potřebujete nejdříve úplně základní informace? Podívejte se na [ethereum
 
 - [Dokumentace Rust-Web3](https://tomusdrw.github.io/rust-web3/web3/index.html)
 - [Příklady Rust-Web3](https://github.com/tomusdrw/rust-web3/blob/master/examples)
-- [Vytvoření tajného hlasování s OASIS SDK](https://docs.oasis.dev/tutorials/ballot.html#prerequisites)
-- [Vytvoření soukromého chatovacího serveru s OASIS SDK](https://docs.oasis.dev/tutorials/messaging.html#prerequisites)
 
 ## Pokročilé používání {#advanced-use-patterns}
 

--- a/src/content/translations/de/rust/index.md
+++ b/src/content/translations/de/rust/index.md
@@ -35,8 +35,6 @@ Brauchst du zuerst einen grundsätzlichen Einstieg? Schaue dir [ethereum.org/lea
 
 - [Rust-Web3-Dokumentation](https://tomusdrw.github.io/rust-web3/web3/index.html)
 - [Rust-Web3-Arbeitsbeispiele](https://github.com/tomusdrw/rust-web3/blob/master/examples)
-- [Erstellen eines geheimen Stimmzettels mit OASIS SDK](https://docs.oasis.dev/tutorials/ballot.html#prerequisites)
-- [Erstellen eines privaten Chat-Servers mit OASIS SDK](https://docs.oasis.dev/tutorials/messaging.html#prerequisites)
 
 ## Fortgeschrittene Verwendungsmuster {#advanced-use-patterns}
 

--- a/src/content/translations/es/developers/docs/programming-languages/rust/index.md
+++ b/src/content/translations/es/developers/docs/programming-languages/rust/index.md
@@ -34,8 +34,6 @@ Utiliza Ethereum para crear aplicaciones descentralizadas (o "dapps"), que aprov
 
 - [Documentación de Rust-Web3](https://tomusdrw.github.io/rust-web3/web3/index.html)
 - [Ejemplos de trabajo de Rust-Web3](https://github.com/tomusdrw/rust-web3/blob/master/examples)
-- [Crear una selección secreta con OASIS SDK](https://docs.oasis.dev/tutorials/ballot.html#prerequisites)
-- [Crear un servidor de chat privado con OASIS SDK](https://docs.oasis.dev/tutorials/messaging.html#prerequisites)
 
 ## Patrones de uso avanzado {#advanced-use-patterns}
 

--- a/src/content/translations/es/rust/index.md
+++ b/src/content/translations/es/rust/index.md
@@ -36,8 +36,6 @@ Utiliza Ethereum para crear aplicaciones descentralizadas (o "dapps"), que aprov
 
 - [Documentación de Rust-Web3](https://tomusdrw.github.io/rust-web3/web3/index.html)
 - [Ejemplos de trabajo de Rust-Web3](https://github.com/tomusdrw/rust-web3/blob/master/examples)
-- [Crear una selección secreta con OASIS SDK](https://docs.oasis.dev/tutorials/ballot.html#prerequisites)
-- [Crear un servidor de chat privado con OASIS SDK](https://docs.oasis.dev/tutorials/messaging.html#prerequisites)
 
 ## Patrones de uso avanzado {#advanced-use-patterns}
 

--- a/src/content/translations/fi/rust/index.md
+++ b/src/content/translations/fi/rust/index.md
@@ -36,8 +36,6 @@ Tarvitsetko perusteellisempaa aloitusta? Katso [ethereum.org/fi/learn](/learn/) 
 
 - [Rust-Web3 -dokumentaatio](https://tomusdrw.github.io/rust-web3/web3/index.html)
 - [Rust-Web3 -työskentelyesimerkit](https://github.com/tomusdrw/rust-web3/blob/master/examples)
-- [Vaalisalaisuuden luominen OASIS SDK:lla](https://docs.oasis.dev/tutorials/ballot.html#prerequisites)
-- [Yksityisen chat-serverin luominen OASIS SDK:lla](https://docs.oasis.dev/tutorials/messaging.html#prerequisites)
 
 ## Edistyneet käyttösuunnittelumallit {#advanced-use-patterns}
 

--- a/src/content/translations/fr/developers/docs/programming-languages/rust/index.md
+++ b/src/content/translations/fr/developers/docs/programming-languages/rust/index.md
@@ -34,7 +34,6 @@ Besoin d’une approche plus élémentaire ? Consultez [ethereum.org/learn](/en
 
 - [Documentation Rust-Web3](https://tomusdrw.github.io/rust-web3/web3/index.html)
 - [Exemples de travail Rust-Web3](https://github.com/tomusdrw/rust-web3/blob/master/examples)
-- [Creating a Private Chat Server with OASIS SDK](https://docs.oasis.dev/tutorials/messaging.html#prerequisites)
 
 ## Modèles d'utilisation avancés {#advanced-use-patterns}
 

--- a/src/content/translations/fr/rust/index.md
+++ b/src/content/translations/fr/rust/index.md
@@ -35,7 +35,6 @@ Besoin d’une approche plus élémentaire&nbsp;? Jetez un oeil à [ethereum.org
 
 - [Documentation Rust-Web3](https://tomusdrw.github.io/rust-web3/web3/index.html)
 - [Rust-Web3 Working Examples](https://github.com/tomusdrw/rust-web3/blob/master/examples)
-- [Creating a Private Chat Server with OASIS SDK](https://docs.oasis.dev/tutorials/messaging.html#prerequisites)
 
 ## Modèles d'utilisation avancés {#advanced-use-patterns}
 

--- a/src/content/translations/hu/developers/docs/programming-languages/rust/index.md
+++ b/src/content/translations/hu/developers/docs/programming-languages/rust/index.md
@@ -34,8 +34,6 @@ Szükséged van egy méginkább kezdőknek szóló alapozóra? Tekintsd meg az [
 
 - [Rust-Web3 dokumentáció](https://tomusdrw.github.io/rust-web3/web3/index.html)
 - [Rust-Web3 működő példák](https://github.com/tomusdrw/rust-web3/blob/master/examples)
-- [Titkos szavazás készítése OASIS SDK-val](https://docs.oasis.dev/tutorials/ballot.html#prerequisites)
-- [Privát chat szerver létrehozása OASIS SDK-val](https://docs.oasis.dev/tutorials/messaging.html#prerequisites)
 
 ## Fejlett használati minták {#advanced-use-patterns}
 

--- a/src/content/translations/hu/rust/index.md
+++ b/src/content/translations/hu/rust/index.md
@@ -36,8 +36,6 @@ Szűkséged van egy még kezdetlegesebb alapozóra? Tekintsd meg a [ethereum.org
 
 - [Rust-Web3 dokumentáció](https://tomusdrw.github.io/rust-web3/web3/index.html)
 - [Rust-Web3 működő példák](https://github.com/tomusdrw/rust-web3/blob/master/examples)
-- [Titkos szavazás készítése OASIS SDK-val](https://docs.oasis.dev/tutorials/ballot.html#prerequisites)
-- [Privát chat szerver létrehozása OASIS SDK-val](https://docs.oasis.dev/tutorials/messaging.html#prerequisites)
 
 ## Fejlett használati minták {#advanced-use-patterns}
 

--- a/src/content/translations/id/rust/index.md
+++ b/src/content/translations/id/rust/index.md
@@ -35,8 +35,6 @@ Perlu penjelasan yang lebih mendasar? Kunjungi [ethereum.org/learn](/id/learn/) 
 
 - [Dokumentasi Rust-Web3](https://tomusdrw.github.io/rust-web3/web3/index.html)
 - [Contoh Rust-Web3 yang sudah berjalan](https://github.com/tomusdrw/rust-web3/blob/master/examples)
-- [Membuat sebuah undian rahasia menggunakan SDK OASIS](https://docs.oasis.dev/tutorials/ballot.html#prerequisites)
-- [Membuat sebuah Server Obrolan Private dengan OASIS SDK](https://docs.oasis.dev/tutorials/messaging.html#prerequisites)
 
 ## Artikel Tingkat Lanjut {#advanced-use-patterns}
 

--- a/src/content/translations/it/developers/docs/programming-languages/rust/index.md
+++ b/src/content/translations/it/developers/docs/programming-languages/rust/index.md
@@ -34,7 +34,6 @@ Hai prima bisogno di nozioni di base? Dai un'occhiata a [ethereum.org/learn](/en
 
 - [Rust-Web3 Documentation](https://tomusdrw.github.io/rust-web3/web3/index.html)
 - [Rust-Web3 Working Examples](https://github.com/tomusdrw/rust-web3/blob/master/examples)
-- [Creating a Private Chat Server with OASIS SDK](https://docs.oasis.dev/tutorials/messaging.html#prerequisites)
 
 ## Modelli d'uso avanzati {#advanced-use-patterns}
 

--- a/src/content/translations/it/rust/index.md
+++ b/src/content/translations/it/rust/index.md
@@ -36,8 +36,6 @@ Ti servono prima le nozioni di base? Dai un'occhiata a [ethereum.org/learn](/it/
 
 - [Documentazione Rust-Web3 (in inglese)](https://tomusdrw.github.io/rust-web3/web3/index.html)
 - [Esempi di lavoro in Rust-Web3 (in inglese)](https://github.com/tomusdrw/rust-web3/blob/master/examples)
-- [Creare una votazione segreta con OASIS SDK (in inglese)](https://docs.oasis.dev/tutorials/ballot.html#prerequisites)
-- [Creare un server di chat privato con OASIS SDK (in inglese)](https://docs.oasis.dev/tutorials/messaging.html#prerequisites)
 
 ## Pattern per uso avanzato {#advanced-use-patterns}
 

--- a/src/content/translations/ja/rust/index.md
+++ b/src/content/translations/ja/rust/index.md
@@ -36,8 +36,6 @@ sidebarDepth: 1
 
 - [Rust-Web3 ドキュメント](https://tomusdrw.github.io/rust-web3/web3/index.html)
 - [Rust-Web3 動作例](https://github.com/tomusdrw/rust-web3/blob/master/examples)
-- [OASIS SDK を使用した Secret Ballot の作成](https://docs.oasis.dev/tutorials/ballot.html#prerequisites)
-- [OASIS SDK を使用したプライベートチャットサーバーの作成](https://docs.oasis.dev/tutorials/messaging.html#prerequisites)
 
 ## 高度な利用パターン {#advanced-use-patterns}
 

--- a/src/content/translations/ko/rust/index.md
+++ b/src/content/translations/ko/rust/index.md
@@ -36,8 +36,6 @@ sidebarDepth: 1
 
 - [Rust-Web3 개발 문서](https://tomusdrw.github.io/rust-web3/web3/index.html)
 - [Rust-Web3 작업 예시](https://github.com/tomusdrw/rust-web3/blob/master/examples)
-- [OASIS SDK로 무기명 투표 솔루션 만들기](https://docs.oasis.dev/tutorials/ballot.html#prerequisites)
-- [OASIS SDK로 비공개 채팅 서버 구축하기](https://docs.oasis.dev/tutorials/messaging.html#prerequisites)
 
 ## 고급 사용 패턴 {#advanced-use-patterns}
 

--- a/src/content/translations/lt/rust/index.md
+++ b/src/content/translations/lt/rust/index.md
@@ -36,8 +36,6 @@ Norėtumėte pradėti nuo ko nors paprastesnio? Apsilankykite [ethereum.org/lear
 
 - [Rust-Web3 dokumentai](https://tomusdrw.github.io/rust-web3/web3/index.html)
 - [Rust-Web3 darbo pavyzdžiai](https://github.com/tomusdrw/rust-web3/blob/master/examples)
-- [Slapto balsavimo kūrimas su OASIS SDK](https://docs.oasis.dev/tutorials/ballot.html#prerequisites)
-- [Privačių poklabių serverio kūrimas su OASIS SDK](https://docs.oasis.dev/tutorials/messaging.html#prerequisites)
 
 ## Pažangaus naudojimo modeliai {#advanced-use-patterns}
 

--- a/src/content/translations/ml/rust/index.md
+++ b/src/content/translations/ml/rust/index.md
@@ -35,8 +35,6 @@ sidebar: true
 
 - [റസ്റ്റ്-വെബ് 3 ഡോക്യുമെന്റേഷൻ](https://tomusdrw.github.io/rust-web3/web3/index.html)
 - [റസ്റ്റ്-വെബ് 3 പ്രവർത്തന ഉദാഹരണങ്ങൾ](https://github.com/tomusdrw/rust-web3/blob/master/examples)
-- [OASIS SDK ഉപയോഗിച്ച് ഒരു രഹസ്യ ബാലറ്റ് സൃഷ്ടിക്കുന്നു](https://docs.oasis.dev/tutorials/ballot.html#prerequisites)
-- [OASIS SDK ഉപയോഗിച്ച് ഒരു സ്വകാര്യ ചാറ്റ് സെർവർ സൃഷ്ടിക്കുന്നു](https://docs.oasis.dev/tutorials/messaging.html#prerequisites)
 
 ## നൂതന ഉപയോഗ പാറ്റേണുകൾ {#advanced-use-patterns}
 

--- a/src/content/translations/nb/rust/index.md
+++ b/src/content/translations/nb/rust/index.md
@@ -35,8 +35,6 @@ Trenger du en mer grunnleggende informasjon først? Sjekk ut [ethereum.org/learn
 
 - [Rust-Web3 Dokumentasjon](https://tomusdrw.github.io/rust-web3/web3/index.html)
 - [Rust-Web3 Arbeidseksempler](https://github.com/tomusdrw/rust-web3/blob/master/examples)
-- [Opprette en hemmelig balant med OASIS SDK](https://docs.oasis.dev/tutorials/ballot.html#prerequisites)
-- [Opprette en Privat Chat Server med OASIS SDK](https://docs.oasis.dev/tutorials/messaging.html#prerequisites)
 
 ## Avansert bruksmønster {#advanced-use-patterns}
 

--- a/src/content/translations/pl/developers/docs/programming-languages/rust/index.md
+++ b/src/content/translations/pl/developers/docs/programming-languages/rust/index.md
@@ -34,8 +34,6 @@ Potrzebujesz bardziej podstawowych informacji? Sprawdź na [ethereum.org/learn](
 
 - [Dokumentacja Rust-Web3](https://tomusdrw.github.io/rust-web3/web3/index.html)
 - [Przykłady działania Rust-Web3](https://github.com/tomusdrw/rust-web3/blob/master/examples)
-- [Tworzenie tajnej karty do głosowania za pomocą pakietu OASIS SDK](https://docs.oasis.dev/tutorials/ballot.html#prerequisites)
-- [Tworzenie prywatnego serwera czatu za pomocą OASIS SDK](https://docs.oasis.dev/tutorials/messaging.html#prerequisites)
 
 ## Przykłady zaawansowane {#advanced-use-patterns}
 

--- a/src/content/translations/pt-br/rust/index.md
+++ b/src/content/translations/pt-br/rust/index.md
@@ -36,8 +36,6 @@ Precisa de uma introdução geral? Confira [ethereum.org/learn](/learn/) ou [eth
 
 - [Documentação Rust-Web3](https://tomusdrw.github.io/rust-web3/web3/index.html)
 - [Exemplos Rust-Web3](https://github.com/tomusdrw/rust-web3/blob/master/examples)
-- [Criando um Secret Ballot com o OASIS SDK](https://docs.oasis.dev/tutorials/ballot.html#prerequisites)
-- [Criando um servidor de bate-papo privado com o OASIS SDK](https://docs.oasis.dev/tutorials/messaging.html#prerequisites)
 
 ## Padrões para uso Avançado {#advanced-use-patterns}
 

--- a/src/content/translations/ro/developers/docs/programming-languages/rust/index.md
+++ b/src/content/translations/ro/developers/docs/programming-languages/rust/index.md
@@ -34,8 +34,6 @@ Ai nevoie de o scurtă introducere? Accesează [ethereum.org/learn](/learn/) sau
 
 - [Documentația Rust-Web3](https://tomusdrw.github.io/rust-web3/web3/index.html)
 - [Exemple practice de Rust-Web3](https://github.com/tomusdrw/rust-web3/blob/master/examples)
-- [Cum să creezi un sistem de vot secret cu Oasis SDK](https://docs.oasis.dev/tutorials/ballot.html#prerequisites)
-- [Cum să creezi un server privat de chat cu Oasis SDK](https://docs.oasis.dev/tutorials/messaging.html#prerequisites)
 
 ## Modele avansate de utilizare {#advanced-use-patterns}
 

--- a/src/content/translations/ro/rust/index.md
+++ b/src/content/translations/ro/rust/index.md
@@ -35,8 +35,6 @@ Ai nevoie de o scurtă introducere? Accesează [ethereum.org/learn](/ro/learn/) 
 
 - [Documentația Rust-Web3](https://tomusdrw.github.io/rust-web3/web3/index.html)
 - [Exemple practice de Rust-Web3](https://github.com/tomusdrw/rust-web3/blob/master/examples)
-- [Cum să creezi un sistem de vot secret cu Oasis SDK](https://docs.oasis.dev/tutorials/ballot.html#prerequisites)
-- [Cum să creezi un server privat de chat cu Oasis SDK](https://docs.oasis.dev/tutorials/messaging.html#prerequisites)
 
 ## Modele avansate de utilizare {#advanced-use-patterns}
 

--- a/src/content/translations/se/rust/index.md
+++ b/src/content/translations/se/rust/index.md
@@ -35,8 +35,6 @@ Behöver du en mer grundläggande introduktion först? Kolla in [ethereum.org/se
 
 - [Rust-Web3-dokumentation](https://tomusdrw.github.io/rust-web3/web3/index.html)
 - [Rust-Web3 arbetsexempel](https://github.com/tomusdrw/rust-web3/blob/master/examples)
-- [Skapa en hemlig omröstning med OASIS SDK](https://docs.oasis.dev/tutorials/ballot.html#prerequisites)
-- [Skapa en privat chattserver med OASIS SDK](https://docs.oasis.dev/tutorials/messaging.html#prerequisites)
 
 ## Avancerad användning av mönster {#advanced-use-patterns}
 

--- a/src/content/translations/sk/rust/index.md
+++ b/src/content/translations/sk/rust/index.md
@@ -35,7 +35,6 @@ Potrebujete ďalšie základné informácie o Ethereu? Pozrite si [ethereum.org/
 
 - [Rust-Web3 Documentation](https://tomusdrw.github.io/rust-web3/web3/index.html)
 - [Rust-Web3 Working Examples](https://github.com/tomusdrw/rust-web3/blob/master/examples)
-- [Creating a Private Chat Server with OASIS SDK](https://docs.oasis.dev/tutorials/messaging.html#prerequisites)
 
 ## Príklady použitia pre pokročilých {#advanced-use-patterns}
 

--- a/src/content/translations/tr/rust/index.md
+++ b/src/content/translations/tr/rust/index.md
@@ -35,7 +35,6 @@ Başlamadan önce daha fazla bilgiye mi ihtiyacın var? Bu adrese göz at [ether
 
 - [Rust-Web3 Documentation](https://tomusdrw.github.io/rust-web3/web3/index.html)
 - [Rust-Web3 Working Examples](https://github.com/tomusdrw/rust-web3/blob/master/examples)
-- [Creating a Private Chat Server with OASIS SDK](https://docs.oasis.dev/tutorials/messaging.html#prerequisites)
 
 ## İleri Düzey Kullanım Şekilleri {#advanced-use-patterns}
 

--- a/src/content/translations/uk/rust/index.md
+++ b/src/content/translations/uk/rust/index.md
@@ -36,8 +36,6 @@ sidebarDepth: 1
 
 - [Документація Rust-Web3](https://tomusdrw.github.io/rust-web3/web3/index.html)
 - [Демонстраційні приклади Rust-Web3](https://github.com/tomusdrw/rust-web3/blob/master/examples)
-- [Створення тайного голосування з використанням OASIS SDK](https://docs.oasis.dev/tutorials/ballot.html#prerequisites)
-- [Створення сервера приватних чатів із використанням OASIS SDK](https://docs.oasis.dev/tutorials/messaging.html#prerequisites)
 
 ## Розширене використання шаблонів {#advanced-use-patterns}
 

--- a/src/content/translations/vi/rust/index.md
+++ b/src/content/translations/vi/rust/index.md
@@ -36,8 +36,6 @@ Cần một hướng dẫn cơ bản hơn? Tham khảo [ethereum.org/learn](/vi/
 
 - [Tài liệu tham khảo Rust-Web3](https://tomusdrw.github.io/rust-web3/web3/index.html)
 - [Ví dụ làm việc của Rust-Web3](https://github.com/tomusdrw/rust-web3/blob/master/examples)
-- [Tạo một lá phiếu bí mật với OASIS SDK](https://docs.oasis.dev/tutorials/ballot.html#prerequisites)
-- [Tạo một máy chủ trò chuyện riêng tư với OASIS SDK](https://docs.oasis.dev/tutorials/messaging.html#prerequisites)
 
 ## Các mẫu sử dụng nâng cao {#advanced-use-patterns}
 

--- a/src/content/translations/zh-tw/rust/index.md
+++ b/src/content/translations/zh-tw/rust/index.md
@@ -35,8 +35,6 @@ sidebar: true
 
 - [Rust-Web3 相關文檔](https://tomusdrw.github.io/rust-web3/web3/index.html)
 - [Rust-Web3 工作示例](https://github.com/tomusdrw/rust-web3/blob/master/examples)
-- [使用 OASIS SDK 創建秘密投票](https://docs.oasis.dev/tutorials/ballot.html#prerequisites)
-- [使用 OASIS SDK 創建私密聊天服務器](https://docs.oasis.dev/tutorials/messaging.html#prerequisites)
 
 ## 高級使用模式 {#advanced-use-patterns}
 

--- a/src/content/translations/zh/developers/docs/programming-languages/rust/index.md
+++ b/src/content/translations/zh/developers/docs/programming-languages/rust/index.md
@@ -34,8 +34,6 @@ incomplete: true
 
 - [Rust-Web3 相关文档](https://tomusdrw.github.io/rust-web3/web3/index.html)
 - [Rust-Web3 工作示例](https://github.com/tomusdrw/rust-web3/blob/master/examples)
-- [使用 OASIS SDK 创建秘密投票](https://docs.oasis.dev/tutorials/ballot.html#prerequisites)
-- [使用 OASIS SDK 创建私密聊天服务器](https://docs.oasis.dev/tutorials/messaging.html#prerequisites)
 
 ## 面向高等程度者的使用模式 {#advanced-use-patterns}
 

--- a/src/content/translations/zh/rust/index.md
+++ b/src/content/translations/zh/rust/index.md
@@ -35,8 +35,6 @@ sidebar: true
 
 - [Rust-Web3 相关文档](https://tomusdrw.github.io/rust-web3/web3/index.html)
 - [Rust-Web3 工作示例](https://github.com/tomusdrw/rust-web3/blob/master/examples)
-- [使用 OASIS SDK 创建秘密投票](https://docs.oasis.dev/tutorials/ballot.html#prerequisites)
-- [使用 OASIS SDK 创建私密聊天服务器](https://docs.oasis.dev/tutorials/messaging.html#prerequisites)
 
 ## 高级使用模式 {#advanced-use-patterns}
 


### PR DESCRIPTION
## Description
Removes a bunch of dead links that have been taken down from the oasis docs

## Related Issue
#4610