### PR TITLE
Remove unwanted EN tags from markdown links

### DIFF
--- a/src/content/developers/docs/bridges/index.md
+++ b/src/content/developers/docs/bridges/index.md
@@ -123,7 +123,7 @@ To monitor contract activity across chains, developers can use subgraphs and dev
 
 ## Further reading {#further-reading}
 
-- [Blockchain Bridges](/en/bridges/) – ethereum.org
+- [Blockchain Bridges](/bridges/) – ethereum.org
 - [Blockchain Bridges: Building Networks of Cryptonetworks](https://medium.com/1kxnetwork/blockchain-bridges-5db6afac44f8) Sep 8, 2021 – Dmitriy Berenzon
 - [The Interoperability Trilemma](https://blog.connext.network/the-interoperability-trilemma-657c2cf69f17) Oct 1, 2021 – Arjun Bhuptani
 - [Clusters: How Trusted & Trust-Minimized Bridges Shape the Multi-Chain Landscape](https://blog.celestia.org/clusters/) Oct 4, 2021 – Mustafa Al-Bassam

--- a/src/content/translations/de/developers/docs/transactions/index.md
+++ b/src/content/translations/de/developers/docs/transactions/index.md
@@ -9,7 +9,7 @@ Transaktionen sind kryptographisch signierte Anweisungen von Konten. Ein Konto w
 
 ## Voraussetzungen {#prerequisites}
 
-Um dir zu helfen, diese Seite besser zu verstehen, empfehlen wir dir, zuerst [ Konten](/developers/docs/accounts/), [Transaktionen](/en/developers/docs/transactions/) und unsere [Einführung in Ethereum](/developers/docs/intro-to-ethereum/) zu lesen.
+Um dir zu helfen, diese Seite besser zu verstehen, empfehlen wir dir, zuerst [ Konten](/developers/docs/accounts/), [Transaktionen](/developers/docs/transactions/) und unsere [Einführung in Ethereum](/developers/docs/intro-to-ethereum/) zu lesen.
 
 ## Was ist eine Transaktion? {#whats-a-transaction}
 

--- a/src/content/translations/it/developers/docs/programming-languages/javascript/index.md
+++ b/src/content/translations/it/developers/docs/programming-languages/javascript/index.md
@@ -32,7 +32,7 @@ Scopri di più sugli [Smart Contract](/developers/docs/smart-contracts/).
 
 ### La macchina virtuale Ethereum {#the-ethereum-virtual-machine}
 
-Esiste un'implementazione JavaScript della [macchina virtuale di Ethereum](/en/developers/docs/evm/), che supporta le regole più recenti relative alle diramazioni della rete. Le regole relative alle diramazioni si riferiscono alle modifiche apportate alla macchina virtuale di Ethereum (EVM) a seguito di upgrade pianificati.
+Esiste un'implementazione JavaScript della [macchina virtuale di Ethereum](/developers/docs/evm/), che supporta le regole più recenti relative alle diramazioni della rete. Le regole relative alle diramazioni si riferiscono alle modifiche apportate alla macchina virtuale di Ethereum (EVM) a seguito di upgrade pianificati.
 
 È suddivisa in vari pacchetti JavaScript che puoi leggere per comprendere meglio:
 

--- a/src/content/translations/it/developers/tutorials/secure-development-workflow/index.md
+++ b/src/content/translations/it/developers/tutorials/secure-development-workflow/index.md
@@ -28,7 +28,7 @@ Considera le funzionalità speciali del tuo contratto:
 - I tuoi contratti sono aggiornabili? Revisiona il tuo codice di aggiornabilità per i difetti con [`slither-check-upgradeability`](https://github.com/crytic/slither/wiki/Upgradeability-Checks) o [Crytic](https://blog.trailofbits.com/2020/06/12/upgradeable-contracts-made-safer-with-crytic/). Abbiamo documentato 17 modi in cui gli aggiornamenti possono andare male.
 - I tuoi contratti pretendono di esser conformi agli ERC? Controllali con [`slither-check-erc`](https://github.com/crytic/slither/wiki/ERC-Conformance). Questo strumento identifica istantaneamente le deviazioni da sei specifiche comuni.
 - Hai test unitari su Truffle? Arricchiscili con [`slither-prop`](https://github.com/crytic/slither/wiki/Property-generation). Genera automaticamente una robusta suite di proprietà di sicurezza per le funzionalità di ERC20 in base al tuo codice specifico.
-- Integri con token di terze parti? Revisiona il nostro [elenco di controllo di integrazione del token](/en/developers/tutorials/token-integration-checklist/) prima di affidarti a contratti esterni.
+- Integri con token di terze parti? Revisiona il nostro [elenco di controllo di integrazione del token](/developers/tutorials/token-integration-checklist/) prima di affidarti a contratti esterni.
 
 Ispeziona visivamente le funzionalità di sicurezza critiche del tuo codice:
 

--- a/src/content/translations/pt-br/developers/docs/transactions/index.md
+++ b/src/content/translations/pt-br/developers/docs/transactions/index.md
@@ -9,7 +9,7 @@ Transações são instruções assinadas criptograficamente de contas. Uma conta
 
 ## Pré-Requisitos {#prerequisites}
 
-Mas para ajudá-lo a entender melhor esta página, recomendamos que você primeiro leia [Contas](/developers/docs/accounts/), [Transações](/en/developers/docs/transactions/)e nossa [introdução ao Ethereum](/developers/docs/intro-to-ethereum/).
+Mas para ajudá-lo a entender melhor esta página, recomendamos que você primeiro leia [Contas](/developers/docs/accounts/), [Transações](/developers/docs/transactions/)e nossa [introdução ao Ethereum](/developers/docs/intro-to-ethereum/).
 
 ## O que é uma transação? {#whats-a-transaction}
 

--- a/src/content/translations/pt-br/developers/tutorials/run-node-raspberry-pi/index.md
+++ b/src/content/translations/pt-br/developers/tutorials/run-node-raspberry-pi/index.md
@@ -72,7 +72,7 @@ Ambas as imagens incluem os mesmos pacotes, a única diferença entre elas é qu
 - Disco SSD 3.0 (ver seção de armazenamento)
 - Fonte de alimentação
 - Cabo de rede
-- Redirecionamento da porta 30303 (camada de execução) e da porta 13000 (camada de consenso) [[4]](/en/developers/tutorials/run-node-raspberry-pi/#references)
+- Redirecionamento da porta 30303 (camada de execução) e da porta 13000 (camada de consenso) [[4]](/developers/tutorials/run-node-raspberry-pi/#references)
 - Um gabinete com dissipador de calor e ventilador (opcional, mas altamente recomendado)
 - Teclado USB, Monitor e cabo HDMI (microHDMI) (opcional)
 


### PR DESCRIPTION
## Description
Get rid of /en/ tags in markdown links

## Related Issue
#6903
