### PR TITLE
Included Erc-4626 in token standards- [Fixes #6255]

### DIFF
--- a/src/content/developers/docs/standards/index.md
+++ b/src/content/developers/docs/standards/index.md
@@ -33,6 +33,7 @@ Certain EIPs relate to application-level standards (e.g. a standard smart-contra
 - [ERC-721](/developers/docs/standards/tokens/erc-721/) - A standard interface for non-fungible tokens, like a deed for artwork or a song.
 - [ERC-777](/developers/docs/standards/tokens/erc-777/) - A token standard improving over ERC-20.
 - [ERC-1155](/developers/docs/standards/tokens/erc-1155/) - A token standard which can contain both fungible and non-fungible assets.
+- [ERC-4626](/developers/docs/standards/tokens/erc-4626/) - A tokenized vault standard designed to optimize and unify the technical parameters of yield-bearing vaults.
 
 Learn more about [token standards](/developers/docs/standards/tokens/).
 

--- a/src/content/developers/docs/standards/tokens/erc-4626/index.md
+++ b/src/content/developers/docs/standards/tokens/erc-4626/index.md
@@ -1,6 +1,6 @@
 ---
 title: ERC-4626 Tokenized Vault Standard
-description: 
+description: A standard for yield bearing vaults.
 lang: en
 sidebar: true
 ---

--- a/src/content/developers/docs/standards/tokens/erc-4626/index.md
+++ b/src/content/developers/docs/standards/tokens/erc-4626/index.md
@@ -1,0 +1,137 @@
+---
+title: ERC-4626 Tokenized Vault Standard
+description: 
+lang: en
+sidebar: true
+---
+
+## Introduction {#introduction}
+
+A standard to optimize and unify the technical parameters of yield-bearing vaults. This standard provides a standard API for tokenized yield-bearing vaults that represent shares of a single underlying ERC-20 token.
+With an optional extension for tokenized vaults utilizing ERC-20, this standard offers basic functionality for depositing, withdrawing tokens and reading balances.
+
+**The role of ERC-4626 in yield-bearing vaults?**
+
+Lending markets, aggregators, and intrinsically interest bearing tokens help users find the best yield on their crypto tokens through the execution of different strategies.
+These strategies are done with slight variation which might be error prone or waste development resources.
+
+ERC-4626 in yield-bearing vaults will lower the integration effort and unlock access to yield in various applications with little specialized effort from developers by creating more consistent and robust implementation patterns.
+
+The ERC-4626 token is described fully in [EIP-4626](https://eips.ethereum.org/EIPS/eip-4626).
+
+## Prerequisites {#prerequisites}
+
+To better understand this page, we recommend you first read about [token standards](/developers/docs/standards/tokens/) and [ERC-20](/developers/docs/standards/tokens/erc-20/).
+
+## ERC-4626 Functions and Features: {#body}
+- [Methods](#methods)
+  - [deposit](#deposit)
+  - [withdraw](#withdraw)
+  - [totalHoldings](#totalholdings)
+  - [balanceOfUnderlying](#balanceofunderlying)
+  - [underlying](#underlying)
+  - [totalSupply](#totalsupply)
+  - [balanceOf](#balanceof)
+  - [redeem](#redeem)
+  - [exchangeRate](#exchangerate)
+  - [baseUnit](#baseunit)
+
+- [Events](#events)
+  - [Deposit Event](#deposit_event)
+  - [Withdraw Event](#withdraw_event)
+
+
+---
+### Methods {#methods}
+#### deposit {#deposit}
+```solidity
+function deposit(address _to, uint256 _value) public returns (uint256 _shares)
+```
+This function deposits the `_value` tokens into the vault and grants ownership to `_to`.
+
+#### withdraw {#withdraw}
+```solidity
+function withdraw(address _to, uint256 _value) public returns (uint256 _shares)
+```
+This function withdraws `_value` token from the vault and transfers them to `_to`.
+
+#### totalHoldings {#totalholdings}
+```solidity
+function totalHoldings() public view returns (uint256)
+```
+This function returns the total amount of underlying tokens held by the vault.
+
+#### balanceOfUnderlying {#balanceofunderlying}
+```solidity
+function balanceOfUnderlying(address _owner) public view returns (uint256)
+```
+This function returns the total amount of underlying tokens held in the vault for `_owner`.
+
+#### underlying {#underlying}
+```solidity
+function underlying() public view returns (address)
+```
+Returns the address of the token the vault uses for accounting, depositing, and withdrawing.
+
+#### totalSupply {#totalsupply}
+```solidity
+function totalSupply() public view returns (uint256)
+```
+Returns the total number of unredeemed vault shares in circulation.
+
+#### balanceOf {#balanceof}
+```solidity
+function balanceOf(address _owner) public view returns (uint256)
+```
+Returns the total amount of vault shares the `_owner` currently has.
+
+#### redeem {#redeem}
+```solidity
+function redeem(address _to, uint256 _shares) public returns (uint256 _value)
+```
+Redeems a specific number of `_shares` for underlying tokens and transfers them to `_to`.
+
+#### exchangeRate {#exchangerate}
+```solidity
+function exchangeRate() public view returns (uint256)
+```
+The amount of underlying tokens one `baseUnit` of vault shares is redeemable for. For example:
+```solidity
+_shares * exchangeRate() / baseUnit() = _value.
+```
+
+```solidity
+exchangeRate() * totalSupply() MUST equal totalHoldings().
+```
+
+#### baseUnit {#baseunit}
+```solidity
+function baseUnit() public view returns(uint256)
+```
+The decimal scalar for vault shares and operations involving `exchangeRate()`.
+
+
+---
+### Events {#events}
+#### Deposit Event
+**MUST** be emitted when tokens are deposited into the vault
+```solidity
+event Deposit(address indexed _from, addres indexed _to, uint256 _value)
+```
+
+Where `_from` is the user who triggered the deposit and approved `_value` underlying tokens to the vault, and `_to` is the user who can withdraw the deposited tokens.
+
+#### Widthdraw Event
+**MUST** be emitted when tokens are withdrawn from the vault by a depositor.
+```solidity
+event Withdraw(address indexed _owner, address indexed _to, uint256 _value)
+```
+Where `_from` is the user who triggered the withdrawal and held `_value` underlying tokens in the vault, and `_to` is the user who received the withdrawn tokens.
+
+---
+_Note_: All batch functions, including the hook, are also available in non-batch versions. This is done to save gas, as transferring just one asset will likely remain to be the most common method. For clarity in the explanations, we've left them out, including the safe transfer rules. Remove the 'Batch' and the names are identical.
+
+## Further reading {#further-reading}
+
+- [EIP-4626: Tokenized vault Standard](https://eips.ethereum.org/EIPS/eip-4626)
+- [ERC-4626: Github Repo](https://github.com/Rari-Capital/solmate/blob/main/src/mixins/ERC4626.sol)

--- a/src/content/developers/docs/standards/tokens/erc-4626/index.md
+++ b/src/content/developers/docs/standards/tokens/erc-4626/index.md
@@ -10,7 +10,7 @@ sidebar: true
 A standard to optimize and unify the technical parameters of yield-bearing vaults. This standard provides a standard API for tokenized yield-bearing vaults that represent shares of a single underlying ERC-20 token.
 With an optional extension for tokenized vaults utilizing ERC-20, this standard offers basic functionality for depositing, withdrawing tokens and reading balances.
 
-**The role of ERC-4626 in yield-bearing vaults?**
+**The role of ERC-4626 in yield-bearing vaults**
 
 Lending markets, aggregators, and intrinsically interest bearing tokens help users find the best yield on their crypto tokens through the execution of different strategies.
 These strategies are done with slight variation which might be error prone or waste development resources.
@@ -41,7 +41,7 @@ To better understand this page, we recommend you first read about [token standar
   - [Withdraw Event](#withdraw_event)
 
 
----
+
 ### Methods {#methods}
 #### deposit {#deposit}
 ```solidity
@@ -111,7 +111,7 @@ function baseUnit() public view returns(uint256)
 The decimal scalar for vault shares and operations involving `exchangeRate()`.
 
 
----
+
 ### Events {#events}
 #### Deposit Event
 **MUST** be emitted when tokens are deposited into the vault
@@ -128,7 +128,8 @@ event Withdraw(address indexed _owner, address indexed _to, uint256 _value)
 ```
 Where `_from` is the user who triggered the withdrawal and held `_value` underlying tokens in the vault, and `_to` is the user who received the withdrawn tokens.
 
----
+
+
 _Note_: All batch functions, including the hook, are also available in non-batch versions. This is done to save gas, as transferring just one asset will likely remain to be the most common method. For clarity in the explanations, we've left them out, including the safe transfer rules. Remove the 'Batch' and the names are identical.
 
 ## Further reading {#further-reading}

--- a/src/content/developers/docs/standards/tokens/erc-4626/index.md
+++ b/src/content/developers/docs/standards/tokens/erc-4626/index.md
@@ -7,13 +7,11 @@ sidebar: true
 
 ## Introduction {#introduction}
 
-A standard to optimize and unify the technical parameters of yield-bearing vaults. This standard provides a standard API for tokenized yield-bearing vaults that represent shares of a single underlying ERC-20 token.
-With an optional extension for tokenized vaults utilizing ERC-20, this standard offers basic functionality for depositing, withdrawing tokens and reading balances.
+ERC-4626 is a standard to optimize and unify the technical parameters of yield-bearing vaults. It provides a standard API for tokenized yield-bearing vaults that represent shares of a single underlying ERC-20 token. ERC-4626 also outlines an optional extension for tokenized vaults utilizing ERC-20, offering basic functionality for depositing, withdrawing tokens and reading balances.
 
 **The role of ERC-4626 in yield-bearing vaults**
 
-Lending markets, aggregators, and intrinsically interest bearing tokens help users find the best yield on their crypto tokens through the execution of different strategies.
-These strategies are done with slight variation which might be error prone or waste development resources.
+Lending markets, aggregators, and intrinsically interest-bearing tokens help users find the best yield on their crypto tokens by executing different strategies. These strategies are done with slight variation, which might be error-prone or waste development resources.
 
 ERC-4626 in yield-bearing vaults will lower the integration effort and unlock access to yield in various applications with little specialized effort from developers by creating more consistent and robust implementation patterns.
 
@@ -24,74 +22,67 @@ The ERC-4626 token is described fully in [EIP-4626](https://eips.ethereum.org/EI
 To better understand this page, we recommend you first read about [token standards](/developers/docs/standards/tokens/) and [ERC-20](/developers/docs/standards/tokens/erc-20/).
 
 ## ERC-4626 Functions and Features: {#body}
-- [Methods](#methods)
-  - [deposit](#deposit)
-  - [withdraw](#withdraw)
-  - [totalHoldings](#totalholdings)
-  - [balanceOfUnderlying](#balanceofunderlying)
-  - [underlying](#underlying)
-  - [totalSupply](#totalsupply)
-  - [balanceOf](#balanceof)
-  - [redeem](#redeem)
-  - [exchangeRate](#exchangerate)
-  - [baseUnit](#baseunit)
-
-- [Events](#events)
-  - [Deposit Event](#deposit_event)
-  - [Withdraw Event](#withdraw_event)
-
-
 
 ### Methods {#methods}
+
 #### deposit {#deposit}
+
 ```solidity
 function deposit(address _to, uint256 _value) public returns (uint256 _shares)
 ```
 This function deposits the `_value` tokens into the vault and grants ownership to `_to`.
 
 #### withdraw {#withdraw}
+
 ```solidity
 function withdraw(address _to, uint256 _value) public returns (uint256 _shares)
 ```
 This function withdraws `_value` token from the vault and transfers them to `_to`.
 
 #### totalHoldings {#totalholdings}
+
 ```solidity
 function totalHoldings() public view returns (uint256)
 ```
 This function returns the total amount of underlying tokens held by the vault.
 
 #### balanceOfUnderlying {#balanceofunderlying}
+
 ```solidity
 function balanceOfUnderlying(address _owner) public view returns (uint256)
 ```
 This function returns the total amount of underlying tokens held in the vault for `_owner`.
 
 #### underlying {#underlying}
+
 ```solidity
 function underlying() public view returns (address)
 ```
 Returns the address of the token the vault uses for accounting, depositing, and withdrawing.
 
 #### totalSupply {#totalsupply}
+
 ```solidity
 function totalSupply() public view returns (uint256)
 ```
 Returns the total number of unredeemed vault shares in circulation.
 
 #### balanceOf {#balanceof}
+
 ```solidity
 function balanceOf(address _owner) public view returns (uint256)
 ```
 Returns the total amount of vault shares the `_owner` currently has.
 
 #### redeem {#redeem}
+
 ```solidity
 function redeem(address _to, uint256 _shares) public returns (uint256 _value)
 ```
 Redeems a specific number of `_shares` for underlying tokens and transfers them to `_to`.
 
 #### exchangeRate {#exchangerate}
+
 ```solidity
 function exchangeRate() public view returns (uint256)
 ```
@@ -105,6 +96,7 @@ exchangeRate() * totalSupply() MUST equal totalHoldings().
 ```
 
 #### baseUnit {#baseunit}
+
 ```solidity
 function baseUnit() public view returns(uint256)
 ```
@@ -113,7 +105,9 @@ The decimal scalar for vault shares and operations involving `exchangeRate()`.
 
 
 ### Events {#events}
+
 #### Deposit Event
+
 **MUST** be emitted when tokens are deposited into the vault
 ```solidity
 event Deposit(address indexed _from, addres indexed _to, uint256 _value)
@@ -122,13 +116,12 @@ event Deposit(address indexed _from, addres indexed _to, uint256 _value)
 Where `_from` is the user who triggered the deposit and approved `_value` underlying tokens to the vault, and `_to` is the user who can withdraw the deposited tokens.
 
 #### Widthdraw Event
+
 **MUST** be emitted when tokens are withdrawn from the vault by a depositor.
 ```solidity
 event Withdraw(address indexed _owner, address indexed _to, uint256 _value)
 ```
 Where `_from` is the user who triggered the withdrawal and held `_value` underlying tokens in the vault, and `_to` is the user who received the withdrawn tokens.
-
-
 
 _Note_: All batch functions, including the hook, are also available in non-batch versions. This is done to save gas, as transferring just one asset will likely remain to be the most common method. For clarity in the explanations, we've left them out, including the safe transfer rules. Remove the 'Batch' and the names are identical.
 

--- a/src/content/developers/docs/standards/tokens/index.md
+++ b/src/content/developers/docs/standards/tokens/index.md
@@ -23,6 +23,8 @@ Here are some of the most popular token standards on Ethereum:
 - [ERC-721](/developers/docs/standards/tokens/erc-721/) - A standard interface for non-fungible tokens, like a deed for artwork or a song.
 - [ERC-777](/developers/docs/standards/tokens/erc-777/) - ERC-777 allows people to build extra functionality on top of tokens such as a mixer contract for improved transaction privacy or an emergency recover function to bail you out if you lose your private keys.
 - [ERC-1155](/developers/docs/standards/tokens/erc-1155/) - ERC-1155 allows for more efficient trades and bundling of transactions – thus saving costs. This token standard allows for creating both utility tokens (such as $BNB or $BAT) and Non-Fungible Tokens like CryptoPunks.
+- [ERC-4626](/developers/docs/standards/tokens/erc-4626/) - A tokenized vault standard designed to optimize and unify the technical parameters of yield-bearing vaults.
+
 
 ## Further reading {#further-reading}
 

--- a/src/data/developer-docs-links.yaml
+++ b/src/data/developer-docs-links.yaml
@@ -156,6 +156,8 @@
               to: /developers/docs/standards/tokens/erc-777/
             - id: docs-nav-erc-1155
               to: /developers/docs/standards/tokens/erc-1155/
+            - id: docs-nav-erc-4626
+              to: /developers/docs/standards/tokens/erc-4626/
     - id: docs-nav-mev
       to: /developers/docs/mev/
       description: docs-nav-mev-description

--- a/src/intl/bg/page-developers-docs.json
+++ b/src/intl/bg/page-developers-docs.json
@@ -17,6 +17,7 @@
   "docs-nav-erc-721": "ERC-721",
   "docs-nav-erc-777": "ERC-777",
   "docs-nav-erc-1155": "ERC-1155",
+  "docs-nav-erc-4626": "ERC-4626",
   "docs-nav-ethereum-client-apis": "API на клиента на Етереум",
   "docs-nav-ethereum-stack": "Обем на Етереум",
   "docs-nav-evm": "Виртуална машина на Етереум (EVM)",

--- a/src/intl/ca/page-developers-docs.json
+++ b/src/intl/ca/page-developers-docs.json
@@ -17,6 +17,7 @@
   "docs-nav-erc-721": "ERC-721",
   "docs-nav-erc-777": "ERC-777",
   "docs-nav-erc-1155": "ERC-1155",
+  "docs-nav-erc-4626": "ERC-4626", 
   "docs-nav-ethereum-client-apis": "APIs de client Ethereum",
   "docs-nav-ethereum-stack": "Pila Ethereum",
   "docs-nav-evm": "Màquina virtual d'Ethereum (MVE)",

--- a/src/intl/en/page-developers-docs.json
+++ b/src/intl/en/page-developers-docs.json
@@ -24,6 +24,7 @@
   "docs-nav-erc-721": "ERC-721: NFTs",
   "docs-nav-erc-777": "ERC-777",
   "docs-nav-erc-1155": "ERC-1155",
+  "docs-nav-erc-4626": "ERC-4626",
   "docs-nav-ethereum-client-apis": "Ethereum client APIs",
   "docs-nav-ethereum-client-apis-description": "Convenience libraries that allow your web app to interact with Ethereum and smart contracts",
   "docs-nav-ethereum-stack": "Ethereum stack",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
In this pull request, I did the following:
- Edited the "Token standards" page by adding ERC-4626 to the list of token standards.
- I created a blog page in the `ERC-4626` folder as `index.md`
- And I wrote a blog post to summarize it.

## Related Issue
This pull request is related to #6255
