### PR TITLE
Updating a typo from `Truffle` -> `Ganache`

### DIFF
--- a/src/content/developers/tutorials/create-and-deploy-a-defi-app/index.md
+++ b/src/content/developers/tutorials/create-and-deploy-a-defi-app/index.md
@@ -288,7 +288,7 @@ To execute this script, run the following cli command:
 truffle exec .\scripts\getMyTokenBalance.js
 ```
 
-We will get the expected result that is 0. If you get an error about the FarmToken not being deployed yet, the truffle network has not received the latest version of your contract code. Just close truffle, quickstart it again and make sure to run `truffle migrate`.
+We will get the expected result that is 0. If you get an error about the FarmToken not being deployed yet, the truffle network has not received the latest version of your contract code. Just close ganache, quickstart it again and make sure to run `truffle migrate`.
 
 Now, let's stake the MyToken to the smart contract. Since the function `deposit(uint256 _amount)` calls the function `safeTransferFrom` from the ERC20, the user must first approve the smart contract to transfer MyToken on the user's behalf. So on the script below, we will first approve this step then we will call the function:
 


### PR DESCRIPTION
Typo fix in tutorial for `MyToken`

<!--- Provide a general summary of your changes in the Title above -->

## Description

The text defines a simple fix to a migration not having gone through and references closing `Truffle` but should be close `Ganache`

## Related Issue

N/A as this is a typo. If this is required, I can open one!
