### PR TITLE
Tweak 'proof-of-stake and security' section

### DIFF
--- a/src/content/developers/docs/consensus-mechanisms/pos/index.md
+++ b/src/content/developers/docs/consensus-mechanisms/pos/index.md
@@ -44,11 +44,17 @@ When the network performs optimally and honestly, there is only ever one new blo
 
 ## Proof-of-stake and security {#pos-and-security}
 
-The threat of a [51% attack](https://www.investopedia.com/terms/1/51-attack.asp) still exists on proof-of-stake as it does on proof-of-work, but it's even riskier for the attackers. A attacker would need 51% of the staked ETH (about $15,000,000,000 USD). They could then use their own attestations to ensure their preferred fork was the one with the most accumulated attestations. The 'weight' of accumulated attestations is what consensus clients use to determine the correct chain, so this attacker would be able to make their fork the canonical one. However, a strength of proof-of-stake over proof-of-work is that the community has flexibility in mounting a counter-attack. For example, the honest validators could decide to keep building on the minority chain and ignore the attacker's fork while encouraging apps, exchanges, and pools to do the same. They could also decide to forcibly remove the attacker from the network and destroy their staked ether. These are strong economic defenses against a 51% attack.
+There are three critical staking percentage thresholds that matter from a security standpoint, each with its own set of risks and set of mitigating factors that would enable the protocol to recover safely from: 33%, 51%, and 66%. Below we outline some of the details associated with each threshold and encourage readers who are interested in diving deeper to explore other (more technical and deep-dive) resources.
+
+**33% of stake**: As noted earlier in the 'finality' section, finality on the network requires two-thirds of stake. [needs more work]
+
+**51% of stake**: The threat of a [51% attack](https://www.investopedia.com/terms/1/51-attack.asp) still exists on proof-of-stake as it does on proof-of-work, but it's even riskier for the attackers. A attacker would need 51% of the staked ETH (about $15,000,000,000 USD). They could then use their own attestations to ensure their preferred fork was the one with the most accumulated attestations. The 'weight' of accumulated attestations is what consensus clients use to determine the correct chain, so this attacker would be able to make their fork the canonical one. However, a strength of proof-of-stake over proof-of-work is that the community has flexibility in mounting a counter-attack. For example, the honest validators could decide to keep building on the minority chain and ignore the attacker's fork while encouraging apps, exchanges, and pools to do the same. They could also decide to forcibly remove the attacker from the network and destroy their staked ether. These are strong economic defenses against a 51% attack.
 
 51% attacks are just one flavor of malicious activity. Bad actors could attempt long-range attacks (although the finality gadget neutralizes this attack vector), short range 'reorgs' (although proposer boosting and attestation deadlines mitigate this), bouncing and balancing attacks (also mitigated by proposer boosting, and these attacks have anyway only been demonstrated under idealized network conditions) or avalanche attacks (neutralized by the fork choice algorithms rule of only considering the latest message).
 
 Overall, proof-of-stake, as it is implemented on Ethereum, has been demonstrated to be more economically secure than proof-of-work.
+
+**66% of stake**:Reorgs and double-spend risk. Recovery here would likely have to necessitate some level of social coordination.[needs more work]
 
 ## Pros and cons {#pros-and-cons}
 


### PR DESCRIPTION
Is it worth laying out more explicitly:

1) What the key staking threshold percentage numbers are: 33%, 51%, 66%
2) What the implications are if a malicious/inactive/incompetent party (or set of colluding or correlated parties) achieves each of those thresholds? i.e. 33% = inability to reach finality, 51% = fork choice rule, 66% = reorgs and double spends 
3) and more critically, how does the protocol use consensus rules + potentially social coordination to recover from each of these scenarios?

Ben Edgington's eth2book may have some of these details or if someone here can write up a draft off the top of their head we can all contribute + add.

Also, do we need a more explicit section that lays out slashing in more detail? Aka what is it? And how does it get triggered?

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
