### PR TITLE
Add link to Crowdin guide to translators guide and TP page

### DIFF
--- a/src/content/contributing/translation-program/index.md
+++ b/src/content/contributing/translation-program/index.md
@@ -126,8 +126,9 @@ If you are an ethereum.org translator or would like to become one, feel free to 
 
 ### Guides {#guides}
 
-- [Translation Style Guide](/contributing/translation-program/translators-guide/) _– Instructions and tips for ethereum.org translators_
-- [Translation FAQs](/contributing/translation-program/faq/) _– Frequently asked questions and answers about the ethereum.org Translation Program_
+- [Translation Style Guide](/contributing/translation-program/translators-guide/) _– instructions and tips for ethereum.org translators_
+- [Translation FAQs](/contributing/translation-program/faq/) _– frequently asked questions and answers about the ethereum.org Translation Program_
+- [Crowdin online editor guide](https://support.crowdin.com/online-editor/) _–an in-depth guide to using the Crowdin online editor and some of Crowdin's advanced features_
 - [Content buckets](/contributing/translation-program/content-buckets/) _– which pages are included in each content bucket of ethereum.org_
 
 ### Tools {#tools}

--- a/src/content/contributing/translation-program/index.md
+++ b/src/content/contributing/translation-program/index.md
@@ -128,7 +128,7 @@ If you are an ethereum.org translator or would like to become one, feel free to 
 
 - [Translation Style Guide](/contributing/translation-program/translators-guide/) _– instructions and tips for ethereum.org translators_
 - [Translation FAQs](/contributing/translation-program/faq/) _– frequently asked questions and answers about the ethereum.org Translation Program_
-- [Crowdin online editor guide](https://support.crowdin.com/online-editor/) _–an in-depth guide to using the Crowdin online editor and some of Crowdin's advanced features_
+- [Crowdin online editor guide](https://support.crowdin.com/online-editor/) _– an in-depth guide to using the Crowdin online editor and some of Crowdin's advanced features_
 - [Content buckets](/contributing/translation-program/content-buckets/) _– which pages are included in each content bucket of ethereum.org_
 
 ### Tools {#tools}

--- a/src/content/contributing/translation-program/translators-guide/index.md
+++ b/src/content/contributing/translation-program/translators-guide/index.md
@@ -13,6 +13,12 @@ This document serves as a general guide and is not specific to any one language.
 
 If you have any questions, suggestions or feedback, feel free to reach out to us at translations@ethereum.org, send a message to @ethdotorg on Crowdin, or [join our Discord](https://discord.gg/XVepFu7sqR), where you can message us in the #translations channel or reach out to any of the team members.
 
+### Using Crowdin {#using-crowdin}
+
+You can find basic instructions on how to join the project in Crowdin and how to use the Crowdin online editor on the [Translation Program page](/contributing/translation-program/#how-to-translate).
+
+If you would like to learn more about Crowdin and using some of its advanced feature, the [Crowdin knowledge base](https://support.crowdin.com/online-editor/) contains a lot of in-depth guides and overviews of all Crowdin functionality.
+
 ### Capturing the essence of the message {#capturing-the-essence}
 
 When translating ethereum.org content, avoid literal translations.


### PR DESCRIPTION
## Description

Add link to the Crowdin knowledge base (specifically the guide to using the Crowdin online editor) to the Resources section of the Translation Program page.
Add links to the Crowdin guide on the TP page and the Crowdin knowledge base to the translation style guide.
Change the capitalization of some segments for consistency.
