### PR TITLE
Update ETH SF to Graph Day

### DIFF
--- a/src/data/community-events.json
+++ b/src/data/community-events.json
@@ -162,11 +162,11 @@
     "endDate": "2022-06-30"
   },
   {
-    "title": "ETH SF",
-    "to": "https://airtable.com/shrZ89OEwQJRtXHPv/",
+    "title": "Graph Day & Graph Hack",
+    "to": "https://thegraph.com/graph-day/2022/",
     "sponsor": null,
     "location": "San Francisco, USA",
-    "description": "The energy and excitement at the first ETHSanFrancisco will be hard to top, but we have our eyes set on delivering an even more impactful experience.",
+    "description": "Join the world’s brightest dreamers & doers for a full day focused on web3, dapps, protocols, and the future of the internet. A three-day hackathon will follow immediately afterwards.",
     "startDate": "2022-06-02",
     "endDate": "2022-06-05"
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Changed June ETH SF to Graph Day / Hack

Background:
**ETHSanFrancisco** is happening on November 4-6, 2022. https://sf.ethglobal.com/
**Graph Day** is happening on June 2, 2022 (plus **Graph Hack** June 3-5, 2022) in SF. https://thegraph.com/graph-day/2022/
**ETH SF** is currently listed as happening on June 2-5, 2022. https://ethereum.org/en/community/events/

I could not find evidence of ETH SF happening during June 2-5, 2022 on any official event sites(?)

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
