### PR TITLE
Fix Issue #5101: fix typo on Block explorers page

### DIFF
--- a/src/content/developers/docs/data-and-analytics/block-explorers/index.md
+++ b/src/content/developers/docs/data-and-analytics/block-explorers/index.md
@@ -246,7 +246,7 @@ The Eth2 top-level data includes the following:
 ## Block explorers {#block-explorers}
 
 - [Etherscan](https://etherscan.io/) – a block explorer you can use to fetch data for Ethereum Mainnet, Ropsten Testnet, Kovan Testnet, Rinkeby Testnet, and Goerli Testnet.
-- [Blockscout](https://blockscout.com/) – focusses on the following networks:
+- [Blockscout](https://blockscout.com/) – focuses on the following networks:
   - xDai – a clever combination of MakerDAO's DAI stablecoin and POA's sidechain and tokenbridge technology.
   - POA – A sidechain and autonomous network secured by a group of trusted validators. All validators on the network are United States notaries, and their information is publicly available.
   - POA Sokol Testnet.


### PR DESCRIPTION
## Description
Fixes #5101

This is a oneliner modifying the index.md to correct a typo from focusses to focuses with the only change been the extra "s" removed

## Related Issue
