### PR TITLE
Use Gatsby functions for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,18 +112,14 @@ $ git push
 
 ### 5. Local development with lambda functions
 
-There may be times where you develop features that make external API requests to other services. For these we write lambda functions to obfuscate API keys. In order to test these locally, you will need to do the following:
+There may be times where you develop features that make external API requests to other services. For these we write lambda functions to obfuscate API keys.
 
-1. Download a CORS enabling browser extension (ex: https://chrome.google.com/webstore/search/cors).
-2. Enable CORS in the downloaded browser extension.
-3. Add the relevant API key to the `.env` file. [Check how to get your own API keys](docs/api-keys.md).
-4. After you have started your development server for ethereum.org (above), start up a netlify lambda server using:
+To use an existing function locally you don't need to do anything. Just check that you have set the necessary ENV variables in the `.env` file.
 
-```sh
-yarn start:lambda
-```
+To create a new function, you will need to create two files:
 
-5. Where you reference /.netlify functions for server calls, add a conditional to call localhost:9000 endpoints when not in the production environment.
+- One in `src/lambdas` where the logic will live. These are the ones that will be deployed to Netlify. These functions follow [this format](https://docs.netlify.com/functions/build-with-javascript/#synchronous-function-format).
+- One in `src/api` that will be just a wrapper around the previous one in order to be compatible with Gatsby functions. More on the [Gatbsy docs](https://www.gatsbyjs.com/docs/reference/functions/getting-started/) for the format they follow.
 
 ### 6. Submit your PR
 

--- a/src/components/ReleaseBanner.js
+++ b/src/components/ReleaseBanner.js
@@ -13,6 +13,9 @@ import Translation from "./Translation"
 // Utils
 import { getFreshData } from "../utils/cache"
 
+// Constants
+import { GATSBY_FUNCTIONS_PATH } from "../constants"
+
 const CloseIconContainer = styled.span`
   position: absolute;
   cursor: pointer;
@@ -55,9 +58,7 @@ const ReleaseBanner = ({ storageKey }) => {
     const fetchBlockInfo = async () => {
       try {
         const data = await getFreshData(
-          process.env.NODE_ENV === "production"
-            ? `${process.env.GATSBY_FUNCTIONS_PATH}/etherscanBlock`
-            : "http://localhost:9000/etherscanBlock"
+          `${GATSBY_FUNCTIONS_PATH}/etherscanBlock`
         )
         setTimeLeft(data)
         setLoading(false)

--- a/src/components/Roadmap.js
+++ b/src/components/Roadmap.js
@@ -5,11 +5,11 @@ import axios from "axios"
 
 import Translation from "../components/Translation"
 import Link from "./Link"
-import { FakeLinkExternal } from "./SharedStyledComponents"
+import { FakeLinkExternal, CardItem as Item } from "./SharedStyledComponents"
 
 import { translateMessageId } from "../utils/translations"
 
-import { CardItem as Item } from "./SharedStyledComponents"
+import { GATSBY_FUNCTIONS_PATH } from "../constants"
 
 const Section = styled.div`
   display: flex;
@@ -67,11 +67,7 @@ const Roadmap = () => {
   // TODO update to pull PRs & issues separately
   useEffect(() => {
     axios
-      .get(
-        process.env.NODE_ENV === "production"
-          ? `${process.env.GATSBY_FUNCTIONS_PATH}/roadmap`
-          : "http://localhost:9000/roadmap"
-      )
+      .get(`${GATSBY_FUNCTIONS_PATH}/roadmap`)
       .then((response) => {
         let issues = []
         if (response.data && response.data.data) {

--- a/src/components/StatsBoxGrid.js
+++ b/src/components/StatsBoxGrid.js
@@ -13,6 +13,8 @@ import Icon from "./Icon"
 import { isLangRightToLeft, translateMessageId } from "../utils/translations"
 import { getData } from "../utils/cache"
 
+import { GATSBY_FUNCTIONS_PATH } from "../constants"
+
 const Value = styled.span`
   position: absolute;
   bottom: 8%;
@@ -349,11 +351,7 @@ const StatsBoxGrid = () => {
 
     const fetchNodes = async () => {
       try {
-        const { result } = await getData(
-          process.env.NODE_ENV === "production"
-            ? `${process.env.GATSBY_FUNCTIONS_PATH}/etherscan`
-            : "http://localhost:9000/etherscan"
-        )
+        const { result } = await getData(`${GATSBY_FUNCTIONS_PATH}/etherscan`)
         const data = result
           .map(({ UTCDate, TotalNodeCount }) => ({
             timestamp: new Date(UTCDate).getTime(),
@@ -378,11 +376,7 @@ const StatsBoxGrid = () => {
 
     const fetchTotalValueLocked = async () => {
       try {
-        const response = await getData(
-          process.env.NODE_ENV === "production"
-            ? `${process.env.GATSBY_FUNCTIONS_PATH}/defipulse`
-            : "http://localhost:9000/defipulse"
-        )
+        const response = await getData(`${GATSBY_FUNCTIONS_PATH}/defipulse`)
         const data = response
           .map(({ date, totalLiquidityUSD }) => ({
             timestamp: parseInt(date) * 1000,
@@ -408,9 +402,7 @@ const StatsBoxGrid = () => {
     const fetchTxCount = async () => {
       try {
         const response = await getData(
-          process.env.NODE_ENV === "production"
-            ? `${process.env.GATSBY_FUNCTIONS_PATH}/txs`
-            : "http://localhost:9000/txs"
+          `${process.env.GATSBY_FUNCTIONS_PATH}/txs`
         )
         const data = response.result
           .map(({ unixTimeStamp, transactionCount }) => ({

--- a/src/components/TranslationsInProgress.js
+++ b/src/components/TranslationsInProgress.js
@@ -1,9 +1,11 @@
 import React, { useState, useEffect } from "react"
 import styled from "styled-components"
 import axios from "axios"
-import { FakeLinkExternal } from "./SharedStyledComponents"
+
+import { FakeLinkExternal, CardItem } from "./SharedStyledComponents"
 import Translation from "./Translation"
-import { CardItem } from "./SharedStyledComponents"
+
+import { GATSBY_FUNCTIONS_PATH } from "../constants"
 
 const LangContainer = styled.div`
   margin-bottom: 2rem;
@@ -19,11 +21,7 @@ const TranslationsInProgress = () => {
 
   useEffect(() => {
     axios
-      .get(
-        process.env.NODE_ENV === "production"
-          ? `${process.env.GATSBY_FUNCTIONS_PATH}/translations`
-          : "http://localhost:9000/translations"
-      )
+      .get(`${GATSBY_FUNCTIONS_PATH}/translations`)
       .then((response) => {
         let languages = []
         if (response.data && response.data.data) {

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,1 @@
+export const GATSBY_FUNCTIONS_PATH = process.env.GATSBY_FUNCTIONS_PATH || "/api"

--- a/src/pages/layer-2.js
+++ b/src/pages/layer-2.js
@@ -31,6 +31,9 @@ import { CardGrid, Content, Page } from "../components/SharedStyledComponents"
 import { getData } from "../utils/cache"
 import { translateMessageId } from "../utils/translations"
 
+// Constants
+import { GATSBY_FUNCTIONS_PATH } from "../constants"
+
 // Styles
 
 const HeroBackground = styled.div`
@@ -188,11 +191,7 @@ const Layer2Page = ({ data }) => {
   useEffect(() => {
     const fetchL2Beat = async () => {
       try {
-        const l2BeatData = await getData(
-          process.env.NODE_ENV === "production"
-            ? `${process.env.GATSBY_FUNCTIONS_PATH}/l2beat`
-            : "http://localhost:9000/l2beat"
-        )
+        const l2BeatData = await getData(`${GATSBY_FUNCTIONS_PATH}/l2beat`)
         // formatted TVL from L2beat API formatted
         const TVL = new Intl.NumberFormat(intl.locale, {
           style: "currency",


### PR DESCRIPTION
Currently to develop locally with our lambda functions, we are using `netlify-lambda` to build and then create a server to serve them. There is no need to do this anymore since we now have them built and hosted by Gatsby running `gatsby develop`.

## Description

This PR uses the functions hosted by Gatsby for local development. It improves the DX since you don't need to have two separate processes running in parallel.