### PR TITLE
Add ETHVietnam to community-events

### DIFF
--- a/src/data/community-events.json
+++ b/src/data/community-events.json
@@ -1,5 +1,14 @@
 [
   {
+    "title": "ETHVietnam",
+    "to": "https://www.eth-vietnam.com/",
+    "sponsor": null,
+    "location": "HoChiMinh City, Vietnam",
+    "description": "The Ethereum Vietnam is the largest & the first annual Vietnam Ethereum event focused on technology and community.",
+    "startDate": "2022-08-31",
+    "endDate": "2022-09-04"
+  },
+  {
     "title": "ETHDenver",
     "to": "https://www.ethdenver.com/",
     "sponsor": null,


### PR DESCRIPTION
    "title": "ETHVietnam",
    "to": "https://www.eth-vietnam.com/",
    "sponsor": null,
    "location": "HoChiMinh City, Vietnam",
    "description": "The Ethereum Vietnam is the largest & the first annual Vietnam Ethereum event focused on technology and community.",
    "startDate": "2022-08-31",
    "endDate": "2022-09-04"


## Description
ETHVIETNAM 2022 is the first blockchain
conference in Vietnam with the organizers
of global large-scale iconic blockchain and
cryptocurrency. Empowers participants to
shape this new world, while cementing the
Viet community as a thriving hub of
Ethereum and blockchain innovation

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
