### PR TITLE
Avoid loading matomo in preview deploys

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -9,7 +9,7 @@ const ignoreContent = (process.env.IGNORE_CONTENT || "")
   .split(",")
   .filter(Boolean)
 
-const isPreviewDelpoy = process.env.GATSBY_IS_PREVIEW === "true"
+const isPreviewDeploy = process.env.GATSBY_CLOUD === "true"
 
 const ignoreTranslations = Object.keys(allLanguages)
   .filter((lang) => !supportedLanguages.includes(lang))
@@ -232,7 +232,7 @@ const config = {
 
 // Avoid loading Matomo in preview deploys since NODE_ENV is `production` in
 // there and it will send testing data as production otherwise
-if (!isPreviewDelpoy) {
+if (!isPreviewDeploy) {
   config.plugins = [
     ...config.plugins,
     // Matomo analtyics

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -9,11 +9,13 @@ const ignoreContent = (process.env.IGNORE_CONTENT || "")
   .split(",")
   .filter(Boolean)
 
+const isPreviewDelpoy = process.env.GATSBY_IS_PREVIEW === "true"
+
 const ignoreTranslations = Object.keys(allLanguages)
   .filter((lang) => !supportedLanguages.includes(lang))
   .map((lang) => `**/translations\/${lang}`)
 
-module.exports = {
+const config = {
   siteMetadata: {
     // `title` & `description` pulls from respective ${lang}.json files in PageMetadata.js
     title: `ethereum.org`,
@@ -52,19 +54,6 @@ module.exports = {
         theme_color: `#222222`,
         display: `standalone`,
         icon: `src/assets/favicon.png`,
-      },
-    },
-    // Matomo analtyics
-    {
-      resolve: "gatsby-plugin-matomo",
-      options: {
-        siteId: "4",
-        matomoUrl: "https://matomo.ethereum.org",
-        siteUrl,
-        matomoPhpScript: "matomo.php",
-        matomoJsScript: "matomo.js",
-        trackLoad: false,
-        // dev: true,
       },
     },
     // Sitemap generator (ethereum.org/sitemap.xml)
@@ -240,3 +229,25 @@ module.exports = {
     FAST_DEV: true, // DEV_SSR, QUERY_ON_DEMAND & LAZY_IMAGES
   },
 }
+
+// Avoid loading Matomo in preview deploys since NODE_ENV is `production` in
+// there and it will send testing data as production otherwise
+if (!isPreviewDelpoy) {
+  config.plugins = [
+    ...config.plugins,
+    // Matomo analtyics
+    {
+      resolve: "gatsby-plugin-matomo",
+      options: {
+        siteId: "4",
+        matomoUrl: "https://matomo.ethereum.org",
+        siteUrl,
+        matomoPhpScript: "matomo.php",
+        matomoJsScript: "matomo.js",
+        trackLoad: false,
+      },
+    },
+  ]
+}
+
+module.exports = config

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -9,7 +9,7 @@ const ignoreContent = (process.env.IGNORE_CONTENT || "")
   .split(",")
   .filter(Boolean)
 
-const isPreviewDeploy = process.env.GATSBY_CLOUD === "true"
+const isGatsbyCloud = process.env.GATSBY_CLOUD === "true"
 
 const ignoreTranslations = Object.keys(allLanguages)
   .filter((lang) => !supportedLanguages.includes(lang))
@@ -230,9 +230,9 @@ const config = {
   },
 }
 
-// Avoid loading Matomo in preview deploys since NODE_ENV is `production` in
+// Avoid loading Matomo in Gatsby Cloud envs since NODE_ENV is `production` in
 // there and it will send testing data as production otherwise
-if (!isPreviewDeploy) {
+if (!isGatsbyCloud) {
   config.plugins = [
     ...config.plugins,
     // Matomo analtyics


### PR DESCRIPTION
We are sending testing data from our preview deploys to Matomo because the plugin sends data when `NODE_ENV === 'production'`.
Ref. https://support.gatsbyjs.com/hc/en-us/articles/360052322954-Environment-Variables-Specific-to-Gatsby-Cloud.

## Description
Since we don't have control over these conditions in the plugin, we are not going to load the plugin when `GATSBY_CLOUD === 'true'`.

So, the end state of this is the following:
- In prod (Netlify), `NODE_ENV='production' & GATSBY_CLOUD=undefined` => will load Matomo normally
- In preview deploys, `NODE_ENV='production' & GATSBY_CLOUD='true'` => will NOT load Matomo
- In dev, `NODE_ENV='dev'` => will load Matomo but the plugin handles this case. It will not send any data in dev mode

## Related Issue

#5998 
