### PR TITLE
Refactor how we hide table of contents and edit on GitHub button

### DIFF
--- a/src/components/TableOfContents.js
+++ b/src/components/TableOfContents.js
@@ -328,6 +328,7 @@ const TableOfContents = ({
   className,
   slug,
   editPath,
+  shouldShowEditButton,
   isMobile = false,
 }) => {
   const { isZenMode, handleZenModeChange } = useContext(ZenModeContext)
@@ -371,12 +372,11 @@ const TableOfContents = ({
   }
 
   const shouldShowZenModeToggle = slug?.includes("/docs/")
-  const shouldShowEditButtom = !!editPath
 
   return (
     <Aside className={className}>
       <OuterList>
-        {shouldShowEditButtom && (
+        {shouldShowEditButton && (
           <ButtonContainer>
             <ButtonLink to={editPath} isSecondary={true} hideArrow mt={0}>
               <ButtonContent>

--- a/src/content/about/index.md
+++ b/src/content/about/index.md
@@ -2,7 +2,6 @@
 title: About Us
 description: About the team, community and mission of ethereum.org
 lang: en
-sidebar: true
 ---
 
 # About ethereum.org {#about-ethereumorg}

--- a/src/content/community/events/index.md
+++ b/src/content/community/events/index.md
@@ -3,6 +3,7 @@ title: Ethereum events
 description: How to get involved in the Ethereum community.
 sidebar: true
 lang: en
+hideEditButton: true
 ---
 
 ## Upcoming events {#events}

--- a/src/content/foundation/index.md
+++ b/src/content/foundation/index.md
@@ -1,7 +1,7 @@
 ---
 title: Ethereum Foundation
 description: Learn about the Ethereum Foundation (EF), a non-profit organization dedicated to supporting Ethereum and related technologies.
-sidebar: false
+hideTableOfContents: true
 lang: en
 ---
 

--- a/src/content/nft/index.md
+++ b/src/content/nft/index.md
@@ -4,7 +4,6 @@ description: An overview of NFTs on Ethereum
 lang: en
 template: use-cases
 emoji: ":frame_with_picture:"
-sidebar: true
 sidebarDepth: 2
 image: ../../assets/infrastructure_transparent.png
 alt: An Eth logo being displayed via hologram.

--- a/src/content/translations/de/foundation/index.md
+++ b/src/content/translations/de/foundation/index.md
@@ -1,7 +1,7 @@
 ---
 title: Ethereum Foundation
 description: Erfahren Sie mehr über die Ethereum Foundation (EF), eine gemeinnützige Organisation, die sich der Förderung von Ethereum und verwandten Technologien widmet.
-sidebar: false
+hideTableOfContents: true
 lang: de
 ---
 

--- a/src/content/translations/es/foundation/index.md
+++ b/src/content/translations/es/foundation/index.md
@@ -1,7 +1,7 @@
 ---
 title: Ethereum Foundation
 description: Obtén más información acerca de la Fundación Ethereum (EF), una organización sin ánimo de lucro dedicada a dar soporte a Ethereum y a otras tecnologías similares.
-sidebar: false
+hideTableOfContents: true
 lang: es
 ---
 

--- a/src/content/translations/fr/foundation/index.md
+++ b/src/content/translations/fr/foundation/index.md
@@ -1,7 +1,7 @@
 ---
 title: Ethereum Foundation
 description: L'Ethereum Foundation (EF) est une organisation à but non lucratif destinée à soutenir Ethereum et les technologies qui y sont associées.
-sidebar: false
+hideTableOfContents: true
 lang: fr
 ---
 

--- a/src/content/translations/id/community/events/index.md
+++ b/src/content/translations/id/community/events/index.md
@@ -1,7 +1,7 @@
 ---
 title: Aksi Ethereum
 description: Cara terlibat di dalam komunitas Ethereum.
-sidebar: false
+hideTableOfContents: true
 lang: id
 ---
 

--- a/src/content/translations/id/foundation/index.md
+++ b/src/content/translations/id/foundation/index.md
@@ -1,7 +1,7 @@
 ---
 title: Yayasan Ethereum
 description: Pelajari tentang Ethereum Foundation (EF), sebuah organisasi nirlaba yang didedikasikan untuk mendukung Ethereum beserta teknologi yang terkait dengannya.
-sidebar: false
+hideTableOfContents: true
 lang: id
 ---
 

--- a/src/content/translations/ig/what-is-ethereum/index.md
+++ b/src/content/translations/ig/what-is-ethereum/index.md
@@ -1,7 +1,7 @@
 ---
 title: Ndi mbido
 lang: ig
-sidebar: false
+hideTableOfContents: true
 ---
 
 # Nnoo! {#what-is-ethereum}

--- a/src/content/translations/it/community/events/index.md
+++ b/src/content/translations/it/community/events/index.md
@@ -1,7 +1,7 @@
 ---
 title: Eventi Ethereum
 description: Come partecipare alla community Ethereum.
-sidebar: false
+hideTableOfContents: true
 lang: it
 ---
 

--- a/src/content/translations/it/foundation/index.md
+++ b/src/content/translations/it/foundation/index.md
@@ -1,7 +1,7 @@
 ---
 title: Ethereum Foundation
 description: Scopri di più sulla Ethereum Foundation (EF), un'organizzazione no-profit dedita al supporto di Ethereum e delle tecnologie correlate.
-sidebar: false
+hideTableOfContents: true
 lang: it
 ---
 

--- a/src/content/translations/pl/foundation/index.md
+++ b/src/content/translations/pl/foundation/index.md
@@ -1,7 +1,7 @@
 ---
 title: Fundacja Ethereum
 description: Dowiedz się więcej o Fundacji Ethereum (EF), organizacji non-profit poświęconej wspieraniu Ethereum i powiązanych technologii.
-sidebar: false
+hideTableOfContents: true
 lang: pl
 ---
 

--- a/src/content/translations/pt-br/community/events/index.md
+++ b/src/content/translations/pt-br/community/events/index.md
@@ -1,7 +1,7 @@
 ---
 title: Eventos Ethereum
 description: Como fazer parte da comunidade Ethereum.
-sidebar: false
+hideTableOfContents: true
 lang: pt-br
 ---
 

--- a/src/content/translations/ro/foundation/index.md
+++ b/src/content/translations/ro/foundation/index.md
@@ -1,7 +1,7 @@
 ---
 title: Fundația Ethereum
 description: Aflați despre Ethereum Foundation (EF), o organizație non-profit dedicată sprijinirii Ethereum și a tehnologiilor conexe.
-sidebar: false
+hideTableOfContents: true
 lang: ro
 ---
 

--- a/src/content/translations/tr/foundation/index.md
+++ b/src/content/translations/tr/foundation/index.md
@@ -1,7 +1,7 @@
 ---
 title: Ethereum Vakfı
 description: Ethereum ve ilgili teknolojileri desteklemeye adanmış, kâr amacı gütmeyen bir organizasyon olan Ethereum Vakfı (EF) hakkında bilgi edinin.
-sidebar: false
+hideTableOfContents: true
 lang: tr
 ---
 

--- a/src/content/translations/zh/foundation/index.md
+++ b/src/content/translations/zh/foundation/index.md
@@ -1,7 +1,7 @@
 ---
 title: 以太坊基金会
 description: 了解以太坊基金会（EF），一个致力于支持以太坊和相关技术的非营利组织。
-sidebar: false
+hideTableOfContents: true
 lang: zh
 ---
 

--- a/src/content/whitepaper/index.md
+++ b/src/content/whitepaper/index.md
@@ -4,6 +4,7 @@ description: An introductory paper to Ethereum, published in 2013 before its lau
 lang: en
 sidebar: true
 sidebarDepth: 2
+hideEditButton: true
 ---
 
 # Ethereum Whitepaper {#ethereum-whitepaper}

--- a/src/templates/docs.tsx
+++ b/src/templates/docs.tsx
@@ -187,6 +187,8 @@ const DocsPage = ({
   const absoluteEditPath = `${editContentUrl}${relativePath}`
   const isDevelopersHome = relativePath.endsWith("/developers/docs/index.md")
   const showMergeBanner = !!mdx.frontmatter.preMergeBanner || isDevelopersHome
+  const shouldShowEditButton =
+    mdx?.frontmatter?.hideEditButton !== true ? true : false
 
   return (
     <Page dir={isRightToLeft ? "rtl" : "ltr"}>
@@ -219,6 +221,7 @@ const DocsPage = ({
             items={tocItems}
             isMobile={true}
             maxDepth={mdx.frontmatter.sidebarDepth}
+            shouldShowEditButton={shouldShowEditButton}
           />
           <MDXProvider components={components}>
             <MDXRenderer>{mdx.body}</MDXRenderer>
@@ -232,13 +235,14 @@ const DocsPage = ({
           <FeedbackCard isArticle />
           <DocsNav relativePath={relativePath}></DocsNav>
         </Content>
-        {mdx.frontmatter.sidebar && tocItems && (
+        {tocItems && (
           <DesktopTableOfContents
             slug={slug}
             editPath={absoluteEditPath}
             items={tocItems}
             isPageIncomplete={isPageIncomplete}
             maxDepth={mdx.frontmatter.sidebarDepth}
+            shouldShowEditButton={shouldShowEditButton}
           />
         )}
       </ContentContainer>
@@ -262,8 +266,9 @@ export const query = graphql`
         description
         lang
         incomplete
-        sidebar
         sidebarDepth
+        hideEditButton
+        hideTableOfContents
         isOutdated
         preMergeBanner
       }

--- a/src/templates/staking.tsx
+++ b/src/templates/staking.tsx
@@ -432,7 +432,7 @@ const StakingPage = ({
           <StyledButtonDropdown list={dropdownLinks} />
           <InfoTitle>{mdx.frontmatter.title}</InfoTitle>
 
-          {mdx.frontmatter.sidebar && tocItems && (
+          {tocItems && (
             <UpgradeTableOfContents
               items={tocItems}
               maxDepth={mdx.frontmatter.sidebarDepth}
@@ -464,7 +464,6 @@ export const stakingPageQuery = graphql`
         title
         description
         lang
-        sidebar
         emoji
         sidebarDepth
         summaryPoints

--- a/src/templates/static.tsx
+++ b/src/templates/static.tsx
@@ -152,8 +152,11 @@ const StaticPage = ({
   pageContext,
 }: PageProps<Queries.StaticPageQuery, Context>) => {
   const intl = useIntl()
-  // Show sidebar unless 'sidebar: false' frontmatter is present
-  const shouldShowSidebar = mdx.frontmatter.sidebar !== false ? true : false
+  // Show table of contents unless 'hideTableOfContents: true' frontmatter is present
+  const shouldShowTableOfContents =
+    mdx?.frontmatter?.hideTableOfContents !== true ? true : false
+  const shouldShowEditButton =
+    mdx?.frontmatter?.hideEditButton !== true ? true : false
 
   if (!siteData || !mdx?.frontmatter || !mdx.parent)
     throw new Error(
@@ -173,11 +176,7 @@ const StaticPage = ({
   const tocItems = mdx.tableOfContents?.items
   const { editContentUrl } = siteData.siteMetadata || {}
   const { relativePath } = pageContext
-  const absoluteEditPath =
-    relativePath.split("/").includes("whitepaper") ||
-    relativePath.split("/").includes("events")
-      ? ""
-      : `${editContentUrl}${relativePath}`
+  const absoluteEditPath = `${editContentUrl}${relativePath}`
 
   const slug = mdx.fields?.slug || ""
 
@@ -200,17 +199,19 @@ const StaticPage = ({
           items={tocItems}
           isMobile={true}
           maxDepth={mdx.frontmatter.sidebarDepth}
+          shouldShowEditButton={shouldShowEditButton}
         />
         <MDXProvider components={components}>
           <MDXRenderer>{mdx.body}</MDXRenderer>
         </MDXProvider>
         <FeedbackCard isArticle />
       </ContentContainer>
-      {shouldShowSidebar && tocItems && (
+      {shouldShowTableOfContents && tocItems && (
         <TableOfContents
           editPath={absoluteEditPath}
           items={tocItems}
           maxDepth={mdx.frontmatter.sidebarDepth}
+          shouldShowEditButton={shouldShowEditButton}
         />
       )}
     </Page>
@@ -232,7 +233,8 @@ export const staticPageQuery = graphql`
         title
         description
         lang
-        sidebar
+        hideTableOfContents
+        hideEditButton
         sidebarDepth
         isOutdated
       }

--- a/src/templates/static.tsx
+++ b/src/templates/static.tsx
@@ -152,6 +152,8 @@ const StaticPage = ({
   pageContext,
 }: PageProps<Queries.StaticPageQuery, Context>) => {
   const intl = useIntl()
+  // Show sidebar unless 'sidebar: false' frontmatter is present
+  const shouldShowSidebar = mdx.frontmatter.sidebar !== false ? true : false
 
   if (!siteData || !mdx?.frontmatter || !mdx.parent)
     throw new Error(
@@ -204,7 +206,7 @@ const StaticPage = ({
         </MDXProvider>
         <FeedbackCard isArticle />
       </ContentContainer>
-      {mdx.frontmatter.sidebar && tocItems && (
+      {shouldShowSidebar && tocItems && (
         <TableOfContents
           editPath={absoluteEditPath}
           items={tocItems}

--- a/src/templates/tutorial.tsx
+++ b/src/templates/tutorial.tsx
@@ -160,6 +160,8 @@ const TutorialPage = ({
 
   const isRightToLeft = isLangRightToLeft(mdx.frontmatter.lang as Lang)
   const showMergeBanner = !!mdx.frontmatter.preMergeBanner
+  const shouldShowEditButton =
+    mdx?.frontmatter?.hideEditButton !== true ? true : false
 
   const tocItems = mdx.tableOfContents?.items
 
@@ -183,6 +185,7 @@ const TutorialPage = ({
             maxDepth={mdx.frontmatter.sidebarDepth}
             editPath={absoluteEditPath}
             isMobile={true}
+            shouldShowEditButton={shouldShowEditButton}
           />
           <MDXProvider components={components}>
             <MDXRenderer>{mdx.body}</MDXRenderer>
@@ -193,11 +196,12 @@ const TutorialPage = ({
           />
           <FeedbackCard />
         </ContentContainer>
-        {mdx.frontmatter.sidebar && tocItems && (
+        {tocItems && (
           <DesktopTableOfContents
             items={tocItems}
             maxDepth={mdx.frontmatter.sidebarDepth}
             editPath={absoluteEditPath}
+            shouldShowEditButton={shouldShowEditButton}
           />
         )}
       </Page>
@@ -231,7 +235,8 @@ export const query = graphql`
         sourceUrl
         skill
         published
-        sidebar
+        hideTableOfContents
+        hideEditButton
         sidebarDepth
         address
         isOutdated

--- a/src/templates/upgrade.tsx
+++ b/src/templates/upgrade.tsx
@@ -391,7 +391,7 @@ const UpgradePage = ({
           <StyledButtonDropdown list={dropdownLinks} />
           <H1>{mdx.frontmatter.title}</H1>
 
-          {mdx.frontmatter.sidebar && tocItems && (
+          {tocItems && (
             <UpgradeTableOfContents
               items={tocItems}
               maxDepth={mdx.frontmatter.sidebarDepth}

--- a/src/templates/use-cases.tsx
+++ b/src/templates/use-cases.tsx
@@ -416,7 +416,7 @@ const UseCasePage = ({
           <StyledButtonDropdown list={dropdownLinks} />
           <InfoTitle>{mdx.frontmatter.title}</InfoTitle>
 
-          {mdx.frontmatter.sidebar && tocItems && (
+          {tocItems && (
             <UpgradeTableOfContents
               items={tocItems}
               maxDepth={mdx.frontmatter.sidebarDepth}
@@ -452,7 +452,6 @@ export const useCasePageQuery = graphql`
         title
         description
         lang
-        sidebar
         emoji
         sidebarDepth
         summaryPoint1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently for every markdown page we must explicitly pass a `sidebar` prop of either true or false. Translators [sometimes translate this field](https://github.com/ethereum/ethereum-org-website/pull/7030/commits/95e043cafd8ffa72d382f261ce12fd5b54770411#r919922168) if:
  - we forget to hide it when adding a new page 
  - we haven't corrected legacy translations 

This leads to a lot of unnecessary work. We currently show the sidebar (`sidebar: true`) 1625 times, but only hide the sidebar (`sidebar: false`) 14 times. I suggest we abstract this into the page templates.

<img width="604" alt="Screenshot 2022-07-13 at 11 29 15" src="https://user-images.githubusercontent.com/62268199/178713257-435e92f1-6057-4d91-96cc-a9b08bb378b7.png">

Edit: we should add `sidebar: false` in a few places: cookie policy, privacy policy, and terms of use. Here is a full list of items defaulting to `sidebar: false` atm. Most are old versions of pages that we're trying to get off of, some the sidebar has been accidentally removed (events), and some (all of the 'use' pages) are no longer used and should be removed.

```
joshua@Joshuas-iMac content % grep -rLE --include=\*.md "sidebar: true" *
cookie-policy/index.md
foundation/index.md
privacy-policy/index.md
terms-of-use/index.md
translations/sl/use/index.md
translations/sk/what-is-ethereum/index.md
translations/sk/dapps/index.md
translations/sk/eth/index.md
translations/sk/wallets/index.md
translations/se/what-is-ethereum/index.md
translations/se/dapps/index.md
translations/se/eth/index.md
translations/se/wallets/index.md
translations/pl/foundation/index.md
translations/pl/use/index.md
translations/ig/what-is-ethereum/index.md
translations/ig/use/index.md
translations/it/foundation/index.md
translations/it/eth/index.md
translations/it/community/events/index.md
translations/ru/use/index.md
translations/ro/foundation/index.md
translations/pt/what-is-ethereum/index.md
translations/pt/use/index.md
translations/zh/foundation/index.md
translations/pt-br/community/events/index.md
translations/nl/what-is-ethereum/index.md
translations/nl/use/index.md
translations/bn/what-is-ethereum/index.md
translations/bn/dapps/index.md
translations/bn/eth/index.md
translations/bn/wallets/index.md
translations/nb/what-is-ethereum/index.md
translations/nb/dapps/index.md
translations/nb/eth/index.md
translations/nb/wallets/index.md
translations/de/foundation/index.md
translations/fi/what-is-ethereum/index.md
translations/fi/dapps/index.md
translations/fi/eth/index.md
translations/fi/wallets/index.md
translations/id/foundation/index.md
translations/id/community/events/index.md
translations/fr/foundation/index.md
translations/es/foundation/index.md
translations/lt/what-is-ethereum/index.md
translations/lt/dapps/index.md
translations/lt/eth/index.md
translations/lt/wallets/index.md
translations/tr/foundation/index.md
```

## To do

Once we agree on the code here we should

- [ ] Remove `sidebar: true` everywhere
- [ ] Hide edit ability on legal pages
- [ ] Reconsider hiding table of contents vs hiding edit button (e.g. foundation page should have toc)

Out of scope, but we should probably refactor `sidebarDepth` -> `tableOfContentsDepth`.

## Related Issue
Ongoing translation efforts
