### PR TITLE
Missing Alt Props Bug [Issue 5289] - Fixed

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -929,6 +929,7 @@ contract SimpleDomainRegistry {
                 key={idx}
                 title={tout.title}
                 description={tout.description}
+                alt={tout.alt}
                 to={tout.to}
                 image={tout.image}
               />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Missing alt props in images #5289 fixed. There was an error showing in the console saying some images are missing an alt property. The reason for this error was a missing alt tag when mapping the touts in src/pages/index.js. 

## Related Issue

Missing alt props in images #5289 

Steps to reproduce: 
1. Steps from Issue #5289 
2. Go to "src/pages/index.js 926
3. Add "alt={tout.alt}" in the tout tag
