### PR TITLE
Added Vyper Discord link

### DIFF
--- a/src/content/developers/docs/programming-languages/python/index.md
+++ b/src/content/developers/docs/programming-languages/python/index.md
@@ -49,9 +49,9 @@ Need a more basic primer first? Check out [ethereum.org/learn](/learn/) or [ethe
 ### Active: {#active}
 
 - [Web3.py](https://github.com/ethereum/web3.py) - _Python library for interacting with Ethereum_
+- [Vyper](https://github.com/ethereum/vyper/) - _Pythonic Smart Contract Language for the EVM_
 - [Ape](https://github.com/ApeWorX/ape) - _The smart contract development tool for Pythonistas, Data Scientists, and Security Professionals_
 - [Brownie](https://github.com/eth-brownie/brownie) - _Python framework for deploying, testing and interacting with Ethereum smart contracts_
-- [Vyper](https://github.com/ethereum/vyper/) - _Pythonic Smart Contract Language for the EVM_
 - [py-evm](https://github.com/ethereum/py-evm) - _implementation of the Ethereum Virtual Machine_
 - [eth-tester](https://github.com/ethereum/eth-tester) - _tools for testing Ethereum-based applications_
 - [eth-utils](https://github.com/ethereum/eth-utils/) - _utility functions for working with Ethereum related codebases_
@@ -79,10 +79,10 @@ The following Ethereum-based projects use tools mentioned on this page. The rela
 - [Sushi](https://sushi.com/) uses [Python in managing and deploying their vesting contracts](https://github.com/sushiswap/sushi-vesting-protocols)
 - [Alpha Finance](https://alphafinance.io/), of Alpha Homora fame, uses [Brownie to test and deploy smart contracts](https://github.com/AlphaFinanceLab/alpha-staking-contract)
 
-## Python Community Contributors {#python-community-contributors}
+## Python Community discussion {#python-community-contributors}
 
-The [Ethereum Python Community Discord](https://discord.gg/9zk7snTfWe) is host to a rapidly growing community and is the dedicated
-resource for discussions on any of the above projects and related topics.
+- [Ethereum Python Community Discord](https://discord.gg/9zk7snTfWe) for Web3.py and other Python framework discussion
+- [Vyper Discord]([https://discord.gg/9zk7snTfWe](https://discord.gg/SdvKC79cJk)) for Vyper smart contract programming disucssion
 
 ## Other aggregated lists {#other-aggregated-lists}
 


### PR DESCRIPTION
Vyper has new Discord.

Separate Discord links for Vyper and rest of Python.

Also bumped Vyper higher on the unordered lists as a lot of people are looking for it.

