### PR TITLE
Whitepaper PDF context added.

### DIFF
--- a/src/content/whitepaper/index.md
+++ b/src/content/whitepaper/index.md
@@ -12,7 +12,7 @@ _This introductory paper was originally published in 2014 by Vitalik Buterin, th
 
 _While several years old, we maintain this paper because it continues to serve as a useful reference and an accurate representation of Ethereum and its vision. To learn about the latest developments of Ethereum, and how changes to the protocol are made, we recommend [this guide](/learn/)._
 
-[Open the Ethereum Whitepaper as a PDF](./whitepaper-pdf/Ethereum_Whitepaper_-_Buterin_2014.pdf)
+[Researchers and academics seeking a historical or canonical version of the whitepaper [from December 2014] should use this PDF.](./whitepaper-pdf/Ethereum_Whitepaper_-_Buterin_2014.pdf)
 
 ## A Next-Generation Smart Contract and Decentralized Application Platform {#a-next-generation-smart-contract-and-decentralized-application-platform}
 


### PR DESCRIPTION
Added a small contextual note that the PDF is the best version for academics or researchers seeking a historical or canonical version of the paper. The version that is on the website is actually a newer version and does not match the PDF . Would be good if someone could pinpoint the source of the website version. I would personally prefer if they were the same, but this should be a good accommodation for now.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
