### PR TITLE
fix link to The Merge

### DIFF
--- a/src/content/developers/docs/mev/index.md
+++ b/src/content/developers/docs/mev/index.md
@@ -9,7 +9,7 @@ Maximal extractable value (MEV) refers to the maximum value that can be extracte
 
 ### Miner extractable value
 
-This concept was first applied under the context of [proof-of-work](/developers/docs/consensus-mechanisms/pow/), and was initially referred to as "miner extractable value". This is because in proof-of-work, miners control transaction inclusion, exclusion, and ordering. However, after the transition to proof-of-stake via [The Merge](/updates/merge) validators will be responsible for these roles, and mining will no longer be applicable. The value extraction methods here will still persist after this transition, and thus a name change was needed. To keep the same acronym for continuity while maintaining the same fundamental meaning, "maximal extractable value" is now used as a more inclusive replacement.
+This concept was first applied under the context of [proof-of-work](/developers/docs/consensus-mechanisms/pow/), and was initially referred to as "miner extractable value". This is because in proof-of-work, miners control transaction inclusion, exclusion, and ordering. However, after the transition to proof-of-stake via [The Merge](/upgrades/merge) validators will be responsible for these roles, and mining will no longer be applicable. The value extraction methods here will still persist after this transition, and thus a name change was needed. To keep the same acronym for continuity while maintaining the same fundamental meaning, "maximal extractable value" is now used as a more inclusive replacement.
 
 ## Prerequisites {#prerequisites}
 


### PR DESCRIPTION
Link to "The Merge" page was referring to a faulty url.

## Description

I updated the link to the correct page.