### PR TITLE
Refactor `DocLink` component

### DIFF
--- a/src/components/DocLink.js
+++ b/src/components/DocLink.js
@@ -15,14 +15,14 @@ const Container = styled(Link)`
   justify-content: space-between;
   padding: 1rem;
   border-radius: 2px;
-  color: ${(props) => props.theme.colors.text};
-  border: 1px solid ${(props) => props.theme.colors.border};
+  color: ${({ theme }) => theme.colors.text};
+  border: 1px solid ${({ theme }) => theme.colors.border};
   &:hover {
-    box-shadow: 0 0 1px ${(props) => props.theme.colors.primary};
-    background: ${(props) => props.theme.colors.tableBackgroundHover};
+    box-shadow: 0 0 1px ${({ theme }) => theme.colors.primary};
+    background: ${({ theme }) => theme.colors.tableBackgroundHover};
     border-radius: 4px;
   }
-  @media (max-width: ${(props) => props.theme.breakpoints.m}) {
+  @media (max-width: ${({ theme }) => theme.breakpoints.m}) {
     width: 100%;
   }
 `
@@ -30,11 +30,11 @@ const Container = styled(Link)`
 const TextCell = styled.div`
   flex: 1;
   flex-direction: column;
-  color: ${(props) => props.theme.colors.text};
+  color: ${({ theme }) => theme.colors.text};
 `
 
 const Title = styled.p`
