### PR TITLE
update contracts in tutorial to work with Solidity 0.8.0

### DIFF
--- a/src/content/developers/tutorials/transfers-and-approval-of-erc-20-tokens-from-a-solidity-smart-contract/index.md
+++ b/src/content/developers/tutorials/transfers-and-approval-of-erc-20-tokens-from-a-solidity-smart-contract/index.md
@@ -24,7 +24,7 @@ For this tutorial we’ll use the code we wrote in the previous tutorial as a ba
 We’ll start our Decentralized exchange code by adding our simple ERC20 codebase:
 
 ```solidity
-pragma solidity ^0.6.0;
+pragma solidity ^0.8.0;
 
 interface IERC20 {
 
@@ -49,19 +49,15 @@ contract ERC20Basic is IERC20 {
     uint8 public constant decimals = 18;
 
 
-    event Approval(address indexed tokenOwner, address indexed spender, uint tokens);
-    event Transfer(address indexed from, address indexed to, uint tokens);
-
-
     mapping(address => uint256) balances;
 
     mapping(address => mapping (address => uint256)) allowed;
 
-    uint256 totalSupply_ = 100 ether;
+    uint256 totalSupply_ = 10 ether;
 
     using SafeMath for uint256;
 
-   constructor(uint256 total) public {
+   constructor() {
 	balances[msg.sender] = totalSupply_;
     }
 
@@ -115,6 +111,7 @@ library SafeMath {
       return c;
     }
 }
+
 ```
 
 Our new DEX smart contract will deploy the ERC-20 and get all the supplied:
