### PR TITLE
Fix broken link on attestations developer doc

### DIFF
--- a/src/content/developers/docs/consensus-mechanisms/pos/attestations/index.md
+++ b/src/content/developers/docs/consensus-mechanisms/pos/attestations/index.md
@@ -82,6 +82,6 @@ Note that in some cases a lucky aggregator may also become the block proposer. I
 ## Further reading {#further-reading}
 
 - [Attestations in Vitalik's annotated consensus spec](https://github.com/ethereum/annotated-spec/blob/master/phase0/beacon-chain.md#attestationdata)
-- [Attestations in eth2book.info](<[/whitepaper/](https://eth2book.info/altair/annotated-spec/#attestation)>)
+- [Attestations in eth2book.info](https://eth2book.info/altair/part3/containers/dependencies#attestationdata)
 
 _Know of a community resource that helped you? Edit this page and add it!_


### PR DESCRIPTION
Fixed broken link to attestations on eth2book.info

<!--- Provide a general summary of your changes in the Title above -->
