### PR TITLE
Add Kaleido to Nodes as a Service list

### DIFF
--- a/src/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
+++ b/src/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
@@ -115,6 +115,26 @@ Here is a list of some of the most popular Ethereum node providers, feel free to
     - Paid archival data
     - Direct Support
     - Dashboard
+- [**Kaleido**](https://kaleido.io/)
+  - [Docs](https://docs.kaleido.io/)
+  - Features
+    - Free startier tier
+    - One-click Ethereum node deployment
+    - Customizable clients and algorithms (Geth, Quorum & Besu || PoA, IBFT & Raft)
+    - 500+ administrative and service APIs
+    - RESTful interface for Ethereum transaction submission (Apache Kafka backed)
+    - Outbound streams for event delivery (Apache Kafka backed)
+    - Deep collection of "off-chain" and ancillary services (e.g. bilateral encrypted messaging transport)
+    - Straightforward network onboarding with governance and role-based access control
+    - Sophisticated user management for both administrators and end users
+    - Highly scalable, resilient, enterprise-grade infrastructure
+    - Cloud HSM private key management
+    - Ethereum Mainnet Tethering 
+    - ISO 27k and SOC 2, Type 2 certifications
+    - Dynamic runtime configuration (e.g. adding cloud integrations, altering node ingresses, etc.)
+    - Support for multi-cloud, multi-region and hybrid deployment orchestrations
+    - Simple hourly SaaS-based pricing
+    - SLAs and 24x7 support
 - [**Moralis**](https://moralis.io/)
   - [Docs](https://docs.moralis.io/)
   - Features


### PR DESCRIPTION
This PR adds details on the Ethereum node running and BaaS (blockchain as a service) capabilities offered by [Kaleido](https://kaleido.io).
