### PR TITLE
Simplify cpubenchmark link

### DIFF
--- a/src/intl/en/page-run-a-node.json
+++ b/src/intl/en/page-run-a-node.json
@@ -107,7 +107,7 @@
   "page-run-a-node-staking-description": "Though not required, with a node up and running you're one step closer to staking your ETH to earn rewards and help contribute to a different component of Ethereum security.",
   "page-run-a-node-staking-link": "Stake ETH",
   "page-run-a-node-staking-plans-title": "Plan on staking?",
-  "page-run-a-node-staking-plans-description": "To maximize the efficiency of your validator, a minimum of 16 GB RAM is recommended, but 32 GB is better, with a CPU benchmark score of 6667+ on cpubenchmark.net. It is also recommended that stakers have access to unlimited high-speed internet bandwidth, though this is not an absolute requirement.",
+  "page-run-a-node-staking-plans-description": "To maximize the efficiency of your validator, a minimum of 16 GB RAM is recommended, but 32 GB is better, with a CPU benchmark score of 6667+ on <a href=\"https://cpubenchmark.net\" target=\"_blank\">cpubenchmark.net</a>. It is also recommended that stakers have access to unlimited high-speed internet bandwidth, though this is not an absolute requirement.",
   "page-run-a-node-staking-plans-ethstaker-link-label": "How to shop for Ethereum validator hardware",
   "page-run-a-node-staking-plans-ethstaker-link-description": "EthStaker goes into more detail in this hour long special",
   "page-run-a-node-sovereignty-title": "Sovereignty",

--- a/src/pages/run-a-node.js
+++ b/src/pages/run-a-node.js
@@ -1004,9 +1004,6 @@ const RunANodePage = ({ data }) => {
             <Translation id="page-run-a-node-staking-plans-ethstaker-link-label" />
           </Link>
         </p>
-        <p>
-          <Link to="https://cpubenchmark.net">cpubenchmark.net</Link>
-        </p>
         <h3 id="rasp-pi">
           <StyledEmoji text=":pie:" size={2} />
           <Translation id="page-run-a-node-rasp-pi-title" />


### PR DESCRIPTION
## Description
This is a proposal to make the section a bit simpler. Just felt redundant having the 2 same urls in the same space.

## Problem
![image](https://user-images.githubusercontent.com/468158/153769553-a62bd50e-8f74-4b9a-b958-bfe3125d7ae9.png)

@wackerow let me know what do you think? perhaps you have some reason why we have done it that way and I'm not considering it