### PR TITLE
Add ECH Discord to Get Involved page

### DIFF
--- a/src/content/community/get-involved/index.md
+++ b/src/content/community/get-involved/index.md
@@ -18,6 +18,7 @@ The Ethereum community includes people of many different backgrounds and skillse
 - Watch or participate in the [Core Dev calls](https://www.youtube.com/playlist?list=PLaM7G4Llrb7zfMXCZVEXEABT8OSnd4-7w)
 - [Ecosystem Support Program's wishlist](https://esp.ethereum.foundation/wishlist/) - tooling, documentation, and infrastructure areas where the Ethereum Ecosystem Support Program is actively seeking grant applications
 - [Web3Bridge](https://www.web3bridge.com/) - join the aspiring web3 community in their initiative to identify, train, and support hundreds of developers and community members throughout Africa
+- Join the [Ethereum Cat Herders Discord](https://discord.io/EthCatHerders)
 
 ## Researchers & Academics <Emoji text=":mag:" size={1} />‍ {#researchers-and-academics}
 


### PR DESCRIPTION
CC @poojaranjan

## Description

Adds the Ethereum Cat Herders Discord server to the Developers sub-heading of the "How can I get involved" page.

## Related Issue

https://canary.discord.com/channels/714888181740339261/895003445436743752/1006953559713140826
![image](https://user-images.githubusercontent.com/45835846/184141409-e24a2941-5a3d-49f5-970c-4075ca7b0358.png)
