### PR TITLE
Add gas to transaction example in Python Tutorial

### DIFF
--- a/src/content/developers/tutorials/a-developers-guide-to-ethereum-part-one/index.md
+++ b/src/content/developers/tutorials/a-developers-guide-to-ethereum-part-one/index.md
@@ -248,7 +248,8 @@ We’re stuck at block zero until there’s a transaction to mine, so let’s gi
 In [10]: tx_hash = w3.eth.send_transaction({
    'from': w3.eth.accounts[0],
    'to': w3.eth.accounts[1],
-   'value': w3.toWei(3, 'ether')
+   'value': w3.toWei(3, 'ether'),
+   'gas': 21000
 })
 ```
 


### PR DESCRIPTION
Without the "gas" value in the transaction there will be an error:
```python TypeError: MockBackend.estimate_gas() takes 2 positional arguments but 3 were given```

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
