### PR TITLE
Staking product attribute indicator bug fix

### DIFF
--- a/src/components/Staking/StakingProductsCardGrid.js
+++ b/src/components/Staking/StakingProductsCardGrid.js
@@ -181,7 +181,6 @@ const StakingProductCard = ({
     svgPath,
     color,
     url,
-    socials,
     platforms,
     ui,
     minEth,
@@ -190,6 +189,8 @@ const StakingProductCard = ({
     bugBounty,
     battleTested,
     trustless,
+    selfCustody,
+    liquidityToken,
     permissionless,
     permissionlessNodes,
     multiClient,
@@ -235,6 +236,14 @@ const StakingProductCard = ({
     {
       label: <Translation id="page-staking-considerations-saas-7-title" />,
       status: diverseClients,
+    },
+    {
+      label: <Translation id="page-staking-considerations-solo-8-title" />,
+      status: selfCustody,
+    },
+    {
+      label: <Translation id="page-staking-considerations-pools-8-title" />,
+      status: liquidityToken,
     },
     {
       label: <Translation id="page-staking-considerations-solo-9-title" />,
@@ -415,13 +424,11 @@ const StakingProductCardGrid = ({ category }) => {
     audits,
     hasBugBounty,
     launchDate,
-    isTrustless,
   }) => ({
     openSource: getFlagFromBoolean(isFoss),
     audited: getFlagFromBoolean(audits?.length),
     bugBounty: getFlagFromBoolean(hasBugBounty),
     battleTested: getBattleTestedFlag(launchDate),
-    trustless: getFlagFromBoolean(isTrustless),
   })
 
   useEffect(() => {
@@ -435,11 +442,12 @@ const StakingProductCardGrid = ({ category }) => {
           ...getBrandProperties(listing),
           ...getTagProperties(listing),
           ...getSharedSecurityProperties(listing),
+          trustless: getFlagFromBoolean(listing.isTrustless),
           permissionlessNodes: getFlagFromBoolean(
             listing.hasPermissionlessNodes
           ),
           diverseClients: getDiversityOfClients(listing.pctMajorityClient),
-          selfCustody: getFlagFromBoolean(listing.tokens?.length),
+          liquidityToken: getFlagFromBoolean(listing.tokens?.length),
           minEth: listing.minEth,
         }))
       )
@@ -452,6 +460,7 @@ const StakingProductCardGrid = ({ category }) => {
           ...getBrandProperties(listing),
           ...getTagProperties(listing),
           ...getSharedSecurityProperties(listing),
+          trustless: getFlagFromBoolean(listing.isTrustless),
           permissionless: getFlagFromBoolean(listing.isPermissionless),
           multiClient: getFlagFromBoolean(listing.multiClient),
           selfCustody: getFlagFromBoolean(true),


### PR DESCRIPTION
## Issue
`/staking/saas`
- Currently these are all listed with a ❌Trustless indicator
- All of these are considered "trusted" setups, since the service operates your validator for you, so this tag should not be present for this category
- Also, "Self custody" is listed in the "What to consider" section, but is not listed on the cards themselves.

`/staking/pools`
- The "What to consider" section mentioned "liquidity token" but this property never got added to the product cards themselves, leaving eight considerations defined, but only seven listed on the cards.
- Note, "liquidity token" takes the place of "self custody" for the pooled options.

## Fix
- Removed the "Trustless" indicator from the SaaS cards
- Added "Self custody" indicator for "SaaS" cards 
- Added "Liquidity token" indicator for "Pool" cards
- (indicators on cards should now match list from section above it)