### PR TITLE
'View in English' Button Link Fixed [Solves #6318]

### DIFF
--- a/src/components/TranslationBanner.js
+++ b/src/components/TranslationBanner.js
@@ -144,7 +144,7 @@ const TranslationBanner = ({
             </div>
             {!isPageContentEnglish && (
               <div>
-                <SecondaryButtonLink isSecondary to={`${originalPagePath}`}>
+                <SecondaryButtonLink isSecondary to="/en/developers/">
                   <Translation id="translation-banner-button-see-english" />
                 </SecondaryButtonLink>
               </div>

--- a/src/components/TranslationBanner.js
+++ b/src/components/TranslationBanner.js
@@ -144,7 +144,7 @@ const TranslationBanner = ({
             </div>
             {!isPageContentEnglish && (
               <div>
-                <SecondaryButtonLink isSecondary to={`/en${ originalPagePath}`}>
+                <SecondaryButtonLink isSecondary to={`/en${originalPagePath}`}>
                   <Translation id="translation-banner-button-see-english" />
                 </SecondaryButtonLink>
               </div>

--- a/src/components/TranslationBanner.js
+++ b/src/components/TranslationBanner.js
@@ -144,7 +144,7 @@ const TranslationBanner = ({
             </div>
             {!isPageContentEnglish && (
               <div>
-                <SecondaryButtonLink isSecondary to="/en/developers/">
+                <SecondaryButtonLink isSecondary to={`${"/en" + originalPagePath}`}>
                   <Translation id="translation-banner-button-see-english" />
                 </SecondaryButtonLink>
               </div>

--- a/src/components/TranslationBanner.js
+++ b/src/components/TranslationBanner.js
@@ -144,7 +144,7 @@ const TranslationBanner = ({
             </div>
             {!isPageContentEnglish && (
               <div>
-                <SecondaryButtonLink isSecondary to={`${"/en" + originalPagePath}`}>
+                <SecondaryButtonLink isSecondary to={`/en${ originalPagePath}`}>
                   <Translation id="translation-banner-button-see-english" />
                 </SecondaryButtonLink>
               </div>


### PR DESCRIPTION
## Description

- Fixed the bug in the `View In English Button` (href).
- Changed `originalPagePath` to `/en/developers/`.  

## Related Issue
- Related to [#6318].
