### PR TITLE
Refactor to avoid using ids in the search inputs

### DIFF
--- a/src/components/Nav/index.js
+++ b/src/components/Nav/index.js
@@ -405,7 +405,7 @@ const Nav = ({ handleThemeChange, isDarkTheme, path }) => {
               )}
             </LeftItems>
             <RightItems>
-              <Search />
+              <Search useKeyboardShortcuts />
               <ThemeToggle
                 onClick={handleThemeChange}
                 aria-label={

--- a/src/components/Search/Input.js
+++ b/src/components/Search/Input.js
@@ -3,8 +3,6 @@ import { useIntl } from "gatsby-plugin-intl"
 import styled from "styled-components"
 import { connectSearchBox } from "react-instantsearch-dom"
 
-import { useKeyPress } from "../../hooks/useKeyPress"
-
 import Icon from "../Icon"
 import { translateMessageId } from "../../utils/translations"
 
@@ -59,7 +57,7 @@ const SearchSlash = styled.p`
   }
 `
 
-const Input = ({ query, setQuery, refine, ...rest }) => {
+const Input = ({ query, setQuery, refine, inputRef, ...rest }) => {
   const intl = useIntl()
   const searchString = translateMessageId("search", intl)
 
@@ -73,20 +71,10 @@ const Input = ({ query, setQuery, refine, ...rest }) => {
     event.preventDefault()
   }
 
-  const focusSearch = (event) => {
-    const searchInput = document.getElementById("header-search")
-    if (document.activeElement !== searchInput) {
-      event.preventDefault()
-      searchInput.focus()
-    }
-  }
-
-  useKeyPress("/", focusSearch)
-
   return (
     <Form onSubmit={handleSubmit}>
       <StyledInput
-        id="header-search"
+        ref={inputRef}
         type="text"
         placeholder={searchString}
         value={query}


### PR DESCRIPTION
## Description

We were having duplicate ids with the search inputs since we have 2, one for mobile and another one for desktop. This is a refactor to avoid using ids to focus the inputs.