### PR TITLE
Fixed a couple of typos 'smart  contact' > 'smart contract'

### DIFF
--- a/src/content/developers/tutorials/nft-minter/index.md
+++ b/src/content/developers/tutorials/nft-minter/index.md
@@ -20,7 +20,7 @@ sidebar: true
 published: 2021-10-06
 ---
 
-One of the greatest challenges for developers coming from a Web2 background is figuring out how to connect your smart contact to a frontend project and interact with it.
+One of the greatest challenges for developers coming from a Web2 background is figuring out how to connect your smart contract to a frontend project and interact with it.
 
 By building an NFT minter — a simple UI where you can input a link to your digital asset, a title, and a description — you'll learn how to:
 
@@ -42,7 +42,7 @@ Before we even start looking at any code, it's important to understand how makin
 
 ### Publish an NFT smart contract on the Ethereum blockchain {#publish-nft}
 
-The biggest difference between the two NFT smart contact standards is that ERC-1155 is a multi-token standard and includes batch functionality, whereas with the ERC-721 is a single-token standard and therefore only supports transferring one token at a time.
+The biggest difference between the two NFT smart contract standards is that ERC-1155 is a multi-token standard and includes batch functionality, whereas with the ERC-721 is a single-token standard and therefore only supports transferring one token at a time.
 
 ### Call the minting function {#minting-function}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

typo : smart contract was misspell smart con**tact**

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
