### PR TITLE
Fix small typo on EthExchanges

### DIFF
--- a/src/components/EthExchanges.js
+++ b/src/components/EthExchanges.js
@@ -619,7 +619,7 @@ const EthExchanges = () => {
           </ResultsContainer>
           <Disclaimer>
             <Translation id="page-get-eth-exchanges-disclaimer" />{" "}
-            <Link to="mailto:website@ethereum.org">website@ethereum.org</Link>.
+            <Link to="mailto:website@ethereum.org">website@ethereum.org</Link>.{" "}
             <Translation id="page-find-wallet-last-updated" />{" "}
             <strong>{lastUpdated}</strong>
           </Disclaimer>


### PR DESCRIPTION
## Description
Fixes a small bug where there was no space between two sentences of the final paragraph on the `EthExchanges` component.

![image](https://user-images.githubusercontent.com/62268199/159701559-171bf357-19bf-4154-b2c8-cd82bbced3ce.png)

## Related Issue
None
