### PR TITLE
Change the checkbox to radio on the profile chooser box

### DIFF
--- a/src/components/FindWallet/WalletPersonasSidebar.tsx
+++ b/src/components/FindWallet/WalletPersonasSidebar.tsx
@@ -89,47 +89,6 @@ const Persona = styled.div<{
 
   h3 {
     color: ${(props) => props.theme.colors.text};
-    position: relative;
-    padding-left: 2rem;
-    &:before {
-      content: "";
-      display: block;
-      border-radius: 100%;
-      width: 1.4rem;
-      height: 1.4rem;
-      left: 0;
-      top: 0.1rem;
-      transition: all 0.5s;
-      border: 1px solid;
-      position: absolute;
-      border-color: ${({ selected, isDark, theme }) =>
-        selected
-          ? isDark
-            ? theme.colors.primary
-            : theme.colors.primary
-          : isDark
-          ? theme.colors.white
-          : theme.colors.black400};
-    }
-    &:after {
-      content: "";
-      display: block;
-      border-radius: 100%;
-      width: 0.9rem;
-      height: 0.9rem;
-      left: 0.25rem;
-      top: 0.35rem;
-      transition: all 0.5s;
-      position: absolute;
-      background: ${({ selected, isDark, theme }) =>
-        selected
-          ? isDark
-            ? theme.colors.primary
-            : theme.colors.primary
-          : isDark
-          ? "rgba(0, 0, 0, 0)"
-          : "rgba(0, 0, 0, 0)"};
-    }
   }
 
   &:hover {
@@ -170,12 +129,6 @@ const Title = styled.div`
   padding: 0.5rem 0.5rem 0 0.5rem;
 `
 
-const Radio = styled.input`
-  display: none;
-  width: 1.4rem;
-  height: 1.4rem;
-`
-
 const H3 = styled.h3`
   margin-left: 0.5rem;
   margin-top: 0;
@@ -209,21 +162,22 @@ const IconContainer = styled.div`
 `
 
 const StyledIcon = styled(Icon)<{ selected: boolean }>`
-  width: 1.3rem;
-  height: 1.3rem;
+  border-radius: 100%;
+  width: 1rem;
+  height: 1rem;
   margin: 0 0.25rem;
   fill: ${(props) =>
-    props.selected === true ? props.theme.colors.white : "rgba(0, 0, 0, 0)"};
+    props.selected === true ? props.theme.colors.primary : "rgba(0, 0, 0, 0)"};
   background: ${(props) =>
     props.selected === true
       ? props.theme.colors.primary
       : props.theme.colors.priceCardBackground};
-  border-radius: 4px;
-  border: 1px solid
+  outline: 1.5px solid
     ${(props) =>
       props.selected === true
         ? props.theme.colors.primary
         : props.theme.colors.text};
+  outline-offset: 3px;
 `
 
 // Types
@@ -574,7 +528,16 @@ const WalletPersonasSidebar = ({
             }}
           >
             <Title>
-              <Radio type="radio" checked={selectedPersona === idx} />
+              <IconContainer
+                role="checkbox"
+                aria-label={`${persona.title} filter`}
+              >
+                <StyledIcon
+                  name="circle"
+                  selected={selectedPersona === idx}
+                  size="2rem"
+                />
+              </IconContainer>
               <H3>{persona.title}</H3>
             </Title>
             <PersonaDescription selected={selectedPersona === idx}>

--- a/src/components/FindWallet/WalletPersonasSidebar.tsx
+++ b/src/components/FindWallet/WalletPersonasSidebar.tsx
@@ -89,6 +89,47 @@ const Persona = styled.div<{
 
   h3 {
     color: ${(props) => props.theme.colors.text};
+    position: relative;
+    padding-left: 2rem;
+    &:before {
+      content: "";
+      display: block;
+      border-radius: 100%;
+      width: 1.4rem;
+      height: 1.4rem;
+      left: 0;
+      top: 0.1rem;
+      transition: all 1.5s;
+      border: 1px solid;
+      position: absolute;
+      border-color: ${({ selected, isDark, theme }) =>
+        selected
+          ? isDark
+            ? theme.colors.primary
+            : theme.colors.primary
+          : isDark
+          ? theme.colors.white
+          : theme.colors.black400};
+    }
+    &:after {
+      content: "";
+      display: block;
+      border-radius: 100%;
+      width: 0.9rem;
+      height: 0.9rem;
+      left: 0.25rem;
+      top: 0.35rem;
+      transition: all 1.5s;
+      position: absolute;
+      background: ${({ selected, isDark, theme }) =>
+        selected
+          ? isDark
+            ? theme.colors.primary
+            : theme.colors.primary
+          : isDark
+          ? "rgba(0, 0, 0, 0)"
+          : "rgba(0, 0, 0, 0)"};
+    }
   }
 
   &:hover {
@@ -527,16 +568,6 @@ const WalletPersonasSidebar = ({
             }}
           >
             <Title>
-              <IconContainer
-                role="checkbox"
-                aria-label={`${persona.title} filter`}
-              >
-                <StyledIcon
-                  name="check"
-                  selected={selectedPersona === idx}
-                  size="2rem"
-                />
-              </IconContainer>
               <H3>{persona.title}</H3>
             </Title>
             <PersonaDescription selected={selectedPersona === idx}>

--- a/src/components/FindWallet/WalletPersonasSidebar.tsx
+++ b/src/components/FindWallet/WalletPersonasSidebar.tsx
@@ -99,7 +99,7 @@ const Persona = styled.div<{
       height: 1.4rem;
       left: 0;
       top: 0.1rem;
-      transition: all 1.5s;
+      transition: all 0.5s;
       border: 1px solid;
       position: absolute;
       border-color: ${({ selected, isDark, theme }) =>
@@ -119,7 +119,7 @@ const Persona = styled.div<{
       height: 0.9rem;
       left: 0.25rem;
       top: 0.35rem;
-      transition: all 1.5s;
+      transition: all 0.5s;
       position: absolute;
       background: ${({ selected, isDark, theme }) =>
         selected
@@ -168,6 +168,12 @@ const Title = styled.div`
   gap: "1rem";
   margin-bottom: 0.6rem;
   padding: 0.5rem 0.5rem 0 0.5rem;
+`
+
+const Radio = styled.input`
+  display: none;
+  width: 1.4rem;
+  height: 1.4rem;
 `
 
 const H3 = styled.h3`
@@ -568,6 +574,7 @@ const WalletPersonasSidebar = ({
             }}
           >
             <Title>
+              <Radio type="radio" checked={selectedPersona === idx} />
               <H3>{persona.title}</H3>
             </Title>
             <PersonaDescription selected={selectedPersona === idx}>


### PR DESCRIPTION

We got a suggestion from "RomoPuma" (if you have a Github profile, please add it) on discord (https://discord.com/channels/714888181740339261/951053072258453574/999409307953143932)to change The checkboxes on the personas box to radio-style buttons.

Here are some screenshots of the change.

![Screen Shot 2022-07-21 09 42 19 PM](https://user-images.githubusercontent.com/1120748/180311678-c24a28f9-df1a-4536-a832-ed1416ddff3f.png)


![Screen Shot 2022-07-21 09 42 09 PM](https://user-images.githubusercontent.com/1120748/180311702-a2b19b04-5567-4c08-b70d-6ca606072748.png)


