### PR TITLE
Fix bug in ERC-20 tutorial

### DIFF
--- a/src/content/developers/tutorials/understand-the-erc-20-token-smart-contract/index.md
+++ b/src/content/developers/tutorials/understand-the-erc-20-token-smart-contract/index.md
@@ -167,7 +167,7 @@ contract ERC20Basic is IERC20 {
         require(numTokens <= allowed[owner][msg.sender]);
 
         balances[owner] = balances[owner]-numTokens;
-        allowed[owner][msg.sender] = allowed[owner][msg.sender]+numTokens;
+        allowed[owner][msg.sender] = allowed[owner][msg.sender]-numTokens;
         balances[buyer] = balances[buyer]+numTokens;
         emit Transfer(owner, buyer, numTokens);
         return true;


### PR DESCRIPTION
Changed: allowed[owner][msg.sender] = allowed[owner][msg.sender]+numTokens;
To: allowed[owner][msg.sender] = allowed[owner][msg.sender]-numTokens;

<!--- Provide a general summary of your changes in the Title above -->

## Description

In the example script of a basic ERC20 Token:
The allowance is increased instead of decreased by the number of tokens transfered via the transferFrom function.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
