### PR TITLE
Add Discord redirect

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -1,5 +1,9 @@
 [
   {
+    "fromPath": "/discord",
+    "toPath": "https://discord.gg/rZz26QWfCg"
+  },
+  {
     "fromPath": "/pdfs/*",
     "toPath": "/en/"
   },

--- a/redirects.json
+++ b/redirects.json
@@ -4,6 +4,10 @@
     "toPath": "https://discord.gg/rZz26QWfCg"
   },
   {
+    "fromPath": "/*/discord",
+    "toPath": "https://discord.gg/rZz26QWfCg"
+  },
+  {
     "fromPath": "/pdfs/*",
     "toPath": "/en/"
   },


### PR DESCRIPTION
## Description

- Redirects from https://ethereum.org/discord to discord invite link.

**Question**: do we also want this to work with language paths? (e.g. https://ethereum.org/en/discord)

## Related Issue
None