### PR TITLE
Add tab handler action for submenus in main menu [Fixes #5412]

### DIFF
--- a/src/components/Nav/Dropdown.js
+++ b/src/components/Nav/Dropdown.js
@@ -124,6 +124,14 @@ const NavDropdown = ({ section, hasSubNav }) => {
   const onKeyDownHandler = (e) => {
     if (e.keyCode === 13) {
       setIsOpen(!isOpen)
+    } else if (e.shiftKey && e.keyCode === 9) {
+      setIsOpen(false)
+    }
+  }
+
+  const tabInteractionHandler = (e, shouldClose) => {
+    if (shouldClose) {
+      e.keyCode === 9 && !e.shiftKey && setIsOpen(false)
     }
   }
 
@@ -152,7 +160,13 @@ const NavDropdown = ({ section, hasSubNav }) => {
           initial="closed"
         >
           {section.items.map((item, idx) => (
-            <DropdownItem key={idx} onClick={() => setIsOpen(false)}>
+            <DropdownItem
+              key={idx}
+              onClick={() => setIsOpen(false)}
+              onKeyDown={(e) =>
+                tabInteractionHandler(e, idx === section.items.length - 1)
+              }
+            >
               <NavLink to={item.to} tabIndex="-1" isPartiallyActive={false}>
                 <Translation id={item.text} />
               </NavLink>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Add `tabInteractionHandler` function to handle when the last item in the submenu is reached and tab is pressed
- Update `onKeyDownHandler` function to close submenu when pressing Shift + Tab on main menu focus
- Update `DropdownItem` styled component to pass if the menu should close

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#5412 