### PR TITLE
Update InfuraProvider on send-token-ethersjs tutorial

### DIFF
--- a/src/content/developers/tutorials/send-token-etherjs/index.md
+++ b/src/content/developers/tutorials/send-token-etherjs/index.md
@@ -67,7 +67,7 @@ ES3(UMD) in the Browser
 Connect to Ropsten testnet
 
 ```javascript
-window.provider = new InfuraProvider("ropsten")
+window.ethersProvider = new ethers.providers.InfuraProvider("ropsten")
 ```
 
 ### 2. Create wallet {#create-wallet}


### PR DESCRIPTION
Not working:
window.provider = new InfuraProvider("ropsten")

Fixed: 
window.ethersProvider = new ethers.providers.InfuraProvider("ropsten")