### PR TITLE
Fix typo in optimism-std-bridge-annotated-code/index.md

### DIFF
--- a/src/content/translations/ro/developers/tutorials/optimism-std-bridge-annotated-code/index.md
+++ b/src/content/translations/ro/developers/tutorials/optimism-std-bridge-annotated-code/index.md
@@ -329,7 +329,7 @@ contract CrossDomainEnabled {
      * Variables *
      *************/
 
-    // Messenger contract used to send and recieve messages from the other domain.
+    // Messenger contract used to send and receive messages from the other domain.
     address public messenger;
 
     /***************


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed typo.
```
recieve -> receive
```