### PR TITLE
Add Turkish translation of the 'What happened to Eth2' blog post

### DIFF
--- a/src/content/community/language-resources/index.md
+++ b/src/content/community/language-resources/index.md
@@ -100,6 +100,7 @@ If you are bilingual and want to help us reach more people, you can also get inv
 ### Turkish {#tr}
 
 - [BTK Akademi](https://www.btkakademi.gov.tr/portal/course/blokzincir-ve-kripto-paralar-10569#!/about) - blockchain and cryptocurrency-focused course
+- [The great renaming: what happened to Eth2?](https://miningturkiye.org/konu/ethereum-madenciligi-bitiyor-mu-onemli-gelisme.655/) - Turkish translation of the great renaming blog post, explaining the move away from 'Eth2' terminology
 
 ### Vietnamese {#vi}
 


### PR DESCRIPTION
## Description

One of our Turkish contributors has translated the 'The great renaming: what happened to Eth2?' blog post into Turkish. We should add this to the Language resources page.
https://blog.ethereum.org/2022/01/24/the-great-eth2-renaming/

