### PR TITLE
Hook to check Language Attribute in a Markdown file

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "generate-heading-ids": "node src/scripts/generate-heading-ids.js",
     "merge-translations": "node src/scripts/merge-translations.js",
+	"check-markdown-language-tag": "node src/scripts/checkMarkdownLanguage.mjs",
     "start": "gatsby develop",
     "start:lambda": "netlify-lambda serve src/lambda",
     "start:static": "gatsby build && gatsby serve",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "prettier": "^2.2.1",
     "pretty-quick": "^3.1.0",
     "react-test-renderer": "^17.0.1",
+    "ts-node": "^10.8.2",
     "typescript": "^4.6.3"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "generate-heading-ids": "node src/scripts/generate-heading-ids.js",
     "merge-translations": "node src/scripts/merge-translations.js",
-	"check-markdown-language-tag": "node src/scripts/checkMarkdownLanguage.mjs",
+    "check-markdown-language-tag": "ts-node --esm src/scripts/checkMarkdownLanguage.mts",
     "start": "gatsby develop",
     "start:lambda": "netlify-lambda serve src/lambda",
     "start:static": "gatsby build && gatsby serve",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged"
+      "pre-commit": "npm run-script check-markdown-language-tag && pretty-quick --staged"
     }
   },
   "volta": {

--- a/src/scripts/checkMarkdownLanguage.mjs
+++ b/src/scripts/checkMarkdownLanguage.mjs
@@ -3,28 +3,30 @@ import { spawn } from "child_process"
 let allMarkdownFilesBuffer = ""
 
 const getAllMarkdownFiles = () => {
-  const allMarkdownFilesCommand = spawn("git", [
-    "diff",
-    "--cached",
-    "--name-only",
-    "--diff-filter",
-    "AM",
-    "--",
-    "*.md",
-  ])
+  return new Promise((resolve, reject) => {
+    const allMarkdownFilesCommand = spawn("git", [
+      "diff",
+      "--cached",
+      "--name-only",
+      "--diff-filter",
+      "AM",
+      "--",
+      "*.md",
+    ])
 
-  allMarkdownFilesCommand.stdout.on("data", (data) => {
-    console.log(data.toString("utf8"))
-    allMarkdownFilesBuffer = data
-  })
+    allMarkdownFilesCommand.stdout.on("data", (data) => {
+      console.log(data.toString("utf8"))
+      allMarkdownFilesBuffer = data
+    })
 
-  allMarkdownFilesCommand.stderr.on("data", (data) => {
-    console.log(data.toString("utf8"))
-  })
+    allMarkdownFilesCommand.stderr.on("data", (data) => {
+      reject(data)
+    })
 
-  allMarkdownFilesCommand.on("error", (error) => {
-    console.error("SHITT", error)
+    allMarkdownFilesCommand.on("error", (error) => {
+      reject(error)
+    })
   })
 }
 
-getAllMarkdownFiles()
+await getAllMarkdownFiles()

--- a/src/scripts/checkMarkdownLanguage.mjs
+++ b/src/scripts/checkMarkdownLanguage.mjs
@@ -19,7 +19,6 @@ const getMarkdownFilesWithLanguage = () => {
     ])
 
     markdownFilesWithLanguageCommand.stdout.on("data", (data) => {
-      console.log(data.toString("utf8"))
       resolve(data)
     })
 
@@ -42,7 +41,6 @@ const getAllMarkdownFiles = () => {
     ])
 
     allMarkdownFilesCommand.stdout.on("data", (data) => {
-      console.log(data.toString("utf8"))
       resolve(data)
     })
 
@@ -58,6 +56,7 @@ const getAllMarkdownFiles = () => {
 
 const doAllMarkdownsHaveALanguage = async () => {
   try {
+    console.log("Checking Markdown Content Files")
     const allMarkdownFilesBuffer = await getAllMarkdownFiles()
     const markdownFilesWithLanguageBuffer = await getMarkdownFilesWithLanguage()
     const comparisonResult = Buffer.compare(

--- a/src/scripts/checkMarkdownLanguage.mjs
+++ b/src/scripts/checkMarkdownLanguage.mjs
@@ -56,4 +56,24 @@ const getAllMarkdownFiles = () => {
   })
 }
 
-await getAllMarkdownFiles()
+const doAllMarkdownsHaveALanguage = async () => {
+  const allMarkdownFilesBuffer = await getAllMarkdownFiles()
+  const markdownFilesWithLanguageBuffer = await getMarkdownFilesWithLanguage()
+  const comparisonResult = Buffer.compare(
+    allMarkdownFilesBuffer,
+    markdownFilesWithLanguageBuffer
+  )
+  return comparisonResult === 0 ? true : false
+}
+
+doAllMarkdownsHaveALanguage()
+  .then((result) => {
+    if (result) {
+      process.exitCode = 0
+    } else {
+      process.exitCode = 1
+    }
+  })
+  .catch((error) => {
+    process.exitCode = 1
+  })

--- a/src/scripts/checkMarkdownLanguage.mjs
+++ b/src/scripts/checkMarkdownLanguage.mjs
@@ -57,13 +57,21 @@ const getAllMarkdownFiles = () => {
 }
 
 const doAllMarkdownsHaveALanguage = async () => {
-  const allMarkdownFilesBuffer = await getAllMarkdownFiles()
-  const markdownFilesWithLanguageBuffer = await getMarkdownFilesWithLanguage()
-  const comparisonResult = Buffer.compare(
-    allMarkdownFilesBuffer,
-    markdownFilesWithLanguageBuffer
-  )
-  return comparisonResult === 0 ? true : false
+  try {
+    const allMarkdownFilesBuffer = await getAllMarkdownFiles()
+    const markdownFilesWithLanguageBuffer = await getMarkdownFilesWithLanguage()
+    const comparisonResult = Buffer.compare(
+      allMarkdownFilesBuffer,
+      markdownFilesWithLanguageBuffer
+    )
+    return comparisonResult === 0 ? true : false
+  } catch (error) {
+    throw error
+  }
+}
+
+const throwError = (message) => {
+  console.log("\x1b[91m%s\x1b[0m", "ERROR", message)
 }
 
 doAllMarkdownsHaveALanguage()
@@ -71,9 +79,13 @@ doAllMarkdownsHaveALanguage()
     if (result) {
       process.exitCode = 0
     } else {
+      throwError(
+        "Markdown content needs to have a lang attribute in the frontmatter"
+      )
       process.exitCode = 1
     }
   })
   .catch((error) => {
+    throwError("checkMarkdownLanguage Hook Failed")
     process.exitCode = 1
   })

--- a/src/scripts/checkMarkdownLanguage.mjs
+++ b/src/scripts/checkMarkdownLanguage.mjs
@@ -1,22 +1,49 @@
 import { spawn } from "child_process"
 
-let allMarkdownFilesBuffer = ""
+const commonDiffCommand = [
+  "diff",
+  "--cached",
+  "--name-only",
+  "--diff-filter",
+  "AM",
+]
+
+const getMarkdownFilesWithLanguage = () => {
+  return new Promise((resolve, reject) => {
+    const markdownFilesWithLanguageCommand = spawn("git", [
+      ...commonDiffCommand,
+      "-G",
+      "lang:",
+      "--",
+      "*.md",
+    ])
+
+    markdownFilesWithLanguageCommand.stdout.on("data", (data) => {
+      console.log(data.toString("utf8"))
+      resolve(data)
+    })
+
+    markdownFilesWithLanguageCommand.stderr.on("data", (data) => {
+      reject(data)
+    })
+
+    markdownFilesWithLanguageCommand.on("error", (error) => {
+      reject(error)
+    })
+  })
+}
 
 const getAllMarkdownFiles = () => {
   return new Promise((resolve, reject) => {
     const allMarkdownFilesCommand = spawn("git", [
-      "diff",
-      "--cached",
-      "--name-only",
-      "--diff-filter",
-      "AM",
+      ...commonDiffCommand,
       "--",
       "*.md",
     ])
 
     allMarkdownFilesCommand.stdout.on("data", (data) => {
       console.log(data.toString("utf8"))
-      allMarkdownFilesBuffer = data
+      resolve(data)
     })
 
     allMarkdownFilesCommand.stderr.on("data", (data) => {

--- a/src/scripts/checkMarkdownLanguage.mjs
+++ b/src/scripts/checkMarkdownLanguage.mjs
@@ -13,9 +13,9 @@ const getMarkdownFilesWithLanguage = () => {
     const markdownFilesWithLanguageCommand = spawn("git", [
       ...commonDiffCommand,
       "-G",
-      "lang:",
+      "lang:[ ]*\\w+",
       "--",
-      "*.md",
+      "src/content/*.md",
     ])
 
     markdownFilesWithLanguageCommand.stdout.on("data", (data) => {
@@ -38,7 +38,7 @@ const getAllMarkdownFiles = () => {
     const allMarkdownFilesCommand = spawn("git", [
       ...commonDiffCommand,
       "--",
-      "*.md",
+      "src/content/*.md",
     ])
 
     allMarkdownFilesCommand.stdout.on("data", (data) => {

--- a/src/scripts/checkMarkdownLanguage.mjs
+++ b/src/scripts/checkMarkdownLanguage.mjs
@@ -1,0 +1,30 @@
+import { spawn } from "child_process"
+
+let allMarkdownFilesBuffer = ""
+
+const getAllMarkdownFiles = () => {
+  const allMarkdownFilesCommand = spawn("git", [
+    "diff",
+    "--cached",
+    "--name-only",
+    "--diff-filter",
+    "AM",
+    "--",
+    "*.md",
+  ])
+
+  allMarkdownFilesCommand.stdout.on("data", (data) => {
+    console.log(data.toString("utf8"))
+    allMarkdownFilesBuffer = data
+  })
+
+  allMarkdownFilesCommand.stderr.on("data", (data) => {
+    console.log(data.toString("utf8"))
+  })
+
+  allMarkdownFilesCommand.on("error", (error) => {
+    console.error("SHITT", error)
+  })
+}
+
+getAllMarkdownFiles()

--- a/src/scripts/checkMarkdownLanguage.mts
+++ b/src/scripts/checkMarkdownLanguage.mts
@@ -5,7 +5,7 @@ const commonDiffCommand = [
   "--cached",
   "--name-only",
   "--diff-filter",
-  "AM",
+  "A",
 ]
 
 const getMarkdownFilesWithLanguage = (): Promise<Buffer> => {

--- a/src/scripts/checkMarkdownLanguage.mts
+++ b/src/scripts/checkMarkdownLanguage.mts
@@ -13,7 +13,7 @@ const getMarkdownFilesWithLanguage = (): Promise<Buffer> => {
     const markdownFilesWithLanguageCommand = spawn("git", [
       ...commonDiffCommand,
       "-G",
-      "lang:[ ]*\\w+",
+      "lang:[ ]*[a-zA-Z]+",
       "--",
       "src/content/*.md",
     ])

--- a/src/scripts/checkMarkdownLanguage.mts
+++ b/src/scripts/checkMarkdownLanguage.mts
@@ -1,7 +1,7 @@
 import { spawn } from "child_process"
 
 const EMPTY_STRING = "EMPTY"
-const NO_VALID_MARKDOWN_FILE = "STAGES md FILES ARE INVALID"
+const NO_VALID_MARKDOWN_FILE = "Staged Markdown Files Are Invalid"
 
 const commonDiffCommand = [
   "diff",
@@ -96,7 +96,15 @@ const doAllMarkdownsHaveALanguage = async (): Promise<boolean> => {
         throwInfo("Markdown files have valid lang")
         return true
       } else {
-        throwInfo("Markdown files without valid lang exists")
+        throwInfo("Markdown files \x1b[92mwith\x1b[0m valid lang")
+        if (
+          markdownFilesWithLanguageBuffer.toString() === NO_VALID_MARKDOWN_FILE
+        ) {
+          console.log("NONE")
+        } else {
+          console.log(markdownFilesWithLanguageBuffer.toString())
+        }
+        throwInfo("Markdown files \x1b[91mwithout\x1b[0m valid lang exists")
         return false
       }
     }

--- a/src/scripts/checkMarkdownLanguage.mts
+++ b/src/scripts/checkMarkdownLanguage.mts
@@ -8,7 +8,7 @@ const commonDiffCommand = [
   "AM",
 ]
 
-const getMarkdownFilesWithLanguage = () => {
+const getMarkdownFilesWithLanguage = (): Promise<Buffer> => {
   return new Promise((resolve, reject) => {
     const markdownFilesWithLanguageCommand = spawn("git", [
       ...commonDiffCommand,
@@ -18,11 +18,11 @@ const getMarkdownFilesWithLanguage = () => {
       "src/content/*.md",
     ])
 
-    markdownFilesWithLanguageCommand.stdout.on("data", (data) => {
+    markdownFilesWithLanguageCommand.stdout.on("data", (data: Buffer) => {
       resolve(data)
     })
 
-    markdownFilesWithLanguageCommand.stderr.on("data", (data) => {
+    markdownFilesWithLanguageCommand.stderr.on("data", (data: Buffer) => {
       reject(data)
     })
 
@@ -32,7 +32,7 @@ const getMarkdownFilesWithLanguage = () => {
   })
 }
 
-const getAllMarkdownFiles = () => {
+const getAllMarkdownFiles = (): Promise<Buffer> => {
   return new Promise((resolve, reject) => {
     const allMarkdownFilesCommand = spawn("git", [
       ...commonDiffCommand,
@@ -40,11 +40,11 @@ const getAllMarkdownFiles = () => {
       "src/content/*.md",
     ])
 
-    allMarkdownFilesCommand.stdout.on("data", (data) => {
+    allMarkdownFilesCommand.stdout.on("data", (data: Buffer) => {
       resolve(data)
     })
 
-    allMarkdownFilesCommand.stderr.on("data", (data) => {
+    allMarkdownFilesCommand.stderr.on("data", (data: Buffer) => {
       reject(data)
     })
 
@@ -54,7 +54,7 @@ const getAllMarkdownFiles = () => {
   })
 }
 
-const doAllMarkdownsHaveALanguage = async () => {
+const doAllMarkdownsHaveALanguage = async (): Promise<boolean> => {
   try {
     console.log("Checking Markdown Content Files")
     const allMarkdownFilesBuffer = await getAllMarkdownFiles()
@@ -69,7 +69,7 @@ const doAllMarkdownsHaveALanguage = async () => {
   }
 }
 
-const throwError = (message) => {
+const throwError = (message: string | unknown): void => {
   console.log("\x1b[91m%s\x1b[0m", "ERROR", message)
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1640,6 +1640,13 @@
   resolved "https://registry.yarnpkg.com/@builder.io/partytown/-/partytown-0.5.4.tgz#1a89069978734e132fa4a59414ddb64e4b94fde7"
   integrity sha512-qnikpQgi30AS01aFlNQV6l8/qdZIcP76mp90ti+u4rucXHsn4afSKivQXApqxvrQG9+Ibv45STyvHizvxef/7A==
 
+"@cspotcode/source-map-support@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
+  dependencies:
+    "@jridgewell/trace-mapping" "0.3.9"
+
 "@emotion/cache@^11.4.0", "@emotion/cache@^11.7.1":
   version "11.7.1"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.7.1.tgz#08d080e396a42e0037848214e8aa7bf879065539"
@@ -2859,6 +2866,14 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz#b6461fb0c2964356c469e115f504c95ad97ab88c"
   integrity sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==
 
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+
 "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.13"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.13.tgz#dcfe3e95f224c8fe97a87a5235defec999aa92ea"
@@ -3471,6 +3486,26 @@
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
+
+"@tsconfig/node10@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.9.tgz#df4907fc07a886922637b15e02d4cebc4c0021b2"
+  integrity sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
+  integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
+  integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.3.tgz#472eaab5f15c1ffdd7f8628bd4c4f753995ec79e"
+  integrity sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==
 
 "@turist/fetch@^7.1.7":
   version "7.1.7"
@@ -4235,6 +4270,11 @@ acorn-jsx@^5.3.1:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
+
+acorn-walk@^8.1.1:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
 acorn@^6.4.1:
   version "6.4.2"
@@ -15636,6 +15676,25 @@ ts-invariant@^0.9.4:
   dependencies:
     tslib "^2.1.0"
 
+ts-node@^10.8.2:
+  version "10.8.2"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.8.2.tgz#3185b75228cef116bf82ffe8762594f54b2a23f2"
+  integrity sha512-LYdGnoGddf1D6v8REPtIH+5iq/gTDuZqv2/UJUU7tKjuEU8xVZorBM+buCGNjj+pGEud+sOoM4CX3/YzINpENA==
+  dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.1"
+    yn "3.1.1"
+
 ts-node@^9:
   version "9.1.1"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"
@@ -16262,6 +16321,11 @@ uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+v8-compile-cache-lib@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
 v8-compile-cache@^2.0.3:
   version "2.3.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Create a script to verify whether a markdown file
part of the `src/content` folder contains a non-empty `lang` attribute
as a part of its front matter.
 
<!--- Describe your changes in detail -->
I have used `git diff` with some regex to see that the Added
markdown file **changes** contains `lang`.

## Caveats

- This hook will work only for newly created markdown files
- This hook will perform a **rudimentary** `lang` attribute check based on a regex match
![image](https://user-images.githubusercontent.com/51415616/179352931-ed67001c-6bf3-4609-a770-6e040df5f460.png)

![image](https://user-images.githubusercontent.com/51415616/179353150-fa5a1eb4-ac04-4960-9157-39e5ea32d77a.png)



## Testing

You will need to create some markdown files at random places
to test out the same.

1. Create a markdown file with an invalid or without lang attribute at a folder other than the `src/content`
2. **Stage the file**
3. Run `npm run-script check-markdown-language-tag`

It will not be detected by the script and hence, the hook will proceed.

- Repeat the above steps but, this time move the markdown file to a place under `src/content`

The script should throw an error

## Related Issue

- related to #4253 
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
