### PR TITLE
fix: remove /*/grants/ redirect to avoid loop

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -200,10 +200,6 @@
     "toPath": "/en/community/grants/"
   },
   {
-    "fromPath": "/*/grants/",
-    "toPath": "/:splat/community/grants"
-  },
-  {
     "fromPath": "/no/*",
     "toPath": "/nb/:splat"
   },


### PR DESCRIPTION
This PR fixes the redirect loop from `/en/community/grants/`
