### PR TITLE
Add a side-note as to why ether is burnt

### DIFF
--- a/src/content/developers/docs/intro-to-ether/index.md
+++ b/src/content/developers/docs/intro-to-ether/index.md
@@ -41,6 +41,10 @@ As well as creating ether through block rewards, ether can get destroyed by a pr
 
 Ether burn occurs in every transaction on Ethereum. When users pay for their transactions, their base gas fee gets destroyed by the protocol. Depending on network demand, [some blocks](https://etherscan.io/block/12965263) burn more ether than they mint.
 
+> Ether burn is essentially a mechanism to control the supply & demand dynamics. 
+> 
+> By burning a certain amount of ether in every transaction, total amount of ether in circulation is controlled, thereby hedging it against such devils as inflation.
+
 ## Denominations of ether {#denominations}
 
 Since many transactions on Ethereum are small, ether has several denominations which may be referenced for smaller amounts. Of these denominations, Wei and gwei are particularly important.

--- a/src/content/developers/docs/intro-to-ether/index.md
+++ b/src/content/developers/docs/intro-to-ether/index.md
@@ -39,7 +39,9 @@ Ether is minted when a miner creates a block on the Ethereum blockchain. As an i
 
 As well as creating ether through block rewards, ether can get destroyed by a process called 'burning'. When ether gets burned, it gets removed from circulation permanently.
 
-Ether burn occurs in every transaction on Ethereum. When users pay for their transactions, their base gas fee gets destroyed by the protocol. Depending on network demand, [some blocks](https://etherscan.io/block/12965263) burn more ether than they mint.
+Ether burn occurs in every transaction on Ethereum. When users pay for their transactions, a base gas fee, set by the network according to transactional demand, gets destroyed. This, coupled with variable block sizes and a maximum gas fee, simplifies transaction fee estimation on Ethereum. When network demand is high, [blocks](https://etherscan.io/block/12965263) can burn more ether than they mint, effectively offsetting ether issuance.
+
+Burning the base fee prevents various ways in which miners could affect its level. For example, if miners got the base fee, they could include their own transactions for free and raise the base fee for everyone else. Alternatively, they could refund the base fee to some users off-chain, leading to a more opaque and complex transaction fee market.
 
 
 ## Denominations of ether {#denominations}

--- a/src/content/developers/docs/intro-to-ether/index.md
+++ b/src/content/developers/docs/intro-to-ether/index.md
@@ -41,9 +41,7 @@ As well as creating ether through block rewards, ether can get destroyed by a pr
 
 Ether burn occurs in every transaction on Ethereum. When users pay for their transactions, their base gas fee gets destroyed by the protocol. Depending on network demand, [some blocks](https://etherscan.io/block/12965263) burn more ether than they mint.
 
-> Ether burn is essentially a mechanism to control the supply & demand dynamics. 
-> 
-> By burning a certain amount of ether in every transaction, total amount of ether in circulation is controlled, thereby hedging it against such devils as inflation.
+> Ether is burned to prevent inflation by reducing its overall supply.
 
 ## Denominations of ether {#denominations}
 

--- a/src/content/developers/docs/intro-to-ether/index.md
+++ b/src/content/developers/docs/intro-to-ether/index.md
@@ -41,7 +41,6 @@ As well as creating ether through block rewards, ether can get destroyed by a pr
 
 Ether burn occurs in every transaction on Ethereum. When users pay for their transactions, their base gas fee gets destroyed by the protocol. Depending on network demand, [some blocks](https://etherscan.io/block/12965263) burn more ether than they mint.
 
-> Ether is burned to prevent inflation by reducing its overall supply.
 
 ## Denominations of ether {#denominations}
 

--- a/src/content/developers/docs/intro-to-ether/index.md
+++ b/src/content/developers/docs/intro-to-ether/index.md
@@ -41,7 +41,7 @@ As well as creating ether through block rewards, ether can get destroyed by a pr
 
 Ether burn occurs in every transaction on Ethereum. When users pay for their transactions, a base gas fee, set by the network according to transactional demand, gets destroyed. This, coupled with variable block sizes and a maximum gas fee, simplifies transaction fee estimation on Ethereum. When network demand is high, [blocks](https://etherscan.io/block/12965263) can burn more ether than they mint, effectively offsetting ether issuance.
 
-Burning the base fee prevents various ways in which miners could affect its level. For example, if miners got the base fee, they could include their own transactions for free and raise the base fee for everyone else. Alternatively, they could refund the base fee to some users off-chain, leading to a more opaque and complex transaction fee market.
+Burning the base fee prevents various ways the miners could manipulate it otherwise. For example, if miners got the base fee, they could include their own transactions for free and raise the base fee for everyone else. Alternatively, they could refund the base fee to some users off-chain, leading to a more opaque and complex transaction fee market.
 
 
 ## Denominations of ether {#denominations}


### PR DESCRIPTION
While reading the documentation, I realized that ether burn was explained but it wasn't clarified as to why it is done.
I understood why minting is required but why to burn, I was clueless.

I have added a side-note under {#burning-ether} section regarding the same.

I'm hoping this will add more clarity to the documentation.