### PR TITLE
Fix lang:en -> lang:ro in Romanian docs

### DIFF
--- a/src/content/translations/ro/developers/docs/programming-languages/ruby/index.md
+++ b/src/content/translations/ro/developers/docs/programming-languages/ruby/index.md
@@ -1,7 +1,7 @@
 ---
 title: Ethereum for Ruby Developers
 description: Learn how to develop for Ethereum using Ruby-based projects and tooling.
-lang: en
+lang: ro
 sidebar: true
 incomplete: false
 ---

--- a/src/content/translations/ro/developers/tutorials/nft-minter/index.md
+++ b/src/content/translations/ro/developers/tutorials/nft-minter/index.md
@@ -13,7 +13,7 @@ tags:
   - "wallet (portofel)"
   - "Pinata"
 skill: intermediar
-lang: en
+lang: ro
 sidebar: true
 published: 2021-10-06
 ---

--- a/src/content/translations/ro/developers/tutorials/optimism-std-bridge-annotated-code/index.md
+++ b/src/content/translations/ro/developers/tutorials/optimism-std-bridge-annotated-code/index.md
@@ -10,7 +10,7 @@ tags:
   - "layer 2 (nivel 2)"
 skill: intermediar
 published: 2022-03-30
-lang: en
+lang: ro
 ---
 
 [Optimism](https://www.optimism.io/) is an [Optimistic Rollup](/developers/docs/scaling/optimistic-rollups/). Optimistic rollups can process transactions for a much lower price than Ethereum Mainnet (also known as layer 1 or L1) because transactions are only processed by a few nodes, instead of every node on the network. At the same time, the data is all written to L1 so everything can be proved and reconstructed with all the integrity and availability guarantees of Mainnet.


### PR DESCRIPTION
## Description
Fix incorrect Romanian lang paths.

## Related Issue
Closes #6471