### PR TITLE
Add redirect for non-hyphenated layer2 path

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -188,6 +188,14 @@
     "toPath": "/en/defi/"
   },
   {
+    "fromPath": "/layer2/",
+    "toPath": "/en/layer-2/"
+  },
+  {
+    "fromPath": "/*/layer2/",
+    "toPath": "/:splat/layer-2/"
+  },
+  {
     "fromPath": "/no/*",
     "toPath": "/nb/:splat"
   },


### PR DESCRIPTION
Found myself forgetting if the hyphen was required or not. Added simply redirect to allow users to just type ethereum.org/layer2 and not have to worry about the hyphen. 