### PR TITLE
Changed 'euros' to 'EUR' [bridges]

### DIFF
--- a/src/content/bridges/index.md
+++ b/src/content/bridges/index.md
@@ -17,9 +17,9 @@ Blockchain bridges work just like the bridges we know in the physical world. Jus
 
 Let's consider an example:
 
-You're from the USA and are planning a trip to Europe. You have USD, but you need euros to spend. To exchange your USD for euros you can use a currency exchange for a small fee.
+You're from the USA and are planning a trip to Europe. You have USD, but you need EUR to spend. To exchange your USD for EUR you can use a currency exchange for a small fee.
 
-But, what do you do if you want to make a similar exchange to use a different blockchain? Let's say you want to exchange ETH on Ethereum Mainnet for ETH on [Arbitrum](https://arbitrum.io/). Like the currency exchange we made for euros, we need a mechanism to move our ETH from Ethereum to Arbitrum. Bridges make such a transaction possible. In this case, [Arbitrum has a native bridge](https://bridge.arbitrum.io/) that can transfer ETH from Mainnet onto Arbitrum.
+But, what do you do if you want to make a similar exchange to use a different blockchain? Let's say you want to exchange ETH on Ethereum Mainnet for ETH on [Arbitrum](https://arbitrum.io/). Like the currency exchange we made for EUR, we need a mechanism to move our ETH from Ethereum to Arbitrum. Bridges make such a transaction possible. In this case, [Arbitrum has a native bridge](https://bridge.arbitrum.io/) that can transfer ETH from Mainnet onto Arbitrum.
 
 ## Why do we need bridges? {#why-do-we-need-bridges}
 


### PR DESCRIPTION
## Description
* Changed three cases of `euros` to `EUR`. I believe this looks better, because we are also using `USD` instead of `dollars` or `American dollars`. 

## Related Issue
* Not related to an issue. 
