### PR TITLE
Update and remove references to end-of-life'd legacy Ropsten testnet faucet [Fixes #5450]

### DIFF
--- a/src/content/developers/docs/networks/index.md
+++ b/src/content/developers/docs/networks/index.md
@@ -100,7 +100,6 @@ A proof-of-work testnet. This means it's the best like-for-like representation o
 ##### Ropsten faucets
 
 - [FaucETH](https://fauceth.komputing.org)(Multi-Chain faucet without the need for social account)
-- [Ropsten faucet](https://faucet.ropsten.be/)
 - [Paradigm faucet](https://faucet.paradigm.xyz/)
 
 ## Private networks {#private-networks}

--- a/src/content/developers/tutorials/hello-world-smart-contract-fullstack/index.md
+++ b/src/content/developers/tutorials/hello-world-smart-contract-fullstack/index.md
@@ -1129,7 +1129,7 @@ You can download and create a Metamask account for free [here](https://metamask.
 
 #### Add ether from a Faucet {#add-ether-from-a-faucet}
 
-To sign a transaction on the Ethereum blockchain, we’ll need some fake Eth. To get Eth you can go to the [Ropsten faucet](https://faucet.ropsten.be/) and enter your Ropsten account address, then click “Send Ropsten Eth.” You should see Eth in your Metamask account soon after!
+To sign a transaction on the Ethereum blockchain, we’ll need some fake Eth. To get Eth you can go to the [FaucETH](https://fauceth.komputing.org) and enter your Ropsten account address, click “Request funds”, then select “Ethereum Testnet Ropsten” in the dropdown and finally click “Request funds” button again. You should see Eth in your Metamask account soon after!
 
 #### Check your Balance {#check-your-balance}
 

--- a/src/content/developers/tutorials/how-to-write-and-deploy-an-nft/index.md
+++ b/src/content/developers/tutorials/how-to-write-and-deploy-an-nft/index.md
@@ -49,7 +49,7 @@ You can download and create a MetaMask account for free [here](https://metamask.
 
 ## Step 4: Add ether from a Faucet {#step-4-add-ether-from-a-faucet}
 
-In order to deploy our smart contract to the test network, we’ll need some fake ETH. To get ETH you can go to the [Ropsten faucet](https://faucet.ropsten.be/) and enter your Ropsten account address, then click “Send Ropsten ETH.” You should see ETH in your MetaMask account soon after!
+In order to deploy our smart contract to the test network, we’ll need some fake ETH. To get ETH you can go to the [FaucETH](https://fauceth.komputing.org) and enter your Ropsten account address, click “Request funds”, then select “Ethereum Testnet Ropsten” in the dropdown and finally click “Request funds” button again. You should see ETH in your MetaMask account soon after!
 
 ## Step 5: Check your Balance {#check-balance}
 

--- a/src/content/translations/es/developers/docs/networks/index.md
+++ b/src/content/translations/es/developers/docs/networks/index.md
@@ -54,7 +54,6 @@ Los ETH no tienen un valor real en las redes de prueba; por lo tanto, no hay mer
 - [Faucet Görli](https://faucet.goerli.mudit.blog/)
 - [Faucet Kovan](https://faucet.kovan.network/)
 - [Faucet Rinkeby](https://faucet.rinkeby.io/)
-- [Faucet Ropsten](https://faucet.ropsten.be/)
 
 ## Redes privadas {#private-networks}
 

--- a/src/content/translations/fr/developers/docs/networks/index.md
+++ b/src/content/translations/fr/developers/docs/networks/index.md
@@ -54,7 +54,6 @@ L'ETH des réseaux de test n'a pas de valeur réelle, il n'existe donc pas de ma
 - [Robinet Görli](https://faucet.goerli.mudit.blog/)
 - [Robinet Kovan](https://faucet.kovan.network/)
 - [Robinet Rinkeby](https://faucet.rinkeby.io/)
-- [Robinet Ropsten](https://faucet.ropsten.be/)
 
 ## Réseaux privés {#private-networks}
 

--- a/src/content/translations/hu/developers/docs/networks/index.md
+++ b/src/content/translations/hu/developers/docs/networks/index.md
@@ -54,7 +54,6 @@ Az ETH-nek a tesztneteken nincs valós értéke; így nincsen piaca sem a tesztn
 - [Görli csap](https://faucet.goerli.mudit.blog/)
 - [Kovan csap](https://faucet.kovan.network/)
 - [Rinkeby csap](https://faucet.rinkeby.io/)
-- [Ropsten csap](https://faucet.ropsten.be/)
 
 ## Privát hálózatok {#private-networks}
 

--- a/src/content/translations/id/developers/docs/networks/index.md
+++ b/src/content/translations/id/developers/docs/networks/index.md
@@ -54,7 +54,6 @@ ETH dalam testnet tidak punya nilai sebenarnya; oleh karena itu, tidak ada pasar
 - [Keran Görli](https://faucet.goerli.mudit.blog/)
 - [Keran Kovan](https://faucet.kovan.network/)
 - [Keran Rinkeby](https://faucet.rinkeby.io/)
-- [Keran Ropsten](https://faucet.ropsten.be/)
 
 ## Jaringan privat {#private-networks}
 

--- a/src/content/translations/it/developers/docs/networks/index.md
+++ b/src/content/translations/it/developers/docs/networks/index.md
@@ -54,7 +54,6 @@ Gli ETH sulle reti di prova non hanno valore reale, quindi non c'è un mercato p
 - [Faucet Görli](https://faucet.goerli.mudit.blog/)
 - [Faucet Kovan](https://faucet.kovan.network/)
 - [Faucet Rinkeby](https://faucet.rinkeby.io/)
-- [Faucet Ropsten](https://faucet.ropsten.be/)
 
 ## Reti private {#private-networks}
 

--- a/src/content/translations/pl/developers/docs/networks/index.md
+++ b/src/content/translations/pl/developers/docs/networks/index.md
@@ -54,7 +54,6 @@ ETH w sieciach testowych nie ma rzeczywistej wartości, dlatego nie ma rynków d
 - [Kran Görli](https://faucet.goerli.mudit.blog/)
 - [Kran Kovan](https://faucet.kovan.network/)
 - [Kran Rinkeby](https://faucet.rinkeby.io/)
-- [Kran Ropsten](https://faucet.ropsten.be/)
 
 ## Sieci prywatne {#private-networks}
 

--- a/src/content/translations/ro/developers/docs/networks/index.md
+++ b/src/content/translations/ro/developers/docs/networks/index.md
@@ -54,7 +54,6 @@ ETH-ul pe rețelele de testate nu are o valoare reală; de aceea, nu există pie
 - [Faucet-ul Görli](https://faucet.goerli.mudit.blog/)
 - [Faucet-ul Kovan](https://faucet.kovan.network/)
 - [Faucet-ul Rinkeby](https://faucet.rinkeby.io/)
-- [Faucet-ul Ropsten](https://faucet.ropsten.be/)
 
 ## Rețele private {#private-networks}
 

--- a/src/content/translations/zh/developers/docs/networks/index.md
+++ b/src/content/translations/zh/developers/docs/networks/index.md
@@ -54,7 +54,6 @@ sidebar: true
 - [Görli 水龙头](https://faucet.goerli.mudit.blog/)
 - [Kovan 水龙头](https://faucet.kovan.network/)
 - [Rinkeby 水龙头](https://faucet.rinkeby.io/)
-- [Ropsten 水龙头](https://faucet.ropsten.be/)
 
 ## 私有网络 {#private-networks}
 


### PR DESCRIPTION
Update legacy Ropsten testnet faucet to an available alternative in tutorials. Remove all references to end-of-life'd legacy Ropsten testnet faucet.

## Description

Update references and instructions for legacy Ropsten testnet faucet to faucETH https://fauceth.komputing.org, an available alternative in tutorials. Remove all references to end-of-life'd legacy Ropsten testnet faucet https://faucet.ropsten.be/

## Related Issue

#5450 
