### PR TITLE
Added missing word to Smart Contact Risk line on Bridges page

### DIFF
--- a/src/content/bridges/index.md
+++ b/src/content/bridges/index.md
@@ -98,7 +98,7 @@ Many bridging solutions adopt models between these two extremes with varying deg
 
 Bridges are in the early stages of development. It is likely that the optimal bridge design has not yet been discovered. Interacting with any type of bridge carries risk:
 
-- **Smart Contract Risk —** the risk of a bug in the code that can cause user funds to be
+- **Smart Contract Risk —** the risk of a bug in the code that can cause user funds to be lost
 - **Technology Risk —** software failure, buggy code, human error, spam, and malicious attacks can possibly disrupt user operations
 
 Moreover, since trusted bridges add trust assumptions, they carry additional risks such as:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added the missing word 'lost' to line 101 in the Introduction to Blockchain Bridges page.


