### PR TITLE
add comment explaining zero address to tutorial

### DIFF
--- a/src/content/developers/docs/smart-contracts/anatomy/index.md
+++ b/src/content/developers/docs/smart-contracts/anatomy/index.md
@@ -376,6 +376,10 @@ contract CryptoPizza is IERC721, ERC165 {
 
         // Checks that Pizza owner is the same as current user
         // Learn more: https://solidity.readthedocs.io/en/v0.5.10/control-structures.html#error-handling-assert-require-revert-and-exceptions
+
+        // note that address(0) is the zero address,
+        // indicating that pizza[id] is not yet allocated to a particular user.
+
         assert(pizzaToOwner[id] == address(0));
 
         // Maps the Pizza to the owner


### PR DESCRIPTION
## Description

Issue #5862 suggested a potential bug in a tutorial smart contract relating to assignment of addresses in a mapping. 

There is no bug, the issue is that `address(0)` is the zero-address. The contract asserts that the current mapping between ID and address is the zero address before allowing the mapping to update (essentially confirming that a particular ID is "available" before allowing a transfer).

This isn't necessarily obvious and is not currently documented in the in-line comments, so I added a short comment.

## Related Issue
#5862 
