### PR TITLE
add alchemy nft api to nft standards

### DIFF
--- a/src/content/developers/docs/standards/tokens/erc-1155/index.md
+++ b/src/content/developers/docs/standards/tokens/erc-1155/index.md
@@ -144,3 +144,4 @@ _Note_: All batch functions including the hook also exist as versions without ba
 - [EIP-1155: Multi Token Standard](https://eips.ethereum.org/EIPS/eip-1155)
 - [ERC-1155: Openzeppelin Docs](https://docs.openzeppelin.com/contracts/3.x/erc1155)
 - [ERC-1155: Github Repo](https://github.com/enjin/erc-1155)
+- [Alchemy NFT API](https://docs.alchemy.com/alchemy/enhanced-apis/nft-api)

--- a/src/content/developers/docs/standards/tokens/erc-721/index.md
+++ b/src/content/developers/docs/standards/tokens/erc-721/index.md
@@ -261,3 +261,4 @@ recent_births = [get_event_data(w3.codec, ck_extra_events_abi[1], log)["args"] f
 - [EIP-721: ERC-721 Non-Fungible Token Standard](https://eips.ethereum.org/EIPS/eip-721)
 - [OpenZeppelin - ERC-721 Docs](https://docs.openzeppelin.com/contracts/3.x/erc721)
 - [OpenZeppelin - ERC-721 Implementation](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC721/ERC721.sol)
+- [Alchemy NFT API](https://docs.alchemy.com/alchemy/enhanced-apis/nft-api)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- add alchemy nft api docs to further reading for erc-721 and erc-1155 pages. This api supports these standards.
