### PR TITLE
Overwrite Persian numbering for StatsBoxes

### DIFF
--- a/src/components/StatsBoxGrid.js
+++ b/src/components/StatsBoxGrid.js
@@ -10,9 +10,12 @@ import Tooltip from "./Tooltip"
 import Link from "./Link"
 import Icon from "./Icon"
 
-import { isLangRightToLeft, translateMessageId } from "../utils/translations"
+import {
+  isLangRightToLeft,
+  translateMessageId,
+  getLocaleForNumberFormat,
+} from "../utils/translations"
 import { getData } from "../utils/cache"
-import { formatLocaleNumbers } from "../utils/formatLocaleNumbers"
 
 const Value = styled.span`
   position: absolute;
@@ -260,7 +263,7 @@ const RangeSelector = ({ state, setState }) => (
 
 const StatsBoxGrid = () => {
   const intl = useIntl()
-  const localeForStatsBoxNumbers = formatLocaleNumbers(intl.locale)
+  const localeForStatsBoxNumbers = getLocaleForNumberFormat(intl.locale)
 
   const [ethPrices, setEthPrices] = useState({
     data: [],

--- a/src/components/StatsBoxGrid.js
+++ b/src/components/StatsBoxGrid.js
@@ -12,6 +12,7 @@ import Icon from "./Icon"
 
 import { isLangRightToLeft, translateMessageId } from "../utils/translations"
 import { getData } from "../utils/cache"
+import { formatLocaleNumbers } from "../utils/formatLocaleNumbers"
 
 const Value = styled.span`
   position: absolute;
