### PR TITLE
Update definition of wallet in developer docs for accounts

### DIFF
--- a/src/content/developers/docs/accounts/index.md
+++ b/src/content/developers/docs/accounts/index.md
@@ -126,7 +126,7 @@ For dapp development, you'll want access to dummy accounts with test ETH so you 
 
 ## A note on wallets {#a-note-on-wallets}
 
-An account is not a wallet. An account is the keypair for a user-owned Ethereum account. A wallet is an application that lets you interact with your Ethereum account.
+An account is not a wallet. An account is the keypair for a user-owned Ethereum account. A wallet is an interface or application that lets you interact with your Ethereum account.
 
 ## A visual demo {#a-visual-demo}
 

--- a/src/content/developers/docs/accounts/index.md
+++ b/src/content/developers/docs/accounts/index.md
@@ -126,7 +126,7 @@ For dapp development, you'll want access to dummy accounts with test ETH so you 
 
 ## A note on wallets {#a-note-on-wallets}
 
-An account is not a wallet. A wallet is the keypair associated with a user-owned account, which allows a user to make transactions from or manage the account.
+An account is not a wallet. An account is the keypair for a user-owned Ethereum account. A wallet is an application that lets you interact with your Ethereum account.
 
 ## A visual demo {#a-visual-demo}
 


### PR DESCRIPTION
## Description
This PR updates the definition of a wallet to more closely match terminology commonly used. The conflicting definitions of wallets on the Ethereum website are confusing for new users to Ethereum. This change creates consistency between the pages https://ethereum.org/en/wallets and https://ethereum.org/en/developers/docs/accounts/#a-note-on-wallets for wallet definitions.

<!--- Describe your changes in detail -->

Updates the definition at https://ethereum.org/en/developers/docs/accounts/#a-note-on-wallets from

> An account is not a wallet. A wallet is the keypair associated with a user-owned account, which allows a user to make transactions from or manage the account.

to

> An account is not a wallet. An account is the keypair for a user-owned Ethereum account. A wallet is an application that lets you interact with your Ethereum account.



## Related Issue
#4821 
