### PR TITLE
Fix bug bounty total leaderboard

### DIFF
--- a/src/pages/bug-bounty.js
+++ b/src/pages/bug-bounty.js
@@ -243,10 +243,28 @@ const BugBountiesPage = ({ data, location }) => {
     (a, b) => b.score - a.score
   )
 
-  const allBounterHunters = [
-    ...consensusBountyHunters,
-    ...executionBountyHunters,
-  ].sort((a, b) => b.score - a.score)
+  // total all counts using name as identifier, then sort
+  const allBounterHunters = Object.values(
+    [...consensusBountyHunters, ...executionBountyHunters].reduce(
+      (acc, next) => {
+        if (acc[next.name]) {
+          return {
+            ...acc,
+            [next.name]: {
+              ...next,
+              score: acc[next.name].score + next.score,
+            },
+          }
+        }
+
+        return {
+          ...acc,
+          [next.name]: next,
+        }
+      },
+      {}
+    )
+  ).sort((a, b) => b.score - a.score)
 
   const clients = [
     {


### PR DESCRIPTION
## Description

This PR [fixes the total score leaderboard](https://github.com/ethereum/ethereum-org-website/issues/6328) on the bug bounty page by accumulating scores per user name.  We go off name as sometimes `username` is an empty string, so full name is our best accumulator.  Having some kind of UUID for users going forward would probably be ideal, but it's OOS for this PR.

## Related Issue

This PR addresses [6328](https://github.com/ethereum/ethereum-org-website/issues/6328)
