### PR TITLE
Remove pseudoelement from headers [Fixes #4922, Fixes #4930]

### DIFF
--- a/src/templates/eth2.js
+++ b/src/templates/eth2.js
@@ -139,7 +139,6 @@ const H2 = styled.h2`
 
   /* Prevent nav overlap */
   &:before {
-    content: "";
     display: block;
     height: 120px;
     margin-top: -120px;
@@ -183,7 +182,6 @@ const H3 = styled.h3`
 
   /* Prevent nav overlap */
   &:before {
-    content: "";
     display: block;
     height: 120px;
     margin-top: -120px;

--- a/src/templates/use-cases.js
+++ b/src/templates/use-cases.js
@@ -128,7 +128,6 @@ const H2 = styled.h2`
 
   /* Prevent nav overlap */
   &:before {
-    content: "";
     display: block;
     height: 120px;
     margin-top: -120px;
@@ -170,7 +169,6 @@ const H3 = styled.h3`
 
   /* Prevent nav overlap */
   &:before {
-    content: "";
     display: block;
     height: 120px;
     margin-top: -120px;


### PR DESCRIPTION
The h3 element following the ul containing the two list items under "Join a DAO" has a psudo ::before element (.gWTLmC::before) which has a negative margin and height of 120px which covers the list and seems to obstruct the mouse from interacting with the list. Removing the content:"" to remove the obstruction of the psudo element for h3 and h2 tag on line number 142 and 185

<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixing two issues: 
https://github.com/ethereum/ethereum-org-website/issues/4930
https://github.com/ethereum/ethereum-org-website/issues/4922