### PR TITLE
Update Alchemy link in NFT tutorial

### DIFF
--- a/src/content/developers/tutorials/how-to-write-and-deploy-an-nft/index.md
+++ b/src/content/developers/tutorials/how-to-write-and-deploy-an-nft/index.md
@@ -17,7 +17,7 @@ In this tutorial, we will walk through creating and deploying an ERC-721 smart c
 
 In Part 2 of this tutorial we’ll go through how we can use our smart contract to mint an NFT, and in Part 3 we’ll explain how to view your NFT on MetaMask.
 
-And of course, if you have questions at any point, don’t hesitate to reach out in the [Alchemy Discord](https://discord.gg/gWuC7zB) or visit [Alchemy's NFT API docs](https://docs.alchemy.com/alchemy/enhanced-apis/nft-api#what-chains-and-networks-are-supported)!
+And of course, if you have questions at any point, don’t hesitate to reach out in the [Alchemy Discord](https://discord.gg/gWuC7zB) or visit [Alchemy's NFT API docs](https://docs.alchemy.com/alchemy/enhanced-apis/nft-api)!
 
 ## Step 1: Connect to the Ethereum network {#connect-to-ethereum}
 


### PR DESCRIPTION
Cleaning up the link to Alchemy's NFT API since it previously went to a specific section that wasn't the top

<!--- Provide a general summary of your changes in the Title above -->

## Cleaning up this link since it went to a specific part of Alchemy's NFT API page erroneously, it should go to the top of the page! LMK if questions!

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
