### PR TITLE
Fix overflow of text on /find-wallet/ header

### DIFF
--- a/src/pages/wallets/find-wallet.js
+++ b/src/pages/wallets/find-wallet.js
@@ -17,16 +17,13 @@ import { Divider, Page } from "../../components/SharedStyledComponents"
 const Subtitle = styled.div`
   font-size: 20px;
   line-height: 140%;
+  max-width: 45ch;
   text-align: center;
   color: ${(props) => props.theme.colors.text200};
-`
 
-const SubtitleTwo = styled.div`
-  font-size: 20px;
-  line-height: 140%;
-  margin-bottom: 2rem;
-  text-align: center;
-  color: ${(props) => props.theme.colors.text300};
+  &:last-of-type {
+    margin-bottom: 2rem;
+  }
 `
 
 const HeroContainer = styled.div`
@@ -110,9 +107,9 @@ const FindWalletPage = ({ location, data }) => {
           <Subtitle>
             <Translation id="page-find-wallet-description" />
           </Subtitle>
-          <SubtitleTwo>
+          <Subtitle>
             <Translation id="page-find-wallet-desc-2" />
-          </SubtitleTwo>
+          </Subtitle>
         </Header>
       </HeroContainer>
       <InfoBannerContainer>

--- a/src/pages/wallets/find-wallet.js
+++ b/src/pages/wallets/find-wallet.js
@@ -15,7 +15,7 @@ import WalletCompare from "../../components/WalletCompare"
 import { Divider, Page } from "../../components/SharedStyledComponents"
 
 const Subtitle = styled.div`
-  font-size: 20px;
+  font-size: 1.25rem;
   line-height: 140%;
   max-width: 45ch;
   text-align: center;


### PR DESCRIPTION
## Description
- Added a max-width of 45 characters to each Subtitle
- Use the same colour on both subtitles (amused this was a mistake? can revert otherwise)
- Use rem over px (a11y)
- Small refactor to remove redundancy 

## Related Issue
Fixes #5010
