### PR TITLE
Remove eth2 card

### DIFF
--- a/src/content/upgrades/merge/index.md
+++ b/src/content/upgrades/merge/index.md
@@ -207,6 +207,21 @@ The Merge is like changing an engine on a rocketship mid-flight and is designed 
 Ethereum does not have downtime.
 </ExpandableCard>
 
+## What happened to 'Eth2'? {#eth2}
+
+The term 'Eth2' has been deprecated as we approach The Merge.
+
+After merging 'Eth1' and 'Eth2' into a single chain, there will no longer be two distinct Ethereum networks; there will only be Ethereum.
+
+To limit confusion, the community has updated these terms:
+
+- 'Eth1' is now the 'execution layer', which handles transactions and execution.
+- 'Eth2' is now the 'consensus layer', which handles proof-of-stake consensus.
+
+These terminology updates only change naming conventions; this does not alter Ethereum's goals or roadmap.
+
+[Learn more about the 'Eth2' renaming](https://blog.ethereum.org/2022/01/24/the-great-eth2-renaming/)
+
 ## Relationship between upgrades {#relationship-between-upgrades}
 
 The Ethereum upgrades are all somewhat interrelated. So let’s recap how The Merge relates to the other upgrades.

--- a/src/intl/ar/common.json
+++ b/src/intl/ar/common.json
@@ -58,8 +58,6 @@
   "consensus-run-beacon-chain": "تشغيل عميل إجماع آراء",
   "consensus-run-beacon-chain-desc": "يحتاج إثيريوم إلى أكبر عدد ممكن من العملاء. ساعد إثيريوم للمصلحة العامة!",
   "consensus-when-shipping": "متى يتم الشحن؟",
-  "eth-upgrade-what-happened": "ماذا حدث لـ 'Eth2؟'",
-  "eth-upgrade-what-happened-description": "لقد تم التخلي عن مصطلح \"Eth2\" ونحن نقترب من الدمج. \"طبقة إجماع الآراء\" تلخص ما كان يعرف سابقاً باسم \"Eth2\".",
   "ethereum": "إثيريوم",
   "ethereum-upgrades": "ترقية إثيريوم",
   "ethereum-brand-assets": "أصول العلامة التجارية لإيثريوم",

--- a/src/intl/az/common.json
+++ b/src/intl/az/common.json
@@ -59,8 +59,6 @@
   "consensus-run-beacon-chain": "Konsensus müştərisini başlat",
   "consensus-run-beacon-chain-desc": "Ethereum mümkün qədər çox müştəriyə ehtiyac duyur. Ethereum ictimai xeyrinə dəstək olun!",
   "consensus-when-shipping": "Nə vaxt göndərilir?",
-  "eth-upgrade-what-happened": "Eth2-ə nə oldu?",
-  "eth-upgrade-what-happened-description": "Birləşmə-yə yaxınlaşdıqca \"Eth2\" termini köhnəldi. “Konsensus təbəqəsi” əvvəllər “Eth2” kimi bilinən anlayışı əhatə edir.",
   "ethereum": "Ethereum",
   "ethereum-upgrades": "Ethereum yenilənmələri",
   "ethereum-brand-assets": "Ethereum brend aktivləri",

--- a/src/intl/bg/common.json
+++ b/src/intl/bg/common.json
@@ -59,8 +59,6 @@
   "consensus-run-beacon-chain": "Активирайте клиент за консенсус",
   "consensus-run-beacon-chain-desc": "Етереум има нужда от колкото може повече клиенти. Помогнете за общественото благо на Етереум!",
   "consensus-when-shipping": "Кога излиза?",
-  "eth-upgrade-what-happened": "Какво се случи с „Eth2“?",
-  "eth-upgrade-what-happened-description": "С наближаването на сливането (The Merge) терминът „Eth2“ бива отхвърлен. Това, което преди беше известно като „Eth2“, сега е „консенсусен слой“ (consensus layer).",
   "ethereum": "Етереум",
   "ethereum-upgrades": "Подобрения на Етереум",
   "ethereum-brand-assets": "Характеристики на марката Етереум",

--- a/src/intl/ca/common.json
+++ b/src/intl/ca/common.json
@@ -58,8 +58,6 @@
   "consensus-run-beacon-chain": "Executar un client de consens",
   "consensus-run-beacon-chain-desc": "Ethereum necessita el màxim possible de clients actius. Ajudeu amb aquest bé públic d’Ethereum!",
   "consensus-when-shipping": "Quan es llençarà?",
-  "eth-upgrade-what-happened": "Què va passar amb «Eth2»?",
-  "eth-upgrade-what-happened-description": "El terme «Eth2» ha quedat obsolet a mida que ens aproximem a la fusió. La «capa de consens» encapsula el que abans era conegut com a «Eth2».",
   "ethereum": "Ethereum",
   "ethereum-upgrades": "Millores d'Ethereum",
   "ethereum-brand-assets": "Actius de la marca Ethereum",

--- a/src/intl/cs/common.json
+++ b/src/intl/cs/common.json
@@ -59,8 +59,6 @@
   "consensus-run-beacon-chain": "Spustit konsensuálního klienta",
   "consensus-run-beacon-chain-desc": "Ethereum potřebuje co nejvíce klientů. Pomozte nám dostat Ethereum do povědomí lidí.",
   "consensus-when-shipping": "Kdy dojde k nasazení?",
-  "eth-upgrade-what-happened": "Co se stalo s „Eth2“?",
-  "eth-upgrade-what-happened-description": "Termín „Eth2“ byl s blížícím se sloučením zastaralý. „Konsensuální vrstva“ zahrnuje to, co se dříve označovalo jako „Eth2“.",
   "ethereum": "Ethereum",
   "ethereum-upgrades": "Vylepšení Etherea",
   "ethereum-brand-assets": "Aktiva značky Ethereum",

--- a/src/intl/da/common.json
+++ b/src/intl/da/common.json
@@ -59,8 +59,6 @@
   "consensus-run-beacon-chain": "Kør en konsensusklient",
   "consensus-run-beacon-chain-desc": "Ethereum har brug for så mange kunder, der kører som muligt. Hjælp med dette fælles gode for Ethereum!",
   "consensus-when-shipping": "Hvornår sendes det?",
-  "eth-upgrade-what-happened": "Hvad skete der med 'Eth2?'",
-  "eth-upgrade-what-happened-description": "Begrebet 'Eth2' er blevet udfaset, da vi nærmer os The Merge. 'Konsensuslaget' indkapsler det der tidligere var kendt som 'Eth2.'",
   "ethereum": "Ethereum",
   "ethereum-upgrades": "Ethereum-opgraderinger",
   "ethereum-brand-assets": "Ethereum-mærkeaktiver",

--- a/src/intl/de/common.json
+++ b/src/intl/de/common.json
@@ -59,8 +59,6 @@
   "consensus-run-beacon-chain": "Einen Consensus-Client ausführen",
   "consensus-run-beacon-chain-desc": "Ethereum braucht so viele Clients wie möglich. Hilf mit diesem öffentlichen Gut!",
   "consensus-when-shipping": "Wann wird es veröffentlicht?",
-  "eth-upgrade-what-happened": "Was ist mit „Eth2“ passiert?",
-  "eth-upgrade-what-happened-description": "Der Begriff „Eth2“ wird schrittweise veralten und wegfallen. Was heute noch als „Eth2“ bekannt ist, wird zukünftig den Namen „Consensus Layer“ tragen.",
   "ethereum": "Ethereum",
   "ethereum-upgrades": "Die Ethereum Upgrades",
   "ethereum-brand-assets": "Ethereum – Marken-Assets",

--- a/src/intl/el/common.json
+++ b/src/intl/el/common.json
@@ -58,8 +58,6 @@
   "consensus-run-beacon-chain": "Εκτέλεση συναινετικής εφαρμογής πελάτη",
   "consensus-run-beacon-chain-desc": "Το Ethereum χρειάζεται όσο το δυνατόν περισσότερους πελάτες. Βοηθήστε με αυτό το δημόσιο αγαθό του Ethereum!",
   "consensus-when-shipping": "Πότε καταφτάνει;",
-  "eth-upgrade-what-happened": "Τι συνέβη στο «Eth2»;",
-  "eth-upgrade-what-happened-description": "Ο όρος «Eth2» έχει υποβαθμιστεί, καθώς πλησιάζουμε στη συγχώνευση. Ο όρος «συναινετικό επίπεδο» αντιπροσωπεύει πλέον αυτό που ήταν γνωστό ως «Eth2».",
   "ethereum": "Ethereum",
   "ethereum-upgrades": "Αναβαθμίσεις Ethereum",
   "ethereum-brand-assets": "Ψηφιακά στοιχεία επωνυμίας Ethereum",

--- a/src/intl/en/common.json
+++ b/src/intl/en/common.json
@@ -61,8 +61,6 @@
   "consensus-run-beacon-chain": "Run a consensus client",
   "consensus-run-beacon-chain-desc": "Ethereum needs as many clients running as possible. Help with this Ethereum public good!",
   "consensus-when-shipping": "When's it shipping?",
-  "eth-upgrade-what-happened": "What happened to 'Eth2?'",
-  "eth-upgrade-what-happened-description": "The term 'Eth2' has been deprecated as we approach The Merge. The 'consensus layer' encapsulates what was formerly known as 'Eth2.'",
   "ethereum": "Ethereum",
   "ethereum-upgrades": "Ethereum upgrades",
   "ethereum-brand-assets": "Ethereum brand assets",

--- a/src/intl/es/common.json
+++ b/src/intl/es/common.json
@@ -59,8 +59,6 @@
   "consensus-run-beacon-chain": "Ejecutar un cliente de consenso",
   "consensus-run-beacon-chain-desc": "Ethereum necesita tantos clientes participando como sea posible. ¡Ayude con este bien público de Ethereum!",
   "consensus-when-shipping": "¿Cuándo se lanza?",
-  "eth-upgrade-what-happened": "¿Qué sucedió con «Eth2»?",
-  "eth-upgrade-what-happened-description": "El término «Eth2» ha quedado obsoleto a medida que nos acercamos a la fusión. La «capa de consenso» engloba lo que en el pasado era más conocido como «Eth2».",
   "ethereum": "Ethereum",
   "ethereum-upgrades": "Actualizaciones de Ethereum",
   "ethereum-brand-assets": "Activos de marca de Ethereum",

--- a/src/intl/fa/common.json
+++ b/src/intl/fa/common.json
@@ -58,8 +58,6 @@
   "consensus-run-beacon-chain": "راه‌اندازی یک کلاینت وفاق",
   "consensus-run-beacon-chain-desc": "اتریوم هر چه بیشتر به کلاینت نیاز دارد. به این کار عام‌المنفعه اتریوم کمک کنید!",
   "consensus-when-shipping": "چه زمانی راه‌اندازی می‌شود؟",
-  "eth-upgrade-what-happened": "چه بر سر «اتر۲» آمد؟",
-  "eth-upgrade-what-happened-description": "اصطلاح «اتر۲» با نزدیک‌شدن ما به ادغام منسوخ شده است. «لایه وفاق» در بر‌گیرنده همان چیزی است که پیشتر با نام «اتر۲» شناخته می‌شد.",
   "ethereum": "اتریوم",
   "ethereum-upgrades": "ارتقاهای اتریوم",
   "ethereum-brand-assets": "دارایی های نام تجاری اتریوم",

--- a/src/intl/fi/common.json
+++ b/src/intl/fi/common.json
@@ -59,8 +59,6 @@
   "consensus-run-beacon-chain": "Suorita konsensusohjelma",
   "consensus-run-beacon-chain-desc": "Ethereum tarvitsee niin monta käynnissä olevaa asiakasohjelmaa kuin vain mahdollista. Auta Ethereumia tällä yleisellä hyvällä!",
   "consensus-when-shipping": "Milloin se julkaistaan?",
-  "eth-upgrade-what-happened": "Mitä tapahtui Eth2:lle?",
-  "eth-upgrade-what-happened-description": "Termi Eth2 on vanhentunut, kun lähestymme yhdistämistä. Konsensuskerros tiivistää sen, minkä ennen käsitti Eth2.",
   "ethereum": "Ethereum",
   "ethereum-upgrades": "Ethereumin päivitykset",
   "ethereum-brand-assets": "Ethereum-mediapankki",

--- a/src/intl/fr/common.json
+++ b/src/intl/fr/common.json
@@ -59,8 +59,6 @@
   "consensus-run-beacon-chain": "Exécuter un client de consensus",
   "consensus-run-beacon-chain-desc": "Ethereum a besoin qu'un maximum de clients s'exécutent. Aidez ce bien public Ethereum !",
   "consensus-when-shipping": "C'est pour quand ?",
-  "eth-upgrade-what-happened": "Qu'est-il arrivé à « Eth2 » ?",
-  "eth-upgrade-what-happened-description": "Le terme « Eth2 » a été déprécié à l'approche de la fusion. La « couche de consensus » comprend ce qui était auparavant appelé « Eth2 ».",
   "ethereum": "Ethereum",
   "ethereum-upgrades": "Mises à niveau d'Ethereum",
   "ethereum-brand-assets": "Éléments de la marque Ethereum",

--- a/src/intl/gl/common.json
+++ b/src/intl/gl/common.json
@@ -59,8 +59,6 @@
   "consensus-run-beacon-chain": "Executar un cliente de consenso",
   "consensus-run-beacon-chain-desc": "Ethereum precisa tantos clientes participando coma sexa posible. Axude con este ben público de Ethereum!",
   "consensus-when-shipping": "Cando se envía?",
-  "eth-upgrade-what-happened": "Que aconteceu con 'Eth2'?",
-  "eth-upgrade-what-happened-description": "O termo \"Eth\" foi quedando obsoleto a medida que nos aproximamos á Fusión. A \"capa de consenso\" engloba o que era anteriormente coñecido como \"Eth2\"",
   "ethereum": "Ethereum",
   "ethereum-upgrades": "Melloras de Ethereum",
   "ethereum-brand-assets": "Activos de marca de Ethereum",

--- a/src/intl/hi/common.json
+++ b/src/intl/hi/common.json
@@ -59,8 +59,6 @@
   "consensus-run-beacon-chain": "सहमति ग्राहक चलाएँ",
   "consensus-run-beacon-chain-desc": "एथेरियम को ज़्यादा से ज़्यादा क्लाइंट चलाने की ज़रूरत होती है। इस एथेरियम सार्वजनिक हित में मदद करें!",
   "consensus-when-shipping": "यह कब शिप हो रहा है?",
-  "eth-upgrade-what-happened": "'Eth2' का क्या हुआ?",
-  "eth-upgrade-what-happened-description": "जैसे-जैसे हम मर्ज के करीब पहुँच रहे हैं, 'Eth2' शब्द का उपयोग बंद किया जा रहा है। 'सहमति परत' में वह चीज़ शामिल है, जिसे पहले 'Eth2' के नाम से जाना जाता था।",
   "ethereum": "Ethereum",
   "ethereum-upgrades": "एथेरियम के अपग्रेड",
   "ethereum-brand-assets": "इथेरियम ब्रांड संपत्ति",

--- a/src/intl/hu/common.json
+++ b/src/intl/hu/common.json
@@ -59,8 +59,6 @@
   "consensus-run-beacon-chain": "Konszenzus kliens futtatása",
   "consensus-run-beacon-chain-desc": "Az Ethereum annyi futó klienst igényel, amennyi lehetséges. Segítsd ezzel az Ethereum közjavat!",
   "consensus-when-shipping": "Mikor lesz kész?",
-  "eth-upgrade-what-happened": "Mi történt az „Eth2”-vel?",
-  "eth-upgrade-what-happened-description": "Az „Eth2” kifejezés elavulttá vált, ahogy közeledünk az egyesítéshez. A „konszenzusos réteg” magában foglalja azt, amit korábban „Eth2” néven ismertünk",
   "ethereum": "Ethereum",
   "ethereum-upgrades": "Az Ethereum fejlesztései",
   "ethereum-brand-assets": "Ethereum márkanév",

--- a/src/intl/id/common.json
+++ b/src/intl/id/common.json
@@ -59,8 +59,6 @@
   "consensus-run-beacon-chain": "Jalankan klien konsensus",
   "consensus-run-beacon-chain-desc": "Ethereum membutuhkan klien yang aktif sebanyak mungkin. Bantu terkait barang publik Ethereum ini!",
   "consensus-when-shipping": "Kapan pengirimannya?",
-  "eth-upgrade-what-happened": "Apa yang terjadi dengan 'Eth2?'",
-  "eth-upgrade-what-happened-description": "Istilah 'Eth2' telah tidak digunakan lagi selagi kita mendekati penggabungan. 'Lapisan konsensus' merangkum apa yang sebelumnya dikenal sebagai 'Eth2.'",
   "ethereum": "Ethereum",
   "ethereum-upgrades": "Peningkatan Ethereum",
   "ethereum-brand-assets": "Aset Merek Ethereum",

--- a/src/intl/it/common.json
+++ b/src/intl/it/common.json
@@ -59,8 +59,6 @@
   "consensus-run-beacon-chain": "Esegui un client di consenso",
   "consensus-run-beacon-chain-desc": "Ethereum ha bisogno del maggior numero possibile di client in esecuzione. Contribuisci con questo bene pubblico di Ethereum!",
   "consensus-when-shipping": "Quando verrà rilasciato?",
-  "eth-upgrade-what-happened": "Cos'è successo a \"Eth2\"?",
-  "eth-upgrade-what-happened-description": "Il termine \"Eth2\" è stato abbandonato mentre ci avvicinavamo alla fusione. Il termine \"consensus layer\" ingloba ciò che prima era noto come \"Eth2\".",
   "ethereum": "Ethereum",
   "ethereum-upgrades": "Aggiornamenti di Ethereum",
   "ethereum-brand-assets": "Risorse del marchio Ethereum",

--- a/src/intl/ja/common.json
+++ b/src/intl/ja/common.json
@@ -59,8 +59,6 @@
   "consensus-run-beacon-chain": "コンセンサスクライアントの実行",
   "consensus-run-beacon-chain-desc": "イーサリアムではできるだけ多くのクライアントが稼働している必要があります。イーサリアムの公益的な活動にご協力ください。",
   "consensus-when-shipping": "導入のタイミング",
-  "eth-upgrade-what-happened": "Eth2の名称廃止",
-  "eth-upgrade-what-happened-description": "「マージ」が近づくにつれて、「Eth2」という用語を廃止しました。旧称「Eth2」として知られていたものは「コンセンサスレイヤ」に含まれます。",
   "ethereum": "イーサリアム",
   "ethereum-upgrades": "イーサリアムのアップグレード",
   "ethereum-brand-assets": "イーサリアムブランドアセット",

--- a/src/intl/ka/common.json
+++ b/src/intl/ka/common.json
@@ -58,8 +58,6 @@
   "consensus-run-beacon-chain": "გაუშვი კონსენსუსის კლიენტი",
   "consensus-run-beacon-chain-desc": "ეთერეუმს სჭირდება რაც შეიძლება მეტი კლიენტი. დაეხმარე ეთერეუმის საზოგადოების საკეთილდღეოდ!",
   "consensus-when-shipping": "როდის არის მიწოდება?",
-  "eth-upgrade-what-happened": "რა დაემართა 'Eth2-ს?'",
-  "eth-upgrade-what-happened-description": "ტერმინი 'Eth2' მოძველებულია, როდესაც ჩვენ ვსაუბრობთ შერწყმაზე. 'კონსენსუსის ფენა' მოიცავს იმას, რაც ადრე ცნობილი იყო როგორც 'Eth2.'",
   "ethereum": "ეთერეუმი",
   "ethereum-upgrades": "ეთერეუმის განახლებები",
   "ethereum-brand-assets": "ეთერეუმის ბრენდის აქტივები",

--- a/src/intl/ko/common.json
+++ b/src/intl/ko/common.json
@@ -58,8 +58,6 @@
   "consensus-run-beacon-chain": "합의 클라이언트 실행하기",
   "consensus-run-beacon-chain-desc": "이더리움은 최대한 많은 클라이언트를 실행해야 합니다. 이더리움의 공익을 위해 이를 도와 주세요!",
   "consensus-when-shipping": "언제 런칭하나요?",
-  "eth-upgrade-what-happened": "'이더2(Eth2)'에게 무슨 일이 있어났나요?",
-  "eth-upgrade-what-happened-description": "'이더2(Eth2)'란 용어는 합병이 진행됨에 따라 더 이상 사용하지 않기로 했습니다. 대신 '합의 레이어(consensus layer)'라는, '이더2'의 의미를 내포하는 용어를 사용합니다.",
   "ethereum": "이더리움",
   "ethereum-upgrades": "이더리움 업그레이드",
   "ethereum-brand-assets": "이더리움 브랜드 자산",

--- a/src/intl/lt/common.json
+++ b/src/intl/lt/common.json
@@ -59,8 +59,6 @@
   "consensus-run-beacon-chain": "Paleisti konsensuso klientą",
   "consensus-run-beacon-chain-desc": "Ethereum reikia kuo daugiau veikiančių klientų. Padėkite su šiuo Ethereum visuomeniniu sieku!",
   "consensus-when-shipping": "Kada bus išsiųstas?",
-  "eth-upgrade-what-happened": "Kas nutiko „Eth2“?",
-  "eth-upgrade-what-happened-description": "Artėjant susijungimui, terminas „Eth2“ buvo panaikintas. Konsensuso klientų tinklas apima tai, kas anksčiau buvo vadinama „Eth2“.",
   "ethereum": "Ethereum",
   "ethereum-upgrades": "Ethereum atnaujinimai",
   "ethereum-brand-assets": "Ethereum prekių ženklo turtas",

--- a/src/intl/ml/common.json
+++ b/src/intl/ml/common.json
@@ -59,8 +59,6 @@
   "consensus-run-beacon-chain": "ഒരു പൊതു കക്ഷി റൺ ചെയ്യുക",
   "consensus-run-beacon-chain-desc": "Ethereum-ന് കഴിയുന്നത്ര കക്ഷികൾ റൺ ചെയ്യേണ്ടത് ആവശ്യമാണ്. പൊതുനന്മയ്ക്കായി ഈ Ethereum-നെ സഹായിക്കൂ!",
   "consensus-when-shipping": "ഇത് ഷിപ്പ് ചെയ്യുന്നത് എപ്പോഴാണ്?",
-  "eth-upgrade-what-happened": "'Eth2' എന്നതിന് എന്ത് സംഭവിച്ചു?",
-  "eth-upgrade-what-happened-description": "ദി മെർജിനെ സമീപിക്കുന്നതിനാൽ 'Eth2' എന്ന പദം ഒഴിവാക്കിയിരിക്കുന്നു. മുമ്പ് 'Eth2' എന്നറിയപ്പെട്ടിരുന്നതിനെ 'പൊതു വരി' എന്ന പദം ഉൾക്കൊള്ളുന്നു.",
   "ethereum": "Ethereum",
   "ethereum-upgrades": "Ethereum അപ്‌ഗ്രേഡുകൾ",
   "ethereum-brand-assets": "Ethereum ബ്രാന്‍ഡ് ആസ്തികള്‍",

--- a/src/intl/ms/common.json
+++ b/src/intl/ms/common.json
@@ -59,8 +59,6 @@
   "consensus-run-beacon-chain": "Jalankan klien sepersetujuan",
   "consensus-run-beacon-chain-desc": "Ethereum memerlukan klien berjalan dengan sebanyak mungkin. Bantu Ethereum ini bagi tujuan kebaikan awam!",
   "consensus-when-shipping": "Bilakah ia dihantar?",
-  "eth-upgrade-what-happened": "Apakah yang terjadi dengan 'Eth2?'",
-  "eth-upgrade-what-happened-description": "Terma 'Eth2' telah diisih ketika kita mendekati Penggabungan. 'Lapisan sepersetujuan' mengurung apa yang dahulunya dikenali sebagai 'Eth2.'",
   "ethereum": "Ethereum",
   "ethereum-upgrades": "Naik taraf Ethereum",
   "ethereum-brand-assets": "Aset Jenama Ethereum",

--- a/src/intl/nl/common.json
+++ b/src/intl/nl/common.json
@@ -58,8 +58,6 @@
   "consensus-run-beacon-chain": "Voer een consensusclient uit",
   "consensus-run-beacon-chain-desc": "Ethereum heeft zoveel mogelijk clients nodig die werken. Help met dit publieke Ethereum goed!",
   "consensus-when-shipping": "Wanneer wordt het verstuurd?",
-  "eth-upgrade-what-happened": "Wat is er met 'Eth2' gebeurd?",
-  "eth-upgrade-what-happened-description": "In de aanloop naar de samenvoeging is de term 'Eth2' verouderd: de 'consensuslaag' omschrijft wat vroeger 'eth2.' werd genoemd.",
   "ethereum": "Ethereum",
   "ethereum-upgrades": "Ethereum-upgrades",
   "ethereum-brand-assets": "Ethereum-merkcontent",

--- a/src/intl/pt-br/common.json
+++ b/src/intl/pt-br/common.json
@@ -58,8 +58,6 @@
   "consensus-run-beacon-chain": "Executar um cliente de consenso",
   "consensus-run-beacon-chain-desc": "Ethereum precisa da maior quantidade possível de clientes sendo executados. Ajude com este bem público do Ethereum!",
   "consensus-when-shipping": "Quando estará disponível?",
-  "eth-upgrade-what-happened": "O que aconteceu com \"Eth2?\"",
-  "eth-upgrade-what-happened-description": "O termo \"Eth2\" está sendo descontinuado conforme o processo de integração se aproxima. A \"camada de consenso\" representa o que anteriormente era conhecido como \"Eth2\".",
   "ethereum": "Ethereum",
   "ethereum-upgrades": "Melhorias na Ethereum",
   "ethereum-brand-assets": "Ativos da marca Ethereum",

--- a/src/intl/ro/common.json
+++ b/src/intl/ro/common.json
@@ -58,8 +58,6 @@
   "consensus-run-beacon-chain": "Rulați un client de consens",
   "consensus-run-beacon-chain-desc": "Ethereum necesită rularea a cât mai multor clienți. Contribuiți în favoarea acestui bun public Ethereum!",
   "consensus-when-shipping": "Când va fi lansat?",
-  "eth-upgrade-what-happened": "Ce s-a întâmplat cu „Eth2”?",
-  "eth-upgrade-what-happened-description": "Termenul „Eth2” a fost abandonat pe măsură ce ne apropiem de fuziune. Termenul „nivelul consensului” încorporează ceea ce era cunoscut anterior ca „Eth2\".",
   "ethereum": "Ethereum",
   "ethereum-upgrades": "Actualizările Ethereum",
   "ethereum-brand-assets": "Materialele de branding Ethereum",

--- a/src/intl/ru/common.json
+++ b/src/intl/ru/common.json
@@ -59,8 +59,6 @@
   "consensus-run-beacon-chain": "Запуск клиента с консенсусом",
   "consensus-run-beacon-chain-desc": "Ethereum нужно как можно больше запущенных клиентов. Помогите Ethereum принести обществу пользу!",
   "consensus-when-shipping": "Когда это запустится?",
-  "eth-upgrade-what-happened": "Что случилось с Eth2?",
-  "eth-upgrade-what-happened-description": "Термин Eth2 вышел из употребления по мере нашего приближения к слиянию. «Уровень консенсуса» включает в себя то, что ранее было известно как Eth2.",
   "ethereum": "Ethereum",
   "ethereum-upgrades": "Обновления Ethereum",
   "ethereum-brand-assets": "Активы бренда Ethereum",

--- a/src/intl/sk/common.json
+++ b/src/intl/sk/common.json
@@ -59,8 +59,6 @@
   "consensus-run-beacon-chain": "Spustiť konsenzuálneho klienta",
   "consensus-run-beacon-chain-desc": "Ethereum potrebuje čo najviac funkčných klientov. Pomôžte pre verejné dobro Etherea!",
   "consensus-when-shipping": "Kedy vychádza?",
-  "eth-upgrade-what-happened": "Čo sa stalo s „Eth2?“",
-  "eth-upgrade-what-happened-description": "Termín „Eth2“ bol zrušený, pretože sa blíži zlúčenie. \n„Vrstva konsenzu\" zahŕňa to, čo bolo predtým známe ako „Eth2“",
   "ethereum": "Ethereum",
   "ethereum-upgrades": "Vylepšenia Etherea",
   "ethereum-brand-assets": "Zdroje značky Ethereum",

--- a/src/intl/sl/common.json
+++ b/src/intl/sl/common.json
@@ -59,8 +59,6 @@
   "consensus-run-beacon-chain": "Zaženite soglasje stranke",
   "consensus-run-beacon-chain-desc": "Ethereum potrebuje čim več aktivnih odjemalcev. Pomagajte v javno dobro Ethereuma.",
   "consensus-when-shipping": "Kdaj bo na voljo?",
-  "eth-upgrade-what-happened": "Kaj se je zgodilo z \"Eth2?\"",
-  "eth-upgrade-what-happened-description": "Izraz \"Eth2\" je z bližajočo se spojitvijo postal zastarel. \"Plast soglasja\" povzema, kar je bilo prej znano kot \"Eth2.\"",
   "ethereum": "Ethereum",
   "ethereum-upgrades": "Ethereum nadgradnje",
   "ethereum-brand-assets": "Gradivo blagovne znamke Ethereum",

--- a/src/intl/sw/common.json
+++ b/src/intl/sw/common.json
@@ -59,8 +59,6 @@
   "consensus-run-beacon-chain": "Endesha programu ya makubaliano",
   "consensus-run-beacon-chain-desc": "Ethereum inahitaji wateja wengi iwezekanavyo. Saidia Ethereum iliyo nzuri kwa umma!",
   "consensus-when-shipping": "Inasfirishwa lini?",
-  "eth-upgrade-what-happened": "Nini kimeipata 'Eth2?'",
-  "eth-upgrade-what-happened-description": "Neno 'Eth2' liumekua likiachwa taratibu tunvyokaribia muungano. 'safu ya makubaliano' hufunuka kile kilichojulikana kama 'Eth2.'",
   "ethereum": "Ethereum",
   "ethereum-upgrades": "Visasisho vya Ethereum",
   "ethereum-brand-assets": "Rasimali zenye chapa ya Ethereum",

--- a/src/intl/th/common.json
+++ b/src/intl/th/common.json
@@ -59,8 +59,6 @@
   "consensus-run-beacon-chain": "ร่วมเป็น Consensus Client",
   "consensus-run-beacon-chain-desc": "Ethereum ต้องการ Client ที่รันอยู่มากที่สุด ร่วมช่วยอีกแรงเพื่อประโยชน์ของส่วนรวมใน Ethereum!",
   "consensus-when-shipping": "จะส่งมอบเมื่อใด",
-  "eth-upgrade-what-happened": "เกิดอะไรขึ้นกับ \"Eth2\"",
-  "eth-upgrade-what-happened-description": "เลิกใช้คำว่า \"Eth2\" เพราะเมื่อมี The Merge แล้ว จะใช้คำว่า \"Consensus Layer\" แทน",
   "ethereum": "อีเธอเรียม",
   "ethereum-upgrades": "การอัปเกรดอีเธอเรียม",
   "ethereum-brand-assets": "สินทรัพย์แบรนด์อีเธอเรียม",

--- a/src/intl/tr/common.json
+++ b/src/intl/tr/common.json
@@ -59,8 +59,6 @@
   "consensus-run-beacon-chain": "Bir mutabakat istemcisi çalıştırın",
   "consensus-run-beacon-chain-desc": "Ethereum için olabildiğince fazla çalışan istemci gerekiyor. Bu Ethereum kamu malı için yardım edin!",
   "consensus-when-shipping": "Ne zaman gönderiliyor?",
-  "eth-upgrade-what-happened": "\"Eth2\"ye ne oldu?",
-  "eth-upgrade-what-happened-description": "Birleşmeye yaklaştığımız bu süreçte \"Eth2\" terimi artık kullanımdan çıkarıldı. \"Mutabakat katmanı\" eskiden \"Eth2\" olarak bilinen şeyi kapsamaktadır.",
   "ethereum": "Ethereum",
   "ethereum-upgrades": "Ethereum yükseltmeleri",
   "ethereum-brand-assets": "Ethereum Marka Varlıkları",

--- a/src/intl/vi/common.json
+++ b/src/intl/vi/common.json
@@ -59,8 +59,6 @@
   "consensus-run-beacon-chain": "Chạy một máy khách đồng thuận",
   "consensus-run-beacon-chain-desc": "Ethereum cần nhiều clients hoạt động nhất có thể. Sử dụng một dịch vụ chung của Ethereum này!",
   "consensus-when-shipping": "Khi nào đi vào hoạt động?",
-  "eth-upgrade-what-happened": "Chuyện gì xảy ra với 'Eth2?'",
-  "eth-upgrade-what-happened-description": "Thuật ngữ 'Eth2' đã không được dùng nữa khi chúng ta tiếp cập giai đoạn hợp nhất. 'Lớp đồng thuận' chính là 'Eth2' trước đây.",
   "ethereum": "Ethereum",
   "ethereum-upgrades": "Các bản nâng cấp của Ethereum",
   "ethereum-brand-assets": "Tài sản thương hiệu Ethereum",

--- a/src/intl/zh-tw/common.json
+++ b/src/intl/zh-tw/common.json
@@ -58,8 +58,6 @@
   "consensus-run-beacon-chain": "運行共識用戶端",
   "consensus-run-beacon-chain-desc": "以太坊需要大量客戶協助運作。請為以太坊的共同利益一起努力！",
   "consensus-when-shipping": "何時生效？",
-  "eth-upgrade-what-happened": "「Eth2」怎麼了?",
-  "eth-upgrade-what-happened-description": "以太坊即將合併時，我們決定不再使用「Eth2」這個稱呼，改以「共識層」取而代之。",
   "ethereum": "以太坊",
   "ethereum-upgrades": "以太坊升級",
   "ethereum-brand-assets": "以太坊品牌資產",

--- a/src/intl/zh/common.json
+++ b/src/intl/zh/common.json
@@ -59,8 +59,6 @@
   "consensus-run-beacon-chain": "运行一个共识客户端",
   "consensus-run-beacon-chain-desc": "以太坊需要尽可能多地处在运行中的客户端支持，为这个以太坊公共产品提供帮助吧！",
   "consensus-when-shipping": "何时发布？",
-  "eth-upgrade-what-happened": "“Eth2”发生了什么？",
-  "eth-upgrade-what-happened-description": "以太坊逐渐合并的同时我们将废弃使用名词\"Eth2\"。取而代之的则是包含了所有“Eth2”含义的“共识层”。",
   "ethereum": "以太坊",
   "ethereum-upgrades": "以太坊升级",
   "ethereum-brand-assets": "以太坊品牌资产",

--- a/src/templates/upgrade.tsx
+++ b/src/templates/upgrade.tsx
@@ -386,18 +386,6 @@ const UpgradePage = ({
               maxDepth={mdx.frontmatter.sidebarDepth}
             />
           )}
-          <DismissibleCard storageKey="dismissed-eth-upgrade-psa">
-            <Emoji text=":cheering_megaphone:" size={5} />
-            <h2>
-              <Translation id="eth-upgrade-what-happened" />
-            </h2>
-            <p>
-              <Translation id="eth-upgrade-what-happened-description" />{" "}
-              <Link to="https://blog.ethereum.org/2022/01/24/the-great-eth2-renaming/">
-                <Translation id="more-info" />.
-              </Link>
-            </p>
-          </DismissibleCard>
         </InfoColumn>
         <ContentContainer id="content">
           {/* <DesktopBreadcrumbs slug={mdx.fields.slug} startDepth={1} /> */}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Removes the Eth2 callout card in favor of an Eth2 section on the merge page.

I used the same Eth2 content from the /upgrades/ page, so hopefully TM in Crowdin should auto-translate this section.

## Related Issue

None, bug pointed out in Discord: https://discord.com/channels/714888181740339261/976195910407163934/986241362515095633

Currently the banner completely blocks the table of contents:
![image](https://user-images.githubusercontent.com/8097623/174326211-3c6c9ad0-7fe0-409a-93b1-cf85cdb0c0a0.png)

View with the banner removed:
![image](https://user-images.githubusercontent.com/8097623/174326527-070e374d-a85a-4ee0-8dd2-2d9b2f7b375f.png)
