### PR TITLE
Add Ethereum Vancouver to list of meetups

### DIFF
--- a/src/data/community-meetups.json
+++ b/src/data/community-meetups.json
@@ -60,6 +60,12 @@
     "link": "https://www.meetup.com/Ethereum-Developers/"
   },
   {
+    "title": "Ethereum Vancouver",
+    "emoji": ":canada:",
+    "location": "Vancouver",
+    "link": "https://www.meetup.com/ethvancouver-meetup-group/"
+  },
+  {
     "title": "Vancouver Ethereum & Blockchain 2.0 Meetup",
     "emoji": ":canada:",
     "location": "Vancouver",


### PR DESCRIPTION
## Description

This PR adds the [Ethereum Vancouver](https://www.meetup.com/ethvancouver-meetup-group/) meetup group to the list of meetups. Here are some social links:

- http://ethvancouver.org/ 
- http://discord.ethvancouver.org/
- http://meetup.ethvancouver.org/

Note that this is a different group than the previous "Vancouver Ethereum Meetup". That group has since rebranded to the Vancouver Blockchain Meetup. In contrast, this new meetup aims to be Ethereum and EVM-focused and will focus on more technical matters as well.

I would recommend removing the other Vancouver meetup from the list since they are no longer Ethereum-focused and it is a meetup group run by a staunch BSV supporter. I have nothing against that meetup, but it may cause confusion for those looking for a local meetup. They also haven't had an event for almost a year. This removal can probably be a separate PR if the reviewers agree it should be removed.