### PR TITLE
fix: always convert nodes stats to Number

### DIFF
--- a/src/components/StatsBoxGrid.js
+++ b/src/components/StatsBoxGrid.js
@@ -348,7 +348,7 @@ const StatsBoxGrid = () => {
         const data = result
           .map(({ UTCDate, TotalNodeCount }) => ({
             timestamp: new Date(UTCDate).getTime(),
-            value: TotalNodeCount,
+            value: Number(TotalNodeCount),
           }))
           .sort((a, b) => a.timestamp - b.timestamp)
         const value = formatNodes(data[data.length - 1].value)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When switching between 30 Days and 90 Days with specific data, the chart becomes unreadable.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/ethereum/ethereum-org-website/issues/4651