### PR TITLE
unnecessary file extension in img alt text

### DIFF
--- a/src/content/contributing/translation-program/translators-guide/index.md
+++ b/src/content/contributing/translation-program/translators-guide/index.md
@@ -90,7 +90,7 @@ If you see a warning like this, please go back and double-check the suggested tr
 **Never ignore these warnings, as they usually mean that something is wrong, or that the translation is missing a key part of the source text.**
 
 An example of a Crowdin warning when you forget to add a tag to your translation:
-![Example of a Crowdin warning.png](./crowdin-warning-example.png)
+![Example of a Crowdin warning](./crowdin-warning-example.png)
 
 ### Dealing with tags and code snippets {#dealing-with-tags}
 


### PR DESCRIPTION
An alt attribute ends up containing ".png" in Crowdin Warning section, which is displayed to readers when hovering the image.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Changed the alt content : 
"Example of a Crowdin warning.png" > "Example of a Crowdin warning"

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
