### PR TITLE
Fix intl string bug

### DIFF
--- a/src/pages/upgrades/get-involved/index.js
+++ b/src/pages/upgrades/get-involved/index.js
@@ -396,8 +396,11 @@ const GetInvolvedPage = ({ data, location }) => {
         <StyledCalloutBanner
           image={getImage(data.rhino)}
           alt={translateMessageId("page-staking-image-alt", intl)}
-          titleKey={"page-upgrades-get-involved-stake"}
-          descriptionKey={"page-upgrades-get-involved-stake-desc"}
+          title={translateMessageId("page-upgrades-get-involved-stake", intl)}
+          description={translateMessageId(
+            "page-upgrades-get-involved-stake-desc",
+            intl
+          )}
         >
           <div>
             <ButtonLink to="/staking/">


### PR DESCRIPTION
## Issue
Recently the `Callout` component was updated to accept `titleKey` and `descriptionKey`. 

The `StyledCalloutBanner` used on the upgrades/get-involved page is a `styled(CalloutBanner)` not a `styled(Callout)` and accidentally had it's props changed to the "key" arrangement.

## Reproduce
Go to https://ethereum.org/en/upgrades/get-involved/ scroll down and see:
![image](https://user-images.githubusercontent.com/54227730/151476375-504156af-7d85-4933-bc01-bb5b588c08a4.png)

## Fix
Reverted back to just `title` and `description`, passing the actual text and not just the look-up key. 

![image](https://user-images.githubusercontent.com/54227730/151476410-2be6be29-9a56-4d78-9336-677bd80711bf.png)
