### PR TITLE
Remove extra H1 from upgrading smart contracts

### DIFF
--- a/src/content/developers/docs/smart-contracts/upgrading/index.md
+++ b/src/content/developers/docs/smart-contracts/upgrading/index.md
@@ -5,8 +5,6 @@ lang: en
 sidebar: true
 ---
 
-# Upgrading Smart Contracts {#upgrading-smart-contracts}
-
 Smart contracts on Ethereum are self-executing programs that run in the Ethereum Virtual Machine (EVM). These programs are immutable by design, which prevents any updates to the business logic once the contract is deployed.
 
 While immutability is necessary for trustlessness, decentralization, and security of smart contracts, it may be a drawback in certain cases. For instance, immutable code can make it impossible for developers to fix vulnerable contracts.


### PR DESCRIPTION
## Description

Noticed we had duplicate H1s here:

<img width="776" alt="Screenshot 2022-07-18 at 10 16 07" src="https://user-images.githubusercontent.com/62268199/179481561-7011463f-ca21-4c09-9b65-6b2f865146af.png">



## Related Issue
#7095
