### PR TITLE
Fix event date inconsistency

### DIFF
--- a/src/data/community-events.json
+++ b/src/data/community-events.json
@@ -50,8 +50,8 @@
     "sponsor": null,
     "location": "NYC, USA",
     "description": "DeFiCon is a nonprofit conference with a mission to elevate the ethos of peer-to-peer crypto.",
-    "startDate": "2022-03-25",
-    "endDate": "2022-03-26"
+    "startDate": "2022-05-07",
+    "endDate": "2022-05-08"
   },
   {
     "title": "ETHDubai",


### PR DESCRIPTION
## Fix event date inconsistency
Fixed an event date 📅
As reported by the website https://deficon.nyc/ , the DeFiCon event will take place on 7-8 May 2022.
Most likely, the date error was associated from here: https://www.eventbrite.com/e/deficon-2022-tickets-164176080075
