### PR TITLE
Only use glossary icon on glossary items

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -97,7 +97,7 @@ const Link: React.FC<IProps> = ({
 
   const isExternal = to.includes("http") || to.includes("mailto:")
   const isHash = isHashLink(to)
-  const isGlossary = to.includes("glossary")
+  const isGlossary = to.includes("glossary#")
   const isStatic = to.includes("static")
   const isPdf = to.includes(".pdf")
 


### PR DESCRIPTION
## Description

@nloureiro pointed out that using the glossary icon on the navigation may be confusing or interpreted as a UI bug. This PR changes the GlossaryLink to only be used when we're linking to a glossary item (e.g. /glossary#pos) but not to the glossary page itself (/glossary/).

## Related Issue
None
