### PR TITLE
Mention go-ethereum rather than core geth

### DIFF
--- a/src/content/developers/docs/nodes-and-clients/client-diversity/index.md
+++ b/src/content/developers/docs/nodes-and-clients/client-diversity/index.md
@@ -70,7 +70,7 @@ Addressing client diversity requires more than individual users to choose minori
 
 [Akula](https://akula.app)
 
-[CoreGeth](https://core-geth.org/)
+[Go-Ethereum](https://geth.ethereum.org/)
 
 ### Consensus clients {#consensus-clients}
 


### PR DESCRIPTION
geth is by far the most used distribution of the codebase, and sending new users to another codebase, especially given all the changes with the merge can be misleading/dangerous.