### PR TITLE
Expand Validium developer docs

### DIFF
--- a/src/content/developers/docs/scaling/validium/index.md
+++ b/src/content/developers/docs/scaling/validium/index.md
@@ -12,33 +12,89 @@ Validium is a [scaling solution](/developers/docs/scaling/) that enforces integr
 
 You should have a good understanding of all the foundational topics and a high-level understanding of [Ethereum scaling](/developers/docs/scaling/). Implementing scaling solutions such as Validium is an advanced topic as the technology is less battle-tested, and continues to be researched and developed.
 
+## What is validium? {#what-is-validium}
+
+Validiums are scaling solutions that use off-chain data availability and computation designed to improve throughput by processing transactions off the Ethereum Mainnet. Like zero-knowledge rollups (ZK-rollups), validiums publish [zero-knowledge proofs](/glossary/#zk-proof) to verify off-chain transactions on Ethereujm. This prevents invalid state transitions and enhances the security guarantees of a validium chain. 
+
+These "validity proofs" can come in the form of ZK-SNARKs (Zero-Knowledge Succinct Non-Interactive Argument of Knowledge) or ZK-STARKs (Zero-Knowledge Scalable Transparent ARgument of Knowledge). More on [zero-knowledge proofs](https://consensys.net/blog/blockchain-explained/zero-knowledge-proofs-starks-vs-snarks/).
+
+Funds belonging to validium users are controlled by a smart contract on Ethereum. Validiums offer near-instant withdrawals, much like ZK-rollups do; once the validity proof for a withdrawal request has been verified on Mainnet, users can withdraw funds by providing [Merkle proofs](/developers/tutorials/merkle-proofs-for-offline-data-integrity/). The Merkle proof validates the inclusion of the user’s withdrawal transaction in a verified transaction batch, allowing the on-chain contract to process the withdrawal. 
+
+However, we must also note that validium users can have their funds frozen and withdrawals restricted. This can happen if data availability managers on the validium chain withhold off-chain state data from users. Without access to transaction data, users cannot compute the Merkle proof required to prove ownership of funds and execute withdrawals.  
+
+This is the major difference between validiums and ZK-rollups—their positions on the data availability spectrum. Both solutions approach data storage differently, which has implications for security and trustlessness. 
+
+## How do validiums interact with Ethereum? {#how-do-validiums-interact-with-ethereum}
+
+Validiums are scaling protocols built on top of the existing Ethereum chain. Although it executes transactions off-chain, a validium chain is administered by a collection of smart contracts deployed on Mainnet including: 
+
+1. **Verifier contract**: The verifier contract verifies the validity of proofs submitted by the validium operator when making state updates. This includes validity proofs attesting to the correctness of off-chain transactions and data availability proofs verifying the existence of off-chain transaction data. 
+
+2. **Main contract**: The main contract stores state commitments (Merkle roots) submitted by block producers and updates the validium's state once a validity proof is verified on-chain. This contract also processes deposits to and withdrawals from the validium chain. 
+
+Validiums also rely on the main Ethereum chain for the following: 
+
+### Settlement {#settlement}
+
+Transactions executed on a validium cannot be fully confirmed until the parent chain verifies their validity. All business conducted on a validium must eventually be settled on Mainnet. The Ethereum blockchain also provides "settlement guarantees" for validium users, meaning off-chain transactions cannot be reversed or altered once committed to on-chain.
+
+### Security {#security}
+
+Ethereum, acting as a settlement layer, also guarantees the validity of state transitions on validium. Off-chain transactions executed on the validium chain are verified via a smart contract on the base Ethereum layer. 
+
+If the on-chain verifier contract deems the proof invalid, the transactions are rejected. This means operators must satisfy validity conditions enforced by the Ethereum protocol before updating the validium's state. 
+
 ## How does validium work? {#how-does-validium-work}
 
-Validiums are a zero-knowledge proof scaling solution that uses off-chain data availability and computation designed to improve throughput by processing transactions off the Ethereum Mainnet. Off-chain transactions executed on the validium chain are verified via a smart contract on the base Ethereum layer using zero-knowledge proofs, which can be SNARKs (Succinct Non-Interactive Argument of Knowledge) or STARKs (Scalable Transparent ARgument of Knowledge).
+### Transactions {#transactions} 
 
-More on [zero-knowledge proofs](https://consensys.net/blog/blockchain-explained/zero-knowledge-proofs-starks-vs-snarks/).
+Users submit transactions to the operator, a node responsible for executing transactions on the validium chain. Some validiums may use a sole operator to execute the chain or rely on a [proof-of-stake (PoS)](/developers/docs/consensus-mechanisms/pos/) mechanism for rotating operators. 
 
-As with ZK-rollups, validity proofs prevent invalid state transitions on validium chains and enhance security guarantees available to users. For instance, a malicious operator cannot steal funds since users can always withdraw funds directly from the on-chain contract [using Merkle proofs](/developers/tutorials/merkle-proofs-for-offline-data-integrity/).
+The operator aggregates transactions into a batch and sends it to a proving circuit for proving. The proving circuit accepts the transaction batch (and other relevant data) as inputs and outputs a validity proof verifying that the operations were performed correctly. 
 
-However, user funds can be frozen, particularly if the data availability managers on the validium chain withhold off-chain data from users. This is the major difference between validiums and ZK-rollups—their positions on the data availability spectrum. Both solutions approach data storage differently, which has implications for security and trustlessness.
+### State commitments {#state-commitments}
 
-### On-chain vs off-chain data availability {#on-chain-vs-off-chain-data-availability}
+The state of the validium is hashed as a Merkle tree with the root stored in the main contract on Ethereum. The Merkle root, also known as the state root, acts as a cryptographic commitment to the current state of accounts and balances on the validium. 
 
-**ZK-rollups** bundle (or "roll-up") off-chain transaction data to Ethereum Mainnet as `calldata`. This information can be used to recreate the state of the rollup, if necessary, to prove the validity (or lack thereof) of a specific state transition. As the data is anchored on Ethereum (**on-chain data availability**), ZK-rollups directly benefit from Ethereum’s security and data availability guarantees—funds are always secure if Mainnet is operational.
+To perform a state update, the operator must compute a new state root (after executing transactions) and submit it to the on-chain contract. If the validity proof checks out, the proposed state is accepted and the validium switches to the new state root. 
 
-**Validiums** store all transaction data off Ethereum Mainnet (**off-chain data availability**). This improves throughput and reduces the costs on validium chains since calldata is not posted to Ethereum Mainnet.
+### Deposits and withdrawals {#deposits-and-withdrawals}
 
-Off-chain data availability does present a problem: data necessary for creating or verifying Merkle proofs may be unavailable. This means users may be unable to withdraw funds from the rollup contract if operators should act maliciously. Various validium solutions attempt to solve this problem by holding off-chain data with trusted parties or randomly assigned validators, who are expected to provide proofs of data availability.
+Users move funds from Ethereum to a validium by depositing ETH (or any ERC-compatible token) in the on-chain contract. The contract relays the deposit event to the validium off-chain, where the user's address is credited with an amount equal to their deposit. The operator also includes this deposit transaction in a new batch. 
+
+To move funds back to Mainnet, a validium user initiates a withdrawal transaction and submits it to the operator who validates the withdrawal request and includes it in a batch. The user's assets on the validium chain are also destroyed before they can exit the system. Once the validity proof associated with the batch is verified, the user can call the main contract to withdraw the remainder of their initial deposit. 
+
+As an anti-censorship mechanism, the validium protocol allows users to withdraw directly from the validium contract without going through the operator. In this case, users need to provide a Merkle proof to the verifier contract showing an account's inclusion in the state root. If the proof is accepted, the user can call the main contract's withdrawal function to exit their funds from the validium. 
+
+### Batch submission {#batch-submission}
+
+After executing a batch of transactions, the operator submits the associated validity proof to the Lverifier contract and proposes a new state root to the main contract. If the proof is valid, the main contract updates the validium's state and finalizes the results of transactions in the batch. 
+
+Unlike a ZK-rollup, block producers on a validium are not required to publish transaction data for transaction batches (only block headers). This makes validium a purely off-chain scaling protocol, as opposed to "hybrid" scaling protocols (i.e., [layer 2](/layer-2/)) that publish state data on the main Ethereum chain as `calldata`.  
+
+### Data availability {#data-availability}
+
+As mentioned, validiums utilize an off-chain data availability model, where operators store all transaction data off Ethereum Mainnet. Validium's low on-chain data footprint improves scalability (throughput isn't limited by Ethereum's data processing capacity) and reduces user fees (the cost of publishing `calldata` is lower).
+
+Off-chain data availability, however, presents a problem: data necessary for creating or verifying Merkle proofs may be unavailable. This means users may be unable to withdraw funds from the on-chain contract if operators should act maliciously. 
+
+Various validium solutions attempt to solve this problem by decentralizing the storage of state data. This involves forcing block producers to send the underlying data to "data availability managers" responsible for storing off-chain data and making it available to users on request. 
+
+Data availability managers in validium attest to the availability of data for off-chain transactions by signing every validium batch. These signatures constitute a form of "availability proof" which the on-chain verifier contract checks before approving state updates. 
+
+Validiums differ in their approach to data availability management. Some rely on trusted parties to store state data, while others use randomly assigned validators for the task. 
 
 #### Data availability committee (DAC)
 
-To guarantee the availability of off-chain data, some validium solutions appoint a group of trusted entities, collectively known as a data availability committee (DAC), to store copies of the state and provide proof of data availability. Users must trust these entities to make the data available when needed. There's the possibility of members of data availability committees [getting compromised by a malicious actor](https://notes.ethereum.org/DD7GyItYQ02d0ax_X-UbWg?view) who can then withhold off-chain data.
+To guarantee the availability of off-chain data, some validium solutions appoint a group of trusted entities, collectively known as a data availability committee (DAC), to store copies of the state and provide proof of data availability. DACs are easier to implement and require less coordination since membership is low. 
+
+However, users must trust the DAC to make the data available when needed (e.g., for generating Merkle proofs). There's the possibility of members of data availability committees [getting compromised by a malicious actor](https://notes.ethereum.org/DD7GyItYQ02d0ax_X-UbWg?view) who can then withhold off-chain data.
 
 [More on data availability committees in validiums](https://medium.com/starkware/data-availability-e5564c416424).
 
 #### Bonded data availability
 
-Other validiums require participants charged with storing offline data to stake (i.e., lock up) tokens in a smart contract before assuming their roles. This stake serves as a “bond” to guarantee honest behavior among data availability managers, and reduces trust assumptions. If these participants fail to prove data availability, the bond is slashed.
+Other validiums require participants charged with storing offline data to stake (i.e., lock up) tokens in a smart contract before assuming their roles. This stake serves as a “bond” to guarantee honest behavior among data availability managers and reduces trust assumptions. If these participants fail to prove data availability, the bond is slashed.
 
 In a bonded data availability scheme, anyone can be assigned to hold off-chain data once they provide the required stake. This expands the pool of eligible data availability managers, reducing the centralization that affects data availability committees (DACs). More importantly, this approach relies on cryptoeconomic incentives to prevent malicious activity, which is considerably more secure than appointing trusted parties to secure offline data in the validium.
 
@@ -46,21 +102,31 @@ In a bonded data availability scheme, anyone can be assigned to hold off-chain d
 
 ## Volitions and validium
 
-Validiums offer many benefits, but come with trade-offs (most notably, data availability). But, as with many scaling solutions, validiums are suited to specific use-cases—which is why volitions were created.
+Validiums offer many benefits but come with trade-offs (most notably, data availability). But, as with many scaling solutions, validiums are suited to specific use-cases—which is why volitions were created.
 
-Volitions combine a ZK-rollup and validium chain and allow users to switch between the two scaling solutions. With volitions, users can take advantage of validium's off-chain data availability for certain transactions, while retaining the freedom to switch to an on-chain data availability solution (ZK-rollup) if needed. This essentially gives users freedom to choose trade-offs as dictated by their unique circumstances.
+Volitions combine a ZK-rollup and validium chain and allow users to switch between the two scaling solutions. With volitions, users can take advantage of validium's off-chain data availability for certain transactions, while retaining the freedom to switch to an on-chain data availability solution (ZK-rollup) if needed. This essentially gives users the freedom to choose trade-offs as dictated by their unique circumstances.
 
 A decentralized exchange (DEX) may prefer using a validium’s scalable and private infrastructure for high-value trades. It can also use a ZK-rollup for users who want a ZK-rollup's higher security guarantees and trustlessness.
+
+## Validiums and EVM compatibility
+
+Like ZK-rollups, validiums are mostly suited to simple applications, such as token swaps and payments. Supporting general computation and smart contract execution among validiums is difficult to implement, given the considerable overhead of proving [EVM](/developers/docs/evm/) instructions in a zero-knowledge proof circuit. 
+
+Some validium projects attempt to sidestep this problem by creating custom bytecode optimized for efficient proving. But this means developers must learn new programming languages and build dapps with an entirely new development stack. 
+
+Some teams, however, are attempting to optimize existing EVM opcodes for zk-proving circuits. This will result in the development of a zero-knowledge Ethereum Virtual Machine (zkEVM), an EVM-compatible VM that produces proofs to verify the correctness of program execution. With a zkEVM, validium chains can execute smart contracts off-chain and submit validity proofs to verify off-chain computation on Mainnet. 
+
+[More on zkEVMs](https://www.alchemy.com/overviews/zkevm). 
 
 ## Pros and cons of validium {#pros-and-cons-of-validium}
 
 | Pros                                                                                                                    | Cons                                                                                                                                    |
 | ----------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| No withdrawal delay (no latency to on-chain/cross-chain tx); consequent greater capital efficiency.                     | Limited support for general computation/smart contracts; specialized languages required.                                                |
-| Not vulnerable to certain economic attacks faced by fraud-proof based systems in high-value applications.               | High computational power required to generate ZK proofs; not cost effective for low throughput applications.                            |
+| Increases capital efficiency for users (no delays in withdrawing funds)                                                 | Limited support for general computation/smart contracts; specialized languages required.                                                |
+| Not vulnerable to certain economic attacks faced by fraud-proof based systems in high-value applications.               | High computational power required to generate ZK proofs; not cost-effective for low throughput applications.                            |
 | Reduces gas fees for users by not posting calldata to Ethereum Mainnet.                                                 | Slower subjective finality time (10-30 min to generate a ZK proof) but faster to full finality because there is no dispute time delay.  |
 | Suitable for specific use-cases, like trading or blockchain gaming that prioritize transaction privacy and scalability. | Generating a proof requires off-chain data to be available at all times.                                                                |
-|                                                                                                                         | Security relies on trust assumptions and cryptoeconomic incentives, unlike ZK-rollups, which rely on cryptographic security mechanisms. |
+|                                                                                                                         | Security model relies on trust assumptions and cryptoeconomic incentives, unlike ZK-rollups, which purely rely on cryptographic security mechanisms. |
 
 ### Use Validium/Volitions {#use-validium-and-volitions}
 
@@ -81,4 +147,4 @@ Multiple projects provide implementations of Validium and volitions that you can
 - [Validium And The Layer 2 Two-By-Two — Issue No. 99](https://www.buildblockchain.tech/newsletter/issues/no-99-validium-and-the-layer-2-two-by-two)
 - [ZK-rollups vs Validium](https://blog.matter-labs.io/zkrollup-vs-validium-starkex-5614e38bc263)
 - [Volition and the Emerging Data Availability spectrum](https://medium.com/starkware/volition-and-the-emerging-data-availability-spectrum-87e8bfa09bb)
-- [Rollups, Validiums and Volitions: Learn About the Hottest Ethereum Scaling Solutions](https://www.defipulse.com/blog/rollups-validiums-and-volitions-learn-about-the-hottest-ethereum-scaling-solutions)
+- [Rollups, Validiums, and Volitions: Learn About the Hottest Ethereum Scaling Solutions](https://www.defipulse.com/blog/rollups-validiums-and-volitions-learn-about-the-hottest-ethereum-scaling-solutions)


### PR DESCRIPTION
Edited the page to add more details about validiums and how they work.

<!--- Provide a general summary of your changes in the Title above -->

## Description

This is part of an overall drive to update the site's documentation on scaling solutions.  I also adjusted some details in the earlier edits. The following is a high-level overview of proposed changes to the page:
- A new section explaining how validiums interact with Ethereum 
- A new section explaining the workflow for validiums (i.e., from transaction execution to batch submission)
- A new section explaining validiums and EVM compatibility issues

Also, I didn't think it was necessary to have an "on-chain vs off-chain data availability" comparing zk-rollups and validiums, so I put the text under the "How do validiums work" section. Since a page on data availability is in progress, explaining it here would be superfluous imo. Nonetheless, I added a brief paragraph contrasting validiums as a purely off-chain system vs "hybrid" scaling protocols that leave some data on-chain. 