### PR TITLE
Adjust `relativePathStart` logic [Fixes #4710]

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -179,7 +179,7 @@ exports.onCreateNode = async ({ node, getNode, actions }) => {
     }
 
     const absolutePath = node.fileAbsolutePath
-    const relativePathStart = absolutePath.indexOf("src/")
+    const relativePathStart = absolutePath.lastIndexOf("src/")
     const relativePath = absolutePath.substring(relativePathStart)
 
     // Boolean if page is outdated (most translated files are)


### PR DESCRIPTION
## Description
Relative path is being passed  with `src/app/www` at the beginning, when it previously did not prior to Gatsby Cloud migration.
- Changes `gatsby-node` logic to find _last_ instance of `src/` as starting point for relative path.
- Corrects `relativePath` and `editPath` for GitHub queries

Deploy preview: https://ethereumorgwebsitedev01-relativepath.gtsb.io/en/developers/docs/
Screenshot:
![image](https://user-images.githubusercontent.com/54227730/145913259-d2b83969-cc59-43a6-a777-50cf5db7234e.png)

## Related Issue
[Fixes #4710]
More comments on the issue here #4762 