### PR TITLE
content: add chat links (gitter/matrix) for ethereum-solidity

### DIFF
--- a/src/content/community/online/index.md
+++ b/src/content/community/online/index.md
@@ -29,9 +29,8 @@ Hundreds of thousands of Ethereum enthusiasts gather in these online forums to s
 <SocialListItem socialIcon="discord"><Link to="https://discord.io/ethstaker">EthStaker Discord</Link> <i>- community oriented around offering project management support to Ethereum development</i></SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/CetY6Y4">Ethereum.org website team</Link> <i>- stop by and chat ethereum.org web development and design with the team and folks from the community</i></SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ZH5aXDgWEU">Web3 University</Link> <i>- community focused on learning web3 development </i></SocialListItem>
-<SocialListItem socialIcon="gitter"><Link to="gitter.im/ethereum/solidity">Solidity Gitter</Link> <i>- chat for solidity development (Gitter)</i></SocialListItem>
-<SocialListItem socialIcon="matrix"><Link to="matrix.to/#/#ethereum_solidity:gitter.im">Solidity Gitter</Link> <i>- chat for solidity development (Matrix)</i></SocialListItem>
-
+<SocialListItem socialIcon="website"><Link to="gitter.im/ethereum/solidity">Solidity Gitter</Link> <i>- chat for solidity development (Gitter)</i></SocialListItem>
+<SocialListItem socialIcon="website"><Link to="matrix.to/#/#ethereum_solidity:gitter.im">Solidity Matrix</Link> <i>- chat for solidity development (Matrix)</i></SocialListItem>
 
 ## YouTube and Twitter {#youtube-and-twitter}
 

--- a/src/content/community/online/index.md
+++ b/src/content/community/online/index.md
@@ -29,6 +29,9 @@ Hundreds of thousands of Ethereum enthusiasts gather in these online forums to s
 <SocialListItem socialIcon="discord"><Link to="https://discord.io/ethstaker">EthStaker Discord</Link> <i>- community oriented around offering project management support to Ethereum development</i></SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/CetY6Y4">Ethereum.org website team</Link> <i>- stop by and chat ethereum.org web development and design with the team and folks from the community</i></SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ZH5aXDgWEU">Web3 University</Link> <i>- community focused on learning web3 development </i></SocialListItem>
+<SocialListItem socialIcon="gitter"><Link to="gitter.im/ethereum/solidity">Solidity Gitter</Link> <i>- chat for solidity development (Gitter)</i></SocialListItem>
+<SocialListItem socialIcon="matrix"><Link to="matrix.to/#/#ethereum_solidity:gitter.im">Solidity Gitter</Link> <i>- chat for solidity development (Matrix)</i></SocialListItem>
+
 
 ## YouTube and Twitter {#youtube-and-twitter}
 

--- a/src/content/community/online/index.md
+++ b/src/content/community/online/index.md
@@ -30,7 +30,7 @@ Hundreds of thousands of Ethereum enthusiasts gather in these online forums to s
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/CetY6Y4">Ethereum.org website team</Link> <i>- stop by and chat ethereum.org web development and design with the team and folks from the community</i></SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ZH5aXDgWEU">Web3 University</Link> <i>- community focused on learning web3 development </i></SocialListItem>
 <SocialListItem socialIcon="webpage"><Link to="gitter.im/ethereum/solidity">Solidity Gitter</Link> <i>- chat for solidity development (Gitter)</i></SocialListItem>
-<SocialListItem socialIcon="website"><Link to="matrix.to/#/#ethereum_solidity:gitter.im">Solidity Matrix</Link> <i>- chat for solidity development (Matrix)</i></SocialListItem>
+<SocialListItem socialIcon="webpage"><Link to="matrix.to/#/#ethereum_solidity:gitter.im">Solidity Matrix</Link> <i>- chat for solidity development (Matrix)</i></SocialListItem>
 
 ## YouTube and Twitter {#youtube-and-twitter}
 

--- a/src/content/community/online/index.md
+++ b/src/content/community/online/index.md
@@ -29,7 +29,7 @@ Hundreds of thousands of Ethereum enthusiasts gather in these online forums to s
 <SocialListItem socialIcon="discord"><Link to="https://discord.io/ethstaker">EthStaker Discord</Link> <i>- community oriented around offering project management support to Ethereum development</i></SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/CetY6Y4">Ethereum.org website team</Link> <i>- stop by and chat ethereum.org web development and design with the team and folks from the community</i></SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ZH5aXDgWEU">Web3 University</Link> <i>- community focused on learning web3 development </i></SocialListItem>
-<SocialListItem socialIcon="website"><Link to="gitter.im/ethereum/solidity">Solidity Gitter</Link> <i>- chat for solidity development (Gitter)</i></SocialListItem>
+<SocialListItem socialIcon="webpage"><Link to="gitter.im/ethereum/solidity">Solidity Gitter</Link> <i>- chat for solidity development (Gitter)</i></SocialListItem>
 <SocialListItem socialIcon="website"><Link to="matrix.to/#/#ethereum_solidity:gitter.im">Solidity Matrix</Link> <i>- chat for solidity development (Matrix)</i></SocialListItem>
 
 ## YouTube and Twitter {#youtube-and-twitter}


### PR DESCRIPTION
Adds chat links for ethereum-solidity.

## Description

 - [x] ~~Not sure if `gitter` and `matrix` are valid `socialIcon` options. Should perhaps be changed to `webpage`.~~
 - [ ] Maybe one of them is enough? (they seem to be bridged anyway)

## Related Issue

Fixes #4753