### PR TITLE
Remove italic tags from SocialListItem markdown

### DIFF
--- a/src/components/SocialListItem.tsx
+++ b/src/components/SocialListItem.tsx
@@ -17,6 +17,14 @@ const StyledIcon = styled(Icon)`
   padding-right: 0.75rem;
 `
 
+const ChildrenContainer = styled.div`
+  font-style: italic;
+
+  > a {
+    font-style: normal;
+  }
+`
+
 export interface IProps {
   socialIcon: string
 }
@@ -26,7 +34,7 @@ const SocialListItem: React.FC<IProps> = ({ children, socialIcon }) => {
       <div>
         <StyledIcon name={socialIcon} size={"2.5rem"} color={true} />
       </div>
-      <div>{children}</div>
+      <ChildrenContainer>{children}</ChildrenContainer>
     </Item>
   )
 }

--- a/src/content/community/online/index.md
+++ b/src/content/community/online/index.md
@@ -11,32 +11,32 @@ Hundreds of thousands of Ethereum enthusiasts gather in these online forums to s
 
 ## Forums {#forums}
 
-<SocialListItem socialIcon="reddit"><Link to="https://www.reddit.com/r/ethereum">r/ethereum</Link> <i>- all things Ethereum</i></SocialListItem>
-<SocialListItem socialIcon="reddit"><Link to="https://www.reddit.com/r/ethfinance/">r/ethfinance</Link> <i>- the financial side of Ethereum, including DeFi</i></SocialListItem>
-<SocialListItem socialIcon="reddit"><Link to="https://www.reddit.com/r/ethdev/">r/ethdev</Link> <i>- focused on Ethereum development</i></SocialListItem>
-<SocialListItem socialIcon="reddit"><Link to="https://www.reddit.com/r/ethtrader/">r/ethtrader</Link> <i>- trends & market analysis</i></SocialListItem>
-<SocialListItem socialIcon="reddit"><Link to="https://www.reddit.com/r/EtherMining/">r/EtherMining</Link> <i>- focused on securing the Ethereum Network (mining)</i></SocialListItem>
-<SocialListItem socialIcon="reddit"><Link to="https://www.reddit.com/r/ethstaker/">r/ethstaker</Link> <i>- welcome to all interested in staking on Ethereum</i></SocialListItem>
-<SocialListItem socialIcon="webpage"><Link to="https://ethereum-magicians.org">Fellowship of Ethereum Magicians</Link> <i>- community oriented around technical standards in Ethereum</i></SocialListItem>
-<SocialListItem socialIcon="stackExchange"><Link to="https://ethereum.stackexchange.com">Ethereum Stackexchange</Link> <i>- discussion and help for Ethereum developers</i></SocialListItem>
-<SocialListItem socialIcon="webpage"><Link to="https://ethresear.ch">Ethereum Research</Link> <i>- the most influential messageboard for cryptoeconomic research</i></SocialListItem>
+<SocialListItem socialIcon="reddit"><Link to="https://www.reddit.com/r/ethereum">r/ethereum</Link> - all things Ethereum</SocialListItem>
+<SocialListItem socialIcon="reddit"><Link to="https://www.reddit.com/r/ethfinance/">r/ethfinance</Link> - the financial side of Ethereum, including DeFi</SocialListItem>
+<SocialListItem socialIcon="reddit"><Link to="https://www.reddit.com/r/ethdev/">r/ethdev</Link> - focused on Ethereum development</SocialListItem>
+<SocialListItem socialIcon="reddit"><Link to="https://www.reddit.com/r/ethtrader/">r/ethtrader</Link> - trends & market analysis</SocialListItem>
+<SocialListItem socialIcon="reddit"><Link to="https://www.reddit.com/r/EtherMining/">r/EtherMining</Link> - focused on securing the Ethereum Network (mining)</SocialListItem>
+<SocialListItem socialIcon="reddit"><Link to="https://www.reddit.com/r/ethstaker/">r/ethstaker</Link> - welcome to all interested in staking on Ethereum</SocialListItem>
+<SocialListItem socialIcon="webpage"><Link to="https://ethereum-magicians.org">Fellowship of Ethereum Magicians</Link> - community oriented around technical standards in Ethereum</SocialListItem>
+<SocialListItem socialIcon="stackExchange"><Link to="https://ethereum.stackexchange.com">Ethereum Stackexchange</Link> - discussion and help for Ethereum developers</SocialListItem>
+<SocialListItem socialIcon="webpage"><Link to="https://ethresear.ch">Ethereum Research</Link> - the most influential messageboard for cryptoeconomic research</SocialListItem>
 
 ## Chat rooms {#chat-rooms}
 
