### PR TITLE
TS migrate asset download

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
   "scripts": {
     "build": "gatsby build",
     "build:lambda": "netlify-lambda build src/lambda",
+    "clean": "gatsby clean",
     "copy-contributors": "node src/scripts/copy-contributors.js",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "generate-heading-ids": "node src/scripts/generate-heading-ids.js",

--- a/src/assets.d.ts
+++ b/src/assets.d.ts
@@ -1,0 +1,5 @@
+declare module "*.svg" {
+  import { ReactElement, SVGProps } from "react"
+  const content: (props: SVGProps<SVGElement>) => ReactElement
+  export default content
+}

--- a/src/components/AssetDownload.tsx
+++ b/src/components/AssetDownload.tsx
@@ -7,7 +7,31 @@ import ButtonLink from "./ButtonLink"
 import Emoji from "./Emoji"
 import Link from "./Link"
 
-const Container = styled.div`
+export interface IHide {
+  shouldHide: boolean
+}
+
+export interface IPropsBase {
+  alt: string
+  artistName?: string
+  artistUrl?: string
+  src?: string
+  shouldHide?: boolean
+  title: string
+}
+
+interface IPropsWithSVG extends IPropsBase {
+  svg: React.FC<React.SVGProps<SVGSVGElement> & { alt: string }>
+  image?: never
+}
+interface IPropsWithImage extends IPropsBase {
+  svg?: never
+  image: string
+}
+
+export type IProps = IPropsWithImage | IPropsWithSVG
+
+const Container = styled.div<IHide>`
   flex: 1 1 45%;
   display: flex;
   flex-direction: column;
@@ -58,7 +82,7 @@ const ButtonContainer = styled.div`
 `
 
 // TODO add ability to download SVGs
-const AssetDownload = ({
+const AssetDownload: React.FC<IProps> = ({
   alt,
   artistName,
   artistUrl,

--- a/src/components/Emoji.tsx
+++ b/src/components/Emoji.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components"
 import { margin, MarginProps } from "styled-system"
 
 export interface IProps extends MarginProps {
-  size: number
+  size?: number
   text: string
 }
 


### PR DESCRIPTION
## Description

Migrate `AssetDownload` to typescript. The component is massively used in the page `assets`.

## Explaination

### Props
Either you have a `svg` or `image`. But we can never have both in the same time from the logic inside the component and the way of this component being used in `pages/assets.js`. That's the purpose of `IPropsWithSVG` and `IPropsWithImage`.

### Declare svg module
importing a svg in React cause the typescript compiler to raise an error : "Could not find module...". svg are not React component so we have to define a module that export it as a React component. That's the purpose of `assets.d.ts`. For the next coming assets file, we can import them as a module in this file.

## Extra

Added a clean command in `package.json` if there are issues related to schema namespace or seg fault compiler error. `.env` parameters `GATSBY_BUILD_LANGS` and `IGNORE_CONTENT` are not enough sometimes.

## Related Issue

Fix: #6626 
Refs: #6392 

