### PR TITLE
Codeblocks in RTL languages bug fixed [Solves #6202]

### DIFF
--- a/src/components/Codeblock.js
+++ b/src/components/Codeblock.js
@@ -21,6 +21,7 @@ const HightlightContainer = styled.div`
       ? `calc((1.2rem * ${LINES_BEFORE_COLLAPSABLE}) + 4.185rem)`
       : "fit-content"};
   overflow: scroll;
+  direction: ltr;
   margin-bottom: ${(props) => (props.fromHomepage ? `0rem` : `1rem`)};
 `
 


### PR DESCRIPTION
## Description
- Added a `direction` property with `ltr` value to the `CodeBlock` component. This way the content inside of a code block stays in LTR, no matter the language. 

## Describe your changes in detail
- Added: `direction: ltr;` (src/components/Codeblock.js, line 24)

## Related Issue
- Related to [Codeblocks in RTL languages #6202]



