### PR TITLE
Updated ECH invite link 

### DIFF
--- a/src/content/community/get-involved/index.md
+++ b/src/content/community/get-involved/index.md
@@ -42,7 +42,7 @@ If you’re not a developer, it can be hard to know where to start in Ethereum. 
 
 ### Offer to take notes for community calls {#take-notes}
 
-- There are many open-source community calls, and having notetakers is a huge help. If you’re interested, join the [Ethereum Cat Herders discord](https://discord.io/EthCatHerders), and introduce yourself!
+- There are many open-source community calls, and having notetakers is a huge help. If you’re interested, join the [Ethereum Cat Herders discord](https://discord.com/invite/Nz6rtfJ8Cu), and introduce yourself!
 
 ### Translate Ethereum content into your native language {#translate-ethereum}
 
@@ -75,7 +75,7 @@ The Ethereum ecosystem is on a mission to fund public goods and impactful projec
 
 ## Product Managers <Emoji text=":fountain_pen:" size={1} />‍ {#product-managers}
 
-- The Ethereum ecosystem needs your talents! Many companies are hiring for product manager roles. If you want to start by contributing to an open source project, get in touch with the [Ethereum Cat Herders](https://discord.io/EthCatHerders) or [MetaCartel](https://www.metacartel.org/)
+- The Ethereum ecosystem needs your talents! Many companies are hiring for product manager roles. If you want to start by contributing to an open source project, get in touch with the [Ethereum Cat Herders](https://discord.com/invite/Nz6rtfJ8Cu) or [MetaCartel](https://www.metacartel.org/)
 
 ## Marketing <Emoji text=":megaphone:" size={1} />‍ {#marketing}
 

--- a/src/content/community/online/index.md
+++ b/src/content/community/online/index.md
@@ -23,7 +23,7 @@ Hundreds of thousands of Ethereum enthusiasts gather in these online forums to s
 
 ## Chat rooms {#chat-rooms}
 
-<SocialListItem socialIcon="discord"><Link to="https://discord.io/EthCatHerders">Ethereum Cat Herders</Link> <i>- community oriented around offering project management support to Ethereum development</i></SocialListItem>
+<SocialListItem socialIcon="discord"><Link to="https://discord.com/invite/Nz6rtfJ8Cu">Ethereum Cat Herders</Link> <i>- community oriented around offering project management support to Ethereum development</i></SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://ethglobal.co/discord">Ethereum Hackers</Link> <i>- Discord chat run by ETHGlobal: an online community for Ethereum hackers all over the world</i></SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/5W5tVb3">CryptoDevs</Link> <i>- Ethereum development focused Discord community</i></SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.io/ethstaker">EthStaker Discord</Link> <i>- community oriented around offering project management support to Ethereum development</i></SocialListItem>


### PR DESCRIPTION
## Description

Updated ECH invite link from `discord.io` page to original discord invite link

## Related Issue

Users don't have to get redirected from `discord.io` the slash page