### PR TITLE
Syntax adjustments

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -112,7 +112,7 @@ const Layout = (props) => {
 
   const isPageLanguageEnglish = intl.language === intl.defaultLanguage
   const isPageContentEnglish = !!props.pageContext.isContentEnglish
-  const isTranslationBannerIgnored = !props.pageContext.ignoreTranslationBanner
+  const isTranslationBannerIgnored = !!props.pageContext.ignoreTranslationBanner
   const isPageTranslationOutdated =
     !!props.pageContext.isOutdated ||
     !!props.data?.pageData?.frontmatter?.isOutdated
@@ -121,7 +121,7 @@ const Layout = (props) => {
   const shouldShowTranslationBanner =
     (isPageTranslationOutdated ||
       (isPageContentEnglish && !isPageLanguageEnglish)) &&
-    isTranslationBannerIgnored
+    !isTranslationBannerIgnored
 
   const path = props.path
 

--- a/src/pages-conditional/eth.js
+++ b/src/pages-conditional/eth.js
@@ -267,7 +267,7 @@ const cardListContent = [
   },
 ]
 
-const WhatIsEthereumPage = (props) => {
+const EthPage = (props) => {
   const intl = useIntl()
   const data = props.data
   return (
@@ -514,7 +514,7 @@ const WhatIsEthereumPage = (props) => {
   )
 }
 
-export default WhatIsEthereumPage
+export default EthPage
 
 export const query = graphql`
   {


### PR DESCRIPTION
## Description
- While debugging another PR, noticed the `eth.js` pages-conditional component was named/exported as `WhatIsEthereumPage`. Updated to just `EthPage`, since `WhatIsEthereumPage` is already used by `what-is-ethereum.js`.

- Also noticed boolean logic in `Layout.js` had `isTranslationBannerIgnored` being set to the opposite of what its name declared, then negated when determining `shouldShowTranslationBanner`. Updated to be more readable. 