### PR TITLE
Add Validium section to scaling page

### DIFF
--- a/src/content/developers/docs/scaling/index.md
+++ b/src/content/developers/docs/scaling/index.md
@@ -78,6 +78,12 @@ A plasma chain is a separate blockchain that is anchored to the main Ethereum ch
 
 Learn more about [Plasma](/developers/docs/scaling/plasma/).
 
+### Validium {#validium}
+
+A Validium chain uses validity proofs like zero-knowledge rollups but data is not stored on the main layer 1 Ethereum chain. This can lead to 10k transactions per second per Validium chain and multiple chains can be run in parallel.
+
+Learn more about [Validium](/developers/docs/scaling/validium/).
+
 ## Why are so many scaling solutions needed? {#why-do-we-need-these}
 
 - Multiple solutions can help reduce the overall congestion on any one part of the network, and also prevents single points of failure.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Noticed we don't link to the Validium page from the Scaling page - it's the only subpage we don't have a section on.

Separate question - is Validium considered an L2? In this PR I kept it separate, like Sidechains & Plasma. Not sure if that's correct. This relates a bit to #5576.

## Related Issue

None