### PR TITLE
Fix typos in EVM developer docs

### DIFF
--- a/src/content/developers/docs/evm/index.md
+++ b/src/content/developers/docs/evm/index.md
@@ -11,7 +11,7 @@ The Ethereum protocol itself exists solely for the purpose of keeping the contin
 
 ## Prerequisites {#prerequisites}
 
-Some basic familiarity with common terminology in computer science such as [bytes](https://en.wikipedia.org/wiki/Byte), [memory](https://en.wikipedia.org/wiki/Computer_memory), and a [stack](<https://en.wikipedia.org/wiki/Stack_(abstract_data_type)>) are necessary to understand the EVM. It would also be helpful to be comfortable with cryptography/blockchain concepts like [hash functions](https://en.wikipedia.org/wiki/Cryptographic_hash_function), [Proof-of-Work](https://en.wikipedia.org/wiki/Proof_of_work) and the [Merkle Tree](https://en.wikipedia.org/wiki/Merkle_tree).
+Some basic familiarity with common terminology in computer science such as [bytes](https://en.wikipedia.org/wiki/Byte), [memory](https://en.wikipedia.org/wiki/Computer_memory), and a [stack](<https://en.wikipedia.org/wiki/Stack_(abstract_data_type)>) are necessary to understand the EVM. It would also be helpful to be comfortable with cryptography/blockchain concepts like [hash functions](https://en.wikipedia.org/wiki/Cryptographic_hash_function), [proof-of-work](https://en.wikipedia.org/wiki/Proof_of_work) and the [Merkle tree](https://en.wikipedia.org/wiki/Merkle_tree).
 
 ## From ledger to state machine {#from-ledger-to-state-machine}
 


### PR DESCRIPTION
## Fix typos in EVM developer docs
Fixed typos in Ethereum Virtual Machine developer docs, in reference to " https://ethereum.org/en/contributing/style-guide/#proof-of "📌