### PR TITLE
Update translation program stats

### DIFF
--- a/src/content/contributing/translation-program/index.md
+++ b/src/content/contributing/translation-program/index.md
@@ -12,8 +12,8 @@ The Translation Program is a collaborative effort to translate ethereum.org into
 Our progress so far:
 
 - [**2,500 +** translators](/contributing/translation-program/acknowledgements/)
-- [**37** languages live on site](/languages/)
-- [**2.7 million** words translated in 2021](/contributing/translation-program/acknowledgements/)
+- [**40** languages live on site](/languages/)
+- [**2.9 million** words translated in 2021](/contributing/translation-program/acknowledgements/)
 
 If you want to get involved and help us grow the global Ethereum community by translating the website into your language, follow the steps below!
 


### PR DESCRIPTION
## Description

Update translation program stats:
Update the number of languages live on the site. There are currently 39 languages live on the site, with a PR open for Marathi as well, so 40 will be the correct number after the next deploy.
Update the number of words, translated by our community in 2021.
