### PR TITLE
Remove Hyperledger Burrow from EVM implementations

### DIFF
--- a/src/content/developers/docs/evm/index.md
+++ b/src/content/developers/docs/evm/index.md
@@ -67,7 +67,6 @@ All [Ethereum clients](/developers/docs/nodes-and-clients/#execution-clients) in
 - [evmone](https://github.com/ethereum/evmone) - _C++_
 - [ethereumjs-vm](https://github.com/ethereumjs/ethereumjs-vm) - _JavaScript_
 - [eEVM](https://github.com/microsoft/eevm) - _C++_
-- [Hyperledger Burrow](https://github.com/hyperledger/burrow) - _Go_
 
 ## Further Reading {#further-reading}
 


### PR DESCRIPTION
Remove Hyperledger Burrow from the list of EVM implementations

<!--- Provide a general summary of your changes in the Title above -->

## Description
As per their [Github](https://github.com/hyperledger/burrow), the project has reached End of Life
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
