### PR TITLE
Fix dead link in Vyper tutorial

### DIFF
--- a/src/content/developers/tutorials/erc-721-vyper-annotated-code/index.md
+++ b/src/content/developers/tutorials/erc-721-vyper-annotated-code/index.md
@@ -40,7 +40,7 @@ implements: ERC721
 ```
 
 The ERC-721 interface is built into the Vyper language.
-[You can see the code definition here](https://github.com/vyperlang/vyper/blob/master/vyper/interfaces/ERC721.py).
+[You can see the code definition here](https://github.com/vyperlang/vyper/blob/master/vyper/builtin_interfaces/ERC721.py).
 The interface definition is written in Python, rather than Vyper, because interfaces are used not only within the
 blockchain, but also when sending the blockchain a transaction from an external client, which may be written in
 Python.


### PR DESCRIPTION
## Description

There was a dead link in the [Vyper ERC-721 Contract Walkthrough](https://ethereum.org/en/developers/tutorials/erc-721-vyper-annotated-code/). This PR fixes it.