### PR TITLE
Fixed a typo on the developers page [fixes #4608]

### DIFF
--- a/src/intl/en/page-developers-index.json
+++ b/src/intl/en/page-developers-index.json
@@ -31,7 +31,7 @@
   "page-developers-gas-link": "Gas",
   "page-developers-get-started": "How would you like to get started?",
   "page-developers-improve-ethereum": "Help us make ethereum.org better",
-  "page-developers-improve-ethereum-desc": "Like ethereum.org, these docs are a community effort. Create a PR if you see mistakes, room for improvement, or new opportunties to help Ethereum developers.",
+  "page-developers-improve-ethereum-desc": "Like ethereum.org, these docs are a community effort. Create a PR if you see mistakes, room for improvement, or new opportunities to help Ethereum developers.",
   "page-developers-into-eth-desc": "An introduction to blockchain and Ethereum",
   "page-developers-intro-ether-desc": "An introduction to cryptocurrency and Ether",
   "page-developers-intro-dapps-desc": "An introduction to decentralized applications",


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Fixed a typo on the developers page where the word "opportunties" was spelt wrong. So it has now been corrected to "opportunities".

### Before:
![image](https://user-images.githubusercontent.com/54685928/144655526-320f68d4-87c5-4bb4-85a1-af4d66299b1c.png)

### After:
![image](https://user-images.githubusercontent.com/54685928/144656766-894d6feb-e6c4-41f4-903d-fbfefe55047c.png)

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
