### PR TITLE
improve grammar / clarity in `Token Standards` doc

### DIFF
--- a/src/content/developers/docs/standards/tokens/index.md
+++ b/src/content/developers/docs/standards/tokens/index.md
@@ -8,7 +8,7 @@ incomplete: true
 
 ## Introduction {#introduction}
 
-One of the many Ethereum development standards focus on token interfaces. These standards help ensure smart contracts remain composable, so for instance when a new project issues a token, that it remains compatible with existing decentralized exchanges.
+Many Ethereum development standards focus on token interfaces. These standards help ensure smart contracts remain composable, so for instance when a new project issues a token, that it remains compatible with existing decentralized exchanges.
 
 ## Prerequisites {#prerequisites}
 


### PR DESCRIPTION
## Description

existing text contained subject / verb number mismatch ("one standard focus on ...", rather than "one standard focuses on ...").

## ~Related Issue~

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
