### PR TITLE
Add find-wallets to Use Ethereum navigation dropdown

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -143,8 +143,8 @@ const Footer: React.FC<IProps> = () => {
       title: "use-ethereum",
       links: [
         {
-          to: `/wallets/`,
-          text: "ethereum-wallets",
+          text: "find-wallet",
+          to: "/wallets/find-wallet/",
         },
         {
           to: `/get-eth/`,
@@ -182,6 +182,10 @@ const Footer: React.FC<IProps> = () => {
         {
           to: `/eth/`,
           text: "what-is-ether",
+        },
+        {
+          to: `/wallets/`,
+          text: "ethereum-wallets",
         },
         {
           to: `/learn/`,

--- a/src/components/Nav/index.tsx
+++ b/src/components/Nav/index.tsx
@@ -150,8 +150,8 @@ const Nav: React.FC<IProps> = ({ handleThemeChange, isDarkTheme, path }) => {
       ariaLabel: "use-ethereum-menu",
       items: [
         {
-          text: "ethereum-wallets",
-          to: "/wallets/",
+          text: "find-wallet",
+          to: "/wallets/find-wallet/",
         },
         {
           text: "get-eth",


### PR DESCRIPTION
## Description
Removes link to /wallets/ and replaces with link to /find-wallets/

## Related Issue
None
