### PR TITLE
Delete Contextually Incorrect Link to EIPs Website

### DIFF
--- a/src/content/developers/docs/standards/index.md
+++ b/src/content/developers/docs/standards/index.md
@@ -10,7 +10,7 @@ incomplete: true
 
 The Ethereum community has adopted many standards that help keep projects (such as [Ethereum clients](/developers/docs/nodes-and-clients/) and wallets) interoperable across implementations, and ensure smart contracts and dapps remain composable.
 
-Typically standards are introduced as [Ethereum Improvement Proposals](/eips/) ([EIPs](https://eips.ethereum.org/), which are discussed by community members through a [standard process](https://eips.ethereum.org/EIPS/eip-1).
+Typically standards are introduced as [Ethereum Improvement Proposals](/eips/) (EIPs), which are discussed by community members through a [standard process](https://eips.ethereum.org/EIPS/eip-1).
 
 - [Introduction to EIPs](/eips/)
 - [List of EIPs](https://eips.ethereum.org/)

--- a/src/content/developers/docs/standards/index.md
+++ b/src/content/developers/docs/standards/index.md
@@ -10,7 +10,7 @@ incomplete: true
 
 The Ethereum community has adopted many standards that help keep projects (such as [Ethereum clients](/developers/docs/nodes-and-clients/) and wallets) interoperable across implementations, and ensure smart contracts and dapps remain composable.
 
-Typically standards are introduced as [Ethereum Improvement Proposals](/eips/) (EIPs), which are discussed by community members through a [standard process](https://eips.ethereum.org/EIPS/eip-1).
+Typically standards are introduced as [Ethereum Improvement Proposals](/eips/) ([EIPs](https://eips.ethereum.org/), which are discussed by community members through a [standard process](https://eips.ethereum.org/EIPS/eip-1).
 
 - [Introduction to EIPs](/eips/)
 - [List of EIPs](https://eips.ethereum.org/)
@@ -25,7 +25,7 @@ Typically standards are introduced as [Ethereum Improvement Proposals](/eips/) (
 
 There are 3 types of EIPs:
 
-- [Standards Track](https://eips.ethereum.org/): describes any change that affects most or all Ethereum implementations
+- Standards Track: describes any change that affects most or all Ethereum implementations
 - [Meta Track](https://eips.ethereum.org/meta): describes a process surrounding Ethereum or proposes a change to a process
 - [Informational Track](https://eips.ethereum.org/informational): describes an Ethereum design issue or provides general guidelines or information to the Ethereum community
 


### PR DESCRIPTION
## Description

~~Moves the https://eips.ethereum.org/ link from the wrong section to a better section.~~ Deletes an unintentionally misleading reference to the EIPs website. It was presumably meant to only link to standards track EIPs, but no such page exists.

The EIPs website has already been linked to.

## Related Issue

N.A.
