### PR TITLE
Fixed spelling of 'constraint' [Fixes #5853]

### DIFF
--- a/src/content/developers/tutorials/how-to-use-manticore-to-find-smart-contract-bugs/index.md
+++ b/src/content/developers/tutorials/how-to-use-manticore-to-find-smart-contract-bugs/index.md
@@ -451,7 +451,7 @@ You can use constraints globally or for a specific state.
 
 #### Global constraint {#state-constraint}
 
-Use `m.constrain(constraint)` to add a global cosntraint.
+Use `m.constrain(constraint)` to add a global constraint.
 For example, you can call a contract from a symbolic address, and restraint this address to be specific values:
 
 ```python


### PR DESCRIPTION
## Description
Fixed typo in 'src/content/developers/tutorials/how-to-use-manticore-to-find-smart-contract-bugs/index.md'. Changed 'cosntraint' to 'constraint'.

## Related Issue
Related issue: [#5853]
