### PR TITLE
Add difficulty bomb info to frontier-thawing

### DIFF
--- a/src/content/history/index.md
+++ b/src/content/history/index.md
@@ -392,9 +392,10 @@ The Homestead fork that looked to the future. It included several protocol chang
 
 #### Summary {#frontier-thawing-summary}
 
-The frontier thawing fork lifted the 5,000 [gas](/glossary/#gas) limit per [block](/glossary/#block) and set the default gas price to 51 [gwei](/glossary/#gwei). This allowed for transactions – transactions require 21,000 gas.
+The frontier thawing fork lifted the 5,000 [gas](/glossary/#gas) limit per [block](/glossary/#block) and set the default gas price to 51 [gwei](/glossary/#gwei). This allowed for transactions – transactions require 21,000 gas. The [difficulty bomb](/glossary/#difficulty-bomb) was introduced to ensured a future hard-fork to [PoS](/glossary/#pos).
 
 [Read the Ethereum Foundation announcement](https://blog.ethereum.org/2015/08/04/the-thawing-frontier/)
+[Read the Ethereum Protocol Update 1](https://blog.ethereum.org/2015/08/04/ethereum-protocol-update-1/)
 
 ---
 

--- a/src/content/history/index.md
+++ b/src/content/history/index.md
@@ -392,7 +392,7 @@ The Homestead fork that looked to the future. It included several protocol chang
 
 #### Summary {#frontier-thawing-summary}
 
-The frontier thawing fork lifted the 5,000 [gas](/glossary/#gas) limit per [block](/glossary/#block) and set the default gas price to 51 [gwei](/glossary/#gwei). This allowed for transactions – transactions require 21,000 gas. The [difficulty bomb](/glossary/#difficulty-bomb) was introduced to ensured a future hard-fork to [PoS](/glossary/#pos).
+The frontier thawing fork lifted the 5,000 [gas](/glossary/#gas) limit per [block](/glossary/#block) and set the default gas price to 51 [gwei](/glossary/#gwei). This allowed for transactions – transactions require 21,000 gas. The [difficulty bomb](/glossary/#difficulty-bomb) was introduced to ensure a future hard-fork to [proof-of-stake](/glossary/#pos).
 
 [Read the Ethereum Foundation announcement](https://blog.ethereum.org/2015/08/04/the-thawing-frontier/)
 [Read the Ethereum Protocol Update 1](https://blog.ethereum.org/2015/08/04/ethereum-protocol-update-1/)


### PR DESCRIPTION
## Description

There seeems to be this misconception that eip-2 introduced the difficulty bomb.

> the client will calculate the difficulty based on a fake block number suggesting the client that the difficulty bomb is adjusting around 6 million blocks later than previously specified with the Homestead fork.

<https://github.com/ethereum/EIPs/pull/1234>

> Due to the "difficulty bomb" (also known as the "ice age"), introduced in EIP #2, an artificial exponential increase in difficulty until chain freeze,

<https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1227.md>

When looking into the homestead fork (specified in eip-2), it seems that the difficulty change has nothing to do with the difficulty bomb.  The difficulty bomb was introduced in the frontier-thawing fork.

> starting from block 200,000 (very roughly 17 days from now), the difficulty will undergo an exponential increase which will only become noticeable in about a year.

<https://blog.ethereum.org/2015/08/04/ethereum-protocol-update-1/>
> A [hard fork](https://ethereum.org/en/glossary/#hard-fork) of Ethereum at block 200,000 to introduce an exponential [difficulty](https://ethereum.org/en/glossary/#difficulty) increase (aka [difficulty bomb](https://ethereum.org/en/glossary/#difficulty-bomb)), motivating a transition to [proof-of-stake](https://ethereum.org/en/glossary/#pos).

<https://ethereum.org/en/glossary/#ice-age>

This information is already in the eth.org site at the ice-age glossary.  It's nice to have this at the history page.

There are 2 blog posts about the frontier-thawing fork.  This PR adds the link to the other one.