### PR TITLE
Fix notation shaking ether -> ETH

### DIFF
--- a/src/content/developers/docs/intro-to-ethereum/index.md
+++ b/src/content/developers/docs/intro-to-ethereum/index.md
@@ -51,7 +51,7 @@ The amount of ether paid corresponds to the time required to do the computation.
 
 In practice, participants don't write new code every time they want to request a computation on the EVM. Rather, application developers upload programs (reusable snippets of code) into EVM state, and users make requests to execute these code snippets with varying parameters. We call the programs uploaded to and executed by the network smart contracts.
 
-At a very basic level, you can think of a smart contract like a sort of vending machine: a script that, when called with certain parameters, performs some actions or computation if certain conditions are satisfied. For example, a simple vendor smart contract could create and assign ownership of a digital asset if the caller sends ether to a specific recipient.
+At a very basic level, you can think of a smart contract like a sort of vending machine: a script that, when called with certain parameters, performs some actions or computation if certain conditions are satisfied. For example, a simple vendor smart contract could create and assign ownership of a digital asset if the caller sends ETH to a specific recipient.
 
 Any developer can create a smart contract and make it public to the network, using the blockchain as its data layer, for a fee paid to the network. Any user can then call the smart contract to execute its code, again for a fee paid to the network.
 
@@ -65,7 +65,7 @@ The sequence of all blocks that have been committed to the Ethereum network in t
 
 ### ETH {#eth}
 
-The native cryptocurrency of Ethereum. Users pay ether to other users to have their code execution requests fulfilled.
+The native cryptocurrency of Ethereum. Users pay ETH to other users to have their code execution requests fulfilled.
 
 [More on ETH](/developers/docs/intro-to-ether/)
 
@@ -83,7 +83,7 @@ The real-life machines which are storing the EVM state. Nodes communicate with e
 
 ### Accounts {#accounts}
 
-Where ether is stored. Users can initialize accounts, deposit ether into the accounts, and transfer ether from their accounts to other users. Accounts and account balances are stored in a big table in the EVM; they are a part of the overall EVM state.
+Where ETH is stored. Users can initialize accounts, deposit ETH into the accounts, and transfer ETH from their accounts to other users. Accounts and account balances are stored in a big table in the EVM; they are a part of the overall EVM state.
 
 [More on accounts](/developers/docs/accounts/)
 
@@ -91,7 +91,7 @@ Where ether is stored. Users can initialize accounts, deposit ether into the acc
 
 A "transaction request" is the formal term for a request for code execution on the EVM, and a "transaction" is a fulfilled transaction request and the associated change in the EVM state. Any user can broadcast a transaction request to the network from a node. For the transaction request to affect the agreed-upon EVM state, it must be validated, executed, and "committed to the network" by another node. Execution of any code causes a state change in the EVM; upon commitment, this state change is broadcast to all nodes in the network. Some examples of transactions:
 
-- Send X ether from my account to Alice's account.
+- Send X ETH from my account to Alice's account.
 - Publish some smart contract code into EVM state.
 - Execute the code of the smart contract at address X in the EVM, with arguments Y.
 

--- a/src/content/developers/docs/intro-to-ethereum/index.md
+++ b/src/content/developers/docs/intro-to-ethereum/index.md
@@ -65,7 +65,7 @@ The sequence of all blocks that have been committed to the Ethereum network in t
 
 ### ETH {#eth}
 
-Ether (ETH) is the native cryptocurrency of Ethereum. Users pay ETH to other users to have their code execution requests fulfilled.
+**Ether (ETH)** is the native cryptocurrency of Ethereum. Users pay ETH to other users to have their code execution requests fulfilled.
 
 [More on ETH](/developers/docs/intro-to-ether/)
 

--- a/src/content/developers/docs/intro-to-ethereum/index.md
+++ b/src/content/developers/docs/intro-to-ethereum/index.md
@@ -65,7 +65,7 @@ The sequence of all blocks that have been committed to the Ethereum network in t
 
 ### ETH {#eth}
 
-The native cryptocurrency of Ethereum. Users pay ETH to other users to have their code execution requests fulfilled.
+Ether (ETH) is the native cryptocurrency of Ethereum. Users pay ETH to other users to have their code execution requests fulfilled.
 
 [More on ETH](/developers/docs/intro-to-ether/)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed a notation shaking in the documentation to be consistent with ETH.
https://ethereum.org/ja/developers/docs/intro-to-ethereum/

The chapter "What is ether?" has been excluded.

