### PR TITLE
Fixes grammar on mining algorithms page

### DIFF
--- a/src/content/developers/docs/consensus-mechanisms/pow/mining-algorithms/index.md
+++ b/src/content/developers/docs/consensus-mechanisms/pow/mining-algorithms/index.md
@@ -5,7 +5,7 @@ lang: en
 sidebar: true
 ---
 
-Ethereum mining has used two mining algorithms, Dagger Hashimoto and Ethash. Dagger Hashimoto was never used to mine Ethereum, being superseded by Ethash before mainet launched. It was a R&D minign algorithm that paved the way for Ethash. However, it has historical significance as an important innovation in Ethereum's development. Proof-of-work mining itself will be deprecated in favor of proof-of-stake during [The Merge](/merge/), which is forecast to happen in Q3-Q4 2022. 
+Ethereum mining has used two mining algorithms, Dagger Hashimoto and Ethash. Dagger Hashimoto was never used to mine Ethereum, being superseded by Ethash before mainet launched. It was a R&D mining algorithm that paved the way for Ethash. However, it has historical significance as an important innovation in Ethereum's development. Proof-of-work mining itself will be deprecated in favor of proof-of-stake during [The Merge](/merge/), which is forecast to happen in Q3-Q4 2022. 
 
 The fundamental idea of both mining algorithms is that a miner tries to find a nonce input using brute force computation so that the result is below a certain difficulty threshold. This difficulty threshold can be dynamically adjusted, allowing block production to happen at a regular interval.
 


### PR DESCRIPTION
Fixes the opening sentence to enhance readability and coherence by removing the second usage of 'to'. Corrects misspelling of the word 'mining'

