### PR TITLE
Update Bloxstaking SaaS entry [Fixes #7144]

### DIFF
--- a/src/data/staking-products.json
+++ b/src/data/staking-products.json
@@ -336,7 +336,7 @@
       "hasBugBounty": false,
       "isTrustless": false,
       "isPermissionless": false,
-      "pctMajorityClient": null,
+      "pctMajorityClient": 43.3,
       "isSelfCustody": true,
       "platforms": ["Linux", "macOS", "Windows"],
       "ui": ["GUI"],


### PR DESCRIPTION
## Description
Updates Bloxstaking with 43.3% Prysm usage value within `staking-products.json`

## Related Issue
- #7144