### PR TITLE
Add 10GB node ram limit as optional build type

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
   "scripts": {
     "build": "gatsby build",
     "build:lambda": "netlify-lambda build src/lambda",
+    "build:10gb": "NODE_OPTIONS=--max-old-space-size=10240 gatsby build",
     "clean": "gatsby clean",
     "copy-contributors": "node src/scripts/copy-contributors.js",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",


### PR DESCRIPTION
## Description
- Adds a package script `yarn build:10gb` that appends a 10gb limit to node option `max-old-space-size`

## Related Issue
None filed, but was having memory heap issues on 16gb machine without this.
In testing, this works to build the entire site, all languages, on a 16gb machine.