### PR TITLE
changed the max-page-width to 1280px for comfort testing

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -409,7 +409,7 @@ const theme: DefaultTheme = {
     xl: "1440px", // Used as the max-width
   },
   variables: {
-    maxPageWidth: "1504px", // xl breakpoint (1440px) + 72px (2rem padding on each side)
+    maxPageWidth: "1280px", // xl breakpoint (1440px) + 72px (2rem padding on each side)
     navHeight: "4.75rem",
     navBannerHeightDesktop: "134px", // 76px + 58px
     navBannerHeightTablet: "159px", // 76px + 83px


### PR DESCRIPTION

One of the first changes in implementing the design system and Chakra UI is updating the media queries.

This is my first test by constraining the max-width to a smaller measure > 1280px

Key benefit: smaller reading lines on more giant screens for better comfort and accessibility. 

![Frame 485](https://user-images.githubusercontent.com/1120748/178474602-55bd40d6-e58b-4e49-9054-9da0ded32ddd.png)
![Frame 486](https://user-images.githubusercontent.com/1120748/178474617-ee716ae0-4689-4f29-8255-84197ab894e8.png)
![Frame 487](https://user-images.githubusercontent.com/1120748/178474621-b223eca4-b394-4495-ad74-67c74ae1c8fb.png)

The only downside is on big screens where we get white space on the sides.

![Frame 488](https://user-images.githubusercontent.com/1120748/178474756-c7176b2e-1a1d-4530-8bde-eb35123a9c86.png)

Check this PR on your browser, and please circle back with your thoughts.






