### PR TITLE
Revert changes to relativePathStart

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -179,7 +179,7 @@ exports.onCreateNode = async ({ node, getNode, actions }) => {
     }
 
     const absolutePath = node.fileAbsolutePath
-    const relativePathStart = absolutePath.lastIndexOf("src/")
+    const relativePathStart = absolutePath.indexOf("src/")
     const relativePath = absolutePath.substring(relativePathStart)
 
     // Boolean if page is outdated (most translated files are)


### PR DESCRIPTION
## Description
Reverts #4763 as it was causing the homepage to not load correctly on deploy previews. 

The page would load initially for a second and then, after the initial render, the page goes blank.

[Video of bug](https://i.gyazo.com/9b256f5b6ceb9689788679414a33ec07.gif)

## Related Issue
#4710
