### PR TITLE
docs: Fixes the anchor tag for ABI link

### DIFF
--- a/src/content/developers/docs/transactions/index.md
+++ b/src/content/developers/docs/transactions/index.md
@@ -107,7 +107,7 @@ With the signature hash, the transaction can be cryptographically proven that it
 ### The data field {#the-data-field}
 
 The vast majority of transactions access a contract from an externally-owned account.
-Most contracts are written in Solidity and interpret their data field in accordance with the [application binary interface (ABI)](/glossary/#abi/).
+Most contracts are written in Solidity and interpret their data field in accordance with the [application binary interface (ABI)](/glossary/#abi).
 
 The first four bytes specify which function to call, using the hash of the function's name and arguments.
 You can sometimes identify the function from the selector using [this database](https://www.4byte.directory/signatures/).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The URL pointing to the glossary entry of ABI, has a trailing slash which makes the anchor tag not work. The fix is too remove the trailing slash.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
