### PR TITLE
[testing] Revert and adjust `relativePath` parsing logic

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -179,8 +179,12 @@ exports.onCreateNode = async ({ node, getNode, actions }) => {
     }
 
     const absolutePath = node.fileAbsolutePath
-    const relativePathStart = absolutePath.indexOf("src/")
-    const relativePath = absolutePath.substring(relativePathStart)
+    let relativePath = absolutePath.startsWith(__dirname)
+      ? absolutePath.slice(__dirname.length)
+      : absolutePath
+    if (relativePath.startsWith("/")) {
+      relativePath = relativePath.slice(1)
+    }
 
     // Boolean if page is outdated (most translated files are)
     createNodeField({


### PR DESCRIPTION
Builds recently stopped working after `relativePath` logic was switched to use `lastIndexOf("src/")`.

Reverts to commit before builds stopped working, and adjusted with new logic for `relativePath`