### PR TITLE
Fix npm install error in tutorial

### DIFF
--- a/src/content/developers/tutorials/how-to-write-and-deploy-an-nft/index.md
+++ b/src/content/developers/tutorials/how-to-write-and-deploy-an-nft/index.md
@@ -244,7 +244,7 @@ Hardhat makes it super easy to integrate [Plugins](https://hardhat.org/plugins/)
 
 In your project directory type:
 
-    npm install --save-dev @nomiclabs/hardhat-ethers 'ethers@^5.0.0'
+    npm install --save-dev @nomiclabs/hardhat-ethers ethers@^5.0.0
 
 We’ll also require ethers in our hardhat.config.js in the next step.
 


### PR DESCRIPTION
npm install --save-dev @nomiclabs/hardhat-ethers 'ethers@^5.0.0'

doesn't work, gives error

npm ERR! code E404
npm ERR! 404 Not Found - GET https://registry.npmjs.org/%27ethers - Not found
npm ERR! 404
npm ERR! 404  ''ethers@5.0.0'' is not in this registry.
npm ERR! 404 This package name is not valid, because
npm ERR! 404  1. name can no longer contain special characters ("~'!()*")
npm ERR! 404
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.

npm install --save-dev @nomiclabs/hardhat-ethers ethers@^5.0.0

does work

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
