### PR TITLE
Fixed spelling of Optimisic Kovan on Networks page [Solves #6404]

### DIFF
--- a/src/content/developers/docs/networks/index.md
+++ b/src/content/developers/docs/networks/index.md
@@ -73,7 +73,7 @@ A proof-of-authority testnet for those running OpenEthereum clients.
 - [Chainlink faucet](https://faucets.chain.link/)
 - [Paradigm faucet](https://faucet.paradigm.xyz/)
 
-#### Optimisic Kovan {#optimistic-kovan}
+#### Optimistic Kovan {#optimistic-kovan}
 
 A testnet for [Optimism](https://www.optimism.io/).
 


### PR DESCRIPTION
## Description
- Changed `Optimisic Kovan` to `Optimistic Kovan`. 

## Related Issue
Related to #6404 
