### PR TITLE
Fixed USDC Typo

### DIFF
--- a/src/intl/en/page-stablecoins.json
+++ b/src/intl/en/page-stablecoins.json
@@ -134,7 +134,7 @@
   "page-stablecoins-top-coins-intro": "Market capitalisation is",
   "page-stablecoins-top-coins-intro-code": "the total number of tokens that exist multiplied by the value per token. This list is dynamic and the projects listed here are not necessarily endorsed by the ethereum.org team.",
   "page-stablecoins-types-of-stablecoin": "How they work: types of stablecoin",
-  "page-stablecoins-usdc-banner-body": "USDc is probably the most famous fiat-backed stablecoin. Its value is roughly a dollar and it’s backed by Circle and Coinbase.",
+  "page-stablecoins-usdc-banner-body": "USDC is probably the most famous fiat-backed stablecoin. Its value is roughly a dollar and it’s backed by Circle and Coinbase.",
   "page-stablecoins-usdc-banner-learn-button": "Learn about USDC",
   "page-stablecoins-usdc-banner-swap-button": "Swap ETH for USDC",
   "page-stablecoins-usdc-banner-title": "USDC",


### PR DESCRIPTION
## Description
* Fixed a small typo, changed `USDc` to `USDC`.

## Related Issue
* Not related to an open issue. 
