### PR TITLE
Fix broken markdown links

### DIFF
--- a/src/content/translations/hu/developers/docs/layer-2-scaling/index.md
+++ b/src/content/translations/hu/developers/docs/layer-2-scaling/index.md
@@ -217,7 +217,7 @@ Kombinálja a többrétegű technológiák legjobb tulajdonságait, és konfigur
 ## További olvasnivaló {#further-reading}
 
 - [Validium And The Layer 2 Two-By-Two — Issue No. 99](https://www.buildblockchain.tech/newsletter/issues/no-99-validium-and-the-layer-2-two-by-two)
-- \[Evaluating Ethereum layer 2 Scaling Solutions: A Comparison Framework\](https://blog.matter-labs.io/evaluating-ethereum-l2-scaling-solutions-a-comparison-framework-b6b2f410f955)
+- [Evaluating Ethereum layer 2 Scaling Solutions: A Comparison Framework](https://blog.matter-labs.io/evaluating-ethereum-l2-scaling-solutions-a-comparison-framework-b6b2f410f955)
 - [Adding Hybrid PoS-Rollup Sidechain to Celer’s Coherent Layer-2 Platform on Ethereum](https://medium.com/celer-network/adding-hybrid-pos-rollup-sidechain-to-celers-coherent-layer-2-platform-d1d3067fe593)
 - [Zero-Knowledge Blockchain Scalability](https://ethworks.io/assets/download/zero-knowledge-blockchain-scaling-ethworks.pdf)
 

--- a/src/content/translations/hu/history/index.md
+++ b/src/content/translations/hu/history/index.md
@@ -145,7 +145,7 @@ A Byzantium fork:
 - A [bányászati](/developers/docs/consensus-mechanisms/pow/mining/) blokk jutalom csökkentése 5-ről 3 ETH-re.
 - A [nehézségi bomba](/glossary/#difficulty-bomb) késleltetése egy évvel.
 - Más szerződések is indíthatnak állapotot nem befolyásoló hívásokat.
-- Bizonyos kriptográfiai metódusok hozzáadása, mely lehetővé teszi a \[2. réteges skálázást\]((/developers/docs/layer-2-scaling/).
+- Bizonyos kriptográfiai metódusok hozzáadása, mely lehetővé teszi a [2. réteges skálázást](/developers/docs/layer-2-scaling/).
 
 [Olvasd el az Ethereum Alapítvány közleményét](https://blog.ethereum.org/2017/10/12/byzantium-hf-announcement/)
 

--- a/src/content/translations/it/developers/docs/layer-2-scaling/index.md
+++ b/src/content/translations/it/developers/docs/layer-2-scaling/index.md
@@ -217,7 +217,7 @@ Combinano le parti migliori di diverse tecnologie di livello 2 e possono offrire
 ## Letture consigliate {#further-reading}
 
 - [Validium And The Layer 2 Two-By-Two — Issue No. 99](https://www.buildblockchain.tech/newsletter/issues/no-99-validium-and-the-layer-2-two-by-two)
-- \[Evaluating Ethereum layer 2 Scaling Solutions: A Comparison Framework\](https://blog.matter-labs.io/evaluating-ethereum-l2-scaling-solutions-a-comparison-framework-b6b2f410f955)
+- [Evaluating Ethereum layer 2 Scaling Solutions: A Comparison Framework](https://blog.matter-labs.io/evaluating-ethereum-l2-scaling-solutions-a-comparison-framework-b6b2f410f955)
 - [Adding Hybrid PoS-Rollup Sidechain to Celer’s Coherent Layer-2 Platform on Ethereum](https://medium.com/celer-network/adding-hybrid-pos-rollup-sidechain-to-celers-coherent-layer-2-platform-d1d3067fe593)
 - [Zero-Knowledge Blockchain Scalability](https://ethworks.io/assets/download/zero-knowledge-blockchain-scaling-ethworks.pdf)
 

--- a/src/content/translations/it/developers/tutorials/how-to-use-manticore-to-find-smart-contract-bugs/index.md
+++ b/src/content/translations/it/developers/tutorials/how-to-use-manticore-to-find-smart-contract-bugs/index.md
@@ -232,7 +232,7 @@ contract_account = m.solidity_create_contract(source_code, owner=user_account)
 
 #### Riepilogo {#summary}
 
-- Puoi creare account utente e di contratto con [m.create_account](https://manticore.readthedocs.io/en/latest/api.html#manticore.ethereum.ManticoreEVM.create_account) e \[m.solidity_create_contract\] (https://manticore.readthedocs.io/en/latest/api.html#manticore.ethereum.ManticoreEVM.solidity_create_contract.
+- Puoi creare account utente e di contratto con [m.create_account](https://manticore.readthedocs.io/en/latest/api.html#manticore.ethereum.ManticoreEVM.create_account) e [m.solidity_create_contract](https://manticore.readthedocs.io/en/latest/api.html#manticore.ethereum.ManticoreEVM.solidity_create_contract.
 
 ### Esecuzione di transazioni {#executing-transactions}
 

--- a/src/content/translations/ro/developers/docs/layer-2-scaling/index.md
+++ b/src/content/translations/ro/developers/docs/layer-2-scaling/index.md
@@ -217,7 +217,7 @@ Combină cele mai bune părți ale mai multor tehnologii de nivel 2 și pot ofer
 ## Referințe suplimentare {#further-reading}
 
 - [Validium And The Layer 2 Two-By-Two — Issue No. 99](https://www.buildblockchain.tech/newsletter/issues/no-99-validium-and-the-layer-2-two-by-two)
-- \[Evaluating Ethereum layer 2 Scaling Solutions: A Comparison Framework\](https://blog.matter-labs.io/evaluating-ethereum-l2-scaling-solutions-a-comparison-framework-b6b2f410f955)
+- [Evaluating Ethereum layer 2 Scaling Solutions: A Comparison Framework](https://blog.matter-labs.io/evaluating-ethereum-l2-scaling-solutions-a-comparison-framework-b6b2f410f955)
 - [Adding Hybrid PoS-Rollup Sidechain to Celer’s Coherent Layer-2 Platform on Ethereum](https://medium.com/celer-network/adding-hybrid-pos-rollup-sidechain-to-celers-coherent-layer-2-platform-d1d3067fe593)
 - [Zero-Knowledge Blockchain Scalability](https://ethworks.io/assets/download/zero-knowledge-blockchain-scaling-ethworks.pdf)
 


### PR DESCRIPTION
## Description
Broken links caused by escape characters / incorrect spacing

## Related Issue
None