### PR TITLE
Remove incomplete frontmatter

### DIFF
--- a/src/content/developers/docs/scaling/sidechains/index.md
+++ b/src/content/developers/docs/scaling/sidechains/index.md
@@ -3,7 +3,6 @@ title: Sidechains
 description: An introduction to sidechains as a scaling solution currently utilized by the Ethereum community.
 lang: en
 sidebar: true
-incomplete: true
 sidebarDepth: 3
 ---
 

--- a/src/content/developers/docs/scaling/validium/index.md
+++ b/src/content/developers/docs/scaling/validium/index.md
@@ -3,7 +3,6 @@ title: Validium
 description: An introduction to Validium as a scaling solution currently utilized by the Ethereum community.
 lang: en
 sidebar: true
-incomplete: true
 sidebarDepth: 3
 ---
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Remove UI banner from sidechains & validium pages:

> This page is incomplete and we'd love your help. Edit this page and add anything that you think might be useful to others.

Thanks to recent PRs from @emmanuel-awosika, we've recently added a good amount of info to both pages:
- https://github.com/ethereum/ethereum-org-website/pull/6508
- https://github.com/ethereum/ethereum-org-website/pull/6502

Doesn't mean we can't expand/edit further in the future, but I think they're to a point where they don't really need that flag anymore.

## Related Issue
- https://github.com/ethereum/ethereum-org-website/pull/6508
- https://github.com/ethereum/ethereum-org-website/pull/6502