### PR TITLE
Fix broken link on EVM docs page

### DIFF
--- a/src/content/developers/docs/evm/index.md
+++ b/src/content/developers/docs/evm/index.md
@@ -34,7 +34,7 @@ Given an old valid state `(S)` and a new set of valid transactions `(T)`, the Et
 
 ### State {#state}
 
-In the context of Ethereum, the state is an enormous data structure called a [modified Merkle Patricia Trie](https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie), which keeps all [accounts](/developers/docs/accounts/) linked by hashes and reducible to a single root hash stored on the blockchain.
+In the context of Ethereum, the state is an enormous data structure called a [modified Merkle Patricia Trie](/developers/docs/data-structures-and-encoding/patricia-merkle-trie/), which keeps all [accounts](/developers/docs/accounts/) linked by hashes and reducible to a single root hash stored on the blockchain.
 
 ### Transactions {#transactions}
 

--- a/src/content/developers/docs/evm/index.md
+++ b/src/content/developers/docs/evm/index.md
@@ -34,7 +34,7 @@ Given an old valid state `(S)` and a new set of valid transactions `(T)`, the Et
 
 ### State {#state}
 
-In the context of Ethereum, the state is an enormous data structure called a [modified Merkle Patricia Trie](https://eth.wiki/en/fundamentals/patricia-tree), which keeps all [accounts](/developers/docs/accounts/) linked by hashes and reducible to a single root hash stored on the blockchain.
+In the context of Ethereum, the state is an enormous data structure called a [modified Merkle Patricia Trie](https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie), which keeps all [accounts](/developers/docs/accounts/) linked by hashes and reducible to a single root hash stored on the blockchain.
 
 ### Transactions {#transactions}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The link to information about Patricia Merkle Trees was broken. I fixed it.
<!--- Describe your changes in detail -->

## Related Issue

None

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
