### PR TITLE
Update Contributors.js to pass alt text [a11y]

### DIFF
--- a/src/components/Contributors.js
+++ b/src/components/Contributors.js
@@ -54,6 +54,7 @@ const Contributors = () => {
             image={contributor.avatar_url}
             to={contributor.profile}
             title={contributor.name}
+            alt={contributor.name}
           />
         ))}
       </Container>


### PR DESCRIPTION
 passed alt to contributor images

<!--- Provide a general summary of your changes in the Title above -->

## Description
 passed alt to contributor images
<!--- Describe your changes in detail -->
passed alt as `{contributor.name}`props in contributor card 

## Related Issue
https://github.com/ethereum/ethereum-org-website/issues/5816
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
