### PR TITLE
remove 'Offchain Labs Arbitrum SCSC' from hybrid rollup solutions

### DIFF
--- a/src/content/developers/docs/scaling/layer-2-rollups/index.md
+++ b/src/content/developers/docs/scaling/layer-2-rollups/index.md
@@ -130,7 +130,6 @@ Hybrid solutions exist that combine the best parts of multiple layer 2 technolog
 
 ### Use hybrid solutions {#use-hybrid-solutions}
 
-- [Offchain Labs Arbitrum SCSC](https://offchainlabs.com/arbitrum.pdf)
 - [Celer](https://www.celer.network/)
 
 ## Further reading {#further-reading}

--- a/src/content/enterprise/index.md
+++ b/src/content/enterprise/index.md
@@ -108,7 +108,6 @@ Examples of L2 solutions that are production ready or will be soon include:
   - [Skale](https://skale.network)
   - [POA Network](https://www.poa.network/)
 - Hybrid solutions that combine properties of multiple categories
-  - [Offchain Labs Arbitrum SCSC](https://offchainlabs.com/arbitrum.pdf)
   - [Celer](https://celer.network)
 
 ## Enterprise applications live on Mainnet {#enterprise-live-on-mainnet}

--- a/src/content/translations/es/developers/docs/layer-2-scaling/index.md
+++ b/src/content/translations/es/developers/docs/layer-2-scaling/index.md
@@ -221,7 +221,6 @@ Combinan las mejores partes de las tecnologías múltiples de capa 2 y pueden of
 
 ### Usos de las soluciones híbridas {#use-hybrid-solutions}
 
-- [Offchain Labs Arbitrum Rollup](https://offchainlabs.com/arbitrum.pdf)
 - [Celer](https://www.celer.network/)
 
 ## Para seguir leyendo {#further-reading}

--- a/src/content/translations/es/enterprise/index.md
+++ b/src/content/translations/es/enterprise/index.md
@@ -102,7 +102,6 @@ Ejemplos de soluciones L2 (de Capa 2) que están listas para la producción o qu
   - [Skale](https://skale.network)
   - [Red POA](https://www.poa.network/)
 - Soluciones híbridas que combinan propiedades de múltiples categorías
-  - [Offchain Labs Arbitrum SCSC](https://https://offchainlabs.com/arbitrum.pdf)
   - [Celer](https://celer.network)
 
 ## Aplicaciones empresariales en vivo en la red principal {#enterprise-live-on-mainnet}

--- a/src/content/translations/fr/developers/docs/layer-2-scaling/index.md
+++ b/src/content/translations/fr/developers/docs/layer-2-scaling/index.md
@@ -221,7 +221,6 @@ Combine les meilleures parties des multiples technologies de couche 2, et peut o
 
 ### Solutions hybrides que vous pouvez utiliser {#use-hybrid-solutions}
 
-- [Offchain Labs Arbitrum SCSC](https://offchainlabs.com/arbitrum.pdf)
 - [Celer](https://www.celer.network/)
 
 ## Complément d'information {#further-reading}

--- a/src/content/translations/fr/enterprise/index.md
+++ b/src/content/translations/fr/enterprise/index.md
@@ -102,7 +102,6 @@ Voici quelques exemples de solutions L2 prêtes pour la production ou qui le ser
   - [Skale](https://skale.network)
   - [POA Network](https://www.poa.network/)
 - Solutions hybrides qui combinent les propriétés de plusieurs catégories
-  - [Offchain Labs Arbitrum SCSC](https://https://offchainlabs.com/arbitrum.pdf)
   - [Celer](https://celer.network)
 
 ## Applications d'entreprise live sur le réseau principal {#enterprise-live-on-mainnet}

--- a/src/content/translations/hu/developers/docs/layer-2-scaling/index.md
+++ b/src/content/translations/hu/developers/docs/layer-2-scaling/index.md
@@ -221,7 +221,6 @@ Kombinálja a többrétegű technológiák legjobb tulajdonságait, és konfigur
 
 ### Hibrid megoldások használata {#use-hybrid-solutions}
 
-- [Offchain Labs Arbitrum SCSC](https://offchainlabs.com/arbitrum.pdf)
 - [Celer](https://www.celer.network/)
 
 ## További olvasnivaló {#further-reading}

--- a/src/content/translations/hu/enterprise/index.md
+++ b/src/content/translations/hu/enterprise/index.md
@@ -102,7 +102,6 @@ Példák L2 megoldásokra, melyek produkcióra készek, vagy hamarosan készen l
   - [Skale](https://skale.network)
   - [POA Network](https://www.poa.network/)
 - Hibrid megoldások, amelyek több kategória tulajdonságait ötvözik
-  - [Offchain Labs Arbitrum SCSC](https://https://offchainlabs.com/arbitrum.pdf)
   - [Celer](https://celer.network)
 
 ## Vállalati alkalmazások a főhálózaton {#enterprise-live-on-mainnet}

--- a/src/content/translations/it/developers/docs/layer-2-scaling/index.md
+++ b/src/content/translations/it/developers/docs/layer-2-scaling/index.md
@@ -221,7 +221,6 @@ Combinano le parti migliori di diverse tecnologie di livello 2 e possono offrire
 
 ### Usano soluzioni Ibride {#use-hybrid-solutions}
 
-- [Offchain Labs Arbitrum SCSC](https://offchainlabs.com/arbitrum.pdf)
 - [Celer](https://www.celer.network/)
 
 ## Letture consigliate {#further-reading}

--- a/src/content/translations/it/enterprise/index.md
+++ b/src/content/translations/it/enterprise/index.md
@@ -102,7 +102,6 @@ Esempi di soluzioni L2 già pronte per la produzione (o che lo saranno presto) i
   - [Skale](https://skale.network)
   - [POA Network](https://www.poa.network/)
 - Soluzioni ibride che combinano le proprietà di più categorie
-  - [Offchain Labs Arbitrum SCSC](https://https://offchainlabs.com/arbitrum.pdf)
   - [Celer](https://celer.network)
 
 ## Applicazioni aziendali attive sulla rete principale {#enterprise-live-on-mainnet}

--- a/src/content/translations/pl/developers/docs/scaling/layer-2-rollups/index.md
+++ b/src/content/translations/pl/developers/docs/scaling/layer-2-rollups/index.md
@@ -114,7 +114,6 @@ Istnieją rozwiązania hybrydowe, które łączą w sobie najlepsze elementy wie
 
 ### Używanie rozwiązań hybrydowych {#use-hybrid-solutions}
 
-- [Offchain Labs Arbitrum SCSC](https://offchainlabs.com/arbitrum.pdf)
 - [Celer](https://www.celer.network/)
 
 ## Dalsza lektura {#further-reading}

--- a/src/content/translations/pl/enterprise/index.md
+++ b/src/content/translations/pl/enterprise/index.md
@@ -102,7 +102,6 @@ Przykłady rozwiązań L2, które są gotowe do produkcji lub wkrótce będą:
   - [Skale](https://skale.network)
   - [Sieć POA](https://www.poa.network/)
 - Rozwiązania hybrydowe łączące właściwości wielu kategorii
-  - [Offchain Labs Arbitrum SCSC](https://https://offchainlabs.com/arbitrum.pdf)
   - [Celer](https://celer.network)
 
 ## Aplikacje korporacyjne działają w sieci głównej {#enterprise-live-on-mainnet}

--- a/src/content/translations/ro/developers/docs/layer-2-scaling/index.md
+++ b/src/content/translations/ro/developers/docs/layer-2-scaling/index.md
@@ -221,7 +221,6 @@ Combină cele mai bune părți ale mai multor tehnologii de nivel 2 și pot ofer
 
 ### Folosește soluții Hybrid {#use-hybrid-solutions}
 
-- [Offchain Labs Arbitrum SCSC](https://offchainlabs.com/arbitrum.pdf)
 - [Celer](https://www.celer.network/)
 
 ## Referințe suplimentare {#further-reading}

--- a/src/content/translations/ro/enterprise/index.md
+++ b/src/content/translations/ro/enterprise/index.md
@@ -102,7 +102,6 @@ Exemple de soluții L2 care sunt pregătite pentru producție sau care vor fi î
   - [Skale](https://skale.network)
   - [POA Network](https://www.poa.network/)
 - Soluții hibride care combină proprietăți din categorii multiple
-  - [Offchain Labs Arbitrum SCSC (SideChains/StateChannels)](https://https://offchainlabs.com/arbitrum.pdf)
   - [Celer](https://celer.network)
 
 ## Aplicațiile de întreprindere „active” pe rețeaua principală {#enterprise-live-on-mainnet}

--- a/src/content/translations/zh/developers/docs/layer-2-scaling/index.md
+++ b/src/content/translations/zh/developers/docs/layer-2-scaling/index.md
@@ -221,7 +221,6 @@ Plasma 是一条独立的区块链。它锚定在以太坊主链上，并使用�
 
 ### 使用混合解决方案 {#use-hybrid-solutions}
 
-- [Offchain Labs Arbitrum SCSC](https://offchainlabs.com/arbitrum.pdf)
 - [Celer](https://www.celer.network/)
 
 ## 延伸阅读 {#further-reading}

--- a/src/content/translations/zh/enterprise/index.md
+++ b/src/content/translations/zh/enterprise/index.md
@@ -102,7 +102,6 @@ sidebar: true
   - [Skale](https://skale.network)
   - [POA Network](https://www.poa.network/)
 - 组合多个类别属性的混合解决方案
-  - [Offchain Labs Arbitrum SCSC](https://https://offchainlabs.com/arbitrum.pdf)
   - [Celer](https://celer.network)
 
 ## 以太主网上的企业级应用 {#enterprise-live-on-mainnet}


### PR DESCRIPTION
Removing "Offchain Labs Arbitrum SCSC" (SCSC is an abbreviation for "SideChains/StateChannels") from hybrid rollup solutions. 

**Reasons:**
- Offchain Labs Arbitrum is already correctly listed in the "optimistic rollup" section;
- Offchain Labs Arbitrum belongs to the optimistic rollup solution and not anymore hybrid;
- link [`https://offchainlabs.com/arbitrum.pdf`](https://offchainlabs.com/arbitrum.pdf) is deprecated;