### PR TITLE
docs: Fix outdated links for UniswapV2Router documentation

### DIFF
--- a/src/content/developers/tutorials/uniswap-v2-annotated-code/index.md
+++ b/src/content/developers/tutorials/uniswap-v2-annotated-code/index.md
@@ -1042,14 +1042,14 @@ for anybody else. Those are in the periphery so they can be updated as needed.
 ### UniswapV2Router01.sol {#UniswapV2Router01}
 
 [This contract](https://github.com/Uniswap/uniswap-v2-periphery/blob/master/contracts/UniswapV2Router01.sol)
-has problems, and [should no longer be used](https://uniswap.org/docs/v2/smart-contracts/router01/). Luckily,
+has problems, and [should no longer be used](https://docs.uniswap.org/protocol/V2/reference/smart-contracts/router-01/). Luckily,
 the periphery contracts are stateless and don't hold any assets, so it is easy to deprecate it and suggest
 people use the replacement, `UniswapV2Router02`, instead.
 
 ### UniswapV2Router02.sol {#UniswapV2Router02}
 
 In most cases you would use Uniswap through [this contract](https://github.com/Uniswap/uniswap-v2-periphery/blob/master/contracts/UniswapV2Router02.sol).
-You can see how to use it [here](https://uniswap.org/docs/v2/smart-contracts/router02/).
+You can see how to use it [here](https://docs.uniswap.org/protocol/V2/reference/smart-contracts/router-02/).
 
 ```solidity
 pragma solidity =0.6.6;

--- a/src/content/translations/id/developers/tutorials/uniswap-v2-annotated-code/index.md
+++ b/src/content/translations/id/developers/tutorials/uniswap-v2-annotated-code/index.md
@@ -892,11 +892,11 @@ Kontrak perifer adalah API (antarmuka program aplikasi) untuk Uniswap. Kontrak i
 
 ### UniswapV2Router01.sol {#UniswapV2Router01}
 
-[Kontrak ini](https://github.com/Uniswap/uniswap-v2-periphery/blob/master/contracts/UniswapV2Router01.sol) memiliki masalah, dan [seharusnya tidak lagi digunakan](https://uniswap.org/docs/v2/smart-contracts/router01/). Untungnya, kontrak perifer bersifat tanpa status dan tidak menampung aset apa pun, sehingga mudah untuk mengusangkannya dan menyarankan orang-orang menggunakan penggantinya, `UniswapV2Router02`, sebagai gantinya.
+[Kontrak ini](https://github.com/Uniswap/uniswap-v2-periphery/blob/master/contracts/UniswapV2Router01.sol) memiliki masalah, dan [seharusnya tidak lagi digunakan](https://docs.uniswap.org/protocol/V2/reference/smart-contracts/router-01/). Untungnya, kontrak perifer bersifat tanpa status dan tidak menampung aset apa pun, sehingga mudah untuk mengusangkannya dan menyarankan orang-orang menggunakan penggantinya, `UniswapV2Router02`, sebagai gantinya.
 
 ### UniswapV2Router02.sol {#UniswapV2Router02}
 
-Dalam kebanyakan kasus, Anda akan menggunakan Uniswap melalui [kontrak ini](https://github.com/Uniswap/uniswap-v2-periphery/blob/master/contracts/UniswapV2Router02.sol). Anda dapat melihat cara menggunakannya [di sini](https://uniswap.org/docs/v2/smart-contracts/router02/).
+Dalam kebanyakan kasus, Anda akan menggunakan Uniswap melalui [kontrak ini](https://github.com/Uniswap/uniswap-v2-periphery/blob/master/contracts/UniswapV2Router02.sol). Anda dapat melihat cara menggunakannya [di sini](https://docs.uniswap.org/protocol/V2/reference/smart-contracts/router-02/).
 
 ```solidity
 pragma solidity =0.6.6;

--- a/src/content/translations/it/developers/tutorials/uniswap-v2-annotated-code/index.md
+++ b/src/content/translations/it/developers/tutorials/uniswap-v2-annotated-code/index.md
@@ -892,11 +892,11 @@ I contratti periferici sono l'API (interfaccia del programma applicativo) per Un
 
 ### UniswapV2Router01.sol {#UniswapV2Router01}
 
-[Questo contratto](https://github.com/Uniswap/uniswap-v2-periphery/blob/master/contracts/UniswapV2Router01.sol) è problematico e [non dovrebbe essere più usato](https://uniswap.org/docs/v2/smart-contracts/router01/). Fortunatamente, i contratti periferici sono privi di stato e non detengono alcuna risorsa, quindi è facile deprecarli e suggerire alle persone di usare una soluzione alternativa, ad esempio `UniswapV2Router02`.
+[Questo contratto](https://github.com/Uniswap/uniswap-v2-periphery/blob/master/contracts/UniswapV2Router01.sol) è problematico e [non dovrebbe essere più usato](https://docs.uniswap.org/protocol/V2/reference/smart-contracts/router-01/). Fortunatamente, i contratti periferici sono privi di stato e non detengono alcuna risorsa, quindi è facile deprecarli e suggerire alle persone di usare una soluzione alternativa, ad esempio `UniswapV2Router02`.
 
 ### UniswapV2Router02.sol {#UniswapV2Router02}
 
-In gran parte dei casi puoi usare Uniswap tramite [questo contratto](https://github.com/Uniswap/uniswap-v2-periphery/blob/master/contracts/UniswapV2Router02.sol). Puoi vedere come usarlo [qui](https://uniswap.org/docs/v2/smart-contracts/router02/).
+In gran parte dei casi puoi usare Uniswap tramite [questo contratto](https://github.com/Uniswap/uniswap-v2-periphery/blob/master/contracts/UniswapV2Router02.sol). Puoi vedere come usarlo [qui](https://docs.uniswap.org/protocol/V2/reference/smart-contracts/router-02/).
 
 ```solidity
 pragma solidity =0.6.6;

--- a/src/content/translations/ro/developers/tutorials/uniswap-v2-annotated-code/index.md
+++ b/src/content/translations/ro/developers/tutorials/uniswap-v2-annotated-code/index.md
@@ -892,11 +892,11 @@ Contractele periferice sunt API-uri (interfață de program de aplicație) pentr
 
 ### UniswapV2Router01.sol {#UniswapV2Router01}
 
-[Acest contract](https://github.com/Uniswap/uniswap-v2-periphery/blob/master/contracts/UniswapV2Router01.sol) are probleme și [ar trebui să nu mai fie utilizat](https://uniswap.org/docs/v2/smart-contracts/router01/). Din fericire, contractele periferice sunt fără stare și nu dețin niciun activ, de aceea este ușor să fie eliminate; se recomandă în schimb utilizarea înlocuitorului lor, `UniswapV2Router02`.
+[Acest contract](https://github.com/Uniswap/uniswap-v2-periphery/blob/master/contracts/UniswapV2Router01.sol) are probleme și [ar trebui să nu mai fie utilizat](https://docs.uniswap.org/protocol/V2/reference/smart-contracts/router-01/). Din fericire, contractele periferice sunt fără stare și nu dețin niciun activ, de aceea este ușor să fie eliminate; se recomandă în schimb utilizarea înlocuitorului lor, `UniswapV2Router02`.
 
 ### UniswapV2Router02.sol {#UniswapV2Router02}
 
-În cele mai multe cazuri, veți utiliza Uniswap prin intermediul [acestui contract](https://github.com/Uniswap/uniswap-v2-periphery/blob/master/contracts/UniswapV2Router02.sol). Puteți vedea cum să îl utilizați [aici](https://uniswap.org/docs/v2/smart-contracts/router02/).
+În cele mai multe cazuri, veți utiliza Uniswap prin intermediul [acestui contract](https://github.com/Uniswap/uniswap-v2-periphery/blob/master/contracts/UniswapV2Router02.sol). Puteți vedea cum să îl utilizați [aici](https://docs.uniswap.org/protocol/V2/reference/smart-contracts/router-02/).
 
 ```solidity
 pragma solidity =0.6.6;

--- a/src/content/translations/zh/developers/tutorials/uniswap-v2-annotated-code/index.md
+++ b/src/content/translations/zh/developers/tutorials/uniswap-v2-annotated-code/index.md
@@ -892,11 +892,11 @@ contract UniswapV2Factory is IUniswapV2Factory {
 
 ### UniswapV2Router01.sol {#UniswapV2Router01}
 
-[该合约](https://github.com/Uniswap/uniswap-v2-periphery/blob/master/contracts/UniswapV2Router01.sol) 存有问题，[不应该再使用](https://uniswap.org/docs/v2/smart-contracts/router01/)。 幸运的是， 外围合约无状态记录，也不拥有任何资产，所以很容易废弃。建议 使用 `UniswapV2Router02` 来替代。
+[该合约](https://github.com/Uniswap/uniswap-v2-periphery/blob/master/contracts/UniswapV2Router01.sol) 存有问题，[不应该再使用](https://docs.uniswap.org/protocol/V2/reference/smart-contracts/router-01/)。 幸运的是， 外围合约无状态记录，也不拥有任何资产，所以很容易废弃。建议 使用 `UniswapV2Router02` 来替代。
 
 ### UniswapV2Router02.sol {#UniswapV2Router02}
 
-在大多数情况下，您会通过[该合约](https://github.com/Uniswap/uniswap-v2-periphery/blob/master/contracts/UniswapV2Router02.sol)使用 Uniswap。 有关使用说明，您可以在[这里](https://uniswap.org/docs/v2/smart-contracts/router02/)找到。
+在大多数情况下，您会通过[该合约](https://github.com/Uniswap/uniswap-v2-periphery/blob/master/contracts/UniswapV2Router02.sol)使用 Uniswap。 有关使用说明，您可以在[这里](https://docs.uniswap.org/protocol/V2/reference/smart-contracts/router-02/)找到。
 
 ```solidity
 pragma solidity =0.6.6;


### PR DESCRIPTION
## Description
The links for UniswapV2Router docs were outdated and redirected into 404 pages
<img width="1097" alt="Screen Shot 2022-05-02 at 01 34 53" src="https://user-images.githubusercontent.com/12984659/166157623-56c5ee83-386c-4eb5-8873-0fd86782dbb3.png">


This PR is to ddd the updated links for UniswapV2Router docs
<img width="1093" alt="Screen Shot 2022-05-02 at 01 35 04" src="https://user-images.githubusercontent.com/12984659/166157638-060b2ef0-54cc-4d9b-bfa1-59c7787d5460.png">
