### PR TITLE
Frontmatter patch for relative image paths

### DIFF
--- a/src/content/translations/fr/dao/index.md
+++ b/src/content/translations/fr/dao/index.md
@@ -6,7 +6,7 @@ template: use-cases
 emoji: ":handshake:"
 sidebar: true
 sidebarDepth: 2
-image: ../../assets/use-cases/dao-2.png
+image: ../../../../assets/use-cases/dao-2.png
 alt: Une représentation d'une DAO qui vote une proposition.
 summaryPoint1: Des communautés appartenant à leurs membres sans pouvoir centraliser.
 summaryPoint2: Un moyen sûr de collaborer avec des étrangers sur Internet.

--- a/src/content/translations/fr/nft/index.md
+++ b/src/content/translations/fr/nft/index.md
@@ -6,7 +6,7 @@ template: use-cases
 emoji: ":frame_with_picture:"
 sidebar: true
 sidebarDepth: 2
-image: ../../assets/infrastructure_transparent.png
+image: ../../../../assets/infrastructure_transparent.png
 alt: Un logo Eth affiché par hologramme.
 summaryPoint1: Un moyen de représenter toute chose unique en tant qu'actif Ethereum.
 summaryPoint2: Les NFT offrent plus de possibilités que jamais aux créateurs de contenus.

--- a/src/content/translations/ru/dao/index.md
+++ b/src/content/translations/ru/dao/index.md
@@ -6,7 +6,7 @@ template: use-cases
 emoji: ":handshake:"
 sidebar: true
 sidebarDepth: 2
-image: ../../assets/use-cases/dao-2.png
+image: ../../../../assets/use-cases/dao-2.png
 alt: Представление голосований DAO по предложению.
 summaryPoint1: Сообщества, принадлежащие его членам, без централизованного аппарата управления.
 summaryPoint2: Безопасный путь совместной работы с незнакомцами из Интернета.

--- a/src/content/translations/ru/defi/index.md
+++ b/src/content/translations/ru/defi/index.md
@@ -5,7 +5,7 @@ lang: ru
 template: use-cases
 emoji: ":money_with_wings:"
 sidebar: true
-image: ../../assets/use-cases/defi.png
+image: ../../../../assets/use-cases/defi.png
 alt: Логотип Eth, сложенный из деталей Лего.
 sidebarDepth: 2
 summaryPoint1: Глобальная открытая альтернатива существующей финансовой системе.

--- a/src/content/translations/ru/nft/index.md
+++ b/src/content/translations/ru/nft/index.md
@@ -6,7 +6,7 @@ template: use-cases
 emoji: ":frame_with_picture:"
 sidebar: true
 sidebarDepth: 2
-image: ../../assets/infrastructure_transparent.png
+image: ../../../../assets/infrastructure_transparent.png
 alt: Логотип Eth отображается с помощью голограммы.
 summaryPoint1: Способ представить что-либо уникальное как актив на основе Ethereum.
 summaryPoint2: С NFT у создателей контента появляется больше возможностей, чем когда-либо прежде.


### PR DESCRIPTION
## Description
Image paths in frontmatter missing extra `../../` to move to proper directory. It was originally thought the recent plugin addition to handle relative paths for markdown files would fix this but does not appear to be. 
This PR reverts to the relative paths that still work to display these frontmatter images.