### PR TITLE
Update eth price granularity

### DIFF
--- a/src/components/StatsBoxGrid.js
+++ b/src/components/StatsBoxGrid.js
@@ -309,10 +309,6 @@ const StatsBoxGrid = () => {
   useEffect(() => {
     const fetchPrices = async () => {
       try {
-        const daysToFetch = 90
-        const toUnixTimestamp = Math.floor(new Date().getTime() / 1000) // "Now" as unix timestamp (seconds)
-        const fromUnixTimestamp = toUnixTimestamp - 60 * 60 * 24 * daysToFetch // {daysToFetch} days ago (in seconds)
-        // TODO: Switch back to `getData()` to use cache before prod
         const {
           data: { prices },
         } = await axios.get(

--- a/src/components/StatsBoxGrid.js
+++ b/src/components/StatsBoxGrid.js
@@ -316,7 +316,7 @@ const StatsBoxGrid = () => {
         const {
           data: { prices },
         } = await axios.get(
-          `https://api.coingecko.com/api/v3/coins/ethereum/market_chart/range?vs_currency=usd&from=${fromUnixTimestamp}&to=${toUnixTimestamp}`
+          `https://api.coingecko.com/api/v3/coins/ethereum/market_chart?vs_currency=usd&days=90&interval=daily`
         )
         const data = prices
           .map(([timestamp, value]) => ({


### PR DESCRIPTION


## Description

This PR updates the granularity of the ether price chart to daily so it visually matches the other charts on the stats box grid.

Examples below (both 90 day)

current site:
<img width="727" alt="current-site" src="https://user-images.githubusercontent.com/14168559/146312454-535c007b-417b-4a32-bf93-5881a4c35279.png">

proposed update:
<img width="733" alt="updated-chart" src="https://user-images.githubusercontent.com/14168559/146312369-534c080b-98b1-4691-86e1-ffb7b772a5e5.png">

this will make the full grid look more uniform, instead of the price being less smooth than the other metrics:

<img width="1453" alt="full-view" src="https://user-images.githubusercontent.com/14168559/146312910-ebc09d04-50fc-4ce3-bf98-012bbadc9caa.png">
