### PR TITLE
Redirect nested routes to default lang

### DIFF
--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -23,6 +23,12 @@ import redirects from "./redirects.json"
 
 const exec = util.promisify(child_process.exec)
 
+const commonRedirectProps = {
+  isPermanent: true,
+  ignoreCase: true,
+  force: true,
+}
+
 /**
  * Markdown isOutdated check
  * Parse header ids in markdown file (both translated and english) and compare their info structure.
@@ -190,13 +196,11 @@ export const createPages: GatsbyNode<any, Context>["createPages"] = async ({
 }) => {
   const { createPage, createRedirect } = actions
 
-  // server side redirects
+  // custom redirects defined in `redirects.json`
   redirects.forEach((redirect) => {
     createRedirect({
+      ...commonRedirectProps,
       ...redirect,
-      isPermanent: true,
-      ignoreCase: true,
-      force: true,
     })
   })
 
@@ -261,11 +265,9 @@ export const createPages: GatsbyNode<any, Context>["createPages"] = async ({
     // e.g. corresponding German file: "src/content/translations/de/community/index.md"
     if (language === defaultLanguage) {
       createRedirect({
+        ...commonRedirectProps,
         fromPath: slug.slice(3),
         toPath: slug,
-        isPermanent: true,
-        ignoreCase: true,
-        force: true,
       })
 
       for (const lang of supportedLanguages) {
@@ -326,11 +328,9 @@ export const createPages: GatsbyNode<any, Context>["createPages"] = async ({
     const originalPath = `/${page}/`
 
     createRedirect({
+      ...commonRedirectProps,
       fromPath: originalPath,
       toPath: `/${defaultLanguage}${originalPath}`,
-      isPermanent: true,
-      ignoreCase: true,
-      force: true,
     })
 
     supportedLanguages.forEach(async (lang) => {
@@ -382,11 +382,9 @@ export const onCreatePage: GatsbyNode<any, Context>["onCreatePage"] = async ({
     const path = page.path.slice(3)
 
     createRedirect({
+      ...commonRedirectProps,
       fromPath: path,
       toPath: page.path,
-      isPermanent: true,
-      ignoreCase: true,
-      force: true,
     })
 
     // create routes without the lang prefix e.g. `/{path}` as our i18n plugin

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -381,17 +381,21 @@ export const onCreatePage: GatsbyNode<any, Context>["onCreatePage"] = async ({
   if (isDefaultLang) {
     const path = page.path.slice(3)
 
-    createRedirect({
-      ...commonRedirectProps,
-      fromPath: path,
-      toPath: page.path,
-    })
-
-    // create routes without the lang prefix e.g. `/{path}` as our i18n plugin
-    // only creates `/{lang}/{path}` routes. This is useful on dev env to avoid
-    // getting a 404 since we don't have server side redirects
     if (IS_DEV) {
+      // create routes without the lang prefix e.g. `/{path}` as our i18n plugin
+      // only creates `/{lang}/{path}` routes. This is useful on dev env to avoid
+      // getting a 404 since we don't have server side redirects
       createPage({ ...page, path })
+    }
+
+    if (!IS_DEV && !path.match(/^\/404(\/|.html)$/)) {
+      // on prod, indicate our servers to redirect the root paths to the
+      // `/{defaultLang}/{path}`
+      createRedirect({
+        ...commonRedirectProps,
+        fromPath: path,
+        toPath: page.path,
+      })
     }
   }
 

--- a/redirects.json
+++ b/redirects.json
@@ -48,88 +48,12 @@
     "toPath": "/en/what-is-ethereum/"
   },
   {
-    "fromPath": "/",
-    "toPath": "/en/"
-  },
-  {
-    "fromPath": "/what-is-ethereum/",
-    "toPath": "/en/what-is-ethereum/"
-  },
-  {
-    "fromPath": "/eth/",
-    "toPath": "/en/eth/"
-  },
-  {
-    "fromPath": "/dapps/",
-    "toPath": "/en/dapps/"
-  },
-  {
-    "fromPath": "/wallets/",
-    "toPath": "/en/wallets/"
-  },
-  {
     "fromPath": "/eth2/",
     "toPath": "/en/upgrades/"
   },
   {
-    "fromPath": "/upgrades/",
-    "toPath": "/en/upgrades/"
-  },
-  {
-    "fromPath": "/staking/",
-    "toPath": "/en/staking/"
-  },
-  {
-    "fromPath": "/learn/",
-    "toPath": "/en/learn/"
-  },
-  {
-    "fromPath": "/community/",
-    "toPath": "/en/community/"
-  },
-  {
     "fromPath": "/build/",
     "toPath": "/en/developers/learning-tools/"
-  },
-  {
-    "fromPath": "/developers/",
-    "toPath": "/en/developers/"
-  },
-  {
-    "fromPath": "/enterprise/",
-    "toPath": "/en/enterprise/"
-  },
-  {
-    "fromPath": "/whitepaper/",
-    "toPath": "/en/whitepaper/"
-  },
-  {
-    "fromPath": "/foundation/",
-    "toPath": "/en/foundation/"
-  },
-  {
-    "fromPath": "/eips/",
-    "toPath": "/en/eips/"
-  },
-  {
-    "fromPath": "/about/",
-    "toPath": "/en/about/"
-  },
-  {
-    "fromPath": "/privacy-policy/",
-    "toPath": "/en/privacy-policy/"
-  },
-  {
-    "fromPath": "/terms-of-use/",
-    "toPath": "/en/terms-of-use/"
-  },
-  {
-    "fromPath": "/cookie-policy/",
-    "toPath": "/en/cookie-policy/"
-  },
-  {
-    "fromPath": "/languages/",
-    "toPath": "/en/languages/"
   },
   {
     "fromPath": "/enterprise/",
@@ -172,28 +96,8 @@
     "toPath": "/en/nft/"
   },
   {
-    "fromPath": "/nfts/",
-    "toPath": "/en/nft/"
-  },
-  {
-    "fromPath": "/dao/",
-    "toPath": "/en/dao/"
-  },
-  {
     "fromPath": "/daos/",
     "toPath": "/en/dao/"
-  },
-  {
-    "fromPath": "/defi/",
-    "toPath": "/en/defi/"
-  },
-  {
-    "fromPath": "/layer2/",
-    "toPath": "/en/layer-2/"
-  },
-  {
-    "fromPath": "/*/layer2/",
-    "toPath": "/:splat/layer-2/"
   },
   {
     "fromPath": "/grants/",


### PR DESCRIPTION
1. For each `defaultLang` page we create, lets also create a redirect from the root paths. E.g. for `/en/nft` create a redirect from `/nft` to `/en/nft`.
2. Cleanup the `redirects.json` file. Leave only the custom redirects. The rest are dynamically generated by the previous logic.

Fixes: #6488 #7097 