### PR TITLE
Add eth-fun to docs

### DIFF
--- a/src/content/developers/docs/apis/javascript/index.md
+++ b/src/content/developers/docs/apis/javascript/index.md
@@ -278,6 +278,12 @@ ethers.utils.formatEther(balance)
 - [Documentation](https://docs.alchemyapi.io/documentation/alchemy-web3)
 - [GitHub](https://github.com/alchemyplatform/alchemy-web3)
 
+
+**eth-fun -** **_Functional and state-less library for the Ethereum JSON-RPC._**
+
+- [Documentation](https://github.com/rugpullindex/eth-fun/blob/master/API.md)
+- [GitHub](https://github.com/rugpullindex/eth-fun)
+
 ## Further reading {#further-reading}
 
 _Know of a community resource that helped you? Edit this page and add it!_


### PR DESCRIPTION
## Description

eth-fun is a library that we created as we saw the need for a pure/stateless alternative to ethersjs and web3. eth-fun is functional and so a shared state between the node and a client is never created, meaning that all requests are atomic. They either return or need to be rescheduled. This allows for more reliable requesting of the JSON-RPC endpoint.

## Related Issue

- no related issue.
