### PR TITLE
Fix typo in javascript APIs developer docs (Chinese)

### DIFF
--- a/src/content/translations/zh/developers/docs/apis/javascript/index.md
+++ b/src/content/translations/zh/developers/docs/apis/javascript/index.md
@@ -46,7 +46,7 @@ var web3 = new Web3("http://localhost:8545")
 var web3 = new Web3(new Web3.providers.HttpProvider("http://localhost:8545"))
 
 // 更改提供者
-web3。 etProvider("ws://localhost:8546")
+web3.setProvider("ws://localhost:8546")
 // 或
 web3.setProvider(new Web3.providers.WebsocketProvider("ws://localhost:8546"))
 


### PR DESCRIPTION
fix wrong spell when use web3.setProvider, change from web3。etProvider to web3.setProvider

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
