### PR TITLE
Fix typo in optimism-std-bridge-annotated-code/index.md

### DIFF
--- a/src/content/developers/tutorials/optimism-std-bridge-annotated-code/index.md
+++ b/src/content/developers/tutorials/optimism-std-bridge-annotated-code/index.md
@@ -346,7 +346,7 @@ contract CrossDomainEnabled {
      * Variables *
      *************/
 
-    // Messenger contract used to send and recieve messages from the other domain.
+    // Messenger contract used to send and receive messages from the other domain.
     address public messenger;
 
     /***************


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed typo.
```
recieve -> receive
```

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
