### PR TITLE
Fix incorrect URL in DAO Doc

### DIFF
--- a/src/content/dao/index.md
+++ b/src/content/dao/index.md
@@ -92,7 +92,7 @@ Ethereum is the perfect foundation for DAOs for a number of reasons:
 
 ### Join a DAO {#join-a-dao}
 
-- [Ethereum community DAOs](/community/#decentralized-autonomous-organizations-daos/community/#decentralized-autonomous-organizations-daos)
+- [Ethereum community DAOs](/community/get-involved/#decentralized-autonomous-organizations-daos)
 - [DAOHaus's list of DAOs](https://app.daohaus.club/explore)
 
 ### Start a DAO {#start-a-dao}


### PR DESCRIPTION
The link for "Ethereum community DAOs" on https://ethereum.org/en/dao/ doesn't work as it points to a page that doesn't exist. Fixed the URL to point to the correct location.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

https://github.com/ethereum/ethereum-org-website/issues/4922
