### PR TITLE
Remove second h1 tag [Fixes #4648]

### DIFF
--- a/src/templates/use-cases.js
+++ b/src/templates/use-cases.js
@@ -109,7 +109,7 @@ const Pre = styled.pre`
   white-space: pre-wrap;
 `
 
-const H1 = styled.h1`
+const InfoTitle = styled.h2`
   font-size: 48px;
   font-weight: 700;
   text-align: right;
@@ -428,7 +428,7 @@ const UseCasePage = ({ data, pageContext }) => {
         />
         <InfoColumn>
           <StyledButtonDropdown list={dropdownLinks} />
-          <H1>{mdx.frontmatter.title}</H1>
+          <InfoTitle>{mdx.frontmatter.title}</InfoTitle>
 
           {mdx.frontmatter.sidebar && tocItems && (
             <Eth2TableOfContents


### PR DESCRIPTION
## Description

This merge will remove the second h1 tag (preserving the style) from the use-case template.
- The landing title remains an `<h1>`.
- The title on the left side of the article (inside `<aside>`) is now an `<h2>`.

## Related Issue

#4648 
