### PR TITLE
Anchor div space

### DIFF
--- a/src/components/SkipLink.js
+++ b/src/components/SkipLink.js
@@ -19,6 +19,11 @@ const Anchor = styled.a`
   }
 `
 
+const DivAnchor = styled.div`
+  height: 80px;
+  margin-top: -80px;
+`
+
 export const SkipLink = ({ hrefId }) => {
   return (
     <Div>
@@ -30,5 +35,5 @@ export const SkipLink = ({ hrefId }) => {
 }
 
 export const SkipLinkAnchor = ({ id }) => {
-  return <div id={id}></div>
+  return <DivAnchor id={id}></DivAnchor>
 }


### PR DESCRIPTION
## Description
Problem: when the user clicks on the "Skip to main content" link, it is scrolling too much and the content is behind the nav bar.
![image](https://user-images.githubusercontent.com/468158/162063887-868f9a12-c45f-4319-8c7b-bb39d8ffee0e.png)

In this PR: adds more space to the anchor target div to avoid being behind the nav bar.
