### PR TITLE
Layout patch [Fixes #6228]

### DIFF
--- a/src/components/CardList.js
+++ b/src/components/CardList.js
@@ -36,7 +36,6 @@ const ItemLink = styled(Link)`
   padding: 1rem;
   width: 100%;
   color: #000000;
-  margin-bottom: 1rem;
   &:hover {
     border-radius: 4px;
     box-shadow: 0 0 1px ${(props) => props.theme.colors.primary};

--- a/src/components/Staking/StakingGuides.js
+++ b/src/components/Staking/StakingGuides.js
@@ -1,8 +1,15 @@
 // Libraries
 import React from "react"
+import styled from "styled-components"
 
 // Components
 import CardList from "../CardList"
+
+const StyledCardList = styled(CardList)`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`
 
 const StakingGuides = () => {
   const guides = [
@@ -23,7 +30,7 @@ const StakingGuides = () => {
     },
   ]
 
-  return <CardList content={guides} />
+  return <StyledCardList content={guides} />
 }
 
 export default StakingGuides


### PR DESCRIPTION
## Description
Removes `margin-bottom` from `CardList.js`, and custom adds back a 1rem gap for the staking guides list specifically.

## Related Issue
[Fixes #6228]