### PR TITLE
Updates nodes-and-clients copy

### DIFF
--- a/src/content/developers/docs/nodes-and-clients/index.md
+++ b/src/content/developers/docs/nodes-and-clients/index.md
@@ -288,6 +288,14 @@ There are new clients to support the [consensus upgrades](/upgrades/beacon-chain
 
 [View consensus clients](/upgrades/get-involved/#clients).
 
+| Client                                                      | Language   | Operating systems     | Networks                              | Sync strategies | State pruning |
+| ----------------------------------------------------------- | ---------- | --------------------- | ------------------------------------- | --------------- | ------------- |
+| [Teku](https://pegasys.tech/teku)                           | Java       | Linux, Windows, macOS | Beacon Chain, Prater                  | Full            |               |
+| [Nimbus](https://nimbus.team/)                              | Nim        | Linux, Windows, macOS | Beacon Chain, Prater                  | Full            |               |
+| [Lighthouse](https://lighthouse-book.sigmaprime.io/)        | Rust       | Linux, Windows, macOS | Beacon Chain, Prater, Pyrmont         | Full            |               |
+| [Lodestar](https://lodestar.chainsafe.io/)                  | TypeScript | Linux, Windows, macOS | Beacon Chain, Prater                  | Full            |               |
+| [Prysm](https://docs.prylabs.network/docs/getting-started/) | Go         | Linux, Windows, macOS | Beacon Chain, Gnosis, Prater, Pyrmont | Full            |               |
+
 ## Further reading {#further-reading}
 
 There is a lot of information about Ethereum clients on the internet. Here are few resources that might be helpful.

--- a/src/content/developers/docs/nodes-and-clients/index.md
+++ b/src/content/developers/docs/nodes-and-clients/index.md
@@ -20,7 +20,7 @@ You can see a real-time view of the Ethereum network by looking at this [map of 
 
 Many [Ethereum clients](/developers/docs/nodes-and-clients/#clients) exist, in a variety of programming languages such as Go, Rust, JavaScript, Python, C# .NET and Java. What these implementations have in common is they all follow a formal specification (originally the [Ethereum Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf)). This specification dictates how the Ethereum network and blockchain functions.
 
-![Eth1x client](./client-diagram.png)
+![Execution client](./client-diagram.png)
 Simplified diagram of what Ethereum client features.
 
 ## Node types {#node-types}
@@ -103,7 +103,7 @@ If somebody runs an Ethereum node with a public API in your community, you can p
 
 On the other hand, if you run a client, you can share it with your friends who might need it.
 
-## Clients {#clients}
+## Execution clients {#execution-clients}
 
 The Ethereum community maintains multiple open-source clients, developed by different teams using different programming languages. This makes the network stronger and more diverse. The ideal goal is to achieve diversity without any client dominating to reduce any single points of failure.
 
@@ -282,11 +282,11 @@ The most convenient and cheap way of running Ethereum node is to use a single bo
 
 Small, affordable and efficient devices like these are ideal for running a node at home.
 
-## Eth2 clients {#eth2-clients}
+## Consensus clients {#consensus-clients}
 
-There are new clients to support the [Eth2 upgrades](/upgrades/beacon-chain/). They will run the Beacon Chain and support the new [proof-of-stake](/developers/docs/consensus-mechanisms/pos/) consensus mechanism.
+There are new clients to support the [consensus upgrades](/upgrades/beacon-chain/). They will run the Beacon Chain and support the new [proof-of-stake](/developers/docs/consensus-mechanisms/pos/) consensus mechanism.
 
-[View Eth2 clients](/upgrades/get-involved/#clients).
+[View consensus clients](/upgrades/get-involved/#clients).
 
 ## Further reading {#further-reading}
 
@@ -306,4 +306,4 @@ There is a lot of information about Ethereum clients on the internet. Here are f
 ## Related tutorials {#related-tutorials}
 
 - [Running a Node with Geth](/developers/tutorials/run-light-node-geth/) _– How to download, install and run Geth. Covering syncmodes, the Javascript console, and more._
-- [Turn your Raspberry Pi 4 into an Eth 1.0 or Eth 2.0 node just by flashing the MicroSD card – Installation guide](/developers/tutorials/run-node-raspberry-pi/) _– Flash your Raspberry Pi 4, plug in an ethernet cable, connect the SSD disk and power up the device to turn the Raspberry Pi 4 into a full Ethereum 1.0 node or an Ethereum 2.0 node (beacon chain / validator)._
+- [Turn your Raspberry Pi 4 into an Eth 1.0 or Eth 2.0 node just by flashing the MicroSD card – Installation guide](/developers/tutorials/run-node-raspberry-pi/) _– Flash your Raspberry Pi 4, plug in an ethernet cable, connect the SSD disk and power up the device to turn the Raspberry Pi 4 into a full Ethereum node running the execution layer (Mainnet) and / or the consensus layer (Beacon Chain / validator)._

--- a/src/content/developers/docs/nodes-and-clients/index.md
+++ b/src/content/developers/docs/nodes-and-clients/index.md
@@ -105,7 +105,7 @@ On the other hand, if you run a client, you can share it with your friends who m
 
 ## Execution clients {#execution-clients}
 
-The Ethereum community maintains multiple open-source clients, developed by different teams using different programming languages. This makes the network stronger and more diverse. The ideal goal is to achieve diversity without any client dominating to reduce any single points of failure.
+The Ethereum community maintains multiple open-source execution clients (previously known as "Eth1 clients", or just "Ethereum clients"), developed by different teams using different programming languages. This makes the network stronger and more diverse. The ideal goal is to achieve diversity without any client dominating to reduce any single points of failure.
 
 This table summarizes the different clients. All of them pass [client tests](https://github.com/ethereum/tests) and are actively maintained to stay updated with network upgrades.
 

--- a/src/content/developers/docs/nodes-and-clients/index.md
+++ b/src/content/developers/docs/nodes-and-clients/index.md
@@ -284,7 +284,7 @@ Small, affordable and efficient devices like these are ideal for running a node 
 
 ## Consensus clients (formerly Eth2 clients) {#consensus-clients}
 
-There are multiple consensus clients (previously known as Eth2 clients) to support the [consensus upgrades](/upgrades/beacon-chain/). They are running the Beacon Chain and will provide proof of stake consensus mechanism to execution clients after [The Merge.](/eth2/merge/)
+There are multiple consensus clients (previously known as Eth2 clients) to support the [consensus upgrades](/upgrades/beacon-chain/). They are running the Beacon Chain and will provide proof-of-stake consensus mechanism to execution clients after [The Merge.](/eth2/merge/)
 
 [View consensus clients](/upgrades/get-involved/#clients).
 

--- a/src/content/developers/docs/nodes-and-clients/index.md
+++ b/src/content/developers/docs/nodes-and-clients/index.md
@@ -284,7 +284,7 @@ Small, affordable and efficient devices like these are ideal for running a node 
 
 ## Consensus clients (formerly Eth2 clients) {#consensus-clients}
 
-There are multiple consensus clients (previously known as Eth2 clients) to support the [consensus upgrades](/upgrades/beacon-chain/). They are running the Beacon Chain and will provide proof-of-stake consensus mechanism to execution clients after [The Merge.](/eth2/merge/)
+There are multiple consensus clients (previously known as Eth2 clients) to support the [consensus upgrades](/upgrades/beacon-chain/). They are running the Beacon Chain and will provide proof-of-stake consensus mechanism to execution clients after [The Merge](/eth2/merge/).
 
 [View consensus clients](/upgrades/get-involved/#clients).
 

--- a/src/content/developers/docs/nodes-and-clients/index.md
+++ b/src/content/developers/docs/nodes-and-clients/index.md
@@ -284,7 +284,7 @@ Small, affordable and efficient devices like these are ideal for running a node 
 
 ## Consensus clients {#consensus-clients}
 
-There are new clients to support the [consensus upgrades](/upgrades/beacon-chain/). They will run the Beacon Chain and support the new [proof-of-stake](/developers/docs/consensus-mechanisms/pos/) consensus mechanism.
+There are multiple consensus clients (previously known as Eth2 clients) to support the [consensus upgrades](/upgrades/beacon-chain/). They run the Beacon Chain and support the [proof-of-stake](/developers/docs/consensus-mechanisms/pos/) consensus mechanism.
 
 [View consensus clients](/upgrades/get-involved/#clients).
 

--- a/src/content/developers/docs/nodes-and-clients/index.md
+++ b/src/content/developers/docs/nodes-and-clients/index.md
@@ -18,7 +18,7 @@ You should understand the concept of a peer-to-peer network and the [basics of t
 
 You can see a real-time view of the Ethereum network by looking at this [map of nodes](https://etherscan.io/nodetracker).
 
-Many [Ethereum clients](/developers/docs/nodes-and-clients/#clients) exist, in a variety of programming languages such as Go, Rust, JavaScript, Python, C# .NET and Java. What these implementations have in common is they all follow a formal specification (originally the [Ethereum Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf)). This specification dictates how the Ethereum network and blockchain functions.
+Many [Ethereum clients](/developers/docs/nodes-and-clients/#clients) exist, in a variety of programming languages such as Go, Rust, JavaScript, Typescript, Python, C# .NET, Nim and Java. What these implementations have in common is they all follow a formal specification (originally the [Ethereum Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf)). This specification dictates how the Ethereum network and blockchain functions.
 
 ![Execution client](./client-diagram.png)
 Simplified diagram of what Ethereum client features.
@@ -103,7 +103,7 @@ If somebody runs an Ethereum node with a public API in your community, you can p
 
 On the other hand, if you run a client, you can share it with your friends who might need it.
 
-## Execution clients {#execution-clients}
+## Execution clients (formerly Eth1 clients) {#execution-clients}
 
 The Ethereum community maintains multiple open-source execution clients (previously known as "Eth1 clients", or just "Ethereum clients"), developed by different teams using different programming languages. This makes the network stronger and more diverse. The ideal goal is to achieve diversity without any client dominating to reduce any single points of failure.
 
@@ -282,19 +282,19 @@ The most convenient and cheap way of running Ethereum node is to use a single bo
 
 Small, affordable and efficient devices like these are ideal for running a node at home.
 
-## Consensus clients {#consensus-clients}
+## Consensus clients (formerly Eth2 clients) {#consensus-clients}
 
-There are multiple consensus clients (previously known as Eth2 clients) to support the [consensus upgrades](/upgrades/beacon-chain/). They run the Beacon Chain and support the [proof-of-stake](/developers/docs/consensus-mechanisms/pos/) consensus mechanism.
+There are multiple consensus clients (previously known as Eth2 clients) to support the [consensus upgrades](/upgrades/beacon-chain/). They are running the Beacon Chain and will provide proof of stake consensus mechanism to execution clients after [The Merge.](/eth2/merge/)
 
 [View consensus clients](/upgrades/get-involved/#clients).
 
-| Client                                                      | Language   | Operating systems     | Networks                              | Sync strategies | State pruning |
-| ----------------------------------------------------------- | ---------- | --------------------- | ------------------------------------- | --------------- | ------------- |
-| [Teku](https://pegasys.tech/teku)                           | Java       | Linux, Windows, macOS | Beacon Chain, Prater                  | Full            |               |
-| [Nimbus](https://nimbus.team/)                              | Nim        | Linux, Windows, macOS | Beacon Chain, Prater                  | Full            |               |
-| [Lighthouse](https://lighthouse-book.sigmaprime.io/)        | Rust       | Linux, Windows, macOS | Beacon Chain, Prater, Pyrmont         | Full            |               |
-| [Lodestar](https://lodestar.chainsafe.io/)                  | TypeScript | Linux, Windows, macOS | Beacon Chain, Prater                  | Full            |               |
-| [Prysm](https://docs.prylabs.network/docs/getting-started/) | Go         | Linux, Windows, macOS | Beacon Chain, Gnosis, Prater, Pyrmont | Full            |               |
+| Client                                                      | Language   | Operating systems     | Networks                              |
+| ----------------------------------------------------------- | ---------- | --------------------- | ------------------------------------- |
+| [Teku](https://pegasys.tech/teku)                           | Java       | Linux, Windows, macOS | Beacon Chain, Prater                  |
+| [Nimbus](https://nimbus.team/)                              | Nim        | Linux, Windows, macOS | Beacon Chain, Prater                  |
+| [Lighthouse](https://lighthouse-book.sigmaprime.io/)        | Rust       | Linux, Windows, macOS | Beacon Chain, Prater, Pyrmont         |
+| [Lodestar](https://lodestar.chainsafe.io/)                  | TypeScript | Linux, Windows, macOS | Beacon Chain, Prater                  |
+| [Prysm](https://docs.prylabs.network/docs/getting-started/) | Go         | Linux, Windows, macOS | Beacon Chain, Gnosis, Prater, Pyrmont |
 
 ## Further reading {#further-reading}
 
@@ -314,4 +314,4 @@ There is a lot of information about Ethereum clients on the internet. Here are f
 ## Related tutorials {#related-tutorials}
 
 - [Running a Node with Geth](/developers/tutorials/run-light-node-geth/) _– How to download, install and run Geth. Covering syncmodes, the Javascript console, and more._
-- [Turn your Raspberry Pi 4 into an Eth 1.0 or Eth 2.0 node just by flashing the MicroSD card – Installation guide](/developers/tutorials/run-node-raspberry-pi/) _– Flash your Raspberry Pi 4, plug in an ethernet cable, connect the SSD disk and power up the device to turn the Raspberry Pi 4 into a full Ethereum node running the execution layer (Mainnet) and / or the consensus layer (Beacon Chain / validator)._
+- [Turn your Raspberry Pi 4 into a validator node just by flashing the MicroSD card – Installation guide](/developers/tutorials/run-node-raspberry-pi/) _– Flash your Raspberry Pi 4, plug in an ethernet cable, connect the SSD disk and power up the device to turn the Raspberry Pi 4 into a full Ethereum node running the execution layer (Mainnet) and / or the consensus layer (Beacon Chain / validator)._

--- a/src/content/translations/es/developers/docs/nodes-and-clients/index.md
+++ b/src/content/translations/es/developers/docs/nodes-and-clients/index.md
@@ -99,7 +99,7 @@ Si alguien ejecuta un nodo de Ethereum con una API pública en tu comunidad, pod
 
 Por otra parte, si administras un cliente, puedes compartirlo con tus amigos que lo necesiten.
 
-## Clientes {#clients}
+## Clientes {#execution-clients}
 
 Ethereum esta diseñado para ofrecer diferentes clientes, desarrollados por diferentes equipos que utilizan diferentes lenguajes de programación. Esto hace que la red sea mas fuerte y más diversa. El objetivo ideal es lograr la diversidad sin que ningún cliente tenga una posición dominante para reducir así los puntos de fracaso.
 
@@ -210,7 +210,7 @@ La manera más conveniente y barata de ejecutar un nodo de Ethereum es usar una 
 
 Los dispositivos pequeños, económicos y eficientes como estos son ideales para ejecutar un nodo en casa.
 
-## Clientes eth2 {#eth2-clients}
+## Clientes eth2 {#consensus-clients}
 
 Hay nuevos clientes que soportan las [actualizaciones de Eth2](/upgrades/beacon-chain/). Ellos ejecutarán la cadena de baliza y apoyarán el nuevo mecanismo de consenso [a prueba de estaturas](/developers/docs/consensus-mechanisms/pos/).
 

--- a/src/content/translations/fr/developers/docs/nodes-and-clients/index.md
+++ b/src/content/translations/fr/developers/docs/nodes-and-clients/index.md
@@ -99,7 +99,7 @@ Si quelqu'un exécute un nœud Ethereum avec une API publique dans votre communa
 
 D'autre part, si vous exécutez un client, vous pouvez le partager avec vos amis qui pourraient en avoir besoin.
 
-## Clients {#clients}
+## Clients {#execution-clients}
 
 Ethereum est conçu pour offrir des clients différents, développés par différentes équipes utilisant différents langages de programmation. Cela rend le réseau plus solide et plus diversifié. L'objectif idéal est de parvenir à une diversité sans qu'aucun client ne domine afin de réduire les points de défaillance uniques.
 
@@ -210,7 +210,7 @@ La façon la plus pratique et la moins chère d'exécuter un nœud Ethereum est 
 
 Les petits appareils abordables et efficaces de ce type sont parfaits pour exécuter un nœud chez soi.
 
-## Clients Eth2 {#eth2-clients}
+## Clients Eth2 {#consensus-clients}
 
 Il existe de nouveaux clients pour prendre en charge les [mises à niveau Eth2](/upgrades/beacon-chain/). Ils exécuteront la chaîne phare et prendront en charge le nouveau mécanisme de consensus de [preuve d'enjeu](/developers/docs/consensus-mechanisms/pos/).
 

--- a/src/content/translations/hu/developers/docs/nodes-and-clients/index.md
+++ b/src/content/translations/hu/developers/docs/nodes-and-clients/index.md
@@ -99,7 +99,7 @@ Ha valaki egy Ethereum csomópontot futtat egy nyilvános API-jal a közössége
 
 Másrészt, ha klienst futtatsz, megoszthatod azokat barátaiddal, akiknek szüksége lehet rá.
 
-## Kliensek {#clients}
+## Kliensek {#execution-clients}
 
 Az Ethereumot úgy tervezték, hogy különböző kliensekkel rendelkezzen, amelyeket különféle csapatok fejlesztettek ki különböző programozási nyelvek felhasználásával. Ez erősebbé és sokszínűbbé teszi a hálózatot. Az ideális cél a sokszínűség elérése anélkül, hogy egy kliens dominálna és a hiba lehetőséget a lehető legkisebbre szűkítsük.
 
@@ -210,7 +210,7 @@ A lehető legkényelmesebb és legegyszerűbb módja egy Ethereum csomópont fut
 
 A kicsi, olcsó, és hatékony eszközök mint ezek ideálisak egy otthoni csomópont futtatására.
 
-## Eth2 kliensek {#eth2-clients}
+## Eth2 kliensek {#consensus-clients}
 
 Az [Eth2 fejlesztéseket](/upgrades/beacon-chain/) új kliensek támogatják. A Beacon Chain-nen fognak futni és az új [proof-of-stake](/developers/docs/consensus-mechanisms/pos/) konszenzus mechanizmust fogják támogatni.
 

--- a/src/content/translations/it/developers/docs/nodes-and-clients/index.md
+++ b/src/content/translations/it/developers/docs/nodes-and-clients/index.md
@@ -99,7 +99,7 @@ Se qualcuno esegue un nodo Ethereum con un'API pubblica nella tua community, puo
 
 D'altro canto, se esegui un client, puoi condividerlo con i amici che potrebbero averne bisogno.
 
-## Client {#clients}
+## Client {#execution-clients}
 
 Ethereum è progettato per offrire client diversi, sviluppati da team diversi, utilizzando linguaggi di programmazione diversi. Questo rende la rete più forte e diversificata. L'obiettivo ideale è raggiungere la diversità senza che nessun client prevalga, per ridurre eventuali punti di errore singoli.
 
@@ -210,7 +210,7 @@ Il modo più conveniente ed economico di eseguire un il nodo Ethereum è quello 
 
 Dispositivi piccoli, convenienti ed efficienti come questi sono ideali per eseguire un nodo a casa.
 
-## Client Eth2 {#eth2-clients}
+## Client Eth2 {#consensus-clients}
 
 Ci sono nuovi client per supportare gli [upgrade a Eth2](/upgrades/beacon-chain/). Eseguiranno la beacon chain e supporteranno il nuovo meccanismo di consenso [proof-of-stake](/developers/docs/consensus-mechanisms/pos/).
 

--- a/src/content/translations/pl/developers/docs/nodes-and-clients/index.md
+++ b/src/content/translations/pl/developers/docs/nodes-and-clients/index.md
@@ -99,7 +99,7 @@ Jeśli ktoś uruchamia węzeł Ethereum z publicznym API w Twojej społeczności
 
 Z drugiej strony, jeśli uruchamiasz klienta, możesz podzielić się nim ze znajomymi, którzy mogą tego potrzebować.
 
-## Klienci {#clients}
+## Klienci {#execution-clients}
 
 Ethereum jest zaprojektowany do oferowania różnych klientów, stworzonych przez różne zespoły przy użyciu różnych języków programowania. Dzięki temu sieć jest silniejsza i bardziej zróżnicowana. Idealnym celem jest osiągnięcie różnorodności bez zdominowania przez żadnego klienta w celu zmniejszenia pojedynczych punktów niepowodzenia.
 
@@ -210,7 +210,7 @@ Najbardziej wygodnym i tanim sposobem uruchomienia węzła Ethereum jest korzyst
 
 Małe, niedrogie i wydajne urządzenia, takie jak te, są idealne do uruchomienia węzła w domu.
 
-## Klienci Eth2 {#eth2-clients}
+## Klienci Eth2 {#consensus-clients}
 
 Pojawili się nowi klienci obsługujący [aktualizacje Eth2](/upgrades/beacon-chain/). Będą obsługiwać łańcuch śledzący i wspierać nowy mechanizm konsensusu [proof-of-stake](/developers/docs/consensus-mechanisms/pos/).
 

--- a/src/content/translations/ro/developers/docs/nodes-and-clients/index.md
+++ b/src/content/translations/ro/developers/docs/nodes-and-clients/index.md
@@ -99,7 +99,7 @@ Dacă cineva rulează un nod Ethereum cu un API public în comunitatea sa, îți
 
 Pe de altă parte, dacă rulezi un client, îl poți partaja cu prietenii tăi care ar putea avea nevoie de el.
 
-## Clienți {#clients}
+## Clienți {#execution-clients}
 
 Ethereum este conceput pentru a oferi clienți diferiți, dezvoltați de diferite echipe care utilizează diferite limbaje de programare. Acest lucru face ca rețeaua să fie mai puternică și mai diversă. Scopul ideal este de a realiza diversitatea fără ca niciun client să domine pentru a reduce punctele de eșec.
 
@@ -210,7 +210,7 @@ Cel mai convenabil și mai ieftin mod de a rula nodul Ethereum este de a utiliza
 
 Dispozitive mici, accesibile și eficiente ca acestea sunt ideale pentru rularea unui nod acasă.
 
-## Clienții Eth2 {#eth2-clients}
+## Clienții Eth2 {#consensus-clients}
 
 Există clienți noi pentru a sprijini [upgrade-urile Eth2](/upgrades/beacon-chain/). Aceștia vor executa lanțul Beacon și vor sprijini noul mecanism de consens al [dovezii mizei (PoS)](/developers/docs/consensus-mechanisms/pos/).
 

--- a/src/content/translations/zh/developers/docs/nodes-and-clients/index.md
+++ b/src/content/translations/zh/developers/docs/nodes-and-clients/index.md
@@ -102,7 +102,7 @@ sidebarDepth: 2
 
 另一方面，如果您运行一个客户端，则可以与可能需要它的朋友分享。
 
-## 客户端 {#clients}
+## 客户端 {#execution-clients}
 
 以太坊社区维护着多个开源客户端，这些客户端由不同团队使用不同的编程语言开发。 这使得该网络更强大、更多样化。 理想的目标是在没有任何客户端支配的情况下实现多样性，以减少任何单点故障。
 
@@ -281,7 +281,7 @@ Erigon（前称 TurbohyGeth）是 Go Ethereum 的一个分叉，注重速度和�
 
 像这样的小型、实惠和高效的设备是在家里运行节点的理想选择。
 
-## 以太坊 2.0 客户端 {#eth2-clients}
+## 以太坊 2.0 客户端 {#consensus-clients}
 
 有新客户端支持[以太坊 2.0 升级](/upgrades/beacon-chain/)。 他们将运行信标链，并支持新的[权益证明](/developers/docs/consensus-mechanisms/pos/)共识机制。
 


### PR DESCRIPTION
`eth2-rebrand <- client-content`

## Description
- Updates terms on `nodes-and-clients` page to use "execution" and "consensus" clients.
- Drafted table for consensus layer clients
- [ ] Complete details of consensus client table

https://www.notion.so/efdn/Update-client-content-47575e2b6d6a41878457ed9f768d537c
