### PR TITLE
Remove broken azure dev kit link on non-English pages

### DIFF
--- a/src/content/translations/de/developers/docs/ides/index.md
+++ b/src/content/translations/de/developers/docs/ides/index.md
@@ -35,7 +35,6 @@ Die meisten etablierten IDEs haben Plugins entwickelt, um die Ethereum-Entwicklu
 **Visual Studio Code –** **_Eine professionelle plattformübergreifende IDE mit offizieller Ethereum-Unterstützung_**
 
 - [Visual Studio Code](https://code.visualstudio.com/)
-- [Blockchain-Development-Kit für Ethereum](https://marketplace.visualstudio.com/items?itemName=AzBlockchain.azure-blockchain)
 - [Azure Blockchain Workbench](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/microsoft-azure-blockchain.azure-blockchain-workbench?tab=Overview)
 - [Code-Beispiele](https://github.com/Azure-Samples/blockchain/blob/master/blockchain-workbench/application-and-smart-contract-samples/readme.md)
 - [GitHub](https://github.com/microsoft/vscode)

--- a/src/content/translations/es/developers/docs/ides/index.md
+++ b/src/content/translations/es/developers/docs/ides/index.md
@@ -27,7 +27,6 @@ La mayoría de los IDE establecidos disponen de plugins integrados para mejorar 
 **Visual Studio Code:** **_IDE multiplataforma profesional con compatibilidad oficial con Ethereum._**
 
 - [Código de Visual Studio](https://code.visualstudio.com/)
-- [Kit de desarrollo de la blockchain para Ethereum](https://marketplace.visualstudio.com/items?itemName=AzBlockchain.azure-blockchain)
 - [Azure Blockchain Workbench](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/microsoft-azure-blockchain.azure-blockchain-workbench?tab=Overview)
 - [Muestras de código](https://github.com/Azure-Samples/blockchain/blob/master/blockchain-workbench/application-and-smart-contract-samples/readme.md)
 - [GitHub](https://github.com/microsoft/vscode)

--- a/src/content/translations/fr/developers/docs/ides/index.md
+++ b/src/content/translations/fr/developers/docs/ides/index.md
@@ -35,7 +35,6 @@ La plupart des IDE ont construit des plugins pour améliorer l'expérience de d�
 **Visual Studio Code -** **_IDE professionnel multiplateforme avec support officiel Ethereum._**
 
 - [Visual Studio Code](https://code.visualstudio.com/)
-- [Kit de développement blockchain pour Ethereum](https://marketplace.visualstudio.com/items?itemName=AzBlockchain.azure-blockchain)
 - [Plan de travail blockchain Azure](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/microsoft-azure-blockchain.azure-blockchain-workbench?tab=Overview)
 - [Exemples de code](https://github.com/Azure-Samples/blockchain/blob/master/blockchain-workbench/application-and-smart-contract-samples/readme.md)
 - [GitHub](https://github.com/microsoft/vscode)

--- a/src/content/translations/hu/developers/docs/ides/index.md
+++ b/src/content/translations/hu/developers/docs/ides/index.md
@@ -27,7 +27,6 @@ A legtöbb megalapozott IDE-nek vannak beépített pluginjai, melyek elősegíti
 **Visual Studio Code -** **_Professzionális cross-platform IDE hivatalos Ethereum támogatással._**
 
 - [Visual Studio Code](https://code.visualstudio.com/)
-- [Blockchain Development Kit for Ethereum](https://marketplace.visualstudio.com/items?itemName=AzBlockchain.azure-blockchain)
 - [Azure Blockchain Workbench](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/microsoft-azure-blockchain.azure-blockchain-workbench?tab=Overview)
 - [Kód minták](https://github.com/Azure-Samples/blockchain/blob/master/blockchain-workbench/application-and-smart-contract-samples/readme.md)
 - [GitHub](https://github.com/microsoft/vscode)

--- a/src/content/translations/id/developers/docs/ides/index.md
+++ b/src/content/translations/id/developers/docs/ides/index.md
@@ -35,7 +35,6 @@ IDE yang paling mapan memiliki plugin untuk meningkatkan pengalaman pengembangan
 **Visual Studio Code -** **_IDE antarplatform profesional dengan dukungan Ethereum resmi._**
 
 - [Visual Studio Code](https://code.visualstudio.com/)
-- [Kotak Peralatan Pengembangan Blockchain untuk Ethereum](https://marketplace.visualstudio.com/items?itemName=AzBlockchain.azure-blockchain)
 - [Meja Kerja Blockchain Azure](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/microsoft-azure-blockchain.azure-blockchain-workbench?tab=Overview)
 - [Contoh kode](https://github.com/Azure-Samples/blockchain/blob/master/blockchain-workbench/application-and-smart-contract-samples/readme.md)
 - [GitHub](https://github.com/microsoft/vscode)

--- a/src/content/translations/it/developers/docs/ides/index.md
+++ b/src/content/translations/it/developers/docs/ides/index.md
@@ -35,7 +35,6 @@ Gli IDE più diffusi hanno plugin integrati che migliorano l'esperienza di svilu
 **Visual Studio Code:** **_IDE professionale multi piattaforma con supporto ufficiale per Ethereum_**
 
 - [Visual Studio Code](https://code.visualstudio.com/)
-- [Blockchain Development Kit per Ethereum](https://marketplace.visualstudio.com/items?itemName=AzBlockchain.azure-blockchain)
 - [Azure Blockchain Workbench](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/microsoft-azure-blockchain.azure-blockchain-workbench?tab=Overview)
 - [Esempi di codice](https://github.com/Azure-Samples/blockchain/blob/master/blockchain-workbench/application-and-smart-contract-samples/readme.md)
 - [GitHub](https://github.com/microsoft/vscode)

--- a/src/content/translations/pl/developers/docs/ides/index.md
+++ b/src/content/translations/pl/developers/docs/ides/index.md
@@ -27,7 +27,6 @@ Większość utworzonych IDE ma wbudowane wtyczki, aby poprawić jakość pracy 
 **Visual Studio Code —** **_profesjonalne wieloplatformowe środowisko IDE z oficjalną obsługą Ethereum._**
 
 - [Visual Studio Code](https://code.visualstudio.com/)
-- [Blockchain Development Kit for Ethereum](https://marketplace.visualstudio.com/items?itemName=AzBlockchain.azure-blockchain)
 - [Azure Blockchain Workbench](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/microsoft-azure-blockchain.azure-blockchain-workbench?tab=Overview)
 - [Przykłady kodu](https://github.com/Azure-Samples/blockchain/blob/master/blockchain-workbench/application-and-smart-contract-samples/readme.md)
 - [GitHub](https://github.com/microsoft/vscode)

--- a/src/content/translations/pt-br/developers/docs/ides/index.md
+++ b/src/content/translations/pt-br/developers/docs/ides/index.md
@@ -35,7 +35,6 @@ A maioria dos IDEs estabelecidos possuem plugins integrados para melhorar a expe
 **Visual Studio Code -** **_IDE profissional multiplataforma com suporte oficial da Ethereum._**
 
 - [Visual Studio Code](https://code.visualstudio.com/)
-- [Kit de desenvolvimento Blockchain para Ethereum](https://marketplace.visualstudio.com/items?itemName=AzBlockchain.azure-blockchain)
 - [Bancada de trabalho para Azure Blockchain](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/microsoft-azure-blockchain.azure-blockchain-workbench?tab=Overview)
 - [Amostras de código](https://github.com/Azure-Samples/blockchain/blob/master/blockchain-workbench/application-and-smart-contract-samples/readme.md)
 - [GitHub](https://github.com/microsoft/vscode)

--- a/src/content/translations/ro/developers/docs/ides/index.md
+++ b/src/content/translations/ro/developers/docs/ides/index.md
@@ -35,7 +35,6 @@ Majoritatea IDE-urilor consacrate au construit plug-inuri pentru creşterea sati
 **Visual Studio Code -** **_IDE profesionist pentru mai multe platforme, acceptat oficial de Ethereum._**
 
 - [Visual Studio Code](https://code.visualstudio.com/)
-- [Kit de dezvoltare Blockchain pentru Ethereum](https://marketplace.visualstudio.com/items?itemName=AzBlockchain.azure-blockchain)
 - [Azure Blockchain Workbench](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/microsoft-azure-blockchain.azure-blockchain-workbench?tab=Overview)
 - [Exemple de cod](https://github.com/Azure-Samples/blockchain/blob/master/blockchain-workbench/application-and-smart-contract-samples/readme.md)
 - [GitHub](https://github.com/microsoft/vscode)

--- a/src/content/translations/tr/developers/docs/ides/index.md
+++ b/src/content/translations/tr/developers/docs/ides/index.md
@@ -35,7 +35,6 @@ Bir [tümleşik geliştirme ortamı (IDE)](https://wikipedia.org/wiki/Integrated
 **Visual Studio Code -** **_Resmi Ethereum destekli, profesyonel çapraz platform IDE'sidir._**
 
 - [Visual Studio Code](https://code.visualstudio.com/)
-- [Ethereum için Blok Zinciri Geliştirme Kiti](https://marketplace.visualstudio.com/items?itemName=AzBlockchain.azure-blockchain)
 - [Azure Blockchain Workbench](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/microsoft-azure-blockchain.azure-blockchain-workbench?tab=Overview)
 - [Kod örnekleri](https://github.com/Azure-Samples/blockchain/blob/master/blockchain-workbench/application-and-smart-contract-samples/readme.md)
 - [GitHub](https://github.com/microsoft/vscode)

--- a/src/content/translations/zh/developers/docs/ides/index.md
+++ b/src/content/translations/zh/developers/docs/ides/index.md
@@ -35,7 +35,6 @@ sidebar: true
 **Visual Studio Code -** **_以太坊官方支持的专业跨平台集成开发环境。_**
 
 - [Visual Studio Code](https://code.visualstudio.com/)
-- [以太坊区块链开发工具包](https://marketplace.visualstudio.com/items?itemName=AzBlockchain.azure-blockchain)
 - [Azure 区块链工作台](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/microsoft-azure-blockchain.azure-blockchain-workbench?tab=Overview)
 - [代码示例](https://github.com/Azure-Samples/blockchain/blob/master/blockchain-workbench/application-and-smart-contract-samples/readme.md)
 - [GitHub](https://github.com/microsoft/vscode)


### PR DESCRIPTION
## Description

Follows #7236, removes the same link in non-English languages.

## Related Issue
#7236
