### PR TITLE
Add FeedbackCard to all langs (developer docs)

### DIFF
--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -211,7 +211,7 @@ const DocsPage = ({ data, pageContext }) => {
               <Translation id="back-to-top" /> ↑
             </a>
           </BackToTop>
-          {locale === "en" && <FeedbackCard />}
+          <FeedbackCard />
           <DocsNav relativePath={relativePath}></DocsNav>
         </Content>
         {mdx.frontmatter.sidebar && tocItems && (

--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -168,7 +168,6 @@ const Contributors = styled(FileContributors)`
 const DocsPage = ({ data, pageContext }) => {
   const { isZenMode } = useContext(ZenModeContext)
   const mdx = data.pageData
-  const { locale } = useIntl()
   const isRightToLeft = isLangRightToLeft(mdx.frontmatter.lang)
 
   const tocItems = mdx.tableOfContents.items


### PR DESCRIPTION
## Description

Removes conditional logic that stopped the `FeedbackCard` from showing on non-English developer doc pages

## Related Issue
None