@@ -259,6 +260,8 @@ const RangeSelector = ({ state, setState }) => (
 
 const StatsBoxGrid = () => {
   const intl = useIntl()
+  const localeForStatsBoxNumbers = formatLocaleNumbers(intl.locale)
+
   const [ethPrices, setEthPrices] = useState({
     data: [],
     value: 0,
@@ -286,7 +289,7 @@ const StatsBoxGrid = () => {
 
   useEffect(() => {
     const formatPrice = (price) => {
-      return new Intl.NumberFormat(intl.locale, {
+      return new Intl.NumberFormat(localeForStatsBoxNumbers, {
         style: "currency",
         currency: "USD",
         minimumSignificantDigits: 3,
@@ -295,7 +298,7 @@ const StatsBoxGrid = () => {
     }
 
     const formatTVL = (tvl) => {
-      return new Intl.NumberFormat(intl.locale, {
+      return new Intl.NumberFormat(localeForStatsBoxNumbers, {
         style: "currency",
         currency: "USD",
         notation: "compact",
@@ -305,7 +308,7 @@ const StatsBoxGrid = () => {
     }
 
     const formatTxs = (txs) => {
-      return new Intl.NumberFormat(intl.locale, {
+      return new Intl.NumberFormat(localeForStatsBoxNumbers, {
         notation: "compact",
         minimumSignificantDigits: 3,
         maximumSignificantDigits: 4,
@@ -313,7 +316,7 @@ const StatsBoxGrid = () => {
     }
 
     const formatNodes = (nodes) => {
-      return new Intl.NumberFormat(intl.locale, {
+      return new Intl.NumberFormat(localeForStatsBoxNumbers, {
         minimumSignificantDigits: 3,
         maximumSignificantDigits: 4,
       }).format(nodes)

--- a/src/pages/layer-2.js
+++ b/src/pages/layer-2.js
@@ -29,8 +29,10 @@ import { CardGrid, Content, Page } from "../components/SharedStyledComponents"
 
 // Utils
 import { getData } from "../utils/cache"
-import { translateMessageId } from "../utils/translations"
-import { formatLocaleNumbers } from "../utils/formatLocaleNumbers"
+import {
+  translateMessageId,
+  getLocaleForNumberFormat,
+} from "../utils/translations"
 
 // Styles
 
@@ -181,7 +183,7 @@ const StatDivider = styled.div`
 
 const Layer2Page = ({ data }) => {
   const intl = useIntl()
-  const localeForStatsBoxNumbers = formatLocaleNumbers(intl.locale)
+  const localeForStatsBoxNumbers = getLocaleForNumberFormat(intl.locale)
   const [tvl, setTVL] = useState("loading...")
   const [percentChangeL2, setL2PercentChange] = useState("loading...")
   const [averageFee, setAverageFee] = useState("loading...")

--- a/src/pages/layer-2.js
+++ b/src/pages/layer-2.js
@@ -30,6 +30,7 @@ import { CardGrid, Content, Page } from "../components/SharedStyledComponents"
 // Utils
 import { getData } from "../utils/cache"
 import { translateMessageId } from "../utils/translations"
+import { formatLocaleNumbers } from "../utils/formatLocaleNumbers"
 
 // Styles
 
@@ -180,7 +181,7 @@ const StatDivider = styled.div`
 
 const Layer2Page = ({ data }) => {
   const intl = useIntl()
-
+  const localeForStatsBoxNumbers = formatLocaleNumbers(intl.locale)
   const [tvl, setTVL] = useState("loading...")
   const [percentChangeL2, setL2PercentChange] = useState("loading...")
   const [averageFee, setAverageFee] = useState("loading...")
@@ -194,7 +195,7 @@ const Layer2Page = ({ data }) => {
             : "http://localhost:9000/l2beat"
         )
         // formatted TVL from L2beat API formatted
-        const TVL = new Intl.NumberFormat(intl.locale, {
+        const TVL = new Intl.NumberFormat(localeForStatsBoxNumbers, {
           style: "currency",
           currency: "USD",
           notation: "compact",
@@ -236,7 +237,7 @@ const Layer2Page = ({ data }) => {
             0
           ) / feeData.length
 
-        const intlFeeAverage = new Intl.NumberFormat(intl.locale, {
+        const intlFeeAverage = new Intl.NumberFormat(localeForStatsBoxNumbers, {
           style: "currency",
           currency: "USD",
           notation: "compact",

--- a/src/utils/formatLocaleNumbers.js
+++ b/src/utils/formatLocaleNumbers.js
@@ -1,0 +1,9 @@
+// Overwrites the default Persian numbering of the Farsi language to use Hindu-Arabic numerals (0-9)
+// Context: https://github.com/ethereum/ethereum-org-website/pull/5490#pullrequestreview-892596553
+export const formatLocaleNumbers = (locale) => {
+  if (locale === "fa") {
+    return "en"
+  }
+
+  return intl.locale
+}

--- a/src/utils/formatLocaleNumbers.js
+++ b/src/utils/formatLocaleNumbers.js
@@ -1,9 +1,0 @@
-// Overwrites the default Persian numbering of the Farsi language to use Hindu-Arabic numerals (0-9)
-// Context: https://github.com/ethereum/ethereum-org-website/pull/5490#pullrequestreview-892596553
-export const formatLocaleNumbers = (locale) => {
-  if (locale === "fa") {
-    return "en"
-  }
-
-  return locale
-}

--- a/src/utils/formatLocaleNumbers.js
+++ b/src/utils/formatLocaleNumbers.js
@@ -5,5 +5,5 @@ export const formatLocaleNumbers = (locale) => {
     return "en"
   }
 
-  return intl.locale
+  return locale
 }

--- a/src/utils/translations.js
+++ b/src/utils/translations.js
@@ -69,7 +69,7 @@ const translateMessageId = (id, intl) => {
 
 // Overwrites the default Persian numbering of the Farsi language to use Hindu-Arabic numerals (0-9)
 // Context: https://github.com/ethereum/ethereum-org-website/pull/5490#pullrequestreview-892596553
-export const getLocaleForNumberFormat = (locale) => {
+const getLocaleForNumberFormat = (locale) => {
   if (locale === "fa") {
     return "en"
   }

--- a/src/utils/translations.js
+++ b/src/utils/translations.js
@@ -67,6 +67,16 @@ const translateMessageId = (id, intl) => {
   return translation
 }
 
+// Overwrites the default Persian numbering of the Farsi language to use Hindu-Arabic numerals (0-9)
+// Context: https://github.com/ethereum/ethereum-org-website/pull/5490#pullrequestreview-892596553
+export const getLocaleForNumberFormat = (locale) => {
+  if (locale === "fa") {
+    return "en"
+  }
+
+  return locale
+}
+
 // Must export using ES5 to import in gatsby-node.js
 module.exports.allLanguages = allLanguages
 module.exports.languageMetadata = languageMetadata
@@ -75,3 +85,4 @@ module.exports.getDefaultMessage = getDefaultMessage
 module.exports.isLangRightToLeft = isLangRightToLeft
 module.exports.translateMessageId = translateMessageId
 module.exports.legacyHomepageLanguages = legacyHomepageLanguages
+module.exports.getLocaleForNumberFormat = getLocaleForNumberFormat


### PR DESCRIPTION
## Description
Context: As noted in #5490, we were mixing Persian and Hindu-Arabic numerals. After consulting Farsi speakers, we realised this was undesirable.

**This PR overwrites the number formatting of the Farsi language on our StatsBox components to use Hindu-Arabic formatting.**

- Updates homepage StatsBox
- Updates layer-2 page StatsBox

## Additional context
- We should do the same for our staking pages

## Preview
- https://ethereumorgwebsitedev01-overwritepersiannumbers.gtsb.io/fa/
- https://ethereumorgwebsitedev01-overwritepersiannumbers.gtsb.io/fa/layer-2

## Related Issue
#5490 #5748