### PR TITLE
Make ExpandableCard question box clickable

### DIFF
--- a/src/components/ExpandableCard.js
+++ b/src/components/ExpandableCard.js
@@ -148,7 +148,7 @@ const ExpandableCard = ({
         onClick={() => {
           // Allow users to select text without expanding the card
           if (window.getSelection().toString().length === 0) {
-            isVisible && trackCustomEvent(matomo)
+            !isVisible && trackCustomEvent(matomo)
             setIsVisible(!isVisible)
           }
         }}

--- a/src/components/ExpandableCard.js
+++ b/src/components/ExpandableCard.js
@@ -4,7 +4,6 @@ import styled from "styled-components"
 import { motion } from "framer-motion"
 
 // Components
-import { FakeLink } from "./SharedStyledComponents"
 import Translation from "../components/Translation"
 
 // Utils
@@ -145,7 +144,15 @@ const ExpandableCard = ({
   }
   return (
     <Card>
-      <Content>
+      <Content
+        onClick={() => {
+          // Allow users to select text without expanding the card
+          if (window.getSelection().toString().length === 0) {
+            isVisible && trackCustomEvent(matomo)
+            setIsVisible(!isVisible)
+          }
+        }}
+      >
         <Question>
           <Header>
             {!!Svg && <Svg alt={alt} />}

--- a/src/components/ExpandableCard.js
+++ b/src/components/ExpandableCard.js
@@ -16,6 +16,7 @@ const Card = styled.div`
   display: flex;
   flex-direction: column;
   margin-bottom: 1rem;
+  cursor: pointer;
   &:hover {
     background-color: ${(props) => props.theme.colors.ednBackground};
   }
@@ -143,16 +144,19 @@ const ExpandableCard = ({
     eventName,
   }
   return (
-    <Card>
-      <Content
-        onClick={() => {
-          // Allow users to select text without expanding the card
-          if (window.getSelection().toString().length === 0) {
-            !isVisible && trackCustomEvent(matomo)
-            setIsVisible(!isVisible)
-          }
-        }}
-      >
+    <Card
+      onClick={() => {
+        // Card will not collapse if clicking on a link or selecting text
+        if (
+          window.getSelection().toString().length === 0 &&
+          !window.event.target.className.includes("ExternalLink")
+        ) {
+          !isVisible && trackCustomEvent(matomo)
+          setIsVisible(!isVisible)
+        }
+      }}
+    >
+      <Content>
         <Question>
           <Header>
             {!!Svg && <Svg alt={alt} />}


### PR DESCRIPTION
## Description
- Make it so that users can click the ExpandableCard question box.
- New function:
    - Users can click the question area to open and close for ExpandableCard
    - click event will be ignored if the user is selecting text
