### PR TITLE
Broken link fixes

### DIFF
--- a/src/content/translations/es/history/index.md
+++ b/src/content/translations/es/history/index.md
@@ -242,7 +242,7 @@ La bifurcación Homestead que miró hacia el futuro. Incluyó varios cambios de 
 <ExpandableCard title="EIP de Homestead" contentPreview="Official improvements included in this fork.">
 
 - [EIP-2](https://eips.ethereum.org/EIPS/eip-2) – _realiza ediciones al proceso de creación de contratos_
-- [EIP-7](https://eips.ethereum. rg/EIPS/eip-7) – _añade un nuevo código de operación: `DELEGATECALL`_
+- [EIP-7](https://eips.ethereum.org/EIPS/eip-7) – _añade un nuevo código de operación: `DELEGATECALL`_
 - [EIP-8](https://eips.ethereum.org/EIPS/eip-8) – _introduce los requisitos de compatibilidad con devp2p hacia delante_
 
 </ExpandableCard>

--- a/src/content/translations/fr/history/index.md
+++ b/src/content/translations/fr/history/index.md
@@ -206,7 +206,7 @@ La fourche Tangerine Whistle est la deuxième réponse aux attaques par déni de
 <ExpandableCard title="EIP Tangerine Whistle" contentPreview="Official improvements included in this fork.">
 
 - [EIP-150](https://eips.ethereum.org/EIPS/eip-150) - Augmente le coût en carburant des codes d'opération qui peuvent être utilisés dans les attaques par spam.
-- [EIP-158](https://eips.ethereum. rg/EIPS/eip-158) -Réduit la taille de l'état en supprimant un grand nombre de comptes vides
+- [EIP-158](https://eips.ethereum.org/EIPS/eip-158) -Réduit la taille de l'état en supprimant un grand nombre de comptes vides
   mis dans l'état à très bas prix en raison de failles dans les versions précédentes du protocole Ethereum.
 
 </ExpandableCard>
@@ -242,7 +242,7 @@ La fourche Homestead tournée vers l'avenir. Elle comprenait plusieurs changemen
 <ExpandableCard title="EIP Homestead" contentPreview="Official improvements included in this fork.">
 
 - [EIP-2](https://eips.ethereum.org/EIPS/eip-2) - Apporte des modifications au processus de création de contrats.
-- [EIP-7](https://eips.ethereum. rg/EIPS/eip-7) - Ajoute le nouveau code d'opération "DELEGATECALL".
+- [EIP-7](https://eips.ethereum.org/EIPS/eip-7) - Ajoute le nouveau code d'opération "DELEGATECALL".
 - [EIP-8](https://eips.ethereum.org/EIPS/eip-8)- Introduit des exigences de compatibilité devp2p.
 
 </ExpandableCard>

--- a/src/content/translations/it/history/index.md
+++ b/src/content/translations/it/history/index.md
@@ -152,9 +152,9 @@ La diramazione di Byzantium:
 <ExpandableCard title="EIP Byzantium" contentPreview="Official improvements included in this fork.">
 
 - [EIP-140](https://eips.ethereum.org/EIPS/eip-140) – _aggiunge l'opcode `REVERT`._
-- [EIP-658](https://eips.ethereum. rg/EIPS/eip-658) – campo di stato aggiunto alle ricevute delle transazioni per indicare il successo o il fallimento.\_
-- [EIP-196](https://eips.ethereum. rg/EIPS/eip-196) – _aggiunge una curva ellittica e una moltiplicazione scalare per consentire [ZK-Snarks](/developers/docs/layer-2-scaling/#rollups)._
-- [EIP-197](https://eips.ethereum. rg/EIPS/eip-197) – _aggiunge la curva ellittica e la moltiplicazione scalare per consentire [ZK-Snarks](/developers/docs/layer-2-scaling/#rollups)._
+- [EIP-658](https://eips.ethereum.org/EIPS/eip-658) – campo di stato aggiunto alle ricevute delle transazioni per indicare il successo o il fallimento.\_
+- [EIP-196](https://eips.ethereum.org/EIPS/eip-196) – _aggiunge una curva ellittica e una moltiplicazione scalare per consentire [ZK-Snarks](/developers/docs/layer-2-scaling/#rollups)._
+- [EIP-197](https://eips.ethereum.org/EIPS/eip-197) – _aggiunge la curva ellittica e la moltiplicazione scalare per consentire [ZK-Snarks](/developers/docs/layer-2-scaling/#rollups)._
 - [EIP-198](https://eips. thereum.org/EIPS/eip-198) – _abilita la verifica della firma RSA._
 - [EIP-211](https://eips.ethereum.org/EIPS/eip-211) – _aggiunge supporto per i valori restituiti a lunghezza variabile._
 - [EIP-214](https://eips.ethereum.org/EIPS/eip-214) – _aggiunge l'opcode `STATICCALL`, consentendo chiamate che non modificano lo stato ad altri contratti._
@@ -183,8 +183,8 @@ La diramazione Spurious Dragon è stata la seconda risposta agli attacchi denial
 
 <ExpandableCard title="EIP Spurious Dragon" contentPreview="Official improvements included in this fork.">
 
-- [EIP-155](https://eips.ethereum. rg/EIPS/eip-155) – _impedisce che le transazioni provenienti da una catena Ethereum siano ritrasmesse su una catena alternativa, ad esempio una transazione sulla rete di test che viene eseguita nuovamente sulla catena principale Ethereum._
-- [EIP-160](https://eips.ethereum. rg/EIPS/eip-160) – _ottimizza i prezzi dell'opcode `EXP`, rende più difficile rallentare la rete attraverso operazioni sui contratti costose dal punto di vista del calcolo._
+- [EIP-155](https://eips.ethereum.org/EIPS/eip-155) – _impedisce che le transazioni provenienti da una catena Ethereum siano ritrasmesse su una catena alternativa, ad esempio una transazione sulla rete di test che viene eseguita nuovamente sulla catena principale Ethereum._
+- [EIP-160](https://eips.ethereum.org/EIPS/eip-160) – _ottimizza i prezzi dell'opcode `EXP`, rende più difficile rallentare la rete attraverso operazioni sui contratti costose dal punto di vista del calcolo._
 - [EIP-161](https://eips.ethereum.org/EIPS/eip-161) – _permette la rimozione di account vuoti aggiunti tramite attacchi DOS._
 - [EIP-170](https://eips.ethereum.org/EIPS/eip-170) – _cambia la dimensione massima del codice che può avere un contratto sulla blockchain a 24576 byte._
 

--- a/src/content/translations/pl/foundation/index.md
+++ b/src/content/translations/pl/foundation/index.md
@@ -31,4 +31,4 @@ Dowiedz się więcej na [devcon.org](https://devcon.org/), sprawdź [Devcon Blog
 
 <br/>
 
-Aby uzyskać więcej informacji na temat Fundacji i ich pracy, odwiedź [ethereum. obwieszczenie](http://ethereum.foundation/)lub sprawdź [Ethereum Foundation Blog](https://blog.ethereum.org/) w celu uzyskania najnowszych informacji i ogłoszeń EF.
+Aby uzyskać więcej informacji na temat Fundacji i ich pracy, odwiedź [ethereum.foundation](http://ethereum.foundation/)lub sprawdź [Ethereum Foundation Blog](https://blog.ethereum.org/) w celu uzyskania najnowszych informacji i ogłoszeń EF.


### PR DESCRIPTION
## Description
- Corrects multiple instances of `ethereum. rg` to `ethereum.org`
- Reverts translating `ethereum.foundation` link