### PR TITLE
Fix typo in ERC-20 annotated code tutorial

### DIFF
--- a/src/content/developers/tutorials/erc20-annotated-code/index.md
+++ b/src/content/developers/tutorials/erc20-annotated-code/index.md
@@ -902,7 +902,7 @@ are not designed to handle it.
 }
 ```
 
-This is the hook function to be called during transfers. It is empty here, buf if you need
+This is the hook function to be called during transfers. It is empty here, but if you need
 it to do something you just override it.
 
 # Conclusion {#conclusion}


### PR DESCRIPTION
fixed typo at line 905

<!--- Provide a general summary of your changes in the Title above -->

## Description
changed `buf` to `but`
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/ethereum/ethereum-org-website/issues/5892