### PR TITLE
Fix typo in the Spanish homepage [Fixes #4877]

### DIFF
--- a/src/intl/es/page-index.json
+++ b/src/intl/es/page-index.json
@@ -3,7 +3,7 @@
   "page-index-meta-description": "Ethereum es una plataforma mundial descentralizada para el dinero y nuevos tipos de aplicaciones. En Ethereum, puedes escribir código que controla el dinero y construir aplicaciones accesibles desde cualquier rincón del mundo.",
   "page-index-meta-title": "Inicio",
   "page-index-title": "Bienvenido a Ethereum",
-  "page-index-description": "Ethereum es la tecnología de gestión comunitaria que implulsa la criptomoneda ether (ETH) y miles de aplicaciones descentralizadas.",
+  "page-index-description": "Ethereum es la tecnología de gestión comunitaria que impulsa la criptomoneda ether (ETH) y miles de aplicaciones descentralizadas.",
   "page-index-title-button": "Explora Ethereum",
   "page-index-get-started": "Empezar",
   "page-index-get-started-description": "ethereum.org es tu portal de entrada al mundo de Ethereum. Esta tecnología es disruptiva y está en constante evolución; tener un guía ayuda. Estas son nuestras recomendaciones para adentrarte en este mundo.",


### PR DESCRIPTION
## Description
- Fix typo in `page-index.json` in Spanish translation

## Related Issue
#4877 
