### PR TITLE
Fix typo on page-run-a-node.json

### DIFF
--- a/src/intl/en/page-run-a-node.json
+++ b/src/intl/en/page-run-a-node.json
@@ -72,7 +72,7 @@
   "page-run-a-node-glyph-alt-hardware": "Hardware glyph",
   "page-run-a-node-glyph-alt-software": "Software download glyph",
   "page-run-a-node-glyph-alt-privacy": "Privacy glyph",
-  "page-run-a-node-glyph-alt-censorship-resistance": "Censorship resistant megephone glyph",
+  "page-run-a-node-glyph-alt-censorship-resistance": "Censorship resistant megaphone glyph",
   "page-run-a-node-glyph-alt-earth": "Earth glyph",
   "page-run-a-node-glyph-alt-decentralization": "Decentralization glyph",
   "page-run-a-node-glyph-alt-vote": "Voice your vote glyph",


### PR DESCRIPTION
## Fix typo on page-run-a-node.json

Fixed typo on page-run-a-node.json, encountered during translation 📣