### PR TITLE
Ensured consistent spelling of 'logo' for alts [Fixes #6803]

### DIFF
--- a/src/intl/en/page-developers-learning-tools.json
+++ b/src/intl/en/page-developers-learning-tools.json
@@ -13,7 +13,7 @@
   "page-learning-tools-consensys-academy-description": "Online Ethereum developer bootcamp.",
   "page-learning-tools-consensys-academy-logo-alt": "ConsenSys Academy logo",
   "page-learning-tools-buildspace-description": "Learn about crypto by building cool projects.",
-  "page-learning-tools-buildspace-logo-alt": "_buildspace Logo",
+  "page-learning-tools-buildspace-logo-alt": "_buildspace logo",
   "page-learning-tools-cryptozombies-description": "Learn Solidity building your own Zombie game.",
   "page-learning-tools-cryptozombies-logo-alt": "CryptoZombies logo",
   "page-learning-tools-documentation": "Learn with documentation",
@@ -27,7 +27,7 @@
   "page-learning-tools-meta-desc": "Web-based coding tools and interactive learning experiences to help you experiment with Ethereum development.",
   "page-learning-tools-meta-title": "Developer learning tools",
   "page-learning-tools-questbook-description": "Self paced tutorials to learn Web 3.0 by building",
-  "page-learning-tools-questbook-logo-alt": "Questbook Logo",
+  "page-learning-tools-questbook-logo-alt": "Questbook logo",
   "page-learning-tools-remix-description": "Develop, deploy and administer smart contracts for Ethereum. Follow tutorials with the Learneth plugin.",
   "page-learning-tools-remix-description-2": "Remix and Replit aren't just sandboxes—developers can write, compile and deploy their smart contracts using them.",
   "page-learning-tools-replit-description": "A customizable development environment for Ethereum with hot reloading, error checking, and first-class testnet support.",
@@ -39,7 +39,7 @@
   "page-learning-tools-vyperfun-description": "Learn Vyper building your own Pokémon game.",
   "page-learning-tools-vyperfun-logo-alt": "Vyper.fun logo",
   "page-learning-tools-nftschool-description": "Explore what's going on with non-fungible tokens, or NFTs from the technical side.",
-  "page-learning-tools-nftschool-logo-alt": "NFT school Logo",
+  "page-learning-tools-nftschool-logo-alt": "NFT school logo",
   "page-learning-tools-pointer-description": "Learn web3 dev skills with fun interactive tutorials. Earn crypto rewards along the way",
-  "page-learning-tools-pointer-logo-alt": "Pointer Logo"
+  "page-learning-tools-pointer-logo-alt": "Pointer logo"
 }


### PR DESCRIPTION
## Description
* Made **four changes** on lines: `16, 30, 42 & 44`.
* Changed `Logo` to `logo`. 

## Related Issue
* PR related to #6803 
