### PR TITLE
docs: add example project for Chainlink usage

### DIFF
--- a/src/content/developers/docs/oracles/index.md
+++ b/src/content/developers/docs/oracles/index.md
@@ -444,3 +444,6 @@ _We'd love more documentation on creating an oracle smart contract. If you can h
 **Tutorials**
 
 - [How to Fetch the Current Price of Ethereum in Solidity](https://blog.chain.link/fetch-current-crypto-price-data-solidity/) - _Chainlink_
+
+**Example projects**
+- [Full Chainlink starter project for Ethereum in Solidity](https://github.com/hackbg/chainlink-fullstack) - _HackBG_


### PR DESCRIPTION
## Description

This change adds a link to a recent project that
demonstrates the whole Chainlink stack in a simple
smart contract accompanied with a consumer application.