### PR TITLE
Add a note on adding wallets to ethereum.org

### DIFF
--- a/src/content/contributing/adding-products/index.md
+++ b/src/content/contributing/adding-products/index.md
@@ -5,6 +5,8 @@ lang: en
 sidebar: true
 ---
 
+_A note on adding wallets: as part of [our Q1 product roadmap](https://github.com/ethereum/ethereum-org-website/issues/5105), we are refining our wallets page. This will include refining the listing criteria for our wallets page. Until we have researched, established, and published refined listing criteria, we will not be actively adding new wallets to the website._ 
+
 # Adding Ethereum products {#adding-products}
 
 Anyone is free to suggest new wallets and dapps to the content on ethereum.org, where it's appropriate to do so. **No, we won't list your dapp on our homepage** 😜


### PR DESCRIPTION
## Description
As discussed at PR grooming: adds a note about us not actively adding wallets until we refine the current listing criteria.

## Related Issue
#5105 
