### PR TITLE
add more info to WalletMoreInfo about state for Matomo event

### DIFF
--- a/src/components/FindWallet/WalletTable.tsx
+++ b/src/components/FindWallet/WalletTable.tsx
@@ -783,7 +783,7 @@ const WalletTable = ({ data, filters, walletData }) => {
                 trackCustomEvent({
                   eventCategory: "WalletMoreInfo",
                   eventAction: `More info wallet`,
-                  eventName: `More info ${wallet.name}`,
+                  eventName: `More info ${wallet.name} ${wallet.moreInfo}`,
                 })
               }}
             >


### PR DESCRIPTION
## Description
- Track whether WalletMoreInfo event is opening or closing more information for a wallet
