### PR TITLE
Fix SVGs on run-a-node page [Fixes #6545]

### DIFF
--- a/src/components/ExpandableCard.js
+++ b/src/components/ExpandableCard.js
@@ -93,7 +93,7 @@ const ExpandableCard = ({
   children,
   contentPreview,
   title,
-  Svg,
+  svg: Svg,
   alt,
   eventCategory,
   eventName,


### PR DESCRIPTION
## Description
Fixes casing for SVG being passed on run-a-node page.

## Related Issue
[Fixes #6545]