### PR TITLE
Fix: svg hover bug on WalletCard

### DIFF
--- a/src/components/WalletCard.js
+++ b/src/components/WalletCard.js
@@ -58,7 +58,7 @@ const CardBack = styled(CardFace)`
   &:hover {
     cursor: pointer;
   }
-  &:hover path {
+  &:hover svg {
     fill: ${({ theme }) => theme.colors.primary};
   }
 `


### PR DESCRIPTION
## Description
Fixes glitch on WalletCard component when hovering over a flipped card. 

## Related Issue
None filed. 
Can reproduce by going here on desktop: https://ethereum.org/en/wallets/find-wallet/
Then flipping any card over and hovering over that card. 
![image](https://user-images.githubusercontent.com/54227730/150224285-30ca5beb-ebc8-4338-ada3-a679ec0b766f.png)
