### PR TITLE
Including client-diversity developer doc in developer docs sidebar navigation

### DIFF
--- a/src/data/developer-docs-links.yaml
+++ b/src/data/developer-docs-links.yaml
@@ -44,6 +44,8 @@
       items:
         - id: docs-nav-run-a-node
           to: /developers/docs/nodes-and-clients/run-a-node/
+        - id: docs-nav-client-diversity
+          to: /developers/docs/nodes-and-clients/client-diversity/
         - id: docs-nav-nodes-as-a-service
           to: /developers/docs/nodes-and-clients/nodes-as-a-service/
     - id: docs-nav-networks

--- a/src/intl/en/page-developers-docs.json
+++ b/src/intl/en/page-developers-docs.json
@@ -56,6 +56,7 @@
   "docs-nav-nodes-and-clients-description": "The individuals participating in the network and the software they run to verify transactions",
   "docs-nav-opcodes": "Opcodes",
   "docs-nav-run-a-node": "Run a node",
+  "docs-nav-client-diversity": "Client diversity",
   "docs-nav-nodes-as-a-service": "Nodes as a service",
   "docs-nav-oracles": "Oracles",
   "docs-nav-oracles-description": "How information is injected into the Ethereum blockchain",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Included client-diversity developer doc https://ethereum.org/en/developers/docs/nodes-and-clients/client-diversity/
in developer docs sidebar navigation under 'Nodes and clients' between between 'Run a node' and 'Nodes as a service'.

 Files edited : `/src/data/developer-docs-links.yaml`

## Related Issue

Issue Fix : Client-diversity developer doc not included in developer docs sidebar navigation #5275
