### PR TITLE
delete header link markdown

### DIFF
--- a/src/content/developers/docs/nodes-and-clients/index.md
+++ b/src/content/developers/docs/nodes-and-clients/index.md
@@ -183,7 +183,7 @@ Synchronization modes represent different approaches to this process with variou
 
 General overview of synchronization approaches used in Mainnet ready clients:
 
-##### Full sync {#full-sync}
+##### Full sync
 
 Full sync downloads all blocks (including headers, transactions, and receipts) and generates the state of the blockchain incrementally by executing every block from genesis.
 


### PR DESCRIPTION
looks like extra text for a header link that is no longer a header

removes {#full-sync}