### PR TITLE
Fix glossary link

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -97,7 +97,7 @@ const Link: React.FC<IProps> = ({
 
   const isExternal = to.includes("http") || to.includes("mailto:")
   const isHash = isHashLink(to)
-  const isGlossary = to.includes("glossary#")
+  const isGlossary = to.includes("glossary") && to.includes("#")
   const isStatic = to.includes("static")
   const isPdf = to.includes(".pdf")
 


### PR DESCRIPTION
## Description
Patch glossary link to include links ending with `/#`

## Related Issue