### PR TITLE
Addition to IDE list

### DIFF
--- a/src/content/developers/docs/ides/index.md
+++ b/src/content/developers/docs/ides/index.md
@@ -49,9 +49,17 @@ Most established IDEs have built plugins to enhance the Ethereum development exp
 - [Download](https://github.com/ethereum/remix-desktop/releases)
 - [GitHub](https://github.com/ethereum/remix-desktop)
 
+**Truffle Development Suite -** **_Gets developers from idea to dapp as comfortably as possible_**
+
+- [Truffle website](https://trufflesuite.com)
+- [Truffle](https://trufflesuite.com/truffle)
+- [Ganache](https://trufflesuite.com/ganache)
+- [Drizzle](https://trufflesuite.com/drizzle)
+- [Github](https://github.com/trufflesuite)
+
 ## Plugins and extensions {#plugins-extensions}
 
-- [solidity](https://marketplace.visualstudio.com/items?itemName=JuanBlanco.solidity) - Ethereum Solidity Language for Visual Studio Code
+- [Solidity](https://marketplace.visualstudio.com/items?itemName=JuanBlanco.solidity) - Ethereum Solidity Language for Visual Studio Code
 - [Prettier Solidity](https://github.com/prettier-solidity/prettier-plugin-solidity) - Code formatter using prettier
 
 ## Further reading {#further-reading}

--- a/src/content/developers/docs/ides/index.md
+++ b/src/content/developers/docs/ides/index.md
@@ -49,7 +49,7 @@ Most established IDEs have built plugins to enhance the Ethereum development exp
 - [Download](https://github.com/ethereum/remix-desktop/releases)
 - [GitHub](https://github.com/ethereum/remix-desktop)
 
-**Truffle Development Suite -** **_Gets developers from idea to dapp as comfortably as possible_**
+**Truffle Development Suite (Truffle, Ganache, and Drizzle) -** **_Gets developers from idea to dapp as comfortably as possible_**
 
 - [Truffle website](https://trufflesuite.com)
 - [Truffle](https://trufflesuite.com/truffle)


### PR DESCRIPTION
Updated index.md to include the Truffle Development Suite.

## Description

I added the Truffle Development Suite to the list of Ethereum IDEs. The section contains links to their website homepage, their pages on their different tools, (Truffle, Ganache, and Drizzle), and their Github page.