### PR TITLE
Fixed common spelling of DEX [Fixes #6405]

### DIFF
--- a/src/intl/en/page-get-eth.json
+++ b/src/intl/en/page-get-eth.json
@@ -45,7 +45,7 @@
   "page-get-eth-swapping": "Swap your tokens for other people's ETH. And vice versa.",
   "page-get-eth-traditional-currencies": "Buy with traditional currencies",
   "page-get-eth-traditional-payments": "Buy ETH with traditional payment types directly from sellers.",
-  "page-get-eth-try-dex": "Try a Dex",
+  "page-get-eth-try-dex": "Try a DEX",
   "page-get-eth-use-your-eth": "Use your ETH",
   "page-get-eth-use-your-eth-dapps": "Now that you own some ETH, check out some Ethereum applications (dapps). There are dapps for finance, social media, gaming and lots of other categories.",
   "page-get-eth-wallet-instructions": "Follow wallet instructions",


### PR DESCRIPTION
## Description
- Changed `Try a Dex` to `Try a DEX`. 

## Related Issue
- Related to [#6405]
