### PR TITLE
Fix Goerli testnet link

### DIFF
--- a/src/components/Staking/StakingLaunchpadWidget.tsx
+++ b/src/components/Staking/StakingLaunchpadWidget.tsx
@@ -64,7 +64,7 @@ const StakingLaunchpadWidget: React.FC<IProps> = () => {
   const data = {
     testnet: {
       label: "Goerli/Prater testnet",
-      url: "https://prater.launchpad.ethereum.org",
+      url: "https://goerli.launchpad.ethereum.org",
     },
     mainnet: {
       label: "Mainnet",

--- a/src/content/developers/docs/development-networks/index.md
+++ b/src/content/developers/docs/development-networks/index.md
@@ -59,9 +59,9 @@ Some consensus clients have built-in tools for spinning up local Beacon chains f
 
 ### Public Beacon Test-chains {#public-beacon-testchains}
 
-There are also public test implementations of the Beacon Chain. The recommended testnet with long-term support is Prater (which will eventually merge with the Goerli chain). The Ropsten Chain was recently merged with its own Beacon Chain and is currently still available for testing consensus client implementations and post-merge application development.
+There are also public test implementations of the Beacon Chain. The recommended testnet with long-term support is Goerli (which will merge with the Prater chain in August 2022). The Ropsten Chain was recently merged with its own Beacon Chain and is currently still available for testing consensus client implementations and post-merge application development.
 
-- [Prater Staking Launchpad](https://prater.launchpad.ethereum.org/en/)
+- [Goerli Staking Launchpad](https://goerli.launchpad.ethereum.org/en/)
 - [Ropsten Staking Launchpad](https://ropsten.launchpad.ethereum.org/en/)
 
 ## Further reading {#further-reading}

--- a/src/content/developers/docs/development-networks/index.md
+++ b/src/content/developers/docs/development-networks/index.md
@@ -61,8 +61,8 @@ Some consensus clients have built-in tools for spinning up local Beacon chains f
 
 There are also public test implementations of the Beacon Chain. The recommended testnet with long-term support is Goerli (which will merge with the Prater chain in August 2022). The Ropsten Chain was recently merged with its own Beacon Chain and is currently still available for testing consensus client implementations and post-merge application development.
 
-- [Goerli Staking Launchpad](https://goerli.launchpad.ethereum.org/en/)
-- [Ropsten Staking Launchpad](https://ropsten.launchpad.ethereum.org/en/)
+- [Goerli Staking Launchpad](https://goerli.launchpad.ethereum.org/)
+- [Ropsten Staking Launchpad](https://ropsten.launchpad.ethereum.org/)
 
 ## Further reading {#further-reading}
 

--- a/src/content/developers/docs/nodes-and-clients/run-a-node/index.md
+++ b/src/content/developers/docs/nodes-and-clients/run-a-node/index.md
@@ -148,7 +148,7 @@ path as an argument. This must be consistent with the `jwtsecret` path provided 
 ### Adding Validators {#adding-validators}
 
 Each of the consensus clients have their own validator software that is described in detail in their respective documentation. The easiest way to get started with
-staking and validator key generation is to use the [Prater Testnet Staking Launchpad](https://prater.launchpad.ethereum.org/), allowing you to test your setup. When you're ready for Mainnet, you can repeat these steps using the [Mainnet Staking Launchpad](https://launchpad.ethereum.org/).
+staking and validator key generation is to use the [Goerli Testnet Staking Launchpad](https://goerli.launchpad.ethereum.org/), allowing you to test your setup. When you're ready for Mainnet, you can repeat these steps using the [Mainnet Staking Launchpad](https://launchpad.ethereum.org/).
 
 ### Using the node {#using-the-node}
 

--- a/src/intl/en/page-staking.json
+++ b/src/intl/en/page-staking.json
@@ -156,7 +156,7 @@
   "page-staking-section-comparison-requirements-title": "Requirements",
   "page-staking-section-comparison-solo-requirements-li1": "You must deposit 32 ETH",
   "page-staking-section-comparison-solo-requirements-li2": "Maintain hardware that runs both an Ethereum execution client and consensus client while connected to the internet",
-  "page-staking-section-comparison-solo-requirements-li3": "The <a href=\"https://prater.launchpad.ethereum.org\" target=\"_blank\">Staking Launchpad</a> will walk you through the process and hardware requirements",
+  "page-staking-section-comparison-solo-requirements-li3": "The <a href=\"https://goerli.launchpad.ethereum.org\" target=\"_blank\">Staking Launchpad</a> will walk you through the process and hardware requirements",
   "page-staking-section-comparison-saas-requirements-li1": "Deposit 32 ETH and generate your keys with assistance",
   "page-staking-section-comparison-saas-requirements-li2": "Store your keys securely",
   "page-staking-section-comparison-saas-requirements-li3": "The rest is taken care of, though specific services will vary",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The Prater testnet URL is currently down. The plan is to redirect this to https://goerli.launchpad.ethereum.org/en/. 

- This PR fixes the broken URLs to use the Goerli launchpad
- Slight tweak to copy

## Related Issue
None
