### PR TITLE
[#5086] Fix translations in CalloutBanner

### DIFF
--- a/src/components/CalloutBanner.js
+++ b/src/components/CalloutBanner.js
@@ -2,6 +2,8 @@ import React from "react"
 import styled from "styled-components"
 import { GatsbyImage } from "gatsby-plugin-image"
 
+import Translation from "./Translation"
+
 const StyledCard = styled.div`
   display: flex;
   flex-direction: row-reverse;
@@ -71,8 +73,8 @@ const H2 = styled.h2`
 const CalloutBanner = ({
   image,
   maxImageWidth,
-  title,
-  description,
+  titleKey,
+  descriptionKey,
   alt,
   children,
   className,
@@ -80,8 +82,12 @@ const CalloutBanner = ({
   <StyledCard className={className}>
     <Image image={image} alt={alt} maxImageWidth={maxImageWidth} />
     <Content>
-      <H2>{title}</H2>
-      <Description>{description}</Description>
+      <H2>
+        <Translation id={titleKey} />
+      </H2>
+      <Description>
+        <Translation id={descriptionKey} />
+      </Description>
       {children}
     </Content>
   </StyledCard>

--- a/src/pages-conditional/dapps.js
+++ b/src/pages-conditional/dapps.js
@@ -1331,14 +1331,8 @@ const DappsPage = ({ data, location }) => {
               </RightColumn>
             </TwoColumnContent>
             <StyledCalloutBanner
-              title={translateMessageId(
-                "page-dapps-wallet-callout-title",
-                intl
-              )}
-              description={translateMessageId(
-                "page-dapps-wallet-callout-description",
-                intl
-              )}
+              titleKey={"page-dapps-wallet-callout-title"}
+              descriptionKey={"page-dapps-wallet-callout-description"}
               image={getImage(data.wallet)}
               maxImageWidth={300}
               alt={translateMessageId(

--- a/src/pages-conditional/eth.js
+++ b/src/pages-conditional/eth.js
@@ -440,8 +440,8 @@ const EthPage = (props) => {
           <Divider />
         </CentralColumn>
         <StyledCalloutBanner
-          title={translateMessageId("page-eth-where-to-buy", intl)}
-          description={translateMessageId("page-eth-where-to-buy-desc", intl)}
+          titleKey={"page-eth-where-to-buy"}
+          descriptionKey={"page-eth-where-to-buy-desc"}
           image={getImage(data.ethCat)}
           alt={translateMessageId("page-eth-cat-img-alt", intl)}
           maxImageWidth={300}

--- a/src/pages/developers/learning-tools.js
+++ b/src/pages/developers/learning-tools.js
@@ -305,11 +305,8 @@ const LearningToolsPage = ({ data }) => {
             "page-index-sections-enterprise-image-alt",
             intl
           )}
-          title={translateMessageId("page-learning-tools-documentation", intl)}
-          description={translateMessageId(
-            "page-learning-tools-documentation-desc",
-            intl
-          )}
+          titleKey={"page-learning-tools-documentation"}
+          descriptionKey={"page-learning-tools-documentation-desc"}
         >
           <div>
             <ButtonLink to="/developers/docs/">

--- a/src/pages/eth2/get-involved/index.js
+++ b/src/pages/eth2/get-involved/index.js
@@ -385,11 +385,8 @@ const GetInvolvedPage = ({ data, location }) => {
         <StyledCalloutBanner
           image={getImage(data.rhino)}
           alt={translateMessageId("eth2-rhino-img-alt", intl)}
-          title={translateMessageId("page-eth2-get-involved-stake", intl)}
-          description={translateMessageId(
-            "page-eth2-get-involved-stake-desc",
-            intl
-          )}
+          titleKey={"page-eth2-get-involved-stake"}
+          descriptionKey={"page-eth2-get-involved-stake-desc"}
         >
           <div>
             <ButtonLink to="/eth2/staking/">

--- a/src/pages/eth2/index.js
+++ b/src/pages/eth2/index.js
@@ -314,8 +314,8 @@ const Eth2IndexPage = ({ data }) => {
       <StyledCallout
         image={getImage(data.oldship)}
         alt={translateMessageId("page-eth-whats-eth-hero-alt", intl)}
-        title={translateMessageId("page-eth2-dive", intl)}
-        description={translateMessageId("page-eth2-dive-desc", intl)}
+        titleKey={"page-eth2-dive"}
+        descriptionKey={"page-eth2-dive-desc"}
       >
         <div>
           <ButtonLink to="/eth2/vision/">

--- a/src/pages/eth2/staking.js
+++ b/src/pages/eth2/staking.js
@@ -297,11 +297,8 @@ const StakingPage = ({ data, location }) => {
       <StyledCallout
         image={getImage(data.rhino)}
         alt={translateMessageId("eth2-rhino-img-alt", intl)}
-        title={translateMessageId("page-eth2-staking-join-community", intl)}
-        description={translateMessageId(
-          "page-eth2-staking-join-community-desc",
-          intl
-        )}
+        titleKey={"page-eth2-staking-join-community"}
+        descriptionKey={"page-eth2-staking-join-community-desc"}
       >
         <div>
           <ButtonLink to="https://www.reddit.com/r/ethstaker/">

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -933,14 +933,8 @@ contract SimpleDomainRegistry {
           })}
         </StyledCardContainer>
         <StyledCalloutBanner
-          title={translateMessageId(
-            "page-index-contribution-banner-title",
-            intl
-          )}
-          description={translateMessageId(
-            "page-index-contribution-banner-description",
-            intl
-          )}
+          titleKey={"page-index-contribution-banner-title"}
+          descriptionKey={"page-index-contribution-banner-description"}
           image={getImage(data.finance)}
           maxImageWidth={600}
           alt={translateMessageId(

--- a/src/pages/stablecoins.js
+++ b/src/pages/stablecoins.js
@@ -731,14 +731,10 @@ const StablecoinsPage = ({ data }) => {
       <Divider />
       <Content>
         <StyledCalloutBanner
-          title={translateMessageId(
-            "page-stablecoins-stablecoins-dapp-callout-title",
-            intl
-          )}
-          description={translateMessageId(
-            "page-stablecoins-stablecoins-dapp-callout-description",
-            intl
-          )}
+          titleKey={"page-stablecoins-stablecoins-dapp-callout-title"}
+          descriptionKey={
+            "page-stablecoins-stablecoins-dapp-callout-description"
+          }
           image={getImage(data.doge)}
           maxImageWidth={600}
           alt={translateMessageId(

--- a/src/pages/wallets/find-wallet.js
+++ b/src/pages/wallets/find-wallet.js
@@ -123,11 +123,8 @@ const FindWalletPage = ({ location, data }) => {
       <WalletCompare location={location} />
       <Divider />
       <CalloutBanner
-        title={translateMessageId("page-find-wallet-use-your-wallet", intl)}
-        description={translateMessageId(
-          "page-find-wallet-use-wallet-desc",
-          intl
-        )}
+        titleKey={"page-find-wallet-use-your-wallet"}
+        descriptionKey={"page-find-wallet-use-wallet-desc"}
         image={getImage(data.dapps)}
         alt={translateMessageId(
           "page-index-sections-individuals-image-alt",


### PR DESCRIPTION
## Description
Refactor [CalloutBanner](https://github.com/ethereum/ethereum-org-website/blob/37ce90359540b3cf0ba6f677ca3e4f30bcfc6e93/src/components/CalloutBanner.js) to accept translation keys - `titleKey` and `descriptionKey`

Props changed in:

- src/pages/get-eth.js
- src/pages/index.js
- src/pages/stablecoins.js
- src/pages/developers/learning-tools.js
- src/pages/eth2/index.js
- src/pages/eth2/staking.js
- src/pages/eth2/get-involved/index.js
- src/pages/wallets/find-wallet.js
- src/pages-conditional/dapps.js
- src/pages-conditional/eth.js