### PR TITLE
fix(banner-notification): type check error on docs template

### DIFF
--- a/src/components/BannerNotification.tsx
+++ b/src/components/BannerNotification.tsx
@@ -6,7 +6,7 @@ export interface IStyledBanner {
 }
 
 export interface IProps {
-  shouldShow?: boolean
+  shouldShow?: boolean | null
   className?: string
 }
 
@@ -31,10 +31,13 @@ const BannerNotification: React.FC<IProps> = ({
   children,
   className,
   shouldShow = false,
-}) => (
-  <Banner shouldShow={shouldShow} className={className}>
-    {children}
-  </Banner>
-)
+}) => {
+  const shouldShowAssign: boolean = shouldShow || false
+  return (
+    <Banner shouldShow={shouldShowAssign} className={className}>
+      {children}
+    </Banner>
+  )
+}
 
 export default BannerNotification

--- a/src/components/BannerNotification.tsx
+++ b/src/components/BannerNotification.tsx
@@ -6,7 +6,7 @@ export interface IStyledBanner {
 }
 
 export interface IProps {
-  shouldShow?: boolean | null
+  shouldShow?: boolean
   className?: string
 }
 
@@ -31,13 +31,10 @@ const BannerNotification: React.FC<IProps> = ({
   children,
   className,
   shouldShow = false,
-}) => {
-  const shouldShowAssign: boolean = shouldShow || false
-  return (
-    <Banner shouldShow={shouldShowAssign} className={className}>
-      {children}
-    </Banner>
-  )
-}
+}) => (
+  <Banner shouldShow={shouldShow} className={className}>
+    {children}
+  </Banner>
+)
 
 export default BannerNotification


### PR DESCRIPTION
## Description

The boolean passed from docs template to banner notification component
has an issue when the variable passed is null. The interface of the
banner props has shouldShow declared as boolean or undefined. To prevent
each component to check against null to boolean, the check is made
internally inside the banner component and shouldShow is declared as
boolean or null or undefined.

## Related Issue

Related to : #6392 
