### PR TITLE
Fix broken sending-transaction links in tutorials [Fixes #5069]

### DIFF
--- a/src/content/developers/tutorials/hello-world-smart-contract/index.md
+++ b/src/content/developers/tutorials/hello-world-smart-contract/index.md
@@ -351,7 +351,7 @@ To understand what’s going on under the hood, let’s navigate to the Explorer
 ![hello world explorer](./hello-world-explorer.png)
 
 Here you’ll see a handful of JSON-RPC calls that Hardhat/Ethers made under the hood for us when we called the `.deploy()` function. Two important ones to call out here are [`eth_sendRawTransaction`](https://docs.alchemyapi.io/alchemy/documentation/alchemy-api-reference/json-rpc#eth_sendrawtransaction), which is the request to actually write our contract onto the Ropsten chain, and [`eth_getTransactionByHash`](https://docs.alchemyapi.io/alchemy/documentation/alchemy-api-reference/json-rpc#eth_gettransactionbyhash) which is a request to read information about our transaction given the hash (a typical pattern when
-transactions). To learn more about sending transactions, check out this tutorial on [sending transactions using Web3](https://docs.alchemyapi.io/alchemy/tutorials/sending-transactions-using-web3-and-alchemy)
+transactions). To learn more about sending transactions, check out this tutorial on [sending transactions using Web3](https://docs.alchemy.com/alchemy/tutorials/sending-txs)
 
 That’s all for part 1 of this tutorial, in part 2 we’ll actually [interact with our smart contract](https://docs.alchemyapi.io/alchemy/tutorials/hello-world-smart-contract#part-2-interact-with-your-smart-contract) by updated our initial message, and in part 3 we’ll [publish our smart contract to Etherscan](https://docs.alchemyapi.io/alchemy/tutorials/hello-world-smart-contract#optional-part-3-publish-your-smart-contract-to-etherscan) so everyone will know how to interact with it.
 

--- a/src/content/developers/tutorials/hello-world-smart-contract/index.md
+++ b/src/content/developers/tutorials/hello-world-smart-contract/index.md
@@ -351,7 +351,7 @@ To understand what’s going on under the hood, let’s navigate to the Explorer
 ![hello world explorer](./hello-world-explorer.png)
 
 Here you’ll see a handful of JSON-RPC calls that Hardhat/Ethers made under the hood for us when we called the `.deploy()` function. Two important ones to call out here are [`eth_sendRawTransaction`](https://docs.alchemyapi.io/alchemy/documentation/alchemy-api-reference/json-rpc#eth_sendrawtransaction), which is the request to actually write our contract onto the Ropsten chain, and [`eth_getTransactionByHash`](https://docs.alchemyapi.io/alchemy/documentation/alchemy-api-reference/json-rpc#eth_gettransactionbyhash) which is a request to read information about our transaction given the hash (a typical pattern when
-transactions). To learn more about sending transactions, check out this tutorial on [sending transactions using Web3](https://docs.alchemy.com/alchemy/tutorials/sending-txs)
+transactions). To learn more about sending transactions, check out this tutorial on [sending transactions using Web3](/developers/tutorials/sending-transactions-using-web3-and-alchemy/)
 
 That’s all for part 1 of this tutorial, in part 2 we’ll actually [interact with our smart contract](https://docs.alchemyapi.io/alchemy/tutorials/hello-world-smart-contract#part-2-interact-with-your-smart-contract) by updated our initial message, and in part 3 we’ll [publish our smart contract to Etherscan](https://docs.alchemyapi.io/alchemy/tutorials/hello-world-smart-contract#optional-part-3-publish-your-smart-contract-to-etherscan) so everyone will know how to interact with it.
 

--- a/src/content/developers/tutorials/how-to-write-and-deploy-an-nft/index.md
+++ b/src/content/developers/tutorials/how-to-write-and-deploy-an-nft/index.md
@@ -215,7 +215,7 @@ Now that we’ve created a MetaMask wallet, Alchemy account, and written our sma
 
 Every transaction sent from your virtual wallet requires a signature using your unique private key. To provide our program with this permission, we can safely store our private key (and Alchemy API key) in an environment file.
 
-To learn more about sending transactions, check out [this tutorial](https://docs.alchemyapi.io/alchemy/tutorials/sending-transactions-using-web3-and-alchemy) on sending transactions using web3.
+To learn more about sending transactions, check out [this tutorial](https://docs.alchemy.com/alchemy/tutorials/sending-txs) on sending transactions using web3.
 
 First, install the dotenv package in your project directory:
 
@@ -340,6 +340,6 @@ To understand what’s going on under the hood, let’s navigate to the Explorer
 
 ![View calls made “under the hood” with Alchemy’s Explorer Dashboard](./alchemy-explorer.png)
 
-Here you’ll see a handful of JSON-RPC calls that Hardhat/Ethers made under the hood for us when we called the .deploy() function. Two important ones to call out here are [eth_sendRawTransaction](/developers/docs/apis/json-rpc/#eth_sendrawtransaction), which is the request to actually write our smart contract onto the Ropsten chain, and [eth_getTransactionByHash](/developers/docs/apis/json-rpc/#eth_gettransactionbyhash) which is a request to read information about our transaction given the hash (a typical pattern when sending transactions). To learn more about sending transactions, check out this tutorial on [sending transactions using Web3](https://docs.alchemyapi.io/alchemy/tutorials/sending-transactions-using-web3-and-alchemy).
+Here you’ll see a handful of JSON-RPC calls that Hardhat/Ethers made under the hood for us when we called the .deploy() function. Two important ones to call out here are [eth_sendRawTransaction](/developers/docs/apis/json-rpc/#eth_sendrawtransaction), which is the request to actually write our smart contract onto the Ropsten chain, and [eth_getTransactionByHash](/developers/docs/apis/json-rpc/#eth_gettransactionbyhash) which is a request to read information about our transaction given the hash (a typical pattern when sending transactions). To learn more about sending transactions, check out this tutorial on [sending transactions using Web3](https://docs.alchemy.com/alchemy/tutorials/sending-txs).
 
 That’s all for Part 1 of this tutorial. In [Part 2, we’ll actually interact with our smart contract by minting an NFT](/developers/tutorials/how-to-mint-an-nft/), and in [Part 3 we’ll show you how to view your NFT in your Ethereum wallet](/developers/tutorials/how-to-view-nft-in-metamask/)!

--- a/src/content/developers/tutorials/how-to-write-and-deploy-an-nft/index.md
+++ b/src/content/developers/tutorials/how-to-write-and-deploy-an-nft/index.md
@@ -215,7 +215,7 @@ Now that we’ve created a MetaMask wallet, Alchemy account, and written our sma
 
 Every transaction sent from your virtual wallet requires a signature using your unique private key. To provide our program with this permission, we can safely store our private key (and Alchemy API key) in an environment file.
 
-To learn more about sending transactions, check out [this tutorial](https://docs.alchemy.com/alchemy/tutorials/sending-txs) on sending transactions using web3.
+To learn more about sending transactions, check out [this tutorial](/developers/tutorials/sending-transactions-using-web3-and-alchemy/) on sending transactions using web3.
 
 First, install the dotenv package in your project directory:
 
@@ -340,6 +340,6 @@ To understand what’s going on under the hood, let’s navigate to the Explorer
 
 ![View calls made “under the hood” with Alchemy’s Explorer Dashboard](./alchemy-explorer.png)
 
-Here you’ll see a handful of JSON-RPC calls that Hardhat/Ethers made under the hood for us when we called the .deploy() function. Two important ones to call out here are [eth_sendRawTransaction](/developers/docs/apis/json-rpc/#eth_sendrawtransaction), which is the request to actually write our smart contract onto the Ropsten chain, and [eth_getTransactionByHash](/developers/docs/apis/json-rpc/#eth_gettransactionbyhash) which is a request to read information about our transaction given the hash (a typical pattern when sending transactions). To learn more about sending transactions, check out this tutorial on [sending transactions using Web3](https://docs.alchemy.com/alchemy/tutorials/sending-txs).
+Here you’ll see a handful of JSON-RPC calls that Hardhat/Ethers made under the hood for us when we called the .deploy() function. Two important ones to call out here are [eth_sendRawTransaction](/developers/docs/apis/json-rpc/#eth_sendrawtransaction), which is the request to actually write our smart contract onto the Ropsten chain, and [eth_getTransactionByHash](/developers/docs/apis/json-rpc/#eth_gettransactionbyhash) which is a request to read information about our transaction given the hash (a typical pattern when sending transactions). To learn more about sending transactions, check out this tutorial on [sending transactions using Web3](/developers/tutorials/sending-transactions-using-web3-and-alchemy/).
 
 That’s all for Part 1 of this tutorial. In [Part 2, we’ll actually interact with our smart contract by minting an NFT](/developers/tutorials/how-to-mint-an-nft/), and in [Part 3 we’ll show you how to view your NFT in your Ethereum wallet](/developers/tutorials/how-to-view-nft-in-metamask/)!


### PR DESCRIPTION
Update some links in the index.md files of 2 different tutorials

## Description

Links here are broken
https://ethereum.org/en/developers/tutorials/how-to-write-and-deploy-an-nft/#connect-metamask-and-alchemy ("To learn more about sending transactions check out this tutorial")
https://ethereum.org/en/developers/tutorials/how-to-write-and-deploy-an-nft/#deploy-contract ("To learn more about sending transactions, check out this tutorial on sending transactions using Web3")
https://ethereum.org/en/developers/tutorials/hello-world-smart-contract/#step-16-deploy-our-contract ("To learn more about sending transactions, check out this tutorial on sending transactions using Web3")

Was here: https://docs.alchemy.com/alchemy/tutorials/sending-transactions-using-web3-and-alchemy
Now here: https://docs.alchemy.com/alchemy/tutorials/sending-txs


## Related Issue
 
#5069
