### PR TITLE
Added missing space on Testing ERC-20 tokens with Waffle page [Fixes #7391]

### DIFF
--- a/src/content/developers/tutorials/testing-erc-20-tokens-with-waffle/index.md
+++ b/src/content/developers/tutorials/testing-erc-20-tokens-with-waffle/index.md
@@ -1044,7 +1044,7 @@ describe("BasicToken", () => {
 })
 ```
 
-So, we use `deployContract` method from `Waffle`to deploy our token. As arguments, we should pass `wallet`, the compiled json file of our contract and default balance.
+So, we use `deployContract` method from `Waffle` to deploy our token. As arguments, we should pass `wallet`, the compiled json file of our contract and default balance.
 
 `Waffle` also allows us to create a `wallet`, which makes it very easy to deploy a contract.
 


### PR DESCRIPTION
## Description
* Added a missing space between 'Waffle' and 'to deploy'. 

## Related Issue
* PR related to #7391 
