### PR TITLE
Improve how-to-write-and-deploy-an-nft tutorial

### DIFF
--- a/src/content/developers/tutorials/how-to-write-and-deploy-an-nft/index.md
+++ b/src/content/developers/tutorials/how-to-write-and-deploy-an-nft/index.md
@@ -320,7 +320,7 @@ Calling deploy() on a ContractFactory will start the deployment, and return a Pr
 
 We’re finally ready to deploy our smart contract! Navigate back to the root of your project directory, and in the command line run:
 
-    npx hardhat run scripts/deploy.js
+    npx hardhat --network ropsten run scripts/deploy.js
 
 You should then see something like:
 

--- a/src/content/developers/tutorials/how-to-write-and-deploy-an-nft/index.md
+++ b/src/content/developers/tutorials/how-to-write-and-deploy-an-nft/index.md
@@ -294,6 +294,7 @@ async function main() {
 
   // Start deployment, returning a promise that resolves to a contract object
   const myNFT = await MyNFT.deploy()
+  await myNFT.deployed()
   console.log("Contract deployed to address:", myNFT.address)
 }
 
@@ -319,7 +320,7 @@ Calling deploy() on a ContractFactory will start the deployment, and return a Pr
 
 We’re finally ready to deploy our smart contract! Navigate back to the root of your project directory, and in the command line run:
 
-    npx hardhat run scripts/deploy.js --network ropsten
+    npx hardhat run scripts/deploy.js
 
 You should then see something like:
 


### PR DESCRIPTION
Changes:

* add missing await which can cause deployment to fail
* move ` --network ropsten` argument to avoid confusion with scripts/deploy.js
