### PR TITLE
Remove inactive Indonesian meetup

### DIFF
--- a/src/data/community-meetups.json
+++ b/src/data/community-meetups.json
@@ -84,12 +84,6 @@
     "link": "https://www.meetup.com/Ethereum-Hong-Kong/"
   },
   {
-    "title": "Ethereum Indonesia",
-    "emoji": ":indonesia:",
-    "location": "Jakarta",
-    "link": "https://www.meetup.com/Ethereum-indonesia/"
-  },
-  {
     "title": "Ethereum Jakarta",
     "emoji": ":indonesia:",
     "location": "Jakarta",


### PR DESCRIPTION
## Description
When reviewing #4999 (to add a Jakarta based meetup) I checked out our other Indonesian meetup group. It has been inactive since 2019 therefore we should probably remove it.

## Related Issue
None
