### PR TITLE
Adds Gray Glacier to History page

### DIFF
--- a/src/content/history/index.md
+++ b/src/content/history/index.md
@@ -24,6 +24,32 @@ Looking for future protocol upgrades? [Learn about upcoming upgrades to Ethereum
 
 <Divider />
 
+## 2022 {#2022}
+
+### _(Planned)_ Gray Glacier {#gray-glacier}
+
+<Emoji text=":calendar:" size={1} mr={"0.5rem"} mb={"0.5rem"} /><code>Estimated: Jun-29-2022</code><br />
+<Emoji text=":bricks:" size={1} mr={"0.5rem"} mb={"0.5rem"} />Block number: <a href="https://etherscan.io/block/15050000">15,050,000</a><br />
+<Emoji text=":money_bag:" size={1} mr={"0.5rem"} mb={"0.5rem"} />ETH price: <i>to be determined</i><br />
+
+#### Summary {#gray-glacier-summary}
+
+The Gray Glacier network upgrade pushes back the [difficulty bomb](/glossary/#difficulty-bomb) by three months. This is the only change introduced in this upgrade, and is similar in nature to the [Arrow Glacier](#arrow-glacier) and [Muir Glacier](#muir-glacier) upgrades. Similar changes have been performed on the [Byzantium](#byzantium), [Constantinople](#constantinople) and [London](#london) network upgrades.
+
+- [EF Blog - Gray Glacier Upgrade Announcement](https://blog.ethereum.org/2022/06/16/gray-glacier-announcement/)
+
+<ExpandableCard title="Gray Glacier EIPs" contentPreview="Official improvements included in this upgrade.">
+
+- [EIP-5133](https://eips.ethereum.org/EIPS/eip-5133) – _delays the difficulty bomb until September 2022_
+
+</ExpandableCard>
+
+#### <Emoji text=":police_car_light:" size={1} mr="0.5rem" />Node operators {#gray-glacier-node-operators}
+
+Be sure to upgrade your client software to the latest version before June 27, 2022 to account for variable block times. This will help avoid having your client sync to a pre-fork chain, resulting in the inability to send funds or properly verify transactions.
+
+<Divider />
+
 ## 2021 {#2021}
 
 ### Arrow Glacier {#arrow-glacier}
@@ -45,10 +71,6 @@ The Arrow Glacier network upgrade pushed back the [difficulty bomb](/glossary/#d
 - [EIP-4345](https://eips.ethereum.org/EIPS/eip-4345) – _delays the difficulty bomb until June 2022_
 
 </ExpandableCard>
-
-#### <Emoji text=":police_car_light:" size={1} mr="0.5rem" />Node operators {#arrow-glacier-node-operators}
-
-Be sure to upgrade your client software to the latest version before December 5, 2021 to account for variable block times. This will help avoid having your client sync to a pre-fork chain, resulting in the inability to send funds or properly verify transactions.
 
 ---
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11592,7 +11592,7 @@ minimatch@^3.1.1, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@^1.2.6:
+minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==


### PR DESCRIPTION
## Description
- Adds Gray Glacier to /history with callout to node operators to update. 

Open question, should we add a banner callout for this anywhere? For Arrow Glacier I believe we added a banner to the homepage only, targeting node operators. We're already in the midst of calling out The Merge with #6710 on the homepage, so not sure if we want to do that or not this time.