### PR TITLE
New color for the theme (mostly seen on safari)

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -49,7 +49,7 @@ module.exports = {
         short_name: `ethereum.org`,
         start_url: `/en/`,
         background_color: `#ffffff`,
-        theme_color: `#1c1ce1`,
+        theme_color: `#222222`,
         display: `standalone`,
         icon: `src/assets/favicon.png`,
       },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The theme color is set to #1c1ce1 and on safari mobile fills the top of the screen. this color does not work on das theme

![Screen Shot 2022-04-14 12 16 33 AM](https://user-images.githubusercontent.com/1120748/163380735-b321b677-1a96-404b-96bb-5322b806ff17.png)


<!--- Describe your changes in detail -->

changed from #1c1ce1 to #222222 to work good on light and dark theme


<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Open the ethereum.org on safari mobile or even in the desktop when scrolling

