### PR TITLE
Add JSON-RPC API endpoint examples

### DIFF
--- a/src/content/developers/docs/apis/json-rpc/index.md
+++ b/src/content/developers/docs/apis/json-rpc/index.md
@@ -766,7 +766,7 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getCode","params":["0xa94f53
 
 The sign method calculates an Ethereum specific signature with: `sign(keccak256("\x19Ethereum Signed Message:\n" + len(message) + message)))`.
 
-By adding a prefix to the message makes the calculated signature recognisable as an Ethereum specific signature. This prevents misuse where a malicious DApp can sign arbitrary data (e.g. transaction) and use the signature to impersonate the victim.
+By adding a prefix to the message makes the calculated signature recognizable as an Ethereum specific signature. This prevents misuse where a malicious DApp can sign arbitrary data (e.g. transaction) and use the signature to impersonate the victim.
 
 Note: the address to sign with must be unlocked.
 

--- a/src/content/developers/docs/apis/json-rpc/index.md
+++ b/src/content/developers/docs/apis/json-rpc/index.md
@@ -72,6 +72,2186 @@ The following options are possible for the defaultBlock parameter:
 - `String "latest"` - for the latest mined block
 - `String "pending"` - for the pending state/transactions
 
+## Examples
+
+On this page we provide examples of how to use individual JSON_RPC API endpoints using the command line tool, [curl](https://curl.se). These individial endpoint examples are found below in the [Curl examples](#curl-examples) section. Further down the page, we also provide an [end-to-end example](#usage-example) for compiling and deploying a smart contract using a Geth node, the json-rpc api and curl..
+
+## Curl examples {#curl-examples}
+
+Examples of using the JSON_RPC API by making [curl](https://curl.se) requests to an Ethereum node are provided below. Each example
+includes a description of the specific endpoint, its parameters, return type, and a worked example of how it should be used.
+
+The curl requests might return an error message relating to the content type. This is because the `--data` option sets the content type to `application/x-www-form-urlencoded`. If your node does complain about this, manually set the header by placing `-H "Content-Type: application/json"` at the start of the call. The examples also do not include the URL/IP & port combination which must be the last argument given to curl (e.g. `127.0.0.1:8545`). A complete curl request including these additional data takes the following form:
+
+```shell
+curl -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"web3_clientVersion","params":[],"id":67}' 127.0.0.1:8545
+```
+
+## Gossip, State, History {#gossip-state-history}
+
+A handful of core JSON-RPC methods require data from the Ethereum network, and fall neatly into three main categories: _Gossip, State, and History_. Use the links in these sections to jump to each method, or use the table of contents to explore the whole list of methods.
+
+### Gossip Methods {#gossip-methods}
+
+> These methods track the head of the chain. This is how transactions make their way around the network, find their way into blocks, and how clients find out about new blocks.
+
+- [eth_blockNumber](#eth_blocknumber)
+- [eth_sendRawTransaction](#eth_sendrawtransaction)
+
+### State Methods {#state_methods}
+
+> Methods that report the current state of all the data stored. The "state" is like one big shared piece of RAM, and includes account balances, contract data, and gas estimations.
+
+- [eth_getBalance](#eth_getbalance)
+- [eth_getStorageAt](#eth_getstorageat)
+- [eth_getTransactionCount](#eth_gettransactioncount)
+- [eth_getCode](#eth_getcode)
+- [eth_call](#eth_call)
+- [eth_estimateGas](#eth_estimategas)
+
+### History Methods {#history_methods}
+
+> Fetches historical records of every block back to genesis. This is like one large append-only file, and includes all block headers, block bodies, uncle blocks, and transaction receipts.
+
+- [eth_getBlockTransactionCountByHash](#eth_getblocktransactioncountbyhash)
+- [eth_getBlockTransactionCountByNumber](#eth_getblocktransactioncountbynumber)
+- [eth_getUncleCountByBlockHash](#eth_getunclecountbyblockhash)
+- [eth_getUncleCountByBlockNumber](#eth_getunclecountbyblocknumber)
+- [eth_getBlockByHash](#eth_getblockbyhash)
+- [eth_getBlockByNumber](#eth_getblockbynumber)
+- [eth_getTransactionByHash](#eth_gettransactionbyhash)
+- [eth_getTransactionByBlockHashAndIndex](#eth_gettransactionbyblockhashandindex)
+- [eth_getTransactionByBlockNumberAndIndex](#eth_gettransactionbyblocknumberandindex)
+- [eth_getTransactionReceipt](#eth_gettransactionreceipt)
+- [eth_getUncleByBlockHashAndIndex](#eth_getunclebyblockhashandindex)
+- [eth_getUncleByBlockNumberAndIndex](#eth_getunclebyblocknumberandindex)
+
+## JSON-RPC API Methods {#json-rpc-methods}
+
+### web3_clientVersion {#web3_clientversion}
+
+Returns the current client version.
+
+**Parameters**
+
+None
+
+**Returns**
+
+`String` - The current client version
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"web3_clientVersion","params":[],"id":67}'
+// Result
+{
+  "id":67,
+  "jsonrpc":"2.0",
+  "result": "Mist/v0.9.3/darwin/go1.4.1"
+}
+```
+
+### web3_sha3 {#web3_sha3}
+
+Returns Keccak-256 (_not_ the standardized SHA3-256) of the given data.
+
+**Parameters**
+
+1. `DATA` - the data to convert into a SHA3 hash
+
+```js
+params: ["0x68656c6c6f20776f726c64"]
+```
+
+**Returns**
+
+`DATA` - The SHA3 result of the given string.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"web3_sha3","params":["0x68656c6c6f20776f726c64"],"id":64}'
+// Result
+{
+  "id":64,
+  "jsonrpc": "2.0",
+  "result": "0x47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad"
+}
+```
+
+### net_version {#net_version}
+
+Returns the current network id.
+
+**Parameters**
+
+None
+
+**Returns**
+
+`String` - The current network id.
+
+The full list of current network IDs is available at [chainlist.org](https://chainlist.org). Sopme common ones are:
+`1`: Ethereum Mainnet
+`2`: Morden testnet (now deprecated)
+`3`: Ropsten testnet
+`4`: Rinkeby testnet
+`5`: Goerli testnet
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"net_version","params":[],"id":67}'
+// Result
+{
+  "id":67,
+  "jsonrpc": "2.0",
+  "result": "3"
+}
+```
+
+### net_listening {#net_peercount}
+
+Returns `true` if client is actively listening for network connections.
+
+**Parameters**
+
+None
+
+**Returns**
+
+`Boolean` - `true` when listening, otherwise `false`.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"net_listening","params":[],"id":67}'
+// Result
+{
+  "id":67,
+  "jsonrpc":"2.0",
+  "result":true
+}
+```
+
+### net_peerCount {#net_listening}
+
+Returns number of peers currently connected to the client.
+
+**Parameters**
+
+None
+
+**Returns**
+
+`QUANTITY` - integer of the number of connected peers.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"net_peerCount","params":[],"id":74}'
+// Result
+{
+  "id":74,
+  "jsonrpc": "2.0",
+  "result": "0x2" // 2
+}
+```
+
+### eth_protocolVersion {#eth_protocolversion}
+
+Returns the current Ethereum protocol version.
+
+**Parameters**
+
+None
+
+**Returns**
+
+`String` - The current Ethereum protocol version
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_protocolVersion","params":[],"id":67}'
+// Result
+{
+  "id":67,
+  "jsonrpc": "2.0",
+  "result": "54"
+}
+```
+
+### eth_syncing {#eth_syncing}
+
+Returns an object with data about the sync status or `false`.
+
+**Parameters**
+
+None
+
+**Returns**
+
+`Object|Boolean`, An object with sync status data or `FALSE`, when not syncing:
+
+- `startingBlock`: `QUANTITY` - The block at which the import started (will only be reset, after the sync reached his head)
+- `currentBlock`: `QUANTITY` - The current block, same as eth_blockNumber
+- `highestBlock`: `QUANTITY` - The estimated highest block
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}'
+// Result
+{
+  "id":1,
+  "jsonrpc": "2.0",
+  "result": {
+    startingBlock: '0x384',
+    currentBlock: '0x386',
+    highestBlock: '0x454'
+  }
+}
+// Or when not syncing
+{
+  "id":1,
+  "jsonrpc": "2.0",
+  "result": false
+}
+```
+
+### eth_coinbase {#eth_coinbase}
+
+Returns the client coinbase address.
+
+**Parameters**
+
+None
+
+**Returns**
+
+`DATA`, 20 bytes - the current coinbase address.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_coinbase","params":[],"id":64}'
+// Result
+{
+  "id":64,
+  "jsonrpc": "2.0",
+  "result": "0x407d73d8a49eeb85d32cf465507dd71d507100c1"
+}
+```
+
+### eth_mining {#eth_mining}
+
+Returns `true` if client is actively mining new blocks.
+
+**Parameters**
+
+None
+
+**Returns**
+
+`Boolean` - returns `true` of the client is mining, otherwise `false`.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_mining","params":[],"id":71}'
+//
+{
+  "id":71,
+  "jsonrpc": "2.0",
+  "result": true
+}
+```
+
+### eth_hashrate {#eth_hashrate}
+
+Returns the number of hashes per second that the node is mining with.
+
+**Parameters**
+
+None
+
+**Returns**
+
+`QUANTITY` - number of hashes per second.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_hashrate","params":[],"id":71}'
+// Result
+{
+  "id":71,
+  "jsonrpc": "2.0",
+  "result": "0x38a"
+}
+```
+
+### eth_gasPrice {#eth_gasprice}
+
+Returns the current price per gas in wei.
+
+**Parameters**
+
+None
+
+**Returns**
+
+`QUANTITY` - integer of the current gas price in wei.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_gasPrice","params":[],"id":73}'
+// Result
+{
+  "id":73,
+  "jsonrpc": "2.0",
+  "result": "0x1dfd14000" // 8049999872 Wei
+}
+```
+
+### eth_accounts {#eth_accounts}
+
+Returns a list of addresses owned by client.
+
+**Parameters**
+
+None
+
+**Returns**
+
+`Array of DATA`, 20 Bytes - addresses owned by the client.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_accounts","params":[],"id":1}'
+// Result
+{
+  "id":1,
+  "jsonrpc": "2.0",
+  "result": ["0x407d73d8a49eeb85d32cf465507dd71d507100c1"]
+}
+```
+
+### eth_blockNumber {#eth_blocknumber}
+
+Returns the number of most recent block.
+
+**Parameters**
+
+None
+
+**Returns**
+
+`QUANTITY` - integer of the current block number the client is on.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":83}'
+// Result
+{
+  "id":83,
+  "jsonrpc": "2.0",
+  "result": "0x4b7" // 1207
+}
+```
+
+### eth_getBalance {#eth_getbalance}
+
+Returns the balance of the account of given address.
+
+**Parameters**
+
+1. `DATA`, 20 Bytes - address to check for balance.
+2. `QUANTITY|TAG` - integer block number, or the string `"latest"`, `"earliest"` or `"pending"`, see the [default block parameter](/developers/docs/apis/json-rpc/#default-block-parameter)
+
+```js
+params: ["0x407d73d8a49eeb85d32cf465507dd71d507100c1", "latest"]
+```
+
+**Returns**
+
+`QUANTITY` - integer of the current balance in wei.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getBalance","params":["0x407d73d8a49eeb85d32cf465507dd71d507100c1", "latest"],"id":1}'
+// Result
+{
+  "id":1,
+  "jsonrpc": "2.0",
+  "result": "0x0234c8a3397aab58" // 158972490234375000
+}
+```
+
+### eth_getStorageAt {#eth_getstorageat}
+
+Returns the value from a storage position at a given address.
+
+**Parameters**
+
+1. `DATA`, 20 Bytes - address of the storage.
+2. `QUANTITY` - integer of the position in the storage.
+3. `QUANTITY|TAG` - integer block number, or the string `"latest"`, `"earliest"` or `"pending"`, see the [default block parameter](/developers/docs/apis/json-rpc/#default-block-parameter)
+
+**Returns**
+
+`DATA` - the value at this storage position.
+
+**Example**
+Calculating the correct position depends on the storage to retrieve. Consider the following contract deployed at `0x295a70b2de5e3953354a6a8344e616ed314d7251` by address `0x391694e7e0b0cce554cb130d723a9d27458f9298`.
+
+```
+contract Storage {
+    uint pos0;
+    mapping(address => uint) pos1;
+    function Storage() {
+        pos0 = 1234;
+        pos1[msg.sender] = 5678;
+    }
+}
+```
+
+Retrieving the value of pos0 is straight forward:
+
+```js
+curl -X POST --data '{"jsonrpc":"2.0", "method": "eth_getStorageAt", "params": ["0x295a70b2de5e3953354a6a8344e616ed314d7251", "0x0", "latest"], "id": 1}' localhost:8545
+{"jsonrpc":"2.0","id":1,"result":"0x00000000000000000000000000000000000000000000000000000000000004d2"}
+```
+
+Retrieving an element of the map is harder. The position of an element in the map is calculated with:
+
+```js
+keccack(LeftPad32(key, 0), LeftPad32(map position, 0))
+```
+
+This means to retrieve the storage on pos1["0x391694e7e0b0cce554cb130d723a9d27458f9298"] we need to calculate the position with:
+
+```js
+keccak(
+  decodeHex(
+    "000000000000000000000000391694e7e0b0cce554cb130d723a9d27458f9298" +
+      "0000000000000000000000000000000000000000000000000000000000000001"
+  )
+)
+```
+
+The geth console which comes with the web3 library can be used to make the calculation:
+
+```js
+> var key = "000000000000000000000000391694e7e0b0cce554cb130d723a9d27458f9298" + "0000000000000000000000000000000000000000000000000000000000000001"
+undefined
+> web3.sha3(key, {"encoding": "hex"})
+"0x6661e9d6d8b923d5bbaab1b96e1dd51ff6ea2a93520fdc9eb75d059238b8c5e9"
+```
+
+Now to fetch the storage:
+
+```js
+curl -X POST --data '{"jsonrpc":"2.0", "method": "eth_getStorageAt", "params": ["0x295a70b2de5e3953354a6a8344e616ed314d7251", "0x6661e9d6d8b923d5bbaab1b96e1dd51ff6ea2a93520fdc9eb75d059238b8c5e9", "latest"], "id": 1}' localhost:8545
+{"jsonrpc":"2.0","id":1,"result":"0x000000000000000000000000000000000000000000000000000000000000162e"}
+```
+
+### eth_getTransactionCount {#eth_gettransactioncount}
+
+Returns the number of transactions _sent_ from an address.
+
+**Parameters**
+
+1. `DATA`, 20 Bytes - address.
+2. `QUANTITY|TAG` - integer block number, or the string `"latest"`, `"earliest"` or `"pending"`, see the [default block parameter](/developers/docs/apis/json-rpc/#default-block-parameter)
+
+```js
+params: [
+  "0x407d73d8a49eeb85d32cf465507dd71d507100c1",
+  "latest", // state at the latest block
+]
+```
+
+**Returns**
+
+`QUANTITY` - integer of the number of transactions send from this address.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getTransactionCount","params":["0x407d73d8a49eeb85d32cf465507dd71d507100c1","latest"],"id":1}'
+// Result
+{
+  "id":1,
+  "jsonrpc": "2.0",
+  "result": "0x1" // 1
+}
+```
+
+### eth_getBlockTransactionCountByHash {#eth_getblocktransactioncountbyhash}
+
+Returns the number of transactions in a block from a block matching the given block hash.
+
+**Parameters**
+
+1. `DATA`, 32 Bytes - hash of a block
+
+```js
+params: ["0xb903239f8543d04b5dc1ba6579132b143087c68db1b2168786408fcbce568238"]
+```
+
+**Returns**
+
+`QUANTITY` - integer of the number of transactions in this block.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getBlockTransactionCountByHash","params":["0xb903239f8543d04b5dc1ba6579132b143087c68db1b2168786408fcbce568238"],"id":1}'
+// Result
+{
+  "id":1,
+  "jsonrpc": "2.0",
+  "result": "0xb" // 11
+}
+```
+
+### eth_getBlockTransactionCountByNumber {#eth_getblocktransactioncountbynumber}
+
+Returns the number of transactions in a block matching the given block number.
+
+**Parameters**
+
+1. `QUANTITY|TAG` - integer of a block number, or the string `"earliest"`, `"latest"` or `"pending"`, as in the [default block parameter](/developers/docs/apis/json-rpc/#default-block-parameter).
+
+```js
+params: [
+  "0xe8", // 232
+]
+```
+
+**Returns**
+
+`QUANTITY` - integer of the number of transactions in this block.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getBlockTransactionCountByNumber","params":["0xe8"],"id":1}'
+// Result
+{
+  "id":1,
+  "jsonrpc": "2.0",
+  "result": "0xa" // 10
+}
+```
+
+### eth_getUncleCountByBlockHash {#eth_getunclecountbyblockhash}
+
+Returns the number of uncles in a block from a block matching the given block hash.
+
+**Parameters**
+
+1. `DATA`, 32 Bytes - hash of a block
+
+```js
+params: ["0xb903239f8543d04b5dc1ba6579132b143087c68db1b2168786408fcbce568238"]
+```
+
+**Returns**
+
+`QUANTITY` - integer of the number of uncles in this block.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getUncleCountByBlockHash","params":["0xb903239f8543d04b5dc1ba6579132b143087c68db1b2168786408fcbce568238"],"id":1}'
+// Result
+{
+  "id":1,
+  "jsonrpc": "2.0",
+  "result": "0x1" // 1
+}
+```
+
+### eth_getUncleCountByBlockNumber {#eth_getunclecountbyblocknumber}
+
+Returns the number of uncles in a block from a block matching the given block number.
+
+**Parameters**
+
+1. `QUANTITY|TAG` - integer of a block number, or the string "latest", "earliest" or "pending", see the [default block parameter](/developers/docs/apis/json-rpc/#default-block-parameter)
+
+```js
+params: [
+  "0xe8", // 232
+]
+```
+
+**Returns**
+
+`QUANTITY` - integer of the number of uncles in this block.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getUncleCountByBlockNumber","params":["0xe8"],"id":1}'
+// Result
+{
+  "id":1,
+  "jsonrpc": "2.0",
+  "result": "0x1" // 1
+}
+```
+
+### eth_getCode {#eth_getcode}
+
+Returns code at a given address.
+
+**Parameters**
+
+1. `DATA`, 20 Bytes - address
+2. `QUANTITY|TAG` - integer block number, or the string `"latest"`, `"earliest"` or `"pending"`, see the [default block parameter](/developers/docs/apis/json-rpc/#default-block-parameter)
+
+```js
+params: [
+  "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+  "0x2", // 2
+]
+```
+
+**Returns**
+
+`DATA` - the code from the given address.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getCode","params":["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b", "0x2"],"id":1}'
+// Result
+{
+  "id":1,
+  "jsonrpc": "2.0",
+  "result": "0x600160008035811a818181146012578301005b601b6001356025565b8060005260206000f25b600060078202905091905056"
+}
+```
+
+### eth_sign {#eth_sign}
+
+The sign method calculates an Ethereum specific signature with: `sign(keccak256("\x19Ethereum Signed Message:\n" + len(message) + message)))`.
+
+By adding a prefix to the message makes the calculated signature recognisable as an Ethereum specific signature. This prevents misuse where a malicious DApp can sign arbitrary data (e.g. transaction) and use the signature to impersonate the victim.
+
+Note: the address to sign with must be unlocked.
+
+**Parameters**
+
+1. `DATA`, 20 Bytes - address
+2. `DATA`, N Bytes - message to sign
+
+**Returns**
+
+`DATA`: Signature
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_sign","params":["0x9b2055d370f73ec7d8a03e965129118dc8f5bf83", "0xdeadbeaf"],"id":1}'
+// Result
+{
+  "id":1,
+  "jsonrpc": "2.0",
+  "result": "0xa3f20717a250c2b0b729b7e5becbff67fdaef7e0699da4de7ca5895b02a170a12d887fd3b17bfdce3481f10bea41f45ba9f709d39ce8325427b57afcfc994cee1b"
+}
+```
+
+### eth_signTransaction {#eth_signtransaction}
+
+Signs a transaction that can be submitted to the network at a later time using with [eth_sendRawTransaction](#eth_sendrawtransaction).
+
+**Parameters**
+
+1. `Object` - The transaction object
+
+- `from`: `DATA`, 20 Bytes - The address the transaction is sent from.
+- `to`: `DATA`, 20 Bytes - (optional when creating new contract) The address the transaction is directed to.
+- `gas`: `QUANTITY` - (optional, default: 90000) Integer of the gas provided for the transaction execution. It will return unused gas.
+- `gasPrice`: `QUANTITY` - (optional, default: To-Be-Determined) Integer of the gasPrice used for each paid gas, in Wei.
+- `value`: `QUANTITY` - (optional) Integer of the value sent with this transaction, in Wei.
+- `data`: `DATA` - The compiled code of a contract OR the hash of the invoked method signature and encoded parameters.
+- `nonce`: `QUANTITY` - (optional) Integer of a nonce. This allows to overwrite your own pending transactions that use the same nonce.
+
+**Returns**
+
+`DATA`, The signed transaction object.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"id": 1,"jsonrpc": "2.0","method": "eth_signTransaction","params": [{"data":"0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675","from": "0xb60e8dd61c5d32be8058bb8eb970870f07233155","gas": "0x76c0","gasPrice": "0x9184e72a000","to": "0xd46e8dd67c5d32be8058bb8eb970870f07244567","value": "0x9184e72a"}]}'
+// Result
+{
+    "id": 1,
+    "jsonrpc": "2.0",
+    "result": "0xa3f20717a250c2b0b729b7e5becbff67fdaef7e0699da4de7ca5895b02a170a12d887fd3b17bfdce3481f10bea41f45ba9f709d39ce8325427b57afcfc994cee1b"
+}
+```
+
+### eth_sendTransaction {#eth_sendtransaction}
+
+Creates new message call transaction or a contract creation, if the data field contains code.
+
+**Parameters**
+
+1. `Object` - The transaction object
+
+- `from`: `DATA`, 20 Bytes - The address the transaction is sent from.
+- `to`: `DATA`, 20 Bytes - (optional when creating new contract) The address the transaction is directed to.
+- `gas`: `QUANTITY` - (optional, default: 90000) Integer of the gas provided for the transaction execution. It will return unused gas.
+- `gasPrice`: `QUANTITY` - (optional, default: To-Be-Determined) Integer of the gasPrice used for each paid gas.
+- `value`: `QUANTITY` - (optional) Integer of the value sent with this transaction.
+- `data`: `DATA` - The compiled code of a contract OR the hash of the invoked method signature and encoded parameters.
+- `nonce`: `QUANTITY` - (optional) Integer of a nonce. This allows to overwrite your own pending transactions that use the same nonce.
+
+```js
+params: [
+  {
+    from: "0xb60e8dd61c5d32be8058bb8eb970870f07233155",
+    to: "0xd46e8dd67c5d32be8058bb8eb970870f07244567",
+    gas: "0x76c0", // 30400
+    gasPrice: "0x9184e72a000", // 10000000000000
+    value: "0x9184e72a", // 2441406250
+    data: "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675",
+  },
+]
+```
+
+**Returns**
+
+`DATA`, 32 Bytes - the transaction hash, or the zero hash if the transaction is not yet available.
+
+Use [eth_getTransactionReceipt](#eth_gettransactionreceipt) to get the contract address, after the transaction was mined, when you created a contract.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{see above}],"id":1}'
+// Result
+{
+  "id":1,
+  "jsonrpc": "2.0",
+  "result": "0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331"
+}
+```
+
+### eth_sendRawTransaction {#eth_sendrawtransaction}
+
+Creates new message call transaction or a contract creation for signed transactions.
+
+**Parameters**
+
+1. `DATA`, The signed transaction data.
+
+```js
+params: [
+  "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675",
+]
+```
+
+**Returns**
+
+`DATA`, 32 Bytes - the transaction hash, or the zero hash if the transaction is not yet available.
+
+Use [eth_getTransactionReceipt](#eth_gettransactionreceipt) to get the contract address, after the transaction was mined, when you created a contract.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":[{see above}],"id":1}'
+// Result
+{
+  "id":1,
+  "jsonrpc": "2.0",
+  "result": "0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331"
+}
+```
+
+### eth_call {#eth_call}
+
+Executes a new message call immediately without creating a transaction on the block chain.
+
+**Parameters**
+
+1. `Object` - The transaction call object
+
+- `from`: `DATA`, 20 Bytes - (optional) The address the transaction is sent from.
+- `to`: `DATA`, 20 Bytes - The address the transaction is directed to.
+- `gas`: `QUANTITY` - (optional) Integer of the gas provided for the transaction execution. eth_call consumes zero gas, but this parameter may be needed by some executions.
+- `gasPrice`: `QUANTITY` - (optional) Integer of the gasPrice used for each paid gas
+- `value`: `QUANTITY` - (optional) Integer of the value sent with this transaction
+- `data`: `DATA` - (optional) Hash of the method signature and encoded parameters. For details see [Ethereum Contract ABI in the Solidity documentation](https://docs.soliditylang.org/en/latest/abi-spec.html)
+
+2. `QUANTITY|TAG` - integer block number, or the string `"latest"`, `"earliest"` or `"pending"`, see the [default block parameter](/developers/docs/apis/json-rpc/#default-block-parameter)
+
+**Returns**
+
+`DATA` - the return value of executed contract.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_call","params":[{see above}],"id":1}'
+// Result
+{
+  "id":1,
+  "jsonrpc": "2.0",
+  "result": "0x"
+}
+```
+
+### eth_estimateGas {#eth_estimategas}
+
+Generates and returns an estimate of how much gas is necessary to allow the transaction to complete. The transaction will not be added to the blockchain. Note that the estimate may be significantly more than the amount of gas actually used by the transaction, for a variety of reasons including EVM mechanics and node performance.
+
+**Parameters**
+
+See [eth_call](#eth_call) parameters, expect that all properties are optional. If no gas limit is specified geth uses the block gas limit from the pending block as an upper bound. As a result the returned estimate might not be enough to executed the call/transaction when the amount of gas is higher than the pending block gas limit.
+
+**Returns**
+
+`QUANTITY` - the amount of gas used.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_estimateGas","params":[{see above}],"id":1}'
+// Result
+{
+  "id":1,
+  "jsonrpc": "2.0",
+  "result": "0x5208" // 21000
+}
+```
+
+### eth_getBlockByHash {#eth_getblockbyhash}
+
+Returns information about a block by hash.
+
+**Parameters**
+
+1. `DATA`, 32 Bytes - Hash of a block.
+2. `Boolean` - If `true` it returns the full transaction objects, if `false` only the hashes of the transactions.
+
+```js
+params: [
+  "0xdc0818cf78f21a8e70579cb46a43643f78291264dda342ae31049421c82d21ae",
+  false,
+]
+```
+
+**Returns**
+
+`Object` - A block object, or `null` when no block was found:
+
+- `number`: `QUANTITY` - the block number. `null` when its pending block.
+- `hash`: `DATA`, 32 Bytes - hash of the block. `null` when its pending block.
+- `parentHash`: `DATA`, 32 Bytes - hash of the parent block.
+- `nonce`: `DATA`, 8 Bytes - hash of the generated proof-of-work. `null` when its pending block.
+- `sha3Uncles`: `DATA`, 32 Bytes - SHA3 of the uncles data in the block.
+- `logsBloom`: `DATA`, 256 Bytes - the bloom filter for the logs of the block. `null` when its pending block.
+- `transactionsRoot`: `DATA`, 32 Bytes - the root of the transaction trie of the block.
+- `stateRoot`: `DATA`, 32 Bytes - the root of the final state trie of the block.
+- `receiptsRoot`: `DATA`, 32 Bytes - the root of the receipts trie of the block.
+- `miner`: `DATA`, 20 Bytes - the address of the beneficiary to whom the mining rewards were given.
+- `difficulty`: `QUANTITY` - integer of the difficulty for this block.
+- `totalDifficulty`: `QUANTITY` - integer of the total difficulty of the chain until this block.
+- `extraData`: `DATA` - the "extra data" field of this block.
+- `size`: `QUANTITY` - integer the size of this block in bytes.
+- `gasLimit`: `QUANTITY` - the maximum gas allowed in this block.
+- `gasUsed`: `QUANTITY` - the total used gas by all transactions in this block.
+- `timestamp`: `QUANTITY` - the unix timestamp for when the block was collated.
+- `transactions`: `Array` - Array of transaction objects, or 32 Bytes transaction hashes depending on the last given parameter.
+- `uncles`: `Array` - Array of uncle hashes.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getBlockByHash","params":["0xdc0818cf78f21a8e70579cb46a43643f78291264dda342ae31049421c82d21ae", false],"id":1}'
+// Result
+{
+{
+"jsonrpc": "2.0",
+"id": 1,
+"result": {
+    "difficulty": "0x4ea3f27bc",
+    "extraData": "0x476574682f4c5649562f76312e302e302f6c696e75782f676f312e342e32",
+    "gasLimit": "0x1388",
+    "gasUsed": "0x0",
+    "hash": "0xdc0818cf78f21a8e70579cb46a43643f78291264dda342ae31049421c82d21ae",
+    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "miner": "0xbb7b8287f3f0a933474a79eae42cbca977791171",
+    "mixHash": "0x4fffe9ae21f1c9e15207b1f472d5bbdd68c9595d461666602f2be20daf5e7843",
+    "nonce": "0x689056015818adbe",
+    "number": "0x1b4",
+    "parentHash": "0xe99e022112df268087ea7eafaf4790497fd21dbeeb6bd7a1721df161a6657a54",
+    "receiptsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+    "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+    "size": "0x220",
+    "stateRoot": "0xddc8b0234c2e0cad087c8b389aa7ef01f7d79b2570bccb77ce48648aa61c904d",
+    "timestamp": "0x55ba467c",
+    "totalDifficulty": "0x78ed983323d",
+    "transactions": [
+    ],
+    "transactionsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+    "uncles": [
+    ]
+}
+}
+```
+
+### eth_getBlockByNumber {#eth_getblockbynumber}
+
+Returns information about a block by block number.
+
+**Parameters**
+
+1. `QUANTITY|TAG` - integer of a block number, or the string `"earliest"`, `"latest"` or `"pending"`, as in the [default block parameter](/developers/docs/apis/json-rpc/#default-block-parameter).
+2. `Boolean` - If `true` it returns the full transaction objects, if `false` only the hashes of the transactions.
+
+```js
+params: [
+  "0x1b4", // 436
+  true,
+]
+```
+
+**Returns**
+See [eth_getBlockByHash](#eth_getblockbyhash)
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x1b4", true],"id":1}'
+```
+
+Result see [eth_getBlockByHash](#eth_getblockbyhash)
+
+### eth_getTransactionByHash {#eth_gettransactionbyhash}
+
+Returns the information about a transaction requested by transaction hash.
+
+**Parameters**
+
+1. `DATA`, 32 Bytes - hash of a transaction
+
+```js
+params: ["0x88df016429689c079f3b2f6ad39fa052532c56795b733da78a91ebe6a713944b"]
+```
+
+**Returns**
+
+`Object` - A transaction object, or `null` when no transaction was found:
+
+- `blockHash`: `DATA`, 32 Bytes - hash of the block where this transaction was in. `null` when its pending.
+- `blockNumber`: `QUANTITY` - block number where this transaction was in. `null` when its pending.
+- `from`: `DATA`, 20 Bytes - address of the sender.
+- `gas`: `QUANTITY` - gas provided by the sender.
+- `gasPrice`: `QUANTITY` - gas price provided by the sender in Wei.
+- `hash`: `DATA`, 32 Bytes - hash of the transaction.
+- `input`: `DATA` - the data send along with the transaction.
+- `nonce`: `QUANTITY` - the number of transactions made by the sender prior to this one.
+- `to`: `DATA`, 20 Bytes - address of the receiver. `null` when its a contract creation transaction.
+- `transactionIndex`: `QUANTITY` - integer of the transactions index position in the block. `null` when its pending.
+- `value`: `QUANTITY` - value transferred in Wei.
+- `v`: `QUANTITY` - ECDSA recovery id
+- `r`: `QUANTITY` - ECDSA signature r
+- `s`: `QUANTITY` - ECDSA signature s
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getTransactionByHash","params":["0x88df016429689c079f3b2f6ad39fa052532c56795b733da78a91ebe6a713944b"],"id":1}'
+// Result
+{
+  "jsonrpc":"2.0",
+  "id":1,
+  "result":{
+    "blockHash":"0x1d59ff54b1eb26b013ce3cb5fc9dab3705b415a67127a003c3e61eb445bb8df2",
+    "blockNumber":"0x5daf3b", // 6139707
+    "from":"0xa7d9ddbe1f17865597fbd27ec712455208b6b76d",
+    "gas":"0xc350", // 50000
+    "gasPrice":"0x4a817c800", // 20000000000
+    "hash":"0x88df016429689c079f3b2f6ad39fa052532c56795b733da78a91ebe6a713944b",
+    "input":"0x68656c6c6f21",
+    "nonce":"0x15", // 21
+    "to":"0xf02c1c8e6114b1dbe8937a39260b5b0a374432bb",
+    "transactionIndex":"0x41", // 65
+    "value":"0xf3dbb76162000", // 4290000000000000
+    "v":"0x25", // 37
+    "r":"0x1b5e176d927f8e9ab405058b2d2457392da3e20f328b16ddabcebc33eaac5fea",
+    "s":"0x4ba69724e8f69de52f0125ad8b3c5c2cef33019bac3249e2c0a2192766d1721c"
+  }
+}
+```
+
+### eth_getTransactionByBlockHashAndIndex {#eth_gettransactionbyblockhashandindex}
+
+Returns information about a transaction by block hash and transaction index position.
+
+**Parameters**
+
+1. `DATA`, 32 Bytes - hash of a block.
+2. `QUANTITY` - integer of the transaction index position.
+
+```js
+params: [
+  "0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331",
+  "0x0", // 0
+]
+```
+
+**Returns**
+See [eth_getTransactionByHash](#eth_gettransactionbyhash)
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getTransactionByBlockHashAndIndex","params":["0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b", "0x0"],"id":1}'
+```
+
+Result see [eth_getTransactionByHash](#eth_gettransactionbyhash)
+
+### eth_getTransactionByBlockNumberAndIndex {#eth_gettransactionbyblocknumberandindex}
+
+Returns information about a transaction by block number and transaction index position.
+
+**Parameters**
+
+1. `QUANTITY|TAG` - a block number, or the string `"earliest"`, `"latest"` or `"pending"`, as in the [default block parameter](/developers/docs/apis/json-rpc/#default-block-parameter).
+2. `QUANTITY` - the transaction index position.
+
+```js
+params: [
+  "0x29c", // 668
+  "0x0", // 0
+]
+```
+
+**Returns**
+See [eth_getTransactionByHash](#eth_gettransactionbyhash)
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getTransactionByBlockNumberAndIndex","params":["0x29c", "0x0"],"id":1}'
+```
+
+Result see [eth_getTransactionByHash](#eth_gettransactionbyhash)
+
+### eth_getTransactionReceipt {#eth_gettransactionreceipt}
+
+Returns the receipt of a transaction by transaction hash.
+
+**Note** That the receipt is not available for pending transactions.
+
+**Parameters**
+
+1. `DATA`, 32 Bytes - hash of a transaction
+
+```js
+params: ["0xb903239f8543d04b5dc1ba6579132b143087c68db1b2168786408fcbce568238"]
+```
+
+**Returns**
+`Object` - A transaction receipt object, or `null` when no receipt was found:
+
+- `transactionHash `: `DATA`, 32 Bytes - hash of the transaction.
+- `transactionIndex`: `QUANTITY` - integer of the transactions index position in the block.
+- `blockHash`: `DATA`, 32 Bytes - hash of the block where this transaction was in.
+- `blockNumber`: `QUANTITY` - block number where this transaction was in.
+- `from`: `DATA`, 20 Bytes - address of the sender.
+- `to`: `DATA`, 20 Bytes - address of the receiver. null when its a contract creation transaction.
+- `cumulativeGasUsed `: `QUANTITY ` - The total amount of gas used when this transaction was executed in the block.
+- `gasUsed `: `QUANTITY ` - The amount of gas used by this specific transaction alone.
+- `contractAddress `: `DATA`, 20 Bytes - The contract address created, if the transaction was a contract creation, otherwise `null`.
+- `logs`: `Array` - Array of log objects, which this transaction generated.
+- `logsBloom`: `DATA`, 256 Bytes - Bloom filter for light clients to quickly retrieve related logs.
+  It also returns _either_ :
+- `root` : `DATA` 32 bytes of post-transaction stateroot (pre Byzantium)
+- `status`: `QUANTITY` either `1` (success) or `0` (failure)
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getTransactionReceipt","params":["0xb903239f8543d04b5dc1ba6579132b143087c68db1b2168786408fcbce568238"],"id":1}'
+// Result
+{
+"id":1,
+"jsonrpc":"2.0",
+"result": {
+     transactionHash: '0xb903239f8543d04b5dc1ba6579132b143087c68db1b2168786408fcbce568238',
+     transactionIndex:  '0x1', // 1
+     blockNumber: '0xb', // 11
+     blockHash: '0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b',
+     cumulativeGasUsed: '0x33bc', // 13244
+     gasUsed: '0x4dc', // 1244
+     contractAddress: '0xb60e8dd61c5d32be8058bb8eb970870f07233155', // or null, if none was created
+     logs: [{
+         // logs as returned by getFilterLogs, etc.
+     }, ...],
+     logsBloom: "0x00...0", // 256 byte bloom filter
+     status: '0x1'
+  }
+}
+```
+
+### eth_getUncleByBlockHashAndIndex {#eth_getunclebyblockhashandindex}
+
+Returns information about a uncle of a block by hash and uncle index position.
+
+**Parameters**
+
+1. `DATA`, 32 Bytes - The hash of a block.
+2. `QUANTITY` - The uncle's index position.
+
+```js
+params: [
+  "0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b",
+  "0x0", // 0
+]
+```
+
+**Returns**
+See [eth_getBlockByHash](#eth_getblockbyhash)
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getUncleByBlockHashAndIndex","params":["0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b", "0x0"],"id":1}'
+```
+
+Result see [eth_getBlockByHash](#eth_getblockbyhash)
+
+**Note**: An uncle doesn't contain individual transactions.
+
+### eth_getUncleByBlockNumberAndIndex {#eth_getunclebyblocknumberandindex}
+
+Returns information about a uncle of a block by number and uncle index position.
+
+**Parameters**
+
+1. `QUANTITY|TAG` - a block number, or the string `"earliest"`, `"latest"` or `"pending"`, as in the [default block parameter](/developers/docs/apis/json-rpc/#default-block-parameter).
+2. `QUANTITY` - the uncle's index position.
+
+```js
+params: [
+  "0x29c", // 668
+  "0x0", // 0
+]
+```
+
+**Returns**
+See [eth_getBlockByHash](#eth_getblockbyhash)
+
+**Note**: An uncle doesn't contain individual transactions.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getUncleByBlockNumberAndIndex","params":["0x29c", "0x0"],"id":1}'
+```
+
+Result see [eth_getBlockByHash](#eth_getblockbyhash)
+
+### eth_getCompilers {#eth_getcompilers}
+
+Returns a list of available compilers in the client.
+
+**Parameters**
+None
+
+**Returns**
+`Array` - Array of available compilers.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getCompilers","params":[],"id":1}'
+// Result
+{
+  "id":1,
+  "jsonrpc": "2.0",
+  "result": ["solidity", "lll", "serpent"]
+}
+```
+
+### eth_compileSolidity {#eth_compile_solidity}
+
+Returns compiled solidity code.
+
+**Parameters**
+
+1. `String` - The source code.
+
+```js
+params: [
+  "contract test { function multiply(uint a) returns(uint d) {   return a * 7;   } }",
+]
+```
+
+**Returns**
+`DATA` - The compiled source code.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_compileSolidity","params":["contract test { function multiply(uint a) returns(uint d) {   return a * 7;   } }"],"id":1}'
+// Result
+{
+  "id":1,
+  "jsonrpc": "2.0",
+  "result": {
+      "code": "0x605880600c6000396000f3006000357c010000000000000000000000000000000000000000000000000000000090048063c6888fa114602e57005b603d6004803590602001506047565b8060005260206000f35b60006007820290506053565b91905056",
+      "info": {
+        "source": "contract test {\n   function multiply(uint a) constant returns(uint d) {\n       return a * 7;\n   }\n}\n",
+        "language": "Solidity",
+        "languageVersion": "0",
+        "compilerVersion": "0.9.19",
+        "abiDefinition": [
+          {
+            "constant": true,
+            "inputs": [
+              {
+                "name": "a",
+                "type": "uint256"
+              }
+            ],
+            "name": "multiply",
+            "outputs": [
+              {
+                "name": "d",
+                "type": "uint256"
+              }
+            ],
+            "type": "function"
+          }
+        ],
+        "userDoc": {
+          "methods": {}
+        },
+        "developerDoc": {
+          "methods": {}
+        }
+      }
+}
+```
+
+### eth_compileLLL {#eth_compileLLL}
+
+Returns compiled LLL code.
+
+**Parameters**
+
+1. `String` - The source code.
+
+```js
+params: ["(returnlll (suicide (caller)))"]
+```
+
+**Returns**
+`DATA` - The compiled source code.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_compileLLL","params":["(returnlll (suicide (caller)))"],"id":1}'
+// Result
+{
+  "id":1,
+  "jsonrpc": "2.0",
+  "result": "0x603880600c6000396000f3006001600060e060020a600035048063c6888fa114601857005b6021600435602b565b8060005260206000f35b600081600702905091905056" // the compiled source code
+}
+```
+
+### eth_compileSerpent {#eth_compileserpent}
+
+Returns compiled serpent code.
+
+**Parameters**
+
+1. `String` - The source code.
+
+```js
+params: ["/* some serpent */"]
+```
+
+**Returns**
+`DATA` - The compiled source code.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_compileSerpent","params":["/* some serpent */"],"id":1}'
+// Result
+{
+  "id":1,
+  "jsonrpc": "2.0",
+  "result": "0x603880600c6000396000f3006001600060e060020a600035048063c6888fa114601857005b6021600435602b565b8060005260206000f35b600081600702905091905056" // the compiled source code
+}
+```
+
+### eth_newFilter {#eth_newfilter}
+
+Creates a filter object, based on filter options, to notify when the state changes (logs).
+To check if the state has changed, call [eth_getFilterChanges](#eth_getfilterchanges).
+
+**A note on specifying topic filters:**
+Topics are order-dependent. A transaction with a log with topics [A, B] will be matched by the following topic filters:
+
+- `[]` "anything"
+- `[A]` "A in first position (and anything after)"
+- `[null, B]` "anything in first position AND B in second position (and anything after)"
+- `[A, B]` "A in first position AND B in second position (and anything after)"
+- `[[A, B], [A, B]]` "(A OR B) in first position AND (A OR B) in second position (and anything after)"
+- **Parameters**
+
+1. `Object` - The filter options:
+
+- `fromBlock`: `QUANTITY|TAG` - (optional, default: `"latest"`) Integer block number, or `"latest"` for the last mined block or `"pending"`, `"earliest"` for not yet mined transactions.
+- `toBlock`: `QUANTITY|TAG` - (optional, default: `"latest"`) Integer block number, or `"latest"` for the last mined block or `"pending"`, `"earliest"` for not yet mined transactions.
+- `address`: `DATA|Array`, 20 Bytes - (optional) Contract address or a list of addresses from which logs should originate.
+- `topics`: `Array of DATA`, - (optional) Array of 32 Bytes `DATA` topics. Topics are order-dependent. Each topic can also be an array of DATA with "or" options.
+
+```js
+params: [
+  {
+    fromBlock: "0x1",
+    toBlock: "0x2",
+    address: "0x8888f1f195afa192cfee860698584c030f4c9db1",
+    topics: [
+      "0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+      null,
+      [
+        "0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+        "0x0000000000000000000000000aff3454fce5edbc8cca8697c15331677e6ebccc",
+      ],
+    ],
+  },
+]
+```
+
+**Returns**
+`QUANTITY` - A filter id.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_newFilter","params":[{"topics":["0x12341234"]}],"id":73}'
+// Result
+{
+  "id":1,
+  "jsonrpc": "2.0",
+  "result": "0x1" // 1
+}
+```
+
+### eth_newBlockFilter {#eth_newblockfilter}
+
+Creates a filter in the node, to notify when a new block arrives.
+To check if the state has changed, call [eth_getFilterChanges](#eth_getfilterchanges).
+
+**Parameters**
+None
+
+**Returns**
+`QUANTITY` - A filter id.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_newBlockFilter","params":[],"id":73}'
+// Result
+{
+  "id":1,
+  "jsonrpc":  "2.0",
+  "result": "0x1" // 1
+}
+```
+
+### eth_newPendingTransactionFilter {#eth_newpendingtransactionfilter}
+
+Creates a filter in the node, to notify when new pending transactions arrive.
+To check if the state has changed, call [eth_getFilterChanges](#eth_getfilterchanges).
+
+**Parameters**
+None
+
+**Returns**
+`QUANTITY` - A filter id.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_newPendingTransactionFilter","params":[],"id":73}'
+// Result
+{
+  "id":1,
+  "jsonrpc":  "2.0",
+  "result": "0x1" // 1
+}
+```
+
+### eth_uninstallFilter {#eth_uninstallfilter}
+
+Uninstalls a filter with given id. Should always be called when watch is no longer needed.
+Additonally Filters timeout when they aren't requested with [eth_getFilterChanges](#eth_getfilterchanges) for a period of time.
+
+**Parameters**
+
+1. `QUANTITY` - The filter id.
+
+```js
+params: [
+  "0xb", // 11
+]
+```
+
+**Returns**
+`Boolean` - `true` if the filter was successfully uninstalled, otherwise `false`.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_uninstallFilter","params":["0xb"],"id":73}'
+// Result
+{
+  "id":1,
+  "jsonrpc": "2.0",
+  "result": true
+}
+```
+
+### eth_getFilterChanges {#eth_getfilterchanges}
+
+Polling method for a filter, which returns an array of logs which occurred since last poll.
+
+**Parameters**
+
+1. `QUANTITY` - the filter id.
+
+```js
+params: [
+  "0x16", // 22
+]
+```
+
+**Returns**
+`Array` - Array of log objects, or an empty array if nothing has changed since last poll.
+
+- For filters created with `eth_newBlockFilter` the return are block hashes (`DATA`, 32 Bytes), e.g. `["0x3454645634534..."]`.
+- For filters created with `eth_newPendingTransactionFilter ` the return are transaction hashes (`DATA`, 32 Bytes), e.g. `["0x6345343454645..."]`.
+- For filters created with `eth_newFilter` logs are objects with following params:
+  - `removed`: `TAG` - `true` when the log was removed, due to a chain reorganization. `false` if its a valid log.
+  - `logIndex`: `QUANTITY` - integer of the log index position in the block. `null` when its pending log.
+  - `transactionIndex`: `QUANTITY` - integer of the transactions index position log was created from. `null` when its pending log.
+  - `transactionHash`: `DATA`, 32 Bytes - hash of the transactions this log was created from. `null` when its pending log.
+  - `blockHash`: `DATA`, 32 Bytes - hash of the block where this log was in. `null` when its pending. `null` when its pending log.
+  - `blockNumber`: `QUANTITY` - the block number where this log was in. `null` when its pending. `null` when its pending log.
+  - `address`: `DATA`, 20 Bytes - address from which this log originated.
+  - `data`: `DATA` - contains one or more 32 Bytes non-indexed arguments of the log.
+  - `topics`: `Array of DATA` - Array of 0 to 4 32 Bytes `DATA` of indexed log arguments. (In _solidity_: The first topic is the _hash_ of the signature of the event (e.g. `Deposit(address,bytes32,uint256)`), except you declared the event with the `anonymous` specifier.)
+- **Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getFilterChanges","params":["0x16"],"id":73}'
+// Result
+{
+  "id":1,
+  "jsonrpc":"2.0",
+  "result": [{
+    "logIndex": "0x1", // 1
+    "blockNumber":"0x1b4", // 436
+    "blockHash": "0x8216c5785ac562ff41e2dcfdf5785ac562ff41e2dcfdf829c5a142f1fccd7d",
+    "transactionHash":  "0xdf829c5a142f1fccd7d8216c5785ac562ff41e2dcfdf5785ac562ff41e2dcf",
+    "transactionIndex": "0x0", // 0
+    "address": "0x16c5785ac562ff41e2dcfdf829c5a142f1fccd7d",
+    "data":"0x0000000000000000000000000000000000000000000000000000000000000000",
+    "topics": ["0x59ebeb90bc63057b6515673c3ecf9438e5058bca0f92585014eced636878c9a5"]
+    },{
+      ...
+    }]
+}
+```
+
+### eth_getFilterLogs {#eth_getfilterlogs}
+
+Returns an array of all logs matching filter with given id.
+
+**Parameters**
+
+1. `QUANTITY` - The filter id.
+
+```js
+params: [
+  "0x16", // 22
+]
+```
+
+**Returns**
+See [eth_getFilterChanges](#eth_getfilterchanges)
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getFilterLogs","params":["0x16"],"id":74}'
+```
+
+Result see [eth_getFilterChanges](#eth_getfilterchanges)
+
+### eth_getLogs {#eth_getlogs}
+
+Returns an array of all logs matching a given filter object.
+
+**Parameters**
+
+1. `Object` - The filter options:
+
+- `fromBlock`: `QUANTITY|TAG` - (optional, default: `"latest"`) Integer block number, or `"latest"` for the last mined block or `"pending"`, `"earliest"` for not yet mined transactions.
+- `toBlock`: `QUANTITY|TAG` - (optional, default: `"latest"`) Integer block number, or `"latest"` for the last mined block or `"pending"`, `"earliest"` for not yet mined transactions.
+- `address`: `DATA|Array`, 20 Bytes - (optional) Contract address or a list of addresses from which logs should originate.
+- `topics`: `Array of DATA`, - (optional) Array of 32 Bytes `DATA` topics. Topics are order-dependent. Each topic can also be an array of DATA with "or" options.
+- `blockhash`: `DATA`, 32 Bytes - (optional, **future**) With the addition of EIP-234, `blockHash` will be a new filter option which restricts the logs returned to the single block with the 32-byte hash `blockHash`. Using `blockHash` is equivalent to `fromBlock` = `toBlock` = the block number with hash `blockHash`. If `blockHash` is present in in the filter criteria, then neither `fromBlock` nor `toBlock` are allowed.
+
+```js
+params: [
+  {
+    topics: [
+      "0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+    ],
+  },
+]
+```
+
+**Returns**
+See [eth_getFilterChanges](#eth_getfilterchanges)
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getLogs","params":[{"topics":["0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b"]}],"id":74}'
+```
+
+Result see [eth_getFilterChanges](#eth_getfilterchanges)
+
+### eth_getWork {#eth_getwork}
+
+Returns the hash of the current block, the seedHash, and the boundary condition to be met ("target").
+
+**Parameters**
+None
+
+**Returns**
+`Array` - Array with the following properties:
+
+1. `DATA`, 32 Bytes - current block header pow-hash
+2. `DATA`, 32 Bytes - the seed hash used for the DAG.
+3. `DATA`, 32 Bytes - the boundary condition ("target"), 2^256 / difficulty.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getWork","params":[],"id":73}'
+// Result
+{
+  "id":1,
+  "jsonrpc":"2.0",
+  "result": [
+      "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+      "0x5EED00000000000000000000000000005EED0000000000000000000000000000",
+      "0xd1ff1c01710000000000000000000000d1ff1c01710000000000000000000000"
+    ]
+}
+```
+
+### eth_submitWork {#eth_submitwork}
+
+Used for submitting a proof-of-work solution.
+
+**Parameters**
+
+1. `DATA`, 8 Bytes - The nonce found (64 bits)
+2. `DATA`, 32 Bytes - The header's pow-hash (256 bits)
+3. `DATA`, 32 Bytes - The mix digest (256 bits)
+
+```js
+params: [
+  "0x0000000000000001",
+  "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+  "0xD1FE5700000000000000000000000000D1FE5700000000000000000000000000",
+]
+```
+
+**Returns**
+`Boolean` - returns `true` if the provided solution is valid, otherwise `false`.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0", "method":"eth_submitWork", "params":["0x0000000000000001", "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef", "0xD1GE5700000000000000000000000000D1GE5700000000000000000000000000"],"id":73}'
+// Result
+{
+  "id":73,
+  "jsonrpc":"2.0",
+  "result": true
+}
+```
+
+### eth_submitHashrate {#eth_submithashrate}
+
+Used for submitting mining hashrate.
+
+**Parameters**
+
+1. `Hashrate`, a hexadecimal string representation (32 bytes) of the hash rate
+2. `ID`, String - A random hexadecimal(32 bytes) ID identifying the client
+
+```js
+params: [
+  "0x0000000000000000000000000000000000000000000000000000000000500000",
+  "0x59daa26581d0acd1fce254fb7e85952f4c09d0915afd33d3886cd914bc7d283c",
+]
+```
+
+**Returns**
+`Boolean` - returns `true` if submitting went through successfully and `false` otherwise.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0", "method":"eth_submitHashrate", "params":["0x0000000000000000000000000000000000000000000000000000000000500000", "0x59daa26581d0acd1fce254fb7e85952f4c09d0915afd33d3886cd914bc7d283c"],"id":73}'
+// Result
+{
+  "id":73,
+  "jsonrpc":"2.0",
+  "result": true
+}
+```
+
+### db_putString (deprecated) {#db_putstring}
+
+Stores a string in the local database.
+
+**Note** this function is deprecated.
+
+**Parameters**
+
+1. `String` - Database name.
+2. `String` - Key name.
+3. `String` - String to store.
+
+```js
+params: ["testDB", "myKey", "myString"]
+```
+
+**Returns**
+`Boolean` - returns `true` if the value was stored, otherwise `false`.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"db_putString","params":["testDB","myKey","myString"],"id":73}'
+// Result
+{
+  "id":1,
+  "jsonrpc":"2.0",
+  "result": true
+}
+```
+
+### db_getString (deprecated) {#db_getstring}
+
+Returns string from the local database.
+**Note** this function is deprecated.
+
+**Parameters**
+
+1. `String` - Database name.
+2. `String` - Key name.
+
+```js
+params: ["testDB", "myKey"]
+```
+
+**Returns**
+`String` - The previously stored string.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"db_getString","params":["testDB","myKey"],"id":73}'
+// Result
+{
+  "id":1,
+  "jsonrpc":"2.0",
+  "result": "myString"
+}
+```
+
+### db_putHex (deprecated) {#db_puthex}
+
+Stores binary data in the local database.
+**Note** this function is deprecated.
+
+**Parameters**
+
+1. `String` - Database name.
+2. `String` - Key name.
+3. `DATA` - The data to store.
+
+```js
+params: ["testDB", "myKey", "0x68656c6c6f20776f726c64"]
+```
+
+**Returns**
+`Boolean` - returns `true` if the value was stored, otherwise `false`.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"db_putHex","params":["testDB","myKey","0x68656c6c6f20776f726c64"],"id":73}'
+// Result
+{
+  "id":1,
+  "jsonrpc":"2.0",
+  "result": true
+}
+```
+
+### db_getHex (deprecated) {#db_gethex}
+
+Returns binary data from the local database.
+**Note** this function is deprecated.
+
+**Parameters**
+
+1. `String` - Database name.
+2. `String` - Key name.
+
+```js
+params: ["testDB", "myKey"]
+```
+
+**Returns**
+`DATA` - The previously stored data.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"db_getHex","params":["testDB","myKey"],"id":73}'
+// Result
+{
+  "id":1,
+  "jsonrpc":"2.0",
+  "result": "0x68656c6c6f20776f726c64"
+}
+```
+
+### shh_version (deprecated) {#shh_post}
+
+Returns the current whisper protocol version.
+
+**Note** this function is deprecated.
+
+**Parameters**
+None
+
+**Returns**
+`String` - The current whisper protocol version
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"shh_version","params":[],"id":67}'
+// Result
+{
+  "id":67,
+  "jsonrpc": "2.0",
+  "result": "2"
+}
+```
+
+### shh_post (deprecated) {#shh_version}
+
+Sends a whisper message.
+
+**Note** this function is deprecated.
+
+**Parameters**
+
+1. `Object` - The whisper post object:
+
+- `from`: `DATA`, 60 Bytes - (optional) The identity of the sender.
+- `to`: `DATA`, 60 Bytes - (optional) The identity of the receiver. When present whisper will encrypt the message so that only the receiver can decrypt it.
+- `topics`: `Array of DATA` - Array of `DATA` topics, for the receiver to identify messages.
+- `payload`: `DATA` - The payload of the message.
+- `priority`: `QUANTITY` - The integer of the priority in a rang from ... (?).
+- `ttl`: `QUANTITY` - integer of the time to live in seconds.
+
+```js
+params: [
+  {
+    from: "0x04f96a5e25610293e42a73908e93ccc8c4d4dc0edcfa9fa872f50cb214e08ebf61a03e245533f97284d442460f2998cd41858798ddfd4d661997d3940272b717b1",
+    to: "0x3e245533f97284d442460f2998cd41858798ddf04f96a5e25610293e42a73908e93ccc8c4d4dc0edcfa9fa872f50cb214e08ebf61a0d4d661997d3940272b717b1",
+    topics: [
+      "0x776869737065722d636861742d636c69656e74",
+      "0x4d5a695276454c39425154466b61693532",
+    ],
+    payload: "0x7b2274797065223a226d6",
+    priority: "0x64",
+    ttl: "0x64",
+  },
+]
+```
+
+**Returns**
+`Boolean` - returns `true` if the message was send, otherwise `false`.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"shh_post","params":[{"from":"0xc931d93e97ab07fe42d923478ba2465f2..","topics": ["0x68656c6c6f20776f726c64"],"payload":"0x68656c6c6f20776f726c64","ttl":0x64,"priority":0x64}],"id":73}'
+// Result
+{
+  "id":1,
+  "jsonrpc":"2.0",
+  "result": true
+}
+```
+
+### shh_newIdentity (deprecated){#shh_newidentity}
+
+Creates new whisper identity in the client.
+
+**Note** this function is deprecated.
+
+**Parameters**
+None
+
+**Returns**
+`DATA`, 60 Bytes - the address of the new identity.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"shh_newIdentity","params":[],"id":73}'
+// Result
+{
+  "id":1,
+  "jsonrpc": "2.0",
+  "result": "0xc931d93e97ab07fe42d923478ba2465f283f440fd6cabea4dd7a2c807108f651b7135d1d6ca9007d5b68aa497e4619ac10aa3b27726e1863c1fd9b570d99bbaf"
+}
+```
+
+### shh_hasIdentity (deprecated){#shh_hasidentity}
+
+Checks if the client hold the private keys for a given identity.
+
+**Note** this function is deprecated.
+
+**Parameters**
+
+1. `DATA`, 60 Bytes - The identity address to check.
+
+```js
+params: [
+  "0x04f96a5e25610293e42a73908e93ccc8c4d4dc0edcfa9fa872f50cb214e08ebf61a03e245533f97284d442460f2998cd41858798ddfd4d661997d3940272b717b1",
+]
+```
+
+**Returns**
+`Boolean` - returns `true` if the client holds the privatekey for that identity, otherwise `false`.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"shh_hasIdentity","params":["0x04f96a5e25610293e42a73908e93ccc8c4d4dc0edcfa9fa872f50cb214e08ebf61a03e245533f97284d442460f2998cd41858798ddfd4d661997d3940272b717b1"],"id":73}'
+// Result
+{
+  "id":1,
+  "jsonrpc": "2.0",
+  "result": true
+}
+```
+
+### shh_newGroup (deprecated){#shh_newgroup}
+
+**Note** this function is deprecated.
+
+**Parameters**
+None
+
+**Returns**
+`DATA`, 60 Bytes - the address of the new group. (?)
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"shh_newGroup","params":[],"id":73}'
+// Result
+{
+  "id":1,
+  "jsonrpc": "2.0",
+  "result": "0xc65f283f440fd6cabea4dd7a2c807108f651b7135d1d6ca90931d93e97ab07fe42d923478ba2407d5b68aa497e4619ac10aa3b27726e1863c1fd9b570d99bbaf"
+}
+```
+
+### shh_addToGroup (deprecated){#shh_addtogroup}
+
+**Note** this function is deprecated.
+
+**Parameters**
+
+1. `DATA`, 60 Bytes - The identity address to add to a group (?).
+
+```js
+params: [
+  "0x04f96a5e25610293e42a73908e93ccc8c4d4dc0edcfa9fa872f50cb214e08ebf61a03e245533f97284d442460f2998cd41858798ddfd4d661997d3940272b717b1",
+]
+```
+
+**Returns**
+`Boolean` - returns `true` if the identity was successfully added to the group, otherwise `false` (?).
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"shh_addToGroup","params":["0x04f96a5e25610293e42a73908e93ccc8c4d4dc0edcfa9fa872f50cb214e08ebf61a03e245533f97284d442460f2998cd41858798ddfd4d661997d3940272b717b1"],"id":73}'
+// Result
+{
+  "id":1,
+  "jsonrpc": "2.0",
+  "result": true
+}
+```
+
+### shh_newFilter (deprecated){#shh_newfilter}
+
+Creates filter to notify, when client receives whisper message matching the filter options.
+**Note** this function is deprecated.
+
+**Parameters**
+
+1. `Object` - The filter options:
+
+- `to`: `DATA`, 60 Bytes - (optional) Identity of the receiver. _When present it will try to decrypt any incoming message if the client holds the private key to this identity._
+- `topics`: `Array of DATA` - Array of `DATA` topics which the incoming message's topics should match. You can use the following combinations:
+  - `[A, B] = A && B`
+  - `[A, [B, C]] = A && (B || C)`
+  - `[null, A, B] = ANYTHING && A && B` `null` works as a wildcard
+  -
+
+```js
+params: [
+  {
+    topics: ["0x12341234bf4b564f"],
+    to: "0x04f96a5e25610293e42a73908e93ccc8c4d4dc0edcfa9fa872f50cb214e08ebf61a03e245533f97284d442460f2998cd41858798ddfd4d661997d3940272b717b1",
+  },
+]
+```
+
+**Returns**
+`QUANTITY` - The newly created filter.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"shh_newFilter","params":[{"topics": ['0x12341234bf4b564f'],"to": "0x2341234bf4b2341234bf4b564f..."}],"id":73}'
+// Result
+{
+  "id":1,
+  "jsonrpc":"2.0",
+  "result": "0x7" // 7
+}
+```
+
+### shh_uninstallFilter (deprecated){#shh_uninstallfilter}
+
+Uninstalls a filter with given id. Should always be called when watch is no longer needed.
+Additionally Filters timeout when they aren't requested with [shh_getFilterChanges](#shh_getfilterchanges) for a period of time.
+**Note** this function is deprecated.
+
+**Parameters**
+
+1. `QUANTITY` - The filter id.
+
+```js
+params: [
+  "0x7", // 7
+]
+```
+
+**Returns**
+`Boolean` - `true` if the filter was successfully uninstalled, otherwise `false`.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"shh_uninstallFilter","params":["0x7"],"id":73}'
+// Result
+{
+  "id":1,
+  "jsonrpc":"2.0",
+  "result": true
+}
+```
+
+### shh_getFilterChanges (deprecated){#shh_getfilterchanges}
+
+Polling method for whisper filters. Returns new messages since the last call of this method.
+**Note** calling the [shh_getMessages](#shh_getmessages) method, will reset the buffer for this method, so that you won't receive duplicate messages.
+**Note** this function is deprecated.
+
+**Parameters**
+
+1. `QUANTITY` - The filter id.
+
+```js
+params: [
+  "0x7", // 7
+]
+```
+
+**Returns**
+`Array` - Array of messages received since last poll:
+
+- `hash`: `DATA`, 32 Bytes (?) - The hash of the message.
+- `from`: `DATA`, 60 Bytes - The sender of the message, if a sender was specified.
+- `to`: `DATA`, 60 Bytes - The receiver of the message, if a receiver was specified.
+- `expiry`: `QUANTITY` - Integer of the time in seconds when this message should expire (?).
+- `ttl`: `QUANTITY` - Integer of the time the message should float in the system in seconds (?).
+- `sent`: `QUANTITY` - Integer of the unix timestamp when the message was sent.
+- `topics`: `Array of DATA` - Array of `DATA` topics the message contained.
+- `payload`: `DATA` - The payload of the message.
+- `workProved`: `QUANTITY` - Integer of the work this message required before it was send (?).
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"shh_getFilterChanges","params":["0x7"],"id":73}'
+// Result
+{
+  "id":1,
+  "jsonrpc":"2.0",
+  "result": [{
+    "hash": "0x33eb2da77bf3527e28f8bf493650b1879b08c4f2a362beae4ba2f71bafcd91f9",
+    "from": "0x3ec052fc33..",
+    "to": "0x87gdf76g8d7fgdfg...",
+    "expiry": "0x54caa50a", // 1422566666
+    "sent": "0x54ca9ea2", // 1422565026
+    "ttl": "0x64", // 100
+    "topics": ["0x6578616d"],
+    "payload": "0x7b2274797065223a226d657373616765222c2263686...",
+    "workProved": "0x0"
+    }]
+}
+```
+
+### shh_getMessages (deprecated) {#shh_getmessages}
+
+Get all messages matching a filter. Unlike `shh_getFilterChanges` this returns all messages.
+
+**Note** this function is deprecated.
+
+**Parameters**
+
+1. `QUANTITY` - The filter id.
+
+```js
+params: [
+  "0x7", // 7
+]
+```
+
+**Returns**
+See [shh_getFilterChanges](#shh_getfilterchanges)
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"shh_getMessages","params":["0x7"
+],"id":73}'
+```
+
+Result see [shh_getFilterChanges](#shh_getfilterchanges)
+
 ## Usage Example {#usage-example}
 
 ### Deploying a contract using JSON_RPC {#deploying-contract}

--- a/src/content/developers/docs/apis/json-rpc/index.md
+++ b/src/content/developers/docs/apis/json-rpc/index.md
@@ -74,7 +74,7 @@ The following options are possible for the defaultBlock parameter:
 
 ## Examples
 
-On this page we provide examples of how to use individual JSON_RPC API endpoints using the command line tool, [curl](https://curl.se). These individial endpoint examples are found below in the [Curl examples](#curl-examples) section. Further down the page, we also provide an [end-to-end example](#usage-example) for compiling and deploying a smart contract using a Geth node, the json-rpc api and curl..
+On this page we provide examples of how to use individual JSON_RPC API endpoints using the command line tool, [curl](https://curl.se). These individual endpoint examples are found below in the [Curl examples](#curl-examples) section. Further down the page, we also provide an [end-to-end example](#usage-example) for compiling and deploying a smart contract using a Geth node, the JSON_RPC API and curl.
 
 ## Curl examples {#curl-examples}
 


### PR DESCRIPTION
## Description

Adds JSON-RPC API endpoint examples from eth.wiki onto json-rpc page at ethereum.org.
Adds deprecation notices to `db_xxxxx` and `shh_xxxxx` endpoints.
Fixes some typos and adds some signposting for navigating the page.

## Related Issue

#6760 
