### PR TITLE
Fix typo in Ethereum glossary [Fixes #7388]

### DIFF
--- a/src/content/glossary/index.md
+++ b/src/content/glossary/index.md
@@ -620,7 +620,7 @@ Short for "main network," this is the main public Ethereum [blockchain](#blockch
 
 ### memory-hard {#memory-hard}
 
-Memory hard functions are processes that experience a drastic decrease in speed or feasibility when the amount of available memory even slightly decreases. An example id the Ethereum mining algorithm [Ethash](#ethash).
+Memory hard functions are processes that experience a drastic decrease in speed or feasibility when the amount of available memory even slightly decreases. An example is the Ethereum mining algorithm [Ethash](#ethash).
 
 ### Merkle Patricia trie {#merkle-patricia-tree}
 


### PR DESCRIPTION
## Description
* Small typo fix, changed `id` to `is`.

## Related Issue
* Related to [#7388]
