### PR TITLE
Remove trailing slashes from urls with header-ids

### DIFF
--- a/src/content/developers/tutorials/run-light-node-geth/index.md
+++ b/src/content/developers/tutorials/run-light-node-geth/index.md
@@ -77,7 +77,7 @@ This console allows direct interaction with Ethereum. For example, running the `
 
 Geth runs your node on [Ethereum Mainnet](/glossary/#mainnet/) by default.
 
-It is also possible to use Geth to run a node on one of the [public test networks](/networks/#testnets/), by running one of the following commands in Terminal:
+It is also possible to use Geth to run a node on one of the [public test networks](/networks/#testnets), by running one of the following commands in Terminal:
 
 ```bash
 geth --syncmode light --ropsten

--- a/src/content/smart-contracts/index.md
+++ b/src/content/smart-contracts/index.md
@@ -75,7 +75,7 @@ They can perform computations, create currency, store data, mint NFTs, send comm
 
 - [Stablecoins](/stablecoins/)
 - [Creating and distributing unique digital assets](/nft/)
-- [An automatic, open currency exchange](/get-eth/#dex/)
+- [An automatic, open currency exchange](/get-eth/#dex)
 - [Decentralized gaming](/dapps/?category=gaming)
 - [An insurance policy that pays out automatically](https://etherisc.com/)
 - [A standard that lets people create customized, interoperable currencies](/developers/docs/standards/tokens/)

--- a/src/content/translations/id/developers/tutorials/run-light-node-geth/index.md
+++ b/src/content/translations/id/developers/tutorials/run-light-node-geth/index.md
@@ -80,7 +80,7 @@ This console allows direct interaction with Ethereum. For example, running the `
 
 Geth runs your node on [Ethereum Mainnet](/glossary/#mainnet/) by default.
 
-It is also possible to use Geth to run a node on one of the [public test networks](/networks/#testnets/), by running one of the following commands in Terminal:
+It is also possible to use Geth to run a node on one of the [public test networks](/networks/#testnets), by running one of the following commands in Terminal:
 
 ```bash
 geth --syncmode light --ropsten

--- a/src/content/translations/ro/developers/tutorials/run-light-node-geth/index.md
+++ b/src/content/translations/ro/developers/tutorials/run-light-node-geth/index.md
@@ -80,7 +80,7 @@ This console allows direct interaction with Ethereum. For example, running the `
 
 Geth runs your node on [Ethereum Mainnet](/glossary/#mainnet/) by default.
 
-It is also possible to use Geth to run a node on one of the [public test networks](/networks/#testnets/), by running one of the following commands in Terminal:
+It is also possible to use Geth to run a node on one of the [public test networks](/networks/#testnets), by running one of the following commands in Terminal:
 
 ```bash
 geth --syncmode light --ropsten

--- a/src/content/translations/zh/developers/tutorials/run-light-node-geth/index.md
+++ b/src/content/translations/zh/developers/tutorials/run-light-node-geth/index.md
@@ -80,7 +80,7 @@ geth attach
 
 Geth 默认在 [以太坊主网](/glossary/#mainnet/) 上运行你的节点。
 
-通过在终端中运行以下命令之一，也可以使用 Geth 在 [公共测试网络](/networks/#testnets/) 之一上运行节点：
+通过在终端中运行以下命令之一，也可以使用 Geth 在 [公共测试网络](/networks/#testnets) 之一上运行节点：
 
 ```bash
 geth --syncmode light --ropsten


### PR DESCRIPTION
## Description
Follow on from: #6207.

I realised any trailing slash will break a header id. This removes broken occurences on the website.

## Related Issue
#6207
