### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ To get more information about the program, learn how to use Crowdin, check on th
   - Primary implementation: `/src/components/Search/index.js`
 - [Crowdin](https://crowdin.com/) - crowdsourcing for our translation efforts (See "Translation initiative" below)
 - [GitHub Actions](https://github.com/features/actions) - Manages CI/CD, and issue tracking
-- [Netlify](https://yarnpkg.com/cli/install) - DNS management and primary host for `master` build. Also provides automatic preview deployments for all pull requests
+- [Netlify](https://www.netlify.com/) - DNS management and primary host for `master` build. Also provides automatic preview deployments for all pull requests
 
 ### Code structure
 


### PR DESCRIPTION
Changed wrong link

<!--- Provide a general summary of your changes in the Title above -->

## Description
changed from "https://yarnpkg.com/cli/install" to "https://www.netlify.com/"
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
