### PR TITLE
Fix broken 'author' frontmatter prop on run a light node tutorial

### DIFF
--- a/src/content/developers/tutorials/run-light-node-geth/index.md
+++ b/src/content/developers/tutorials/run-light-node-geth/index.md
@@ -1,7 +1,7 @@
 ---
 title: How to run a light node with Geth
 description: How to download, install and run a lightclient with Geth.
-authors: "Brian Gu"
+author: "Brian Gu"
 tags: ["clients", "geth", "nodes"]
 skill: beginner
 lang: en

--- a/src/content/translations/id/developers/tutorials/run-light-node-geth/index.md
+++ b/src/content/translations/id/developers/tutorials/run-light-node-geth/index.md
@@ -1,7 +1,7 @@
 ---
 title: Cara menjalankan node ringan dengan Geth
 description: How to download, install and run a lightclient with Geth.
-authors: "Brain Gu"
+author: "Brain Gu"
 tags:
   - "klien"
   - "geth"

--- a/src/content/translations/ro/developers/tutorials/run-light-node-geth/index.md
+++ b/src/content/translations/ro/developers/tutorials/run-light-node-geth/index.md
@@ -1,7 +1,7 @@
 ---
 title: Cum se execută un nod ușor cu Geth
 description: How to download, install and run a lightclient with Geth.
-authors: "Brian Gu"
+author: "Brian Gu"
 tags:
   - "clienți"
   - "geth"

--- a/src/content/translations/tr/developers/tutorials/run-light-node-geth/index.md
+++ b/src/content/translations/tr/developers/tutorials/run-light-node-geth/index.md
@@ -1,7 +1,7 @@
 ---
 title: Geth ile bir hafif (light) düğüm nasıl çalıştırılır
 description: Geth ile bir lightclient nasıl indirilir, kurulur ve çalıştırılır.
-authors: "Brian Gu"
+author: "Brian Gu"
 tags:
   - "istemciler"
   - "geth"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The frontmatter prop is broken, causing the author's name to not render.

![Screenshot 2022-07-06 at 21 52 08](https://user-images.githubusercontent.com/62268199/177641099-9df08c93-fb8f-46fe-8442-2ed062a71f5d.png)

## Related Issue
None
