### PR TITLE
fix: add note for Arbitrum

### DIFF
--- a/src/data/layer-2.json
+++ b/src/data/layer-2.json
@@ -5,7 +5,7 @@
       "website": "https://arbitrum.io/",
       "developerDocs": "https://developer.offchainlabs.com/docs/developer_quickstart",
       "l2beat": "https://l2beat.com/projects/arbitrum/",
-      "noteKey": ""
+      "noteKey": "layer-2-arbitrum-note"
     },
     {
       "name": "Optimism",

--- a/src/intl/en/page-layer-2.json
+++ b/src/intl/en/page-layer-2.json
@@ -1,4 +1,5 @@
 {
+  "layer-2-arbitrum-note": "Fraud proofs only for whitelisted users, whitelist not open yet",
   "layer-2-boba-note": "State validation in development",
   "layer-2-metis-note": "Fraud proofs in development",
   "layer-2-optimism-note": "Fault proofs in development"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Adds a disclaimer for Arbitrum. According to Arbitrum's documentation, Arbitrum's fraud proofs can currently only be used by [whitelisted addresses](https://developer.offchainlabs.com/docs/mainnet). This whitelist is currently not open to the general public, which has important effects on the security model of the system (only the Arbitrum team can currently use the fraud proof system). This is important to note (alongside the notes described for other L2s).