@@ -127,7 +124,7 @@ contract DEX {
     event Bought(uint256 amount);
     event Sold(uint256 amount);
 
-    constructor() public {
+    constructor() {
         token = new ERC20Basic();
     }
 
@@ -159,7 +156,7 @@ To keep things simple, we just exchange 1 token for 1 Wei.
 function buy() payable public {
     uint256 amountTobuy = msg.value;
     uint256 dexBalance = token.balanceOf(address(this));
-    require(amountTobuy > 0, "You need to send some ether");
+    require(amountTobuy > 0, "You need to send some Ether");
     require(amountTobuy <= dexBalance, "Not enough tokens in the reserve");
     token.transfer(msg.sender, amountTobuy);
     emit Bought(amountTobuy);
@@ -180,7 +177,7 @@ function sell(uint256 amount) public {
     uint256 allowance = token.allowance(msg.sender, address(this));
     require(allowance >= amount, "Check the token allowance");
     token.transferFrom(msg.sender, address(this), amount);
-    msg.sender.transfer(amount);
+    payable(msg.sender).transfer(amount);
     emit Sold(amount);
 }
 ```
@@ -198,7 +195,7 @@ Once you make a transaction we have a Javascript tutorial to [wait and get detai
 Here is the complete code for the tutorial:
 
 ```solidity
-pragma solidity ^0.6.0;
+pragma solidity ^0.8.0;
 
 interface IERC20 {
 
@@ -223,10 +220,6 @@ contract ERC20Basic is IERC20 {
     uint8 public constant decimals = 18;
 
 
-    event Approval(address indexed tokenOwner, address indexed spender, uint tokens);
-    event Transfer(address indexed from, address indexed to, uint tokens);
-
-
     mapping(address => uint256) balances;
 
     mapping(address => mapping (address => uint256)) allowed;
@@ -235,7 +228,7 @@ contract ERC20Basic is IERC20 {
 
     using SafeMath for uint256;
 
-   constructor() public {
+   constructor() {
 	balances[msg.sender] = totalSupply_;
     }
 
@@ -298,14 +291,14 @@ contract DEX {
 
     IERC20 public token;
 
-    constructor() public {
+    constructor() {
         token = new ERC20Basic();
     }
 
     function buy() payable public {
         uint256 amountTobuy = msg.value;
         uint256 dexBalance = token.balanceOf(address(this));
-        require(amountTobuy > 0, "You need to send some ether");
+        require(amountTobuy > 0, "You need to send some Ether");
         require(amountTobuy <= dexBalance, "Not enough tokens in the reserve");
         token.transfer(msg.sender, amountTobuy);
         emit Bought(amountTobuy);
@@ -316,7 +309,7 @@ contract DEX {
         uint256 allowance = token.allowance(msg.sender, address(this));
         require(allowance >= amount, "Check the token allowance");
         token.transferFrom(msg.sender, address(this), amount);
-        msg.sender.transfer(amount);
+        payable(msg.sender).transfer(amount);
         emit Sold(amount);
     }
 

--- a/src/content/developers/tutorials/transfers-and-approval-of-erc-20-tokens-from-a-solidity-smart-contract/index.md
+++ b/src/content/developers/tutorials/transfers-and-approval-of-erc-20-tokens-from-a-solidity-smart-contract/index.md
@@ -1,7 +1,7 @@
 ---
 title: Transfers and approval of ERC-20 tokens from a solidity smart contract
 description: How to use a smart contract to interact with a token using the Solidity language
-author: "jdourlens, updated 2022 by jcook"
+author: "jdourlens"
 tags: ["smart contracts", "tokens", "solidity", "getting started", "erc-20"]
 skill: intermediate
 lang: en

--- a/src/content/developers/tutorials/transfers-and-approval-of-erc-20-tokens-from-a-solidity-smart-contract/index.md
+++ b/src/content/developers/tutorials/transfers-and-approval-of-erc-20-tokens-from-a-solidity-smart-contract/index.md
@@ -143,7 +143,7 @@ To keep things simple, we just exchange 1 token for 1 Wei.
 function buy() payable public {
     uint256 amountTobuy = msg.value;
     uint256 dexBalance = token.balanceOf(address(this));
-    require(amountTobuy > 0, "You need to send some Ether");
+    require(amountTobuy > 0, "You need to send some ether");
     require(amountTobuy <= dexBalance, "Not enough tokens in the reserve");
     token.transfer(msg.sender, amountTobuy);
     emit Bought(amountTobuy);

--- a/src/content/developers/tutorials/transfers-and-approval-of-erc-20-tokens-from-a-solidity-smart-contract/index.md
+++ b/src/content/developers/tutorials/transfers-and-approval-of-erc-20-tokens-from-a-solidity-smart-contract/index.md
@@ -296,7 +296,7 @@ contract DEX {
     function buy() payable public {
         uint256 amountTobuy = msg.value;
         uint256 dexBalance = token.balanceOf(address(this));
-        require(amountTobuy > 0, "You need to send some Ether");
+        require(amountTobuy > 0, "You need to send some ether");
         require(amountTobuy <= dexBalance, "Not enough tokens in the reserve");
         token.transfer(msg.sender, amountTobuy);
         emit Bought(amountTobuy);

--- a/src/content/developers/tutorials/transfers-and-approval-of-erc-20-tokens-from-a-solidity-smart-contract/index.md
+++ b/src/content/developers/tutorials/transfers-and-approval-of-erc-20-tokens-from-a-solidity-smart-contract/index.md
@@ -55,7 +55,6 @@ contract ERC20Basic is IERC20 {
 
     uint256 totalSupply_ = 10 ether;
 
-    using SafeMath for uint256;
 
    constructor() {
 	balances[msg.sender] = totalSupply_;
@@ -71,8 +70,8 @@ contract ERC20Basic is IERC20 {
 
     function transfer(address receiver, uint256 numTokens) public override returns (bool) {
         require(numTokens <= balances[msg.sender]);
-        balances[msg.sender] = balances[msg.sender].sub(numTokens);
-        balances[receiver] = balances[receiver].add(numTokens);
+        balances[msg.sender] = balances[msg.sender]-numTokens;
+        balances[receiver] = balances[receiver]+numTokens;
         emit Transfer(msg.sender, receiver, numTokens);
         return true;
     }
@@ -91,26 +90,14 @@ contract ERC20Basic is IERC20 {
         require(numTokens <= balances[owner]);
         require(numTokens <= allowed[owner][msg.sender]);
 
-        balances[owner] = balances[owner].sub(numTokens);
-        allowed[owner][msg.sender] = allowed[owner][msg.sender].sub(numTokens);
-        balances[buyer] = balances[buyer].add(numTokens);
+        balances[owner] = balances[owner]-numTokens;
+        allowed[owner][msg.sender] = allowed[owner][msg.sender]+numTokens;
+        balances[buyer] = balances[buyer]+numTokens;
         emit Transfer(owner, buyer, numTokens);
         return true;
     }
 }
 
-library SafeMath {
-    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
-      assert(b <= a);
-      return a - b;
-    }
-
-    function add(uint256 a, uint256 b) internal pure returns (uint256) {
-      uint256 c = a + b;
-      assert(c >= a);
-      return c;
-    }
-}
 
 ```
 
@@ -226,7 +213,6 @@ contract ERC20Basic is IERC20 {
 
     uint256 totalSupply_ = 10 ether;
 
-    using SafeMath for uint256;
 
    constructor() {
 	balances[msg.sender] = totalSupply_;
@@ -242,8 +228,8 @@ contract ERC20Basic is IERC20 {
 
     function transfer(address receiver, uint256 numTokens) public override returns (bool) {
         require(numTokens <= balances[msg.sender]);
-        balances[msg.sender] = balances[msg.sender].sub(numTokens);
-        balances[receiver] = balances[receiver].add(numTokens);
+        balances[msg.sender] = balances[msg.sender]-numTokens;
+        balances[receiver] = balances[receiver]+numTokens;
         emit Transfer(msg.sender, receiver, numTokens);
         return true;
     }
@@ -262,26 +248,14 @@ contract ERC20Basic is IERC20 {
         require(numTokens <= balances[owner]);
         require(numTokens <= allowed[owner][msg.sender]);
 
-        balances[owner] = balances[owner].sub(numTokens);
-        allowed[owner][msg.sender] = allowed[owner][msg.sender].sub(numTokens);
-        balances[buyer] = balances[buyer].add(numTokens);
+        balances[owner] = balances[owner]-numTokens;
+        allowed[owner][msg.sender] = allowed[owner][msg.sender]+numTokens;
+        balances[buyer] = balances[buyer]+numTokens;
         emit Transfer(owner, buyer, numTokens);
         return true;
     }
 }
 
-library SafeMath {
-    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
-      assert(b <= a);
-      return a - b;
-    }
-
-    function add(uint256 a, uint256 b) internal pure returns (uint256) {
-      uint256 c = a + b;
-      assert(c >= a);
-      return c;
-    }
-}
 
 contract DEX {
 

--- a/src/content/developers/tutorials/transfers-and-approval-of-erc-20-tokens-from-a-solidity-smart-contract/index.md
+++ b/src/content/developers/tutorials/transfers-and-approval-of-erc-20-tokens-from-a-solidity-smart-contract/index.md
@@ -1,7 +1,7 @@
 ---
 title: Transfers and approval of ERC-20 tokens from a solidity smart contract
 description: How to use a smart contract to interact with a token using the Solidity language
-author: "jdourlens"
+author: "jdourlens, updated 2022 by jcook"
 tags: ["smart contracts", "tokens", "solidity", "getting started", "erc-20"]
 skill: intermediate
 lang: en
@@ -156,7 +156,31 @@ In the case where the buy is successful we should see two events in the transact
 
 ## The sell function {#the-sell-function}
 
-The function responsible for the sell will first require the user to have approved the amount by calling the approve function beforehand. Then when the sell function is called, we’ll check if the transfer from the caller address to the contract address was successful and then send the Ethers back to the caller address.
+The function responsible for the sell will first require the user to have approved the amount by calling the approve function beforehand. Approving the transfer requires the ERC20Basic token instantiated by the DEX to be called by the user. This can be achieved by first calling the DEX contract's `token()` function to retrieve the address where DEX deployed the ERC20Basic contract called `token`. Then we create an instance of that contract in our session and call its `approve` function. Then we are able to call the DEX's `sell` function and swap our tokens back for ether. For example, this is how this looks in an interactive brownie session:
+
+```python
+#### Python in interactive brownie console...
+
+# deploy the DEX
+dex = DEX.deploy({'from':account1})
+
+# call the buy function to swap ether for token
+# 1e18 is 1 ether denominated in wei
+dex.buy({'from': account2, 1e18})
+
+# get the deployment address for the ERC20 token
+# that was deployed during DEX contract creation
+# dex.token() returns the deployed address for token
+token = ERC20Basic.at(dex.token())
+
+# call the token's approve function
+# approve the dex address as spender
+# and how many of your tokens it is allowed to spend
+token.approve(dex.address, 3e18, {'from':account2})
+
+```
+
+Then when the sell function is called, we’ll check if the transfer from the caller address to the contract address was successful and then send the Ethers back to the caller address.
 
 ```solidity
 function sell(uint256 amount) public {

--- a/src/content/developers/tutorials/understand-the-erc-20-token-smart-contract/index.md
+++ b/src/content/developers/tutorials/understand-the-erc-20-token-smart-contract/index.md
@@ -181,6 +181,8 @@ contract ERC20Basic is IERC20 {
     }
 }
 
+// note that the SafeMath library is not required for Solidity v0.8 and above.
+
 library SafeMath {
     function sub(uint256 a, uint256 b) internal pure returns (uint256) {
       assert(b <= a);
@@ -195,6 +197,6 @@ library SafeMath {
 }
 ```
 
-This implementation uses the SafeMath library. Read our tutorial about it if you’d like to learn [how the library helps you with handling overflows and underflows in your smart contracts](https://ethereumdev.io/using-safe-math-library-to-prevent-from-overflows/).
+This implementation uses the SafeMath library. Read our tutorial about it if you’d like to learn [how the library helps you with handling overflows and underflows in your smart contracts](https://ethereumdev.io/using-safe-math-library-to-prevent-from-overflows/). Solidity 0.8 introduced compiler overflow and underflow protections that make the SafeMath unnecessary in many contracts.
 
 Another excellent implementation of the ERC-20 token standard is the [OpenZeppelin ERC-20 implementation](https://github.com/OpenZeppelin/openzeppelin-contracts/tree/master/contracts/token/ERC20).

--- a/src/content/developers/tutorials/understand-the-erc-20-token-smart-contract/index.md
+++ b/src/content/developers/tutorials/understand-the-erc-20-token-smart-contract/index.md
@@ -100,7 +100,7 @@ This event is emitted when the amount of tokens (`value`) is approved by the `ow
 Here is the most simple code to base your ERC-20 token from:
 
 ```solidity
-pragma solidity ^0.6.0;
+pragma solidity ^0.8.0;
 
 interface IERC20 {
 
@@ -125,21 +125,14 @@ contract ERC20Basic is IERC20 {
     uint8 public constant decimals = 18;
 
 
-    event Approval(address indexed tokenOwner, address indexed spender, uint tokens);
-    event Transfer(address indexed from, address indexed to, uint tokens);
-
-
     mapping(address => uint256) balances;
 
     mapping(address => mapping (address => uint256)) allowed;
 
-    uint256 totalSupply_;
-
-    using SafeMath for uint256;
+    uint256 totalSupply_ = 10 ether;
 
 
-   constructor(uint256 total) public {
-	totalSupply_ = total;
+   constructor() {
 	balances[msg.sender] = totalSupply_;
     }
 
@@ -153,8 +146,8 @@ contract ERC20Basic is IERC20 {
 
     function transfer(address receiver, uint256 numTokens) public override returns (bool) {
         require(numTokens <= balances[msg.sender]);
-        balances[msg.sender] = balances[msg.sender].sub(numTokens);
-        balances[receiver] = balances[receiver].add(numTokens);
+        balances[msg.sender] = balances[msg.sender]-numTokens;
+        balances[receiver] = balances[receiver]+numTokens;
         emit Transfer(msg.sender, receiver, numTokens);
         return true;
     }
@@ -173,30 +166,13 @@ contract ERC20Basic is IERC20 {
         require(numTokens <= balances[owner]);
         require(numTokens <= allowed[owner][msg.sender]);
 
-        balances[owner] = balances[owner].sub(numTokens);
-        allowed[owner][msg.sender] = allowed[owner][msg.sender].sub(numTokens);
-        balances[buyer] = balances[buyer].add(numTokens);
+        balances[owner] = balances[owner]-numTokens;
+        allowed[owner][msg.sender] = allowed[owner][msg.sender]+numTokens;
+        balances[buyer] = balances[buyer]+numTokens;
         emit Transfer(owner, buyer, numTokens);
         return true;
     }
 }
-
-// note that the SafeMath library is not required for Solidity v0.8 and above.
-
-library SafeMath {
-    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
-      assert(b <= a);
-      return a - b;
-    }
-
-    function add(uint256 a, uint256 b) internal pure returns (uint256) {
-      uint256 c = a + b;
-      assert(c >= a);
-      return c;
-    }
-}
 ```
-
-This implementation uses the SafeMath library. Read our tutorial about it if you’d like to learn [how the library helps you with handling overflows and underflows in your smart contracts](https://ethereumdev.io/using-safe-math-library-to-prevent-from-overflows/). Solidity 0.8 introduced compiler overflow and underflow protections that make the SafeMath unnecessary in many contracts.
 
 Another excellent implementation of the ERC-20 token standard is the [OpenZeppelin ERC-20 implementation](https://github.com/OpenZeppelin/openzeppelin-contracts/tree/master/contracts/token/ERC20).


### PR DESCRIPTION

## Description

Noticed this issue has been hanging for a while so had a crack at it - hope that's ok.

Issue #5354 describes a declaration error thrown when the contract in tutorial in the developer docs [here](https://github.com/ethereum/ethereum-org-website/blob/864d77178dee04e80d5f983b3911cc351118fb26/src/content/developers/tutorials/transfers-and-approval-of-erc-20-tokens-from-a-solidity-smart-contract/index.md) is compiled using Solidity 0.8.0.

This is not really a huge problem since the tutorial is written with a clear `pragma Solidity ^0.6.0` statement. As long as the pragma statement remains unchanged at `^0.6.0` the contracts compile perfectly and behave as expected. Therefore, the mods might decide this PR is unnecessary and close it without merging. However, some users might want to use the most up to date Solidity compiler, especially because there have been significant breaking changes between v0.6 and v0.8.

This PR includes an amended tutorial page with contracts that compile and run as expected using Solidity v0.8. Specifically the following actions were taken:

1) Removed redundant access modifiers from the constructors
2) The v0.8 compiler no longer implicitly converts `address` to `address payable`. Contract amended accordingly.
3) The events that were declared twice in the previous version are now declared once in the interface definition and inherited by the contract, fixing the `DeclarationError`.
4) Solidity 0.8 includes built-in overflow checking that makes SafeMath redundant. Removed in updated version.
5) Added an explicit description of the token approval process to the tutorial as I thought this was opaque in the original. Especially because it requires instantiation of the token contract at the address where it was deployed during the DEX contract creation. 
6) Added a note to the prerequisite page explaining that SafeMath is unneccessary for Solidity 0.8.

Original and updated tutorial contracts tested using Brownie v1.14.6. Site updates checked by hosting locally.

This PR is kind of a patch stimulated by issue #5354 but perhaps a completely fresh tutorial on this topic might be good soon?

## Related Issue

#5354 
