### PR TITLE
Remove hardcoded English path from homepage callout

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -949,7 +949,7 @@ contract SimpleDomainRegistry {
           )}
         >
           <ButtonRow>
-            <ButtonLink to="/en/contributing/">
+            <ButtonLink to="/contributing/">
               <Translation id="page-index-contribution-banner-button" />
             </ButtonLink>
             <StyledButtonLink


### PR DESCRIPTION
## Description
- Removes a hardcoded /en/ path from the homepage

## Related Issue
None