### PR TITLE
Fix styling for node services list

### DIFF
--- a/src/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
+++ b/src/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
@@ -209,13 +209,16 @@ Here is a list of some of the most popular Ethereum node providers, feel free to
     - Suitable for Developers to Enterprises
 - [**Rivet**](https://rivet.cloud/)
   - [Docs](https://rivet.readthedocs.io/en/latest/)
-  - Features - Free tier option - Scale as you go -[**SenseiNode**](https://senseinode.com)
+  - Features
+    - Free tier option
+    - Scale as you go
+- [**SenseiNode**](https://senseinode.com)
   - [Docs](https://docs.senseinode.com/)
   - Features
-  - Dedicated and Share nodes
-  - Dashboard
-  - Hosting off AWS on multiple hosting providers accross different locations in Latin America
-  - Prysm and Lighthouse clients
+    - Dedicated and Share nodes
+    - Dashboard
+    - Hosting off AWS on multiple hosting providers accross different locations in Latin America
+    - Prysm and Lighthouse clients
 - [**SettleMint**](https://console.settlemint.com/)
   - [Docs](https://docs.settlemint.com/)
   - Features


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The list items for "Rivet" and "SenseiNode" were mixed together, and their indentation was not in line with the other items of the list.

## Related Issue

Considering this is a minor styling fix, I have not opened an issue for it. I hope that's ok.