### PR TITLE
Fixed allows vs allow on Smart contracts page

### DIFF
--- a/src/content/smart-contracts/index.md
+++ b/src/content/smart-contracts/index.md
@@ -7,7 +7,7 @@ sidebar: true
 
 # Introduction to smart contracts {#introduction-to-smart-contracts}
 
-Smart contracts are the fundamental building blocks of [Ethereum applications](/dapps/). They are computer programs stored on the blockchain that allows us to convert traditional contracts into digital parallels. Smart contracts are very logical - following an if this then that structure. This means they behave exactly as programmed and cannot be changed.
+Smart contracts are the fundamental building blocks of [Ethereum applications](/dapps/). They are computer programs stored on the blockchain that allow converting traditional contracts into digital parallels. Smart contracts are very logical - following an if this then that structure. This means they behave exactly as programmed and cannot be changed.
 
 Nick Szabo coined the term "smart contract". In 1994, he wrote [an introduction to the concept](https://www.fon.hum.uva.nl/rob/Courses/InformationInSpeech/CDROM/Literature/LOTwinterschool2006/szabo.best.vwh.net/smart.contracts.html) and, in 1996, [an exploration of what smart contracts could do](https://www.fon.hum.uva.nl/rob/Courses/InformationInSpeech/CDROM/Literature/LOTwinterschool2006/szabo.best.vwh.net/smart_contracts_2.html).
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There is a plural/singular error in the page. 

They are computer programs stored on the blockchain that allow\*s\* us to convert traditional contracts into digital parallels.

<!--- Describe your changes in detail -->

I changed it to

 They are computer programs stored on the blockchain that allow converting traditional contracts into digital parallels.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
