### PR TITLE
Add `hyphens` settings to tables [Fixes #6268]

### DIFF
--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -419,6 +419,10 @@ table {
   border-collapse: collapse;
   width: 100%;
 }
+th,
+td {
+  hyphens: auto;
+}
 fieldset {
   margin-left: 0;
   margin-right: 0;


### PR DESCRIPTION
Before:
<img width="385" alt="ScreenShot 2022-05-29 22 25 54" src="https://user-images.githubusercontent.com/10495516/170871231-db5176a9-9559-41c7-b6ff-a8fed1a4d12a.png">

After:
<img width="380" alt="ScreenShot 2022-05-29 22 25 12" src="https://user-images.githubusercontent.com/10495516/170871209-4a8c8b4a-1c2e-4019-95da-af0711d92ae6.png">


## Description

When viewed on a small screen such as iPhone 8, the layout of a table may be broken for languages with long words such as German.
This can be solved by adding the setting `hyphens: auto;` to the `th` and `td` elements of the `table`.

## Related Issue

#6268