### PR TITLE
Create open/active Ethereum research page

### DIFF
--- a/src/content/community/get-involved/index.md
+++ b/src/content/community/get-involved/index.md
@@ -27,6 +27,8 @@ Do you have a background in mathematics, cryptography, or economics? You might b
 - [Ethresear.ch](https://ethresear.ch) - Ethereum’s primary forum for research, and the world’s most influential forum for cryptoeconomics
 - [Ecosystem Support Program's wishlist](https://esp.ethereum.foundation/wishlist/) - research areas where the Ethereum Ecosystem Support Program is actively seeking grant applications
 
+[Explore more active areas of research](/community/get-involved/open-research/).
+
 ## Non-technical skillsets <Emoji text=":briefcase:" size={1} />‍ {#non-technical}
 
 If you’re not a developer, it can be hard to know where to start in Ethereum. Here are a few suggestions, along with resources for specific professional backgrounds.

--- a/src/content/community/get-involved/open-research/index.md
+++ b/src/content/community/get-involved/open-research/index.md
@@ -1,0 +1,34 @@
+---
+title: Active areas of Ethereum research
+description: Explore different areas of open research and learn how to get involved.
+sidebar: true
+lang: en
+---
+
+# Ethereum open areas of research
+
+Do you have a background in mathematics, cryptography, or economics? You might be interested in some of the cutting-edge work being done within the Ethereum ecosystem.
+
+TODOs
+
+- [x] Create basic page
+- [ ] Talk to researchers - what are the open questions? What are topics & resources?
+- [ ] Decide how topics should be categorized - what's the hierarchy?
+- [ ] Create
+- [ ] Create
+
+Derp derp derp
+
+List different categories of research...
+
+Protocol?
+e.g. various upgrades https://ethereum.org/en/upgrades/
+
+Cryptography?
+e.g. topics on https://cryptography-research.netlify.app/research
+
+Copied over from "get involved" section:
+
+- [Challenges.ethereum.org](https://challenges.ethereum.org/) - a series of high-value research bounties, where you can earn >$100,000 USD
+- [Ethresear.ch](https://ethresear.ch) - Ethereum’s primary forum for research, and the world’s most influential forum for cryptoeconomics
+- [Ecosystem Support Program's wishlist](https://esp.ethereum.foundation/wishlist/) - research areas where the Ethereum Ecosystem Support Program is actively seeking grant applications


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Basic scaffolding for a new "get involved" page to highlight active areas of Ethereum research.

## Related Issue

None, surfaced from IRL conversation at Devconnect. Basic use case here is there's many academics looking for open areas of research, e.g. for students looking for areas to dig into / write their thesis on. There's currently no great resource to find these active areas of research, so we'd like to create a page that aggregates these topics & links out to resources/publications where they can learn more. The hope is the research community can help add to this & maintain it over time.