### PR TITLE
Update index.md

### DIFF
--- a/src/content/translations/es/developers/docs/index.md
+++ b/src/content/translations/es/developers/docs/index.md
@@ -7,7 +7,7 @@ sidebar: true
 
 Esta documentación está diseñada para ayudarte a construir con Ethereum. Cubre Ethereum como un concepto, explica la pila de tecnología de Ethereum, y documenta temas avanzados para aplicaciones y casos de uso más complejos.
 
-Este es un esfuerzo comunitario de código abierto, así que siéntete libre de sugerir nuevos temas, agregue nuevo contenido y proporcione ejemplos dondequiera que crea que puede ser útil. Toda la documentación puede editarse a través de GitHub - si no esta seguro/a de cómo hacerlo, [ siga estas instrucciones](https://github.com/ethereum/ethereum-org-website/tree/dev/docs/contributing/EDITING_MARKDOWN.md).
+Este es un esfuerzo comunitario de código abierto, así que siéntete libre de sugerir nuevos temas, agregue nuevo contenido y proporcione ejemplos dondequiera que crea que puede ser útil. Toda la documentación puede editarse a través de GitHub - si no esta seguro/a de cómo hacerlo, [ siga estas instrucciones](https://github.com/ethereum/ethereum-org-website/tree/dev/docs/contributing/editing-markdown.md).
 
 ## Módulos de desarrollo {#development-modules}
 


### PR DESCRIPTION
Broken link follow these instructions.

The link 'follow these instructions it is broken. Error 404 page not found.

## Description

Change URL link. I have changed upper case to lower case EDITING_MARKDOWN.md to editing-markdown.md

## Related Issue

Go to https://ethereum.org/es/developers/docs/
Click on: [siga estas instrucciones](https://github.com/ethereum/ethereum-org-website/tree/dev/docs/contributing/EDITING_MARKDOWN.md).
This is the broken link:
https://github.com/ethereum/ethereum-org-website/tree/dev/docs/contributing/EDITING_MARKDOWN.md
I have changed it to:
https://github.com/ethereum/ethereum-org-website/tree/dev/docs/contributing/editing-markdown.md