-<SocialListItem socialIcon="discord"><Link to="https://discord.com/invite/Nz6rtfJ8Cu">Ethereum Cat Herders</Link> <i>- community oriented around offering project management support to Ethereum development</i></SocialListItem>
-<SocialListItem socialIcon="discord"><Link to="https://ethglobal.co/discord">Ethereum Hackers</Link> <i>- Discord chat run by ETHGlobal: an online community for Ethereum hackers all over the world</i></SocialListItem>
-<SocialListItem socialIcon="discord"><Link to="https://discord.gg/5W5tVb3">CryptoDevs</Link> <i>- Ethereum development focused Discord community</i></SocialListItem>
-<SocialListItem socialIcon="discord"><Link to="https://discord.io/ethstaker">EthStaker Discord</Link> <i>- community oriented around offering project management support to Ethereum development</i></SocialListItem>
-<SocialListItem socialIcon="discord"><Link to="https://discord.gg/CetY6Y4">Ethereum.org website team</Link> <i>- stop by and chat ethereum.org web development and design with the team and folks from the community</i></SocialListItem>
-<SocialListItem socialIcon="discord"><Link to="https://discord.gg/ZH5aXDgWEU">Web3 University</Link> <i>- community focused on learning web3 development </i></SocialListItem>
-<SocialListItem socialIcon="webpage"><Link to="https://gitter.im/ethereum/solidity/">Solidity Gitter</Link> <i>- chat for solidity development (Gitter)</i></SocialListItem>
-<SocialListItem socialIcon="webpage"><Link to="https://matrix.to/#/#ethereum_solidity:gitter.im">Solidity Matrix</Link> <i>- chat for solidity development (Matrix)</i></SocialListItem>
+<SocialListItem socialIcon="discord"><Link to="https://discord.com/invite/Nz6rtfJ8Cu">Ethereum Cat Herders</Link> - community oriented around offering project management support to Ethereum development</SocialListItem>
+<SocialListItem socialIcon="discord"><Link to="https://ethglobal.co/discord">Ethereum Hackers</Link> - Discord chat run by ETHGlobal: an online community for Ethereum hackers all over the world</SocialListItem>
+<SocialListItem socialIcon="discord"><Link to="https://discord.gg/5W5tVb3">CryptoDevs</Link> - Ethereum development focused Discord community</SocialListItem>
+<SocialListItem socialIcon="discord"><Link to="https://discord.io/ethstaker">EthStaker Discord</Link> - community oriented around offering project management support to Ethereum development</SocialListItem>
+<SocialListItem socialIcon="discord"><Link to="https://discord.gg/CetY6Y4">Ethereum.org website team</Link> - stop by and chat ethereum.org web development and design with the team and folks from the community</SocialListItem>
+<SocialListItem socialIcon="discord"><Link to="https://discord.gg/ZH5aXDgWEU">Web3 University</Link> - community focused on learning web3 development </SocialListItem>
+<SocialListItem socialIcon="webpage"><Link to="https://gitter.im/ethereum/solidity/">Solidity Gitter</Link> - chat for solidity development (Gitter)</SocialListItem>
+<SocialListItem socialIcon="webpage"><Link to="https://matrix.to/#/#ethereum_solidity:gitter.im">Solidity Matrix</Link> - chat for solidity development (Matrix)</SocialListItem>
 
 ## YouTube and Twitter {#youtube-and-twitter}
 
-<SocialListItem socialIcon="youtube"><Link to="https://www.youtube.com/c/EthereumFoundation">Ethereum Foundation</Link> <i>- Keep up to date with the latest from the Ethereum Foundation</i></SocialListItem>
-<SocialListItem socialIcon="twitter"><Link to="https://twitter.com/ethereum">@ethereum</Link> <i>- Offical account of the Ethereum Foundation</i></SocialListItem>
-<SocialListItem socialIcon="twitter"><Link to="https://twitter.com/ethdotorg">@ethdotorg</Link> <i>- The portal to Ethereum, built for our growing global community</i></SocialListItem>
+<SocialListItem socialIcon="youtube"><Link to="https://www.youtube.com/c/EthereumFoundation">Ethereum Foundation</Link> - Keep up to date with the latest from the Ethereum Foundation</SocialListItem>
+<SocialListItem socialIcon="twitter"><Link to="https://twitter.com/ethereum">@ethereum</Link> - Offical account of the Ethereum Foundation</SocialListItem>
+<SocialListItem socialIcon="twitter"><Link to="https://twitter.com/ethdotorg">@ethdotorg</Link> - The portal to Ethereum, built for our growing global community</SocialListItem>
 <SocialListItem socialIcon="webpage"><Link to="https://hive.one/c/Ethereum?page=1">List of influential Ethereum twitter accounts</Link></SocialListItem>
 
 <Divider />


### PR DESCRIPTION
## Description
Our online communities page was using `<i>` tags inside of a React component. But, Crowdin rebuilds any HTML tag in markdown using markdown syntax (underscores instead of `<i>` tags) causing the styling to not be applied as markdown syntax doesn't work inside a React component. This PR moves that styling into a Styled children container.

Error in markdown:
<img width="500" alt="Screenshot 2022-07-13 at 12 15 15" src="https://user-images.githubusercontent.com/62268199/178727126-0bb4f6e2-1ddc-4933-bc19-7794e56b20c7.png">

Error on page:
<img width="500" alt="Screenshot 2022-07-13 at 12 49 49" src="https://user-images.githubusercontent.com/62268199/178726990-356a44ee-d543-4f24-b88c-d133f8529c95.png">


## Related Issue
None