### PR TITLE
Re-add StatsBoxGrid component

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -13,7 +13,7 @@ import Codeblock from "../components/Codeblock"
 import LegacyPageHome from "../components/LegacyPageHome"
 import Morpher from "../components/Morpher"
 import PageMetadata from "../components/PageMetadata"
-// import StatsBoxGrid from "../components/StatsBoxGrid"
+import StatsBoxGrid from "../components/StatsBoxGrid"
 import Translation from "../components/Translation"
 import TitleCardList from "../components/TitleCardList"
 import {
@@ -902,7 +902,7 @@ contract SimpleDomainRegistry {
           </Codeblock>
         </CodeboxModal>
       </DeveloperContainer>
-      {/* <StyledGrayContainer>
+      <StyledGrayContainer>
         <StyledContent>
           <h2>
             <Translation id="page-index-network-stats-title" />
@@ -912,7 +912,7 @@ contract SimpleDomainRegistry {
           </Subtitle>
         </StyledContent>
         <StatsBoxGrid />
-      </StyledGrayContainer> */}
+      </StyledGrayContainer>
       <StyledContent>
         <h2>
           <Translation id="page-index-touts-header" />


### PR DESCRIPTION
## Description
PR #4788 fixed bugs being caused by `gatsby-plugin-lodash` library. StatsBoxGrid component was removed temporarily from the homepage while debugging, but was not the root cause. This re-adds the metrics to the homepage.