### PR TITLE
Advise readers of Rinkeby faucet unreliability

### DIFF
--- a/src/content/developers/docs/networks/index.md
+++ b/src/content/developers/docs/networks/index.md
@@ -88,10 +88,10 @@ A proof-of-authority testnet for those running Geth client.
 ##### Rinkeby faucets
 
 - [FaucETH](https://fauceth.komputing.org)(Multi-Chain faucet without the need for social account)
-- [Rinkeby faucet](https://faucet.rinkeby.io/)
 - [Alchemy faucet](https://RinkebyFaucet.com)
 - [Chainlink faucet](https://faucets.chain.link/)
 - [Paradigm faucet](https://faucet.paradigm.xyz/)
+- [Rinkeby faucet](https://faucet.rinkeby.io/)
 
 #### Ropsten {#ropsten}
 

--- a/src/content/developers/docs/networks/index.md
+++ b/src/content/developers/docs/networks/index.md
@@ -55,6 +55,7 @@ ETH on testnets has no real value; therefore, there are no markets for testnet E
 - [Görli faucet](https://faucet.goerli.mudit.blog/)
 - [Kovan faucet](https://faucet.kovan.network/)
 - [Rinkeby faucet](https://faucet.rinkeby.io/)
+-    This faucet is currently unreliable. Check the Chainlink faucet for test ETH.
 - [Ropsten faucet](https://faucet.ropsten.be/)
 - [Alchemy faucet](https://RinkebyFaucet.com)
 - [Komputing faucet](https://fauceth.komputing.org/)

--- a/src/content/developers/docs/networks/index.md
+++ b/src/content/developers/docs/networks/index.md
@@ -31,35 +31,76 @@ It’s generally important to test any contract code you write on a testnet befo
 
 Most testnets use a proof-of-authority consensus mechanism. This means a small number of nodes are chosen to validate transactions and create new blocks – staking their identity in the process. It's hard to incentivise mining on a proof-of-work testnet which can leave it vulnerable.
 
+ETH on testnets has no real value; therefore, there are no markets for testnet ETH. Since you need ETH to actually interact with Ethereum, most people get testnet ETH from faucets. Most faucets are webapps where you can input an address which you request ETH to be sent to.
+
+#### Arbitrum Rinkeby {#arbitrum-rinkeby}
+
+A testnet for [Arbitrum](https://arbitrum.io/).
+
+##### Arbitrum Rinkeby faucets
+
+- [FaucETH](https://fauceth.komputing.org)(Multi-Chain faucet without the need for social account)
+- [Chainlink faucet](https://faucets.chain.link/)
+- [Paradigm faucet](https://faucet.paradigm.xyz/)
+
 #### Görli {#goerli}
 
 A proof-of-authority testnet that works across clients.
+
+##### Görli faucets
+
+- [Görli faucet](https://faucet.goerli.mudit.blog/)
+- [Chainlink faucet](https://faucets.chain.link/)
+
+#### Kintsugi {#kintsugi}
+
+A merge testnet for Ethereum.
+
+##### Kintsugi faucets
+
+- [FaucETH](https://fauceth.komputing.org)(Multi-Chain faucet without the need for social account)
+- [Kintsugi faucet](https://faucet.kintsugi.themerge.dev/)
 
 #### Kovan {#kovan}
 
 A proof-of-authority testnet for those running OpenEthereum clients.
 
+##### Kovan faucets
+
+- [FaucETH](https://fauceth.komputing.org)(Multi-Chain faucet without the need for social account)
+- [Kovan faucet](https://faucet.kovan.network/)
+- [Chainlink faucet](https://faucets.chain.link/)
+- [Paradigm faucet](https://faucet.paradigm.xyz/)
+
+#### Optimisic Kovan {#optimistic-kovan}
+
+A testnet for [Optimism](https://www.optimism.io/).
+
+##### Optimistic Kovan faucets
+
+- [FaucETH](https://fauceth.komputing.org)(Multi-Chain faucet without the need for social account)
+- [Paradigm faucet](https://faucet.paradigm.xyz/)
+
 #### Rinkeby {#rinkeby}
 
 A proof-of-authority testnet for those running Geth client.
+
+##### Rinkeby faucets
+
+- [FaucETH](https://fauceth.komputing.org)(Multi-Chain faucet without the need for social account)
+- [Rinkeby faucet](https://faucet.rinkeby.io/)
+- [Alchemy faucet](https://RinkebyFaucet.com)
+- [Chainlink faucet](https://faucets.chain.link/)
+- [Paradigm faucet](https://faucet.paradigm.xyz/)
 
 #### Ropsten {#ropsten}
 
 A proof-of-work testnet. This means it's the best like-for-like representation of Ethereum.
 
-### Testnet faucets {#testnet-faucets}
+##### Ropsten faucets
 
-ETH on testnets has no real value; therefore, there are no markets for testnet ETH. Since you need ETH to actually interact with Ethereum, most people get testnet ETH from faucets. Most faucets are webapps where you can input an address which you request ETH to be sent to.
-
-- [FaucETH](https://fauceth.komputing.org) (Multi-Chain faucet without the need for social account)
-- [Görli faucet](https://faucet.goerli.mudit.blog/)
-- [Kovan faucet](https://faucet.kovan.network/)
-- [Rinkeby faucet](https://faucet.rinkeby.io/)
--    This faucet is currently unreliable. Check the Chainlink faucet for test ETH.
+- [FaucETH](https://fauceth.komputing.org)(Multi-Chain faucet without the need for social account)
 - [Ropsten faucet](https://faucet.ropsten.be/)
-- [Alchemy faucet](https://RinkebyFaucet.com)
-- [Komputing faucet](https://fauceth.komputing.org/)
-- [Chainlink faucet](https://faucets.chain.link/)
 - [Paradigm faucet](https://faucet.paradigm.xyz/)
 
 ## Private networks {#private-networks}


### PR DESCRIPTION
The Rinkeby Faucet has been unreliable/ not sending out test ETH for a few months now. Getting test ETH for Rinkeby from the Chainlink faucet is a better option until the Rinkeby issue is resolved.  I wrote  a note letting users know this in case they experience difficulty with the Rinkeby faucet.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
