### PR TITLE
Implement Ethereum.org style guide for Mainnet

### DIFF
--- a/src/content/eth2/shard-chains/index.md
+++ b/src/content/eth2/shard-chains/index.md
@@ -36,7 +36,7 @@ With lower hardware requirements, sharding will make it easier to run [clients](
 <br />
 
 <InfoBanner isWarning={true}>
-  At first, you'll need to run a mainnet client at the same time as your Eth2 client. <a href="https://launchpad.ethereum.org" target="_blank">The launchpad</a> will walk you through the hardware requirements and process. Alternatively you can use a <a href="/en/developers/docs/apis/backend/#available-libraries">backend API</a>.
+  At first, you'll need to run a Mainnet client at the same time as your Eth2 client. <a href="https://launchpad.ethereum.org" target="_blank">The launchpad</a> will walk you through the hardware requirements and process. Alternatively you can use a <a href="/en/developers/docs/apis/backend/#available-libraries">backend API</a>.
 </InfoBanner>
 
 ## Shard chains version 1: data availability {#data-availability}

--- a/src/content/translations/fr/developers/docs/programming-languages/delphi/index.md
+++ b/src/content/translations/fr/developers/docs/programming-languages/delphi/index.md
@@ -33,7 +33,7 @@ Besoin d’une approche plus élémentaire ? Consultez [ethereum.org/learn](/le
 
 - [What is Delphereum?](https://github.com/svanas/delphereum/blob/master/README.md)
 - [Connecting Delphi to a local (in-memory) blockchain](https://medium.com/@svanas/connecting-delphi-to-a-local-in-memory-blockchain-9a1512d6c5b0)
-- [Connecting Delphi to the Ethereum main net](https://medium.com/@svanas/connecting-delphi-to-the-ethereum-main-net-5faf1feffd83)
+- [Connecting Delphi to the Ethereum Mainnet](https://medium.com/@svanas/connecting-delphi-to-the-ethereum-main-net-5faf1feffd83)
 - [Connecting Delphi to Smart Contracts](https://medium.com/@svanas/connecting-delphi-to-smart-contracts-3146b12803a1)
 
 **Vous voulez éviter toute configuration pour l'instant et accéder directement aux échantillons ?**

--- a/src/content/translations/fr/glossary/index.md
+++ b/src/content/translations/fr/glossary/index.md
@@ -446,7 +446,7 @@ Client Ethereum qui ne stocke aucune copie locale de la [blockchain](#blockchain
 
 ### réseau principal {#mainnet}
 
-Également appelé "mainnet" (pour "main network"), il s'agit de la [blockchain](#blockchain) principale du réseau public Ethereum. De vrais ETH, une valeur et des conséquences réelles. Aussi connu sous le nom de "Couche 1" lors des discussions sur les solutions d'évolutivité de la [couche 2](#layer-2). (Voir aussi [réseau de test](#testnet))
+Également appelé "Mainnet" (pour "main network"), il s'agit de la [blockchain](#blockchain) principale du réseau public Ethereum. De vrais ETH, une valeur et des conséquences réelles. Aussi connu sous le nom de "Couche 1" lors des discussions sur les solutions d'évolutivité de la [couche 2](#layer-2). (Voir aussi [réseau de test](#testnet))
 
 ### arbre de Merkle {#merkle-patricia-tree}
 

--- a/src/content/translations/hu/glossary/index.md
+++ b/src/content/translations/hu/glossary/index.md
@@ -444,7 +444,7 @@ Egy Ethereum kliens, mely nem tárolja a [blokklánc](#blockchain) lokális más
 
 ## M {#section-m}
 
-### mainnet (főhálózat) {#mainnet}
+### Mainnet (főhálózat) {#mainnet}
 
 A "main network" rövidítése, ez a fő nyilvános Ethereum [blokklánc](#blockchain). Valódi ETH, valódi érték, és valódi következmények. 1. rétegként is hivatkozunk rá, amikor a [2. rétegű](#layer-2) skálázhatósági megoldásokról beszélünk. (Ezenkívül lásd [tesztnet](#testnet))
 

--- a/src/content/translations/it/developers/docs/programming-languages/delphi/index.md
+++ b/src/content/translations/it/developers/docs/programming-languages/delphi/index.md
@@ -33,7 +33,7 @@ Hai prima bisogno di nozioni di base? Dai un'occhiata a [ethereum.org/learn](/le
 
 - [What is Delphereum?](https://github.com/svanas/delphereum/blob/master/README.md)
 - [Connecting Delphi to a local (in-memory) blockchain](https://medium.com/@svanas/connecting-delphi-to-a-local-in-memory-blockchain-9a1512d6c5b0)
-- [Connecting Delphi to the Ethereum main net](https://medium.com/@svanas/connecting-delphi-to-the-ethereum-main-net-5faf1feffd83)
+- [Connecting Delphi to the Ethereum Mainnet](https://medium.com/@svanas/connecting-delphi-to-the-ethereum-main-net-5faf1feffd83)
 - [Connecting Delphi to Smart Contracts](https://medium.com/@svanas/connecting-delphi-to-smart-contracts-3146b12803a1)
 
 **Vuoi lasciare stare la configurazione per ora e passare direttamente agli esempi?**

--- a/src/content/translations/it/glossary/index.md
+++ b/src/content/translations/it/glossary/index.md
@@ -446,7 +446,7 @@ Client di Ethereum che non memorizza una copia locale della [blockchain](#blockc
 
 ### rete principale {#mainnet}
 
-In inglese mainnet, è la [blockchain](#blockchain) Ethereum pubblica principale. ETH reali, valore reale e conseguenze reali. Viene detta livello 1 quando si parla di soluzioni per passare al [livello 2](#layer-2). (Vedi anche [rete di prova](#testnet))
+In inglese Mainnet, è la [blockchain](#blockchain) Ethereum pubblica principale. ETH reali, valore reale e conseguenze reali. Viene detta livello 1 quando si parla di soluzioni per passare al [livello 2](#layer-2). (Vedi anche [rete di prova](#testnet))
 
 ### albero di Merkle Patricia {#merkle-patricia-tree}
 

--- a/src/intl/pt-br/page-developers-index.json
+++ b/src/intl/pt-br/page-developers-index.json
@@ -54,7 +54,7 @@
   "page-developers-mev-link": "Valor extraível da mineração (MEV)",
   "page-developers-mining-desc": "Como criar novos blocos e entrar em consenso",
   "page-developers-mining-link": "Mineração",
-  "page-developers-networks-desc": "Uma visão geral do mainnet e das redes de teste",
+  "page-developers-networks-desc": "Uma visão geral do Mainnet e das redes de teste",
   "page-developers-networks-link": "Redes",
   "page-developers-node-clients-desc": "Como os blocos e as transações são verificados na rede",
   "page-developers-node-clients-link": " Nós e clientes",

--- a/src/intl/tr/page-eth2-index.json
+++ b/src/intl/tr/page-eth2-index.json
@@ -17,7 +17,7 @@
   "page-eth2-bug-bounty": "Bug bounty programını görüntüle",
   "page-eth2-clients": "Eth2 müşterilerine göz at",
   "page-eth2-deposit-contract-title": "Para yatırma sözleşmesi adresini kontrol edin",
-  "page-eth2-diagram-ethereum-mainnet": " Ethereum mainnet",
+  "page-eth2-diagram-ethereum-mainnet": " Ethereum Mainnet",
   "page-eth2-diagram-h2": "Geliştirmeler birbirine nasıl uyuyor",
   "page-eth2-diagram-link-1": "Çalışma prensibi hakkında daha fazla bilgi",
   "page-eth2-diagram-link-2": "Zincir parçaları hakkında daha fazla bilgi",


### PR DESCRIPTION
This fixes https://github.com/ethereum/ethereum-org-website/issues/4968

Using style guide at https://ethereum.org/en/contributing/style-guide/#mainnet

---

Also fixes all translations based on what is appropriate for that language.
