### PR TITLE
Remove legacy meetup (they are now BSV maxis)

### DIFF
--- a/src/data/community-meetups.json
+++ b/src/data/community-meetups.json
@@ -66,12 +66,6 @@
     "link": "https://www.meetup.com/ethvancouver-meetup-group/"
   },
   {
-    "title": "Vancouver Ethereum & Blockchain 2.0 Meetup",
-    "emoji": ":canada:",
-    "location": "Vancouver",
-    "link": "https://www.meetup.com/Vancouver-Ethereum-Meetup/"
-  },
-  {
     "title": "Ethereum Paris",
     "emoji": ":fr:",
     "location": "Paris",


### PR DESCRIPTION
## Description

As I mentioned briefly in #5826, the old Vancouver Ethereum meetup group is now a BSV maxi group.

If you click the link: https://www.meetup.com/Vancouver-Ethereum-Meetup

You will be greeted by a "Bitcoin is BSV" meetup:

<img width="941" alt="image" src="https://user-images.githubusercontent.com/943555/162135867-0f533180-e12d-4002-9e73-cfa411bbf9b7.png">

My understanding is that the Ethereum Foundation would not want to confuse users and demonstrate supporting a BSV maxi group that has nothing to do with Ethereum on their website. Therefore, I propose removing this meetup from the list of Ethereum meetups.