### PR TITLE
Correct tutorial link [Fixes #6672]

### DIFF
--- a/src/data/externalTutorials.json
+++ b/src/data/externalTutorials.json
@@ -133,7 +133,7 @@
     "publishDate": "02/11/2022"
   },
   {
-    "url": "https://www.youtube.com/watch?v=pdsYCkUWrgQ",
+    "url": "https://www.youtube.com/watch?v=AhJtmUqhAqg",
     "title": "How to build an on-chain DAO",
     "description": "Using Compound and Openzeppelin as a basis, we build a 100% on-chain DAO using an ERC20 governance token for votes.",
     "author": "Patrick Collins",


### PR DESCRIPTION
The tutorials page was not rendering correctly because there were two keys with the same value.  The values used for the keys are links and one was a duplicate so I replaced it with the correct link - see #6672  for the original issue.

## Description

I replaced the duplicate link & provided the link to the description provided.  

## Related Issue

The following is taken directly from #6672: 

> To Reproduce
> Steps to reproduce the behavior:
> 
>     1. Go to https://ethereum.org/en/developers/tutorials/
>     2. Click on any tag... we'll go with "Analytics (1)" here
>     3. Scroll down, and notice more than one tutorial is being shown, and when I do this the external one is not tagged "Analytics"
>     4. Try refreshing (or clearing filter) and then filtering "SQL (1)"
>     5. Here I'm getting 5 results.. 1 external without the "SQL" tag, 4 all of the same tutorial, just translated (en, id, it, ro).

