### PR TITLE
Remove ethmiami until legitimacy can be confirmed

### DIFF
--- a/src/data/community-events.json
+++ b/src/data/community-events.json
@@ -90,15 +90,6 @@
     "endDate": "2022-04-09"
   },
   {
-    "title": "ETHMiami",
-    "to": "https://ethmiami.net/",
-    "sponsor": null,
-    "location": "Miami, FL",
-    "description": "Join and support the first ever ETHMiami event, a community event for developers, researchers, and BUIDLers in the Ethereum ecosystem on April 9th. It’s all about knowledge sharing, networking and having fun.",
-    "startDate": "2022-04-09",
-    "endDate": "2022-04-09"
-  },
-  {
     "title": "DevConnect",
     "to": "https://devconnect.org/",
     "sponsor": null,


### PR DESCRIPTION
Have received reports of this event not being legitimate, focusing on monetizing rather than educating, and implying that the Ethereum Foundation is a sponsor when it is not. I would suggest removing until this can be proven otherwise.

