### PR TITLE
Remove `gatsby-plugin-lodash`

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -59,28 +59,6 @@ module.exports = {
         // dev: true,
       },
     },
-    {
-      resolve: `gatsby-plugin-lodash`,
-      options: {
-        disabledFeatures: [
-          `shorthands`,
-          `currying`,
-          `caching`,
-          `collections`,
-          `exotics`,
-          `guards`,
-          `metadata`,
-          `deburring`,
-          `unicode`,
-          `chaining`,
-          `momoizing`,
-          `coercions`,
-          `flattening`,
-          `paths`,
-          `placeholders`,
-        ],
-      },
-    },
     // Sitemap generator (ethereum.org/sitemap.xml)
     {
       resolve: `gatsby-plugin-sitemap`,

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "gatsby-plugin-gatsby-cloud": "^4.3.0",
     "gatsby-plugin-image": "^2.0.0",
     "gatsby-plugin-intl": "^0.3.3",
-    "gatsby-plugin-lodash": "^5.0.0",
     "gatsby-plugin-manifest": "^4.0.0",
     "gatsby-plugin-matomo": "^0.9.0",
     "gatsby-plugin-mdx": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7801,15 +7801,6 @@ gatsby-plugin-intl@^0.3.3:
     intl "^1.2.5"
     react-intl "^3.12.0"
 
-gatsby-plugin-lodash@^5.0.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-lodash/-/gatsby-plugin-lodash-5.3.0.tgz#71f1b7f3e07397ddab68d5b9d6370662afb0e679"
-  integrity sha512-kxLs7rhYKNSNKFCSGUOA1C7WZ5xQ+6/UTyFgN1zz2UpnPzEniTsB+zXzQ2ga6QfUssv5kcGO9AKyMPNU+UlSIQ==
-  dependencies:
-    "@babel/runtime" "^7.15.4"
-    babel-plugin-lodash "^3.3.4"
-    lodash-webpack-plugin "^0.11.6"
-
 gatsby-plugin-manifest@^4.0.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-manifest/-/gatsby-plugin-manifest-4.3.0.tgz#2e6ce2a15d149ba84b956569b3f5243ee6d7a745"
@@ -8087,6 +8078,13 @@ gatsby-remark-images@^6.0.0:
     unist-util-select "^3.0.4"
     unist-util-visit-parents "^3.1.1"
 
+gatsby-remark-reading-time@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/gatsby-remark-reading-time/-/gatsby-remark-reading-time-1.1.0.tgz#f23590ae34233c3625e656e0368ad0e0e84761a1"
+  integrity sha512-J2I/Aerw6iEcYUs9MH5r7Ky5PIe7Aiq7+M3sDWdRa0ddWYIOZGxPq8U1xYsIBwQjVtPovk8N4aMTau9kjQQLQA==
+  dependencies:
+    reading-time "^1.1.3"
+
 gatsby-source-filesystem@^4.0.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/gatsby-source-filesystem/-/gatsby-source-filesystem-4.3.0.tgz#0a4f21cecc0cc942096c11c1b583a698f1edf2d8"
@@ -8105,13 +8103,6 @@ gatsby-source-filesystem@^4.0.0:
     progress "^2.0.3"
     valid-url "^1.0.9"
     xstate "^4.25.0"
-
-gatsby-remark-reading-time@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/gatsby-remark-reading-time/-/gatsby-remark-reading-time-1.1.0.tgz#f23590ae34233c3625e656e0368ad0e0e84761a1"
-  integrity sha512-J2I/Aerw6iEcYUs9MH5r7Ky5PIe7Aiq7+M3sDWdRa0ddWYIOZGxPq8U1xYsIBwQjVtPovk8N4aMTau9kjQQLQA==
-  dependencies:
-    reading-time "^1.1.3"
 
 gatsby-telemetry@^3.3.0:
   version "3.3.0"
@@ -10758,13 +10749,6 @@ lockfile@^1.0:
   integrity sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==
   dependencies:
     signal-exit "^3.0.2"
-
-lodash-webpack-plugin@^0.11.6:
-  version "0.11.6"
-  resolved "https://registry.yarnpkg.com/lodash-webpack-plugin/-/lodash-webpack-plugin-0.11.6.tgz#8204c6b78beb62ce5211217dfe783c21557ecd33"
-  integrity sha512-nsHN/+IxZK/C425vGC8pAxkKJ8KQH2+NJnhDul14zYNWr6HJcA95w+oRR7Cp0oZpOdMplDZXmjVROp8prPk7ig==
-  dependencies:
-    lodash "^4.17.20"
 
 lodash.assignin@^4.0.9:
   version "4.2.0"


### PR DESCRIPTION
## Description
Recent builds have been presenting with a large variety of bugs. The errors received followed the theme of `TypeError: ___ is not a function`. A recent bug presented similarly where nav menus were broken, and was fixed by removing the use of `lodash` in that PR. Noted that we have both `lodash` and `gatsby-plugin-lodash` installed. 
Attempting to switch usage of `lodash` library in components, to using the gatby plugin resulted in a broken build.

Removing the gatsby plugin in lieu of the standard `lodash` library seems to fix the array of bugs we've been seeing.

- Removes `gatsby-plugin-lodash` package