### PR TITLE
Add focus when tabbing through content to network statistic section [Fixes #4229]

### DIFF
--- a/src/components/StatsBoxGrid.js
+++ b/src/components/StatsBoxGrid.js
@@ -123,11 +123,10 @@ const Button = styled.button`
   background: ${(props) => props.theme.colors.background};
   font-family: ${(props) => props.theme.fonts.monospace};
   font-size: 1.25rem;
-  color: ${({theme}) => theme.colors.text};
+  color: ${({ theme }) => theme.colors.text};
   padding: 2px 15px;
   border-radius: 1px;
-  border: 1px solid ${({theme, color}) => theme.colors[color]};
-  outline: none;
+  border: 1px solid ${({ theme, color }) => theme.colors[color]};
   cursor: pointer;
 
   &:disabled {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- Remove `outline: none` to `Button` component in network statistics graph on home page. This will allow to show focus when tabbing.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#4229 