### PR TITLE
Render StatsBoxGrid as a span [Fixes #4757]

### DIFF
--- a/src/components/StatsBoxGrid.js
+++ b/src/components/StatsBoxGrid.js
@@ -15,7 +15,7 @@ import { getData } from "../utils/cache"
 const Value = styled.span`
   position: absolute;
   bottom: 8%;
-  font-size: min(4.4vw, 64px);
+  font-size: min(4.4vw, 4rem);
   font-weight: 600;
   margin-top: 0rem;
   margin-bottom: 1rem;

--- a/src/components/StatsBoxGrid.js
+++ b/src/components/StatsBoxGrid.js
@@ -12,7 +12,7 @@ import Icon from "./Icon"
 import { isLangRightToLeft } from "../utils/translations"
 import { getData } from "../utils/cache"
 
-const Value = styled.h3`
+const Value = styled.span`
   position: absolute;
   bottom: 8%;
   font-size: min(4.4vw, 64px);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR renders the StatsBoxGrid result as a `span` as opposed to an `h3` element.

<!--- Describe your changes in detail -->

## Related Issue
#4757

## With change
![Screen Shot 2021-12-14 at 12 48 06 PM](https://user-images.githubusercontent.com/20748598/146062160-5e57ea23-1ddf-4808-b6e2-07b8cec6af24.png)

