### PR TITLE
Upgrade solidity version in Hardhat config [Fixes #5389]

### DIFF
--- a/src/content/developers/tutorials/how-to-write-and-deploy-an-nft/index.md
+++ b/src/content/developers/tutorials/how-to-write-and-deploy-an-nft/index.md
@@ -265,7 +265,7 @@ Update your hardhat.config.js to look like this:
     require("@nomiclabs/hardhat-ethers");
     const { API_URL, PRIVATE_KEY } = process.env;
     module.exports = {
-       solidity: "0.8.0",
+       solidity: "0.8.1",
        defaultNetwork: "ropsten",
        networks: {
           hardhat: {},


### PR DESCRIPTION
Upgrade solidity version in Hardhat config code snippet shown in NFT minting tutorial to fix contract compilation error.

## Description

Upgrade from `0.8.0` to `0.8.1` to meet the requirement of `@openzeppelin/contracts/utils/Address.sol`.

## Related Issue

#5389 
