### PR TITLE
Moved up the gas expense paragraph; removed kLast reference

### DIFF
--- a/src/content/developers/tutorials/uniswap-v2-annotated-code/index.md
+++ b/src/content/developers/tutorials/uniswap-v2-annotated-code/index.md
@@ -207,11 +207,16 @@ by this pool.
 The reserves the pool has for each token type. We assume that the two represent the same amount of value,
 and therefore each token0 is worth reserve1/reserve0 token1's.
 
+
 ```solidity
     uint32  private blockTimestampLast; // uses single storage slot, accessible via getReserves
 ```
 
 The timestamp for the last block in which an exchange occurred, used to track exchange rates across time.
+
+One of the biggest gas expenses of Ethereum contracts is storage, which persists from one call of the contract
+to the next. Each storage cell is 256 bits long. So three variables, reserve0, reserve1, and blockTimestampLast, are allocated in such
+a way a single storage value can include all three of them (112+112+32=256).
 
 ```solidity
     uint public price0CumulativeLast;
@@ -221,9 +226,7 @@ The timestamp for the last block in which an exchange occurred, used to track ex
 These variables hold the cumulative costs for each token (each in term of the other). They can be used to calculate
 the average exchange rate over a period of time.
 
-One of the biggest gas expenses of Ethereum contracts is storage, which persists from one call of the contract
-to the next. Each storage cell is 256 bits long. So there variable, and `kLast` below, are allocated in such
-a way a single storage value can include all three of them (112+112+32=256).
+
 
 ```solidity
     uint public kLast; // reserve0 * reserve1, as of immediately after the most recent liquidity event


### PR DESCRIPTION
## Description

The paragraph in the Uniswap-V2 Contract Walk Through document about gas saving by packing variables refers to three variables, `reserve0`, `reserve1`, and `blockTimestampLast`, and is moved up to be closer to the relevant code chunks. `kLast` is a regular uint256 and not packed in a single slot with other variables and its reference removed.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
