### PR TITLE
Remove public from solidity constructor

### DIFF
--- a/src/content/developers/tutorials/how-to-write-and-deploy-an-nft/index.md
+++ b/src/content/developers/tutorials/how-to-write-and-deploy-an-nft/index.md
@@ -168,7 +168,7 @@ Open up the my-nft project in your favorite editor (we like [VSCode](https://cod
        using Counters for Counters.Counter;
        Counters.Counter private _tokenIds;
 
-       constructor() public ERC721("MyNFT", "NFT") {}
+       constructor() ERC721("MyNFT", "NFT") {}
 
        function mintNFT(address recipient, string memory tokenURI)
            public onlyOwner


### PR DESCRIPTION
Visibility for constructors is not needed anymore, and hardhat throws a warning when public is used.
https://docs.soliditylang.org/en/v0.7.0/070-breaking-changes.html#functions-and-events

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
