### PR TITLE
Update glossary for eth2 rebrand

### DIFF
--- a/src/content/glossary/index.md
+++ b/src/content/glossary/index.md
@@ -61,7 +61,7 @@ A validator vote for a [Beacon Chain](#beacon-chain) or [shard](#shard) [block](
 
 ### Beacon Chain {#beacon-chain}
 
-An Eth2 upgrade that will become the coordinator for the Ethereum network. It introduces [proof-of-stake](#pos) and [validators](#validator) to Ethereum. It will eventually be merged with [Mainnet](#mainnet).
+A network upgrade that introduced a new consensus layer, which will become the coordinator for the entire Ethereum network. It introduces [proof-of-stake](#pos) and [validators](#validator) to Ethereum. It will eventually be merged with [Mainnet](#mainnet).
 
 <DocLink to="/upgrades/beacon-chain/">
   Beacon Chain
@@ -627,10 +627,10 @@ A type of [layer 2](#layer-2) scaling solution that batches multiple transaction
 
 ### Serenity {#serenity}
 
-The fourth and final development stage of Ethereum, otherwise known as Ethereum 2.0.
+The stage of Ethereum development that initiated a set of scaling and sustainability upgrades, previously known as Ethereum 2.0, or Eth2.
 
 <DocLink to="/upgrades/">
-  Ethereum 2.0 (Eth2)
+  Ethereum upgrades
 </DocLink>
 
 ### Secure Hash Algorithm (SHA) {#sha}
@@ -639,7 +639,7 @@ A family of cryptographic hash functions published by the National Institute of 
 
 ### shard / shard chain {#shard}
 
-A [proof-of-stake](#pos) chain that is coordinated by the [Beacon Chain](#beacon-chain) and secured by [validators](#validator). There will be 64 added to the network as part of the Eth2 shard chain upgrade. Shard chains will offer increased transaction throughput for Ethereum by providing additional data to [layer 2](#layer-2) solutions like [optimistic rollups](#optimistic-rollups) and [ZK-rollups](#zk-rollups).
+A [proof-of-stake](#pos) chain that is coordinated by the [Beacon Chain](#beacon-chain) and secured by [validators](#validator). There will be 64 added to the network as part of the shard chain upgrade. Shard chains will offer increased transaction throughput for Ethereum by providing additional data to [layer 2](#layer-2) solutions like [optimistic rollups](#optimistic-rollups) and [ZK-rollups](#zk-rollups).
 
 <DocLink to="/upgrades/shard-chains">
   Shard chains

--- a/src/content/glossary/index.md
+++ b/src/content/glossary/index.md
@@ -627,7 +627,7 @@ A type of [layer 2](#layer-2) scaling solution that batches multiple transaction
 
 ### Serenity {#serenity}
 
-The stage of Ethereum development that initiated a set of scaling and sustainability upgrades, previously known as Ethereum 2.0, or Eth2.
+The stage of Ethereum development that initiated a set of scaling and sustainability upgrades, previously known as "Ethereum 2.0", or "Eth2".
 
 <DocLink to="/upgrades/">
   Ethereum upgrades


### PR DESCRIPTION
`eth2-rebrand <- glossary`

## Description
Did a basic update to glossary terms for eth2 rebrand. Left one note about "Ethereum 2.0" and "Eth2" in the Serenity definition.

Did not add new terms due to scope, though separately we should consider adding some new terms here like "consensus layer", "execution layer", and "merge"