### PR TITLE
Local plugin to fix translated mdx images urls

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -127,6 +127,10 @@ module.exports = {
         // See: https://www.gatsbyjs.org/docs/mdx/plugins/
         gatsbyRemarkPlugins: [
           {
+            // Local plugin to adjust the images urls of the translated md files
+            resolve: require.resolve(`./plugins/gatsby-remark-image-urls`),
+          },
+          {
             resolve: `gatsby-remark-autolink-headers`,
             options: {
               enableCustomId: true,

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "gatsby-transformer-gitinfo": "^1.1.0",
     "gatsby-transformer-remark": "^3.0.0",
     "gatsby-transformer-sharp": "^4.0.0",
+    "is-relative-url": "^3.0.0",
     "lodash": "^4.17.21",
     "luxon": "^1.24.1",
     "netlify-lambda": "^2.0.3",
@@ -59,7 +60,8 @@
     "react-select": "^4.3.0",
     "recharts": "1.8.5",
     "styled-components": "^5.1.1",
-    "styled-system": "^5.1.5"
+    "styled-system": "^5.1.5",
+    "unist-util-visit-parents": "^2.1.2"
   },
   "devDependencies": {
     "babel-jest": "^26.6.3",

--- a/plugins/gatsby-remark-image-urls/index.js
+++ b/plugins/gatsby-remark-image-urls/index.js
@@ -1,0 +1,37 @@
+const path = require("path")
+const visitWithParents = require("unist-util-visit-parents")
+const isRelativeUrl = require("is-relative-url")
+
+/**
+ * Modify the images urls on translated md files to point to the source ones.
+ *
+ * E.g.
+ * Before
+ * - Source file:     ./image.png
+ * - Translated file: ./image.png
+ *
+ * After
+ * - Source file:     ./image.png
+ * - Translated file: ../path/to/source/image.png
+ */
+module.exports = ({ markdownNode, markdownAST }) => {
+  const fileAbsoluteDir = path.dirname(markdownNode.fileAbsolutePath)
+  const sourceAbsoluteDir = fileAbsoluteDir.replace(/translations\/\w{2}\//, "")
+  const relativePath = path.relative(fileAbsoluteDir, sourceAbsoluteDir)
+
+  // if it is not a translated file, skip it
+  if (!fileAbsoluteDir.includes("/translations")) {
+    return markdownAST
+  }
+
+  // loop for each image node in the mdx file
+  visitWithParents(markdownAST, ["image"], (node) => {
+    const isRelativeToMdFile = isRelativeUrl(node.url)
+    if (isRelativeToMdFile) {
+      const fileName = path.basename(node.url)
+      node.url = `${relativePath}/${fileName}`
+    }
+  })
+
+  return markdownAST
+}

--- a/plugins/gatsby-remark-image-urls/package.json
+++ b/plugins/gatsby-remark-image-urls/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "gatsby-remark-image-urls",
+  "version": "1.0.0",
+  "description": "Set correct images urls in translated md files",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "echo \"No build script setup\""
+  },
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "image",
+    "markdown",
+    "remark"
+  ]
+}

--- a/src/content/translations/ro/developers/tutorials/getting-started-with-ethereum-development-using-alchemy/index.md
+++ b/src/content/translations/ro/developers/tutorials/getting-started-with-ethereum-development-using-alchemy/index.md
@@ -19,7 +19,7 @@ source: Mediu
 sourceUrl: https://medium.com/alchemy-api/getting-started-with-ethereum-development-using-alchemy-c3d6a45c567f
 ---
 
-![Logouri Ethereum și Alchemy](../../../../../developers/tutorials/getting-started-with-ethereum-development-using-alchemy/ethereum-alchemy.png)
+![Logouri Ethereum și Alchemy](./ethereum-alchemy.png)
 
 Acesta este un ghid pentru începători pentru a demara cu dezvoltarea Ethereum folosind [Alchemy](https://alchemyapi.io/), cea mai importantă platformă de programator blockchain alimentând milioane de utilizatori din 70% din aplicațiile blockchain de top, inclusiv Maker, 0x, MyEtherWallet, Dharma și Kyber.
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -15336,7 +15336,7 @@ unist-util-visit-children@^1.0.0:
   resolved "https://registry.yarnpkg.com/unist-util-visit-children/-/unist-util-visit-children-1.1.4.tgz#e8a087e58a33a2815f76ea1901c15dec2cb4b432"
   integrity sha512-sA/nXwYRCQVRwZU2/tQWUqJ9JSFM1X3x7JIOsIgSzrFHcfVt6NkzDtKzyxg2cZWkCwGF9CO8x4QNZRJRMK8FeQ==
 
-unist-util-visit-parents@^2.0.0:
+unist-util-visit-parents@^2.0.0, unist-util-visit-parents@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz#25e43e55312166f3348cae6743588781d112c1e9"
   integrity sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==


### PR DESCRIPTION
## Description
The following proposal tries to solve having different images urls between source and translated md files. With this, we won't need to adjust the images urls in translated files (we wil keep the same as in the source file).

## Solution
By using a local gatsby plugin we can intercept the nodes created by `gatsby-plugin-mdx` and adjust the images urls. We can think about it as a "translator" for urls.
- If we are in a source file => the plugin will ignore it
- If we are in a translated file => the plugin will modify the url by pointing them to the source file folder (what we were doing manually)

Check working example https://ethereumorgwebsitedev01-mdximagespaths.gtsb.io/ro/developers/tutorials/getting-started-with-ethereum-development-using-alchemy/

## Related Issue
#2585 

## TODO
- [x] Change variable names that contains `path` with `url`
- [x] Add more docs