### PR TITLE
Added Matos to community-meetups.json

### DIFF
--- a/src/data/community-meetups.json
+++ b/src/data/community-meetups.json
@@ -288,6 +288,12 @@
     "link": "https://www.meetup.com/Chicago-Ethereum-Meetup/"
   },
   {
+    "title": "Matos Cryptobar",
+    "emoji": ":sweden:",
+    "location": "Stockholm",
+    "link": "https://matos.club/"
+  },
+  {
     "title": "Web3Dubai",
     "emoji": ":uae:",
     "location": "Dubai",


### PR DESCRIPTION
We're a community running bi-weekly Cryptobars in the heart of Stockholm. Matos is the creators club where crypto natives, Ethereum enthusiasts and industrial figureheads go to hang out. Come build with us.

## Description

Added [Matos](https://matos.club/) to the Ethereum meetups list.
