### PR TITLE
Add link to smart contract intro

### DIFF
--- a/src/content/developers/docs/smart-contracts/index.md
+++ b/src/content/developers/docs/smart-contracts/index.md
@@ -13,6 +13,8 @@ Smart contracts are a type of [Ethereum account](/developers/docs/accounts/). Th
 
 ## Prerequisites {#prerequisites}
 
+If you're just getting started or looking for a less technical introduction, we recommend our [introduction to smart contracts](/smart-contracts/).
+
 Make sure you've read up on [accounts](/developers/docs/accounts/), [transactions](/developers/docs/transactions/) and the [Ethereum virtual machine](/developers/docs/evm/) before jumping into the world of smart contracts.
 
 ## A digital vending machine {#a-digital-vending-machine}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add link to smart contract intro.

We may want to add a similar notification & link on other smart contract documentation page? Main user journey I'm looking to solve for here is non-technical folks who land directly on these pages (which rank very well in search, e.g. for "smart contracts").

## Related Issue
None
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
