### PR TITLE
Adds code-examples string to intl page-index.json files [Fixes #5066]

### DIFF
--- a/src/intl/ar/page-index.json
+++ b/src/intl/ar/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "حدود جديدة للتطوير",
   "page-index-developers-description": "الإيثيريوم وتطبيقاته شفافة ومفتوحة المصدر. يمكنك تفريع التعليمات البرمجية وإعادة استخدام الوظائف الأخرى التي تم بناؤها بالفعل. إذا كنت لا ترغب في تعلم لغة جديدة يمكنك فقط التفاعل مع التعليمات البرمجية المفتوحة المصدر باستخدام جافا سكريبت وغيرها من اللغات الموجودة.",
   "page-index-developers-button": "بوابة المبرمج",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "البنك الخاص بك",
   "page-index-developers-code-example-description-0": "يمكنك بناء بنك يديره المنطق الذي قمت ببرمجته.",
   "page-index-developers-code-example-title-1": "عملتك الخاصة",

--- a/src/intl/bg/page-index.json
+++ b/src/intl/bg/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "Нова граница за развитие",
   "page-index-developers-description": "Етереум и неговите приложения за прозрачни и с отворен код. Вие може да създадете разклонение на кода и отново да използвате функционалности, които другите вече са създали. Ако не желаете да учите нов език може просто да работите с отворен код, ползвайки JavaScript и другите съществуващи езици.",
   "page-index-developers-button": "Портал за програмисти",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "Твоя собствена банка",
   "page-index-developers-code-example-description-0": "Може да изградите банка, управлявана от логиката, програмирана от вас.",
   "page-index-developers-code-example-title-1": "Твоя собствена валута",

--- a/src/intl/bn/page-index.json
+++ b/src/intl/bn/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "উন্নয়নের একটি নতুন গন্তব্য",
   "page-index-developers-description": "ইথেরিয়াম এবং এর অ্যাপগুলি খুবই স্বচ্ছ এবং ওপেন সোর্স। আপনি কোড বের করে আনতে পারবেন এবং অন্যরা যেসব কার্যকারিতা ইতিমধ্যেই তৈরি করেছেন, সেগুলি পুনরায় ব্যবহার করতে পারেন। আপনি যদি একটি নতুন ভাষা শিখতে না চান, তাহলে শুধুমাত্র জাভাস্ক্রিপ্ট এবং অন্যান্য বিদ্যমান ভাষা ব্যবহার করে ওপেন-সোর্স কোড ব্যবহার করে আপনি কাজ করতে পারবেন।",
   "page-index-developers-button": "ডেভেলপার পোর্টাল",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "আপনার নিজস্ব ব্যাঙ্ক",
   "page-index-developers-code-example-description-0": "আপনার প্রোগ্রাম করা লজিকের মাধ্যমে পরিচালিত একটি ব্যাঙ্ক আপনি তৈরি করে নিতে পারবেন।",
   "page-index-developers-code-example-title-1": "আপনার নিজস্ব মুদ্রা",

--- a/src/intl/ca/page-index.json
+++ b/src/intl/ca/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "Una nova frontera per al desenvolupament",
   "page-index-developers-description": "Ethereum i les seves aplicacions són transparents i de codi obert. Pots bifurcar el codi i reutilitzar les funcionalitats que altres hagin creat. Si no vols aprendre un nou llenguatge pots simplement interactuar amb codis de font oberta utilitzant JavaScript o altres llenguatges existents.",
   "page-index-developers-button": "Portal de desenvolupadors",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "El teu propi banc",
   "page-index-developers-code-example-description-0": "Pots construir un compte bancari a través de la lògica que tu hagis programat.",
   "page-index-developers-code-example-title-1": "La teva pròpia moneda",

--- a/src/intl/cs/page-index.json
+++ b/src/intl/cs/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "Otevřený vývoj",
   "page-index-developers-description": "Ethereum a jeho aplikace jsou transparentní a open source. Můžete forknout kód a znovu použít funkce, které již ostatní vytvořili. Pokud se nechcete učit nový jazyk, můžete komunikovat s otevřeným kódem pomocí JavaScriptu a dalších existujících jazyků.",
   "page-index-developers-button": "Vývojářský portál",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "Vaše vlastní banka",
   "page-index-developers-code-example-description-0": "Můžete vytvořit vlastní banku s pravidly, která naprogramujete.",
   "page-index-developers-code-example-title-1": "Vaše vlastní měna",

--- a/src/intl/de/page-index.json
+++ b/src/intl/de/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "Neue Möglichkeiten für Entwickler",
   "page-index-developers-description": "Ethereum und seine Apps sind transparent und open-source. Du kannst den Code forken und Funktionen, die andere bereits erstellt haben, wiederverwenden oder erweitern. Wenn du keine neue Programmiersprache lernen möchtest, kannst du einfach den bereitgestellten Open-Source-Code in JavaScript und anderen Programmiersprachen nutzen.",
   "page-index-developers-button": "Entwicklerportal",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "Deine eigene Bank",
   "page-index-developers-code-example-description-0": "Du kannst eine Bank erschaffen, die mit der von dir programmierten Logik arbeitet.",
   "page-index-developers-code-example-title-1": "Deine eigene Währung",

--- a/src/intl/el/page-index.json
+++ b/src/intl/el/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "Ένα νέο σύνορο ανάπτυξης",
   "page-index-developers-description": "Το Ethereum και οι εφαρμογές του χαρακτηρίζονται από διαφάνεια και είναι ανοιχτού κώδικα. Μπορείτε να κάνετε διακλάδωση κώδικα και να χρησιμοποιήσετε ξανά λειτουργίες που έχουν δημιουργήσει άλλοι πριν από εσάς. Έτσι, εάν δεν θέλετε να μάθετε μια νέα γλώσσα προγραμματισμού, μπορείτε απλά να αλληλεπιδράσετε με έναν ανοικτό κώδικα, χρησιμοποιώντας JavaScript και άλλες υπάρχουσες γλώσσες προγραμματισμού.",
   "page-index-developers-button": "Πύλη προγραμματιστών",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "Η δική σας τράπεζα",
   "page-index-developers-code-example-description-0": "Μπορείτε να δημιουργήσετε μια τράπεζα με βάση τον δικό σας λογικό προγραμματισμό.",
   "page-index-developers-code-example-title-1": "Το δικό σας νόμισμα",

--- a/src/intl/es/page-index.json
+++ b/src/intl/es/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "Una nueva frontera para el desarrollo",
   "page-index-developers-description": "Ethereum y sus aplicaciones son transparentes y de código abierto. Puedes bifurcar el código y reutilizar la funcionalidad que otros hayan creado previamente. Si no quieres aprender un nuevo lenguaje, simplemente puedes interactuar con código de fuente abierta usando JavaScript y otros lenguajes existentes.",
   "page-index-developers-button": "Portal para desarrolladores",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "Tu propio banco",
   "page-index-developers-code-example-description-0": "Puedes construir un banco gestionado por la lógica que hayas programado.",
   "page-index-developers-code-example-title-1": "Tu propia moneda",

--- a/src/intl/fa/page-index.json
+++ b/src/intl/fa/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "مرز جدیدی برای توسعه",
   "page-index-developers-description": "اتریوم و برنامه های آن شفاف و منبع باز هستند. می توانید کد را فورک کرده و از قابلیت هایی که دیگران قبلاً ساخته اند استفاده کنید. اگر نمی خواهید زبانی جدید یاد بگیرید، فقط می توانید با استفاده از جاوا اسکریپت و سایر زبان های موجود با کد منبع باز تعامل داشته باشید.",
   "page-index-developers-button": "پورتال توسعه دهنده",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "بانک خودتان",
   "page-index-developers-code-example-description-0": "شما می توانید بانکی ایجاد کنید که بر اساس منطقی که برنامه ریزی کرده اید اداره می شود.",
   "page-index-developers-code-example-title-1": "واحد پول خودتان",

--- a/src/intl/fi/page-index.json
+++ b/src/intl/fi/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "Kehityksen uusi ulottuvuus",
   "page-index-developers-description": "Ethereum ja sen sovellukset pohjautuvat avoimeen lähdekoodiin. Voit muokata koodia ja hyödyntää muiden rakentamia toimintoja. Jos et halua oppia uutta kieltä, voit työskennellä avoimen koodin kanssa JavaScriptin ja muiden olemassa olevien kielten avulla.",
   "page-index-developers-button": "Kehittäjäportaali",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "Oma pankkisi",
   "page-index-developers-code-example-description-0": "Voit luoda ohjelmoimasi logiikan mukaisen pankin.",
   "page-index-developers-code-example-title-1": "Oma valuuttasi",

--- a/src/intl/fr/page-index.json
+++ b/src/intl/fr/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "Une nouvelle frontière pour le développement",
   "page-index-developers-description": "Ethereum et ses applications sont libres et open-source. Vous pouvez modifier notre code et réutiliser des fonctionnalités que d'autres ont déjà créées. Si vous ne voulez pas apprendre un nouveau langage, vous pouvez juste interagir avec le code open-source en utilisant JavaScript et d'autres langages existants.",
   "page-index-developers-button": "Portail des développeurs",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "Votre propre banque",
   "page-index-developers-code-example-description-0": "Vous pouvez construire une banque exécutée par le code que vous avez programmé.",
   "page-index-developers-code-example-title-1": "Votre propre monnaie",

--- a/src/intl/hi/page-index.json
+++ b/src/intl/hi/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "विकास का एक नया फ्रंटियर",
   "page-index-developers-description": "Ethereum और इसके ऐप पूरी तरह पारदर्शी और ओपन सोर्स हैं। आप कोड निकाल सकते हैं और दूसरों द्वारा पहले ही बनाई जा चुकी सुविधा का फिर से उपयोग कर सकते हैं। अगर आप नई भाषा नहीं सीखना चाहते, तो आप JavaScript और अन्य मौजूदा भाषाओं का उपयोग करके भी ओपन-सोर्स कोड की मदद से इंटरैक्ट कर सकते हैं।",
   "page-index-developers-button": "डेवलपर पोर्टल",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "आपका अपना बैंक",
   "page-index-developers-code-example-description-0": "आप अपने द्वारा प्रोग्राम किए गए लॉजिक से चलने वाला बैंक बना सकते हैं।",
   "page-index-developers-code-example-title-1": "आपकी अपनी करेंसी",

--- a/src/intl/hr/page-index.json
+++ b/src/intl/hr/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "Nova granica razvoja",
   "page-index-developers-description": "Ethereum i njegove aplikacije transparentne su i otvorenog izvora. Možete razdvojiti kod i ponovno koristiti funkcionalnost koju su drugi već izgradili. Ako ne želite učiti novi jezik, možete jednostavno komunicirati s kodom otvorenog izvora koristeći JavaScript i druge postojeće jezike.",
   "page-index-developers-button": "Portal za razvojne inženjere",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "Vaša vlastita banka",
   "page-index-developers-code-example-description-0": "Možete izgraditi banku koju pokrećete logikom koju ste programirali.",
   "page-index-developers-code-example-title-1": "Vaša vlastita valuta",

--- a/src/intl/hu/page-index.json
+++ b/src/intl/hu/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "A fejlődés új dimenziója",
   "page-index-developers-description": "Az Ethereum és alkalmazásai átláthatóak és nyílt forráskódúak. Szétágaztathatja a kódot, és újra felhasználhatja a mások által már létrehozott funkciókat. Ha nem szeretne új nyelvet tanulni, akkor csak használja a nyílt forráskódú kódot a JavaScript és más nyelvek segítségével.",
   "page-index-developers-button": "Fejlesztői portál",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "Saját bank",
   "page-index-developers-code-example-description-0": "Felépíthet egy bankot az Ön által programozott logika alapján.",
   "page-index-developers-code-example-title-1": "Saját pénznem",

--- a/src/intl/id/page-index.json
+++ b/src/intl/id/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "Sebuah garda baru bagi pengembangan",
   "page-index-developers-description": "Ethereum dan aplikasinya transparan dan open source. Anda dapat melakukan kode fork dan menggunakan kembali fungsionalitas yang telah dibuat oleh orang lain. Jika Anda tidak mau mempelajari bahasa baru, Anda cukup berinteraksi dengan kode open-source menggunakan JavaScript dan bahasa-bahasa lain yang tersedia.",
   "page-index-developers-button": "Portal pengembang",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "Bank Anda sendiri",
   "page-index-developers-code-example-description-0": "Anda dapat membangun bank yang dijalankan dengan logika yang telah Anda programkan.",
   "page-index-developers-code-example-title-1": "Mata uang Anda sendiri",

--- a/src/intl/ig/page-index.json
+++ b/src/intl/ig/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "Oke ọhụrụ maka mmepe",
   "page-index-developers-description": "Ethereum na ngwa ọrụ ya doro anya na buru nke mepere emepe. Ị nwere ike iji koodu nrụpụta ya nakwa jiri ọrụ ndị ọzọ rụrụla. Ọ bụrụ na ịchọghị ịmụ asụsụ ọhụrụ ị nwere ike ịmekọrịta naanị na koodu mepere emepe site na iji Javascript na asụsụ ndị ọzọ dị adị.",
   "page-index-developers-button": "Ọwa onye nrụpụta",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "Ụlọ akụ nke gị",
   "page-index-developers-code-example-description-0": "Ị nwere ike wulite ụlọ akụ site na mgbagha ị dere.",
   "page-index-developers-code-example-title-1": "Ego nke gị",

--- a/src/intl/it/page-index.json
+++ b/src/intl/it/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "Una nuova frontiera per lo sviluppo",
   "page-index-developers-description": "Ethereum e le sue applicazioni sono trasparenti e open source. È possibile eseguire un codice fork e riutilizzare funzionalità già costruite da altri. Se non vuoi imparare un nuovo linguaggio, puoi semplicemente interagire con il codice open source utilizzando JavaScript e altri linguaggi esistenti.",
   "page-index-developers-button": "Portale Sviluppatori",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "La tua banca",
   "page-index-developers-code-example-description-0": "Puoi costruire una banca gestita dalla logica che hai programmato.",
   "page-index-developers-code-example-title-1": "La tua valuta",

--- a/src/intl/ja/page-index.json
+++ b/src/intl/ja/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "開発の新境地",
   "page-index-developers-description": "Ethereumとそのアプリは透明でオープンソースです。コードをフォークして、他の人がすでに作った機能を再利用することができます。新しい言語を学びたくなければ、JavaScriptやその他の既存の言語を使って、オープンソースのコードを扱うことができます。",
   "page-index-developers-button": "開発者ポータル",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "自分の銀行",
   "page-index-developers-code-example-description-0": "自分がプログラムしたロジックで動く銀行を構築することができます。",
   "page-index-developers-code-example-title-1": "自分の通貨",

--- a/src/intl/ko/page-index.json
+++ b/src/intl/ko/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "개발의 새로운 지평",
   "page-index-developers-description": "이더리움과 그 앱은 투명한 오픈 소스입니다. 코드를 분기하고 다른 사람들이 이미 구축한 기능을 재사용할 수 있습니다. 새로운 언어를 배우고 싶지 않다면 JavaScript 및 다른 기존 언어를 사용하여 오픈 소스 코드와 상호작용할 수 있습니다.",
   "page-index-developers-button": "개발자 포털",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "나만의 은행",
   "page-index-developers-code-example-description-0": "여러분이 직접 프로그래밍한 로직으로 뱅크런을 구축할 수 있습니다.",
   "page-index-developers-code-example-title-1": "나만의 화폐",

--- a/src/intl/ml/page-index.json
+++ b/src/intl/ml/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "വികസനത്തിനായി ഒരു പുതിയ അതിർത്തി",
   "page-index-developers-description": "Ethereum-വും അതിന്റെ ആപ്പുകളും സുതാര്യവും ഓപ്പൺ സോഴ്സുമാണ്. നിങ്ങൾക്ക് ഫോർക്ക് കോഡ് ചെയ്യാനും മറ്റുള്ളവർ ഇതിനകം നിർമ്മിച്ച പ്രവർത്തനശേഷി വീണ്ടും ഉപയോഗിക്കാനും കഴിയും. നിങ്ങൾക്ക് ഒരു പുതിയ ഭാഷ പഠിക്കാൻ താൽപ്പര്യമില്ലെങ്കിൽ, ജാവസ്ക്രിപ്റ്റും നിലവിലുള്ള മറ്റ് ഭാഷകളും ഉപയോഗിച്ച് നിങ്ങൾക്ക് ഓപ്പൺ സോഴ്‌സ് ചെയ്ത കോഡുമായി സംവദിക്കാം.",
   "page-index-developers-button": "ഡവലപ്പർ പോർട്ടൽ",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "നിങ്ങളുടെ സ്വന്തം ബാങ്ക്",
   "page-index-developers-code-example-description-0": "നിങ്ങൾ പ്രോഗ്രാം ചെയ്‌ത ലോജിക് ഉപയോഗിച്ച് നിങ്ങൾക്ക് ഒരു ബാങ്ക് നിർമ്മിക്കാൻ കഴിയും.",
   "page-index-developers-code-example-title-1": "നിങ്ങളുടെ സ്വന്തം കറൻസി",

--- a/src/intl/mr/page-index.json
+++ b/src/intl/mr/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "विकासाची नवी सीमा",
   "page-index-developers-description": "Ethereum आणि त्याचे अनुप्रयोग पारदर्शक आणि मुक्त स्रोत आहेत. तुम्ही सांकेतिक लेखनाला फाटा देऊ शकता आणि इतरांनी आधीपासूनच निर्माण केलेल्या फंक्शनॅलिटीचा पुनर्वापर करू शकता. तुम्हाला नवीन भाषा शिकायची नसेल तर तुम्ही JavaScript आणि इतर विद्यमान भाषा वापरून मुक्त स्रोत सांकेतिक लेखनानी संवाद साधू शकता.",
   "page-index-developers-button": "विकासकाचे पोर्टल",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "तुमची स्वतःची बँक",
   "page-index-developers-code-example-description-0": "तुम्ही प्रोगॅमिंग केलेल्या तर्कावर चालणारी बँक तयार करू शकता.",
   "page-index-developers-code-example-title-1": "तुमचे स्व:तचे चलन",

--- a/src/intl/ms/page-index.json
+++ b/src/intl/ms/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "Satu sempadan baharu untuk pembangunan",
   "page-index-developers-description": "Ethereum dan aplikasinya adalah telus dan sumber terbuka. Anda boleh fork kod dan gunakan semula fungsi yang telah dibina oleh orang lain. Sekiranya anda tidak mahu belajar bahasa baharu, anda boleh berinteraksi dengan kod sumber terbuka menggunakan JavaScript dan bahasa lain yang ada.",
   "page-index-developers-button": "Portal pembangun",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "Bank anda tersendiri",
   "page-index-developers-code-example-description-0": "Anda boleh membina bank yang dijalankan oleh logik yang anda telah programkan.",
   "page-index-developers-code-example-title-1": "Mata wang anda tersendiri",

--- a/src/intl/nb/page-index.json
+++ b/src/intl/nb/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "Utviklingens nye front",
   "page-index-developers-description": "Ethereum og appene der er utviklet i åpenhet og med åpen kildekode. Du kan forgrene koden og bruke om igjen funksjonaliteter andre allerede har bygget. Hvis du ikke vil lære et nytt språk, kan du bare samhandle med åpen kildekode ved å bruke JavaScript og andre eksisterende språk.",
   "page-index-developers-button": "Utviklerportal",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "Din egen bank",
   "page-index-developers-code-example-description-0": "Du kan bygge en bank drevet med logikk du har programmert.",
   "page-index-developers-code-example-title-1": "Din egen valuta",

--- a/src/intl/nl/page-index.json
+++ b/src/intl/nl/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "Een nieuwe grens voor ontwikkeling",
   "page-index-developers-description": "Ethereum en de apps daarop zijn transparant en open source. Je kunt code forken en functionaliteit hergebruiken die anderen al hebben gebouwd. Als je geen nieuwe taal wilt leren kun je gewoon interageren met open-sourced code door middel van JavaScript en andere bestaande talen.",
   "page-index-developers-button": "Ontwikkelaarsportaal",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "Je eigen bank",
   "page-index-developers-code-example-description-0": "Je kunt een bank bouwen die wordt uitgevoerd volgens logica die je hebt geprogrammeerd.",
   "page-index-developers-code-example-title-1": "Je eigen valuta",

--- a/src/intl/pl/page-index.json
+++ b/src/intl/pl/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "Nowa możliwość rozwoju",
   "page-index-developers-description": "Ethereum i jego aplikacje są przejrzyste i oparte na otwartym oprogramowaniu. Możesz forkować kod i używać ponownie funkcji stworzonych przez innych. Jeśli nie chcesz się uczyć nowego języka programowania, możesz po prostu wykorzystać otwarty kod, używając JavaScript lub innego istniejącego języka.",
   "page-index-developers-button": "Portal deweloperski",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "Twój własny bank",
   "page-index-developers-code-example-description-0": "Możesz otworzyć własny, zaprogramowany przez siebie bank.",
   "page-index-developers-code-example-title-1": "Twoja własna waluta",

--- a/src/intl/pt-br/page-index.json
+++ b/src/intl/pt-br/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "Uma nova fronteira para o desenvolvimento",
   "page-index-developers-description": "Ethereum e seus aplicativos são transparentes e de código aberto. Você pode fazer o fork do código e reusar a funcionalidade que outros já desenvolveram. Se você não quer aprender uma nova linguagem, pode simplesmente interagir com código aberto usando JavaScript e outras linguagens existentes.",
   "page-index-developers-button": "Portal do desenvolvedor",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "Seu próprio banco",
   "page-index-developers-code-example-description-0": "Você pode criar um banco executado pela lógica que você programou.",
   "page-index-developers-code-example-title-1": "Sua própria moeda",

--- a/src/intl/pt/page-index.json
+++ b/src/intl/pt/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "Uma nova fronteira para o desenvolvimento",
   "page-index-developers-description": "O Ethereum e as suas aplicações transparentes e de código aberto. Pode fazer fork do código e reutilizar a funcionalidade que outros já construíram. Se não quiser aprender uma nova linguagem, pode simplesmente interagir com código aberto usando JavaScript e outras linguagens existentes.",
   "page-index-developers-button": "Portal do programador",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "O seu próprio banco",
   "page-index-developers-code-example-description-0": "Pode criar um banco que funcionará com base na lógica com que o programou.",
   "page-index-developers-code-example-title-1": "A sua própria moeda",

--- a/src/intl/ro/page-index.json
+++ b/src/intl/ro/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "O nouă graniță pentru dezvoltare",
   "page-index-developers-description": "Ethereum și aplicațiile sale sunt transparente și cu sursă accesibilă în mod public. Poți descărca codul și reutiliza funcționalitățile deja create de alții. Dacă nu dorești să înveți o nouă limbă, poți interacționa cu un cod sursă folosind JavaScript şi alte limbaje existente.",
   "page-index-developers-button": "Portal pentru programatori",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "Banca ta proprie",
   "page-index-developers-code-example-description-0": "Poți înființa o bancă bazată pe condițiile programate de tine.",
   "page-index-developers-code-example-title-1": "Propria ta monedă",

--- a/src/intl/ru/page-index.json
+++ b/src/intl/ru/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "Новый рубеж для развития",
   "page-index-developers-description": "Ethereum и его приложения прозрачны и имеют открытый исходный код. Вы можете разветвлять код и повторно использовать функции, уже созданные другими. Если вы не хотите изучать новый язык, вы можете просто взаимодействовать с открытым исходным кодом, используя JavaScript и другие существующие языки.",
   "page-index-developers-button": "Портал для разработчиков",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "Ваш собственный банк",
   "page-index-developers-code-example-description-0": "Вы можете создать банк, управляемый логикой, которую вы запрограммировали.",
   "page-index-developers-code-example-title-1": "Ваша собственная валюта",

--- a/src/intl/se/page-index.json
+++ b/src/intl/se/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "En ny bortre gräns för utveckling",
   "page-index-developers-description": "Ethereum och dess appar är transparent med öppen källkod. Du kan kopiera kod, bygga vidare på, och återanvända funktioner som andra redan skrivit. Om du inte vill lära dig ett nytt språk kan du använda JavaScript eller andra existerande språk för att interagera med den öppna källkoden.",
   "page-index-developers-button": "Portal för utvecklare",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "Din egen bank",
   "page-index-developers-code-example-description-0": "Du kan skapa en bank som styrs av logik som du har programmerat.",
   "page-index-developers-code-example-title-1": "Din egen valuta",

--- a/src/intl/sk/page-index.json
+++ b/src/intl/sk/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "Nové hranice pre vývoj",
   "page-index-developers-description": "Ethereum a jeho aplikácie sú transparentné a majú otvorený zdrojový kód. Môžete ich kopírovať a opätovne využívať funkcionality, ktoré vybudovali ostatní pred vami. Ak sa nechcete učiť nový programovací jazyk, môžete interagovať s open-source kódom prostredníctvom JavaScriptu a iných jazykov.",
   "page-index-developers-button": "Vývojársky portál",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "Vaša vlastná banka",
   "page-index-developers-code-example-description-0": "Môžete vybudovať banku, poháňanú logikou, ktorú sami naprogramujete.",
   "page-index-developers-code-example-title-1": "Vaša vlastná mena",

--- a/src/intl/sl/page-index.json
+++ b/src/intl/sl/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "Novo področje razvoja",
   "page-index-developers-description": "Ethereum in njegove aplikacije so transparentne in odprtokodne. Kodo lahko razcepite in ponovno uporabite funkcionalnosti, ki so že bile razvite. Če se ne želite naučiti novega programskega jezika, lahko za interakcijo z odprto kodo preprosto uporabite JavaScript ali druge programske jezike.",
   "page-index-developers-button": "Portal za razvijalce",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "Vaša lastna banka",
   "page-index-developers-code-example-description-0": "Ustvarite lahko banko, ki jo upravlja vaša programirana logika.",
   "page-index-developers-code-example-title-1": "Vaša lastna valuta",

--- a/src/intl/sr/page-index.json
+++ b/src/intl/sr/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "Nova granica za razvoj",
   "page-index-developers-description": "Ethereum i njegove aplikacije su transparentne i otvorenog koda. Možete forkirati kod i ponovo koristiti funkcije koje su drugi već izgradili. Ako ne želite da učite novi jezik, možete samo da stupite u interakciju sa kodom otvorenog koda koristeći JavaScript i druge postojeće jezike.",
   "page-index-developers-button": "Portal za programere",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "Vaša banka",
   "page-index-developers-code-example-description-0": "Možete izgraditi banku koju pokreće logika koju ste programirali.",
   "page-index-developers-code-example-title-1": "Vaša valuta",

--- a/src/intl/sw/page-index.json
+++ b/src/intl/sw/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "Mpaka mpya wa maendeleo",
   "page-index-developers-description": "Ethereum na programu zake ni huria na zinapatikana katika vyanzo vinavyofunguka. Unaweza kutengeneza msimbo mpya na kutumia vipengele ambavyo wengine waliunda. Kama hutaki kujifunza lugha mpya unaweza kupitia msimbo huria kwa JavaScript na lugha nyingine zilizopo.",
   "page-index-developers-button": "Mlango wa msanidi",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "Benki unayomiliki",
   "page-index-developers-code-example-description-0": "Unaweza kujenga benki inayoendeshwa na mantiki uliyoprogramu.",
   "page-index-developers-code-example-title-1": "Fedha unayoimiliki",

--- a/src/intl/th/page-index.json
+++ b/src/intl/th/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "ดินแดนใหม่แห่งการพัฒนา",
   "page-index-developers-description": "อีเธอเรียมและแอปพลิเคชันที่ใช้นั้นโปร่งใสและเป็นโอเพ่นซอร์ส คุณสามารถร่วมเขียนโค้ดหรือนำโค้ดที่ผู้อื่นเขียนมาใช้งานได้ และถ้าคุณไม่ต้องการที่จะเรียนรู้โค้ดในภาษาใหม่ ก็สามารถทำงานกับโอเพ่นซอร์สโค้ดโดยใช้ JavaScript หรือ ภาษาอื่นๆ ที่มีอยู่",
   "page-index-developers-button": "พอร์ทัลนักพัฒนา",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "ธนาคารของคุณ",
   "page-index-developers-code-example-description-0": "คุณสามารถสร้างธนาคารที่ดำเนินการด้วยตรรกะที่คุณโปรแกรมเองได้",
   "page-index-developers-code-example-title-1": "สกุลเงินของคุณ",

--- a/src/intl/tr/page-index.json
+++ b/src/intl/tr/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "Geliştirme için yeni bir sınır",
   "page-index-developers-description": "Ethereum ve uygulamaları şeffaf ve açık kaynaklıdır. Bu kodu ayrıştırabilir ve diğer insanların halihazırda kurduğu işlevselliği tekrardan kullanabilirsiniz. Yeni bir yazılım dili öğrenmek istemiyorsanız da JavaScript veya diğer mevcut yazılım dillerini kullanarak açık kaynak kod üzerinde çalışabilirsiniz.",
   "page-index-developers-button": "Geliştirici portalı",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "Kendi bankanız",
   "page-index-developers-code-example-description-0": "Kendi programladığınız mantıkla çalışan bir banka kurabilirsiniz.",
   "page-index-developers-code-example-title-1": "Kendi para biriminiz",

--- a/src/intl/uk/page-index.json
+++ b/src/intl/uk/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "Нова межа для розвитку",
   "page-index-developers-description": "Технологія Ethereum і її програми прості для розуміння та мають відкритий вихідний код. Ви можете розділити код і повторно використовувати функції, розроблені іншими. Якщо ви не хочете вивчати нову мову, можна просто взаємодіяти з відкритим вихідним кодом за допомогою JavaScript та інших наявних мов.",
   "page-index-developers-button": "Портал для розробників",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "Ваш власний банк",
   "page-index-developers-code-example-description-0": "Ви можете створити банк, керування яким здійснюється за логікою, яку ви створили.",
   "page-index-developers-code-example-title-1": "Ваша власна валюта",

--- a/src/intl/zh-tw/page-index.json
+++ b/src/intl/zh-tw/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "全新的開發領域",
   "page-index-developers-description": "以太坊及其應用程式的來源開放且公開透明。您能擷取程式碼並重複使用他人建立好的程式功能。若您不想重新學習新的程式語言，也可以使用 JavaScript 或其他現存的程式語言和來源開放的程式碼互動。",
   "page-index-developers-button": "開發人員入口",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "您的個人銀行",
   "page-index-developers-code-example-description-0": "您可以建立一個藉由您編寫的邏輯來運作的銀行。",
   "page-index-developers-code-example-title-1": "您的個人貨幣",

--- a/src/intl/zh/page-index.json
+++ b/src/intl/zh/page-index.json
@@ -37,6 +37,7 @@
   "page-index-developers": "全新发展领域",
   "page-index-developers-description": "以太坊及其应用程序具有透明和开源性质。你可以分叉代码并重新使用已由他人建立的功能。如果不想学习新语言，你可以直接使用 JavaScript 和其他现有语言与开源代码进行交互。",
   "page-index-developers-button": "开发者门户",
+  "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "您自己的银行",
   "page-index-developers-code-example-description-0": "您可以通过自己编写的逻辑来建立银行。",
   "page-index-developers-code-example-title-1": "自己的货币",


### PR DESCRIPTION
## Description
Defaulting to english copy for this string. 
Placing key in intl files to prevent homepage from being flagged as out-of-date over two english words.

## Related Issue
[Fixes #5066]