### PR TITLE
Add ETH SD to list of meetups

### DIFF
--- a/src/data/community-meetups.json
+++ b/src/data/community-meetups.json
@@ -228,6 +228,12 @@
     "link": "https://www.meetup.com/Blockchain-and-Brews/"
   },
   {
+    "title": "ETH SD",
+    "emoji": ":us:",
+    "location": "San Diego",
+    "link": "https://withkoji.com/@ethsd"
+  },
+  {
     "title": "SF Ethereum Developers",
     "emoji": ":us:",
     "location": "SF/ Bay Area",


### PR DESCRIPTION
## Description

This PR adds the [ETH SD](https://withkoji.com/@ethsd) meetup group to the list of meetups.

ETH SD is dedicated to creating a diverse community of web3 engineers, creatives, and builders in San Diego 🏄 
