### PR TITLE
Fix typo in execution-bounty-hunters.csv

### DIFF
--- a/src/data/execution-bounty-hunters.csv
+++ b/src/data/execution-bounty-hunters.csv
@@ -48,6 +48,6 @@ daenamkim, "Daenam Kim", 750
 , "jazzybedi", 500
 feeker, "Feeker - 360 ESG Codesafe Team", 500
 ethernomad, "Jonathan Brown", 500
-davidmurdoch, "David Murdoch, 500
+davidmurdoch, "David Murdoch", 500
 wadeAlexC, "Alexander Wade", 500
 gitpusha, "Luis Schliesske", 200


### PR DESCRIPTION
Rendering is broken because of this:
<img width="703" alt="Screenshot" src="https://user-images.githubusercontent.com/20340/176326473-934c09ca-987a-4649-bfdd-d6390bf07277.png">
