### PR TITLE
Fix ordering of data-strctures-and-encoding docs

### DIFF
--- a/src/data/developer-docs-links.yaml
+++ b/src/data/developer-docs-links.yaml
@@ -206,9 +206,9 @@
       to: /developers/docs/data-structures-and-encoding/
       description: docs-nav-data-structures-and-encoding-description
       items:
-        - id: docs-nav-data-structures-and-encoding-rlp
-          to: /developers/docs/data-structures-and-encoding/rlp/
         - id: docs-nav-data-structures-and-encoding-patricia-merkle-trie
           to: /developers/docs/data-structures-and-encoding/patricia-merkle-trie/
+        - id: docs-nav-data-structures-and-encoding-rlp
+          to: /developers/docs/data-structures-and-encoding/rlp/
         - id: docs-nav-data-structures-and-encoding-ssz
           to: /developers/docs/data-structures-and-encoding/ssz/


### PR DESCRIPTION
## Description
https://ethereum.org/en/developers/docs/data-structures-and-encoding/
- Aligns the order of the dev docs within the `data-strctures-and-encoding` path to match the root markdown page
