### PR TITLE
Fix links from compiling contracts -> evm across all translations

### DIFF
--- a/src/content/developers/docs/smart-contracts/compiling/index.md
+++ b/src/content/developers/docs/smart-contracts/compiling/index.md
@@ -276,4 +276,4 @@ Below is the ABI for the ERC-20 token contract. An ERC-20 is a token you can tra
 ## Related topics {#related-topics}
 
 - [JavaScript client libraries](/developers/docs/apis/javascript/)
-- [Ethereum virtual machine](/developers/docs/ethereum-virtual-machine/)
+- [Ethereum virtual machine](/developers/docs/evm/)

--- a/src/content/translations/es/developers/docs/smart-contracts/compiling/index.md
+++ b/src/content/translations/es/developers/docs/smart-contracts/compiling/index.md
@@ -276,4 +276,4 @@ A continuación se muestra la ABI para el contrato de token ERC-20. Un ERC-20 es
 ## Temas relacionados {#related-topics}
 
 - [Bibliotecas de cliente de JavaScript](/developers/docs/apis/javascript/)
-- [Máquina virtual de Ehereum](/developers/docs/ethereum-virtual-machine/)
+- [Máquina virtual de Ehereum](/developers/docs/evm/)

--- a/src/content/translations/fr/developers/docs/smart-contracts/compiling/index.md
+++ b/src/content/translations/fr/developers/docs/smart-contracts/compiling/index.md
@@ -276,4 +276,4 @@ Vous trouverez ci-dessous l’ABI pour le contrat de jetons ERC-20. Un jeton ERC
 ## Sujets connexes {#related-topics}
 
 - [Bibliothèques clientes JavaScript](/developers/docs/apis/javascript/)
-- [Machine virtuelle Ethereum (EVM)](/developers/docs/ethereum-virtual-machine/)
+- [Machine virtuelle Ethereum (EVM)](/developers/docs/evm/)

--- a/src/content/translations/hu/developers/docs/smart-contracts/compiling/index.md
+++ b/src/content/translations/hu/developers/docs/smart-contracts/compiling/index.md
@@ -276,4 +276,4 @@ Lentebb van az ERC-20 token szerződés ABI-ja. Az ERC-20 egy token, mellyel az 
 ## Kapcsolódó témák {#related-topics}
 
 - [JavaScript kliens könyvtárak](/developers/docs/apis/javascript/)
-- [Ethereum virtuális gép](/developers/docs/ethereum-virtual-machine/)
+- [Ethereum virtuális gép](/developers/docs/evm/)

--- a/src/content/translations/id/developers/docs/smart-contracts/compiling/index.md
+++ b/src/content/translations/id/developers/docs/smart-contracts/compiling/index.md
@@ -276,4 +276,4 @@ Di bawah ini adalah ABI untuk kontrak token ERC-20. ERC-20 adalah token yang bis
 ## Topik terkait {#related-topics}
 
 - [Pustaka klien JavaScript](/developers/docs/apis/javascript/)
-- [Mesin virtual Ethereum](/developers/docs/ethereum-virtual-machine/)
+- [Mesin virtual Ethereum](/developers/docs/evm/)

--- a/src/content/translations/it/developers/docs/smart-contracts/compiling/index.md
+++ b/src/content/translations/it/developers/docs/smart-contracts/compiling/index.md
@@ -276,4 +276,4 @@ Di seguito è riportato l'ABI per il contratto token ERC-20. Un ERC-20 è un tok
 ## Argomenti correlati {#related-topics}
 
 - [Librerie client JavaScript](/developers/docs/apis/javascript/)
-- [Macchina virtuale Ethereum](/developers/docs/ethereum-virtual-machine/)
+- [Macchina virtuale Ethereum](/developers/docs/evm/)

--- a/src/content/translations/pl/developers/docs/smart-contracts/compiling/index.md
+++ b/src/content/translations/pl/developers/docs/smart-contracts/compiling/index.md
@@ -276,4 +276,4 @@ Poniżej znajduje się ABI dla kontraktu z tokenem ERC-20. ERC-20 to token, któ
 ## Powiązane tematy {#related-topics}
 
 - [Biblioteki JavaScript](/developers/docs/apis/javascript/)
-- [Maszyna Wirtualna Ethereum](/developers/docs/ethereum-virtual-machine/)
+- [Maszyna Wirtualna Ethereum](/developers/docs/evm/)

--- a/src/content/translations/pt-br/developers/docs/smart-contracts/compiling/index.md
+++ b/src/content/translations/pt-br/developers/docs/smart-contracts/compiling/index.md
@@ -276,4 +276,4 @@ Abaixo está a ABI para o contrato de token ERC-20. Um ERC-20 é um token que vo
 ## Tópicos relacionados {#related-topics}
 
 - [JavaScript client libraries](/developers/docs/apis/javascript/)
-- [Máquina virtual Ethereum](/developers/docs/ethereum-virtual-machine/)
+- [Máquina virtual Ethereum](/developers/docs/evm/)

--- a/src/content/translations/ro/developers/docs/smart-contracts/compiling/index.md
+++ b/src/content/translations/ro/developers/docs/smart-contracts/compiling/index.md
@@ -276,4 +276,4 @@ Mai jos este ABI-ul pentru contractul de token ERC-20. Un ERC-20 este un token p
 ## Subiecte corelate {#related-topics}
 
 - [JavaScript client libraries](/developers/docs/apis/javascript/)
-- [Mașina virtuală Ethereum](/developers/docs/ethereum-virtual-machine/)
+- [Mașina virtuală Ethereum](/developers/docs/evm/)

--- a/src/content/translations/tr/developers/docs/smart-contracts/compiling/index.md
+++ b/src/content/translations/tr/developers/docs/smart-contracts/compiling/index.md
@@ -276,4 +276,4 @@ Aşağıda ERC-20 token sözleşmesinin ABI'si bulunuyor. Bir ERC-20, Ethereum �
 ## İlgili konular {#related-topics}
 
 - [JavaScript istemci kütüphaneleri](/developers/docs/apis/javascript/)
-- [Ethereum sanal makinesi](/developers/docs/ethereum-virtual-machine/)
+- [Ethereum sanal makinesi](/developers/docs/evm/)

--- a/src/content/translations/zh/developers/docs/smart-contracts/compiling/index.md
+++ b/src/content/translations/zh/developers/docs/smart-contracts/compiling/index.md
@@ -276,4 +276,4 @@ Anchor Link Xpath: /ul[19]/li/a 文件： Decentralized Storage
 ## 相关主题 {#related-topics}
 
 - [JavaScript 客户端库](/developers/docs/apis/javascript/)
-- [以太坊虚拟机](/developers/docs/ethereum-virtual-machine/)
+- [以太坊虚拟机](/developers/docs/evm/)


### PR DESCRIPTION
## Description

Fixes link to the Ethereum Virtual Machine page from compiling contracts

## Related Issue

Fixes #6642 
