### PR TITLE
Fix stacking button elements in container [Fixes #4598]

### DIFF
--- a/src/pages/stablecoins.js
+++ b/src/pages/stablecoins.js
@@ -249,8 +249,15 @@ const InfoIcon = styled(Icon)`
   fill: ${(props) => props.theme.colors.text};
 `
 
-const ButtonLinkRight = styled(ButtonLink)`
-  margin-left: 1rem;
+const ButtonLinkWrap = styled(ButtonLink)`
+  white-space: break-spaces;
+`
+
+const ButtonLinkContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  flex-flow: wrap;
+  gap: 1em;
 `
 
 const tooltipContent = (
@@ -807,14 +814,14 @@ const StablecoinsPage = ({ data }) => {
             intl
           )}
         >
-          <div>
+          <ButtonLinkContainer>
             <ButtonLink to="/dapps/">
               <Translation id="page-stablecoins-explore-dapps" />
             </ButtonLink>
-            <ButtonLinkRight isSecondary to="/defi/">
+            <ButtonLinkWrap isSecondary to="/defi/">
               <Translation id="page-stablecoins-more-defi-button" />
-            </ButtonLinkRight>
-          </div>
+            </ButtonLinkWrap>
+          </ButtonLinkContainer>
         </StyledCalloutBanner>
         <h2>
           <Translation id="page-stablecoins-save-stablecoins" />


### PR DESCRIPTION
Issue with buttons not stacking properly in `/stablecoins`, `Use you stablecoins` container.

## Description

- Remove `ButtonLinkRight` since it only adds `margin-right` to the button
- Add  `ButtonLinkContainer` to be a container around buttons to display flex in rows
- Update second button to be `ButtonLink`

## Related Issue

#4598 
Changed PR #4667 to this one due to issues with code