### PR TITLE
Add spanish tutorials w/external links

### DIFF
--- a/src/content/community/language-resources/index.md
+++ b/src/content/community/language-resources/index.md
@@ -92,6 +92,9 @@ If you are bilingual and want to help us reach more people, you can also get inv
 - [Ethereum Madrid](https://ethereummadrid.com/) - blockchain, DeFi, and governance courses, events and blog
 - [Cointelegraph](https://es.cointelegraph.com/ethereum-for-beginners) - Ethereum guide for beginners in Spanish
 - [Tutoriales online](https://tutoriales.online/curso/solidity) - learn Solidity and programming on Ethereum
+- [Curso Introducción a Ethereum Development](https://youtube.com/playlist?list=PLTqiwJDd_R8y9pfUBjhkVa1IDMwyQz-fU) - Solidity basics, testing and deployment of your first smart contract
+- [Curso Introducción a Seguridad y Hacking en Ethereum](https://youtube.com/playlist?list=PLTqiwJDd_R8yHOvteko_DmUxUTMHnlfci) - understand common vulnerabilities and security issues in real smart contracts
+- [Curso Introducción a DeFi Development](https://youtube.com/playlist?list=PLTqiwJDd_R8zZiP9_jNdaPqA3HqoW2lrS) - learn how DeFi smart contracts work in Solidity and create your own Automated Market Maker
 
 ### Turkish {#tr}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Added tutorials in spanish to the language resources page , before the refactor regarding support to external  tutorial links in non-English languages.

<!--- Describe your changes in detail -->

## Related Issues
[ Related Issue #1](https://github.com/ethereum/ethereum-org-website/issues/5128)
[ Related Issue #2](https://github.com/ethereum/ethereum-org-website/issues/5126)
[ Related Issue #3](https://github.com/ethereum/ethereum-org-website/issues/5124)

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
