### PR TITLE
Fix typo in the Ethereum glossary

### DIFF
--- a/src/content/glossary/index.md
+++ b/src/content/glossary/index.md
@@ -184,7 +184,7 @@ Decentralized application. At a minimum, it is a [smart contract](#smart-contrac
 A type of [dapp](#dapp) that lets you swap tokens with peers on the network. You need [ether](#ether) to use one (to pay [transactions fees](#transaction-fee)) but they are not subject to geographical restrictions like centralized exchanges – anyone can participate.
 
 <DocLink to="/get-eth/#dex">
-  Decentalized exchanges
+  Decentralized exchanges
 </DocLink>
 
 ### deed {#deed}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Under the entry for 'decentralized exchange', the button linking to the /get-eth/dex page contains a typo. Specifically, the incorrect spelling is 'Decentalized exchanges'
 [Fixes #5762]

## Related Issue

[https://github.com/ethereum/ethereum-org-website/issues/5762](url)
