### PR TITLE
Remove redundant link

### DIFF
--- a/src/content/community/online/index.md
+++ b/src/content/community/online/index.md
@@ -28,7 +28,6 @@ Hundreds of thousands of Ethereum enthusiasts gather in these online forums to s
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/5W5tVb3">CryptoDevs</Link> <i>- Ethereum development focused Discord community</i></SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.io/ethstaker">EthStaker Discord</Link> <i>- community oriented around offering project management support to Ethereum development</i></SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/CetY6Y4">Ethereum.org website team</Link> <i>- stop by and chat ethereum.org web development and design with the team and folks from the community</i></SocialListItem>
-<SocialListItem socialIcon="discord"><Link to="https://discord.gg/CetY6Y4">Ethereum.org website team</Link> <i>- stop by and chat ethereum.org web development and design with the team and folks from the community</i></SocialListItem>
 
 ## YouTube and Twitter {#youtube-and-twitter}
 


### PR DESCRIPTION
Removed the extra link for joining Ethereum Org Website team discord server

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
The same discord server link for Ethereum Org website team was given twice.
I have just removed the extra one .
## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/ethereum/ethereum-org-website/issues/4804
