### PR TITLE
Update cryptography and security channels description on Language Resources page

### DIFF
--- a/src/content/community/language-resources/index.md
+++ b/src/content/community/language-resources/index.md
@@ -66,8 +66,8 @@ If you are bilingual and want to help us reach more people, you can also get inv
 
 **For cryptography researchers**
 
-- [SecbitLabs](https://mp.weixin.qq.com/s/69_tqBJpr_sbaKtR1sBRMw) - a WeChat acccount, explaining cryptography, security, etc.
-- [Sparkbyte](https://mp.weixin.qq.com/s/9KgKTc_jtJ7bWKdbNPoqvQ) - a WeChat acccount, explaining zk technology
+- [SecbitLabs](https://mp.weixin.qq.com/s/69_tqBJpr_sbaKtR1sBRMw) - a WeChat account, explaining cryptography, security, etc.
+- [Sparkbyte](https://mp.weixin.qq.com/s/9KgKTc_jtJ7bWKdbNPoqvQ) - a WeChat account, explaining zk technology
 
 ### French {#fr}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed typos in line number 69 and 70 for cryptography and security channels description on 
Language Resources page

`acccount` to `account`
