### PR TITLE
Remove incomplete banner from smart contract testing page

### DIFF
--- a/src/content/developers/docs/smart-contracts/testing/index.md
+++ b/src/content/developers/docs/smart-contracts/testing/index.md
@@ -3,7 +3,6 @@ title: Testing smart contracts
 description: An overview of techniques and considerations for testing Ethereum smart contracts
 lang: en
 sidebar: true
-incomplete: true
 ---
 
 Testing [smart contracts](/developers/docs/smart-contracts/) is one of the most important measures for improving [smart contract security](/developers/docs/smart-contracts/security/). Unlike traditional software, smart contracts cannot typically be updated after launching, making it imperative to test rigorously before deploying contracts on the Ethereum network. 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Similar to #7068 - I don't think this page needs to have the "incomplete" banner.

## Related Issue

This PR added significant content: https://github.com/ethereum/ethereum-org-website/pull/6501
