### PR TITLE
dev/networks: update public testnets

### DIFF
--- a/src/content/developers/docs/networks/index.md
+++ b/src/content/developers/docs/networks/index.md
@@ -56,22 +56,23 @@ Görli faucets:
 
 #### Ropsten _(deprecated)_ {#ropsten}
 
-_Note, the Ropsten testnet is [deprecated](https://github.com/ethereum/pm/issues/460) and will no longer recieve protocol upgrades. Please consider migrating your applications to Sepolia or Goerli._
+_Note, [the Ropsten testnet is deprecated](https://github.com/ethereum/pm/issues/460) and will no longer receive protocol upgrades. Please consider migrating your applications to Sepolia or Görli._
 
-A very old proof-of-work testnet. It only serves historical relevance and is mainly used by core developers for testing protocol upgrades.
+A proof-of-work testnet. It only serves historical relevance and is mainly used by core developers for testing protocol upgrades.
 
-Ropsten faucets:
+##### Ropsten faucets
 
 - [FaucETH](https://fauceth.komputing.org) (multi-Chain faucet without the need for social account)
 - [Paradigm faucet](https://faucet.paradigm.xyz/)
 
 #### Rinkeby _(deprecated)_ {#rinkeby}
 
-_Note, the Rinkey testnet is [deprecated](https://github.com/ethereum/pm/issues/460) and will no longer recieve protocol upgrades. Please consider migrating your applications to Sepolia or Goerli._
+_Note: [the Rinkeby testnet is deprecated](https://github.com/ethereum/pm/issues/460) and will no longer receive protocol upgrades. Please consider migrating your applications to Sepolia or Görli._
 
-A very old proof-of-authority testnet for those running old versions of the Geth client.
+A proof-of-authority testnet for those running old versions of the Geth client.
 
-Rinkeby faucets:
+##### Rinkeby faucets
+
 - [FaucETH](https://fauceth.komputing.org) (multi-Chain faucet without the need for social account)
 - [Alchemy faucet](https://RinkebyFaucet.com)
 - [Chainlink faucet](https://faucets.chain.link/)
@@ -80,18 +81,18 @@ Rinkeby faucets:
 
 #### Kovan _(deprecated)_ {#kovan}
 
-_Note, the Kovan testnet is [deprecated](https://github.com/ethereum/pm/issues/460) and will no longer recieve protocol upgrades. Please consider migrating your applications to Sepolia or Goerli._
+_Note: [the Kovan testnet is deprecated](https://github.com/ethereum/pm/issues/460) and will no longer receive protocol upgrades. Please consider migrating your applications to Sepolia or Görli._
 
 A very old proof-of-authority testnet for those still running OpenEthereum clients.
 
-Kovan faucets:
+##### Kovan faucets
 - [FaucETH](https://fauceth.komputing.org) (multi-Chain faucet without the need for social account)
 - [Chainlink faucet](https://faucets.chain.link/)
 - [Paradigm faucet](https://faucet.paradigm.xyz/)
 
-### Layer-2 Testnets {#layer-2-testnets}
+### Layer 2 testnets {#layer-2-testnets}
 
-[Layer 2 (L2)](/layer-2/) is a collective term to describe a specific set of Ethereum scaling solutions. A layer 2 is separate blockchain that extends Ethereum and inherits the security guarantees of Ethereum. Layer-2 testnets are usually tightly coupled to public Ethereum testnets.
+[Layer 2 (L2)](/layer-2/) is a collective term to describe a specific set of Ethereum scaling solutions. A layer 2 is a separate blockchain that extends Ethereum and inherits the security guarantees of Ethereum. Layer 2 testnets are usually tightly coupled to public Ethereum testnets.
 
 #### Arbitrum Rinkeby {#arbitrum-rinkeby}
 

--- a/src/content/developers/docs/networks/index.md
+++ b/src/content/developers/docs/networks/index.md
@@ -48,7 +48,7 @@ A proof-of-authority testnet that works across clients; an ideal testnet for app
 - [Github](https://github.com/goerli/testnet)
 - [Etherscan](https://goerli.etherscan.io)
 
-Görli faucets:
+##### Görli faucets
 
 - [Görli faucet](https://faucet.goerli.mudit.blog/)
 - [Chainlink faucet](https://faucets.chain.link/)

--- a/src/content/developers/docs/networks/index.md
+++ b/src/content/developers/docs/networks/index.md
@@ -86,6 +86,7 @@ _Note: [the Kovan testnet is deprecated](https://github.com/ethereum/pm/issues/4
 A very old proof-of-authority testnet for those still running OpenEthereum clients.
 
 ##### Kovan faucets
+
 - [FaucETH](https://fauceth.komputing.org) (multi-Chain faucet without the need for social account)
 - [Chainlink faucet](https://faucets.chain.link/)
 - [Paradigm faucet](https://faucet.paradigm.xyz/)

--- a/src/content/developers/docs/networks/index.md
+++ b/src/content/developers/docs/networks/index.md
@@ -17,13 +17,13 @@ You should understand the basics of Ethereum before reading up on the different 
 
 Public networks are accessible to anyone in the world with an internet connection. Anyone can read or create transactions on a public blockchain and validate the transactions being executed. Agreement on transactions and the state of the network is decided by a consensus of peers.
 
-### Mainnet {#mainnet}
+### Ethereum Mainnet {#ethereum-mainnet}
 
 Mainnet is the primary public Ethereum production blockchain, where actual-value transactions occur on the distributed ledger.
 
 When people and exchanges discuss ETH prices, they're talking about Mainnet ETH.
 
-### Testnets {#testnets}
+### Ethereum Testnets {#ethereum-testnets}
 
 In addition to Mainnet, there are public testnets. These are networks used by protocol developers or smart contract developers to test both protocol upgrades as well as potential smart contracts in a production-like environment before deployment to Mainnet. Think of this as an analog to production versus staging servers.
 
@@ -33,43 +33,72 @@ Most testnets use a proof-of-authority consensus mechanism. This means a small n
 
 ETH on testnets has no real value; therefore, there are no markets for testnet ETH. Since you need ETH to actually interact with Ethereum, most people get testnet ETH from faucets. Most faucets are webapps where you can input an address which you request ETH to be sent to.
 
-#### Arbitrum Rinkeby {#arbitrum-rinkeby}
 
-A testnet for [Arbitrum](https://arbitrum.io/).
+#### Sepolia {#sepolia}
 
-##### Arbitrum Rinkeby faucets
+A proof-of-work testnet; this means it's the best like-for-like representation of Ethereum.
 
-- [FaucETH](https://fauceth.komputing.org)(Multi-Chain faucet without the need for social account)
-- [Chainlink faucet](https://faucets.chain.link/)
-- [Paradigm faucet](https://faucet.paradigm.xyz/)
+- [Github](https://github.com/goerli/sepolia)
+- [Otterscan](https://sepolia.otterscan.io/)
 
 #### Görli {#goerli}
 
-A proof-of-authority testnet that works across clients.
+A proof-of-authority testnet that works across clients; an ideal testnet for application developers.
 
-##### Görli faucets
+- [Github](https://github.com/goerli/testnet)
+- [Etherscan](https://goerli.etherscan.io)
+
+Görli faucets:
 
 - [Görli faucet](https://faucet.goerli.mudit.blog/)
 - [Chainlink faucet](https://faucets.chain.link/)
 - [Alchemy Goerli Faucet](https://goerlifaucet.com/)
 
-#### Kintsugi {#kintsugi}
+#### Ropsten _(deprecated)_ {#ropsten}
 
-A merge testnet for Ethereum.
+_Note, the Ropsten testnet is [deprecated](https://github.com/ethereum/pm/issues/460) and will no longer recieve protocol upgrades. Please consider migrating your applications to Sepolia or Goerli._
 
-##### Kintsugi faucets
+A very old proof-of-work testnet. It only serves historical relevance and is mainly used by core developers for testing protocol upgrades.
 
-- [FaucETH](https://fauceth.komputing.org)(Multi-Chain faucet without the need for social account)
-- [Kintsugi faucet](https://faucet.kintsugi.themerge.dev/)
+Ropsten faucets:
 
-#### Kovan {#kovan}
+- [FaucETH](https://fauceth.komputing.org) (multi-Chain faucet without the need for social account)
+- [Paradigm faucet](https://faucet.paradigm.xyz/)
 
-A proof-of-authority testnet for those running OpenEthereum clients.
+#### Rinkeby _(deprecated)_ {#rinkeby}
 
-##### Kovan faucets
+_Note, the Rinkey testnet is [deprecated](https://github.com/ethereum/pm/issues/460) and will no longer recieve protocol upgrades. Please consider migrating your applications to Sepolia or Goerli._
 
-- [FaucETH](https://fauceth.komputing.org)(Multi-Chain faucet without the need for social account)
-- [Kovan faucet](https://faucet.kovan.network/)
+A very old proof-of-authority testnet for those running old versions of the Geth client.
+
+Rinkeby faucets:
+- [FaucETH](https://fauceth.komputing.org) (multi-Chain faucet without the need for social account)
+- [Alchemy faucet](https://RinkebyFaucet.com)
+- [Chainlink faucet](https://faucets.chain.link/)
+- [Paradigm faucet](https://faucet.paradigm.xyz/)
+- [Rinkeby faucet](https://faucet.rinkeby.io/)
+
+#### Kovan _(deprecated)_ {#kovan}
+
+_Note, the Kovan testnet is [deprecated](https://github.com/ethereum/pm/issues/460) and will no longer recieve protocol upgrades. Please consider migrating your applications to Sepolia or Goerli._
+
+A very old proof-of-authority testnet for those still running OpenEthereum clients.
+
+Kovan faucets:
+- [FaucETH](https://fauceth.komputing.org) (multi-Chain faucet without the need for social account)
+- [Chainlink faucet](https://faucets.chain.link/)
+- [Paradigm faucet](https://faucet.paradigm.xyz/)
+
+### Layer-2 Testnets {#layer-2-testnets}
+
+[Layer 2 (L2)](/layer-2/) is a collective term to describe a specific set of Ethereum scaling solutions. A layer 2 is separate blockchain that extends Ethereum and inherits the security guarantees of Ethereum. Layer-2 testnets are usually tightly coupled to public Ethereum testnets.
+
+#### Arbitrum Rinkeby {#arbitrum-rinkeby}
+
+A testnet for [Arbitrum](https://arbitrum.io/).
+
+Arbitrum Rinkeby faucets:
+- [FaucETH](https://fauceth.komputing.org) (multi-Chain faucet without the need for social account)
 - [Chainlink faucet](https://faucets.chain.link/)
 - [Paradigm faucet](https://faucet.paradigm.xyz/)
 
@@ -77,30 +106,8 @@ A proof-of-authority testnet for those running OpenEthereum clients.
 
 A testnet for [Optimism](https://www.optimism.io/).
 
-##### Optimistic Kovan faucets
-
-- [FaucETH](https://fauceth.komputing.org)(Multi-Chain faucet without the need for social account)
-- [Paradigm faucet](https://faucet.paradigm.xyz/)
-
-#### Rinkeby {#rinkeby}
-
-A proof-of-authority testnet for those running Geth client.
-
-##### Rinkeby faucets
-
-- [FaucETH](https://fauceth.komputing.org)(Multi-Chain faucet without the need for social account)
-- [Alchemy faucet](https://RinkebyFaucet.com)
-- [Chainlink faucet](https://faucets.chain.link/)
-- [Paradigm faucet](https://faucet.paradigm.xyz/)
-- [Rinkeby faucet](https://faucet.rinkeby.io/)
-
-#### Ropsten {#ropsten}
-
-A proof-of-work testnet. This means it's the best like-for-like representation of Ethereum.
-
-##### Ropsten faucets
-
-- [FaucETH](https://fauceth.komputing.org)(Multi-Chain faucet without the need for social account)
+Optimistic Kovan faucets:
+- [FaucETH](https://fauceth.komputing.org) (multi-Chain faucet without the need for social account)
 - [Paradigm faucet](https://faucet.paradigm.xyz/)
 
 ## Private networks {#private-networks}


### PR DESCRIPTION
## Description

Adds some clarifications to public Ethereum networks.
- creates a section for L2 testnets to avoid confusion
- adds a deprecation notice for Kovan, Rinkeby, and Ropsten
- adds [Sepolia](https://github.com/goerli/sepolia) testnet
- removes some broken links

## Related Issue

- https://github.com/ethereum/pm/issues/460