### PR TITLE
Put wallet hero image below hero content on mobile screens

### DIFF
--- a/src/pages-conditional/wallets.tsx
+++ b/src/pages-conditional/wallets.tsx
@@ -245,7 +245,7 @@ const WalletsPage = ({
         description={translateMessageId("page-wallets-meta-description", intl)}
         image={getImage(data.ogImage)?.images.fallback.src}
       />
-      <PageHero content={heroContent} />
+      <PageHero content={heroContent} isReverse />
       <StyledGrayContainer>
         <Intro>
           <H2>


### PR DESCRIPTION
## Description
Put wallet hero image below hero content on mobile screens


Before:
![Screenshot 2022-08-05 at 16 54 15](https://user-images.githubusercontent.com/62268199/183115003-38d2f30f-1a9b-4aea-8d89-f821d2ebb404.png)

After:
![Screenshot 2022-08-05 at 16 54 03](https://user-images.githubusercontent.com/62268199/183114996-5a2dd9f8-4bad-49b1-aafa-f5d304603dad.png)


## Related Issue
None
