### PR TITLE
simplified language in crowdin warnings section

### DIFF
--- a/src/content/contributing/translation-program/translators-guide/index.md
+++ b/src/content/contributing/translation-program/translators-guide/index.md
@@ -84,7 +84,7 @@ You can find some examples of what these strings look like for translators and h
 
 ### Crowdin warnings {#crowdin-warnings}
 
-Crowdin has a built-in feature that warns translators when they are about to make a mistake. If you suggest a translation and forget to include a tag from the source, translate elements that should not be translated, add several consecutive spaces, forget end punctuation, etc., Crowdin will automatically warn you of this before saving your translation.
+Crowdin has a built-in feature that warns translators when they are about to make a mistake. Crowdin will automatically warn you of this before saving your translation if you forget to include a tag from the source, translate elements that should not be translated, add several consecutive spaces, forget end punctuation, etc.
 If you see a warning like this, please go back and double-check the suggested translation.
 
 **Never ignore these warnings, as they usually mean that something is wrong, or that the translation is missing a key part of the source text.**


### PR DESCRIPTION
A sentence was long and object was at the end, making the sentence slightly difficult to understand. There's room for simplification.

<!--- Provide a general summary of your changes in the Title above -->

## Description
To simplify I reverted to position object first and finished by examples.

_Note_ : I followed the following guideline regarding punctuation of _'etc.'_ : https://klmoravec.wordpress.com/2019/09/16/tricky-punctuation-etc-at-the-end-of-a-sentence/
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
