### PR TITLE
Fixed the typo in the Grants Page [Fixes #5246]

### DIFF
--- a/src/content/community/grants/index.md
+++ b/src/content/community/grants/index.md
@@ -26,7 +26,7 @@ These programs support the broad Ethereum ecosystem by offering grants to a wide
 
 These projects have created their own grants for projects aimed at developing and experimenting with their own technology.
 
-- [TheGraph](https://airtable.com/shrdfvnFvVch3IOVm) – _[The Graph](https://thegraph.com/) ecosystem_
+- [The Graph](https://airtable.com/shrdfvnFvVch3IOVm) – _[The Graph](https://thegraph.com/) ecosystem_
 - [Uniswap Grants Program](https://www.unigrants.org/) – _[Uniswap](https://uniswap.org/) community_
 - [Balancer](https://forms.gle/c68e4fM7JHCQkPkN7) – _[Balancer](https://balancer.fi/) Ecosystem Fund_
 - [mStable](https://docs.mstable.org/advanced/grants-program) - _[mStable](https://mstable.org/) community_


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I fixed the typo in the Grants Page via updating the index.md file.

Similar typos exist in the translation files, but I didn't want to 
update them, as I don't know if they're really typos or specific 
spelling rules in that language.

## Related Issue

[👉 Issue](https://github.com/ethereum/ethereum-org-website/issues/5246)
