### PR TITLE
Update pages using `upgrade` template

### DIFF
--- a/src/content/upgrades/beacon-chain/index.md
+++ b/src/content/upgrades/beacon-chain/index.md
@@ -1,13 +1,13 @@
 ---
 title: The Beacon Chain
-description: Learn about the beacon chain - the first major Eth2 upgrade to Ethereum.
+description: Learn about the Beacon Chain - the upgrade that introduced proof-of-stake Ethereum.
 lang: en
 template: upgrade
 sidebar: true
 image: ../../../assets/upgrades/core.png
-summaryPoint1: The beacon chain doesn't change anything about the Ethereum we use today.
-summaryPoint2: It will coordinate the network.
-summaryPoint3: It introduces proof-of-stake to the Ethereum ecosystem.
+summaryPoint1: The Beacon Chain doesn't change anything about the Ethereum we use today.
+summaryPoint2: It will coordinate the network, serving as the consensus layer.
+summaryPoint3: It introduced proof-of-stake to the Ethereum ecosystem.
 summaryPoint4: You might know this as "Phase 0" on technical roadmaps.
 ---
 
@@ -33,7 +33,7 @@ Staking and becoming a validator is easier than [mining](/developers/docs/mining
 If you're interested in becoming a validator and helping secure the Beacon Chain, <a href="/staking/">learn more about staking</a>.
 </InfoBanner>
 
-This is also an important change for another Eth2 upgrade: [shard chains](/upgrades/shard-chains/).
+This is also an important change for another upgrade: [shard chains](/upgrades/shard-chains/).
 
 ### Setting up for shard chains {#setting-up-for-shard-chains}
 
@@ -43,7 +43,7 @@ Eventually the Beacon Chain will also be responsible for randomly assigning stak
 
 ## Relationship between upgrades {#relationship-between-upgrades}
 
-The Eth2 upgrades are all somewhat interrelated. So let’s recap how the Beacon Chain affects the other upgrades.
+The Ethereum upgrades are all somewhat interrelated. So let’s recap how the Beacon Chain affects the other upgrades.
 
 ### Mainnet and the Beacon Chain {#mainnet-and-beacon-chain}
 

--- a/src/content/upgrades/merge/index.md
+++ b/src/content/upgrades/merge/index.md
@@ -12,7 +12,7 @@ summaryPoint4: We formerly referred to this as "the docking."
 ---
 
 <UpgradeStatus date="~Q1/Q2 2022">
-  This upgrade represents the official switch to proof-of-stake consensus. This eliminates the need for energy-intensive mining, and instead secures the network using staked ether. A truly exciting step in realizing the <a href="/upgrades/vision/">Eth2 vision</a> – more scalability, security, and sustainability.
+  This upgrade represents the official switch to proof-of-stake consensus. This eliminates the need for energy-intensive mining, and instead secures the network using staked ether. A truly exciting step in realizing the <a href="/upgrades/vision/">Ethereum vision</a> – more scalability, security, and sustainability.
 </UpgradeStatus>
 
 ## What is the merge? {#what-is-the-docking}
@@ -29,7 +29,7 @@ Mainnet will bring the ability to run smart contracts into the proof-of-stake sy
 
 ## After the merge {#after-the-merge}
 
-This will signal the end of proof-of-work for Ethereum and start the era of a more sustainable, eco-friendly Ethereum. At this point Ethereum will be one step closer to achieving the full scale, security and sustainability outlined in its [Eth2 vision](/upgrades/vision/).
+This will signal the end of proof-of-work for Ethereum and start the era of a more sustainable, eco-friendly Ethereum. At this point Ethereum will be one step closer to achieving the full scale, security and sustainability outlined in its [Ethereum vision](/upgrades/vision/).
 
 It is important to note that an implementation goal of the merge is simplicity in order to expedite the transition from proof-of-work to proof-of-stake. Developers are focusing their efforts on this transition, and minimizing additional features that could delay this goal.
 
@@ -37,7 +37,7 @@ It is important to note that an implementation goal of the merge is simplicity i
 
 ## Relationship between upgrades {#relationship-between-upgrades}
 
-The Eth2 upgrades are all somewhat interrelated. So let’s recap how the merge relates to the other upgrades.
+The Ethereum upgrades are all somewhat interrelated. So let’s recap how the merge relates to the other upgrades.
 
 ### The merge and the Beacon Chain {#docking-and-beacon-chain}
 

--- a/src/content/upgrades/shard-chains/index.md
+++ b/src/content/upgrades/shard-chains/index.md
@@ -31,12 +31,12 @@ Sharding is a good way to scale if you want to keep things decentralized as the 
 
 Sharding will eventually let you run Ethereum on a personal laptop or phone. So more people should be able to participate, or run [clients](/developers/docs/nodes-and-clients/), in a sharded Ethereum. This will increase security because the more decentralized the network, the smaller the attack surface area.
 
-With lower hardware requirements, sharding will make it easier to run [clients](/developers/docs/nodes-and-clients/) on your own, without relying on any intermediary services at all. And if you can, consider running multiple clients. This can help network health by further reducing points of failure. [Run an Eth2 client](/upgrades/get-involved/)
+With lower hardware requirements, sharding will make it easier to run [clients](/developers/docs/nodes-and-clients/) on your own, without relying on any intermediary services at all. And if you can, consider running multiple clients. This can help network health by further reducing points of failure. [Run a Beacon Chain client](/upgrades/get-involved/)
 
 <br />
 
 <InfoBanner isWarning={true}>
-  At first, you'll need to run a mainnet client at the same time as your Eth2 client. <a href="https://launchpad.ethereum.org" target="_blank">The launchpad</a> will walk you through the hardware requirements and process. Alternatively you can use a <a href="/en/developers/docs/apis/backend/#available-libraries">backend API</a>.
+  At first, you'll need to run a Mainnet client at the same time as your Beacon Chain client. <a href="https://launchpad.ethereum.org" target="_blank">The launchpad</a> will walk you through the hardware requirements and process. Alternatively you can use a <a href="/en/developers/docs/apis/backend/#available-libraries">backend API</a>.
 </InfoBanner>
 
 ## Shard chains version 1: data availability {#data-availability}
@@ -46,7 +46,7 @@ When the first shard chains are shipped they will just provide extra data to the
 Rollups are a "layer 2" technology that exists today. They allow dapps to bundle or “roll up” transactions into a single transaction off-chain, generate a cryptographic proof and then submit it to the chain. This reduces the data needed for a transaction. Combine this with all the extra data availability provided by shards and you get 100,000 transactions per second.
 
 <InfoBanner isWarning={false}>
-  Given recent progress in layer 2 scaling solution research and development, this has prompted the prioritization of the merge upgrade ahead of shard chains. These will be the focus following mainnet transition to proof-of-stake.
+  Given recent progress in layer 2 scaling solution research and development, this has prompted the prioritization of the merge upgrade ahead of shard chains. These will be the focus following Mainnet transition to proof-of-stake.
 
 [More on rollups](/developers/docs/scaling/layer-2-rollups/)
 </InfoBanner>
@@ -85,7 +85,7 @@ This is still an active discussion point. We’ll update these pages once we kno
 
 ## Relationship between upgrades {#relationship-between-upgrades}
 
-The Eth2 upgrades are all somewhat interrelated. So let’s recap how the shard chains relate the other upgrades.
+The Ethereum upgrades are all somewhat interrelated. So let’s recap how the shard chains relate the other upgrades.
 
 ### Shards and the beacon chain {#shards-and-beacon-chain}
 
@@ -97,9 +97,9 @@ The Beacon Chain contains all the logic for keeping shards secure and synced up.
 
 ### Shards and the merge {#shards-and-docking}
 
-By the time additional shards are added, Ethereum Mainnet will already be secured by the Beacon Chain using proof-of-stake. This enables a fertile mainnet to build shard chains off of, powered by layer 2 solutions that supercharge the scalability.
+By the time additional shards are added, Ethereum Mainnet will already be secured by the Beacon Chain using proof-of-stake. This enables a fertile Mainnet to build shard chains off of, powered by layer 2 solutions that supercharge the scalability.
 
-It remains to be seen whether mainnet will exist as the only “smart” shard that can handle code execution – but either way, the decision to expand shards can be revisited as needed.
+It remains to be seen whether Mainnet will exist as the only “smart” shard that can handle code execution – but either way, the decision to expand shards can be revisited as needed.
 
 <ButtonLink to="/upgrades/merge/">
   The merge


### PR DESCRIPTION
`eth2-rebrand <- upgrade-template`

## Description
Updates the following pages removing eth2 terminology
- beacon-chain
- merge
- shard-chains
