### PR TITLE
Fix buggy markdown link syntax

### DIFF
--- a/src/content/translations/es/glossary/index.md
+++ b/src/content/translations/es/glossary/index.md
@@ -542,7 +542,7 @@ Una cadena de [prueba de participación](#proof-of-stake) coordinada por la [cad
 
 ### Sidechain {#sidechain}
 
-Una solución de escalado que usa una cadena separada con diferentes [reglas de consenso]{#consensus-rules}. Se precisa un puente para conectar estas sidechains a la [red principal](#mainnet). Los [Rollups](#rollups) también usan sidechains, pero trabajan en colaboración con la [red principal](#mainnet).
+Una solución de escalado que usa una cadena separada con diferentes [reglas de consenso](#consensus-rules). Se precisa un puente para conectar estas sidechains a la [red principal](#mainnet). Los [Rollups](#rollups) también usan sidechains, pero trabajan en colaboración con la [red principal](#mainnet).
 
 <DocLink to="/developers/docs/layer-2-scaling/#sidechains" title="Sidechains" />
 

--- a/src/content/translations/fr/glossary/index.md
+++ b/src/content/translations/fr/glossary/index.md
@@ -542,7 +542,7 @@ Chaîne de [preuve d'enjeu](#proof-of-stake) coordonnée par la [chaîne phare](
 
 ### chaînes latérales {#sidechain}
 
-Solution d'évolutivité qui utilise une chaîne séparée avec des [règles de consensus]{#consensus-rules} différentes, souvent plus rapides. Un pont est nécessaire pour connecter ces chaînes latérales au [réseau principal](#mainnet). Les [rollups](#rollups) utilisent également les chaînes latérales, mais ils fonctionnent en collaboration avec le [réseau principal](#mainnet) à la place.
+Solution d'évolutivité qui utilise une chaîne séparée avec des [règles de consensus](#consensus-rules) différentes, souvent plus rapides. Un pont est nécessaire pour connecter ces chaînes latérales au [réseau principal](#mainnet). Les [rollups](#rollups) utilisent également les chaînes latérales, mais ils fonctionnent en collaboration avec le [réseau principal](#mainnet) à la place.
 
 <DocLink to="/developers/docs/layer-2-scaling/#sidechains" title="chaînes latérales" />
 

--- a/src/content/translations/hu/glossary/index.md
+++ b/src/content/translations/hu/glossary/index.md
@@ -542,7 +542,7 @@ Egy [proof-of-stake](#proof-of-stake) lánc, melyet a [Beacon Chain](#beacon-cha
 
 ### Sidechain (melléklánc) {#sidechain}
 
-Egy skálázási megoldás, mely egy különálló láncot használ másfajta, gyakran gyorsabb, [konszenzus szabályokkal]{#consensus-rules}. Egy áthidalás szükséges, hogy ezek a mellékláncok a [főhálózathoz](#mainnet) csatlakozzanak. Az [összegzők](#rollups) szintén mellékláncokat használnak, de ehelyett a [főhálózattal](#mainnet) együttműködve teszik ezt.
+Egy skálázási megoldás, mely egy különálló láncot használ másfajta, gyakran gyorsabb, [konszenzus szabályokkal](#consensus-rules). Egy áthidalás szükséges, hogy ezek a mellékláncok a [főhálózathoz](#mainnet) csatlakozzanak. Az [összegzők](#rollups) szintén mellékláncokat használnak, de ehelyett a [főhálózattal](#mainnet) együttműködve teszik ezt.
 
 <DocLink to="/developers/docs/layer-2-scaling/#sidechains" title="Mellékláncok" />
 

--- a/src/content/translations/it/glossary/index.md
+++ b/src/content/translations/it/glossary/index.md
@@ -542,7 +542,7 @@ Catena [proof-of-stake](#proof-of-stake) coordinata dalla [beacon chain](#beacon
 
 ### sidechain {#sidechain}
 
-Soluzione per la scalabilità che utilizza una catena separata con [regole di consenso]{#consensus-rules} diverse e spesso più veloci. Per collegare queste sidechain alla [rete principale](#mainnet) è necessario un bridge. Anche i [rollup](#rollups) utilizzano le sidechain, ma operano in collaborazione con la [rete principale](#mainnet).
+Soluzione per la scalabilità che utilizza una catena separata con [regole di consenso](#consensus-rules) diverse e spesso più veloci. Per collegare queste sidechain alla [rete principale](#mainnet) è necessario un bridge. Anche i [rollup](#rollups) utilizzano le sidechain, ma operano in collaborazione con la [rete principale](#mainnet).
 
 <DocLink to="/developers/docs/layer-2-scaling/#sidechains" title="Sidechain" />
 

--- a/src/content/translations/zh/glossary/index.md
+++ b/src/content/translations/zh/glossary/index.md
@@ -542,7 +542,7 @@ Gigawei 的缩写，[ether](#ether) 的一个货币单位，通常用于计算 [
 
 ### Sidechain 侧链 {#sidechain}
 
-一个使用不同链、常常更快的[协商一致规则]{#consensus-rules} 的扩容解决方案。 需要桥来连接这些侧链到 [mainnet](#mainnet)。 [Rollup](#rollups) 也使用侧链，但是他们可以与[主网](#mainnet)进行操作。
+一个使用不同链、常常更快的[协商一致规则](#consensus-rules) 的扩容解决方案。 需要桥来连接这些侧链到 [mainnet](#mainnet)。 [Rollup](#rollups) 也使用侧链，但是他们可以与[主网](#mainnet)进行操作。
 
 <DocLink to="/developers/docs/layer-2-scaling/#sidechains" title="侧链" />
 


### PR DESCRIPTION
## Description
Fixes syntax for a markdown link on the intl glossary pages.

## Related Issue
None filed.
![image](https://user-images.githubusercontent.com/54227730/146599350-0d206bf9-c141-4dd9-a290-94ca86b27292.png)
Taken from https://ethereum.org/zh/glossary/#sidechain