### PR TITLE
Fix overflow of text on /get-eth/ header

### DIFF
--- a/src/pages/get-eth.js
+++ b/src/pages/get-eth.js
@@ -31,10 +31,7 @@ const Subtitle = styled.div`
   text-align: center;
   color: ${(props) => props.theme.colors.text200};
 
-  /* Add margin-bottom to the second subtitle */
-  &:nth-last-of-type(2) {
-    margin-bottom: 2rem;
-  }
+  margin-bottom: ${(props) => props.mb || ""};
 `
 
 const HeroContainer = styled.div`
@@ -245,7 +242,7 @@ const GetETHPage = ({ data }) => {
           <Subtitle>
             <Translation id="page-get-eth-where-to-buy-desc" />
           </Subtitle>
-          <Subtitle>
+          <Subtitle mb="2rem">
             <Translation id="page-get-eth-where-to-buy-desc-2" />
           </Subtitle>
           <StyledEthPriceCard />

--- a/src/pages/get-eth.js
+++ b/src/pages/get-eth.js
@@ -25,18 +25,16 @@ import {
 } from "../components/SharedStyledComponents"
 
 const Subtitle = styled.div`
-  font-size: 20px;
+  font-size: 1.25rem;
   line-height: 140%;
+  max-width: 45ch;
   text-align: center;
   color: ${(props) => props.theme.colors.text200};
-`
 
-const SubtitleTwo = styled.div`
-  font-size: 20px;
-  line-height: 140%;
-  margin-bottom: 2rem;
-  text-align: center;
-  color: ${(props) => props.theme.colors.text300};
+  /* Add margin-bottom to the second subtitle */
+  &:nth-last-of-type(2) {
+    margin-bottom: 2rem;
+  }
 `
 
 const HeroContainer = styled.div`
@@ -247,9 +245,9 @@ const GetETHPage = ({ data }) => {
           <Subtitle>
             <Translation id="page-get-eth-where-to-buy-desc" />
           </Subtitle>
-          <SubtitleTwo>
+          <Subtitle>
             <Translation id="page-get-eth-where-to-buy-desc-2" />
-          </SubtitleTwo>
+          </Subtitle>
           <StyledEthPriceCard />
           <ButtonLink to="#country-picker">
             <Translation id="page-get-eth-search-by-country" />


### PR DESCRIPTION
## Description

Similar to #5011, fixes overflowing text on language with longer sentences.

- Added a max-width of 45 characters to each Subtitle
- Use the same colour on both subtitles (amused this was a mistake? can revert otherwise)
- Use rem over px (a11y)
- Small refactor to remove redundancy

## Related Issue
#5010