### PR TITLE
Upgrade home icon to svg

### DIFF
--- a/src/assets/eth-home-icon.svg
+++ b/src/assets/eth-home-icon.svg
@@ -1,0 +1,8 @@
+<svg width="115" height="182" viewBox="0 0 115 182" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M57.5054 181V135.84L1.64064 103.171L57.5054 181Z" fill="#F0CDC2" stroke="#1616B4" stroke-linejoin="round"/>
+<path d="M57.6906 181V135.84L113.555 103.171L57.6906 181Z" fill="#C9B3F5" stroke="#1616B4" stroke-linejoin="round"/>
+<path d="M57.5055 124.615V66.9786L1 92.2811L57.5055 124.615Z" fill="#88AAF1" stroke="#1616B4" stroke-linejoin="round"/>
+<path d="M57.6903 124.615V66.9786L114.196 92.2811L57.6903 124.615Z" fill="#C9B3F5" stroke="#1616B4" stroke-linejoin="round"/>
+<path d="M1.00006 92.2811L57.5054 1V66.9786L1.00006 92.2811Z" fill="#F0CDC2" stroke="#1616B4" stroke-linejoin="round"/>
+<path d="M114.196 92.2811L57.6906 1V66.9786L114.196 92.2811Z" fill="#B8FAF6" stroke="#1616B4" stroke-linejoin="round"/>
+</svg>

--- a/src/components/Nav/index.js
+++ b/src/components/Nav/index.js
@@ -1,7 +1,5 @@
 import React, { useState } from "react"
-import { useStaticQuery, graphql } from "gatsby"
 import { useIntl } from "gatsby-plugin-intl"
-import { GatsbyImage, getImage } from "gatsby-plugin-image"
 import styled from "styled-components"
 import { cloneDeep } from "lodash"
 
@@ -14,6 +12,7 @@ import Search from "../Search"
 import Translation from "../Translation"
 import { NavLink } from "../SharedStyledComponents"
 import { translateMessageId } from "../../utils/translations"
+import HomeIcon from "../../assets/eth-home-icon.svg"
 
 const NavContainer = styled.div`
   position: sticky;
@@ -104,7 +103,8 @@ const HomeLogoNavLink = styled(Link)`
   align-items: center;
 `
 
-const HomeLogo = styled(GatsbyImage)`
+const HomeLogo = styled(HomeIcon)`
+  width: 22px;
   opacity: 0.85;
   &:hover {
     opacity: 1;
@@ -134,21 +134,6 @@ const NavIcon = styled(Icon)`
 const Nav = ({ handleThemeChange, isDarkTheme, path }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
   const [isSearchOpen, setIsSearchOpen] = useState(false)
-
-  const data = useStaticQuery(graphql`
-    {
-      file(relativePath: { eq: "eth-home-icon.png" }) {
-        childImageSharp {
-          gatsbyImageData(
-            width: 22
-            layout: FIXED
-            placeholder: BLURRED
-            quality: 100
-          )
-        }
-      }
-    }
-  `)
   const intl = useIntl()
 
   const linkSections = [
@@ -396,10 +381,7 @@ const Nav = ({ handleThemeChange, isDarkTheme, path }) => {
       <StyledNav aria-label={translateMessageId("nav-primary", intl)}>
         <NavContent>
           <HomeLogoNavLink to="/">
-            <HomeLogo
-              image={getImage(data.file)}
-              alt={translateMessageId("ethereum-logo", intl)}
-            />
+            <HomeLogo alt={translateMessageId("ethereum-logo", intl)} />
           </HomeLogoNavLink>
           {/* Desktop */}
           <InnerContent>


### PR DESCRIPTION
## Description
- Upgrades home icon to SVG
- As a result the `svg:hover` selector in the `Link.tsx` component causes this to scale by 2% on hover (since it is now an SVG)... which I thought was a nice bonus, so I kept it in there
- Note, there is an existing SVG with a heavier stroke width that didn't quite match our existing home logo, hence the new file. If we feel it's too redundant, would suggest we remove the old one and replace it with this new one on the assets page. (This PR doesn't touch the assets page)

<-- old / new -->
<img width="1005" alt="image" src="https://user-images.githubusercontent.com/54227730/174925723-8bbe9cdb-bc15-4ec5-9058-86bc8095a004.png">
