### PR TITLE
Fix broken link to The Graph Network Overview page

### DIFF
--- a/src/content/developers/docs/data-and-analytics/index.md
+++ b/src/content/developers/docs/data-and-analytics/index.md
@@ -31,6 +31,6 @@ Developers can then process and transform this data to give their users unique i
 
 ## Further Reading {#further-reading}
 
-- [Graph Network Overview](https://thegraph.com/docs/network#overview)
+- [Graph Network Overview](https://thegraph.com/docs/en/about/network/)
 - [Graph Query Playground](https://thegraph.com/explorer/subgraph/graphprotocol/graph-network-mainnet?version=current)
 - [API code examples on EtherScan](https://etherscan.io/apis#contracts)


### PR DESCRIPTION
The resource at the old URI on The Graph's documentation site is gone, causing a broken link on the [Data and analytics](https://ethereum.org/en/developers/docs/data-and-analytics/) page.

## Description

Replaced broken link to https://thegraph.com/docs/en/network#overview with https://thegraph.com/docs/en/about/network/

Just something I noticed while reading the docs.