### PR TITLE
fix mistake on date formats

### DIFF
--- a/src/content/contributing/translation-program/translators-guide/index.md
+++ b/src/content/contributing/translation-program/translators-guide/index.md
@@ -253,8 +253,8 @@ Some examples of what to be particularly mindful of:
 
 - When translating dates, there are a number of considerations and differences based on the language. These include the date format, separator, capitalization and leading zeros. There are also differences between full-length and numerical dates.
   - Some examples of different date formats:
-    - English UK (mm/dd/yyyy) – 1st January, 2022
-    - English US (dd/mm/yyyy) – January 1, 2022
+    - English UK (dd/mm/yyyy) – 1st January, 2022
+    - English US (mm/dd/yyy) – January 1, 2022
     - Chinese (yyyy-mm-dd) – 2022 年 1 月 1 日
     - French (dd/mm/yyyy) – 1er janvier 2022
     - Italian (dd/mm/yyyy) – 1º gennaio 2022


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description


Date formats for english UK and US were mixed up, I inverted them.

<!--- Describe your changes in detail -->
English UK : mm/dd/yyyy > dd/mm/yyyy
English US : dd/mm/yyyy > mm/dd/yyyy

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Originally reported on On Crowdin : https://crowdin.com/project/ethereum-org/discussions/28
