### PR TITLE
Remove trailing slashes from glossary links

### DIFF
--- a/src/content/developers/tutorials/run-light-node-geth/index.md
+++ b/src/content/developers/tutorials/run-light-node-geth/index.md
@@ -75,7 +75,7 @@ This console allows direct interaction with Ethereum. For example, running the `
 
 ## Mainnet and testnets {#mainnet-and-testnets}
 
-Geth runs your node on [Ethereum Mainnet](/glossary/#mainnet/) by default.
+Geth runs your node on [Ethereum Mainnet](/glossary/#mainnet) by default.
 
 It is also possible to use Geth to run a node on one of the [public test networks](/networks/#testnets/), by running one of the following commands in Terminal:
 

--- a/src/content/translations/es/developers/docs/transactions/index.md
+++ b/src/content/translations/es/developers/docs/transactions/index.md
@@ -105,7 +105,7 @@ Mediante el hash de la firma, se puede demostrar criptográficamente que la tran
 
 ### The data field {#the-data-field}
 
-The vast majority of transactions access a contract from an externally-owned account. Most contracts are written in Solidity and interpret their data field in accordance with the [application binary interface (ABI)](/glossary/#abi/).
+The vast majority of transactions access a contract from an externally-owned account. Most contracts are written in Solidity and interpret their data field in accordance with the [application binary interface (ABI)](/glossary/#abi).
 
 The first four bytes specify which function to call, using the hash of the function's name and arguments. You can sometimes identify the function from the selector using [this database](https://www.4byte.directory/signatures/).
 

--- a/src/content/translations/fa/developers/docs/transactions/index.md
+++ b/src/content/translations/fa/developers/docs/transactions/index.md
@@ -105,7 +105,7 @@ sidebar: true
 
 ### The data field {#the-data-field}
 
-The vast majority of transactions access a contract from an externally-owned account. Most contracts are written in Solidity and interpret their data field in accordance with the [application binary interface (ABI)](/glossary/#abi/).
+The vast majority of transactions access a contract from an externally-owned account. Most contracts are written in Solidity and interpret their data field in accordance with the [application binary interface (ABI)](/glossary/#abi).
 
 The first four bytes specify which function to call, using the hash of the function's name and arguments. You can sometimes identify the function from the selector using [this database](https://www.4byte.directory/signatures/).
 

--- a/src/content/translations/id/developers/docs/transactions/index.md
+++ b/src/content/translations/id/developers/docs/transactions/index.md
@@ -105,7 +105,7 @@ Dengan hash tanda tangan, transaksi bisa dibuktikan secara kriptografi berasal d
 
 ### The data field {#the-data-field}
 
-The vast majority of transactions access a contract from an externally-owned account. Most contracts are written in Solidity and interpret their data field in accordance with the [application binary interface (ABI)](/glossary/#abi/).
+The vast majority of transactions access a contract from an externally-owned account. Most contracts are written in Solidity and interpret their data field in accordance with the [application binary interface (ABI)](/glossary/#abi).
 
 The first four bytes specify which function to call, using the hash of the function's name and arguments. You can sometimes identify the function from the selector using [this database](https://www.4byte.directory/signatures/).
 

--- a/src/content/translations/id/developers/tutorials/run-light-node-geth/index.md
+++ b/src/content/translations/id/developers/tutorials/run-light-node-geth/index.md
@@ -78,7 +78,7 @@ This console allows direct interaction with Ethereum. For example, running the `
 
 ## Mainnet and testnets {#mainnet-and-testnets}
 
-Geth runs your node on [Ethereum Mainnet](/glossary/#mainnet/) by default.
+Geth runs your node on [Ethereum Mainnet](/glossary/#mainnet) by default.
 
 It is also possible to use Geth to run a node on one of the [public test networks](/networks/#testnets/), by running one of the following commands in Terminal:
 

--- a/src/content/translations/ro/developers/docs/transactions/index.md
+++ b/src/content/translations/ro/developers/docs/transactions/index.md
@@ -105,7 +105,7 @@ Cu hash-ul semnăturii, se poate dovedi criptografic că tranzacția a venit de 
 
 ### The data field {#the-data-field}
 
-The vast majority of transactions access a contract from an externally-owned account. Most contracts are written in Solidity and interpret their data field in accordance with the [application binary interface (ABI)](/glossary/#abi/).
+The vast majority of transactions access a contract from an externally-owned account. Most contracts are written in Solidity and interpret their data field in accordance with the [application binary interface (ABI)](/glossary/#abi).
 
 The first four bytes specify which function to call, using the hash of the function's name and arguments. You can sometimes identify the function from the selector using [this database](https://www.4byte.directory/signatures/).
 

--- a/src/content/translations/ro/developers/tutorials/run-light-node-geth/index.md
+++ b/src/content/translations/ro/developers/tutorials/run-light-node-geth/index.md
@@ -78,7 +78,7 @@ This console allows direct interaction with Ethereum. For example, running the `
 
 ## Mainnet and testnets {#mainnet-and-testnets}
 
-Geth runs your node on [Ethereum Mainnet](/glossary/#mainnet/) by default.
+Geth runs your node on [Ethereum Mainnet](/glossary/#mainnet) by default.
 
 It is also possible to use Geth to run a node on one of the [public test networks](/networks/#testnets/), by running one of the following commands in Terminal:
 

--- a/src/content/translations/zh/developers/tutorials/run-light-node-geth/index.md
+++ b/src/content/translations/zh/developers/tutorials/run-light-node-geth/index.md
@@ -78,7 +78,7 @@ geth attach
 
 ## 主网和测试网 {#mainnet-and-testnets}
 
-Geth 默认在 [以太坊主网](/glossary/#mainnet/) 上运行你的节点。
+Geth 默认在 [以太坊主网](/glossary/#mainnet) 上运行你的节点。
 
 通过在终端中运行以下命令之一，也可以使用 Geth 在 [公共测试网络](/networks/#testnets/) 之一上运行节点：
 


### PR DESCRIPTION
## Description

In #6192, a contributor noted that a trailing slash breaks the URL id selector in glossary links. This builds on #6192 to remove all instances of this.

For example:
https://ethereum.org/en/glossary/#mainnet/ (with trailing slash) vs visiting https://ethereum.org/en/glossary/#mainnet (no slash)


## Related Issue
#6192
