### PR TITLE
CORS esp domain

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -16,3 +16,8 @@
   # Directory with the serverless Lambda functions to deploy to AWS.
   # netlify-lambda needs this netlify.toml file in order to build
   functions = "public/functions"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Access-Control-Allow-Origin = "https://esp.ethereum.foundation"


### PR DESCRIPTION
## Description
From the ESP site, we need to access the Matomo script located in the eth.org domain. This will enable us to access it.
