### PR TITLE
Fix typo in smart contract developer docs(Chinese)

### DIFF
--- a/src/content/translations/zh/developers/docs/smart-contracts/libraries/index.md
+++ b/src/content/translations/zh/developers/docs/smart-contracts/libraries/index.md
@@ -17,7 +17,7 @@ sidebar: true
 
 ### 行为 {#behaviors}
 
-当编写智能合约时，您很可能会发现自己在写重复的代码。 比如说在智能合约中指派一个*管理员*地址执行受保护的操作，或添加一个紧急暂停按钮以应对预料不到的问题。
+当编写智能合约时，您很可能会发现自己在写重复的代码。 比如说在智能合约中指派一个*管理员*地址执行受保护的操作，或添加一个紧急*暂停*按钮以应对预料不到的问题。
 
 智能合约库通常提供这些行为的可复用实现方式为[标准库](https://solidity.readthedocs.io/en/v0.7.2/contracts.html#libraries)或在 solidity 中通过[继承](https://solidity.readthedocs.io/en/v0.7.2/contracts.html#inheritance)的方式实现。
 

--- a/src/content/translations/zh/developers/docs/smart-contracts/libraries/index.md
+++ b/src/content/translations/zh/developers/docs/smart-contracts/libraries/index.md
@@ -9,7 +9,7 @@ sidebar: true
 
 ## 前置要求 {#prerequisites}
 
-在我们跳转到智能合约库之前，清楚地了解一个智能合约的构成是一个不错的主意。 如果尚未进行智能合约的了解，请直接点击</[智能合约](/developers/docs/smart-contracts/anatomy/)。
+在我们跳转到智能合约库之前，清楚地了解一个智能合约的构成是一个不错的主意。 如果尚未进行智能合约的了解，请直接点击[智能合约](/developers/docs/smart-contracts/anatomy/)。
 
 ## 资料库中的内容 {#whats-in-a-library}
 
@@ -17,7 +17,7 @@ sidebar: true
 
 ### 行为 {#behaviors}
 
-当编写智能合约时，您很可能会发现自己在写重复的代码。 比如说在智能合约中指派一个*管理员*地址执行受保护的操作，或添加一个紧急*暂停*按钮以应对预料不到的问题。
+当编写智能合约时，您很可能会发现自己在写重复的代码。 比如说在智能合约中指派一个*管理员*地址执行受保护的操作，或添加一个紧急暂停按钮以应对预料不到的问题。
 
 智能合约库通常提供这些行为的可复用实现方式为[标准库](https://solidity.readthedocs.io/en/v0.7.2/contracts.html#libraries)或在 solidity 中通过[继承](https://solidity.readthedocs.io/en/v0.7.2/contracts.html#inheritance)的方式实现。
 


### PR DESCRIPTION
fix some typo in smart contract lib Chinese translator

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