-  color: ${(props) => props.theme.colors.text300};
+  color: ${({ theme }) => theme.colors.text300};
   font-weight: 600;
   margin: 0;
 `
@@ -50,15 +50,15 @@ const EmojiCell = styled.div`
   align-items: center;
 `
 
-const DocLink = ({ to, title, className }) => (
+const DocLink = ({ to, children, className }) => (
   <Container to={to} className={className}>
     <EmojiCell>
       <Emoji size={1} text=":page_with_curl:" mr={`1rem`} />
     </EmojiCell>
     <TextCell>
-      <Title>{title}</Title>
+      <Title>{children}</Title>
     </TextCell>
-    <Arrow name="arrowRight" color={(props) => props.theme.colors.text} />
+    <Arrow name="arrowRight" color={({ theme }) => theme.colors.text} />
   </Container>
 )
 

--- a/src/content/community/support/index.md
+++ b/src/content/community/support/index.md
@@ -13,9 +13,13 @@ Are you looking for the official Ethereum support? The first thing you should kn
 
 Understanding the decentralized nature of Ethereum is vital because anyone claiming to be official support for Ethereum is probably trying to scam you! The best protection against scammers is educating yourself and taking security seriously.
 
-<DocLink to="/security/" title="Ethereum security and scam prevention" />
+<DocLink to="/security/">
+  Ethereum security and scam prevention
+</DocLink>
 
-<DocLink to="/learn/" title="Learn Ethereum fundamentals" />
+<DocLink to="/learn/">
+  Learn Ethereum fundamentals
+</DocLink>
 
 Despite the lack of official support, many groups, communities, and projects across the Ethereum ecosystem are happy to help.
 

--- a/src/content/dao/index.md
+++ b/src/content/dao/index.md
@@ -78,7 +78,9 @@ The backbone of a DAO is its smart contract. The contract defines the rules of t
 
 This is possible because smart contracts are tamper-proof once they go live on Ethereum. You can't just edit the code (the DAOs rules) without people noticing because everything is public.
 
-<DocLink to="/developers/docs/smart-contracts/" title="More on smart contracts" />
+<DocLink to="/developers/docs/smart-contracts/">
+  More on smart contracts
+</DocLink>
 
 ## Ethereum and DAOs {#ethereum-and-daos}
 

--- a/src/content/glossary/index.md
+++ b/src/content/glossary/index.md
@@ -22,7 +22,9 @@ A type of attack on a decentralized [network](#network) where a group gains cont
 
 An object containing an [address](#address), balance, [nonce](#nonce), and optional storage and code. An account can be a [contract account](#contract-account) or an [externally owned account (EOA)](#eoa).
 
-<DocLink to="/developers/docs/accounts" title="Ethereum Accounts" />
+<DocLink to="/developers/docs/accounts">
+  Ethereum Accounts
+</DocLink>
 
 ### address {#address}
 
@@ -33,7 +35,9 @@ Most generally, this represents an [EOA](#eoa) or [contract](#contract-accouint)
 The standard way to interact with [contracts](#contract-account) in the Ethereum ecosystem,
 both from outside the blockchain and for contract-to-contract interactions.
 
-<DocLink to="/developers/docs/smart-contracts/compiling/#web-applications" title="ABI" />
+<DocLink to="/developers/docs/smart-contracts/compiling/#web-applications">
+  ABI
+</DocLink>
 
 ### application programming interface {#api}
 
@@ -43,7 +47,9 @@ An Application Programming Interface (API) is a set of definitions for how to us
 
 In [Solidity](#solidity), `assert(false)` compiles to `0xfe`, an invalid opcode, which uses up all remaining [gas](#gas) and reverts all changes. When an `assert()` statement fails, something very wrong and unexpected is happening, and you will need to fix your code. You should use `assert()` to avoid conditions that should never, ever occur.
 
-<DocLink to="/developers/docs/smart-contracts/security/" title="Smart contract security" />
+<DocLink to="/developers/docs/smart-contracts/security/">
+  Smart contract security
+</DocLink>
 
 ### attestation {#attestation}
 
@@ -57,7 +63,9 @@ A validator vote for a [Beacon Chain](#beacon-chain) or [shard](#shard) [block](
 
 An Eth2 upgrade that will become the coordinator for the Ethereum network. It introduces [proof-of-stake](#pos) and [validators](#validator) to Ethereum. It will eventually be merged with [Mainnet](#mainnet).
 
-<DocLink to="/eth2/beacon-chain/" title="Beacon Chain" />
+<DocLink to="/eth2/beacon-chain/">
+  Beacon Chain
+</DocLink>
 
 ### big-endian {#big-endian}
 
@@ -67,13 +75,17 @@ A positional number representation where the most significant digit is first in 
 
 A collection of required information (a block header) about the comprised [transactions](#transaction), and a set of other block headers known as [ommers](#ommer). Blocks are added to the Ethereum network by [miners](#miner).
 
-<DocLink to="/developers/docs/blocks/" title="Blocks" />
+<DocLink to="/developers/docs/blocks/">
+  Blocks
+</DocLink>
 
 ### blockchain {#blockchain}
 
 In Ethereum, a sequence of [blocks](#block) validated by the [proof-of-work](#pow) system, each linking to its predecessor all the way to the [genesis block](#genesis-block). There is no block size limit; it instead uses varying [gas limits](#gas-limit).
 
-<DocLink to="/developers/docs/intro-to-ethereum#what-is-a-blockchain" title="What is a Blockchain?" />
+<DocLink to="/developers/docs/intro-to-ethereum#what-is-a-blockchain">
+  What is a Blockchain?
+</DocLink>
 
 ### bytecode {#bytecode}
 
@@ -91,7 +103,9 @@ The first of two [hard forks](#hard-fork) for the [Metropolis](#metropolis) deve
 
 Converting code written in a high-level programming language (e.g., [Solidity](#solidity)) into a lower-level language (e.g., EVM [bytecode](#bytecode)).
 
-<DocLink to="/developers/docs/smart-contracts/compiling/" title="Compiling Smart Contracts" />
+<DocLink to="/developers/docs/smart-contracts/compiling/">
+  Compiling Smart Contracts
+</DocLink>
 
 ### committee {#committee}
 
@@ -121,7 +135,9 @@ A special [transaction](#transaction), with the [zero address](#zero-address) as
 
 A crosslink provides a summary of a shard's state. It's how [shard](#shard) chains will communicate with one another via the [Beacon Chain](#beacon-chain) in the sharded [proof-of-stake system](#proof-of-stake).
 
-<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work" title="Proof-of-stake" />
+<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work">
+  Proof-of-stake
+</DocLink>
 
 <Divider />
 
@@ -131,19 +147,25 @@ A crosslink provides a summary of a shard's state. It's how [shard](#shard) chai
 
 A company or other organization that operates without hierarchical management. DAO may also refer to a contract named "The DAO" launched on April 30, 2016, which was then hacked in June 2016; this ultimately motivated a [hard fork](#hard-fork) (codenamed DAO) at block 1,192,000, which reversed the hacked DAO contract and caused Ethereum and Ethereum Classic to split into two competing systems.
 
-<DocLink to="/dao/" title="Decentralized Autonomous Organizations (DAOs)" />
+<DocLink to="/dao/">
+  Decentralized Autonomous Organizations (DAOs)
+</DocLink>
 
 ### Dapp {#dapp}
 
 Decentralized application. At a minimum, it is a [smart contract](#smart-contract) and a web user interface. More broadly, a Dapp is a web application that is built on top of open, decentralized, peer-to-peer infrastructure services. In addition, many Dapps include decentralized storage and/or a message protocol and platform.
 
-<DocLink to="/developers/docs/dapps/" title="Introduction to Dapps" />
+<DocLink to="/developers/docs/dapps/">
+  Introduction to Dapps
+</DocLink>
 
 ### decentralized exchange (DEX) {#dex}
 
 A type of [dapp](#dapp) that lets you swap tokens with peers on the network. You need [ether](#ether) to use one (to pay [transactions fees](#transaction-fee)) but they are not subject to geographical restrictions like centralized exchanges – anyone can participate.
 
-<DocLink to="/get-eth/#dex" title="Decentalized exchanges" />
+<DocLink to="/get-eth/#dex">
+  Decentalized exchanges
+</DocLink>
 
 ### deed {#deed}
 
@@ -153,7 +175,9 @@ See [non-fungible token (NFT)](#nft)
 
 Short for "decentralized finance," a broad category of [dapps](#dapp) aiming to provide financial services backed by the blockchain, without any intermediaries, so anyone with an internet connection can participate.
 
-<DocLink to="/defi/" title="Decentralized Finance (DeFi)" />
+<DocLink to="/defi/">
+  Decentralized Finance (DeFi)
+</DocLink>
 
 ### difficulty {#difficulty}
 
@@ -179,13 +203,17 @@ A cryptographic algorithm used by Ethereum to ensure that funds can only be spen
 
 A period of 32 [slots](#slot) (6.4 minutes) in the [Beacon Chain](#beacon-chain)-coordinated system. [Validator](#validator) [committees](#committee) are shuffled every epoch for security reasons. There's an opportunity at each epoch for the chain to be [finalized](#finality).
 
-<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work" title="Proof-of-stake" />
+<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work">
+  Proof-of-stake
+</DocLink>
 
 ### Ethereum Improvement Proposal (EIP) {#eip}
 
 A design document providing information to the Ethereum community, describing a proposed new feature or its processes or environment (see [ERC](#erc)).
 
-<DocLink to="/eips/" title="Introduction to EIPs" />
+<DocLink to="/eips/">
+  Introduction to EIPs
+</DocLink>
 
 ### Ethereum Name Service (ENS) {#ens}
 
@@ -205,7 +233,9 @@ An [account](#account) created by or for human users of the Ethereum network.
 
 A label given to some [EIPs](#eip) that attempt to define a specific standard of Ethereum usage.
 
-<DocLink to="/eips/" title="Introduction to EIPs" />
+<DocLink to="/eips/">
+  Introduction to EIPs
+</DocLink>
 
 ### Ethash {#ethash}
 
@@ -217,19 +247,25 @@ A [proof-of-work](#pow) algorithm for Ethereum 1.0.
 
 The native cryptocurrency used by the Ethereum ecosystem, which covers [gas](#gas) costs when executing transactions. Also written as ETH or its symbol Ξ, the Greek uppercase Xi character.
 
-<DocLink to="/eth/" title="Currency for our digital future" />
+<DocLink to="/eth/">
+  Currency for our digital future
+</DocLink>
 
 ### events {#events}
 
 Allows the use of [EVM](#evm) logging facilities. [Dapps](#dapp) can listen for events and use them to trigger JavaScript callbacks in the user interface.
 
-<DocLink to="/developers/docs/smart-contracts/anatomy/#events-and-logs" title="Events and Logs" />
+<DocLink to="/developers/docs/smart-contracts/anatomy/#events-and-logs">
+  Events and Logs
+</DocLink>
 
 ### Ethereum Virtual Machine (EVM) {#evm}
 
 A stack-based virtual machine that executes [bytecode](#bytecode). In Ethereum, the execution model specifies how the system state is altered given a series of bytecode instructions and a small tuple of environmental data. This is specified through a formal model of a virtual state machine.
 
-<DocLink to="/developers/docs/evm/" title="Ethereum Virtual Machine" />
+<DocLink to="/developers/docs/evm/">
+  Ethereum Virtual Machine
+</DocLink>
 
 ### EVM assembly language {#evm-assembly-language}
 
@@ -247,14 +283,20 @@ A default function called in the absence of data or a declared function name.
 
 A service carried out via [smart contract](#smart-contract) that dispenses funds in the form of free test ether that can be used on a testnet.
 
-<DocLink to="/developers/docs/networks/#testnet-faucets" title="Testnet Faucets" />
+<DocLink to="/developers/docs/networks/#testnet-faucets">
+  Testnet Faucets
+</DocLink>
 
 ### finality {#finality}
 
 Finality is the guarantee that a set of transactions before a given time will not change and can't be reverted.
 
-<DocLink to="/developers/docs/consensus-mechanisms/pow/#finality" title="Proof-of-work finality" />
-<DocLink to="/developers/docs/consensus-mechanisms/pos/#finality" title="Proof-of-stake finality" />
+<DocLink to="/developers/docs/consensus-mechanisms/pow/#finality">
+  Proof-of-work finality
+</DocLink>
+<DocLink to="/developers/docs/consensus-mechanisms/pos/#finality">
+  Proof-of-stake finality
+</DocLink>
 
 ### finney {#finney}
 
@@ -268,7 +310,9 @@ A change in protocol causing the creation of an alternative chain, or a temporal
 
 A security model for certain [layer 2](#layer-2) solutions where, to increase speed, transactions are [rolled up](#rollups) into batches and submitted to Ethereum in a single transaction. They are assumed valid but can be challenged if fraud is suspected. A fraud proof will then run the transaction to see if fraud took place. This method increases the amount of transactions possible while maintaining security. Some [rollups](#rollups) use [validity proofs](#validity-proof).
 
-<DocLink to="/developers/docs/scaling/layer-2-rollups/#optimistic-rollups" title="Optimistic rollups" />
+<DocLink to="/developers/docs/scaling/layer-2-rollups/#optimistic-rollups">
+  Optimistic rollups
+</DocLink>
 
 ### frontier {#frontier}
 
@@ -282,7 +326,9 @@ The initial test development stage of Ethereum, which lasted from July 2015 to M
 
 A virtual fuel used in Ethereum to execute smart contracts. The [EVM](#evm) uses an accounting mechanism to measure the consumption of gas and limit the consumption of computing resources (see [Turing complete](#turing-complete)).
 
-<DocLink to="/developers/docs/gas/" title="Gas and Fees" />
+<DocLink to="/developers/docs/gas/">
+  Gas and Fees
+</DocLink>
 
 ### gas limit {#gas-limit}
 
@@ -348,13 +394,17 @@ A [hard fork](#hard-fork) of Ethereum at block 200,000 to introduce an exponenti
 
 A user interface that typically combines a code editor, compiler, runtime, and debugger.
 
-<DocLink to="/developers/docs/ides/" title="Integrated Development Environments" />
+<DocLink to="/developers/docs/ides/">
+  Integrated Development Environments
+</DocLink>
 
 ### immutable deployed code problem {#immutable-deployed-code-problem}
 
 Once a [contract's](#smart-contract) (or [library's](#library)) code is deployed, it becomes immutable. Standard software development practices rely on being able to fix possible bugs and add new features, so this represents a challenge for smart contract development.
 
-<DocLink to="/developers/docs/smart-contracts/deploying/" title="Deploying Smart Contracts" />
+<DocLink to="/developers/docs/smart-contracts/deploying/">
+  Deploying Smart Contracts
+</DocLink>
 
 ### internal transaction {#internal-transaction}
 
@@ -368,7 +418,9 @@ A [transaction](#transaction) sent from a [contract account](#contract-account) 
 
 Also known as a "password stretching algorithm," it is used by [keystore](#keystore-file) formats to protect against brute-force, dictionary, and rainbow table attacks on passphrase encryption, by repeatedly hashing the passphrase.
 
-<DocLink to="/developers/docs/smart-contracts/security/" title="Smart contract security" />
+<DocLink to="/developers/docs/smart-contracts/security/">
+  Smart contract security
+</DocLink>
 
 ### keccak-256 {#keccak-256}
 
@@ -386,7 +438,9 @@ A JSON-encoded file that contains a single (randomly generated) [private key](#p
 
 An area of development focused on layering improvements on top of the Ethereum protocol. These improvements are related to [transaction](#transaction) speeds, cheaper [transaction fees](#transaction-fee), and transaction privacy.
 
-<DocLink to="/developers/docs/scaling/layer-2-rollups/" title="Layer 2" />
+<DocLink to="/developers/docs/scaling/layer-2-rollups/">
+  Layer 2
+</DocLink>
 
 ### LevelDB {#level-db}
 
@@ -396,7 +450,9 @@ An open source on-disk key-value store, implemented as a lightweight, single-pur
 
 A special type of [contract](#smart-contract) that has no payable functions, no fallback function, and no data storage. Therefore, it cannot receive or hold ether, or store data. A library serves as previously deployed code that other contracts can call for read-only computation.
 
-<DocLink to="/developers/docs/smart-contracts/libraries/" title="Smart Contract Libraries" />
+<DocLink to="/developers/docs/smart-contracts/libraries/">
+  Smart Contract Libraries
+</DocLink>
 
 ### lightweight client {#lightweight-client}
 
@@ -430,7 +486,9 @@ The third development stage of Ethereum, launched in October 2017.
 
 A network [node](#node) that finds valid [proof-of-work](#pow) for new blocks, by repeated pass hashing (see [Ethash](#ethash)).
 
-<DocLink to="/developers/docs/consensus-mechanisms/pow/mining/" title="Mining" />
+<DocLink to="/developers/docs/consensus-mechanisms/pow/mining/">
+  Mining
+</DocLink>
 
 <Divider />
 
@@ -440,20 +498,28 @@ A network [node](#node) that finds valid [proof-of-work](#pow) for new blocks, b
 
 Referring to the Ethereum network, a peer-to-peer network that propagates transactions and blocks to every Ethereum node (network participant).
 
-<DocLink to="/developers/docs/networks/" title="Networks" />
+<DocLink to="/developers/docs/networks/">
+  Networks
+</DocLink>
 
 ### non-fungible token (NFT) {#nft}
 
 Also known as a "deed," this is a token standard introduced by the ERC-721 proposal. NFTs can be tracked and traded, but each token is unique and distinct; they are not interchangeable like ETH and [ERC-20 tokens](#token-standard). NFTs can represent ownership of digital or physical assets.
 
-<DocLink to="/nft/" title="Non-Fungible Tokens (NFTs)" />
-<DocLink to="/developers/docs/standards/tokens/erc-721/" title="ERC-721 Non-Fungible Token Standard" />
+<DocLink to="/nft/">
+  Non-Fungible Tokens (NFTs)
+</DocLink>
+<DocLink to="/developers/docs/standards/tokens/erc-721/">
+  ERC-721 Non-Fungible Token Standard
+</DocLink>
 
 ### node {#node}
 
 A software client that participates in the network.
 
-<DocLink to="/developers/docs/nodes-and-clients/" title="Nodes and Clients" />
+<DocLink to="/developers/docs/nodes-and-clients/">
+  Nodes and Clients
+</DocLink>
 
 ### nonce {#nonce}
 
@@ -471,13 +537,17 @@ When a [miner](#miner) finds a valid [block](#block), another miner may have pub
 
 A [rollup](#rollups) of transactions that use [fraud proofs](#fraud-proof) to offer increased [layer 2](#layer-2) transaction throughput while using the security provided by [Mainnet](#mainnet) (layer 1). Unlike [Plasma](#plasma), a similar layer 2 solution, Optimistic rollups can handle more complex transaction types – anything possible in the [EVM](#evm). They do have latency issues compared to [Zero-knowledge rollups](#zk-rollups) because a transaction can be challenged via the fraud proof.
 
-<DocLink to="/developers/docs/scaling/layer-2-rollups/#optimistic-rollups" title="Optimistic Rollups" />
+<DocLink to="/developers/docs/scaling/layer-2-rollups/#optimistic-rollups">
+  Optimistic Rollups
+</DocLink>
 
 ### Oracle {#oracle}
 
 An oracle is a bridge between the [blockchain](#blockchain) and the real world. They act as on-chain [APIs](#api) that can be queried for information and used in [smart contracts](#smart-contract).
 
-<DocLink to="/developers/docs/oracles/" title="Oracles" />
+<DocLink to="/developers/docs/oracles/">
+  Oracles
+</DocLink>
 
 <Divider />
 
@@ -491,7 +561,9 @@ One of the most prominent interoperable implementations of the Ethereum client s
 
 An off-chain scaling solution that uses [fraud proofs](#fraud-proof), like [Optimistic rollups](#optimistic-rollups). Plasma is limited to simple transactions like basic token transfers and swaps.
 
-<DocLink to="/developers/docs/scaling/plasma" title="Plasma" />
+<DocLink to="/developers/docs/scaling/plasma">
+  Plasma
+</DocLink>
 
 ### private key (secret key) {#private-key}
 
@@ -501,13 +573,17 @@ A secret number that allows Ethereum users to prove ownership of an account or c
 
 A method by which a cryptocurrency blockchain protocol aims to achieve distributed [consensus](#consensus). PoS asks users to prove ownership of a certain amount of cryptocurrency (their "stake" in the network) in order to be able to participate in the validation of transactions.
 
-<DocLink to="/developers/docs/consensus-mechanisms/pos/" title="Proof-of-stake" />
+<DocLink to="/developers/docs/consensus-mechanisms/pos/">
+  Proof-of-stake
+</DocLink>
 
 ### Proof-of-work (PoW) {#pow}
 
 A piece of data (the proof) that requires significant computation to find. In Ethereum, [miners](#miner) must find a numeric solution to the [Ethash](#ethash) algorithm that meets a network-wide [difficulty](#difficulty) target.
 
-<DocLink to="/developers/docs/consensus-mechanisms/pow/" title="Proof-of-work" />
+<DocLink to="/developers/docs/consensus-mechanisms/pow/">
+  Proof-of-work
+</DocLink>
 
 ### public key {#public-key}
 
@@ -525,7 +601,9 @@ Data returned by an Ethereum client to represent the result of a particular [tra
 
 An attack that consists of an attacker contract calling a victim contract function in such a way that during execution the victim calls the attacker contract again, recursively. This can result, for example, in the theft of funds by skipping parts of the victim contract that update balances or count withdrawal amounts.
 
-<DocLink to="/developers/docs/smart-contracts/security/#re-entrancy" title="Re-entrancy" />
+<DocLink to="/developers/docs/smart-contracts/security/#re-entrancy">
+  Re-entrancy
+</DocLink>
 
 ### reward {#reward}
 
@@ -539,7 +617,9 @@ An encoding standard designed by the Ethereum developers to encode and serialize
 
 A type of [layer 2](#layer-2) scaling solution that batches multiple transactions and submits them to [the Ethereum main chain](#mainnet) in a single transaction. This allows for reductions in [gas](#gas) costs and increases in [transaction](#transaction) throughput. There are Optimistic and Zero-knowledge rollups which use different security methods to offer these scalability gains.
 
-<DocLink to="/developers/docs/scaling/layer-2-rollups/" title="Rollups" />
+<DocLink to="/developers/docs/scaling/layer-2-rollups/">
+  Rollups
+</DocLink>
 
 <Divider />
 
@@ -549,7 +629,9 @@ A type of [layer 2](#layer-2) scaling solution that batches multiple transaction
 
 The fourth and final development stage of Ethereum, otherwise known as Ethereum 2.0.
 
-<DocLink to="/eth2/" title="Ethereum 2.0 (Eth2)" />
+<DocLink to="/eth2/">
+  Ethereum 2.0 (Eth2)
+</DocLink>
 
 ### Secure Hash Algorithm (SHA) {#sha}
 
@@ -559,13 +641,17 @@ A family of cryptographic hash functions published by the National Institute of 
 
 A [proof-of-stake](#pos) chain that is coordinated by the [Beacon Chain](#beacon-chain) and secured by [validators](#validator). There will be 64 added to the network as part of the Eth2 shard chain upgrade. Shard chains will offer increased transaction throughput for Ethereum by providing additional data to [layer 2](#layer-2) solutions like [optimistic rollups](#optimistic-rollups) and [ZK-rollups](#zk-rollups).
 
-<DocLink to="/eth2/shard-chains" title="Shard chains" />
+<DocLink to="/eth2/shard-chains">
+  Shard chains
+</DocLink>
 
 ### sidechain {#sidechain}
 
 A scaling solution that uses a separate chain with different, often faster, [consensus rules](#consensus-rules). A bridge is needed to connect these sidechains to [Mainnet](#mainnet). [Rollups](#rollups) also use sidechains, but they operate in collaboration with [Mainnet](#mainnet) instead.
 
-<DocLink to="/developers/docs/scaling/sidechains/" title="Sidechains" />
+<DocLink to="/developers/docs/scaling/sidechains/">
+  Sidechains
+</DocLink>
 
 ### singleton {#singleton}
 
@@ -575,19 +661,25 @@ A computer programming term that describes an object of which only a single inst
 
 A period of time (12 seconds) in which a new [Beacon Chain](#beacon-chain) and [shard](#shard) chain block can be proposed by a [validator](#validator) in the [proof-of-stake](#pos) system. A slot may be empty. 32 slots make up an [epoch](#epoch).
 
-<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work" title="Proof-of-stake" />
+<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work">
+  Proof-of-stake
+</DocLink>
 
 ### smart contract {#smart-contract}
 
 A program that executes on the Ethereum computing infrastructure.
 
-<DocLink to="/developers/docs/smart-contracts/" title="Introduction to Smart Contracts" />
+<DocLink to="/developers/docs/smart-contracts/">
+  Introduction to Smart Contracts
+</DocLink>
 
 ### Solidity {#solidity}
 
 A procedural (imperative) programming language with syntax that is similar to JavaScript, C++, or Java. The most popular and most frequently used language for Ethereum [smart contracts](#smart-contract). Created by Dr. Gavin Wood.
 
-<DocLink to="/developers/docs/smart-contracts/languages/#solidity" title="Solidity" />
+<DocLink to="/developers/docs/smart-contracts/languages/#solidity">
+  Solidity
+</DocLink>
 
 ### Solidity inline assembly {#solidity-inline-assembly}
 
@@ -601,19 +693,25 @@ A [hard fork](#hard-fork) of the Ethereum blockchain, which occurred at block 2,
 
 An [ERC-20 token](#token-standard) with a value pegged to another asset's value. There are stablecoins backed by fiat currency like dollars, precious metals like gold, and other cryptocurrencies like Bitcoin.
 
-<DocLink to="/eth/#tokens" title="ETH isn't the only crypto on Ethereum" />
+<DocLink to="/eth/#tokens">
+  ETH isn't the only crypto on Ethereum
+</DocLink>
 
 ### staking {#staking}
 
 Depositing a quantity of [ether](#ether) (your stake) to become a validator and secure the [network](#network). A validator checks [transactions](#transaction) and proposes [blocks](#block) under a [proof-of-stake](#pos) consensus model. Staking gives you an economic incentive to act in the best interests of the network. You'll get rewards for carrying out your [validator](#validator) duties, but lose varying amounts of ETH if you don't.
 
-<DocLink to="/eth2/staking/" title="Stake your ETH to become an Ethereum validator" />
+<DocLink to="/eth2/staking/">
+  Stake your ETH to become an Ethereum validator
+</DocLink>
 
 ### state channels {#state-channels}
 
 A [layer 2](#layer-2) solution where a channel is set up between participants, where they can transact freely and cheaply. Only a [transaction](#transaction) to set up the channel and close the channel is sent to [Mainnet](#mainnet). This allows for very high transaction throughput, but does rely on knowing number of participants up front and locking up of funds.
 
-<DocLink to="/developers/docs/scaling/state-channels/#state-channels" title="State channels" />
+<DocLink to="/developers/docs/scaling/state-channels/#state-channels">
+  State channels
+</DocLink>
 
 ### szabo {#szabo}
 
@@ -631,19 +729,25 @@ A [hard fork](#hard-fork) of the Ethereum blockchain, which occurred at block 2,
 
 Short for "test network," a network used to simulate the behavior of the main Ethereum network (see [Mainnet](#mainnet)).
 
-<DocLink to="/developers/docs/networks/#testnets" title="Testnets" />
+<DocLink to="/developers/docs/networks/#testnets">
+  Testnets
+</DocLink>
 
 ### token standard {#token-standard}
 
 Introduced by ERC-20 proposal, this provides a standardized [smart contract](#smart-contract) structure for fungible tokens. Tokens from the same contract can be tracked, traded, and are interchangeable, unlike [NFTs](#nft).
 
-<DocLink to="/developers/docs/standards/tokens/erc-20/" title="ERC-20 Token Standard" />
+<DocLink to="/developers/docs/standards/tokens/erc-20/">
+  ERC-20 Token Standard
+</DocLink>
 
 ### transaction {#transaction}
 
 Data committed to the Ethereum Blockchain signed by an originating [account](#account), targeting a specific [address](#address). The transaction contains metadata such as the [gas limit](#gas-limit) for that transaction.
 
-<DocLink to="/developers/docs/transactions/" title="Transactions" />
+<DocLink to="/developers/docs/transactions/">
+  Transactions
+</DocLink>
 
 ### transaction fee {#transaction-fee}
 
@@ -665,26 +769,36 @@ A concept named after English mathematician and computer scientist Alan Turing- 
 
 A [node](#node) in a [proof-of-stake](#pos) system responsible for storing data, processing transactions, and adding new blocks to the blockchain. To active validator software, you need to be able to [stake](#staking) 32 ETH.
 
-<DocLink to="/developers/docs/consensus-mechanisms/pos" title="Proof-of-stake" />
-<DocLink to="/eth2/staking/" title="Staking in Ethereum" />
+<DocLink to="/developers/docs/consensus-mechanisms/pos">
+  Proof-of-stake
+</DocLink>
+<DocLink to="/eth2/staking/">
+  Staking in Ethereum
+</DocLink>
 
 ### Validity proof {#validity-proof}
 
 A security model for certain [layer 2](#layer-2) solutions where, to increase speed, transactions are [rolled up](/#rollups) into batches and submitted to Ethereum in a single transaction. The transaction computation is done off-chain and then supplied to the main chain with a proof of their validity. This method increases the amount of transactions possible while maintaining security. Some [rollups](#rollups) use [fraud proofs](#fraud-proof).
 
-<DocLink to="/developers/docs/scaling/layer-2-rollups/#zk-rollups" title="Zero-knowledge rollups" />
+<DocLink to="/developers/docs/scaling/layer-2-rollups/#zk-rollups">
+  Zero-knowledge rollups
+</DocLink>
 
 ### Validium {#validium}
 
 An off-chain solution that uses [validity proofs](#validity-proof) to improve transaction throughput. Unlike [Zero-knowledge rollups](#zk-rollup), Validium data isn't stored on layer 1 [Mainnet](#mainnet).
 
-<DocLink to="/developers/docs/scaling/validium/" title="Validium" />
+<DocLink to="/developers/docs/scaling/validium/">
+  Validium
+</DocLink>
 
 ### Vyper {#vyper}
 
 A high-level programming language with Python-like syntax. Intended to get closer to a pure functional language. Created by Vitalik Buterin.
 
-<DocLink to="/developers/docs/smart-contracts/languages/#vyper" title="Vyper" />
+<DocLink to="/developers/docs/smart-contracts/languages/#vyper">
+  Vyper
+</DocLink>
 
 <Divider />
 
@@ -694,13 +808,17 @@ A high-level programming language with Python-like syntax. Intended to get close
 
 Software that holds [private keys](#private-key). Used to access and control Ethereum [accounts](#account) and interact with [smart contracts](#smart-contract). Keys need not be stored in a wallet, and can instead be retrieved from offline storage (i.e. a memory card or paper) for improved security. Despite the name, wallets never store the actual coins or tokens.
 
-<DocLink to="/wallets/" title="Ethereum Wallets" />
+<DocLink to="/wallets/">
+  Ethereum Wallets
+</DocLink>
 
 ### Web3 {#web3}
 
 The third version of the web. First proposed by Dr. Gavin Wood, Web3 represents a new vision and focus for web applications- from centrally owned and managed applications, to applications built on decentralized protocols (see [Dapp](#dapp)).
 
-<DocLink to="/developers/docs/web2-vs-web3/" title="Web2 vs Web3" />
+<DocLink to="/developers/docs/web2-vs-web3/">
+  Web2 vs Web3
+</DocLink>
 
 ### wei {#wei}
 
@@ -718,7 +836,9 @@ A special Ethereum address, composed entirely of zeros, that is specified as the
 
 A [rollup](#rollups) of transactions that use [validity proofs](#validity-proof) to offer increased [layer 2](#layer-2) transaction throughput while using the security provided by [Mainnet](#mainnet) (layer 1). Although they can't handle complex transaction types, like [Optimistic rollups](#optimistic-rollups), they don't have latency issues because transactions are provably valid when submitted.
 
-<DocLink to="/developers/docs/scaling/layer-2-rollups/#zk-rollups" title="Zero-knowledge Rollups" />
+<DocLink to="/developers/docs/scaling/layer-2-rollups/#zk-rollups">
+  Zero-knowledge Rollups
+</DocLink>
 
 <Divider />
 

--- a/src/content/history/index.md
+++ b/src/content/history/index.md
@@ -138,7 +138,9 @@ The [Beacon Chain](/eth2/beacon-chain/) needed 16384 deposits of 32 staked ETH t
 
 [Read the Ethereum Foundation announcement](https://blog.ethereum.org/2020/11/27/eth2-quick-update-no-21/)
 
-<DocLink to="/eth2/beacon-chain/" title="The Beacon Chain" />
+<DocLink to="/eth2/beacon-chain/">
+  The Beacon Chain
+</DocLink>
 
 ---
 
@@ -155,7 +157,9 @@ The staking deposit contract introduced [staking](/glossary/#staking) to the Eth
 
 [Read the Ethereum Foundation announcement](https://blog.ethereum.org/2020/11/04/eth2-quick-update-no-19/)
 
-<DocLink to="/eth2/staking/" title="Staking" />
+<DocLink to="/eth2/staking/">
+  Staking
+</DocLink>
 
 ---
 
@@ -440,4 +444,6 @@ The Yellow Paper, authored by Dr. Gavin Wood, is a technical definition of the E
 
 The introductory paper, published in 2013 by Vitalik Buterin, the founder of Ethereum, before the project's launch in 2015.
 
-<DocLink to="/whitepaper/" title="Whitepaper" />
+<DocLink to="/whitepaper/">
+  Whitepaper
+</DocLink>

--- a/src/content/security/index.md
+++ b/src/content/security/index.md
@@ -111,9 +111,13 @@ Browser extensions like Chrome extensions or Add-ons for Firefox can augment use
 
 One of the biggest reasons people get scammed in crypto generally is a lack of understanding. For example, if you don't understand that the Ethereum network is decentralized and owned by no one, then it's easy to fall prey to someone pretending to be a customer service agent that promises to return your lost ETH in exchange for your private keys. Educating yourself on how Ethereum works is a worthwhile investment.
 
-<DocLink to="/what-is-ethereum/" title="What is Ethereum?" />
+<DocLink to="/what-is-ethereum/">
+  What is Ethereum?
+</DocLink>
 
-<DocLink to="/eth/" title="What is ether?" />
+<DocLink to="/eth/">
+  What is ether?
+</DocLink>
 <Divider />
 
 ## Wallet security {#wallet-security}
@@ -124,7 +128,9 @@ One of the biggest reasons people get scammed in crypto generally is a lack of u
 
 The private key to your wallet acts as a password to your Ethereum wallet. It is the only thing stopping someone who knows your wallet address from draining your account of all of its assets!
 
-<DocLink to="/wallets/" title="What's an Ethereum wallet?" />
+<DocLink to="/wallets/">
+  What's an Ethereum wallet?
+</DocLink>
 
 #### Don't take screenshots of your seed phrases/private keys {#screenshot-private-keys}
 

--- a/src/content/translations/es/glossary/index.md
+++ b/src/content/translations/es/glossary/index.md
@@ -22,7 +22,9 @@ Un tipo de ataque a una [red](#network) descentralizada donde un grupo obtiene e
 
 Un objeto que contiene una [dirección](#address), balance, [nonce](#nonce) y, opcionalmente, código fuente y almacenamiento. Una cuenta puede ser una [cuenta de contrato](#contract-account) o una [cuenta de propiedad externa (EOA)](#eoa).
 
-<DocLink to="/developers/docs/accounts" title="Cuentas de Ethereum" />
+<DocLink to="/developers/docs/accounts">
+  Cuentas de Ethereum
+</DocLink>
 
 ### dirección {#address}
 
@@ -32,7 +34,9 @@ Generalmente, representa una [EOA](#eoa) o un [contrato](#contract-accouint) que
 
 En [Solidity](#solidity), `assert(false)` se compila en `0xfe`, un opcode inválido, que agota todo el [gas](#gas) restante y revierte todos los cambios. Cuando una sentencia `assert()` falla, algo muy malo e inesperado está sucediendo y tendrás que arreglar tu código. Deberías usar `assert()` para evitar condiciones que nunca, nunca deberían ocurrir.
 
-<DocLink to="/developers/docs/smart-contracts/security/" title="Seguridad" />
+<DocLink to="/developers/docs/smart-contracts/security/">
+  Seguridad
+</DocLink>
 
 ### certificación {#attestation}
 
@@ -46,7 +50,9 @@ Un validador vota por una [cadena de faros](#beacon-chain) o [fragmento](#shard)
 
 Una actualización de Eth2 que se convertirá en el coordinador de la red Ethereum. Introduce [pruebas de apuesta](#proof-of-stake) y [validadores](#validator) en Ethereum. Posiblemente se fusionará con la [red principal](#mainnet).
 
-<DocLink to="/eth2/beacon-chain/" title="Cadena de baliza" />
+<DocLink to="/eth2/beacon-chain/">
+  Cadena de baliza
+</DocLink>
 
 ### grande-endiano {#big-endian}
 
@@ -56,13 +62,17 @@ Una representación de números de posición donde el dígito más significativo
 
 Una colección de información requerida (un encabezado de bloque) acerca de las [transacciones](#transaction) comprendidas, y un conjunto de otras encabezados de bloque conocidas como [ommers](#ommer). Los bloques se añadiden a la red de Ethereum mediante los[mineros](#miner).
 
-<DocLink to="/developers/docs/blocks/" title="Bloques" />
+<DocLink to="/developers/docs/blocks/">
+  Bloques
+</DocLink>
 
 ### blockchain {#blockchain}
 
 En Ethereum, una secuencia de [bloques](#block) validados por el sistema [proof-of-work/prueba de trabajo](#pow), cada uno de los cuales se vincula con su predecesor hasta llegar al [bloque génesis](#genesis-block). No hay límite en el tamaño del bloque; en su lugar, utiliza [límites-de-gas](#gas-limit) variables.
 
-<DocLink to="/developers/docs/intro-to-ethereum#what-is-a-blockchain" title="¿Qué es una blockchain?" />
+<DocLink to="/developers/docs/intro-to-ethereum#what-is-a-blockchain">
+  ¿Qué es una blockchain?
+</DocLink>
 
 ### código de bytes {#bytecode}
 
@@ -80,7 +90,9 @@ La primera de dos [ bifurcaciones duras de codigo](#hard-fork) para la etapa de 
 
 Convierte código escrito en un lenguaje de programación de alto nivel (por ejemplo, [solidity](#solidity)) en un lenguaje de menor nivel (por ejemplo, bytecode de la [EVM](#bytecode)).
 
-<DocLink to="/developers/docs/smart-contracts/compiling/" title="Compilación de contratos inteligentes" />
+<DocLink to="/developers/docs/smart-contracts/compiling/">
+  Compilación de contratos inteligentes
+</DocLink>
 
 ### comité {#committee}
 
@@ -110,7 +122,9 @@ Una [transacción](#transaction) especial, con la [dirección-cero](#zero-addres
 
 El enlace cruzado proporciona un resumen del estado de un fragmento. Es la forma en que las cadenas [shard](#shard) se comunicarán entre sí a través de la [cadena de balizas](#beacon-chain) en el sistema sharded [Prueba de participación](#proof-of-stake).
 
-<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work" title="Prueba de participación" />
+<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work">
+  Prueba de participación
+</DocLink>
 
 <Divider />
 
@@ -120,19 +134,25 @@ El enlace cruzado proporciona un resumen del estado de un fragmento. Es la forma
 
 Una empresa u otra organización que funciona sin gestión jerárquica. DAO también puede referirse a un contrato llamado "The DAO" lanzado el 30 de abril de 2016, que luego fue hackeado en junio de 2016; esto finalmente motivó una [fuerte bifurcación](#hard-fork) (con nombre de código DAO) en el bloque 1 192 000, que revirtió el contrato DAO hackeado y provocó que Ethereum y Ethereum Classic se dividieran en dos sistemas competidores.
 
-<DocLink to="/community/#decentralized-autonomous-organizations-daos" title="Organizaciones Autónomas Descentralizadas (DAO)" />
+<DocLink to="/community/#decentralized-autonomous-organizations-daos">
+  Organizaciones Autónomas Descentralizadas (DAO)
+</DocLink>
 
 ### Dapp {#dapp}
 
 Aplicación descentralizada. Como mínimo, es un [contrato inteligente](#smart-contract) y una interfaz de usuario web. En líneas generales, una Dapp es una aplicación web que se construye sobre servicios de infraestructura abiertos, descentralizados y entre pares. Además, muchas Dapps incluyen almacenamiento descentralizado y/o un protocolo y una plataforma de mensajes.
 
-<DocLink to="/developers/docs/dapps/" title="Introducción a Dapps" />
+<DocLink to="/developers/docs/dapps/">
+  Introducción a Dapps
+</DocLink>
 
 ### intercambio descentralizado (DEX) {#dex}
 
 Un tipo de [dapp](#dapp) que te permite intercambiar tokens con pares en la red. Necesitas [ether](#ether) para usar uno (para pagar [tasas de transacción](#transaction-fee)), pero no están sujetos a restricciones geográficas como los intercambios centralizados; cualquiera puede participar.
 
-<DocLink to="/get-eth/#dex" title="Intercambios descentralizados" />
+<DocLink to="/get-eth/#dex">
+  Intercambios descentralizados
+</DocLink>
 
 ### deed {#deed}
 
@@ -142,7 +162,9 @@ Ver [token no fungibles (NFT)](#nft)
 
 Abreviatura para "finanzas descentralizadas", una amplia categoría de [Dapps](#dapp) que tiene como objetivo proporcionar servicios financieros respaldados por la blockchain, sin intermediarios, para que cualquier persona con una conexión a Internet pueda participar.
 
-<DocLink to="/dapps/#explore" title="Dapps de Defi" />
+<DocLink to="/dapps/#explore">
+  Dapps de Defi
+</DocLink>
 
 ### dificultad {#difficulty}
 
@@ -168,13 +190,17 @@ Algoritmo criptográfico utilizado por Ethereum para garantizar que los fondos s
 
 Un periodo de 32 [slots](#slot) (6,4 minutos) en el sistema coordinado de [cadena de balizas](#beacon-chain). Los [comités](#committee) de[validadores](#validator) se mezclan cada época por razones de seguridad. Hay una oportunidad en cada época para que la cadena sea [finalizada](#finality).
 
-<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work" title="Prueba de participación" />
+<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work">
+  Prueba de participación
+</DocLink>
 
 ### Propuestas de mejora de Ethereum (EIP) {#eip}
 
 Documento de diseño que proporciona información a la comunidad de Ethereum, describiendo una nueva característica propuesta o sus procesos o entorno (ver [ERC](#erc)).
 
-<DocLink to="/eips/" title="Introducción a EIP" />
+<DocLink to="/eips/">
+  Introducción a EIP
+</DocLink>
 
 ### Servicio de nombres de Ethereum (ENS) {#ens}
 
@@ -194,7 +220,9 @@ Una [cuenta](#account) creada por o para usuarios humanos de la red de Ethereum.
 
 Una etiqueta dada a algunos [EIP](#eip) que intentan definir un estándar específico de uso de Ethereum.
 
-<DocLink to="/eips/" title="Introducción a EIP" />
+<DocLink to="/eips/">
+  Introducción a EIP
+</DocLink>
 
 ### Ethash {#ethash}
 
@@ -206,19 +234,25 @@ Algoritmo de [Prueba de trabajo](#pow) para Ethereum 1.0.
 
 Criptomoneda nativa utilizada por el ecosistema Ethereum, que cubre los costes del [gas](#gas) al ejecutar las transacciones. También se escribe como ETH o su símbolo Ξ, el símbolo griego Xi en mayúscula.
 
-<DocLink to="/eth/" title="Moneda para nuestro futuro digital" />
+<DocLink to="/eth/">
+  Moneda para nuestro futuro digital
+</DocLink>
 
 ### eventos {#events}
 
 Permite el uso de las instalaciones de registro de la [EVM](#evm). Las [Dapps](#dapp) pueden recibir eventos y utilizarlos para activar las llamadas de retorno de JavaScript en la interfaz de usuario.
 
-<DocLink to="/developers/docs/smart-contracts/anatomy/#events-and-logs" title="Eventos y logs" />
+<DocLink to="/developers/docs/smart-contracts/anatomy/#events-and-logs">
+  Eventos y logs
+</DocLink>
 
 ### Máquina virtual de Ethereum (EVM) {#evm}
 
 Una máquina virtual basada en la pila que ejecuta [bytecode](#bytecode). En Ethereum, el modelo de ejecución determina cómo se modifica el estado del sistema, dada una serie de instrucciones mediante bytecode y una pequeña tupla de datos del entorno. Esto se especifica a través de un modelo formal de una máquina virtual.
 
-<DocLink to="/developers/docs/evm/" title="Máquina virtual de Ethereum" />
+<DocLink to="/developers/docs/evm/">
+  Máquina virtual de Ethereum
+</DocLink>
 
 ### Lenguaje ensamblador EVM {#evm-assembly-language}
 
@@ -236,13 +270,19 @@ Una función por defecto llamada en ausencia de datos o de un nombre de función
 
 Un servicio realizado a través de un [contrato inteligente](#smart-contract) que dispensa fondos en forma de éter gratuito de prueba que puede utilizarse en una red de prueba.
 
-<DocLink to="/developers/docs/networks/#testnet-faucets" title="Faucets para redes de prueba" />
+<DocLink to="/developers/docs/networks/#testnet-faucets">
+  Faucets para redes de prueba
+</DocLink>
 
 ### finalidad {#finality}
 
 La finalidad es la garantía de que un conjunto de transacciones anteriores a un momento dado no cambiará y no podrá revertirse.
 
-<DocLink to="/developers/docs/consensus-mechanisms/pow/#finality" title="Finalidad de la prueba de trabajo" /> <DocLink to="/developers/docs/consensus-mechanisms/pos/#finality" title="Finalidad de la prueba de participación" />
+<DocLink to="/developers/docs/consensus-mechanisms/pow/#finality">
+  Finalidad de la prueba de trabajo
+</DocLink> <DocLink to="/developers/docs/consensus-mechanisms/pos/#finality">
+  Finalidad de la prueba de participación
+</DocLink>
 
 ### finney {#finney}
 
@@ -256,7 +296,9 @@ Un cambio en el protocolo que provoca la creación de una cadena alternativa, o 
 
 Modelo de seguridad para ciertas soluciones de [capa 2](#layer-2) en las que, para aumentar la velocidad, las transacciones son [envueltas](#rollups) en lotes y enviadas a Ethereum en una única transacción. Se supone que son válidos, pero se pueden poner en tela de juicio si se sospecha el fraude. Una prueba de fraude ejecutará entonces la transacción para ver si se ha producido el fraude. Este método aumenta la cantidad de transacciones posibles manteniendo la seguridad. Algunos [rollups](#rollups) utilizan [pruebas de validez](#validity-proof).
 
-<DocLink to="/developers/docs/layer-2-scaling/#optimistic-rollups" title="Optimistic Rollups" />
+<DocLink to="/developers/docs/layer-2-scaling/#optimistic-rollups">
+  Optimistic Rollups
+</DocLink>
 
 ### frontera {#frontier}
 
@@ -270,7 +312,9 @@ Etapa inicial de desarrollo de prueba de Ethereum, que duró desde julio de 2015
 
 Un combustible virtual utilizado en Ethereum para ejecutar contratos inteligentes. La [EVM](#evm) utiliza un mecanismo de contabilidad para medir el consumo de gas y limitar el consumo de recursos informáticos (ver [Turing complete](#turing-complete)).
 
-<DocLink to="/developers/docs/gas/" title="Gas y tarifas" />
+<DocLink to="/developers/docs/gas/">
+  Gas y tarifas
+</DocLink>
 
 ### límite de gas {#gas-limit}
 
@@ -332,13 +376,17 @@ Una [bifurcación fuerte](#hard-fork) de Ethereum en el bloque 200 000 para int
 
 Una interfaz de usuario que normalmente combina un editor de código, compilador, tiempo de ejecución y depurador.
 
-<DocLink to="/developers/docs/ides/" title="Entornos de desarrollo integrados" />
+<DocLink to="/developers/docs/ides/">
+  Entornos de desarrollo integrados
+</DocLink>
 
 ### problema de código implementado inmutable {#immutable-deployed-code-problem}
 
 Una vez que el código de un [contrato](#smart-contract) (o [biblioteca](#library)) se implementa, se vuelve inmutable. Las prácticas habituales de desarrollo de software se basan en la posibilidad de corregir posibles errores y añadir nuevas funciones, por lo que esto supone un reto para el desarrollo de contratos inteligentes.
 
-<DocLink to="/developers/docs/smart-contracts/deploying/" title="Implementación de contratos inteligentes" />
+<DocLink to="/developers/docs/smart-contracts/deploying/">
+  Implementación de contratos inteligentes
+</DocLink>
 
 ### transacción interna {#internal-transaction}
 
@@ -352,7 +400,9 @@ Una vez que el código de un [contrato](#smart-contract) (o [biblioteca](#librar
 
 También conocido como "algoritmo de estiramiento de contraseñas", es utilizado por los formatos [keystore](#keystore-file) para protegerse contra los ataques de fuerza bruta, de diccionario y de tabla de arcoíris en el cifrado de frases de contraseña, mediante el hashing repetido de la frase de contraseña.
 
-<DocLink to="/developers/docs/smart-contracts/security/" title="Seguridad" />
+<DocLink to="/developers/docs/smart-contracts/security/">
+  Seguridad
+</DocLink>
 
 ### keccak-256 {#keccak-256}
 
@@ -370,7 +420,9 @@ Un archivo codificado en JSON que contiene una única (generada aleatoriamente) 
 
 Un área de desarrollo centrada en la superposición de mejoras sobre el protocolo de Ethereum. Estas mejoras están relacionadas con las velocidades de [transacción](#transaction), el abaratamiento de las [tarifas de transacción](#transaction-fee) y la privacidad de las transacciones.
 
-<DocLink to="/developers/docs/layer-2-scaling/" title="Capa 2" />
+<DocLink to="/developers/docs/layer-2-scaling/">
+  Capa 2
+</DocLink>
 
 ### NivelDB {#level-db}
 
@@ -380,7 +432,9 @@ Es un almacenamiento en disco de código abierto, livianamente implementado, bib
 
 Un tipo especial de [contrato](#smart-contract) sin funciones pagaderas, sin función de reserva y sin almacenamiento de datos. Por lo tanto, no puede recibir ni guardar ether o almacenar datos. Una biblioteca sirve como un código implementado previamente al que puede acceder otro contrato para realizar funciones de computación de solo lectura.
 
-<DocLink to="/developers/docs/smart-contracts/libraries/" title="Bibliotecas de contrato inteligente" />
+<DocLink to="/developers/docs/smart-contracts/libraries/">
+  Bibliotecas de contrato inteligente
+</DocLink>
 
 ### cliente ligero {#lightweight-client}
 
@@ -414,7 +468,9 @@ La tercera fase de desarrollo de Ethereum, que se lanzó en octubre de 2017.
 
 Es un [nodo](#node) de red que encuentra [pruebas de trabajo](#pow) válidas para bloques nuevos, mediante el hashing de pase repetido (ver [Ethash](#ethash)).
 
-<DocLink to="/developers/docs/consensus-mechanisms/pow/mining/" title="Minería" />
+<DocLink to="/developers/docs/consensus-mechanisms/pow/mining/">
+  Minería
+</DocLink>
 
 <Divider />
 
@@ -424,21 +480,29 @@ Es un [nodo](#node) de red que encuentra [pruebas de trabajo](#pow) válidas par
 
 Si nos referimos a la red de Ethereum, se trata de una red de punto a punto que propaga transacciones y bloques a cada nodo de Ethereum (que participe en la red).
 
-<DocLink to="/developers/docs/networks/" title="Redes" />
+<DocLink to="/developers/docs/networks/">
+  Redes
+</DocLink>
 
 ### tokens no fungibles (NFT) {#nft}
 
 También conocido como "deed", se trata de un estándar de token presentado mediante la propuesta de ERC-721. Los NFT pueden rastrearse y comercializarse, pero cada token es único e inconfundible y no son son intercambiables como los ERC-20. Los NFT pueden representar la propiedad de activos digitales o físicos.
 
-<DocLink to="/developers/docs/standards/tokens/erc-721/" title="Estándar de token no fungible ERC-721" />
+<DocLink to="/developers/docs/standards/tokens/erc-721/">
+  Estándar de token no fungible ERC-721
+</DocLink>
 
 ### nodo {#node}
 
 Un cliente de software que participa en la red.
 
-<DocLink to="/developers/docs/nodes-and-clients/" title="Nodos y clientes" />
+<DocLink to="/developers/docs/nodes-and-clients/">
+  Nodos y clientes
+</DocLink>
 
-<DocLink to="/developers/docs/nodes-and-clients/" title="Nodos y clientes" />
+<DocLink to="/developers/docs/nodes-and-clients/">
+  Nodos y clientes
+</DocLink>
 
 ### nonce {#nonce}
 
@@ -456,7 +520,9 @@ Cuando un [minero](#miner) encuentra un [bloque](#block) válido, otro minero po
 
 Un [rollup](#rollups) de transacciones que utilizan [pruebas de fraude](#fraud-proof) para ofrecer una transacción completa y aumentada de [capa 2](#layer-2), mientras utiliza la seguridad proporcionada por la [red principal](#mainnet) (capa 1). A diferencia de [Plasma](#plasma), una solución de capa 2 parecida, los Optimistic Rollups pueden gestionar tipos de transacciones más complejos; todos los que sean posibles en la [EVM](#evm). En comparación con los [Zero-knowledge Rollups](#zk-rollups), tienen problemas de latencia porque la transacción se puede desafiar mediante la prueba de fraude.
 
-<DocLink to="/developers/docs/layer-2-scaling/#optimistic-rollups" title="Rollups Optimistas" />
+<DocLink to="/developers/docs/layer-2-scaling/#optimistic-rollups">
+  Rollups Optimistas
+</DocLink>
 
 <Divider />
 
@@ -470,7 +536,9 @@ Una de las implementaciones interoperables más destacadas del software cliente 
 
 Una solución de escala de [capa 2](#layer-2) que utiliza [pruebas de fraude](#fraud-proof), como los [Optimistic Rollups](#optimistic-rollups). Plasma se limita a transacciones simples como transferencias básicas de tokens y swaps.
 
-<DocLink to="/developers/docs/layer-2-scaling/#Plasma" title="Plasma" />
+<DocLink to="/developers/docs/layer-2-scaling/#Plasma">
+  Plasma
+</DocLink>
 
 ### clave privada (clave secreta) {#private-key}
 
@@ -480,13 +548,17 @@ Un número secreto que permite a los usuarios de Ethereum probar la propiedad de
 
 Un método mediante el que un protocolo de blockchain de criptomonedas intenta lograr el [consenso](#consensus) distribuido. La PoS solicita a los usuarios que demuestren la propiedad de una cierta cantidad de criptomonedas (su "participación" en la red) para poder participar en la validación de las transacciones.
 
-<DocLink to="/developers/docs/consensus-mechanisms/pos/" title="Prueba de participación" />
+<DocLink to="/developers/docs/consensus-mechanisms/pos/">
+  Prueba de participación
+</DocLink>
 
 ### prueba de trabajo (PoW) {#pow}
 
 Una cantidad de datos (la prueba) que precisa encontrar un cálculo significativo. En Ethereum, los [mineros](#miner) deben encontrar una solución numérica para el algoritmo [Ethash](#ethash) que cumpla con un objetivo de [dificultad](#difficulty) en toda la red.
 
-<DocLink to="/developers/docs/consensus-mechanisms/pow/" title="Prueba de trabajo" />
+<DocLink to="/developers/docs/consensus-mechanisms/pow/">
+  Prueba de trabajo
+</DocLink>
 
 ### clave pública {#public-key}
 
@@ -504,7 +576,9 @@ Datos que devuelve un cliente de Ethereum para representar el resultado de una [
 
 Un ataque que consiste en un contrato del atacante que solicita un contrato de víctima de modo que, durante la ejecución, la víctima vuelve a solicitar el contrato del atacante de manera recurrente. Las consecuencias de esta acción pueden ser, entre otras, el robo de fondos mediante la omisión de partes del contrato de la víctima que actualizan el saldo la información de las cantidades retiradas.
 
-<DocLink to="/developers/docs/smart-contracts/security/#re-entrancy" title="Reentrada" />
+<DocLink to="/developers/docs/smart-contracts/security/#re-entrancy">
+  Reentrada
+</DocLink>
 
 ### recompensa {#reward}
 
@@ -518,7 +592,9 @@ Un estándar de codificación diseñado por los desarrolladores de Ethereum para
 
 Un tipo de solución de escala de [capa 2](#layer-2) que agrupa varias transacciones y las envía a la [cadena principal de Ethereum](#mainnet) mediante una única transacción. Esto permite disfrutar de reducciones en el coste del [gas](#gas) y, como consecuencia, aumentos en las [transacción](#transaction). Existen Optimistic Rollups y Zero-knowledge Rollups que utilizan diferentes métodos de seguridad para ofrecer estos beneficios de escalabilidad.
 
-<DocLink to="/developers/docs/layer-2-scaling/#rollups" title="Rollups" />
+<DocLink to="/developers/docs/layer-2-scaling/#rollups">
+  Rollups
+</DocLink>
 
 <Divider />
 
@@ -528,7 +604,9 @@ Un tipo de solución de escala de [capa 2](#layer-2) que agrupa varias transacci
 
 La cuarta y última fase de desarrollo de Ethereum.
 
-<DocLink to="/eth2/" title="Ethereum 2.0 (Eth2)" />
+<DocLink to="/eth2/">
+  Ethereum 2.0 (Eth2)
+</DocLink>
 
 ### Algoritmo seguro de Hash (SHA) {#sha}
 
@@ -538,13 +616,17 @@ Una familia de funciones de hash criptográficas publicadas por el NIST (siglas 
 
 Una cadena de [prueba de participación](#proof-of-stake) coordinada por la [cadena de baliza](#beacon-chain) y asegurada mediante los [validadores](#validator). Se producirán 64 adiciones a la red como parte de la actualización de la cadena de fragmentos Eth2. Las cadenas de fragmentos ofrecerán un mayor rendimiento de la transacción para Ethereum, ya que proporcionan datos adicionales a soluciones de [capa 2](#layer-2) como [Optimistic Rollups](#optimistic-rollups) y [ZK Rollups](#zk-rollups).
 
-<DocLink to="/eth2/shard-chains" title="Cadenas de fragmentos" />
+<DocLink to="/eth2/shard-chains">
+  Cadenas de fragmentos
+</DocLink>
 
 ### Sidechain {#sidechain}
 
 Una solución de escalado que usa una cadena separada con diferentes [reglas de consenso]{#consensus-rules}. Se precisa un puente para conectar estas sidechains a la [red principal](#mainnet). Los [Rollups](#rollups) también usan sidechains, pero trabajan en colaboración con la [red principal](#mainnet).
 
-<DocLink to="/developers/docs/layer-2-scaling/#sidechains" title="Sidechains" />
+<DocLink to="/developers/docs/layer-2-scaling/#sidechains">
+  Sidechains
+</DocLink>
 
 ### singleton {#singleton}
 
@@ -554,19 +636,25 @@ Un término de programación informática que describe un objeto del que solamen
 
 Un periodo de tiempo (12 segundos) en el que una nueva [cadena de baliza](#beacon-chain) y un nuevo bloque de cadena de [fragmentos](#shard) se pueden proponer mediante un [validador](#validator) en el sistema de [Prueba de participación](#proof-of-stake). Un slot puede estar vacío. 32 slots componen un [epoch](#epoch).
 
-<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work" title="Prueba de participación" />
+<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work">
+  Prueba de participación
+</DocLink>
 
 ### contrato inteligente {#smart-contract}
 
 Un programa que se ejecuta en la infraestructura informática de Ethereum.
 
-<DocLink to="/developers/docs/smart-contracts/" title="Introducción a los contratos inteligentes" />
+<DocLink to="/developers/docs/smart-contracts/">
+  Introducción a los contratos inteligentes
+</DocLink>
 
 ### Solidity {#solidity}
 
 Un lenguaje de programación (imperativo) procesual con sintaxis similar a JavaScript, C++ o Java. El lenguaje más popular y utilizado para los [contratos inteligentes](#smart-contract) de Ethereum. Creado por Dr. Gavin Wood.
 
-<DocLink to="/developers/docs/smart-contracts/languages/#solidity" title="Solidity" />
+<DocLink to="/developers/docs/smart-contracts/languages/#solidity">
+  Solidity
+</DocLink>
 
 ### Solidity inline assembly {#solidity-inline-assembly}
 
@@ -580,19 +668,25 @@ Una [bifurcación dura](#hard-fork) de la blockchain de Ethereum, que se produjo
 
 Un [token ERC-20](#token-standard) con un valor vinculado al valor de otro activo. Hay monedas estables respaldadas por monedas fiat como dólares, metales preciosos como el oro y otras criptomonedas como Bitcoin.
 
-<DocLink to="/eth/#tokens" title="El ETH no es la única criptografía de Ethereum" />
+<DocLink to="/eth/#tokens">
+  El ETH no es la única criptografía de Ethereum
+</DocLink>
 
 ### participación {#staking}
 
 Depositar una cantidad de [ether](#ether) (tu participación) para convertirte en un validador y asegurar la [red](#network). Un validador comprueba las [transacciones](#transaction) y propone [bloques](#block) bajo un modelo de consenso de [prueba de participación](#pos). La participación te proporciona un incentivo económico para actuar en el mejor interés de la red. Obtendrás recompensas por llevar a cabo tus tareas como [validador](#validator), pero perderás cantidades diferentes de ETH si no las llevas a cabo.
 
-<DocLink to="/eth2/staking/" title="Apuesta tus ETH para llegar a ser un validador de Ethereum" />
+<DocLink to="/eth2/staking/">
+  Apuesta tus ETH para llegar a ser un validador de Ethereum
+</DocLink>
 
 ### canales de estado {#state-channels}
 
 Una solución de [capa 2](#layer-2) en el que un canal está configurado entre los participantes y les permite realizar transacciones de manera libre y económica. Solo se envía a la [red principal](#mainnet) una [transacción](#transaction) para configurar y cerrar el canal. Esto permite realizar transacciones muy elevadas, pero depende en gran nivel de si conocemos el número de participantes y el cierre de fondos por adelantado.
 
-<DocLink to="/developers/docs/layer-2-scaling/#state-channels" title="Canales de estado" />
+<DocLink to="/developers/docs/layer-2-scaling/#state-channels">
+  Canales de estado
+</DocLink>
 
 ### szabo {#szabo}
 
@@ -610,19 +704,25 @@ Una [bifurcación dura](#hard-fork) de la blockchain de Ethereum, que se produjo
 
 Una red que se utiliza para simular el comportamiento de la red principal de Ethereum (consulta [red principal](#mainnet)).
 
-<DocLink to="/developers/docs/networks/#testnets" title="Redes de pruebas" />
+<DocLink to="/developers/docs/networks/#testnets">
+  Redes de pruebas
+</DocLink>
 
 ### estándar de token {#token-standard}
 
 Presentado mediante la propuesta de ERC-20, esto proporciona una estructura de [contrato inteligente](#smart-contract) estandarizada para tokens fungibles. A diferencia de lo que sucede con [NFT](#nft), es posible realizar un seguimiento, comercializar e intercambiar los tokens del mismo contrato.
 
-<DocLink to="/developers/docs/standards/tokens/erc-20/" title="Estándar de token ERC-20" />
+<DocLink to="/developers/docs/standards/tokens/erc-20/">
+  Estándar de token ERC-20
+</DocLink>
 
 ### transacción {#transaction}
 
 Datos comprometidos con la blockchain de Ethereum, firmados por una [cuenta](#account)originaria, con una [dirección](#address) específica. La transacción contiene metadatos como el [límite de gas](#gas-limit) para esa transacción.
 
-<DocLink to="/developers/docs/transactions/" title="Transacciones" />
+<DocLink to="/developers/docs/transactions/">
+  Transacciones
+</DocLink>
 
 ### tarifa de transacción {#transaction-fee}
 
@@ -644,25 +744,35 @@ Un concepto que lleva el nombre del matemático y informático inglés Alan Turi
 
 Un [nodo](#node) en un sistema de [Prueba de participación](#proof-of-stake) responsable de almacenar datos, procesar transacciones y agregar nuevos bloques a la blockchain. Para activar el software validador, debes poder [participar](#staking) con 32 ETH.
 
-<DocLink to="/developers/docs/consensus-mechanisms/pos" title="Prueba de participación" /> <DocLink to="/eth2/staking/" title="Participación en Ethereum" />
+<DocLink to="/developers/docs/consensus-mechanisms/pos">
+  Prueba de participación
+</DocLink> <DocLink to="/eth2/staking/">
+  Participación en Ethereum
+</DocLink>
 
 ### Prueba de validación {#validity-proof}
 
 Modelo de seguridad para ciertas soluciones de [capa 2](#layer-2) en las que, para aumentar la velocidad, las transacciones se [agrupan](/#rollups) en lotes y se envían a Ethereum en una única transacción. El cálculo de la transacción se realiza fuera de la cadena y, a continuación, se suministra a la cadena principal con una prueba de su validez. Este método aumenta la cantidad de transacciones posibles sin comprometer la seguridad. Algunos [rollups](#rollups) utilizan [pruebas de fraude](#fraud-proof).
 
-<DocLink to="/developers/docs/layer-2-scaling/#zk-rollups" title="Zero-knowledge Rollups" />
+<DocLink to="/developers/docs/layer-2-scaling/#zk-rollups">
+  Zero-knowledge Rollups
+</DocLink>
 
 ### Validium {#validium}
 
 Una solución de [capa 2](#layer-2) que usa [pruebas de validez](#validity-proof) para mejorar la transacción. A diferencia de [Zero-knowlege Rollups](#zk-rollup), los datos de Validium no se almacenan en la [red principal](#mainnet) de la capa 1.
 
-<DocLink to="/developers/docs/layer-2-scaling/#validium" title="Validium" />
+<DocLink to="/developers/docs/layer-2-scaling/#validium">
+  Validium
+</DocLink>
 
 ### Vyper {#vyper}
 
 Un lenguaje de programación de alto nivel con sintaxis de tipo Python. Se diseñó para acercarse a un lenguaje funcional puro. Creado por Vitalik Buterin.
 
-<DocLink to="/developers/docs/smart-contracts/languages/#vyper" title="Vyper" />
+<DocLink to="/developers/docs/smart-contracts/languages/#vyper">
+  Vyper
+</DocLink>
 
 <Divider />
 
@@ -672,13 +782,17 @@ Un lenguaje de programación de alto nivel con sintaxis de tipo Python. Se dise�
 
 Un software que contiene [claves privadas](#private-key). Se utiliza para acceder y controlar las cuentas de [Ethereum](#account) e interactuar con [contratos inteligentes](#smart-contract). No es necesario almacenar las claves en una cartera y, además, se pueden recuperar del almacenamiento sin conexión (es decir, con una tarjeta de memoria o un papel) para mejorar la seguridad. A pesar de su nombre, las carteras nunca almacenan las monedas o tokens reales.
 
-<DocLink to="/wallets/" title="Carteras de Ethereum" />
+<DocLink to="/wallets/">
+  Carteras de Ethereum
+</DocLink>
 
 ### Web3 {#web3}
 
 La tercera versión de la web. Propuesta inicialmente por el Dr. Gavin Wood, Web3 representa una visión y un enfoque novedosos para aplicaciones web, desde aplicaciones de propiedad y gestión centralizadas hasta aplicaciones construidas en protocolos descentralizados (consulta [Dapp](#dapp)).
 
-<DocLink to="/developers/docs/web2-vs-web3/" title="Web2 versus Web3" />
+<DocLink to="/developers/docs/web2-vs-web3/">
+  Web2 versus Web3
+</DocLink>
 
 ### wei {#wei}
 
@@ -696,7 +810,9 @@ Una dirección especial de Ethereum, compuesta íntegramente por ceros, que se e
 
 Un [rollup](#rollups) de transacciones que utiliza [pruebas de validez](#validity-proof) para ofrecer una transacción completa y aumentada de [capa 2](#layer-2), mientras utiliza la seguridad proporcionada por la [red principal](#mainnet) (capa 1). Aunque no pueden gestionar tipos de transacción complejos, como [Optimistic Rollups](#optimistic-rollups), no tienen problemas de latencia porque las transacciones probablemente son válidas cuando se envian.
 
-<DocLink to="/developers/docs/layer-2-scaling/#zk-rollups" title="Zero-knowledge Rollups" />
+<DocLink to="/developers/docs/layer-2-scaling/#zk-rollups">
+  Zero-knowledge Rollups
+</DocLink>
 
 <Divider />
 

--- a/src/content/translations/es/history/index.md
+++ b/src/content/translations/es/history/index.md
@@ -35,7 +35,9 @@ La [cadena de baliza](/eth2/beacon-chain/) ha necesitado 16 384 depósitos de 3
 
 [Leer la declaración de la Fundación Ethereum](https://blog.ethereum.org/2020/11/27/eth2-quick-update-no-21/)
 
-<DocLink to="/eth2/beacon-chain/" title="La cadena de baliza" />
+<DocLink to="/eth2/beacon-chain/">
+  La cadena de baliza
+</DocLink>
 
 ---
 
@@ -49,7 +51,9 @@ El contrato de depósito de participación introdujo la [participación](/glossa
 
 [Leer la declaración de la Fundación Ethereum](https://blog.ethereum.org/2020/11/04/eth2-quick-update-no-19/)
 
-<DocLink to="/eth2/staking/" title="Participación" />
+<DocLink to="/eth2/staking/">
+  Participación
+</DocLink>
 
 ---
 
@@ -301,4 +305,6 @@ El Yellow Paper, escrito por el Dr. Gavin Wood, es una definición técnica del 
 
 Documento introductorio, publicado en el 2013 por Vitalik Buterin, fundador de Ethereum, antes del lanzamiento del proyecto en 2015.
 
-<DocLink to="/whitepaper/" title="Papel en blanco" />
+<DocLink to="/whitepaper/">
+  Papel en blanco
+</DocLink>

--- a/src/content/translations/fr/glossary/index.md
+++ b/src/content/translations/fr/glossary/index.md
@@ -22,7 +22,9 @@ Type d'attaque mené sur un [réseau](#network) décentralisé au cours de laque
 
 Objet contenant une [adresse](#address), un solde, un [nonce](#nonce), ainsi qu'un stockage et un code facultatifs. Il peut s'agir d'un [compte de contrat](#contract-account) ou d'un [compte externe (EOA)](#eoa).
 
-<DocLink to="/developers/docs/accounts" title="comptes Ethereum" />
+<DocLink to="/developers/docs/accounts">
+  comptes Ethereum
+</DocLink>
 
 ### adresse {#address}
 
@@ -32,7 +34,9 @@ Plus généralement, il s'agit d'un [EOA](#eoa) ou d'un [compte de contrat](#con
 
 Dans [Solidity](#solidity), `assert(false)` compile en `0xfe`, un code d'opération (opcode) non valide, qui utilise tout le [carburant](#gas) restant et annule toutes les modifications. Lorsqu'une déclaration `assert()` échoue, quelque chose ne fonctionne pas du tout comme prévu, et vous devez corriger votre code. Il est conseillé d'utiliser `assert()` pour éviter les conditions qui ne doivent jamais se produire.
 
-<DocLink to="/developers/docs/smart-contracts/security/" title="sécurité" />
+<DocLink to="/developers/docs/smart-contracts/security/">
+  sécurité
+</DocLink>
 
 ### attestation {#attestation}
 
@@ -46,7 +50,9 @@ Il s'agit du vote d'un validateur pour un bloc de la [chaîne phare](#beacon-cha
 
 Une mise à niveau Eth2 qui deviendra la coordinatrice du réseau Ethereum. Elle introduit la [preuve d'enjeu](#proof-of-stake) et [les validateurs](#validator) sur Ethereum. Elle finira par être fusionnée avec le [réseau principal](#mainnet).
 
-<DocLink to="/eth2/beacon-chain/" title="Chaîne phare" />
+<DocLink to="/eth2/beacon-chain/">
+  Chaîne phare
+</DocLink>
 
 ### gros-boutiste {#big-endian}
 
@@ -56,13 +62,17 @@ Représentation de nombre positionnel où le chiffre le plus important est le pr
 
 Collection d'informations requises (en-tête de bloc) concernant les [transactions](#transaction) incluses, et ensemble d'autres en-têtes de blocs appelés [ommers](#ommer). Les blocs sont ajoutés au réseau Ethereum par les [mineurs](#miner).
 
-<DocLink to="/developers/docs/blocks/" title="blocs" />
+<DocLink to="/developers/docs/blocks/">
+  blocs
+</DocLink>
 
 ### blockchain {#blockchain}
 
 Dans Ethereum, il s'agit d'une suite de [blocs](#block) validée par le système de [preuve de travail](#pow), chaque bloc étant relié à son prédécesseur jusqu'au [bloc d'origine](#genesis-block). Il n'existe pas de limite de taille de bloc. La blockchain utilise à la place différentes [limites de carburant](#gas-limit).
 
-<DocLink to="/developers/docs/intro-to-ethereum#what-is-a-blockchain" title="Qu'est-ce qu'une blockchain ?" />
+<DocLink to="/developers/docs/intro-to-ethereum#what-is-a-blockchain">
+  Qu'est-ce qu'une blockchain ?
+</DocLink>
 
 ### bytecode {#bytecode}
 
@@ -80,7 +90,9 @@ La première des deux [fourches majeures](#hard-fork) (scissions) de l'étape de
 
 Traduire du code écrit dans un langage de programmation de haut niveau (par exemple, [Solidity](#solidity)) en un langage de niveau inférieur (par exemple, le [bytecode](#bytecode) de l'EVM).
 
-<DocLink to="/developers/docs/smart-contracts/compiling/" title="Compiler des contrats intelligents" />
+<DocLink to="/developers/docs/smart-contracts/compiling/">
+  Compiler des contrats intelligents
+</DocLink>
 
 ### comité {#committee}
 
@@ -110,7 +122,9 @@ Transaction [spéciale](#transaction), avec [adresse zéro](#zero-address) comme
 
 Un lien croisé fournit un résumé de l'état d'un fragment. Il s'agit de la façon dont les [fragments](#shard) communiqueront les uns avec les autres via la [chaîne phare](#beacon-chain) dans le système de [preuve d'enjeu](#proof-of-stake) fragmenté.
 
-<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work" title="preuve d'enjeu" />
+<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work">
+  preuve d'enjeu
+</DocLink>
 
 <Divider />
 
@@ -120,19 +134,25 @@ Un lien croisé fournit un résumé de l'état d'un fragment. Il s'agit de la fa
 
 Entreprise ou autre organisation fonctionnant sans gestion hiérarchique. DAO peut également faire référence à un contrat intitulé "The DAO" lancé le 30 avril 2016, qui a ensuite été piraté en juin 2016. Ceci a finalement motivé une [fourche majeure](#hard-fork) (nom de code DAO) au bloc 1 192 000, qui a inversé le contrat DAO piraté et a causé la division d'Ethereum et d'Ethereum Classic en deux systèmes concurrents.
 
-<DocLink to="/community/#decentralized-autonomous-organizations-daos" title="organisation autonome décentralisée (DAO)" />
+<DocLink to="/community/#decentralized-autonomous-organizations-daos">
+  organisation autonome décentralisée (DAO)
+</DocLink>
 
 ### DApp {#dapp}
 
 Application décentralisée. Au minimum, il s'agit d'un [contrat intelligent](#smart-contract) et d'une interface utilisateur Web. Plus généralement, une DApp est une application Web construite sur des services d'infrastructure ouverts, décentralisés et P2P. Par ailleurs, de nombreuses DApps incluent un stockage décentralisé, une plateforme et/ou un protocole de message.
 
-<DocLink to="/developers/docs/dapps/" title="Introduction aux DApps" />
+<DocLink to="/developers/docs/dapps/">
+  Introduction aux DApps
+</DocLink>
 
 ### échange décentralisé (DEX) {#dex}
 
 Type de [DApp](#dapp) qui vous permet d'échanger des jetons avec des pairs sur le réseau. Vous avez besoin d'[Ether](#ether) pour en utiliser un (pour payer les [frais de transaction](#transaction-fee)), mais ils ne sont soumis à aucune restriction géographique comme les échanges centralisés. N'importe qui peut participer.
 
-<DocLink to="/get-eth/#dex" title="échanges décentralisés (DEX)" />
+<DocLink to="/get-eth/#dex">
+  échanges décentralisés (DEX)
+</DocLink>
 
 ### deed {#deed}
 
@@ -142,7 +162,9 @@ Voir [jeton non fongible (NFT)](#nft)
 
 Abréviation de "Decentralized Finance" (finance décentralisée), une large catégorie de [DApps](#dapp) visant à fournir des services financiers portés par la blockchain, sans aucun intermédiaire, de sorte que toute personne avec une connexion Internet peut participer.
 
-<DocLink to="/dapps/#explore" title="DApps DeFi " />
+<DocLink to="/dapps/#explore">
+  DApps DeFi 
+</DocLink>
 
 ### difficulté {#difficulty}
 
@@ -168,13 +190,17 @@ Algorithme cryptographique utilisé par Ethereum pour garantir que les fonds ne 
 
 Période de 32 [créneaux](#slot) (6,4 minutes) dans le système coordonné de la [chaîne phare](#beacon-chain). Les [comités](#committee) de [validateurs](#validator) sont remaniés lors de chaque période pour des raisons de sécurité. Chaque période représente une opportunité de [finaliser](#finality) la chaîne.
 
-<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work" title="preuve d'enjeu" />
+<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work">
+  preuve d'enjeu
+</DocLink>
 
 ### proposition d'amélioration d'Ethereum (EIP) {#eip}
 
 Document de conception qui fournit des informations à la communauté Ethereum, décrivant une nouvelle fonctionnalité proposée, ses processus ou environnements (voir [ERC](#erc)).
 
-<DocLink to="/eips/" title="Introduction aux EIP" />
+<DocLink to="/eips/">
+  Introduction aux EIP
+</DocLink>
 
 ### Ethereum Name Service (ENS) {#ens}
 
@@ -194,7 +220,9 @@ En cryptographie, désigne le manque de prévisibilité ou le niveau d’aléato
 
 Libellé donné à certaines [EIP](#eip) qui visent à définir un standard spécifique d'utilisation d'Ethereum.
 
-<DocLink to="/eips/" title="Introduction aux EIP" />
+<DocLink to="/eips/">
+  Introduction aux EIP
+</DocLink>
 
 ### Ethash {#ethash}
 
@@ -206,19 +234,25 @@ Algorithme de [preuve de travail](#pow) pour Ethereum 1.0.
 
 Cryptomonnaie native utilisée par l'écosystème Ethereum, qui couvre les coûts de [carburant](#gas) lors de l'exécution des transactions. S'écrit également sous la forme ETH ou avec son symbole Ξ, qui est le caractère grec Xi en majuscule.
 
-<DocLink to="/eth/" title="Monnaie de notre avenir numérique" />
+<DocLink to="/eth/">
+  Monnaie de notre avenir numérique
+</DocLink>
 
 ### événements {#events}
 
 Permet d'utiliser les dispositifs de journalisation de l'[EVM](#evm). Les [DApps](#dapp) peuvent écouter les événements et les utiliser pour déclencher des rappels JavaScript dans l'interface utilisateur.
 
-<DocLink to="/developers/docs/smart-contracts/anatomy/#events-and-logs" title="Événements et journaux" />
+<DocLink to="/developers/docs/smart-contracts/anatomy/#events-and-logs">
+  Événements et journaux
+</DocLink>
 
 ### machine virtuelle Ethereum (EVM) {#evm}
 
 Machine virtuelle basée sur une pile, qui exécute du [bytecode](#bytecode). Dans Ethereum, le modèle d'exécution spécifie comment l'état du système est modifié, en fonction d'une série d'instructions en bytecode et d'un petit tuple de données environnementales. Ceci est spécifié via un modèle formel de machine d'état virtuelle.
 
-<DocLink to="/developers/docs/evm/" title="Machine virtuelle Ethereum" />
+<DocLink to="/developers/docs/evm/">
+  Machine virtuelle Ethereum
+</DocLink>
 
 ### langage d'assemblage de l'EVM {#evm-assembly-language}
 
@@ -236,13 +270,19 @@ Fonction par défaut appelée en l'absence de données ou d'un nom de fonction d
 
 Service effectué via un [contrat intelligent](#smart-contract), qui distribue des fonds sous la forme d'ethers de test gratuits peuvant être utilisés sur un réseau de test.
 
-<DocLink to="/developers/docs/networks/#testnet-faucets" title="robinets de réseau de test" />
+<DocLink to="/developers/docs/networks/#testnet-faucets">
+  robinets de réseau de test
+</DocLink>
 
 ### finalisation {#finality}
 
 La finalisation est la garantie qu'avant une heure donnée, un ensemble de transactions ne changera pas et ne pourra pas être annulé.
 
-<DocLink to="/developers/docs/consensus-mechanisms/pow/#finality" title="Finalité de la preuve de travail" /> <DocLink to="/developers/docs/consensus-mechanisms/pos/#finality" title="Finalité de la preuve d'enjeu" />
+<DocLink to="/developers/docs/consensus-mechanisms/pow/#finality">
+  Finalité de la preuve de travail
+</DocLink> <DocLink to="/developers/docs/consensus-mechanisms/pos/#finality">
+  Finalité de la preuve d'enjeu
+</DocLink>
 
 ### finney {#finney}
 
@@ -256,7 +296,9 @@ Changement de protocole causant la création d'une chaîne alternative, ou diver
 
 Modèle de sécurité pour certaines solutions de [couche 2](#layer-2) où, pour augmenter la vitesse, les transactions sont [regroupées](#rollups) en lots et soumises sur Ethereum en une seule transaction. Elles sont supposées être valides, mais peuvent être contestées si un cas de fraude est suspecté. Une preuve de fraude exécutera alors la transaction pour vérifier l'existence d'une fraude. Cette méthode augmente le nombre de transactions possibles tout en maintenant le niveau de sécurité. Certains [rollups](#rollups) utilisent des [preuves de validité](#validity-proof).
 
-<DocLink to="/developers/docs/layer-2-scaling/#optimistic-rollups" title="rollups optimisés" />
+<DocLink to="/developers/docs/layer-2-scaling/#optimistic-rollups">
+  rollups optimisés
+</DocLink>
 
 ### Frontier {#frontier}
 
@@ -270,7 +312,9 @@ Phase initiale de développement des tests Ethereum, qui a duré de juillet 2015
 
 Carburant virtuel utilisé dans Ethereum pour exécuter les contrats intelligents. L'[EVM](#evm) utilise un mécanisme de comptabilité pour mesurer la consommation de carburant et limiter la consommation de ressources informatiques (voir [Turing complet](#turing-complete)).
 
-<DocLink to="/developers/docs/gas/" title="carburant et frais" />
+<DocLink to="/developers/docs/gas/">
+  carburant et frais
+</DocLink>
 
 ### limite de carburant {#gas-limit}
 
@@ -332,13 +376,17 @@ Encodage d'adresse Ethereum partiellement compatible avec l'encodage du numéro 
 
 Interface utilisateur qui combine généralement un éditeur de code, un compilateur, un environnement d'exécution et un débogueur.
 
-<DocLink to="/developers/docs/ides/" title="environnement de développement intégrés (IDE)" />
+<DocLink to="/developers/docs/ides/">
+  environnement de développement intégrés (IDE)
+</DocLink>
 
 ### problème du code déployé immuable {#immutable-deployed-code-problem}
 
 Une fois que le code d'un [contrat](#smart-contract) (ou celui d'une [bibliothèque](#library)) est déployé, il devient immuable. Les pratiques de développement de logiciels standard reposent sur la possibilité de corriger d'éventuels bogues et d'ajouter de nouvelles fonctionnalités. Cela représente donc un problème pour le développement de contrats intelligents.
 
-<DocLink to="/developers/docs/smart-contracts/deploying/" title="Déployer des contrats intelligents" />
+<DocLink to="/developers/docs/smart-contracts/deploying/">
+  Déployer des contrats intelligents
+</DocLink>
 
 ### transaction interne {#internal-transaction}
 
@@ -352,7 +400,9 @@ Une fois que le code d'un [contrat](#smart-contract) (ou celui d'une [bibliothè
 
 Aussi appelé "algorithme d'étirement de mot de passe", elle est utilisée par les formats de [keystore](#keystore-file) pour protéger contre les attaques de force brute, de dictionnaire et de table arc-en-ciel sur le chiffrement des phrases de sécurité, en hachant celles-ci de façon répétée.
 
-<DocLink to="/developers/docs/smart-contracts/security/" title="Sécurité" />
+<DocLink to="/developers/docs/smart-contracts/security/">
+  Sécurité
+</DocLink>
 
 ### keccak-256 {#keccak-256}
 
@@ -370,7 +420,9 @@ Fichier encodé en JSON qui contient une seule [clé privée](#private-key) (gé
 
 Domaine de développement axé sur les améliorations par couche sur le protocole Ethereum. Ces améliorations sont liées aux vitesses de [transaction](#transaction), à la réduction des [frais de transaction](#transaction-fee) et à la confidentialité des transactions.
 
-<DocLink to="/developers/docs/layer-2-scaling/" title="Couche 2" />
+<DocLink to="/developers/docs/layer-2-scaling/">
+  Couche 2
+</DocLink>
 
 ### LevelDB {#level-db}
 
@@ -380,7 +432,9 @@ Système open source de stockage de clé-valeur sur disque, implémenté en tant
 
 Type spécial de [contrat](#smart-contract) qui n'a ni fonction de paiement, ni fonction de secours, ni stockage de données. Par conséquent, une bibliothèque ne peut ni recevoir ni détenir l'Ether, ni stocker des données. Elle sert de code précédemment déployé que d'autres contrats peuvent appeler pour obtenir un calcul en lecture seule.
 
-<DocLink to="/developers/docs/smart-contracts/libraries/" title="Bibliothèques de contrats intelligents" />
+<DocLink to="/developers/docs/smart-contracts/libraries/">
+  Bibliothèques de contrats intelligents
+</DocLink>
 
 ### client léger {#lightweight-client}
 
@@ -414,7 +468,9 @@ La troisième phase de développement d'Ethereum, lancée en octobre 2017.
 
 [Nœud](#node) du réseau qui trouve une [preuve de travail](#pow) valide pour de nouveaux blocs, par hachage de passes répétées (voir [Ethash](#ethash)).
 
-<DocLink to="/developers/docs/consensus-mechanisms/pow/mining/" title="Minage" />
+<DocLink to="/developers/docs/consensus-mechanisms/pow/mining/">
+  Minage
+</DocLink>
 
 <Divider />
 
@@ -424,21 +480,29 @@ La troisième phase de développement d'Ethereum, lancée en octobre 2017.
 
 Se référant à Ethereum, réseau P2P qui propage les transactions et les blocs à chaque nœud Ethereum (participant au réseau).
 
-<DocLink to="/developers/docs/networks/" title="Réseaux" />
+<DocLink to="/developers/docs/networks/">
+  Réseaux
+</DocLink>
 
 ### jeton non fongible (NFT) {#nft}
 
 Aussi connu sous le nom de "deed", il s'agit d'une norme de jeton introduite par la proposition ERC-721. Les NFT peuvent être suivis et échangés, mais chaque jeton est unique et distinct. Ils ne sont pas interchangeables comme les jetons ERC-20. Les NFT peuvent représenter la propriété des actifs numériques ou physiques.
 
-<DocLink to="/developers/docs/standards/tokens/erc-721/" title="Norme de jeton non fongible ERC-721" />
+<DocLink to="/developers/docs/standards/tokens/erc-721/">
+  Norme de jeton non fongible ERC-721
+</DocLink>
 
 ### nœud {#node}
 
 Client logiciel qui participe au réseau.
 
-<DocLink to="/developers/docs/nodes-and-clients/" title="Nœuds et clients" />
+<DocLink to="/developers/docs/nodes-and-clients/">
+  Nœuds et clients
+</DocLink>
 
-<DocLink to="/developers/docs/nodes-and-clients/" title="Nœuds et clients" />
+<DocLink to="/developers/docs/nodes-and-clients/">
+  Nœuds et clients
+</DocLink>
 
 ### nonce {#nonce}
 
@@ -456,7 +520,9 @@ Quand un [mineur](#miner) trouve un [bloc](#block) valide, un autre mineur peut 
 
 Un [rollup](#rollups) (ou regroupement) de transactions qui utilise les [preuves de fraude](#fraud-proof) pour permettre un débit de transactions plus élevé sur la [couche 2](#layer-2) tout en bénéficiant de la sécurité apportée par le [réseau principal](#mainnet) (couche 1). Contrairement à [Plasma](#plasma), une solution similaire sur la couche 2, les Optimistic rollups peuvent gérer des transactions plus complexes, en fait tout ce qui est possible au sein de l'[EVM](#evm). Ils ont des problèmes de latence par rapport aux [rollups ZK](#zk-rollups), car une transaction peut être contestée par l'intermédiaire de la preuve de fraude.
 
-<DocLink to="/developers/docs/layer-2-scaling/#optimistic-rollups" title="rollups optimisés" />
+<DocLink to="/developers/docs/layer-2-scaling/#optimistic-rollups">
+  rollups optimisés
+</DocLink>
 
 <Divider />
 
@@ -470,7 +536,9 @@ Une des implémentations interopérables les plus importantes du logiciel Ethere
 
 Une solution d'évolutivité de [couche 2](#layer-2) qui utilise les [preuves de fraude](#fraud-proof), comme les [rollups optimisés](#optimistic-rollups). Plasma se limite aux transactions simples comme les échanges et transferts de jetons de base.
 
-<DocLink to="/developers/docs/layer-2-scaling/#Plasma" title="Plasma" />
+<DocLink to="/developers/docs/layer-2-scaling/#Plasma">
+  Plasma
+</DocLink>
 
 ### clé privée (clé secrète) {#private-key}
 
@@ -480,13 +548,17 @@ Nombre secret qui permet aux utilisateurs Ethereum de prouver la propriété d'u
 
 Méthode par laquelle un protocole de blockchain de cryptomonnaie vise à atteindre un [consensus](#consensus) distribué. La PoS demande aux utilisateurs de prouver qu'ils sont propriétaires d'une certaine quantité de cryptomonnaie (leur "mise" sur le réseau) afin de pouvoir participer à la validation des transactions.
 
-<DocLink to="/developers/docs/consensus-mechanisms/pos/" title="preuve d'enjeu" />
+<DocLink to="/developers/docs/consensus-mechanisms/pos/">
+  preuve d'enjeu
+</DocLink>
 
 ### preuve de travail (PoW) {#pow}
 
 Portion de données (la preuve) qui nécessite des calculs significatifs pour être trouvée. Dans Ethereum, les [mineurs](#miner) doivent trouver une solution numérique à l'algorithme [Ethash](#ethash), qui répond à un objectif de [difficulté](#difficulty) à l'échelle du réseau.
 
-<DocLink to="/developers/docs/consensus-mechanisms/pow/" title="Preuve de travail" />
+<DocLink to="/developers/docs/consensus-mechanisms/pow/">
+  Preuve de travail
+</DocLink>
 
 ### clé publique {#public-key}
 
@@ -504,7 +576,9 @@ Données renvoyées par un client Ethereum pour représenter le résultat d'une 
 
 Attaque qui consiste en un contrat attaquant qui appelle une fonction du contrat de la victime de telle façon que, pendant l'exécution, la victime rappelle le contrat de l'attaquant de façon récursive. Par exemple, en ignorant certaines parties du contrat de la victime qui mettent à jour les soldes ou comptabilisent les montants de retrait, cela peut aboutir à un vol de fonds.
 
-<DocLink to="/developers/docs/smart-contracts/security/#re-entrancy" title="réentrance" />
+<DocLink to="/developers/docs/smart-contracts/security/#re-entrancy">
+  réentrance
+</DocLink>
 
 ### récompense {#reward}
 
@@ -518,7 +592,9 @@ Un standard d'encodage conçu par les développeurs Ethereum pour encoder et sé
 
 Type de solution d'évolutivité de [couche 2](#layer-2) qui regroupe plusieurs transactions et les soumet à la [chaîne principale Ethereum](#mainnet) en une seule transaction. Cela permet de réduire les frais de [carburant](#gas) et d'augmenter le débit des [transactions](#transaction). Il existe des rollups optimisés et des rollups ZK qui utilisent différentes méthodes de sécurité pour offrir ces avantages d'évolutivité.
 
-<DocLink to="/developers/docs/layer-2-scaling/#rollups" title="rollups" />
+<DocLink to="/developers/docs/layer-2-scaling/#rollups">
+  rollups
+</DocLink>
 
 <Divider />
 
@@ -528,7 +604,9 @@ Type de solution d'évolutivité de [couche 2](#layer-2) qui regroupe plusieurs 
 
 Quatrième et dernière phase de développement d'Ethereum.
 
-<DocLink to="/eth2/" title="Ethereum 2.0 (Eth2)" />
+<DocLink to="/eth2/">
+  Ethereum 2.0 (Eth2)
+</DocLink>
 
 ### algorithme de hachage sécurisé (SHA) {#sha}
 
@@ -538,13 +616,17 @@ Famille de fonctions de hachage cryptographique publiées par le National Instit
 
 Chaîne de [preuve d'enjeu](#proof-of-stake) coordonnée par la [chaîne phare](#beacon-chain) et sécurisée par les [validateurs](#validator). 64 seront ajoutés au réseau dans le cadre de la mise à niveau de la chaîne de fragments Eth2. Les chaînes de fragments offriront un débit de transaction accru pour Ethereum en fournissant des données supplémentaires aux solutions de la [couche 2](#layer-2) comme les [rollups optimisés](#optimistic-rollups) et les [rollups ZK](#zk-rollups).
 
-<DocLink to="/eth2/shard-chains" title="chaînes de fragments" />
+<DocLink to="/eth2/shard-chains">
+  chaînes de fragments
+</DocLink>
 
 ### chaînes latérales {#sidechain}
 
 Solution d'évolutivité qui utilise une chaîne séparée avec des [règles de consensus]{#consensus-rules} différentes, souvent plus rapides. Un pont est nécessaire pour connecter ces chaînes latérales au [réseau principal](#mainnet). Les [rollups](#rollups) utilisent également les chaînes latérales, mais ils fonctionnent en collaboration avec le [réseau principal](#mainnet) à la place.
 
-<DocLink to="/developers/docs/layer-2-scaling/#sidechains" title="chaînes latérales" />
+<DocLink to="/developers/docs/layer-2-scaling/#sidechains">
+  chaînes latérales
+</DocLink>
 
 ### singleton {#singleton}
 
@@ -554,19 +636,25 @@ Terme de programmation informatique qui décrit un objet dont il ne peut exister
 
 Période de temps (12 secondes) dans laquelle un nouveau bloc de [chaîne phare](#beacon-chain) et de [chaîne de fragments](#shard) peut être proposé par un [validateur](#validator) dans le système de [preuve d'enjeu](#proof-of-stake). Un créneau peut être vide. 32 créneaux forment une [période](#epoch).
 
-<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work" title="preuve d'enjeu" />
+<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work">
+  preuve d'enjeu
+</DocLink>
 
 ### contrat intelligent {#smart-contract}
 
 Programme qui s'exécute sur l'infrastructure de calcul Ethereum.
 
-<DocLink to="/developers/docs/smart-contracts/" title="Introduction aux contrats intelligents" />
+<DocLink to="/developers/docs/smart-contracts/">
+  Introduction aux contrats intelligents
+</DocLink>
 
 ### Solidity {#solidity}
 
 Langage de programmation procédural (impératif) dont la syntaxe est similaire à JavaScript, C++ ou Java. Il s'agit du langage le plus populaire et le plus fréquemment utilisé pour les [contrats intelligents](#smart-contract) Ethereum. Créé par Dr. Gavin Wood.
 
-<DocLink to="/developers/docs/smart-contracts/languages/#solidity" title="Solidity" />
+<DocLink to="/developers/docs/smart-contracts/languages/#solidity">
+  Solidity
+</DocLink>
 
 ### assemblage en ligne Solidity {#solidity-inline-assembly}
 
@@ -580,19 +668,25 @@ Langage d'assemblage de l'[EVM](#evm) dans un programme [Solidity](#solidity). L
 
 [jeton ERC-20](#token-standard) dont la valeur est liée à celle d'un autre actif. Il existe des stablecoins liés à des monnaies fiduciaires comme le dollar, des métaux précieux comme l'or, et d'autres cryptomonnaies comme le Bitcoin.
 
-<DocLink to="/eth/#tokens" title="L'ETH n'est pas la seule crypto sur Ethereum" />
+<DocLink to="/eth/#tokens">
+  L'ETH n'est pas la seule crypto sur Ethereum
+</DocLink>
 
 ### miser {#staking}
 
 Déposer une quantité d'[ether](#ether) (votre mise) pour devenir validateur et sécuriser le [réseau](#network). Un validateur vérifie les [transactions](#transaction) et propose des [blocs](#block) sous un modèle de consensus de [preuve d'enjeu](#pos). Miser vous incite économiquement à agir dans le meilleur intérêt du réseau. Vous obtiendrez des récompenses pour effectuer vos tâches de [validateur](#validator) , mais perdrez diverses quantités d'ETH dans le cas contraire.
 
-<DocLink to="/eth2/staking/" title="Misez votre ETH pour devenir un validateur Ethereum" />
+<DocLink to="/eth2/staking/">
+  Misez votre ETH pour devenir un validateur Ethereum
+</DocLink>
 
 ### canaux d'état {#state-channels}
 
 Solution de la [couche 2](#layer-2) où un canal est mis en place entre les participants pour qu'ils puissent effectuer des transactions librement et à moindre coût. Une seule [transaction ](#transaction) est envoyée au [réseau principal](#mainnet) pour configurer et fermer le canal. Cela permet un débit de transaction très élevé, mais repose sur la connaissance du nombre de participants au départ et le blocage de fonds.
 
-<DocLink to="/developers/docs/layer-2-scaling/#state-channels" title="canaux d'état" />
+<DocLink to="/developers/docs/layer-2-scaling/#state-channels">
+  canaux d'état
+</DocLink>
 
 ### szabo {#szabo}
 
@@ -610,19 +704,25 @@ Dénomination de l'[ether](#ether). 1 szabo = 10<sup>12</sup> [wei](#wei), 10<su
 
 Réseau utilisé pour simuler le comportement du réseau principal Ethereum (voir [réseau principal](#mainnet)).
 
-<DocLink to="/developers/docs/networks/#testnets" title="réseaux de test" />
+<DocLink to="/developers/docs/networks/#testnets">
+  réseaux de test
+</DocLink>
 
 ### norme de jeton {#token-standard}
 
 Introduite par la proposition ERC-20, elle fournit une structure de [contrat intelligent](#smart-contract) standardisée pour les jetons fongibles. Les jetons du même contrat peuvent être suivis, négociés, et sont interchangeables, contrairement aux [NFT](#nft).
 
-<DocLink to="/developers/docs/standards/tokens/erc-20/" title="norme de jeton ERC-20" />
+<DocLink to="/developers/docs/standards/tokens/erc-20/">
+  norme de jeton ERC-20
+</DocLink>
 
 ### transaction {#transaction}
 
 Données enregistrées dans la blockchain Ethereum signées par un [compte](#account) émetteur, ciblant une [adresse](#address) spécifique. La transaction contient des métadonnées comme sa [limite de carburant](#gas-limit).
 
-<DocLink to="/developers/docs/transactions/" title="Transactions" />
+<DocLink to="/developers/docs/transactions/">
+  Transactions
+</DocLink>
 
 ### frais de transaction {#transaction-fee}
 
@@ -644,25 +744,35 @@ Concept nommé d'après le mathématicien et informaticien anglais Alan Turing. 
 
 Dans un système de [preuve d'enjeu](#proof-of-stake), [nœud](#node) responsable du stockage des données, du traitement des transactions, et de l'ajout de nouveaux blocs à la blockchain. Pour activer le logiciel validateur, vous devez pouvoir [miser](#staking) 32 ETH.
 
-<DocLink to="/developers/docs/consensus-mechanisms/pos" title="preuve d'enjeu" /> <DocLink to="/eth2/staking/" title="Miser sur Ethereum" />
+<DocLink to="/developers/docs/consensus-mechanisms/pos">
+  preuve d'enjeu
+</DocLink> <DocLink to="/eth2/staking/">
+  Miser sur Ethereum
+</DocLink>
 
 ### preuve de validité {#validity-proof}
 
 Modèle de sécurité pour certaines solutions de la [couche 2](#layer-2) où, pour augmenter la vitesse, les transactions sont [regroupées](/#rollups) en lots et soumises à Ethereum en une seule transaction. Le calcul des transactions se fait hors chaîne et est ensuite fourni à la chaîne principale avec une preuve de leur validité. Cette méthode augmente le nombre de transactions possibles tout en maintenant le niveau de sécurité. Certains [rollups](#rollups) utilisent des [preuves de fraude](#fraud-proof).
 
-<DocLink to="/developers/docs/layer-2-scaling/#zk-rollups" title="rollups ZK" />
+<DocLink to="/developers/docs/layer-2-scaling/#zk-rollups">
+  rollups ZK
+</DocLink>
 
 ### Validium {#validium}
 
 Solution de la [couche 2](#layer-2) utilisant les [preuves de validité](#validity-proof) pour améliorer le débit de transactions. Contrairement à celles des [rollups ZK](#zk-rollup), les données Validium ne sont pas stockées sur la couche 1 du [réseau principal](#mainnet).
 
-<DocLink to="/developers/docs/layer-2-scaling/#validium" title="Validité" />
+<DocLink to="/developers/docs/layer-2-scaling/#validium">
+  Validité
+</DocLink>
 
 ### Vyper {#vyper}
 
 Langage de programmation de haut niveau dont la syntaxe est similaire à celle de Python. Conçu pour se rapprocher d'un langage purement fonctionnel. Créé par Vitalik Buterin.
 
-<DocLink to="/developers/docs/smart-contracts/languages/#vyper" title="Vyper" />
+<DocLink to="/developers/docs/smart-contracts/languages/#vyper">
+  Vyper
+</DocLink>
 
 <Divider />
 
@@ -672,13 +782,17 @@ Langage de programmation de haut niveau dont la syntaxe est similaire à celle d
 
 Logiciel qui conserve des [clés privées](#private-key). Utilisé pour accéder aux [comptes](#account) Ethereum et les contrôler, et interagir avec les [contrats intelligents](#smart-contract). Les clés ne doivent pas nécessairement être stockées dans un portefeuille, et peuvent être récupérées depuis un stockage hors ligne (une carte mémoire ou une feuille papier), pour plus de sécurité. Malgré leur nom, les portefeuilles ne stockent jamais la monnaie ni les jetons en eux-mêmes.
 
-<DocLink to="/wallets/" title="Portefeuilles Ethereum" />
+<DocLink to="/wallets/">
+  Portefeuilles Ethereum
+</DocLink>
 
 ### Web3 {#web3}
 
 Troisième version du Web. D'abord proposé par le Dr. Gavin Wood, Web3 représente une nouvelle vision et une nouvelle orientation pour les applications Web, des applications gérées et possédées de façon centralisée aux applications construites sur des protocoles décentralisés (voir [DApp](#dapp)).
 
-<DocLink to="/developers/docs/web2-vs-web3/" title="Web2 et Web3" />
+<DocLink to="/developers/docs/web2-vs-web3/">
+  Web2 et Web3
+</DocLink>
 
 ### wei {#wei}
 
@@ -696,7 +810,9 @@ Adresse Ethereum spéciale, composée entièrement de zéros et spécifiée comm
 
 Un [rollup](#rollups) (ou regroupement) de transactions utilisant les [preuves de validité](#validity-proof) pour permettre un débit plus élevé de transactions sur la [couche 2](#layer-2) tout en bénéficiant de la sécurité offerte par le [réseau principal](#mainnet) (couche 1). Bien qu'ils ne puissent pas prendre en charge des types de transactions complexes comme le font les [rollups optimisés](#optimistic-rollups), les rollups ZK n'ont pas de problème de latence dans la mesure où les transactions sont prouvées valides à la soumission.
 
-<DocLink to="/developers/docs/layer-2-scaling/#zk-rollups" title="Rollups ZK" />
+<DocLink to="/developers/docs/layer-2-scaling/#zk-rollups">
+  Rollups ZK
+</DocLink>
 
 <Divider />
 

--- a/src/content/translations/fr/history/index.md
+++ b/src/content/translations/fr/history/index.md
@@ -35,7 +35,9 @@ La [chaîne phare](/eth2/beacon-chain/) avait besoin de 16 384 dépôts de 32 E
 
 [Lire l'annonce de l'Ethereum Foundation](https://blog.ethereum.org/2020/11/27/eth2-quick-update-no-21/)
 
-<DocLink to="/eth2/beacon-chain/" title="Chaîne phare" />
+<DocLink to="/eth2/beacon-chain/">
+  Chaîne phare
+</DocLink>
 
 ---
 
@@ -49,7 +51,9 @@ Le contrat de dépôt de mise en jeu a introduit la [mise en jeu](/glossary/#sta
 
 [Lire l'annonce de l'Ethereum Foundation](https://blog.ethereum.org/2020/11/04/eth2-quick-update-no-19/)
 
-<DocLink to="/eth2/staking/" title="Miser" />
+<DocLink to="/eth2/staking/">
+  Miser
+</DocLink>
 
 ---
 
@@ -301,4 +305,6 @@ Le Livre jaune, rédigé par le Dr. Gavin Wood, est une définition technique du
 
 Document d'introduction publié en 2013 par Vitalik Buterin, le fondateur d'Ethereum, précédant le lancement du projet en 2015.
 
-<DocLink to="/whitepaper/" title="Livre blanc" />
+<DocLink to="/whitepaper/">
+  Livre blanc
+</DocLink>

--- a/src/content/translations/hu/glossary/index.md
+++ b/src/content/translations/hu/glossary/index.md
@@ -22,7 +22,9 @@ Egy decentralizált [hálózat](#network) ellen irányuló támadás, amikor egy
 
 Egy objektum, mely egy [címet](#address), egy egyenleget, [egy nonce-t](#nonce), és opcionálisan tárhelyet és kódot tartalmazhat. Egy számla lehet [szerződéses számla](#contract-account) vagy egy [külső tulajdonú számla (EOA)](#eoa).
 
-<DocLink to="/developers/docs/accounts" title="Ethereum számlák" />
+<DocLink to="/developers/docs/accounts">
+  Ethereum számlák
+</DocLink>
 
 ### address (cím) {#address}
 
@@ -32,7 +34,9 @@ Egy objektum, mely egy [címet](#address), egy egyenleget, [egy nonce-t](#nonce)
 
 A [Solidity-ben](#solidity), az `assert(false)` a `0xfe` opkódra fordítódik, mely egy érvénytelen opkód, ami felhasználja az összes megmaradt [gázt](#gas) és visszaállítja a változásokat. Ha egy `assert()` állítás meghiúsul, akkor valami nagyon rossz és váratlan történik, és meg kell javítanod a kódot. Az `assert()` kódot, olyan feltételek elkerülésére kell használnod, melynek soha sem szabad megtörténnie.
 
-<DocLink to="/developers/docs/smart-contracts/security/" title="Biztonság" />
+<DocLink to="/developers/docs/smart-contracts/security/">
+  Biztonság
+</DocLink>
 
 ### attestation (tanúsítás) {#attestation}
 
@@ -46,7 +50,9 @@ Egy validátor szavazata egy [Beacon Chain](#beacon-chain) vagy egy [shard](#sha
 
 Egy Eth2 fejlesztés, mely az Ethereum hálózat koordinátora lesz. Bevezeti a [letétbizonyítékot](#proof-of-stake) és a [validátorokat](#validator) az Ethereumra. Idővel össze fog olvadni a [főhálózattal](#mainnet).
 
-<DocLink to="/eth2/beacon-chain/" title="Beacon Chain" />
+<DocLink to="/eth2/beacon-chain/">
+  Beacon Chain
+</DocLink>
 
 ### big-endian {#big-endian}
 
@@ -56,13 +62,17 @@ Helyzeti számábrázolás, ahol a legfontosabb számjegy az első a memóriába
 
 A szükséges információ (egy blokk fejléc) gyűjteménye a befoglalt [tranzakciókról](#transaction), és más blokk fejlécek halmaza, melyet [ommereknek](#ommer) hívunk. A blokkokat a [bányászok](#miner) adják hozzá az Ethereum hálózathoz.
 
-<DocLink to="/developers/docs/blocks/" title="Blokkok" />
+<DocLink to="/developers/docs/blocks/">
+  Blokkok
+</DocLink>
 
 ### blokklánc {#blockchain}
 
 Az Ethereumban [blokkok](#block) sorozatát jelenti, melyeket a [proof-of-work](#pow) rendszer érvényesít, mindegyik kapcsolódik az előzőhöz egészen a [genezis blokkig](#genesis-block). Nincsen blokk méret határ, ehelyett [gáz limitet](#gas-limit) használunk.
 
-<DocLink to="/developers/docs/intro-to-ethereum#what-is-a-blockchain" title="Mi az a blokklánc?" />
+<DocLink to="/developers/docs/intro-to-ethereum#what-is-a-blockchain">
+  Mi az a blokklánc?
+</DocLink>
 
 ### bytecode {#bytecode}
 
@@ -80,7 +90,9 @@ Az első a két [hard forkból](#hard-fork) a [Metropolis](#metropolis) fejleszt
 
 Egy magas szintű nyelvben (pl.: [Solidity](#solidity)) írt kód átkonvertálása egy alacsonyabb szintű nyelvre (pl.: EVM [bájtkód](#bytecode)).
 
-<DocLink to="/developers/docs/smart-contracts/compiling/" title="Okos szerződések fordítása" />
+<DocLink to="/developers/docs/smart-contracts/compiling/">
+  Okos szerződések fordítása
+</DocLink>
 
 ### committee (bizottság) {#committee}
 
@@ -110,7 +122,9 @@ Egy speciális [tranzakció](#transaction), a [zéró címmel](#zero-address) mi
 
 A kereszt kapcsolat egy összesítést ad vissza egy shard állapotáról. Így fognak a [shard](#shard) láncok kommunikálni egymással [Beacon Chain-en](#beacon-chain) keresztül a [proof-of-stake rendszerben](#proof-of-stake).
 
-<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work" title="Proof-of-stake" />
+<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work">
+  Proof-of-stake
+</DocLink>
 
 <Divider />
 
@@ -120,19 +134,25 @@ A kereszt kapcsolat egy összesítést ad vissza egy shard állapotáról. Így 
 
 Egy olyan vállalat vagy szervezet, amely hierarchikus menedzsment nélkül működik. A DAO utalhat a "The DAO" nevű szerződésre, melyet 2016 április 30.-án indítottak, és 2016 júniusában meghackeltek; ez végül erősen motiválta a [hard forkot](#hard-fork) (DAO kódnév) az 1,192,000 blokkban, mely visszaállította a meghackelt DAO szerződést és az Ethereum és az Ethereum Classic szétválását okozta két rivális rendszerré.
 
-<DocLink to="/community/#decentralized-autonomous-organizations-daos" title="Decentralizált autonóm szervezetek (DAO-k)" />
+<DocLink to="/community/#decentralized-autonomous-organizations-daos">
+  Decentralizált autonóm szervezetek (DAO-k)
+</DocLink>
 
 ### Dapp {#dapp}
 
 Decentralizált alkalmazás. Legalább egy [okosszerződés](#smart-contract) és egy webes felhasználói felület. Tágabb értelemben egy dapp egy olyan web alkalmazás, mely egy decentralizált, peer-to-peer infrastruktúra szolgáltatásra épült. Továbbá sok dapp tartalmazhat decentralizált tárhelyet és/vagy egy üzenetküldő protokollt és platformot.
 
-<DocLink to="/developers/docs/dapps/" title="Bevezetés a dappokba" />
+<DocLink to="/developers/docs/dapps/">
+  Bevezetés a dappokba
+</DocLink>
 
 ### decentralizált tőzsde (DEX) {#dex}
 
 Egy [dapp](#dapp) típus, mellyel tokeneket cserélhetsz a peerekkel a hálózaton. Szükséged lesz [etherre](#ether) a használatukhoz (a [tranzakciós díjak](#transaction-fee) kifizetésére) de nincsenek kitéve a földrajzi megszorításoknak, mint a centralizált tőzsdék – bárki használhatja őket.
 
-<DocLink to="/get-eth/#dex" title="Decentralizált tőzsdék" />
+<DocLink to="/get-eth/#dex">
+  Decentralizált tőzsdék
+</DocLink>
 
 ### deed {#deed}
 
@@ -142,7 +162,9 @@ Lásd [nem felcserélhető token (NFT)](#nft)
 
 A "decentralized finance", vagyis "decentralizált pénzügy" rövidítése, amely olyan [Dappok](#dapp) széles kategóriája, melyeknek célkitűzése blokklánc alapú pénzügyi szolgáltatások létrehozása, köztes szereplők nélkül, így bárki részt vehet benne internetkapcsolattal.
 
-<DocLink to="/dapps/#explore" title="Defi dappok" />
+<DocLink to="/dapps/#explore">
+  Defi dappok
+</DocLink>
 
 ### difficulty (nehézség) {#difficulty}
 
@@ -168,13 +190,17 @@ Az Ethereum által használt kriptográfiai algoritmus, mely biztosítja, hogy a
 
 Egy 32 [slotból](#slot) álló periódus (6.4 perc) a [Beacon Chain](#beacon-chain)-által koordinált rendszerben. A [validátor](#validator) [bizottságokat](#committee) összekeverik minden korszakban biztonsági okokból. Minden korszakban esély van a lánc [véglelesítésére](#finality).
 
-<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work" title="Proof-of-stake" />
+<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work">
+  Proof-of-stake
+</DocLink>
 
 ### Ethereum Fejlesztési Javaslatok (EIP-k) {#eip}
 
 Tervezési dokumentum, amely információkat nyújt az Ethereum közösség számára, és ismerteti a javasolt új funkciót, annak folyamatait vagy környezetét (lásd [ERC](#erc)).
 
-<DocLink to="/eips/" title="Bevezetés az EIP-kbe" />
+<DocLink to="/eips/">
+  Bevezetés az EIP-kbe
+</DocLink>
 
 ### Ethereum Name Service (ENS) {#ens}
 
@@ -194,7 +220,9 @@ Egy emberi felhasználók által vagy számára létrehozott [számla](#account)
 
 Néhány [EIP-hez](#eip) tartozó címke, melyek specifikus Ethereum használati szabványokat definiálnak.
 
-<DocLink to="/eips/" title="Bevezetés az EIP-kbe" />
+<DocLink to="/eips/">
+  Bevezetés az EIP-kbe
+</DocLink>
 
 ### Ethash {#ethash}
 
@@ -206,19 +234,25 @@ Az Ethereum 1.0 [munkabizonyíték](#pow) algoritmusa.
 
 Az Ethereum ökoszisztéma által használt natív kriptovaluta, mely fedezi a [gáz](#gas) költségeket tranzakciók végrehajtásakor. Írásban találkozhatunk vele ETH-ként vagy a Ξ szimbólumként is, ami a nagybetűs görög kszí karakter.
 
-<DocLink to="/eth/" title="A digitális jövőnk valutája" />
+<DocLink to="/eth/">
+  A digitális jövőnk valutája
+</DocLink>
 
 ### events (események) {#events}
 
 Az [EVM](#evm) logolási lehetőségeinek használatát teszi lehetővé. A [dappok](#dapp) figyelhetik az eseményeket és a használatukkal JavaScript callback függvényeket triggerelhetnek az felhasználói felületen.
 
-<DocLink to="/developers/docs/smart-contracts/anatomy/#events-and-logs" title="Események és naplózások" />
+<DocLink to="/developers/docs/smart-contracts/anatomy/#events-and-logs">
+  Események és naplózások
+</DocLink>
 
 ### Ethereum virtuális gép (EVM) {#evm}
 
 Egy stack alapú virtuális gép, mely [bájtkódot](#bytecode) futtat. Az Ethereumban a lefutási modell előírja, hogyan fog a rendszerállapot megváltozni adott bájtkód sorozattól és a környezeti adatok egy kis sorától. Ez a virtuális állapot gép formális modelljében van előírva.
 
-<DocLink to="/developers/docs/evm/" title="Ethereum virtuális gép" />
+<DocLink to="/developers/docs/evm/">
+  Ethereum virtuális gép
+</DocLink>
 
 ### EVM assembly nyelv {#evm-assembly-language}
 
@@ -236,13 +270,19 @@ Egy alap függvény, mely adat vagy deklarált függvény név hiánya esetén h
 
 Egy [okosszerződés](#smart-contract) által működtetett szolgáltatás, mely javakat bocsájt ki ingyenes teszt ether formájában, melyet a tesztneten lehet használni.
 
-<DocLink to="/developers/docs/networks/#testnet-faucets" title="Tesztnet csapok" />
+<DocLink to="/developers/docs/networks/#testnet-faucets">
+  Tesztnet csapok
+</DocLink>
 
 ### véglegesség {#finality}
 
 A véglegesség a garancia arra, hogy az adott tranzakciók egy bizonyos idő előtt nem fognak megváltozni és nem lehet visszavonni őket.
 
-<DocLink to="/developers/docs/consensus-mechanisms/pow/#finality" title="Proof-of-work véglegesség" /> <DocLink to="/developers/docs/consensus-mechanisms/pos/#finality" title="Proof-of-stake véglegesség" />
+<DocLink to="/developers/docs/consensus-mechanisms/pow/#finality">
+  Proof-of-work véglegesség
+</DocLink> <DocLink to="/developers/docs/consensus-mechanisms/pos/#finality">
+  Proof-of-stake véglegesség
+</DocLink>
 
 ### finney {#finney}
 
@@ -256,7 +296,9 @@ Egy protokoll változtatás, mely egy alternatív lánc létrejöttét vonja mag
 
 Bizonyos [2. réteg](#layer-2) megoldások biztonsági modellje, ahol a sebesség növelése érdekében a tranzakciókat csoportokba [összegzik](#rollups) és egy tranzakcióként továbbítják az Ethereumra. Érvényesnek feltételezzük őket, de meg lehet kérdőjelezni, ha csalást feltételezünk. Ekkor lefut egy csalási bizonyítás, mely ellenőrzi, hogy történt-e csalás. Ez a módszer növeli a lehetséges tranzakciók mennyiségét mialatt fenntartja a biztonságot. Néhány [összegző](#rollups) [érvényességi bizonyítást](#validity-proof) használ.
 
-<DocLink to="/developers/docs/layer-2-scaling/#optimistic-rollups" title="Optimista összegzők" />
+<DocLink to="/developers/docs/layer-2-scaling/#optimistic-rollups">
+  Optimista összegzők
+</DocLink>
 
 ### frontier {#frontier}
 
@@ -270,7 +312,9 @@ Az Ethereum kezdeti teszt fejlesztési fázisa, mely 2015 júliusától 2016 má
 
 Egy virtuális üzemanyag, melyet az Ethereumon használunk okosszerződések végrehajtására. Az [EVM](#evm) egy könyvelési mechanizmust használ, amivel méri a gázfogyasztást és behatárolja a számítási kapacitások fogyasztását (lásd [Turing teljes](#turing-complete)).
 
-<DocLink to="/developers/docs/gas/" title="Gáz és tranzakciós díjak" />
+<DocLink to="/developers/docs/gas/">
+  Gáz és tranzakciós díjak
+</DocLink>
 
 ### gas limit (gáz limit) {#gas-limit}
 
@@ -332,13 +376,17 @@ Egy Ethereum [hard fork](#hard-fork) a 200,000 blokknál, mely bevezeti az expon
 
 Egy felhasználói felület, mely általában egy kód szerkesztőt, egy fordítót, egy runtime-ot és egy debuggert egyesít.
 
-<DocLink to="/developers/docs/ides/" title="Integrált Fejlesztői Környezetek" />
+<DocLink to="/developers/docs/ides/">
+  Integrált Fejlesztői Környezetek
+</DocLink>
 
 ### immutable deployed code problem (nem megváltoztatható kód problémája) {#immutable-deployed-code-problem}
 
 Amint egy [szerződés](#smart-contract) (vagy [könyvtár](#library)) kód telepítésre került, megváltoztathatatlanná válik. A standard szoftverfejlesztési gyakorlat a lehetséges bugok javítására és új funkciók hozzáadására támaszkodik, így ez egy kihívást jelent az okosszerződés fejlesztésnél.
 
-<DocLink to="/developers/docs/smart-contracts/deploying/" title="Okosszerződések telepítése" />
+<DocLink to="/developers/docs/smart-contracts/deploying/">
+  Okosszerződések telepítése
+</DocLink>
 
 ### internal transaction (belső tranzakció) {#internal-transaction}
 
@@ -352,7 +400,9 @@ Egy [tranzakció](#transaction) egy [szerződéses számláról](#contract-accou
 
 Más néven "jelszó nyújtó algoritmus", melyet a [keystore](#keystore-file) formátumok használnak, hogy védekezzenek a brute-force, dictionary és a szivárvány tábla támadásokkal szemben a jelszó titkosításoknál a jelszó ismételt hashelésével.
 
-<DocLink to="/developers/docs/smart-contracts/security/" title="Biztonság" />
+<DocLink to="/developers/docs/smart-contracts/security/">
+  Biztonság
+</DocLink>
 
 ### keccak-256 {#keccak-256}
 
@@ -370,7 +420,9 @@ Egy JSON kódolású fájl, mely egy (véletlenszerűen generált) [privát kulc
 
 Egy fejlesztési terület, mely az Ethereum protokollra épített fejlesztési rétegekre fókuszál. Ezek a fejlesztések a [tranzakciókhoz](#transaction) sebességhez, olcsóbb[tranzakciós díjakhoz](#transaction-fee) és a privát tranzakciókhoz kapcsolódnak.
 
-<DocLink to="/developers/docs/layer-2-scaling/" title="2. réteg" />
+<DocLink to="/developers/docs/layer-2-scaling/">
+  2. réteg
+</DocLink>
 
 ### LevelDB {#level-db}
 
@@ -380,7 +432,9 @@ Egy nyílt forráskódú on-disk, kulcspár tároló, mely egy könnyű, egyedi 
 
 Egy speciális [szerződés](#smart-contract) típus, melynek nincsenek payable függvényei, fallback függvényei vagy adattárolója. Így nem tud ethert tartani vagy kapni, illetve adatot tárolni. Egy könyvtár korábban telepített kódként szolgál, melyet más szerződések meghívhatnak read-only számítás céljából.
 
-<DocLink to="/developers/docs/smart-contracts/libraries/" title="Okosszerződés könyvtárak" />
+<DocLink to="/developers/docs/smart-contracts/libraries/">
+  Okosszerződés könyvtárak
+</DocLink>
 
 ### lightweight client (könnyű kliens) {#lightweight-client}
 
@@ -414,7 +468,9 @@ Az Ethereum harmadik fejlesztési fázisa, mely 2017 októberében indult el.
 
 Egy hálózati [csomópont](#node), mely érvényes [munkabizonyítékokat](#pow) keres az új blokkoknak ismételt hasheléssel (lásd [Ethash](#ethash)).
 
-<DocLink to="/developers/docs/consensus-mechanisms/pow/mining/" title="Bányászat" />
+<DocLink to="/developers/docs/consensus-mechanisms/pow/mining/">
+  Bányászat
+</DocLink>
 
 <Divider />
 
@@ -424,21 +480,29 @@ Egy hálózati [csomópont](#node), mely érvényes [munkabizonyítékokat](#pow
 
 Az Ethereum hálózatra utal, mely egy peer-to-peer hálózat, mely tranzakciókat és blokkokat terjeszt az összes Ethereum csomópont (hálózati résztvevő) számára.
 
-<DocLink to="/developers/docs/networks/" title="Hálózatok" />
+<DocLink to="/developers/docs/networks/">
+  Hálózatok
+</DocLink>
 
 ### nem felcserélhető token (NFT) {#nft}
 
 Más néven "deed", ez egy token szabvány, melyet az ERC-721 javaslat vezetett be. Az NFT-ket nyomon lehet követni és kereskedni velük, de minden egyes token egyedi és különböző; nem felcserélhetőek, mint az ERC-20 tokenek. Az NFT-k tulajdonjogot reprezentálhatnak digitális vagy fizikai eszközöknél.
 
-<DocLink to="/developers/docs/standards/tokens/erc-721/" title="ERC-721 Nem Felcserélhető Token Szabvány" />
+<DocLink to="/developers/docs/standards/tokens/erc-721/">
+  ERC-721 Nem Felcserélhető Token Szabvány
+</DocLink>
 
 ### node (csomópont) {#node}
 
 Egy szoftver kliens, mely részt vesz a hálózatban.
 
-<DocLink to="/developers/docs/nodes-and-clients/" title="Csomópontok és kliensek" />
+<DocLink to="/developers/docs/nodes-and-clients/">
+  Csomópontok és kliensek
+</DocLink>
 
-<DocLink to="/developers/docs/nodes-and-clients/" title="Csomópontok és kliensek" />
+<DocLink to="/developers/docs/nodes-and-clients/">
+  Csomópontok és kliensek
+</DocLink>
 
 ### nonce {#nonce}
 
@@ -456,7 +520,9 @@ Amikor egy [bányász](#miner) talál egy érvényes [blokkot](#block), lehetsé
 
 Olyan [összevont tranzakció](#rollups), amely [csalási bizonyítást](#fraud-proof) használ annak érdekében, hogy növelje a [2. rétegen](#layer-2) végrehajtható tranzakciók számát, ugyanakkor a [főhálózat](#mainnet) (1. réteg) biztonsági protokollját használja. Ellentétben egy hasonló 2. réteges megoldással, a [Plasmával](#plasma), az Optimistic típusú összevont tranzakciók komplexebb tranzakciókat is képesek kezelni - az [EVM](#evm)-ben bármi lehetséges. Vannak azonban késleltetési problémái a [Zero-knowledge típusú összevont tranzakciókhoz](#zk-rollups) képest, mivel egy tranzakciót meg lehet kérdőjelezni egy csalási bizonyítással.
 
-<DocLink to="/developers/docs/layer-2-scaling/#optimistic-rollups" title="Optimista összegzők" />
+<DocLink to="/developers/docs/layer-2-scaling/#optimistic-rollups">
+  Optimista összegzők
+</DocLink>
 
 <Divider />
 
@@ -470,7 +536,9 @@ Az Ethereum kliens szoftver egyik legprominensebb, interoperábilis implementác
 
 Egy [2. réteges](#layer-2)skálázási megoldás, mely [csalási bizonyításokat használ](#fraud-proof), mint az [optimista összegzők](#optimistic-rollups). A Plasma csak egyszerű tranzakciókra alkalmas, mint az egyszerű token átutalás vagy cserélés.
 
-<DocLink to="/developers/docs/layer-2-scaling/#Plasma" title="Plasma" />
+<DocLink to="/developers/docs/layer-2-scaling/#Plasma">
+  Plasma
+</DocLink>
 
 ### private key (secret key) / privát kulcs (titkos kulcs) {#private-key}
 
@@ -480,13 +548,17 @@ Egy titkos szám, mely lehetővé teszi az Ethereum felhasználóknak, hogy bizo
 
 Egy metódus, mellyel egy kriptovaluta blokklánc protokoll eléri az elosztott [konszenzust](#consensus). A PoS utasítja a felhasználókat, hogy bizonyítsák a tulajdonjogukat egy bizonyos összegű kriptovaluta felett (a "letétük" a hálózatban) azért, hogy részt vehessenek a tranzakciók validálásában.
 
-<DocLink to="/developers/docs/consensus-mechanisms/pos/" title="Proof-of-stake" />
+<DocLink to="/developers/docs/consensus-mechanisms/pos/">
+  Proof-of-stake
+</DocLink>
 
 ### proof-of-work (PoW) / munkabizonyíték {#pow}
 
 Egy adatsor (a bizonyíték), melynek megtalálása jelentős mennyiségű számítást igényel. Az Ethereumban a [bányászoknak](#miner) meg kell találniuk a numerikus megoldását az [Ethash](#ethash) algoritmusnak, mely eléri a hálózati szintű [nehézségi](#difficulty) célt.
 
-<DocLink to="/developers/docs/consensus-mechanisms/pow/" title="Proof-of-work" />
+<DocLink to="/developers/docs/consensus-mechanisms/pow/">
+  Proof-of-work
+</DocLink>
 
 ### public key (publikus kulcs) {#public-key}
 
@@ -504,7 +576,9 @@ Egy Ethereum kliens által visszadott adat, mely egy adott [tranzakció](#transa
 
 Egy támadás, mely során egy támadó szerződés meghívja az áldozat szerződés egyik függvényét úgy, hogy újra meghívja a függvényt lefutás közben rekurzívan. Ez például a pénz ellopását eredményezheti úgy, hogy kihagy egy pár lépést az áldozat szerződéséből, mely frissítené az egyenlegeket vagy számolná a kiutalási mennyiségeket.
 
-<DocLink to="/developers/docs/smart-contracts/security/#re-entrancy" title="Újbóli belépés (re-entrancy)" />
+<DocLink to="/developers/docs/smart-contracts/security/#re-entrancy">
+  Újbóli belépés (re-entrancy)
+</DocLink>
 
 ### reward (jutalom) {#reward}
 
@@ -518,7 +592,9 @@ Egy Ethereum fejlesztők által megtervezett kódolási szabvány tetszőlegesen
 
 A [2. réteg](#layer-2) skálázódásának egyik módszere, amely több tranzakciót gyűjt össze, és egyszerre, egyetlen tranzakcióban küldi el őket az [Ethereum főhálózatára](#mainnet). Ez lehetővé teszi a [gáz](#gas) költségének csökkentését, és növeli a feldolgozható [tranzakciók](#transaction) számát. Vannak Optimistic és Zero-knowledge típusú összevont tranzakciók, melyek különböző biztonsági módszert használnak, hogy elérjék a skálázási eredményt.
 
-<DocLink to="/developers/docs/layer-2-scaling/#rollups" title="Összegzők" />
+<DocLink to="/developers/docs/layer-2-scaling/#rollups">
+  Összegzők
+</DocLink>
 
 <Divider />
 
@@ -528,7 +604,9 @@ A [2. réteg](#layer-2) skálázódásának egyik módszere, amely több tranzak
 
 Az Ethereum negyedik és végső fejlesztési fázisa.
 
-<DocLink to="/eth2/" title="Ethereum 2.0 (Eth2)" />
+<DocLink to="/eth2/">
+  Ethereum 2.0 (Eth2)
+</DocLink>
 
 ### Secure Hash Algorithm (SHA) {#sha}
 
@@ -538,13 +616,17 @@ Kriptográfiai hash függvények egy családja, melyet a National Institute of S
 
 Egy [proof-of-stake](#proof-of-stake) lánc, melyet a [Beacon Chain](#beacon-chain) koordinált és a [validátorok](#validator) tartják biztonságban. 64 lesz hozzáadva a hálózathoz az Eth2 shard lánc fejlesztés részeként. A shard láncok megnövelt tranzakció átvitelt tesznek majd lehetővé az Ethereumon extra adat szolgáltatással az olyan [2. réteg](#layer-2) megoldások részére, mint az [optimista összegzők](#optimistic-rollups) és az [ZK összegzők](#zk-rollups).
 
-<DocLink to="/eth2/shard-chains" title="Shard láncok" />
+<DocLink to="/eth2/shard-chains">
+  Shard láncok
+</DocLink>
 
 ### Sidechain (melléklánc) {#sidechain}
 
 Egy skálázási megoldás, mely egy különálló láncot használ másfajta, gyakran gyorsabb, [konszenzus szabályokkal]{#consensus-rules}. Egy áthidalás szükséges, hogy ezek a mellékláncok a [főhálózathoz](#mainnet) csatlakozzanak. Az [összegzők](#rollups) szintén mellékláncokat használnak, de ehelyett a [főhálózattal](#mainnet) együttműködve teszik ezt.
 
-<DocLink to="/developers/docs/layer-2-scaling/#sidechains" title="Mellékláncok" />
+<DocLink to="/developers/docs/layer-2-scaling/#sidechains">
+  Mellékláncok
+</DocLink>
 
 ### singleton {#singleton}
 
@@ -554,19 +636,25 @@ Egy számítógép programozási fogalom, mely egy olyan objektumot jelent, amin
 
 Időperiódus (12 másodperc), amely alatt egy új [Beacon Chain](#beacon-chain) és [shard](#shard) lánc blokkot terjeszthet elő egy [validátor](#validator) a [letétbizonyíték](#proof-of-stake) alapú rendszerben. A slot lehet üres is. 32 slot tesz ki egy [epochát](#epoch).
 
-<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work" title="Proof-of-stake" />
+<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work">
+  Proof-of-stake
+</DocLink>
 
 ### smart contract (okosszerződés) {#smart-contract}
 
 Egy program, amelyet az Ethereum számítási infrastruktúráján lehet futtatni.
 
-<DocLink to="/developers/docs/smart-contracts/" title="Bevezetés az okosszerződésekbe" />
+<DocLink to="/developers/docs/smart-contracts/">
+  Bevezetés az okosszerződésekbe
+</DocLink>
 
 ### Solidity {#solidity}
 
 Egy eljárásközpontú (imperatív) programozási nyelv, amelynek szintaxisa hasonló mint a JavaScript, a C++ és a Java. Az Ethereum [okosszerződések](#smart-contract) legnépszerűbb, leggyakrabban használt programozási nyelve. Dr. Gavin Wood alkotta meg.
 
-<DocLink to="/developers/docs/smart-contracts/languages/#solidity" title="Solidity" />
+<DocLink to="/developers/docs/smart-contracts/languages/#solidity">
+  Solidity
+</DocLink>
 
 ### Solidity inline assembly {#solidity-inline-assembly}
 
@@ -580,19 +668,25 @@ Az Ethereum blokklánc [hard-forkja](#hard-fork), ami a 2.675.000 számú blokkn
 
 Olyan [ERC-20 token](#token-standard), amelynek értéke egy másik vagyontárgyéhoz van kötve. Léteznek hagyományos devizához, például dollárhoz, nemesfémekhez, például aranyhoz, és más kriptovalutákhoz, például Bitcoinhoz kötött értékű stablecoinok.
 
-<DocLink to="/eth/#tokens" title="Az ETH nem az egyedüli kripto az Ethereumon" />
+<DocLink to="/eth/#tokens">
+  Az ETH nem az egyedüli kripto az Ethereumon
+</DocLink>
 
 ### staking (letétbe helyezés) {#staking}
 
 Adott mennyiségű [ether](#ether) letétbe helyezése a validátorrá válás és a [hálózat](#network) biztosításának érdekében. A validátor ellenőrzi a [tranzakciókat](#transaction), és új [blokkokat](#block) terjeszt elő a [letétbizonyíték](#pos) konszenzus-modellje alapján. A letétbe helyezés pénzügyi motivációt ad arra, hogy a hálózat érdekét szem előtt tartva járj el. A [validátori](#validator) feladatok elvégzéséért jutalomban részesülsz, de váltzó mennyiségű ETH-t veszíthetsz el, ha nem így teszel.
 
-<DocLink to="/eth2/staking/" title="Helyezd letétbe az ETH-ed, hogy Ethereum validátorrá válhass" />
+<DocLink to="/eth2/staking/">
+  Helyezd letétbe az ETH-ed, hogy Ethereum validátorrá válhass
+</DocLink>
 
 ### state channels (állapot csatornák) {#state-channels}
 
 Egy [2. rétegű](#layer-2) megoldás, ahol egy csatorna van létrehozva a résztvevők között és ahol szabadon és kis költséggel indíthatnak tranzakciókat. Csak egy, a csatornát megnyitó és a csatornát lezáró, [tranzakció](#transaction) kerül fel a [főhálózatra](#mainnet). Ez nagyon magas tranzakció átvitelt tesz lehetővé, de a résztvevők számának előzetes ismeretére, valamint a tőke lekötésére támaszkodik.
 
-<DocLink to="/developers/docs/layer-2-scaling/#state-channels" title="Állapot csatornák" />
+<DocLink to="/developers/docs/layer-2-scaling/#state-channels">
+  Állapot csatornák
+</DocLink>
 
 ### szabo {#szabo}
 
@@ -610,19 +704,25 @@ Az Ethereum blokklánc egyik[hard-forkja](#hard-fork), mely az 2,463,000 számú
 
 A "test network", (vagyis "teszthálózat") rövidítése. A fő Ethereum hálózat (lásd: [főhálózat](#mainnet)) viselkedésének szimulálására használt hálózat.
 
-<DocLink to="/developers/docs/networks/#testnets" title="Tesztnetek" />
+<DocLink to="/developers/docs/networks/#testnets">
+  Tesztnetek
+</DocLink>
 
 ### token standard (token szabvány) {#token-standard}
 
 Az ERC-20 előterjesztéssel került be a rendszerbe ez a standardizált [okosszerződési](#smart-contract) struktúra a felcserélhető tokenek kezelésére. Az egyazon szerződésből származó tokenek követhetők, eladhatók, és az [NFT](#nft)-kkel ellentétben felcserélhetők.
 
-<DocLink to="/developers/docs/standards/tokens/erc-20/" title="ERC-20 Token Szabvány" />
+<DocLink to="/developers/docs/standards/tokens/erc-20/">
+  ERC-20 Token Szabvány
+</DocLink>
 
 ### tranzakció {#transaction}
 
 Az Ethereum Blokkláncra küldött, egy feladó [számla](#account) által aláírt, egy bizonyos [címet](#address) célzó adat. A tranzakció metaadatokat tartalmaz, mint például az adott tranzakció [gáz limitje](#gas-limit).
 
-<DocLink to="/developers/docs/transactions/" title="Tranzakciók" />
+<DocLink to="/developers/docs/transactions/">
+  Tranzakciók
+</DocLink>
 
 ### transaction fee (tranzakciós díj) {#transaction-fee}
 
@@ -644,25 +744,35 @@ Az angol matematikus és számítástechnikus Alan Turing után elnevezett fogal
 
 Egy [csomópont](#node) a [letétbizonyíték](#proof-of-stake) alapú rendszerben, amely az adattárolásért, a tranzakciók felolgozásáért, és az új blokkok blokklánchoz való hozzáadásáért felel. A validátor-szoftver aktiválásához 32 ETH-t kell [letétbe helyezned](#staking).
 
-<DocLink to="/developers/docs/consensus-mechanisms/pos" title="Proof-of-stake" /> <DocLink to="/eth2/staking/" title="Letétbe helyezés az Ethereumon" />
+<DocLink to="/developers/docs/consensus-mechanisms/pos">
+  Proof-of-stake
+</DocLink> <DocLink to="/eth2/staking/">
+  Letétbe helyezés az Ethereumon
+</DocLink>
 
 ### Validity proof (érvényességi bizonyíték) {#validity-proof}
 
 Egyes [2. réteges](#layer-2) megoldások biztonsági modellje, amely a feldolgozási sebesség növelésének érdekében a tranzakciókat [összevonják](/#rollups), és egyetlen tranzakció keretében küldik el az Ethereum hálózatra. A tranzakciós számítások a láncon kívül történnek, majd az érvényességük bizonyítékával együtt kerülnek fel a láncra. Ez a módszer növeli a végrehajtható tranzakciók számát, mialatt a biztonságot is fenntartja. Egyes [összesített tranzakciók](#rollups) [csalási bizonyítást](#fraud-proof) használnak.
 
-<DocLink to="/developers/docs/layer-2-scaling/#zk-rollups" title="Zero-knowledge összegzők" />
+<DocLink to="/developers/docs/layer-2-scaling/#zk-rollups">
+  Zero-knowledge összegzők
+</DocLink>
 
 ### Validium {#validium}
 
 [2. réteges](#layer-2) megoldás, amely [érvényességi bizonyítást](#validity-proof) használ a feldolgozható tranzakciók számának növelésére. A [Zero-knowledge összegzőkkel](#zk-rollup) ellentétben a Validium adat nem az 1. rétegű [főhálózaton](#mainnet) tárolódik.
 
-<DocLink to="/developers/docs/layer-2-scaling/#validium" title="Validium" />
+<DocLink to="/developers/docs/layer-2-scaling/#validium">
+  Validium
+</DocLink>
 
 ### Vyper {#vyper}
 
 Egy magas szintű programozási nyelv Python-szerű szintaxissal. Az a célja, hogy megközelítse a tiszta funkcionális nyelvet. Vitalik Buterin készítette.
 
-<DocLink to="/developers/docs/smart-contracts/languages/#vyper" title="Vyper" />
+<DocLink to="/developers/docs/smart-contracts/languages/#vyper">
+  Vyper
+</DocLink>
 
 <Divider />
 
@@ -672,13 +782,17 @@ Egy magas szintű programozási nyelv Python-szerű szintaxissal. Az a célja, h
 
 Szoftver, amely a [privát kulcsokat](#private-key) tartalmazza. Az Ethereum [számlák](#account) elérésére és kezelésére, valamint az [okosszerződésekkel](#smart-contract) való interakcióra használható. A kulcsokat nem kell a tárcában tárolni, a nagyobb biztonság érdekében lehetséges offline tárhelyen (például memóriakártyán vagy papíron) őrizni azokat. Neve ellenére a tárca soha nem tartalmazza a tényleges érméket vagy tokeneket.
 
-<DocLink to="/wallets/" title="Ethereum tárcák" />
+<DocLink to="/wallets/">
+  Ethereum tárcák
+</DocLink>
 
 ### Web3 {#web3}
 
 A világháló harmadik verziója. A Web3, amit először Dr. Gavin Wood írt le, új célt tűz ki a webes applikációknak - központilag birtokolt és menedzselt applikációk helyett decentralizált protokollokra épülő applikációk (lásd: [Dapp](#dapp)).
 
-<DocLink to="/developers/docs/web2-vs-web3/" title="Web2 vs Web3" />
+<DocLink to="/developers/docs/web2-vs-web3/">
+  Web2 vs Web3
+</DocLink>
 
 ### wei {#wei}
 
@@ -696,7 +810,9 @@ Egy speciális, kizárólag nullákat tartalmazó Ethereum cím, amely a [szerz�
 
 [Érvényességi bizonyítást](#validity-proof) használó tranzakciók [összevonása](#rollups), a [2. réteg](#layer-2) tranzakciófelolgozási kapacitásának, és a [főhálózat](#mainnet) (1. réteg) által nyújtott biztonság elérésének érdekében. Bár ezek nem képesek olyan komplex tranzakciókat kezelni, mint az [Optimistic típusú összevont tranzakciók](#optimistic-rollups), nincsenek késleltetési problémáik, mert a tranzakciók feltételezhetően érvényesek a hálózatra küldés pillanatában.
 
-<DocLink to="/developers/docs/layer-2-scaling/#zk-rollups" title="Zero-knowledge összegzők" />
+<DocLink to="/developers/docs/layer-2-scaling/#zk-rollups">
+  Zero-knowledge összegzők
+</DocLink>
 
 <Divider />
 

--- a/src/content/translations/hu/history/index.md
+++ b/src/content/translations/hu/history/index.md
@@ -35,7 +35,9 @@ A [Beacon Chain](/eth2/beacon-chain/) biztonságos elindításához 16384 darab 
 
 [Olvasd el az Ethereum Alapítvány közleményét](https://blog.ethereum.org/2020/11/27/eth2-quick-update-no-21/)
 
-<DocLink to="/eth2/beacon-chain/" title="A Beacon Chain" />
+<DocLink to="/eth2/beacon-chain/">
+  A Beacon Chain
+</DocLink>
 
 ---
 
@@ -49,7 +51,9 @@ A letétbe helyezési szerződés bemutatta a [letétbe helyezés](/glossary/#st
 
 [Olvasd el az Ethereum Alapítvány közleményét](https://blog.ethereum.org/2020/11/04/eth2-quick-update-no-19/)
 
-<DocLink to="/eth2/staking/" title="Letétbe helyezés" />
+<DocLink to="/eth2/staking/">
+  Letétbe helyezés
+</DocLink>
 
 ---
 
@@ -301,4 +305,6 @@ A Sárga Könyv, melynek a szerzője Dr. Gavin Wood, az Ethereum protokoll műsz
 
 A bemutatkozó kiadvány, melyet Vitalik Buterin az Ethereum alapítója adott ki 2013-ban, a projekt 2015-ös indulása előtt.
 
-<DocLink to="/whitepaper/" title="Fehérkönyv" />
+<DocLink to="/whitepaper/">
+  Fehérkönyv
+</DocLink>

--- a/src/content/translations/it/glossary/index.md
+++ b/src/content/translations/it/glossary/index.md
@@ -22,7 +22,9 @@ Tipo di attacco nei confronti di una [rete](#network) decentralizzata dove un gr
 
 Oggetto contenente un [indirizzo](#address), saldo, [nonce](#nonce), e facoltativamente uno spazio di archiviazione e codice. Può essere un [account contratto](#contract-account) o un [account con proprietà esterna (EOA)](#eoa).
 
-<DocLink to="/developers/docs/accounts" title="Account Ethereum" />
+<DocLink to="/developers/docs/accounts">
+  Account Ethereum
+</DocLink>
 
 ### indirizzo {#address}
 
@@ -32,7 +34,9 @@ Generalmente, rappresenta un [EOA](#eoa) o un [contratto](#contract-accouint) ch
 
 In [Solidity](#solidity), `assert(false)` viene compilata in `0xfe`, un opcode non valido che usa tutto il [carburante](#gas) rimanente e annulla tutte le modifiche. Quando un'istruzione `assert()` fallisce, avviene qualcosa di molto sbagliato e imprevisto ed è necessario correggere il codice. Devi usare `assert()` per evitare condizioni che non dovrebbero verificarsi mai.
 
-<DocLink to="/developers/docs/smart-contracts/security/" title="Sicurezza" />
+<DocLink to="/developers/docs/smart-contracts/security/">
+  Sicurezza
+</DocLink>
 
 ### attestazione {#attestation}
 
@@ -46,7 +50,9 @@ Il voto di un validatore per una [beacon chain](#beacon-chain) o [blocco](#block
 
 Aggiornamento a Eth2 che diventerà il coordinatore della rete Ethereum. Introduce la [proof-of-stake](#proof-of-stake) e i [validatori](#validator) in Ethereum. Alla fine sarà unita con la [rete principale](#mainnet).
 
-<DocLink to="/eth2/beacon-chain/" title="Beacon chain" />
+<DocLink to="/eth2/beacon-chain/">
+  Beacon chain
+</DocLink>
 
 ### big-endian {#big-endian}
 
@@ -56,13 +62,17 @@ Rappresentazione numerica posizionale dove la cifra più significativa è la pri
 
 Raccolta di informazioni necessarie (intestazione di un blocco) sulle [transazioni](#transaction) incluse e una serie di altre intestazioni di blocco note come [ommer](#ommer). I blocchi vengono aggiunti alla rete Ethereum dai [miner](#miner).
 
-<DocLink to="/developers/docs/blocks/" title="Blocchi" />
+<DocLink to="/developers/docs/blocks/">
+  Blocchi
+</DocLink>
 
 ### blockchain {#blockchain}
 
 In Ethereum, sequenza di [blocchi](#block) convalidati dal sistema [proof-of-work](#pow), ognuna collegata al proprio predecessore fino al [blocco genesi](#genesis-block). Non esiste un limite della dimensione del blocco, ma ci sono diversi [limiti per il carburante](#gas-limit).
 
-<DocLink to="/developers/docs/intro-to-ethereum#what-is-a-blockchain" title="Cos'è una Blockchain?" />
+<DocLink to="/developers/docs/intro-to-ethereum#what-is-a-blockchain">
+  Cos'è una Blockchain?
+</DocLink>
 
 ### bytecode {#bytecode}
 
@@ -80,7 +90,9 @@ La prima di due [diramazioni permanenti](#hard-fork) per la fase di sviluppo di 
 
 Convertire il codice scritto in un linguaggio di programmazione di alto livello (es. [Solidity](#solidity)) in un linguaggio di livello inferiore (es. [bytecode](#bytecode) di EVM).
 
-<DocLink to="/developers/docs/smart-contracts/compiling/" title="Compilare Smart Contract" />
+<DocLink to="/developers/docs/smart-contracts/compiling/">
+  Compilare Smart Contract
+</DocLink>
 
 ### commissione {#committee}
 
@@ -110,7 +122,9 @@ Account che contiene codice che viene eseguito ogni volta che viene ricevuta una
 
 Un crosslink fornisce un riepilogo dello stato di uno shard. È così che le catene [shard](#shard) comunicheranno tra di loro attraverso la [beacon chain](#beacon-chain) nel [sistema proof-of-stake](#proof-of-stake) a shard.
 
-<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work" title="Proof-of-stake" />
+<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work">
+  Proof-of-stake
+</DocLink>
 
 <Divider />
 
@@ -120,19 +134,25 @@ Un crosslink fornisce un riepilogo dello stato di uno shard. È così che le cat
 
 Azienda o altra organizzazione che opera senza gestione gerarchica. DAO potrebbe anche riferirsi a un contratto denominato "The DAO" lanciato il 30 aprile 2016, che fu poi hackerato a giugno 2016; questo motivò alla fine una [diramazione permanente](#hard-fork) (denominata DAO) al blocco 1.192.000 che invertì il contratto DAO hackerato e causò la divisione di Ethereum ed Ethereum Classic in due sistemi concorrenti.
 
-<DocLink to="/community/#decentralized-autonomous-organizations-daos" title="Organizzazioni Autonome Decentralizzate (DAO)" />
+<DocLink to="/community/#decentralized-autonomous-organizations-daos">
+  Organizzazioni Autonome Decentralizzate (DAO)
+</DocLink>
 
 ### dapp {#dapp}
 
 Applicazione decentralizzata. È almeno uno [Smart Contract](#smart-contract) con un'interfaccia utente Web. Più in generale, una dapp è un'applicazione Web creata sulla base di servizi di infrastruttura peer-to-peer, decentralizzati e aperti. Inoltre, molte dapp includono memoria decentralizzata e/o un protocollo e una piattaforma per messaggi.
 
-<DocLink to="/developers/docs/dapps/" title="Introduzione alle dapp" />
+<DocLink to="/developers/docs/dapps/">
+  Introduzione alle dapp
+</DocLink>
 
 ### scambio decentralizzato (DEX) {#dex}
 
 Tipo di [dapp](#dapp) che permette di scambiare token con altri utenti allo stesso livello sulla rete. Per l'uso servono [ether](#ether) (per pagare le [commissioni sulle transazioni](#transaction-fee)) ma non sono soggetti a restrizioni geografiche come gli scambi centralizzati. Tutti possono partecipare.
 
-<DocLink to="/get-eth/#dex" title="Scambi decentralizzati" />
+<DocLink to="/get-eth/#dex">
+  Scambi decentralizzati
+</DocLink>
 
 ### atto notarile {#deed}
 
@@ -142,7 +162,9 @@ Vedi [token non fungibile (NFT)](#nft)
 
 Abbreviazione di "finanza decentralizzata", una vasta categoria di [dapp](#dapp) che mirano a fornire servizi finanziari supportati dalla blockchain, senza alcun intermediario, a cui può partecipare chiunque abbia una connessione Internet.
 
-<DocLink to="/dapps/#explore" title="Dapp defi" />
+<DocLink to="/dapps/#explore">
+  Dapp defi
+</DocLink>
 
 ### difficoltà {#difficulty}
 
@@ -168,13 +190,17 @@ Algoritmo crittografico utilizzato da Ethereum per garantire che i fondi possano
 
 Periodo di 32 [slot](#slot) (6,4 minuti) nel sistema coordinato [beacon chain](#beacon-chain). In ogni epoca, per motivi di sicurezza, le [commissioni](#committee) di [validatori](#validator) vengono cambiate. In ogni epoca c'è un'opportunità per [finalizzare](#finality) la catena.
 
-<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work" title="Proof-of-stake" />
+<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work">
+  Proof-of-stake
+</DocLink>
 
 ### Proposta di miglioramento di Ethereum (EIP) {#eip}
 
 Un documento di progettazione che fornisce informazioni alla community Ethereum, descrivendo una nuova funzionalità proposta, i processi o l'ambiente (vedi [ERC](#erc)).
 
-<DocLink to="/eips/" title="Introduzione alle EIP" />
+<DocLink to="/eips/">
+  Introduzione alle EIP
+</DocLink>
 
 ### Servizio dei nomi Ethereum (ENS) {#ens}
 
@@ -194,7 +220,9 @@ Nel contesto della crittografia, mancanza di prevedibilità o livello di casuali
 
 Etichetta assegnata ad alcune [EIP](#eip) per tentare di definire uno standard specifico per l'uso di Ethereum.
 
-<DocLink to="/eips/" title="Introduzione alle EIP" />
+<DocLink to="/eips/">
+  Introduzione alle EIP
+</DocLink>
 
 ### Ethash {#ethash}
 
@@ -206,19 +234,25 @@ Algoritmo [proof-of-work](#pow) per Ethereum 1.0.
 
 Criptovaluta nativa usata dall'ecosistema di Ethereum, che copre i costi del [carburante](#gas) per l'esecuzione delle transazioni. Indicata anche come ETH o con il simbolo Ξ, il carattere greco maiuscolo Xi.
 
-<DocLink to="/eth/" title="Valuta per il nostro futuro digitale" />
+<DocLink to="/eth/">
+  Valuta per il nostro futuro digitale
+</DocLink>
 
 ### eventi {#events}
 
 Consentono l'uso delle risorse di registrazione dell'[EVM](#evm). Le [dapp](#dapp) possono rimanere in attesa di eventi e usarli per innescare callback JavaScript nell'interfaccia utente.
 
-<DocLink to="/developers/docs/smart-contracts/anatomy/#events-and-logs" title="Eventi e registri" />
+<DocLink to="/developers/docs/smart-contracts/anatomy/#events-and-logs">
+  Eventi e registri
+</DocLink>
 
 ### macchina virtuale Ethereum (EVM) {#evm}
 
 Macchina virtuale basata su stack che esegue il [bytecode](#bytecode). In Ethereum, il modello di esecuzione specifica in che modo lo stato di sistema viene alterato in base a una serie di istruzioni bytecode e una piccola tupla di dati ambientali. È specificato tramite un modello formale di macchina a stati virtuale.
 
-<DocLink to="/developers/docs/evm/" title="Macchina virtuale Ethereum" />
+<DocLink to="/developers/docs/evm/">
+  Macchina virtuale Ethereum
+</DocLink>
 
 ### linguaggio assembly dell'EVM {#evm-assembly-language}
 
@@ -236,13 +270,19 @@ Funzione predefinita chiamata in assenza di dati o di un nome di funzione dichia
 
 Servizio fornito tramite [Smart Contract](#smart-contract) che dispensa fondi sotto forma di ether di test gratuiti, utilizzabili su una rete di prova.
 
-<DocLink to="/developers/docs/networks/#testnet-faucets" title="Faucet della rete di prova" />
+<DocLink to="/developers/docs/networks/#testnet-faucets">
+  Faucet della rete di prova
+</DocLink>
 
 ### finalità {#finality}
 
 La finalità è la garanzia che una serie di transazioni prima di un dato periodo non cambieranno né saranno annullate.
 
-<DocLink to="/developers/docs/consensus-mechanisms/pow/#finality" title="Finalità della proof-of-work" /> <DocLink to="/developers/docs/consensus-mechanisms/pos/#finality" title="Finalità della proof-of-stake" />
+<DocLink to="/developers/docs/consensus-mechanisms/pow/#finality">
+  Finalità della proof-of-work
+</DocLink> <DocLink to="/developers/docs/consensus-mechanisms/pos/#finality">
+  Finalità della proof-of-stake
+</DocLink>
 
 ### finney {#finney}
 
@@ -256,7 +296,9 @@ Cambio nel protocollo che causa la creazione di una catena alternativa o diverge
 
 Modello di sicurezza per determinate soluzioni di [livello 2](#layer-2) in cui, per aumentare la velocità, viene eseguito il [roll up](#rollups) delle transazioni in batch e poi queste ultime vengono inviate a Ethereum come una sola transazione. Sono considerate valide ma sono contestabili se si sospetta una frode. In questo caso, una prova di frode eseguirà la transazione per controllare se si sia effettivamente verificata una frode. Questo metodo aumenta la quantità di transazioni possibili mantenendo la sicurezza. Alcuni [rollup](#rollups) usano [prove di validità](#validity-proof).
 
-<DocLink to="/developers/docs/layer-2-scaling/#optimistic-rollups" title="Optimistic rollup" />
+<DocLink to="/developers/docs/layer-2-scaling/#optimistic-rollups">
+  Optimistic rollup
+</DocLink>
 
 ### frontiera {#frontier}
 
@@ -270,7 +312,9 @@ Fase di sviluppo di test iniziale di Ethereum, che durò dal luglio 2015 al marz
 
 Carburante virtuale usato in Ethereum per eseguire gli Smart Contract. L'[EVM](#evm) usa un meccanismo di contabilità per misurare il consumo di carburante e limitare il consumo delle risorse informatiche (vedi [Turing completo](#turing-complete)).
 
-<DocLink to="/developers/docs/gas/" title="Carburante e commissioni" />
+<DocLink to="/developers/docs/gas/">
+  Carburante e commissioni
+</DocLink>
 
 ### limite di carburante {#gas-limit}
 
@@ -332,13 +376,17 @@ Codifica degli indirizzi Ethereum parzialmente compatibile con la codifica IBAN 
 
 Interfaccia utente che tipicamente combina un editor di codice, un compilatore, un ambiente runtime e un debugger.
 
-<DocLink to="/developers/docs/ides/" title="Ambienti di sviluppo integrati" />
+<DocLink to="/developers/docs/ides/">
+  Ambienti di sviluppo integrati
+</DocLink>
 
 ### problema del codice distribuito immutabile {#immutable-deployed-code-problem}
 
 Una volta distribuito il codice di un [contratto](#smart-contract) (o di una [libreria](#library)), questo diventa immutabile. Le pratiche di sviluppo standard del software si basano sul poter risolvere possibili bug e aggiungere nuove funzionalità, quindi questo rappresenta una sfida per lo sviluppo degli Smart Contract.
 
-<DocLink to="/developers/docs/smart-contracts/deploying/" title="Distribuzione di Smart Contract" />
+<DocLink to="/developers/docs/smart-contracts/deploying/">
+  Distribuzione di Smart Contract
+</DocLink>
 
 ### transazione interna {#internal-transaction}
 
@@ -352,7 +400,9 @@ Una volta distribuito il codice di un [contratto](#smart-contract) (o di una [li
 
 Detta anche "algoritmo di allungamento della password", è usata dai formati [keystore](#keystore-file) per proteggere contro attacchi di forza bruta, dictionary e rainbow table ai danni della crittografia di una passphrase, mediante continuo hashing della passphrase.
 
-<DocLink to="/developers/docs/smart-contracts/security/" title="Sicurezza" />
+<DocLink to="/developers/docs/smart-contracts/security/">
+  Sicurezza
+</DocLink>
 
 ### keccak-256 {#keccak-256}
 
@@ -370,7 +420,9 @@ File con codifica JSON che contiene una [chiave privata](#private-key) singola (
 
 Area di sviluppo incentrata sui miglioramenti alla stratificazione, in base al protocollo Ethereum. Questi miglioramenti riguardano la velocità delle [transazioni](#transaction), l'importo delle [commissioni sulle transazioni](#transaction-fee) e la privacy delle transazioni.
 
-<DocLink to="/developers/docs/layer-2-scaling/" title="Livello 2" />
+<DocLink to="/developers/docs/layer-2-scaling/">
+  Livello 2
+</DocLink>
 
 ### LevelDB {#level-db}
 
@@ -380,7 +432,9 @@ Store open source chiave-valore su disco, implementato come [libreria](#library)
 
 Tipo speciale di [contratto](#smart-contract) privo di funzioni pagabili, funzione di fallback e storage dati. Non può quindi ricevere o contenere ether o archiviare dati. Una libreria funge da codice distribuito precedentemente che altri contratti possono chiamare per calcoli di sola lettura.
 
-<DocLink to="/developers/docs/smart-contracts/libraries/" title="Librerie degli Smart Contract" />
+<DocLink to="/developers/docs/smart-contracts/libraries/">
+  Librerie degli Smart Contract
+</DocLink>
 
 ### client leggero {#lightweight-client}
 
@@ -414,7 +468,9 @@ Terza fase di sviluppo di Ethereum, lanciata nell'ottobre 2017.
 
 [Nodo](#node) della rete che trova [proof-of-work](#pow) valide per i nuovi blocchi, tramite passaggi ripetuti di hash (vedi [Ethash](#ethash)).
 
-<DocLink to="/developers/docs/consensus-mechanisms/pow/mining/" title="Mining" />
+<DocLink to="/developers/docs/consensus-mechanisms/pow/mining/">
+  Mining
+</DocLink>
 
 <Divider />
 
@@ -424,21 +480,29 @@ Terza fase di sviluppo di Ethereum, lanciata nell'ottobre 2017.
 
 Se si parla di rete Ethereum, rete peer-to-peer che propaga le transazioni e i blocchi a ogni nodo di Ethereum (partecipante alla rete).
 
-<DocLink to="/developers/docs/networks/" title="Reti" />
+<DocLink to="/developers/docs/networks/">
+  Reti
+</DocLink>
 
 ### token non fungibile (NFT) {#nft}
 
 Detto anche "atto notarile" (deed), si tratta di uno standard token introdotto dalla proposta ERC-721. Gli NFT possono essere tracciati e scambiati, ma ogni token è unico e distinto; non sono intercambiabili come i token ERC-20. Gli NFT possono rappresentare la proprietà delle risorse digitali o fisiche.
 
-<DocLink to="/developers/docs/standards/tokens/erc-721/" title="Standard token non fungibile ERC-721" />
+<DocLink to="/developers/docs/standards/tokens/erc-721/">
+  Standard token non fungibile ERC-721
+</DocLink>
 
 ### nodo {#node}
 
 Software client che partecipa alla rete.
 
-<DocLink to="/developers/docs/nodes-and-clients/" title="Nodi e client" />
+<DocLink to="/developers/docs/nodes-and-clients/">
+  Nodi e client
+</DocLink>
 
-<DocLink to="/developers/docs/nodes-and-clients/" title="Nodi e client" />
+<DocLink to="/developers/docs/nodes-and-clients/">
+  Nodi e client
+</DocLink>
 
 ### nonce {#nonce}
 
@@ -456,7 +520,9 @@ Nel momento in cui un [miner](#miner) trova un [blocco](#block) valido, un altro
 
 [Rollup](#rollups) di transazioni che utilizzano [prove di frode](#fraud-proof) per offrire maggiori volumi di transazioni di [livello 2](#layer-2) e la sicurezza fornita dalla [rete principale](#mainnet) (livello 1). A differenza di [Plasma](#plasma), una soluzione simile di livello 2, gli Optimistic rollup possono gestire tipi di transazioni più complessi. Tutto ciò è possibile nell'[EVM](#evm). Hanno problemi di latenza rispetto ai [rollup Zero-knowledge](#zk-rollups) perché una transazione può essere contestata tramite la prova di frode.
 
-<DocLink to="/developers/docs/layer-2-scaling/#optimistic-rollups" title="Optimistic rollup" />
+<DocLink to="/developers/docs/layer-2-scaling/#optimistic-rollups">
+  Optimistic rollup
+</DocLink>
 
 <Divider />
 
@@ -470,7 +536,9 @@ Una delle implementazioni interoperabili più importanti del software client Eth
 
 Soluzione per il passaggio al [livello 2](#layer-2) che utilizza [prove di frode](#fraud-proof), come gli [Optimistic rollup](#optimistic-rollups). Plasma è limitato a transazioni semplici come trasferimenti e scambi base di token.
 
-<DocLink to="/developers/docs/layer-2-scaling/#Plasma" title="Plasma" />
+<DocLink to="/developers/docs/layer-2-scaling/#Plasma">
+  Plasma
+</DocLink>
 
 ### chiave privata (chiave segreta) {#private-key}
 
@@ -480,13 +548,17 @@ Numero segreto che consente agli utenti di Ethereum di dimostrare la proprietà 
 
 Metodo con cui un protocollo blockchain di criptovalute mira a raggiungere il [consenso distribuito](#consensus). La PoS chiede agli utenti di dimostrare la proprietà di una determinata quantità di criptovalute (la loro "stake", o quota, nella rete) per poter partecipare alla convalida delle transazioni.
 
-<DocLink to="/developers/docs/consensus-mechanisms/pos/" title="Proof-of-stake" />
+<DocLink to="/developers/docs/consensus-mechanisms/pos/">
+  Proof-of-stake
+</DocLink>
 
 ### Proof-of-work (PoW) {#pow}
 
 Informazioni (la prova) che richiedono calcoli significativi per essere trovate. In Ethereum, i [miner](#miner) devono trovare una soluzione numerica per l'algoritmo [Ethash](#ethash) che soddisfi una [difficoltà](#difficulty) specificata a livello di rete.
 
-<DocLink to="/developers/docs/consensus-mechanisms/pow/" title="Proof-of-work" />
+<DocLink to="/developers/docs/consensus-mechanisms/pow/">
+  Proof-of-work
+</DocLink>
 
 ### chiave pubblica {#public-key}
 
@@ -504,7 +576,9 @@ Dati restituiti da un client Ethereum per rappresentare il risultato di una part
 
 Attacco che consiste nella chiamata da parte del contratto di un aggressore alla funzione del contratto della vittima in modo che, durante l'esecuzione, la vittima chiami di nuovo il contratto dell'aggressore, in modo ricorsivo. Questo può causare, ad esempio, il furto di fondi perché vengono ignorate le parti del contratto della vittima che aggiornano i saldi o contano gli importi prelevati.
 
-<DocLink to="/developers/docs/smart-contracts/security/#re-entrancy" title="Codice rientrante" />
+<DocLink to="/developers/docs/smart-contracts/security/#re-entrancy">
+  Codice rientrante
+</DocLink>
 
 ### ricompensa {#reward}
 
@@ -518,7 +592,9 @@ Standard di codifica progettato dagli sviluppatori di Ethereum per codificare e 
 
 Tipo di soluzione per il passaggio al [livello 2](#layer-2) che raggruppa più transazioni e le invia alla [catena principale Ethereum](#mainnet) in una sola transazione. Consente di ridurre i costi del [carburante](#gas) e di aumentare il volume delle [transazioni](#transaction). I rollup possono essere di tipo Optimistic e Zero-knowledge. Utilizzano diversi metodi di sicurezza per offrire vantaggi in termini di scalabilità.
 
-<DocLink to="/developers/docs/layer-2-scaling/#rollups" title="Rollup" />
+<DocLink to="/developers/docs/layer-2-scaling/#rollups">
+  Rollup
+</DocLink>
 
 <Divider />
 
@@ -528,7 +604,9 @@ Tipo di soluzione per il passaggio al [livello 2](#layer-2) che raggruppa più t
 
 Quarta e ultima fase di sviluppo di Ethereum.
 
-<DocLink to="/eth2/" title="Ethereum 2.0 (Eth2)" />
+<DocLink to="/eth2/">
+  Ethereum 2.0 (Eth2)
+</DocLink>
 
 ### Secure Hash Algorithm (SHA) {#sha}
 
@@ -538,13 +616,17 @@ Famiglia di funzioni hash crittografiche pubblicata dal National Institute of St
 
 Catena [proof-of-stake](#proof-of-stake) coordinata dalla [beacon chain](#beacon-chain) e protetta dai [validatori](#validator). Ne verranno aggiunte 64 alla rete all'interno dell'upgrade alla shard chain Eth2. Le shard chain offriranno maggiori volumi di transazioni a Ethereum fornendo dati aggiuntivi alle soluzioni di [livello 2](#layer-2) come gli [Optimistic rollup](#optimistic-rollups) e i [rollup ZK](#zk-rollups).
 
-<DocLink to="/eth2/shard-chains" title="Shard chain" />
+<DocLink to="/eth2/shard-chains">
+  Shard chain
+</DocLink>
 
 ### sidechain {#sidechain}
 
 Soluzione per la scalabilità che utilizza una catena separata con [regole di consenso]{#consensus-rules} diverse e spesso più veloci. Per collegare queste sidechain alla [rete principale](#mainnet) è necessario un bridge. Anche i [rollup](#rollups) utilizzano le sidechain, ma operano in collaborazione con la [rete principale](#mainnet).
 
-<DocLink to="/developers/docs/layer-2-scaling/#sidechains" title="Sidechain" />
+<DocLink to="/developers/docs/layer-2-scaling/#sidechains">
+  Sidechain
+</DocLink>
 
 ### singleton {#singleton}
 
@@ -554,19 +636,25 @@ Termine appartenente al contesto di programmazione che descrive un oggetto di cu
 
 Periodo di tempo (12 secondi) in cui un nuovo blocco della [beacon chain](#beacon-chain) e della [shard chain](#shard) può essere proposto da un [validatore](#validator) nel sistema [proof-of-stake](#proof-of-stake). Uno slot può rimanere vuoto. 32 slot formano un'[epoca](#epoch).
 
-<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work" title="Proof-of-stake" />
+<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work">
+  Proof-of-stake
+</DocLink>
 
 ### Smart Contract {#smart-contract}
 
 Programma eseguito sull'infrastruttura di calcolo Ethereum.
 
-<DocLink to="/developers/docs/smart-contracts/" title="Introduzione agli Smart Contract" />
+<DocLink to="/developers/docs/smart-contracts/">
+  Introduzione agli Smart Contract
+</DocLink>
 
 ### Solidity {#solidity}
 
 Linguaggio di programmazione procedurale (imperativo) con sintassi simile a JavaScript, C++ o Java. Il linguaggio più popolare e più usato per gli [Smart Contract](#smart-contract) Ethereum. Creato dal dott. Gavin Wood.
 
-<DocLink to="/developers/docs/smart-contracts/languages/#solidity" title="Solidity" />
+<DocLink to="/developers/docs/smart-contracts/languages/#solidity">
+  Solidity
+</DocLink>
 
 ### Assembly in linea Solidity {#solidity-inline-assembly}
 
@@ -580,19 +668,25 @@ Linguaggio assembly dell'[EVM](#evm) in un programma [Solidity](#solidity). Il s
 
 Token [ERC-20](#token-standard) con un valore ancorato al valore di un'altra risorsa. Ci sono stablecoins supportati da valute legali come dollari, metalli preziosi come l'oro e altre criptovalute come bitcoin.
 
-<DocLink to="/eth/#tokens" title="ETH non è l'unica criptovaluta su Ethereum" />
+<DocLink to="/eth/#tokens">
+  ETH non è l'unica criptovaluta su Ethereum
+</DocLink>
 
 ### staking {#staking}
 
 Depositare una quantità di [ether](#ether) (lo stake) per diventare validatore e proteggere la [rete](#network). Un validatore controlla [transazioni](#transaction) e propone [blocchi](#block) secondo un modello di consenso [proof-of-stake](#pos). Lo staking dà un incentivo economico per agire nel miglior interesse della rete. Si ottengono ricompense per svolgere i compiti di [validatore](#validator), ma si perdono quantità variabili di ETH se non si svolgono tali compiti.
 
-<DocLink to="/eth2/staking/" title="Fai staking con i tuoi ETH per diventare validatore di Ethereum" />
+<DocLink to="/eth2/staking/">
+  Fai staking con i tuoi ETH per diventare validatore di Ethereum
+</DocLink>
 
 ### canali di stato {#state-channels}
 
 Soluzione di [livello 2](#layer-2) in cui un canale è configurato tra i partecipanti per eseguire transazioni liberamente e in modo economico. Viene inviata alla [rete principale](#mainnet) solo una [transazione](#transaction) per configurare il canale e chiuderlo. Questo consente un volume di transazioni molto elevato, ma si basa sulla conoscenza del numero di partecipanti in anticipo e sul blocco dei fondi.
 
-<DocLink to="/developers/docs/layer-2-scaling/#state-channels" title="Canali di stato" />
+<DocLink to="/developers/docs/layer-2-scaling/#state-channels">
+  Canali di stato
+</DocLink>
 
 ### szabo {#szabo}
 
@@ -610,19 +704,25 @@ Uno dei tagli dell'[ether](#ether). 1 szabo = 10<sup>12</sup> [wei](#wei), 10<su
 
 In inglese testnet, è una rete utilizzata per simulare il comportamento della rete principale Ethereum (vedi [rete principale](#mainnet)).
 
-<DocLink to="/developers/docs/networks/#testnets" title="Reti di test" />
+<DocLink to="/developers/docs/networks/#testnets">
+  Reti di test
+</DocLink>
 
 ### standard token {#token-standard}
 
 Introdotto dalla proposta ERC-20, offre una struttura standardizzata per [Smart Contract](#smart-contract) per i token fungibili. I token dello stesso contratto possono essere tracciati, scambiati e sono intercambiabili, a differenza degli [NFT](#nft).
 
-<DocLink to="/developers/docs/standards/tokens/erc-20/" title="Standard token ERC-20" />
+<DocLink to="/developers/docs/standards/tokens/erc-20/">
+  Standard token ERC-20
+</DocLink>
 
 ### transazione {#transaction}
 
 Dati salvati nella blockchain Ethereum firmati da un [account](#account) di origine, che puntano a un [indirizzo](#address) specifico. La transazione contiene metadati come il [limite di carburante](#gas-limit) per la transazione.
 
-<DocLink to="/developers/docs/transactions/" title="Transazioni" />
+<DocLink to="/developers/docs/transactions/">
+  Transazioni
+</DocLink>
 
 ### commissione sulle transazioni {#transaction-fee}
 
@@ -644,25 +744,35 @@ Concetto che prende il nome dal matematico e informatico inglese Alan Turing. Un
 
 [Nodo](#node) in un sistema [proof-of-stake](#proof-of-stake) responsabile della memorizzazione dei dati, dell'elaborazione delle transazioni e dell'aggiunta di nuovi blocchi alla blockchain. Per il software di validatore attivo, è necessario essere in grado di fare [staking](#staking) con 32 ETH.
 
-<DocLink to="/developers/docs/consensus-mechanisms/pos" title="Proof-of-stake" /> <DocLink to="/eth2/staking/" title="Staking in Ethereum" />
+<DocLink to="/developers/docs/consensus-mechanisms/pos">
+  Proof-of-stake
+</DocLink> <DocLink to="/eth2/staking/">
+  Staking in Ethereum
+</DocLink>
 
 ### prova di validità {#validity-proof}
 
 Modello di sicurezza per determinate soluzioni di [livello 2](#layer-2) in cui, per aumentare la velocità, viene eseguito il [roll up](/#rollups) delle transazioni in batch e poi queste ultime vengono inviate a Ethereum come una sola transazione. Il calcolo della transazione viene effettuato esternamente alla catena e poi fornito alla catena principale con una prova di validità. Questo metodo aumenta la quantità di transazioni possibili garantendo comunque la sicurezza. Alcuni [rollup](#rollups) usano [prove di frode](#fraud-proof).
 
-<DocLink to="/developers/docs/layer-2-scaling/#zk-rollups" title="Rollup zero-knowledge" />
+<DocLink to="/developers/docs/layer-2-scaling/#zk-rollups">
+  Rollup zero-knowledge
+</DocLink>
 
 ### Validium {#validium}
 
 Soluzione di [livello 2](#layer-2) che utilizza [prove di validità](#validity-proof) per aumentare il volume delle transazioni. A differenza dei [rollup Zero-knowlege](#zk-rollup), i dati Validium non vengono memorizzati al livello 1 della [rete principale](#mainnet).
 
-<DocLink to="/developers/docs/layer-2-scaling/#validium" title="Validium" />
+<DocLink to="/developers/docs/layer-2-scaling/#validium">
+  Validium
+</DocLink>
 
 ### Vyper {#vyper}
 
 Linguaggio di programmazione di alto livello con sintassi simile a Python. Pensato per avvicinarsi a un linguaggio funzionale puro. Creato da Vitalik Buterin.
 
-<DocLink to="/developers/docs/smart-contracts/languages/#vyper" title="Vyper" />
+<DocLink to="/developers/docs/smart-contracts/languages/#vyper">
+  Vyper
+</DocLink>
 
 <Divider />
 
@@ -672,13 +782,17 @@ Linguaggio di programmazione di alto livello con sintassi simile a Python. Pensa
 
 Software che contiene [chiavi private](#private-key). Utilizzato per accedere agli [account](#account), permetterne il controllo e interagire con gli [Smart Contract](#smart-contract). Le chiavi non devono essere memorizzate in un portafoglio, ma possono essere recuperate offline (ad esempio da una scheda di memoria o su carta) per migliorare la sicurezza. Nonostante il nome, i portafogli non contengono mai le monete o i token reali.
 
-<DocLink to="/wallets/" title="Portafogli di Ethereum" />
+<DocLink to="/wallets/">
+  Portafogli di Ethereum
+</DocLink>
 
 ### Web3 {#web3}
 
 Terza versione del Web. Proposto per la prima volta dal dott. Gavin Wood, il Web3 rappresenta una nuova visione per le applicazioni web: dalle applicazioni centralizzate e gestite, alle applicazioni create sulla base di protocolli decentralizzati (vedi [dapp](#dapp)).
 
-<DocLink to="/developers/docs/web2-vs-web3/" title="Web2 e Web3" />
+<DocLink to="/developers/docs/web2-vs-web3/">
+  Web2 e Web3
+</DocLink>
 
 ### wei {#wei}
 
@@ -696,7 +810,9 @@ Indirizzo Ethereum speciale, composto interamente da zeri, specificato come indi
 
 [Rollup](#rollups) di transazioni che utilizzano [prove di validità](#validity-proof) per offrire maggiori volumi di transazioni di [livello 2](#layer-2) e la sicurezza fornita dalla [rete principale](#mainnet) (livello 1). Anche se non sono in grado di gestire tipi di transazioni complessi, come gli [Optimistic rollup](#optimistic-rollups), non hanno problemi di latenza perché le transazioni sono già dimostrate come valide quando vengono inviate.
 
-<DocLink to="/developers/docs/layer-2-scaling/#zk-rollups" title="Rollup zero-knowledge" />
+<DocLink to="/developers/docs/layer-2-scaling/#zk-rollups">
+  Rollup zero-knowledge
+</DocLink>
 
 <Divider />
 

--- a/src/content/translations/it/history/index.md
+++ b/src/content/translations/it/history/index.md
@@ -35,7 +35,9 @@ La [beacon chain](/eth2/beacon-chain/) necessitava di 16384 depositi di 32 ETH i
 
 [Leggi l'annuncio della Ethereum Foundation](https://blog.ethereum.org/2020/11/27/eth2-quick-update-no-21/)
 
-<DocLink to="/eth2/beacon-chain/" title="La beacon chain" />
+<DocLink to="/eth2/beacon-chain/">
+  La beacon chain
+</DocLink>
 
 ---
 
@@ -49,7 +51,9 @@ Il contratto di deposito in staking ha introdotto lo [staking](/glossary/#stakin
 
 [Leggi l'annuncio della Ethereum Foundation](https://blog.ethereum.org/2020/11/04/eth2-quick-update-no-19/)
 
-<DocLink to="/eth2/staking/" title="Staking" />
+<DocLink to="/eth2/staking/">
+  Staking
+</DocLink>
 
 ---
 
@@ -301,4 +305,6 @@ Lo yellowpaper, redatto dal dott. Gavin Wood, è una definizione tecnica del pro
 
 Documento introduttivo, pubblicato nel 2013 da Vitalik Buterin, il fondatore di Ethereum, prima del lancio del progetto nel 2015.
 
-<DocLink to="/whitepaper/" title="Whitepaper" />
+<DocLink to="/whitepaper/">
+  Whitepaper
+</DocLink>

--- a/src/content/translations/pl/glossary/index.md
+++ b/src/content/translations/pl/glossary/index.md
@@ -22,7 +22,9 @@ Rodzaj ataku na zdecentralizowaną [sieć](#network), w której grupa przejmuje 
 
 Obiekt zawierający [adres](#address), saldo, [nonce](#nonce) oraz opcjonalną pamięć i kod. Konto może być [kontem kontraktowym](#contract-account) lub [kontem należącym do podmiotu zewnętrznego (EOA)](#eoa).
 
-<DocLink to="/developers/docs/accounts" title="Konta Ethereum" />
+<DocLink to="/developers/docs/accounts">
+  Konta Ethereum
+</DocLink>
 
 ### adres {#address}
 
@@ -32,13 +34,17 @@ Najczęściej jest to [EOA](#eoa) lub [umowa](#contract-accouint), która może 
 
 Standardowy sposób pracy z [kontraktami](#contract-account) w ekosystemie Ethereum, zarówno spoza blockchainu, jak i w działaniach między kontraktami.
 
-<DocLink to="/developers/docs/smart-contracts/compiling/#web-applications" title="ABI - binarny interfejs aplikacji" />
+<DocLink to="/developers/docs/smart-contracts/compiling/#web-applications">
+  ABI - binarny interfejs aplikacji
+</DocLink>
 
 ### assert {#assert}
 
 W [Solidity](#solidity) instrukcja `assert(false)` kompiluje się do `0xfe`, nieprawidłowego kodu operacji, który zużywa całe pozostałe [paliwo](#gas) i cofa wszystkie zmiany. Gdy instrukcja `assert()` nie powiedzie się, dzieje się coś bardzo złego i nieoczekiwanego i musisz naprawić swój kod. Instrukcji `assert()` należy użyć, aby uniknąć warunków, które nigdy nie powinny wystąpić.
 
-<DocLink to="/developers/docs/smart-contracts/security/" title="Ochrona" />
+<DocLink to="/developers/docs/smart-contracts/security/">
+  Ochrona
+</DocLink>
 
 ### poświadczenie {#attestation}
 
@@ -52,7 +58,9 @@ Walidator głosuje na [łańcuch śledzący](#beacon-chain) lub [blok](#block) [
 
 Ulepszenie Eth2, które stanie się koordynatorem sieci Ethereum. Wprowadza [proof of stake](#proof-of-stake) i [walidatorów](#validator) do Ethereum. Zostanie on ostatecznie połączony z [siecią główną](#mainnet).
 
-<DocLink to="/eth2/beacon-chain/" title="Łańcuch śledzący" />
+<DocLink to="/eth2/beacon-chain/">
+  Łańcuch śledzący
+</DocLink>
 
 ### big-endian {#big-endian}
 
@@ -62,13 +70,17 @@ Reprezentacja liczby pozycyjnej, w której najbardziej znacząca cyfra jest pier
 
 Zbiór wymaganych informacji (nagłówek bloku) o zawartych [transakcjach](#transaction) oraz zestaw innych nagłówków bloków znanych jako [ommers](#ommer). Bloki są dodawane do sieci Ethereum przez [górników](#miner).
 
-<DocLink to="/developers/docs/blocks/" title="Bloki" />
+<DocLink to="/developers/docs/blocks/">
+  Bloki
+</DocLink>
 
 ### blockchain {#blockchain}
 
 W Ethereum, sekwencja [bloków](#block) zwalidowana przez system [proof-of-work,](#pow) każdy jest powiązany ze swoim poprzednikiem w całej drodze do bloku genezy [](#genesis-block). Nie ma limitu rozmiaru bloku; zamiast tego wykorzystuje się zmienne [wartości graniczne paliwa](#gas-limit).
 
-<DocLink to="/developers/docs/intro-to-ethereum#what-is-a-blockchain" title="Czym jest blockchain?" />
+<DocLink to="/developers/docs/intro-to-ethereum#what-is-a-blockchain">
+  Czym jest blockchain?
+</DocLink>
 
 ### kod bajtowy {#bytecode}
 
@@ -86,7 +98,9 @@ Pierwszy z dwóch [hard forków](#hard-fork) na etapie rozwoju [Metropolis](#met
 
 Konwertowanie kodu napisanego w wysokopoziomowym języku programowania (np. [Solidity](#solidity)) na język niższego poziomu (np. [kod bajtowy](#bytecode) EVM).
 
-<DocLink to="/developers/docs/smart-contracts/compiling/" title="Kompilowanie inteligentnych kontraktów" />
+<DocLink to="/developers/docs/smart-contracts/compiling/">
+  Kompilowanie inteligentnych kontraktów
+</DocLink>
 
 ### komitet {#committee}
 
@@ -116,7 +130,9 @@ Specjalna transakcja [](#transaction) z [zerowym adresem](#zero-address) odbiorc
 
 Połączenie krzyżowe zawiera podsumowanie stanu odłamka. W ten sposób łańcuchy [odłamkowe](#shard) komunikują się ze sobą za pośrednictwem [łańcucha śledzącego](#beacon-chain) w podzielonym [systemie proof of stake](#proof-of-stake).
 
-<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work" title="Proof-of-stake" />
+<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work">
+  Proof-of-stake
+</DocLink>
 
 <Divider />
 
@@ -126,19 +142,25 @@ Połączenie krzyżowe zawiera podsumowanie stanu odłamka. W ten sposób łańc
 
 Przedsiębiorstwo lub inna organizacja działająca bez zarządzania hierarchicznego. DAO może również oznaczać kontrakt The DAO uruchomiony 30 kwietnia 2016 r. i złamany w czerwcu tego roku. Ostatecznie doprowadziło to do [hard forku](#hard-fork) (o nazwie DAO) w bloku 1 192 000, co spowodowało anulowanie złamanego kontraktu DAO i podział Ethereum i Ethereum Classic na dwa konkurencyjne systemy.
 
-<DocLink to="/dao/" title="Zdecentralizowane Organizacje Autonomiczne (DAO)" />
+<DocLink to="/dao/">
+  Zdecentralizowane Organizacje Autonomiczne (DAO)
+</DocLink>
 
 ### Dapp {#dapp}
 
 Zdecentralizowana aplikacja. W minimalnej postaci obejmuje [inteligentny kontrakt](#smart-contract) i internetowy interfejs użytkownika. Na bardziej ogólnym poziomie jest to aplikacja internetowa oparta na otwartych, zdecentralizowanych usługach infrastrukturalnych w modelu peer-to-peer. Ponadto wiele aplikacji dapp obejmuje zdecentralizowaną pamięć i/lub komunikatów oraz platformę rozwoju aplikacji.
 
-<DocLink to="/developers/docs/dapps/" title="Wprowadzenie do zdecentralizowanych aplikacji" />
+<DocLink to="/developers/docs/dapps/">
+  Wprowadzenie do zdecentralizowanych aplikacji
+</DocLink>
 
 ### giełda zdecentralizowana (DEX) {#dex}
 
 Typ [dapp](#dapp), który pozwala wymieniać tokeny z uczestnikami w sieci. Potrzebujesz [etheru](#ether), aby z niej skorzystać (aby zapłacić [opłaty za transakcje](#transaction-fee)), ale nie podlegają one ograniczeniom geograficznym, takim jak scentralizowane giełdy — każdy może uczestniczyć.
 
-<DocLink to="/get-eth/#dex" title="Giełdy scentralizowane" />
+<DocLink to="/get-eth/#dex">
+  Giełdy scentralizowane
+</DocLink>
 
 ### deed {#deed}
 
@@ -148,7 +170,9 @@ Zobacz [niewymienny token (NFT)](#nft)
 
 Skrót „zdecentralizowanych finansów”, szeroka kategoria [aplikacji zdecentralizowanych](#dapp) mająca na celu świadczenie usług finansowych zabezpieczonych przez blockchain, bez żadnych pośredników, tak aby każdy z dostępem do Internetu mógł uczestniczyć.
 
-<DocLink to="/defi/" title="Zdecentralizowane finanse (DeFi)" />
+<DocLink to="/defi/">
+  Zdecentralizowane finanse (DeFi)
+</DocLink>
 
 ### trudność {#difficulty}
 
@@ -174,13 +198,17 @@ Algorytm kryptograficzny używany przez Ethereum w celu zapewnienia, że fundusz
 
 Okres 32 [slotów](#slot) (6,4 minuty) w systemie skoordynowanym [łańcuchem śledzącym](#beacon-chain). [Komitety](#committee) [walidatorów](#validator) są losowane co epokę ze względów bezpieczeństwa. W każdej epoce jest szansa na [finalizację](#finality) łańcucha.
 
-<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work" title="Proof-of-stake" />
+<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work">
+  Proof-of-stake
+</DocLink>
 
 ### Wniosek dotyczący usprawnienia Ethereum (EIP) {#eip}
 
 Dokument projektowy dostarczający informacji społeczności Ethereum, opisujący proponowaną nową funkcję lub jej procesy lub środowisko (patrz [ERBN](#erc)).
 
-<DocLink to="/eips/" title="Wprowadzenie do EIP" />
+<DocLink to="/eips/">
+  Wprowadzenie do EIP
+</DocLink>
 
 ### Usługa nazw Ethereum (ENS) {#ens}
 
@@ -200,7 +228,9 @@ W kontekście kryptografii brak przewidywalności lub poziom losowości. Podczas
 
 Etykieta nadana niektórym [EIP](#eip), które próbują zdefiniować określony standard użycia Ethereum.
 
-<DocLink to="/eips/" title="Wprowadzenie do EIP" />
+<DocLink to="/eips/">
+  Wprowadzenie do EIP
+</DocLink>
 
 ### Ethash {#ethash}
 
@@ -212,19 +242,25 @@ Algorytm [proof-of-work](#pow) dla Ethereum 1.0.
 
 Natywna kryptowaluta używana przez ekosystem Ethereum, który pokrywa koszty [gazu](#gas) podczas realizacji transakcji. Zapisywany również jako ETH lub symbol Ξ, grecka wielka litera Xi.
 
-<DocLink to="/eth/" title="Waluta na naszą cyfrową przyszłość" />
+<DocLink to="/eth/">
+  Waluta na naszą cyfrową przyszłość
+</DocLink>
 
 ### wydarzenia {#events}
 
 Pozwala na korzystanie z urządzeń [EVM](#evm) do rejestrowania danych. [Aplikacje zdecentralizowane](#dapp) mogą nasłuchiwać wydarzeń i używać ich do uruchamiania wywołań zwrotnych JavaScript w interfejsie użytkownika.
 
-<DocLink to="/developers/docs/smart-contracts/anatomy/#events-and-logs" title="Wydarzenia i dzienniki" />
+<DocLink to="/developers/docs/smart-contracts/anatomy/#events-and-logs">
+  Wydarzenia i dzienniki
+</DocLink>
 
 ### Maszyna Wirtualna Ethereum (EVM) {#evm}
 
 Wirtualna maszyna bazująca na stosie, która wykonuje [kod bajtowy](#bytecode). W Ethereum model wykonania określa, w jaki sposób stan systemu jest zmieniany na podstawie serii instrukcji kodu bajtowego i małej krotki danych środowiskowych. Jest to określone przez formalny model wirtualnej maszyny stanu.
 
-<DocLink to="/developers/docs/evm/" title="Maszyna Wirtualna Ethereum" />
+<DocLink to="/developers/docs/evm/">
+  Maszyna Wirtualna Ethereum
+</DocLink>
 
 ### język asemblera EVM {#evm-assembly-language}
 
@@ -242,13 +278,19 @@ Domyślna funkcja wywołana w przypadku braku danych lub zadeklarowanej nazwy fu
 
 Usługa wykonana za pośrednictwem [inteligentnego kontraktu](#smart-contract), która wypłaca środki w postaci bezpłatnego eteru testowego, który może być użyty w sieci testowej.
 
-<DocLink to="/developers/docs/networks/#testnet-faucets" title="Krany sieci testowej" />
+<DocLink to="/developers/docs/networks/#testnet-faucets">
+  Krany sieci testowej
+</DocLink>
 
 ### nieodwołalność {#finality}
 
 Nieodwołalność jest gwarancją, że zestaw transakcji przed upływem danego czasu nie zmieni się i nie będzie mógł zostać wycofany.
 
-<DocLink to="/developers/docs/consensus-mechanisms/pow/#finality" title="Nieodwołalność proof-of-work" /> <DocLink to="/developers/docs/consensus-mechanisms/pos/#finality" title="Nieodwołalność proof-of-stake" />
+<DocLink to="/developers/docs/consensus-mechanisms/pow/#finality">
+  Nieodwołalność proof-of-work
+</DocLink> <DocLink to="/developers/docs/consensus-mechanisms/pos/#finality">
+  Nieodwołalność proof-of-stake
+</DocLink>
 
 ### finney {#finney}
 
@@ -262,7 +304,9 @@ Zmiana protokołu, powodująca utworzenie alternatywnego łańcucha lub czasowe 
 
 Model bezpieczeństwa dla niektórych rozwiązań [warstwy 2](#layer-2), gdzie w celu zwiększenia szybkości transakcje są [wrzucane](#rollups) do partii i przesyłane do Ethereum w jednej transakcji. Zakłada się, że są one ważne, ale można je zakwestionować, jeżeli podejrzewa się nadużycia finansowe. Dowód oszustwa przeprowadzi następnie transakcję, aby sprawdzić, czy doszło do oszustwa. Ta metoda zwiększa liczbę możliwych transakcji przy jednoczesnym zachowaniu bezpieczeństwa. Niektóre [wartości zbiorcze](#rollups) używają [dowodów ważności](#validity-proof).
 
-<DocLink to="/developers/docs/scaling/layer-2-rollups/#optimistic-rollups" title="Optymistyczne pakiety zbiorcze" />
+<DocLink to="/developers/docs/scaling/layer-2-rollups/#optimistic-rollups">
+  Optymistyczne pakiety zbiorcze
+</DocLink>
 
 ### granica {#frontier}
 
@@ -276,7 +320,9 @@ Pierwotny etap testowania Ethereum, trwający od lipca 2015 r. do marca 2016 r.
 
 Paliwo wirtualne używane w Ethereum do realizacji inteligentnych kontraktów. [EVM](#evm) wykorzystuje mechanizm księgowy do pomiaru zużycia gazu i ograniczenia zużycia zasobów obliczeniowych (patrz [Kompletność w sensie Turinga](#turing-complete)).
 
-<DocLink to="/developers/docs/gas/" title="Gaz i opłaty" />
+<DocLink to="/developers/docs/gas/">
+  Gaz i opłaty
+</DocLink>
 
 ### limit gazu {#gas-limit}
 
@@ -342,13 +388,17 @@ Kodowanie adresu Ethereum, które jest częściowo kompatybilne z kodowaniem mi�
 
 Interfejs użytkownika, który zazwyczaj łączy edytor kodu, kompilator, środowisko uruchomieniowe i debuger.
 
-<DocLink to="/developers/docs/ides/" title="Środowisko IDE" />
+<DocLink to="/developers/docs/ides/">
+  Środowisko IDE
+</DocLink>
 
 ### problem niemodyfikowalności wdrożonego kodu {#immutable-deployed-code-problem}
 
 Po wdrożeniu kod [kontraktu](#smart-contract) (lub [biblioteki](#library)) staje się niezmienny. Standardowe techniki rozwoju oprogramowania są oparte na możliwości poprawiania ewentualnych błędów i dodawania nowych funkcji, dlatego niemodyfikowalność stanowi wyzwanie dla twórców inteligentnych kontraktów.
 
-<DocLink to="/developers/docs/smart-contracts/deploying/" title="Wdrażanie inteligentnych kontraktów" />
+<DocLink to="/developers/docs/smart-contracts/deploying/">
+  Wdrażanie inteligentnych kontraktów
+</DocLink>
 
 ### transakcja wewnętrzna {#internal-transaction}
 
@@ -362,7 +412,9 @@ Po wdrożeniu kod [kontraktu](#smart-contract) (lub [biblioteki](#library)) staj
 
 Znana również jako „algorytm rozszerzania hasła”, jest używana w pliku [kestore](#keystore-file) do ochrony zaszyfrowanego hasła przed przed atakami siłowymi, atakami słownikowymi i atakami z użyciem tablic tęczowych, wielokrotnie haszując hasło.
 
-<DocLink to="/developers/docs/smart-contracts/security/" title="Ochrona" />
+<DocLink to="/developers/docs/smart-contracts/security/">
+  Ochrona
+</DocLink>
 
 ### keccak-256 {#keccak-256}
 
@@ -380,7 +432,9 @@ Plik w formacie JSON zawierający jeden (losowo wygenerowany) [klucz prywatny](#
 
 Obszar rozwoju skupiony na ulepszeniach w zakresie warstwowania w uzupełnieniu protokołu Ethereum. Te ulepszenia są związane z szybkościami [transakcji](#transaction), niższymi [opłatami transakcyjnymi](#transaction-fee) i prywatnością transakcji.
 
-<DocLink to="/developers/docs/scaling/layer-2-rollups/" title="Warstwa 2" />
+<DocLink to="/developers/docs/scaling/layer-2-rollups/">
+  Warstwa 2
+</DocLink>
 
 ### LevelDB {#level-db}
 
@@ -390,7 +444,9 @@ Przechowywany na dysku magazyn open source typu klucz-wartość, zaimplementowan
 
 [Kontrakt ](#smart-contract) specjalnego rodzaju, który nie ma funkcji do odbioru płatności, funkcji rezerwowej ani pamięci na dane. W związku z tym nie może odbierać ani przechowywać etherów, ani przechowywać danych. Biblioteka to zainstalowany kod, który może być wywoływany w trybie odczytu przez inne kontrakty na potrzeby obliczeń.
 
-<DocLink to="/developers/docs/smart-contracts/libraries/" title="Biblioteki kontraktów inteligentnych" />
+<DocLink to="/developers/docs/smart-contracts/libraries/">
+  Biblioteki kontraktów inteligentnych
+</DocLink>
 
 ### lekki klient {#lightweight-client}
 
@@ -424,7 +480,9 @@ Trzeci etap rozwoju Ethereum rozpoczęty w październiku 2017 r.
 
 [Węzeł](#node) w sieci, który za pomocą wielokrotnego obliczania skrótów znajduje prawidłowe [dowody pracy](#pow) (proof of work) dla nowych bloków (patrz [ethash](#ethash)).
 
-<DocLink to="/developers/docs/consensus-mechanisms/pow/mining/" title="Wydobycie" />
+<DocLink to="/developers/docs/consensus-mechanisms/pow/mining/">
+  Wydobycie
+</DocLink>
 
 <Divider />
 
@@ -434,21 +492,31 @@ Trzeci etap rozwoju Ethereum rozpoczęty w październiku 2017 r.
 
 Oznacza tu sieć Ethereum — sieć P2P, w której transakcje i bloki są przekazywane do wszystkich węzłów sieci Ethereum (użytkowników sieci).
 
-<DocLink to="/developers/docs/networks/" title="Sieci" />
+<DocLink to="/developers/docs/networks/">
+  Sieci
+</DocLink>
 
 ### token niezamienny (NFT) {#nft}
 
 Nazywany także deed. Jest to standardowy token wprowadzony na podstawie propozycji ERC721. Tokeny NFT można śledzić i handlować nimi, ale każdy token jest unikatowy i odmienny; nie są zamienne jak ETH i [tokeny ERC-20](#token-standard). Tokeny NFT mogą reprezentować prawo własności zasobów cyfrowych lub fizycznych.
 
-<DocLink to="/nft/" title="Tokeny niewymienne (NFT)" /> <DocLink to="/developers/docs/standards/tokens/erc-721/" title="ERC-721 – standard tokenów niewymiennych" />
+<DocLink to="/nft/">
+  Tokeny niewymienne (NFT)
+</DocLink> <DocLink to="/developers/docs/standards/tokens/erc-721/">
+  ERC-721 – standard tokenów niewymiennych
+</DocLink>
 
 ### node {#node}
 
 Klient działający w sieci.
 
-<DocLink to="/developers/docs/nodes-and-clients/" title="Węzły i klienci" />
+<DocLink to="/developers/docs/nodes-and-clients/">
+  Węzły i klienci
+</DocLink>
 
-<DocLink to="/developers/docs/nodes-and-clients/" title="Węzły i klienci" />
+<DocLink to="/developers/docs/nodes-and-clients/">
+  Węzły i klienci
+</DocLink>
 
 ### nonce {#nonce}
 
@@ -466,7 +534,9 @@ Kiedy [górnik](#miner) znajdzie poprawny [blok](#block), może się okazać, ż
 
 [Pakiet zbiorczy](#rollups) transakcji, które używają [dowodów oszustwa](#fraud-proof), aby zaoferować większą przepustowość transakcji [warstwy 2](#layer-2) przy użyciu zabezpieczeń dostarczanych przez [sieć główną](#mainnet) (warstwa 1). W przeciwieństwie do [plazmy](#plasma), podobnego rozwiązania warstwy 2, optymistyczne pakiety zbiorcze mogą obsługiwać bardziej złożone typy transakcji – wszystko co jest możliwe w [EVM](#evm). W porównaniu z [pakietami zbiorczymi o wiedzy zerowej](#zk-rollups) doświadczają opóźnień, ponieważ transakcję można zakwestionować za pomocą dowodu oszustwa.
 
-<DocLink to="/developers/docs/scaling/layer-2-rollups/#optimistic-rollups" title="Optymistyczne pakiety zbiorcze" />
+<DocLink to="/developers/docs/scaling/layer-2-rollups/#optimistic-rollups">
+  Optymistyczne pakiety zbiorcze
+</DocLink>
 
 <Divider />
 
@@ -480,7 +550,9 @@ Jest to jedna z najważniejszych implementacji oprogramowania klienckiego Ethere
 
 Rozwiązanie skalowania off-chain wykorzystujące [dowody oszustwa](#fraud-proof), na przykład [optymistyczne pakiety zbiorcze](#optimistic-rollups). Plazma jest ograniczona do prostych transakcji, takich jak podstawowe transfery i zamiany tokenów.
 
-<DocLink to="/developers/docs/scaling/plasma" title="Plazma" />
+<DocLink to="/developers/docs/scaling/plasma">
+  Plazma
+</DocLink>
 
 ### klucz prywatny (tajny klucz) {#private-key}
 
@@ -490,13 +562,17 @@ Jest to tajna liczba, która umożliwia użytkownikom w sieci Ethereum dowodzeni
 
 Jest to metoda, za pomocą której protokół blockchainu kryptowaluty umożliwia uzyskanie [konsensusu](#consensus) w środowisku rozproszonym. PoS wymaga przedstawienia dowodu własności określonej kwoty kryptowaluty (jest to „stawka”, jaką użytkownik ma w sieci), aby dana osoba mogła uczestniczyć w weryfikacji transakcji.
 
-<DocLink to="/developers/docs/consensus-mechanisms/pos/" title="Proof-of-stake" />
+<DocLink to="/developers/docs/consensus-mechanisms/pos/">
+  Proof-of-stake
+</DocLink>
 
 ### Proof-of-work (PoW) {#pow}
 
 Są do dane (dowód), których uzyskanie wymaga intensywnych obliczeń. W Ethereum [górnicy](#miner) muszą znaleźć liczbowe rozwiązanie algorytmu [Ethash](#ethash) zgodnie z poziomem [trudności](#difficulty) obowiązującym na poziomie sieci.
 
-<DocLink to="/developers/docs/consensus-mechanisms/pow/" title="Proof-of-work" />
+<DocLink to="/developers/docs/consensus-mechanisms/pow/">
+  Proof-of-work
+</DocLink>
 
 ### klucz publiczny {#public-key}
 
@@ -514,7 +590,9 @@ Dane zwracane przez klienta Ethereum, reprezentujące wynik konkretnej [transakc
 
 Atak składający się z kontraktu atakującego wywołującego kontrakt ofiary w taki sposób, że podczas wykonania ofiara ponownie wywołuje kontrakt atakującego rekursywnie. Może to skutkować na przykład kradzieżą środków poprzez pominięcie tych części kontraktu ofiary, które aktualizują saldo lub liczą kwoty odstąpienia.
 
-<DocLink to="/developers/docs/smart-contracts/security/#re-entrancy" title="Wielobieżność" />
+<DocLink to="/developers/docs/smart-contracts/security/#re-entrancy">
+  Wielobieżność
+</DocLink>
 
 ### nagroda {#reward}
 
@@ -528,7 +606,9 @@ Standard kodowania zaprojektowany przez deweloperów Ethereum do kodowania i ser
 
 Typ rozwiązania skalowania [warstwy 2](#layer-2) który zawiera wiele transakcji i przesyła je do [głównego łańcucha Ethereum](#mainnet) w pojedynczej transakcji. Pozwala to na zmniejszenie kosztów [gazu](#gas) i zwiększenie przepustowości [transakcji](#transaction). Istnieją pakiety zbiorcze optymistyczne i o wiedzy zerowej, wykorzystujące różne metody zabezpieczania, aby zaoferować wymienione korzyści skalowalności.
 
-<DocLink to="/developers/docs/scaling/layer-2-rollups/" title="Pakiety zbiorcze" />
+<DocLink to="/developers/docs/scaling/layer-2-rollups/">
+  Pakiety zbiorcze
+</DocLink>
 
 <Divider />
 
@@ -538,7 +618,9 @@ Typ rozwiązania skalowania [warstwy 2](#layer-2) który zawiera wiele transakcj
 
 Czwarty i ostatni etap rozwoju Ethereum, znany pod nazwą Ethereum 2.0.
 
-<DocLink to="/eth2/" title="Ethereum 2.0 (Eth2)" />
+<DocLink to="/eth2/">
+  Ethereum 2.0 (Eth2)
+</DocLink>
 
 ### SHA (Secure Hash Algorithm) {#sha}
 
@@ -548,13 +630,17 @@ Rodzina kryptograficznych funkcji skrótu opublikowanych przez Narodowy Instytut
 
 Łańcuch [proof-of-stake](#proof-of-stake) koordynowany przez [łańcuch śledzący](#beacon-chain) i zabezpieczony przez [walidatorów](#validator). Do sieci zostaną dodane 64 w ramach aktualizacji łańcucha odłamkowego Eth2. Łańcuchy odłamkowe będą oferować Ethereum zwiększoną przepustowość transakcji dzięki dostarczeniu dodatkowych danych do rozwiązań [warstwy 2](#layer-2) takich jak [optymistyczne pakiety zbiorcze](#optimistic-rollups) i [pakiety zbiorcze ZK](#zk-rollups).
 
-<DocLink to="/eth2/shard-chains" title="Łańcuchy szczątkowe" />
+<DocLink to="/eth2/shard-chains">
+  Łańcuchy szczątkowe
+</DocLink>
 
 ### łańcuch boczny {#sidechain}
 
 Rozwiązanie skalujące wykorzystujące oddzielny łańcuch z innymi, często szybszymi, [regułami konsensusu](#consensus-rules). Aby podłączyć łańcuchy boczne do [sieci głównej](#mainnet), potrzebny jest mostek. [Pakiety zbiorcze](#rollups) również używają łańcuchów bocznych, ale współpracują z [siecią główną](#mainnet).
 
-<DocLink to="/developers/docs/scaling/sidechains/" title="Łańcuchy boczne" />
+<DocLink to="/developers/docs/scaling/sidechains/">
+  Łańcuchy boczne
+</DocLink>
 
 ### singleton {#singleton}
 
@@ -564,19 +650,25 @@ Pojęcie z obszaru programowania komputerów oznaczające obiekt klasy, która u
 
 Okres (12 sekund) w którym [walidator](#validator) w systemie [proof-of-stake](#proof-of-stake) może zaproponować nowy [łańcuch śledzący](#beacon-chain) i blok łańcucha [odłamków](#shard). Slot może być pusty. 32 sloty tworzą [epokę](#epoch).
 
-<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work" title="Proof-of-stake" />
+<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work">
+  Proof-of-stake
+</DocLink>
 
 ### inteligentny kontrakt {#smart-contract}
 
 Program działający w infrastrukturze obliczeniowej Ethereum.
 
-<DocLink to="/developers/docs/smart-contracts/" title="Wprowadzenie do inteligentnych kontraktów" />
+<DocLink to="/developers/docs/smart-contracts/">
+  Wprowadzenie do inteligentnych kontraktów
+</DocLink>
 
 ### Solidity {#solidity}
 
 Proceduralny (imperatywny) język programowania o składni podobnej do JavaScript, C++ lub Java. Najpopularniejszy i najczęściej używany język do tworzenia [inteligentnych kontraktów](#smart-contract) w Ethereum. Jego twórcą jest dr Gavin Wood.
 
-<DocLink to="/developers/docs/smart-contracts/languages/#solidity" title="Solidity" />
+<DocLink to="/developers/docs/smart-contracts/languages/#solidity">
+  Solidity
+</DocLink>
 
 ### wewnątrzwierszowy język asemblerowy dla Solidity {#solidity-inline-assembly}
 
@@ -590,19 +682,25 @@ Jest to język asemblerowy dla maszyny [EVM](#evm) używany w programach w języ
 
 Token [ERC-20](#token-standard) o wartości powiązanej z wartością innego zasobu. Istnieją sablecoiny zabezpieczone walutami fiducjarnymi, takimi jak dolary, metale szlachetne, złoto, i innymi kryptowalutami, takimi jak bitcoin.
 
-<DocLink to="/eth/#tokens" title="ETH nie jest jedyną kryptowalutą na Ethereum" />
+<DocLink to="/eth/#tokens">
+  ETH nie jest jedyną kryptowalutą na Ethereum
+</DocLink>
 
 ### układanie w stos {#staking}
 
 Deponowanie ilości [etheru](#ether) (Twoja stawka) aby stać się walidatorem i zabezpieczyć [sieć](#network). Walidator sprawdza [transakcje](#transaction) i proponuje [bloki](#block) w modelu konsensusu [proof-of-stake](#pos). Staking stanowi dla Ciebie ekonomiczną zachętę do działania w najlepszym interesie sieci. Otrzymasz nagrody za wykonywanie obowiązków [walidatora](#validator), ale stracisz różne ilości ETH, jeśli tego nie zrobisz.
 
-<DocLink to="/eth2/staking/" title="Zestakuj swój ETH, aby zostać walidatorem Ethereum" />
+<DocLink to="/eth2/staking/">
+  Zestakuj swój ETH, aby zostać walidatorem Ethereum
+</DocLink>
 
 ### kanały uzyskiwania informacyji {#state-channels}
 
 Rozwiązanie [warstwy 2](#layer-2), polegające na ustanowieniu między uczestnikami kanału, w którym mogą swobodnie i tanio przeprowadzać transakcje. Tylko [transakcja](#transaction) ustanawiająca i zamykająca kanał jest wysyłana do [sieci głównej](#mainnet). Pozwala to na bardzo wysoką przepustowość transakcji, ale opiera się na wcześniejszej znajomości liczby uczestników i blokowaniu funduszy.
 
-<DocLink to="/developers/docs/scaling/state-channels/#state-channels" title="Kanały uzyskiwania informacji" />
+<DocLink to="/developers/docs/scaling/state-channels/#state-channels">
+  Kanały uzyskiwania informacji
+</DocLink>
 
 ### szabo {#szabo}
 
@@ -620,19 +718,25 @@ Nazwa [etheru](#ether). 1 szabo = 10<sup>12</sup> [wei](#wei), 10<sup>6</sup> sz
 
 Skrót od nazwy „sieć testowa”, służy do symulowania zachowania głównej sieci Ethereum (patrz [sieć główna](#mainnet)).
 
-<DocLink to="/developers/docs/networks/#testnets" title="Sieci testowe" />
+<DocLink to="/developers/docs/networks/#testnets">
+  Sieci testowe
+</DocLink>
 
 ### standard tokenów {#token-standard}
 
 Wprowadzony we wniosku ERC-20 zapewnia znormalizowaną strukturę [kontraktów inteligentnych](#smart-contract) dla zamiennych tokenów. Tokeny z tego samego kontraktu mogą być śledzone, sprzedawane i wymieniane, w przeciwieństwie do [NFT](#nft).
 
-<DocLink to="/developers/docs/standards/tokens/erc-20/" title="Standard tokena ERC-20" />
+<DocLink to="/developers/docs/standards/tokens/erc-20/">
+  Standard tokena ERC-20
+</DocLink>
 
 ### transakcja {#transaction}
 
 Dane przeznaczone do blockchainu Ethereum, podpisane przez [konto](#account) źródłowe skierowane pod określony [adres](#address). Transakcja zawiera metadane, np. [limit gazu](#gas-limit) dla tej transakcji.
 
-<DocLink to="/developers/docs/transactions/" title="Transakcje" />
+<DocLink to="/developers/docs/transactions/">
+  Transakcje
+</DocLink>
 
 ### opłata transakcyjna {#transaction-fee}
 
@@ -654,25 +758,35 @@ Nazwa ta pochodzi od brytyjskiego matematyka i informatyka Alana Turinga. System
 
 [Węzeł](#node) w systemie [proof-of-stake](#proof-of-stake) odpowiedzialny za przechowywanie danych, przetwarzanie transakcji i dodawanie nowych bloków do blockchainu. Aby aktywować oprogramowanie walidatora, musisz mieć możliwość [stakingu](#staking) 32 ETH.
 
-<DocLink to="/developers/docs/consensus-mechanisms/pos" title="Proof-of-stake" /> <DocLink to="/eth2/staking/" title="Stakowanie w Ethereum" />
+<DocLink to="/developers/docs/consensus-mechanisms/pos">
+  Proof-of-stake
+</DocLink> <DocLink to="/eth2/staking/">
+  Stakowanie w Ethereum
+</DocLink>
 
 ### Dowód ważności {#validity-proof}
 
 Model bezpieczeństwa dla niektórych rozwiązań [warstwy 2](#layer-2), gdzie w celu zwiększenia szybkości transakcje są [wrzucane](/#rollups) do partii i przesyłane do Ethereum w jednej transakcji. Obliczanie transakcji odbywa się poza łańcuchem, a następnie jest dostarczane do głównego łańcucha wraz z dowodem ich ważności. Ta metoda zwiększa liczbę możliwych transakcji przy jednoczesnym zachowaniu bezpieczeństwa. Niektóre [pakiety zbiorcze](#rollups) używają [dowodu oszustwa](#fraud-proof).
 
-<DocLink to="/developers/docs/scaling/layer-2-rollups/#zk-rollups" title="Pakiety zbiorcze o wiedzy zerowej" />
+<DocLink to="/developers/docs/scaling/layer-2-rollups/#zk-rollups">
+  Pakiety zbiorcze o wiedzy zerowej
+</DocLink>
 
 ### Validium {#validium}
 
 Rozwiązanie, które używa [dowodów ważności](#validity-proof) w celu poprawy przepustowości transakcji. W przeciwieństwie do [pakietów zbiorczych z zerową wiedzą](#zk-rollup), dane Validium nie są przechowywane w warstwie 1 [sieci głównej](#mainnet).
 
-<DocLink to="/developers/docs/scaling/validium/" title="Validium" />
+<DocLink to="/developers/docs/scaling/validium/">
+  Validium
+</DocLink>
 
 ### Vyper {#vyper}
 
 Wysokopoziomowy jęsyk programowania wysokiego poziomu o składni zbliżonej do Pythona. Ma być językiem zbliżonym do języków czysto funkcyjnych. Utworzony przez Vitalika Buterina.
 
-<DocLink to="/developers/docs/smart-contracts/languages/#vyper" title="Vyper" />
+<DocLink to="/developers/docs/smart-contracts/languages/#vyper">
+  Vyper
+</DocLink>
 
 <Divider />
 
@@ -682,13 +796,17 @@ Wysokopoziomowy jęsyk programowania wysokiego poziomu o składni zbliżonej do 
 
 Oprogramowanie przechowujące [klucze prywatne](#private-key). Pozwala uzyskać dostęp do [kont](#account) Ethereum, kontrolować je i komunikować się z [inteligentnymi kontraktami](#smart-contract). Klucze nie muszą być przechowywane w portfelu i mogą być pobierane z magazynu offline (tj. karty pamięci lub kartki papieru) w celu poprawy bezpieczeństwa. Pomimo nazwy portfele nigdy nie przechowują pieniędzy ani tokenów.
 
-<DocLink to="/wallets/" title="Portfele Ethereum" />
+<DocLink to="/wallets/">
+  Portfele Ethereum
+</DocLink>
 
 ### Web3 {#web3}
 
 Trzecia wersja Internetu. Po raz pierwszy zaproponował ją dr Gavin Wood. Sieć Web3 reprezentuje nową wizję opartą na aplikacjach sieciowych. Ma pozwolić przejść od zarządzanych aplikacji z jednym właścicielem do aplikacji rozwijanych za pomocą decentralizowanych protokołów (patrz [Dapp](#dapp)).
 
-<DocLink to="/developers/docs/web2-vs-web3/" title="Web2 vs Web3" />
+<DocLink to="/developers/docs/web2-vs-web3/">
+  Web2 vs Web3
+</DocLink>
 
 ### wei {#wei}
 
@@ -706,7 +824,9 @@ To specjalny adres w Ethereum, obejmujący same zera. Jest on podawany jako adre
 
 [Pakiet zbiorczy](#rollups)transakcji korzystający z [ dowodów ważności](#validity-proof) w celu zwiększenia przepustowości transakcji [warstwy 2](#layer-2) przy zastosowaniu zabezpieczeń zapewnianych przez [sieć główną](#mainnet) (warstwa 1). Pakiety zbiorcze o wiedzy zerowej nie mogą obsługiwać złożonych transakcji (co mogą robić [optymistyczne pakiety zbiorcze](#optimistic-rollups)), ale nie dotyczą ich problemy z opóźnieniami, ponieważ przedłożone transakcje są ewidentnie ważne.
 
-<DocLink to="/developers/docs/scaling/layer-2-rollups/#zk-rollups" title="Pakiety zbiorcze o wiedzy zerowej" />
+<DocLink to="/developers/docs/scaling/layer-2-rollups/#zk-rollups">
+  Pakiety zbiorcze o wiedzy zerowej
+</DocLink>
 
 <Divider />
 

--- a/src/content/translations/pl/history/index.md
+++ b/src/content/translations/pl/history/index.md
@@ -84,7 +84,9 @@ Uaktualnienie Berlin optymalizuje koszt gazu przy pewnych działaniach EVM oraz 
 
 [Przeczytaj ogłoszenie Fundacji Ethereum](https://blog.ethereum.org/2020/11/27/eth2-quick-update-no-21/)
 
-<DocLink to="/eth2/beacon-chain/" title="Łańcuch śledzący" />
+<DocLink to="/eth2/beacon-chain/">
+  Łańcuch śledzący
+</DocLink>
 
 ---
 
@@ -98,7 +100,9 @@ Do ekosystemu Ethereum został wprowadzony kontrakt depozytu na staking Choć by
 
 [Przeczytaj ogłoszenie Fundacji Ethereum](https://blog.ethereum.org/2020/11/04/eth2-quick-update-no-19/)
 
-<DocLink to="/eth2/staking/" title="Staking" />
+<DocLink to="/eth2/staking/">
+  Staking
+</DocLink>
 
 ---
 
@@ -334,4 +338,6 @@ Dokumentacja Yellow Paper autorstwa dr Gavina Wood, jest techniczną definicją 
 
 Artykuł wprowadzający, opublikowany w 2013 roku przez Vitalika Buterina, założyciela Ethereum, przed uruchomieniem projektu w 2015 roku.
 
-<DocLink to="/whitepaper/" title="Dokumentacja" />
+<DocLink to="/whitepaper/">
+  Dokumentacja
+</DocLink>

--- a/src/content/translations/ro/history/index.md
+++ b/src/content/translations/ro/history/index.md
@@ -35,7 +35,9 @@ Aceste modificări de regulă pot crea o divizare temporară în rețea. Blocuri
 
 [Citește anunțul Fundației Ethereum](https://blog.ethereum.org/2020/11/27/eth2-quick-update-no-21/)
 
-<DocLink to="/eth2/beacon-chain/" title="Lanțul Beacon" />
+<DocLink to="/eth2/beacon-chain/">
+  Lanțul Beacon
+</DocLink>
 
 ---
 
@@ -49,7 +51,9 @@ Contractul de depozit de miză a introdus [miza](/glossary/#staking) în ecosist
 
 [Citește anunțul Fundației Ethereum](https://blog.ethereum.org/2020/11/04/eth2-quick-update-no-19/)
 
-<DocLink to="/eth2/staking/" title="Mizare" />
+<DocLink to="/eth2/staking/">
+  Mizare
+</DocLink>
 
 ---
 
@@ -301,4 +305,6 @@ Yellow Paper, scris de Dr. Gavin Wood, este o definiție tehnică a protocolului
 
 Lucrarea introductivă, publicată în 2013 de Vitalik Buterin, fondatorul Ethereum, înainte de lansarea proiectului în 2015.
 
-<DocLink to="/whitepaper/" title="Whitepaper" />
+<DocLink to="/whitepaper/">
+  Whitepaper
+</DocLink>

--- a/src/content/translations/zh/glossary/index.md
+++ b/src/content/translations/zh/glossary/index.md
@@ -22,7 +22,9 @@ sidebarDepth: 2
 
 帐户是一个对象，它包含[地址](#address)、余额、[nonce](#nonce)，并且存储了状态和代码（皆可为空）。 一个帐户可以是[合约帐户](#contract-account)，也可以是[外部帐户（EOA）](#eoa)。
 
-<DocLink to="/developers/docs/accounts" title="以太坊帐户" />
+<DocLink to="/developers/docs/accounts">
+  以太坊帐户
+</DocLink>
 
 ### address 地址 {#address}
 
@@ -32,7 +34,9 @@ sidebarDepth: 2
 
 在 [Solidity 语言里](#solidity)，`assert(false)` 会被编译成 `0xfe`，这是一个无效的操作码，它会消耗完剩下的 [gas](#gas) 并复原所有的变更。 当一个 `assert()` 语句失效，表明出现了非常严重和没有预期的问题，你将需要修复你的代码。 你应该使用 `assert()` 以避免永远不应该发生的情况。
 
-<DocLink to="/developers/docs/smart-contracts/security/" title="安全性" />
+<DocLink to="/developers/docs/smart-contracts/security/">
+  安全性
+</DocLink>
 
 ### attestation 证明 {#attestation}
 
@@ -46,7 +50,9 @@ sidebarDepth: 2
 
 Eth2 升级的一部分，它将成为以太坊网络的协调者。 它会给以太坊引入[权益证明](#proof-of-stake)和[验证者](#validator) 。 它最终将并入[主网](#mainnet)。
 
-<DocLink to="/eth2/beacon-chain/" title="信标链" />
+<DocLink to="/eth2/beacon-chain/">
+  信标链
+</DocLink>
 
 ### big-endian 大端模式 {#big-endian}
 
@@ -56,13 +62,17 @@ Eth2 升级的一部分，它将成为以太坊网络的协调者。 它会给�
 
 一个关于其所包含[交易](#transaction)的所需信息（区块头）的集合，以及称为 [ommer（叔块）](#ommer)的一组其他区块头。 区块由以太坊网络中的[矿工](#miner)添加上链。
 
-<DocLink to="/developers/docs/blocks/" title="区块" />
+<DocLink to="/developers/docs/blocks/">
+  区块
+</DocLink>
 
 ### blockchain 区块链 {#blockchain}
 
 以太坊网络中由[工作量证明](#pow)验证的[区块](#block)序列，每个区块与其父块相连，可一直追溯到[创世纪块](#genesis-block)。 它没有区块大小限制，而使用 [ gas 上限](#gas-limit)来调整区块大小。
 
-<DocLink to="/developers/docs/intro-to-ethereum#what-is-a-blockchain" title="什么是区块链？" />
+<DocLink to="/developers/docs/intro-to-ethereum#what-is-a-blockchain">
+  什么是区块链？
+</DocLink>
 
 ### bytecode 字节码 {#bytecode}
 
@@ -80,7 +90,9 @@ Eth2 升级的一部分，它将成为以太坊网络的协调者。 它会给�
 
 把用高级编程语言 (例如，[Solidity](#solidity)) 写的代码转换为低级语言 (例如，EVM [“字节码”](#bytecode))。
 
-<DocLink to="/developers/docs/smart-contracts/compiling/" title="编译智能合约" />
+<DocLink to="/developers/docs/smart-contracts/compiling/">
+  编译智能合约
+</DocLink>
 
 ### committee 委员会 {#committee}
 
@@ -110,7 +122,9 @@ Eth2 升级的一部分，它将成为以太坊网络的协调者。 它会给�
 
 交叉链接提供一个分片状态的总结。 这是在实现分片的[权益证明系统](#proof-of-stake)里[分片](#shard)链通过[信标链](#beacon-chain)互相通信的方式。
 
-<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work" title="权益证明" />
+<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work">
+  权益证明
+</DocLink>
 
 <Divider />
 
@@ -120,19 +134,25 @@ Eth2 升级的一部分，它将成为以太坊网络的协调者。 它会给�
 
 不以等级体系管理来运作的公司或其他组织。 DAO 可能还指一份名为 "The DAO" 的合约，在 2016 年 4 月 30 日发布，它后来在 2016 年 6 月被攻击了；这件事最终引发了一次[硬分叉](#hard-fork)（代码名称为 DAO），分叉的区块高度是 1,192,000，这次分叉回滚了被攻击的 DAO 合约，并导致产生了以太坊和以太坊经典两个分开的、互相竞争的系统。
 
-<DocLink to="/community/#decentralized-autonomous-organizations-daos" title="Decentralized Autonomous Organization (DAO) 去中心化自治组织" />
+<DocLink to="/community/#decentralized-autonomous-organizations-daos">
+  Decentralized Autonomous Organization (DAO) 去中心化自治组织
+</DocLink>
 
 ### DApp 去中心化应用 {#dapp}
 
 去中心化应用。 最基本的定义是，它是一个[智能合约](#smart-contract)和一个网络用户界面。 从更广义来说，Dapp 是一个建在开放、去中心化、点对点的基础设施服务上的网络应用。 此外，很多 Dapp 还包括去中心化存储和/或一个通信协议以及平台。
 
-<DocLink to="/developers/docs/dapps/" title="Dapp 介绍" />
+<DocLink to="/developers/docs/dapps/">
+  Dapp 介绍
+</DocLink>
 
 ### decentralized exchange (DEX) 去中心化交易所 {#dex}
 
 是 [dapp](#dapp) 的一种类型，让人们可以在网络上与对等点交换代币。 你需要有 [ Eth](#ether) 才可以使用 Dex（以支付[交易费](#transaction-fee)），但它们不像中心化交易所那样受地理限制——任何人都可以参与。
 
-<DocLink to="/get-eth/#dex" title="去中心化交易所" />
+<DocLink to="/get-eth/#dex">
+  去中心化交易所
+</DocLink>
 
 ### deed {#deed}
 
@@ -142,7 +162,9 @@ Eth2 升级的一部分，它将成为以太坊网络的协调者。 它会给�
 
 去中心化金融的缩写，旨在通过区块链提供金融服务的一类[去中心化应用](#dapp)，无需中介，任何连接互联网的人都可以参与。
 
-<DocLink to="/dapps/#explore" title="Defi dapps" />
+<DocLink to="/dapps/#explore">
+  Defi dapps
+</DocLink>
 
 ### difficulty 挖矿难度 {#difficulty}
 
@@ -168,13 +190,17 @@ Eth2 升级的一部分，它将成为以太坊网络的协调者。 它会给�
 
 在[信标链](#beacon-chain)协作系统里，每 32 个[slot](#slot)（6.4 分钟）组成的时间间隔称作为一个 epoch。 为了确保安全，每个 epoch 对会对[验证者](#validator)[委员会](#committee)进行混洗。 每个 epoch 里都有为链做[最终确定](#finality)的一次机会。
 
-<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work" title="权益证明（PoS)" />
+<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work">
+  权益证明（PoS)
+</DocLink>
 
 ### Ethereum Improvement Proposal (EIP) 以太坊改进提案 (EIP) {#eip}
 
 为以太坊社区提供信息的一种设计文档，说明一个提议的新功能或它的流程或环境（请参阅 [ERC](#erc)）。
 
-<DocLink to="/eips/" title="EIP 简介" />
+<DocLink to="/eips/">
+  EIP 简介
+</DocLink>
 
 ### Ethereum Name Service (ENS) 以太坊域名服务 (ENS) {#ens}
 
@@ -194,7 +220,9 @@ ENS 注册表是一个单一总[合约](#smart-contract)，如 [EIP](#eip) 137 �
 
 ERC 是部分试图定义以太坊具体使用标准的[ EIP ](#eip)贴上的标签。
 
-<DocLink to="/eips/" title="EIP 简介" />
+<DocLink to="/eips/">
+  EIP 简介
+</DocLink>
 
 ### Ethash {#ethash}
 
@@ -206,19 +234,25 @@ ERC 是部分试图定义以太坊具体使用标准的[ EIP ](#eip)贴上的标
 
 以太坊生态系统中使用的原生加密货币，用来支付执行事务时的[ gas ](#gas)开销。 也被写作 ETH 或符号形式 Ξ，这是希腊字母 Xi 的大写。
 
-<DocLink to="/eth/" title="我们数字未来的货币" />
+<DocLink to="/eth/">
+  我们数字未来的货币
+</DocLink>
 
 ### events 事件 {#events}
 
 [EVM](#evm) 使用的日志工具。 [Dapps](#dapp) 可以监听事件，并在用户界面使用它们来触发 JavaScript 回调。
 
-<DocLink to="/developers/docs/smart-contracts/anatomy/#events-and-logs" title="事件（Events）和日志（Logs）" />
+<DocLink to="/developers/docs/smart-contracts/anatomy/#events-and-logs">
+  事件（Events）和日志（Logs）
+</DocLink>
 
 ### Ethereum Virtual Machine (EVM) 以太坊虚拟机 {#evm}
 
 可执行[字节码](#bytecode)的基于堆栈的虚拟机。 在以太坊，执行模型指定了在给定一系列字节码指令和一小组环境数据的情况下如何改变系统状态。 这是通过虚拟状态机的正式模型指定的。
 
-<DocLink to="/developers/docs/evm/" title="以太坊虚拟机（Evm）" />
+<DocLink to="/developers/docs/evm/">
+  以太坊虚拟机（Evm）
+</DocLink>
 
 ### EVM assembly language EVM 汇编语言 {#evm-assembly-language}
 
@@ -236,13 +270,19 @@ ERC 是部分试图定义以太坊具体使用标准的[ EIP ](#eip)贴上的标
 
 通过[智能合约](#smart-contract)，免费提供测试网可用的测试以太币的服务
 
-<DocLink to="/developers/docs/networks/#testnet-faucets" title="测试网水龙头" />
+<DocLink to="/developers/docs/networks/#testnet-faucets">
+  测试网水龙头
+</DocLink>
 
 ### finality 终局性 {#finality}
 
 终局性是保证在指定时间之前的一组交易不会被改变且无法撤销。
 
-<DocLink to="/developers/docs/consensus-mechanisms/pow/#finality" title="工作量证明的终局性" /> <DocLink to="/developers/docs/consensus-mechanisms/pos/#finality" title="权益证明的终局性" />
+<DocLink to="/developers/docs/consensus-mechanisms/pow/#finality">
+  工作量证明的终局性
+</DocLink> <DocLink to="/developers/docs/consensus-mechanisms/pos/#finality">
+  权益证明的终局性
+</DocLink>
 
 ### finney {#finney}
 
@@ -256,7 +296,9 @@ ERC 是部分试图定义以太坊具体使用标准的[ EIP ](#eip)贴上的标
 
 [二层](#layer-2)解决方案的安全模型，为了提高交易速度，交易 [合并](#rollups) 在单笔交易中提交到以太坊中。 交易默认假定为是有效的，但如果怀疑有欺诈行为，可以对它们提出质疑。 然后，对交易进行欺诈证明，以确定是否发生欺诈。 这种方法提升了交易量，同时保证安全性。 一些 [rollup](#rollups) 使用的是 [欺诈证明](#validity-proof)。
 
-<DocLink to="/developers/docs/layer-2-scaling/#optimistic-rollups" title="Optimistic Rollup" />
+<DocLink to="/developers/docs/layer-2-scaling/#optimistic-rollups">
+  Optimistic Rollup
+</DocLink>
 
 ### frontier {#frontier}
 
@@ -270,7 +312,9 @@ ERC 是部分试图定义以太坊具体使用标准的[ EIP ](#eip)贴上的标
 
 以太坊网络中为执行智能合约所消耗的虚拟 “燃油”。 以太坊[虚拟机](#evm)使用一种记账方法来衡量 gas 用量，以限制算力资源（参见[图灵完备](#turing-complete)）的消耗。
 
-<DocLink to="/developers/docs/gas/" title="Gas 和费用" />
+<DocLink to="/developers/docs/gas/">
+  Gas 和费用
+</DocLink>
 
 ### gas limit gas 上限 {#gas-limit}
 
@@ -332,13 +376,17 @@ Gigawei 的缩写，[ether](#ether) 的一个货币单位，通常用于计算 [
 
 将代码编辑器、编译器、运行时和调试器合并的用户界面。
 
-<DocLink to="/developers/docs/ides/" title="集成开发环境 (IDE）" />
+<DocLink to="/developers/docs/ides/">
+  集成开发环境 (IDE）
+</DocLink>
 
 ### immutable deployed code problem 已部署代码不可变的问题 {#immutable-deployed-code-problem}
 
 [合约](#smart-contract)（或[库](#library)）的代码一旦部署，它就不可变更了。 传统标准软件开发习惯于能够修复可能的缺陷并增加新的功能，但这是对智能合约的开发是一个挑战。
 
-<DocLink to="/developers/docs/smart-contracts/deploying/" title="部署智能合约" />
+<DocLink to="/developers/docs/smart-contracts/deploying/">
+  部署智能合约
+</DocLink>
 
 ### internal transaction 内部交易 {#internal-transaction}
 
@@ -352,7 +400,9 @@ Gigawei 的缩写，[ether](#ether) 的一个货币单位，通常用于计算 [
 
 也称为密钥延伸算法，通过[密钥库](#keystore-file)文件格式来防止暴力破解，防止攻击者预先计算派生密钥的字典或 “彩虹表”，通过重复计算密令的哈希来实现。
 
-<DocLink to="/developers/docs/smart-contracts/security/" title="安全性" />
+<DocLink to="/developers/docs/smart-contracts/security/">
+  安全性
+</DocLink>
 
 ### keccak-256 {#keccak-256}
 
@@ -370,7 +420,9 @@ Gigawei 的缩写，[ether](#ether) 的一个货币单位，通常用于计算 [
 
 在以太坊协议之上的聚焦与分层优化的开发实现。 这些改进关系到 [交易](#transaction) 速度、更便宜的 [交易费](#transaction-fee)以及交易隐私。
 
-<DocLink to="/developers/docs/layer-2-scaling/" title="二层" />
+<DocLink to="/developers/docs/layer-2-scaling/">
+  二层
+</DocLink>
 
 ### LevelDB {#level-db}
 
@@ -380,7 +432,9 @@ Gigawei 的缩写，[ether](#ether) 的一个货币单位，通常用于计算 [
 
 特殊类型的[合约](#smart-contract)， 没有 payable 函数，没有 fallback 函数，也没有数据存储。 因此，它不能接收或持有以太坊，也不能储存数据。 一个存储库代表以前部署的代码，其他合约只能进行只读调用。
 
-<DocLink to="/developers/docs/smart-contracts/libraries/" title="智能合约库" />
+<DocLink to="/developers/docs/smart-contracts/libraries/">
+  智能合约库
+</DocLink>
 
 ### lightweight client 轻量级客户端 {#lightweight-client}
 
@@ -414,7 +468,9 @@ Gigawei 的缩写，[ether](#ether) 的一个货币单位，通常用于计算 [
 
 通过不断做哈希运算，找到新区块的有效[工作量证明](#pow)的网络节点。
 
-<DocLink to="/developers/docs/consensus-mechanisms/pow/mining/" title="采矿" />
+<DocLink to="/developers/docs/consensus-mechanisms/pow/mining/">
+  采矿
+</DocLink>
 
 <Divider />
 
@@ -424,21 +480,29 @@ Gigawei 的缩写，[ether](#ether) 的一个货币单位，通常用于计算 [
 
 指以太坊网络，一个对等网络向每个以太坊节点（网络参与者）推广交易和块。
 
-<DocLink to="/developers/docs/networks/" title="Networks 网络" />
+<DocLink to="/developers/docs/networks/">
+  Networks 网络
+</DocLink>
 
 ### non-fungible token (NFT) 非同质化代币 {#nft}
 
 也叫 “所有权证书” 或 “权证”，是由 ERC721 议案提出的代币标准。 NFT 能够被追溯也可以交易，每个代币是唯一且独一无二的，不像 ERC20 代币，每个 NFT 都是无法互换的。 NFT 能够代表数字或物理资产的所有权。
 
-<DocLink to="/developers/docs/standards/tokens/erc-721/" title="ERC-721 非同质化代币标准" />
+<DocLink to="/developers/docs/standards/tokens/erc-721/">
+  ERC-721 非同质化代币标准
+</DocLink>
 
 ### node 节点 {#node}
 
 参与点对点网络的软件客户端。
 
-<DocLink to="/developers/docs/nodes-and-clients/" title="节点和客户端" />
+<DocLink to="/developers/docs/nodes-and-clients/">
+  节点和客户端
+</DocLink>
 
-<DocLink to="/developers/docs/nodes-and-clients/" title="节点和客户端" />
+<DocLink to="/developers/docs/nodes-and-clients/">
+  节点和客户端
+</DocLink>
 
 ### nonce {#nonce}
 
@@ -456,7 +520,9 @@ Gigawei 的缩写，[ether](#ether) 的一个货币单位，通常用于计算 [
 
 [Rollup](#rollups) 交易使用 [欺诈证明](#fraud-proof) 提供增加[二层](#layer-2)的交易吞吐量，同时使用[主网](#mainnet)（一层）提供的安全保障。 与 [Plasma](#plasma)（一个类似的二层的解决方案）不同， Optimistic rollup 可以处理更复杂的交易类型 -- [EVM](#evm) 中任何可能的事情。 与 [Zk Rollup](#zk-rollups) 相比，他们确实有延迟问题，因为交易可以通过欺诈证据被质疑。
 
-<DocLink to="/developers/docs/layer-2-scaling/#optimistic-rollups" title="Optimistic Rollup" />
+<DocLink to="/developers/docs/layer-2-scaling/#optimistic-rollups">
+  Optimistic Rollup
+</DocLink>
 
 <Divider />
 
@@ -470,7 +536,9 @@ Gigawei 的缩写，[ether](#ether) 的一个货币单位，通常用于计算 [
 
 [二层](#layer-2)使用[欺诈校验](#fraud-proof)的扩容解决方案，例如 [Optimistic rollup](#optimistic-rollups)。 Plasma 仅限于简单的交易，例如基本令牌传输和交换。
 
-<DocLink to="/developers/docs/layer-2-scaling/#Plasma" title="以太坊 Plasma 扩容解决方案" />
+<DocLink to="/developers/docs/layer-2-scaling/#Plasma">
+  以太坊 Plasma 扩容解决方案
+</DocLink>
 
 ### private key (secret key) 私钥（密钥） {#private-key}
 
@@ -480,13 +548,17 @@ Gigawei 的缩写，[ether](#ether) 的一个货币单位，通常用于计算 [
 
 在区块链中实现分布式[共识](#consensus)的方法。 PoS 要求用户证明自己拥有一定数量的加密货币（在网络中“质押”），以便能够参与交易的验证。
 
-<DocLink to="/developers/docs/consensus-mechanisms/pos/" title="权益证明（PoS）" />
+<DocLink to="/developers/docs/consensus-mechanisms/pos/">
+  权益证明（PoS）
+</DocLink>
 
 ### proof of work (PoW) 工作量证明 {#pow}
 
 需要大量计算才能得出的数据（证明）。 在以太坊中， [矿工](#miner) 必须找到符合整个网络范围的 [算力难度](#difficulty) 目标的 [Ethash](#ethash) 算法的数值。
 
-<DocLink to="/developers/docs/consensus-mechanisms/pow/" title="工作量证明（PoW)" />
+<DocLink to="/developers/docs/consensus-mechanisms/pow/">
+  工作量证明（PoW)
+</DocLink>
 
 ### public key 公钥 {#public-key}
 
@@ -504,7 +576,9 @@ Gigawei 的缩写，[ether](#ether) 的一个货币单位，通常用于计算 [
 
 攻击者合约调用受害者合约函数，使得在调用执行过程中受害者合约会循环调用攻击者合约。 这可能导致通过跳过受害者合约的余额更新或提款金额计算的部分来盗窃资金。
 
-<DocLink to="/developers/docs/smart-contracts/security/#re-entrancy" title="重入攻击" />
+<DocLink to="/developers/docs/smart-contracts/security/#re-entrancy">
+  重入攻击
+</DocLink>
 
 ### reward 区块奖励 {#reward}
 
@@ -518,7 +592,9 @@ Gigawei 的缩写，[ether](#ether) 的一个货币单位，通常用于计算 [
 
 一种[二层](#layer-2)扩容解决方案，将多笔交易分批提交到[以太坊主链](#mainnet)的单笔交易中。 这就可以降低 [gas](#gas) 成本，增加[交易](#transaction)吞吐量。 有些 Optimistic 和 ZK Rollup 使用两种不同的安全方法来提供扩容能力。
 
-<DocLink to="/developers/docs/layer-2-scaling/#rollups" title="Rollup" />
+<DocLink to="/developers/docs/layer-2-scaling/#rollups">
+  Rollup
+</DocLink>
 
 <Divider />
 
@@ -528,7 +604,9 @@ Gigawei 的缩写，[ether](#ether) 的一个货币单位，通常用于计算 [
 
 以太坊第四个也是最后一个开发阶段。
 
-<DocLink to="/eth2/" title="以太坊 2.0（Eth2）" />
+<DocLink to="/eth2/">
+  以太坊 2.0（Eth2）
+</DocLink>
 
 ### Secure Hash Algorithm (SHA) 安全哈希算法 {#sha}
 
@@ -538,13 +616,17 @@ Gigawei 的缩写，[ether](#ether) 的一个货币单位，通常用于计算 [
 
 由[信标链](#beacon-chain)管理并由[验证者](#validator)保护的[权益证明](#proof-of-stake)链。 作为 Eth2 分片链升级的一部分，将有 64 个加入该网络。 分片链为[二层](#layer-2)解决方案提供额外数据，例如为 [optimistic rollup](#optimistic-rollups) 和 [ZK rollup](#zk-rollups) 提供额外的交易吞吐量。
 
-<DocLink to="/eth2/shard-chains" title="分片链" />
+<DocLink to="/eth2/shard-chains">
+  分片链
+</DocLink>
 
 ### Sidechain 侧链 {#sidechain}
 
 一个使用不同链、常常更快的[协商一致规则]{#consensus-rules} 的扩容解决方案。 需要桥来连接这些侧链到 [mainnet](#mainnet)。 [Rollup](#rollups) 也使用侧链，但是他们可以与[主网](#mainnet)进行操作。
 
-<DocLink to="/developers/docs/layer-2-scaling/#sidechains" title="侧链" />
+<DocLink to="/developers/docs/layer-2-scaling/#sidechains">
+  侧链
+</DocLink>
 
 ### singleton 单例 {#singleton}
 
@@ -554,19 +636,25 @@ Gigawei 的缩写，[ether](#ether) 的一个货币单位，通常用于计算 [
 
 一个时间段（12 秒），在这个时间段内，[验证者](#validator)可以在[权益证明](#proof-of-stake)系统中提出一个新的[信标链](#beacon-chain)和[分片](#shard)链区块。 一个插槽有可能是空的。 32 个插槽构成一个 [epoch](#epoch)。
 
-<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work" title="权益证明" />
+<DocLink to="/developers/docs/consensus-mechanisms/pos/#how-does-validation-work">
+  权益证明
+</DocLink>
 
 ### smart contract 智能合约 {#smart-contract}
 
 在以太坊计算基础框架上执行的程序。
 
-<DocLink to="/developers/docs/smart-contracts/" title="智能合约简介" />
+<DocLink to="/developers/docs/smart-contracts/">
+  智能合约简介
+</DocLink>
 
 ### Solidity {#solidity}
 
 一种语法类似 JavaScript、C++ 或 Java 的程序化（命令式）编程语言， 是用于编写以太坊[智能合约](#smart-contract)的最流行也最常用的编程语言。 由 Gavin Wood 博士创建。
 
-<DocLink to="/developers/docs/smart-contracts/languages/#solidity" title="Solidity" />
+<DocLink to="/developers/docs/smart-contracts/languages/#solidity">
+  Solidity
+</DocLink>
 
 ### Solidity 内联汇编 {#solidity-inline-assembly}
 
@@ -580,19 +668,25 @@ Gigawei 的缩写，[ether](#ether) 的一个货币单位，通常用于计算 [
 
 一种 [ERC-20 代币](#token-standard)，其价值与另一种资产的价值锚定。 稳定币的锚定资产包括法币（如美元），贵金属（如黄金）以及其他加密货币（如比特币）。
 
-<DocLink to="/eth/#tokens" title="ETH 不是以太坊上唯一的加密货币" />
+<DocLink to="/eth/#tokens">
+  ETH 不是以太坊上唯一的加密货币
+</DocLink>
 
 ### staking 权益质押 {#staking}
 
 存入一定量的 [ether](#ether)（质押金）成为验证者并参与维护[以太坊网络](#network)。 验证者在 [proof-of-stake（权益证明）](#pos) 共识模型中检查 [交易](#transaction) 并且提议 [区块](#block)。 质押能够为符合网络利益的行为提供经济激励。 你将会因为履行[验证者](#validator)义务而获得奖励，反之将损失一定量的 ETH。
 
-<DocLink to="/eth2/staking/" title="质押您的 ETH 并成为以太坊验证者" />
+<DocLink to="/eth2/staking/">
+  质押您的 ETH 并成为以太坊验证者
+</DocLink>
 
 ### state channels 状态通道 {#state-channels}
 
 一种[二层](#layer-2)解决方案，在参与者之间设置一个通道，他们可以在通道中自由交易且成本低廉。 只有开设和关闭通道的[交易](#transaction)被提交到 [主网](#mainnet)。 这使得交易吞吐量大幅提升，但依赖于已知的参与人数和锁定资金。
 
-<DocLink to="/developers/docs/layer-2-scaling/#state-channels" title="状态通道" />
+<DocLink to="/developers/docs/layer-2-scaling/#state-channels">
+  状态通道
+</DocLink>
 
 ### szabo {#szabo}
 
@@ -610,19 +704,25 @@ Gigawei 的缩写，[ether](#ether) 的一个货币单位，通常用于计算 [
 
 "测试网络"的简称，用于模拟以太坊主网行为的网络（参阅 [mainnet 主网](#mainnet)）。
 
-<DocLink to="/developers/docs/networks/#testnets" title="测试网" />
+<DocLink to="/developers/docs/networks/#testnets">
+  测试网
+</DocLink>
 
 ### token standard 代币标准 {#token-standard}
 
 由 ERC-20 提案引入，为同质化代币（fungible tokens）提供了标准化的 [智能合约](#smart-contract) 结构。 不同于 [NFT（非同质化代币）](#nft)，同一合约中的代币可以被追踪、交易及置换。
 
-<DocLink to="/developers/docs/standards/tokens/erc-20/" title="ERC-20 代币标准" />
+<DocLink to="/developers/docs/standards/tokens/erc-20/">
+  ERC-20 代币标准
+</DocLink>
 
 ### transaction 交易 {#transaction}
 
 由一个原始[帐户](#account)签署并以一个特定地址为目标的提交到以太坊区块链上的数据， 该交易包含交易[ gas 上限](#gas-limit)等元数据。
 
-<DocLink to="/developers/docs/transactions/" title="交易" />
+<DocLink to="/developers/docs/transactions/">
+  交易
+</DocLink>
 
 ### transaction fee 交易费 {#transaction-fee}
 
@@ -644,25 +744,35 @@ Gigawei 的缩写，[ether](#ether) 的一个货币单位，通常用于计算 [
 
 [权益证明](#proof-of-stake)系统中的[节点](#node)，负责存储数据、处理交易并且在区块链中添加新区块。 要激活一名验证者，需要[质押](#staking) 32 ETH。
 
-<DocLink to="/developers/docs/consensus-mechanisms/pos" title="权益证明" /> <DocLink to="/eth2/staking/" title="质押" />
+<DocLink to="/developers/docs/consensus-mechanisms/pos">
+  权益证明
+</DocLink> <DocLink to="/eth2/staking/">
+  质押
+</DocLink>
 
 ### Validity proof 有效性证明 {#validity-proof}
 
 某些[二层](#layer-2)解决方案的安全模型，以提高速度，交易 [合并](/#rollups)为交易批并在单次交易中提交到以太坊。 交易计算在链下进行，然后提交给主链，并附带有效性证明。 这种方法提升了交易量，同时保证安全性。 一些 [rollup](#rollups) 使用的是[欺诈证明](#fraud-proof)。
 
-<DocLink to="/developers/docs/layer-2-scaling/#zk-rollups" title="ZK Rollup" />
+<DocLink to="/developers/docs/layer-2-scaling/#zk-rollups">
+  ZK Rollup
+</DocLink>
 
 ### Validium {#validium}
 
 [二层](#layer-2)解决方案，使用[有效性证明](#validity-proof)来提高交易吞吐量。 与[ZK Rollup](#zk-rollup)不同，Validium 的数据没有存储在一层[主网](#mainnet)中。
 
-<DocLink to="/developers/docs/layer-2-scaling/#validium" title="Validium" />
+<DocLink to="/developers/docs/layer-2-scaling/#validium">
+  Validium
+</DocLink>
 
 ### Vyper {#vyper}
 
 高层次的编程语言与，语法与 Python 类似。 旨在更接近纯函数式语言。 由 Vitalik Buterin 创造。
 
-<DocLink to="/developers/docs/smart-contracts/languages/#vyper" title="Vyper" />
+<DocLink to="/developers/docs/smart-contracts/languages/#vyper">
+  Vyper
+</DocLink>
 
 <Divider />
 
@@ -672,13 +782,17 @@ Gigawei 的缩写，[ether](#ether) 的一个货币单位，通常用于计算 [
 
 保存用户[密钥](#private-key)的软件， 可以用来访问并管理你的以太坊[帐户](#account)并与[智能合约](#smart-contract)交互。 密钥不一定要存储在钱包中，为了提高安全性，可以离线存储（如写在一张记忆卡或者纸上）。 虽然称其为 “钱包”，但它并不存储代币本身。
 
-<DocLink to="/wallets/" title="以太坊钱包" />
+<DocLink to="/wallets/">
+  以太坊钱包
+</DocLink>
 
 ### Web3 {#web3}
 
 万维网的第三个版本。 由 Gavin Wood 博士首次提议，代表了对网络应用的新愿景与新焦点：从中心化所有并管理的应用转移到在[去中心化协议](#dapp))上构建的应用。
 
-<DocLink to="/developers/docs/web2-vs-web3/" title="Web2 与 Web3 对比" />
+<DocLink to="/developers/docs/web2-vs-web3/">
+  Web2 与 Web3 对比
+</DocLink>
 
 ### wei {#wei}
 
@@ -696,7 +810,9 @@ Gigawei 的缩写，[ether](#ether) 的一个货币单位，通常用于计算 [
 
 使用[有效性证明的交易[rollup](#rollups)](#validity-proof)以在使用[主网](#mainnet)（一层）安全性的同时提高[二层](#layer-2)交易吞吐量。 虽然他们无法处理复杂的交易类型，如 [Optimistic rollup](#optimistic-rollups)，但没有延迟问题，因为提交交易时可以证明有效。
 
-<DocLink to="/developers/docs/layer-2-scaling/#zk-rollups" title="ZK Rollup" />
+<DocLink to="/developers/docs/layer-2-scaling/#zk-rollups">
+  ZK Rollup
+</DocLink>
 
 <Divider />
 

--- a/src/content/translations/zh/history/index.md
+++ b/src/content/translations/zh/history/index.md
@@ -35,7 +35,9 @@ isOutdated: true
 
 [请阅读以太坊基金会公告](https://blog.ethereum.org/2020/11/27/eth2-quick-update-no-21/)
 
-<DocLink to="/eth2/beacon-chain/" title="信标链" />
+<DocLink to="/eth2/beacon-chain/">
+  信标链
+</DocLink>
 
 ---
 
@@ -49,7 +51,9 @@ isOutdated: true
 
 [请阅读以太坊基金会公告](https://blog.ethereum.org/2020/11/04/eth2-quick-update-no-19/)
 
-<DocLink to="/eth2/staking/" title="权益质押" />
+<DocLink to="/eth2/staking/">
+  权益质押
+</DocLink>
 
 ---
 
@@ -308,4 +312,6 @@ Gavin Wood 博士撰写的黄皮书，是关于以太坊协议的技术定义。
 
 该项目在 2015 年启动。但早在 2013 年，以太坊的创始人 Vitalik Buterin 就发表了介绍性文章。
 
-<DocLink to="/whitepaper/" title="白皮书" />
+<DocLink to="/whitepaper/">
+  白皮书
+</DocLink>

--- a/src/intl/en/page-dapps.json
+++ b/src/intl/en/page-dapps.json
@@ -84,6 +84,8 @@
   "page-dapps-dapp-description-token-sets": "Crypto investment strategies that automatically rebalance.",
   "page-dapps-dapp-description-tornado-cash": "Send anonymous transactions on Ethereum.",
   "page-dapps-dapp-description-uniswap": "Swap tokens simply or provide tokens for % rewards.",
+  "page-dapps-docklink-dapps": "Intro to dapps",
+  "page-dapps-docklink-smart-contracts": "Smart contracts",
   "page-dapps-dark-forest-logo-alt": "Dark Forest logo",
   "page-dapps-decentraland-logo-alt": "Decentraland logo",
   "page-dapps-index-coop-logo-alt": "Index Coop logo",

--- a/src/pages-conditional/dapps.js
+++ b/src/pages-conditional/dapps.js
@@ -292,8 +292,6 @@ const AddDappButton = styled(ButtonLink)`
   }
 `
 
-const StyledDocLink = styled(DocLink)``
-
 const StyledCallout = styled(Callout)`
   flex: 1 1 416px;
   min-height: 100%;
@@ -1627,14 +1625,12 @@ const DappsPage = ({ data, location }) => {
             <p>
               <Translation id="page-dapps-how-dapps-work-p3" />
             </p>
-            <StyledDocLink
-              to="/developers/docs/dapps/"
-              title="Intro to dapps"
-            />
-            <StyledDocLink
-              to="/developers/docs/smart-contracts/"
-              title="Smart contracts"
-            />
+            <DocLink to="/developers/docs/dapps/">
+              <Translation id="page-dapps-docklink-dapps" />
+            </DocLink>
+            <DocLink to="/developers/docs/smart-contracts/">
+              <Translation id="page-dapps-docklink-smart-contracts" />
+            </DocLink>
           </LeftColumn>
           <RightColumn>
             <StyledCallout


### PR DESCRIPTION
## Description
- Change `DocLink` to take the title as a child to the component
- Allows using as `block` component within markdown by splitting syntax over three lines
- Updates all usage of this component with new syntax
