### PR TITLE
Rename 'content versions' to 'content buckets'

### DIFF
--- a/src/content/contributing/translation-program/index.md
+++ b/src/content/contributing/translation-program/index.md
@@ -54,17 +54,17 @@ The ethereum.org Translation Program aims to make Ethereum accessible to everyon
    You will need to log in to your Crowdin account or sign up if you don’t already have one. All that is required to sign up is an e-mail account and password.
 
 2. **Open the language you want to translate and find a document to work on**  
-   The website content is divided into a number of documents and language versions. You can check the progress of each document on the right – if translation progress is below 100%, please contribute!
+   The website content is divided into a number of documents and content buckets. You can check the progress of each document on the right – if translation progress is below 100%, please contribute!
 
    Don't see your language listed? [Open an issue](https://github.com/ethereum/ethereum-org-website/issues/new/choose) or ask in our [Discord](https://discord.gg/6WX7E97)
 
    ![Translated and untranslated files on Crowdin](./crowdin-files.png)
 
-   A note on content versions: we use 'content buckets' within Crowdin to get the highest priority content released first. When you check out a language, for example, [Filipino](https://crowdin.com/project/ethereum-org/fil#) you'll see folders for content bucket ("1. Homepage", "2. Use Ethereum Pages", etc.).
+   A note on content buckets: we use 'content buckets' within Crowdin to get the highest priority content released first. When you check out a language, for example, [Filipino](https://crowdin.com/project/ethereum-org/fil#) you'll see folders for content bucket ("1. Homepage", "2. Use Ethereum Pages", etc.).
 
    We encourage you to translate in this numerical order (1 → 2 → 3 → ⋯) to ensure the highest impact pages are translated first.
 
-   [Learn more about ethereum.org content versions](/contributing/translation-program/content-versions/)
+   [Learn more about ethereum.org content buckets](/contributing/translation-program/content-buckets/)
 
 3. **Translate**  
    After selecting the file you want to translate, it will open in the online editor. If you have never used Crowdin before, you can use this quick guide to go over the basics.
@@ -95,7 +95,7 @@ The ethereum.org Translation Program aims to make Ethereum accessible to everyon
    Want to learn more? Feel free to check out the [documentation on using the Crowdin online editor](https://support.crowdin.com/online-editor/)
 
 4. **Review process**  
-   Once you've completed the translation (i.e. all files for a content version display 100%), our professional translation service will review (and potentially edit) the content. Once the review is complete (i.e. review progress is 100%), we will add it to the website.
+   Once you've completed the translation (i.e. all files for a content bucket display 100%), our professional translation service will review (and potentially edit) the content. Once the review is complete (i.e. review progress is 100%), we will add it to the website.
 
 <InfoBanner shouldCenter emoji=":warning:">
   Please do not use machine translation to translate the project. All the translations will be reviewed before being added to the website. If your suggested translations are found to be machine translated, they will be dismissed and contributors who use machine translation often will be removed from the project.
@@ -128,7 +128,7 @@ If you are an ethereum.org translator or would like to become one, feel free to 
 
 - [Translation Style Guide](/contributing/translation-program/translators-guide/) _– Instructions and tips for ethereum.org translators_
 - [Translation FAQs](/contributing/translation-program/faq/) _– Frequently asked questions and answers about the ethereum.org Translation Program_
-- [Content versions](/contributing/translation-program/content-versions/) _– which pages are included in each content version of ethereum.org_
+- [Content buckets](/contributing/translation-program/content-buckets/) _– which pages are included in each content bucket of ethereum.org_
 
 ### Tools {#tools}
 


### PR DESCRIPTION
## Description

Remove all mentions of content versions on the Translation Program page, change the naming of these to content buckets