### PR TITLE
docs: added Arbitrum AnyTrust to the validium page

### DIFF
--- a/src/content/developers/docs/scaling/validium/index.md
+++ b/src/content/developers/docs/scaling/validium/index.md
@@ -29,6 +29,7 @@ Multiple projects provide implementations of Validium that you can integrate int
 - [Starkware](https://starkware.co/)
 - [Matter Labs zkPorter](https://matter-labs.io/)
 - [Loopring](https://loopring.org/#/)
+- [Arbitrum AnyTrust](https://medium.com/offchainlabs/introducing-anytrust-chains-cheaper-faster-l2-chains-with-minimal-trust-assumptions-31def59eb8d7)
 
 ## Further reading {#further-reading}
 


### PR DESCRIPTION
## Description

Added a link to the Arbitrum AnyTrust announcement on the Validium page.

## Related Issue

Resolves #5972 
