### PR TITLE
Updated link to testnet 'in node as a service article', fixes #6384

### DIFF
--- a/src/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
+++ b/src/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
@@ -18,7 +18,7 @@ If you don't already have an understanding of what nodes and clients are, check 
 
 Node service providers run distributed node clients behind the scenes for you, so you don't have to.
 
-These services typically provide an API key that you can use to write to and read from the blockchain. They often include access to [Ethereum testnets](/developers/docs/networks/#testnets) in addition to Mainnet.
+These services typically provide an API key that you can use to write to and read from the blockchain. They often include access to [Ethereum testnets](/developers/docs/networks/#ethereum-testnets) in addition to Mainnet.
 
 Some services offer you your own dedicated node that they manage for you, while others use load balancers to distribute activity across nodes.
 
@@ -223,7 +223,7 @@ Here is a list of some of the most popular Ethereum node providers, feel free to
     - Unlimited TX fee and infinite Gas for sending transactions
     - Fastest getting of the new block and reading of the blockchain
     - The best price per API call guarantee
- 
+
 ## Further reading {#further-reading}
 
 - [List of Ethereum node services](https://ethereumnodes.com/)


### PR DESCRIPTION
## Description
Changed "Ethereum Testnets" link on [this article](https://ethereum.org/en/developers/docs/nodes-and-clients/nodes-as-a-service/) to reference `/developers/docs/networks/#ethereum-testnets` instead of `/developers/docs/networks/#testnets`.

## Related Issue
Issue contains reproducibility steps - #6384 