### PR TITLE
Include Arbitrum key in layer-2.json

### DIFF
--- a/src/data/layer-2/layer-2.json
+++ b/src/data/layer-2/layer-2.json
@@ -10,7 +10,7 @@
       "blockExplorer": "https://explorer.arbitrum.io/",
       "ecosystemPortal": "https://portal.arbitrum.one/",
       "tokenLists": "https://arbucks.io/tokens/",
-      "noteKey": "",
+      "noteKey": "layer-2-arbitrum-key",
       "purpose": ["universal"],
       "descriptionKey": "arbitrum-description",
       "imageKey": "arbitrum",

--- a/src/data/layer-2/layer-2.json
+++ b/src/data/layer-2/layer-2.json
@@ -10,7 +10,7 @@
       "blockExplorer": "https://explorer.arbitrum.io/",
       "ecosystemPortal": "https://portal.arbitrum.one/",
       "tokenLists": "https://arbucks.io/tokens/",
-      "noteKey": "layer-2-arbitrum-key",
+      "noteKey": "layer-2-arbitrum-note",
       "purpose": ["universal"],
       "descriptionKey": "arbitrum-description",
       "imageKey": "arbitrum",


### PR DESCRIPTION
Key was missing, meaning the note wasn't being shown on the website.