### PR TITLE
update testnet url for setting up light node docs

### DIFF
--- a/src/content/developers/tutorials/run-light-node-geth/index.md
+++ b/src/content/developers/tutorials/run-light-node-geth/index.md
@@ -77,7 +77,7 @@ This console allows direct interaction with Ethereum. For example, running the `
 
 Geth runs your node on [Ethereum Mainnet](/glossary/#mainnet) by default.
 
-It is also possible to use Geth to run a node on one of the [public test networks](/networks/#testnets), by running one of the following commands in Terminal:
+It is also possible to use Geth to run a node on one of the [public test networks](/developers/docs/networks/#ethereum-testnets), by running one of the following commands in Terminal:
 
 ```bash
 geth --syncmode light --ropsten


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The testnet URL in the `run-light-node-geth` docs is no longer directing to the correct path of the document. Updating the url to point to the latest testnet section.
<!--- Describe your changes in detail -->

## Related Issue
[Fixes #6148]
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
