### PR TITLE
Fix link to /glossary/#zk-proof

### DIFF
--- a/src/content/developers/docs/data-availability/index.md
+++ b/src/content/developers/docs/data-availability/index.md
@@ -80,8 +80,7 @@ However, for Ethereum to guarantee the security of rollups, it needs a mechanism
 
 [Optimistic rollups](/developers/docs/scaling/optimistic-rollups/) post compressed transaction data to Ethereum as `calldata`. This allows anyone to verify the state of the rollup and also provides guarantees of transaction validity. If a transaction is invalid, a verifier can use the available transaction data to construct a [fraud proof](/glossary/#fraud-proof) to challenge it.
 
-[Zero-knowledge (ZK) rollups](/developers/docs/scaling/zk-rollups) don't need to post transaction data since zero-knowledge proofs
-validity proofs](/glossary/#zk-proof) guarantee the correctness of state transitions. However, we cannot guarantee the functionality of the ZK-rollup (or interact with it) without access to its state data.
+[Zero-knowledge (ZK) rollups](/developers/docs/scaling/zk-rollups) don't need to post transaction data since [zero-knowledge validity proofs](/glossary/#zk-proof) guarantee the correctness of state transitions. However, we cannot guarantee the functionality of the ZK-rollup (or interact with it) without access to its state data.
 
 For example, users cannot know their balances if an operator withholds details about the rollup’s state. Also, they cannot perform state updates using information contained in a newly added block.
 


### PR DESCRIPTION
Fix the link in the document
## Description
Just a simple fix of the link.