### PR TITLE
Update broken url in paragraph in blog post [Fixes #4937]

### DIFF
--- a/src/content/developers/tutorials/calling-a-smart-contract-from-javascript/index.md
+++ b/src/content/developers/tutorials/calling-a-smart-contract-from-javascript/index.md
@@ -95,7 +95,7 @@ In the next part we’ll call the `balanceOf` function to retrieve the current a
 
 ## Call: Reading value from a smart contract {#call-reading-value-from-a-smart-contract}
 
-The first example will call a “constant” method and execute its smart contract method in the EVM without sending any transaction. For this we’ll read the ERC20 balance of an address. [Read our article about ERC20 tokens](/developers/tutorials/understand-the-erc20-token-smart-contract/).
+The first example will call a “constant” method and execute its smart contract method in the EVM without sending any transaction. For this we’ll read the ERC20 balance of an address. [Read our article about ERC20 tokens](/developers/tutorials/understand-the-erc-20-token-smart-contract/).
 
 You can access an instantiated smart contract methods that you provided the ABI for as follows: `yourContract.methods.methodname`. By using the `call` function you’ll receive the result of executing the function.
 

--- a/src/content/developers/tutorials/understand-the-erc-20-token-smart-contract/index.md
+++ b/src/content/developers/tutorials/understand-the-erc-20-token-smart-contract/index.md
@@ -8,7 +8,7 @@ lang: en
 sidebar: true
 published: 2020-04-05
 source: EthereumDev
-sourceUrl: https://ethereumdev.io/understand-the-erc20-token-smart-contract/
+sourceUrl: https://ethereumdev.io/understand-the-erc-20-token-smart-contract/
 address: "0x19dE91Af973F404EDF5B4c093983a7c6E3EC8ccE"
 ---
 

--- a/src/content/translations/pl/developers/tutorials/calling-a-smart-contract-from-javascript/index.md
+++ b/src/content/translations/pl/developers/tutorials/calling-a-smart-contract-from-javascript/index.md
@@ -98,7 +98,7 @@ W następnej części wywołamy funkcję `balanceOf`, aby pobrać aktualną ilo�
 
 ## Call: Odczyt wartości z inteligentnego kontraktu {#call-reading-value-from-a-smart-contract}
 
-Pierwszy przykład wywoła metodę „stałą” i wykona metodę inteligentnego kontraktu w EVM bez wysyłania żadnej transakcji. W tym celu odczytamy saldo adresu ERC20. [Przeczytaj nasz artykuł o tokenach ERC20](/developers/tutorials/understand-the-erc20-token-smart-contract/).
+Pierwszy przykład wywoła metodę „stałą” i wykona metodę inteligentnego kontraktu w EVM bez wysyłania żadnej transakcji. W tym celu odczytamy saldo adresu ERC20. [Przeczytaj nasz artykuł o tokenach ERC20](/developers/tutorials/understand-the-erc-20-token-smart-contract/).
 
 Możesz uzyskać dostęp do metod utworzonej instancji kontraktu inteligentnego, dla którego podano ABI, w następujący sposób: `yourContract.methods.methodname`. Używając funkcji `call`, otrzymasz wynik wykonania funkcji.
 

--- a/src/content/translations/pl/developers/tutorials/understand-the-erc-20-token-smart-contract/index.md
+++ b/src/content/translations/pl/developers/tutorials/understand-the-erc-20-token-smart-contract/index.md
@@ -13,7 +13,7 @@ lang: pl
 sidebar: true
 published: 2020-04-05
 source: EthereumDev
-sourceUrl: https://ethereumdev.io/understand-the-erc20-token-smart-contract/
+sourceUrl: https://ethereumdev.io/understand-the-erc-20-token-smart-contract/
 address: "0x19dE91Af973F404EDF5B4c093983a7c6E3EC8ccE"
 ---
 

--- a/src/content/translations/ro/developers/tutorials/calling-a-smart-contract-from-javascript/index.md
+++ b/src/content/translations/ro/developers/tutorials/calling-a-smart-contract-from-javascript/index.md
@@ -95,7 +95,7 @@ const receiverAddress = "0x19dE91Af973F404EDF5B4c093983a7c6E3EC8ccE"
 
 ## Call: citirea valorii dintr-un contract inteligent {#call-reading-value-from-a-smart-contract}
 
-Primul exemplu va apela o metodă „constant” și va executa metoda sa de contract inteligent în EVM fără a trimite nicio tranzacție. Pentru aceasta, vom citi soldul ERC20 al unei adrese. [Citește articolul nostru despre tokenuri ERC20](/developers/tutorials/understand-the-erc20-token-smart-contract/).
+Primul exemplu va apela o metodă „constant” și va executa metoda sa de contract inteligent în EVM fără a trimite nicio tranzacție. Pentru aceasta, vom citi soldul ERC20 al unei adrese. [Citește articolul nostru despre tokenuri ERC20](/developers/tutorials/understand-the-erc-20-token-smart-contract/).
 
 Poți accesa o metodă unei instanțe de contract inteligent pentru care ai furnizat ABI-ul astfel: `yourContract.methods.methodname`. Prin utilizarea funcției `call` vei primi rezultatul executării funcției.
 

--- a/src/content/translations/ro/developers/tutorials/understand-the-erc-20-token-smart-contract/index.md
+++ b/src/content/translations/ro/developers/tutorials/understand-the-erc-20-token-smart-contract/index.md
@@ -9,7 +9,7 @@ lang: ro
 sidebar: true
 published: 2020-04-05
 source: EthereumDev
-sourceUrl: https://ethereumdev.io/understand-the-erc20-token-smart-contract/
+sourceUrl: https://ethereumdev.io/understand-the-erc-20-token-smart-contract/
 address: "0x19dE91Af973F404EDF5B4c093983a7c6E3EC8ccE"
 ---
 

--- a/src/content/translations/zh/developers/tutorials/calling-a-smart-contract-from-javascript/index.md
+++ b/src/content/translations/zh/developers/tutorials/calling-a-smart-contract-from-javascript/index.md
@@ -99,7 +99,7 @@ const receiverAddress = "0x19dE91Af973F404EDF5B4c093983a7c6E3EC8ccE"
 
 ## 调用：从智能合约读取值 {#call-reading-value-from-a-smart-contract}
 
-第一个例子，将调用“常量（constant）”方法并且在 EVM 中执行这个智能合约方法，并不发送任何交易。 为此我们将读取一个地址的 ECR20 余额。 [阅读关于 ECR20 代币的文章](/developers/tutorials/understand-the-erc20-token-smart-contract/).
+第一个例子，将调用“常量（constant）”方法并且在 EVM 中执行这个智能合约方法，并不发送任何交易。 为此我们将读取一个地址的 ECR20 余额。 [阅读关于 ECR20 代币的文章](/developers/tutorials/understand-the-erc-20-token-smart-contract/).
 
 您可以访问为其提供 ABI 的实例化智能合约方法，如下所示：`yourContract.methods.methodname`。 通过使用`call`函数，您可以接收执行函数的结果。
 

--- a/src/content/translations/zh/developers/tutorials/understand-the-erc-20-token-smart-contract/index.md
+++ b/src/content/translations/zh/developers/tutorials/understand-the-erc-20-token-smart-contract/index.md
@@ -13,7 +13,7 @@ lang: zh
 sidebar: true
 published: 2020-04-05
 source: EtherumDev
-sourceUrl: https://ethereumdev.io/understand-the-erc20-token-smart-contract/
+sourceUrl: https://ethereumdev.io/understand-the-erc-20-token-smart-contract/
 address: "0x19dE91Af973F404EDF5B4c093983a7c6E3EC8ccE"
 ---
 


### PR DESCRIPTION
## Description
- Fix 404 url in paragraph in tutorial `Calling a smart contract from JavaScript`

## Related Issue
#4937 
