### PR TITLE
Open PDFs in browser

### DIFF
--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -157,7 +157,7 @@ const Link = ({
   // Download link for internally hosted PDF's (ex: whitepaper)
   if (isPdf && !isExternal) {
     return (
-      <a href={to} download>
+      <a href={to} target="_blank">
         {children}
       </a>
     )


### PR DESCRIPTION
## Description

Currently, the pdfs are downloaded by default when you click on them. With this change they will open in a new tab.

This will improve the UX and will be useful to link or bookmark the files inside eth.org.