### PR TITLE
Change author

### DIFF
--- a/src/content/developers/tutorials/nft-minter/index.md
+++ b/src/content/developers/tutorials/nft-minter/index.md
@@ -1,7 +1,7 @@
 ---
 title: NFT Minter Tutorial
 description: In this tutorial, you’ll build an NFT minter and learn how to create a full stack dApp by connecting your smart contract to a React frontend using MetaMask and Web3 tools.
-author: "nstrike2"
+author: "smudgil"
 tags:
   [
     "solidity",


### PR DESCRIPTION
Hey, following up on [this](https://github.com/ethereum/ethereum-org-website/pull/2653). My job while interning at Alchemy was just to put up the existing NFT Minter tutorial from our website on the Ethereum Foundation. After looking at the thread of comments a few months later on the linked PR, @smudgil is absolutely right — she is the rightful owner of this tutorial, and I had no clue!

I've gone ahead and taken down the Twitter post that Sumi linked, and in addition, this is a PR with a request to change the top level name to Sumi's GitHub. Please see that this PR is merged, and Sumi becomes the official rightful owner here.

Thank you!! @samajammin @wackerow @minimalsm @pettinarip 