### PR TITLE
Remove mention of Eth2 and change punctuation of Beacon Chain

### DIFF
--- a/src/content/contributing/translation-program/faq/index.md
+++ b/src/content/contributing/translation-program/faq/index.md
@@ -84,7 +84,7 @@ The Crowdin glossary is the best place for clarification of terms and definition
 
 ### Terminology translation policy {#terminology}
 
-_For names (brands, companies, people) and new tech terms (Eth2, beacon chain, etc.)_
+_For names (brands, companies, people) and new tech terms (Beacon Chain, shard chains, etc.)_
 
 Ethereum presents a lot of new terms that have been coined recently. Some terms will vary from translator to translator as there is no official translation in their respective language. Such inconsistencies can cause misunderstanding and decrease readability.
 


### PR DESCRIPTION
## Description

Remove mention of 'Eth2' and change punctuation of Beacon Chain in the terminology section of the translator FAQs.

