### PR TITLE
A few small updates to L2 Page requested by the OP team

### DIFF
--- a/src/content/developers/docs/bridges/index.md
+++ b/src/content/developers/docs/bridges/index.md
@@ -41,7 +41,7 @@ While there are many [types of bridge designs](https://blog.li.fi/what-are-block
 
 Bridges can usually be classified into one of the following buckets:
 
-- **Native bridges –** These bridges are typically built to bootstrap liquidity on a particular blockchain, making it easier for users to move funds to the ecosystem. For example, the [Arbitrum Bridge](https://bridge.arbitrum.io/) is built to make it convenient for users to bridge from Ethereum Mainnet to Arbitrum. Other such bridges include Polygon PoS Bridge, [Optimism Gateway](https://gateway.optimism.io/), etc.
+- **Native bridges –** These bridges are typically built to bootstrap liquidity on a particular blockchain, making it easier for users to move funds to the ecosystem. For example, the [Arbitrum Bridge](https://bridge.arbitrum.io/) is built to make it convenient for users to bridge from Ethereum Mainnet to Arbitrum. Other such bridges include Polygon PoS Bridge, [Optimism Gateway](https://app.optimism.io/bridge), etc.
 - **Validator or oracle based bridges –** These bridges rely on an external validator set or oracles to validate cross-chain transfers. Examples: Multichain and Across.
 - **Generalized message passing bridges –** These bridges can transfer assets, along with messages and arbitrary data across chains. Examples: Nomad and LayerZero.
 - **Liquidity networks –** These bridges primarily focus on transferring assets from one chain to another via atomic swaps. Generally, they don’t support cross-chain message passing. Examples: Connext and Hop.

--- a/src/data/layer-2/cex-layer-2-support.json
+++ b/src/data/layer-2/cex-layer-2-support.json
@@ -7,13 +7,13 @@
   },
   {
     "name": "Crypto.com",
-    "supports_withdrawals": ["Arbitrum"],
-    "supports_deposits": ["Arbitrum"],
+    "supports_withdrawals": ["Arbitrum", "Optimism"],
+    "supports_deposits": ["Arbitrum", "Optimism"],
     "url": "https://crypto.com/"
   },
   {
     "name": "OKX",
-    "supports_withdrawals": ["Arbitrum"],
+    "supports_withdrawals": ["Arbitrum", "Optimism"],
     "supports_deposits": ["Arbitrum"],
     "url": "https://www.okx.com/"
   },

--- a/src/data/layer-2/layer-2.json
+++ b/src/data/layer-2/layer-2.json
@@ -21,7 +21,7 @@
       "website": "https://optimism.io/",
       "developerDocs": "https://community.optimism.io/docs/developers/",
       "l2beat": "https://l2beat.com/projects/optimism/",
-      "bridge": "https://gateway.optimism.io/",
+      "bridge": "https://app.optimism.io/bridge",
       "bridgeWallets": ["MetaMask", "WalletConnect", "Coinbase Wallet"],
       "blockExplorer": "https://optimistic.etherscan.io/",
       "ecosystemPortal": "https://www.optimism.io/apps/all",

--- a/src/intl/en/page-layer-2.json
+++ b/src/intl/en/page-layer-2.json
@@ -122,7 +122,7 @@
   "scaling-layer-1-with-shard-chains": "Scaling layer 1 with shard chains",
   "understanding-rollup-economics-from-first-principals": "Understanding rollup economics from first principals",
   "arbitrum-description": "Arbitrum is an Optimistic Rollup that aims to feel exactly like interacting with Ethereum, but with transactions costing a fraction of what they do on L1.",
-  "optimism-description": "Optimistic Ethereum is an EVM-equivalent Optimistic Rollup chain. It aims to be fast, simple, and secure.",
+  "optimism-description": "Optimism is a fast, simple, and secure EVM-equivalent Optimistic Rollup. It scales Ethereum's tech while also scaling its values through retroactive public goods funding.",
   "boba-description": "Boba is an Optimistic Rollup originally forked from Optimism which is a scaling solution that aims to reduce gas fees, improve transaction throughput, and extend the capabilities of smart contracts.",
   "dydx-description": "dYdX aims to build a powerful and professional exchange for trading crypto assets where users can truly own their trades and, eventually, the exchange itself.",
   "loopring-description": "Loopring's zkRollup L2 solution aims to offer the same security guarantees as Ethereum mainnet, with a big scalability boost: throughput increased by 1000x, and cost reduced to just 0.1% of L1.",

--- a/src/intl/en/page-layer-2.json
+++ b/src/intl/en/page-layer-2.json
@@ -122,7 +122,7 @@
   "scaling-layer-1-with-shard-chains": "Scaling layer 1 with shard chains",
   "understanding-rollup-economics-from-first-principals": "Understanding rollup economics from first principals",
   "arbitrum-description": "Arbitrum is an Optimistic Rollup that aims to feel exactly like interacting with Ethereum, but with transactions costing a fraction of what they do on L1.",
-  "optimism-description": "Optimism is a fast, simple, and secure EVM-equivalent Optimistic Rollup. It scales Ethereum's tech while also scaling its values through retroactive public goods funding.",
+  "optimism-description": "Optimism is a fast, simple, and secure EVM-equivalent optimistic rollup. It scales Ethereum's tech while also scaling its values through retroactive public goods funding.",
   "boba-description": "Boba is an Optimistic Rollup originally forked from Optimism which is a scaling solution that aims to reduce gas fees, improve transaction throughput, and extend the capabilities of smart contracts.",
   "dydx-description": "dYdX aims to build a powerful and professional exchange for trading crypto assets where users can truly own their trades and, eventually, the exchange itself.",
   "loopring-description": "Loopring's zkRollup L2 solution aims to offer the same security guarantees as Ethereum mainnet, with a big scalability boost: throughput increased by 1000x, and cost reduced to just 0.1% of L1.",


### PR DESCRIPTION
## Description

Optimism bridge should direct to https://app.optimism.io/bridge
Optimism description should read "Optimism is a fast, simple, and secure EVM-equivalent Optimistic Rollup. It scales Ethereum's tech while also scaling its values through retroactive public goods funding."
Crypto.com has withdraws / deposits for Optimism
OKX has withdraws for Optimism

## Related Issue
N/A
