### PR TITLE
Fix Chinese Simplified language code

### DIFF
--- a/src/content/contributing/translation-program/translators-guide/index.md
+++ b/src/content/contributing/translation-program/translators-guide/index.md
@@ -68,7 +68,7 @@ If you are unsure which language code to use, you can check the translation memo
 Some examples of language codes for the most widely spoken languages:
 
 - Arabic - ar
-- Chinese Simplified - zn
+- Chinese Simplified - zh
 - French - fr
 - Hindi - hi
 - Spanish - es


### PR DESCRIPTION
## Description

The two-letter language code for Chinese Simplified in the translators guide is incorrect, it should be 'zh'.
