### PR TITLE
Update links in standards developer docs

### DIFF
--- a/src/content/developers/docs/standards/index.md
+++ b/src/content/developers/docs/standards/index.md
@@ -16,7 +16,7 @@ Typically standards are introduced as [Ethereum Improvement Proposals](/eips/) (
 - [List of EIPs](https://eips.ethereum.org/)
 - [EIP github repo](https://github.com/ethereum/EIPs)
 - [EIP discussion board](https://ethereum-magicians.org/c/eips)
-- [Ethereum Governance Overview](https://blog.bmannconsulting.com/ethereum-governance/) _March 31, 2019 - Boris Mann_
+- [Ethereum Governance Overview](https://ethereum.org/en/governance/)
 - [Ethereum Protocol Development Governance and Network Upgrade Coordination](https://hudsonjameson.com/2020-03-23-ethereum-protocol-development-governance-and-network-upgrade-coordination/) _March 23, 2020 - Hudson Jameson_
 - [Playlist of all Ethereum Core Dev Meetings](https://www.youtube.com/playlist?list=PLaM7G4Llrb7zfMXCZVEXEABT8OSnd4-7w) _(YouTube Playlist)_
 

--- a/src/content/developers/docs/standards/index.md
+++ b/src/content/developers/docs/standards/index.md
@@ -16,7 +16,8 @@ Typically standards are introduced as [Ethereum Improvement Proposals](/eips/) (
 - [List of EIPs](https://eips.ethereum.org/)
 - [EIP github repo](https://github.com/ethereum/EIPs)
 - [EIP discussion board](https://ethereum-magicians.org/c/eips)
-- [Ethereum Governance Overview](https://ethereum.org/en/governance/)
+- [Introduction to Ethereum Governance](/governance/)
+- [Ethereum Governance Overview](https://web.archive.org/web/20201107234050/https://blog.bmannconsulting.com/ethereum-governance/) _March 31, 2019 - Boris Mann_ 
 - [Ethereum Protocol Development Governance and Network Upgrade Coordination](https://hudsonjameson.com/2020-03-23-ethereum-protocol-development-governance-and-network-upgrade-coordination/) _March 23, 2020 - Hudson Jameson_
 - [Playlist of all Ethereum Core Dev Meetings](https://www.youtube.com/playlist?list=PLaM7G4Llrb7zfMXCZVEXEABT8OSnd4-7w) _(YouTube Playlist)_
 


### PR DESCRIPTION
dead end ("not found") the link https://blog.bmannconsulting.com/ethereum-governance/ for more about Ethereum Governance