### PR TITLE
Remove duplicate content in translation FAQ

### DIFF
--- a/src/content/contributing/translation-program/faq/index.md
+++ b/src/content/contributing/translation-program/faq/index.md
@@ -103,9 +103,7 @@ We recommend you leave names of brands, companies, and personnel untranslated as
 
 ## How does the review process work? {#review-process}
 
-To ensure a certain level of quality and consistency in our translations, we work with [Acolad](https://www.acolad.com/), one of the largest language service providers globally. Acolad has 20,000 professional linguists and can provide professional reviewers in any language.
-
-Acolad is one of the largest language service providers in the world, working with 20,000 professional linguists. This means that they can provide professional reviewers for every language and type of content we need.
+To ensure a certain level of quality and consistency in our translations, we work with [Acolad](https://www.acolad.com/), one of the largest language service providers globally. Acolad has 20,000 professional linguists, which means that they can provide professional reviewers for every language and type of content we need.
 
 The review process is straightforward; once a certain [content bucket](/contributing/translation-program/content-buckets) is 100% translated, we order a review for that content bucket. The review process takes place directly in Crowdin. Once the review is complete, we update the website with the translated content.
 


### PR DESCRIPTION
## Description

Remove duplicate content about the review process in the translation FAQ section.
