### PR TITLE
Remove Hyperledger Burrow from /evm/ developer doc in all languages

### DIFF
--- a/src/content/translations/de/developers/docs/evm/index.md
+++ b/src/content/translations/de/developers/docs/evm/index.md
@@ -65,7 +65,6 @@ Alle [Ethereum-Clients](/developers/docs/nodes-and-clients/#execution-clients) e
 - [evmone](https://github.com/ethereum/evmone) - _C++_
 - [ethereumjs-vm](https://github.com/ethereumjs/ethereumjs-vm) - _JavaScript_
 - [eEVM](https://github.com/microsoft/eevm) - _C++_
-- [Hyperledger Burrow](https://github.com/hyperledger/burrow) - _Go_
 
 ## Weiterführende Informationen {#further-reading}
 

--- a/src/content/translations/es/developers/docs/evm/index.md
+++ b/src/content/translations/es/developers/docs/evm/index.md
@@ -65,8 +65,6 @@ Todos los [clientes de Ethereum](/developers/docs/nodes-and-clients/#execution-c
 - [evmone](https://github.com/ethereum/evmone) - _C++_.
 - [ethereumjs-vm](https://github.com/ethereumjs/ethereumjs-vm) - _JavaScript_.
 - [eEVM](https://github.com/microsoft/eevm) - _C++_.
-- [Hyperledger Burrow](https://github.com/hyperledger/burrow) - _Go_.
-- [hevm](https://github.com/dapphub/dapptools/tree/master/src/hevm) - _Haskell_
 
 ## Más información {#further-reading}
 

--- a/src/content/translations/fa/developers/docs/evm/index.md
+++ b/src/content/translations/fa/developers/docs/evm/index.md
@@ -65,8 +65,6 @@ EVM به صورت یک [ماشین پشته‌ای](https://wikipedia.org/wiki/S
 - [evmone](https://github.com/ethereum/evmone) - _سی‌پلاس‌پلاس_
 - [ethereumjs-vm](https://github.com/ethereumjs/ethereumjs-vm) - _جاوا اسکریپت_
 - [eEVM](https://github.com/microsoft/eevm) - _سی‌پلاس‌پلاس_
-- [Hyperledger Burrow](https://github.com/hyperledger/burrow) - _گو_
-- [hevm](https://github.com/dapphub/dapptools/tree/master/src/hevm) - _هسکل_
 
 ## اطلاعات بیشتر {#further-reading}
 

--- a/src/content/translations/fr/developers/docs/evm/index.md
+++ b/src/content/translations/fr/developers/docs/evm/index.md
@@ -65,7 +65,6 @@ Tous les [clients Ethereum](/developers/docs/nodes-and-clients/#execution-client
 - [evmone](https://github.com/ethereum/evmone) - _C++_
 - [ethereumjs-vm](https://github.com/ethereumjs/ethereumjs-vm) - _JavaScript_
 - [eEVM](https://github.com/microsoft/eevm) - _C++_
-- [Hyperledger Burrow](https://github.com/hyperledger/burrow) - _Go_
 
 ## Complément d'information {#further-reading}
 

--- a/src/content/translations/hu/developers/docs/evm/index.md
+++ b/src/content/translations/hu/developers/docs/evm/index.md
@@ -65,7 +65,6 @@ Az összes [Ethereum kliens](/developers/docs/nodes-and-clients/#execution-clien
 - [evmone](https://github.com/ethereum/evmone) - _C++_
 - [ethereumjs-vm](https://github.com/ethereumjs/ethereumjs-vm) - _JavaScript_
 - [eEVM](https://github.com/microsoft/eevm) - _C++_
-- [Hyperledger Burrow](https://github.com/hyperledger/burrow) - _Go_
 
 ## További olvasnivaló {#further-reading}
 

--- a/src/content/translations/id/developers/docs/evm/index.md
+++ b/src/content/translations/id/developers/docs/evm/index.md
@@ -65,8 +65,6 @@ Semua [klien Ethereum](/developers/docs/nodes-and-clients/#execution-clients) me
 - [evmone](https://github.com/ethereum/evmone) - _C++_
 - [ethereumjs-vm](https://github.com/ethereumjs/ethereumjs-vm) - _JavaScript_
 - [eEVM](https://github.com/microsoft/eevm) - _C++_
-- [Hyperledger Burrow](https://github.com/hyperledger/burrow) - _Go_
-- [hevm](https://github.com/dapphub/dapptools/tree/master/src/hevm) - _Haskell_
 
 ## Bacaan Lebih Lanjut {#further-reading}
 

--- a/src/content/translations/it/developers/docs/evm/index.md
+++ b/src/content/translations/it/developers/docs/evm/index.md
@@ -65,7 +65,6 @@ Tutti i [client Ethereum](/developers/docs/nodes-and-clients/#execution-clients)
 - [evmone](https://github.com/ethereum/evmone) - _C++_
 - [ethereumjs-vm](https://github.com/ethereumjs/ethereumjs-vm) - _JavaScript_
 - [eEVM](https://github.com/microsoft/eevm) - _C++_
-- [Hyperledger Burrow](https://github.com/hyperledger/burrow) - _Go_
 
 ## Letture consigliate {#further-reading}
 

--- a/src/content/translations/pl/developers/docs/evm/index.md
+++ b/src/content/translations/pl/developers/docs/evm/index.md
@@ -70,7 +70,6 @@ Wszyscy [klienci Ethereum](/developers/docs/nodes-and-clients/#execution-clients
 - [evmone](https://github.com/ethereum/evmone) - _C++_
 - [ethereumjs-vm](https://github.com/ethereumjs/ethereumjs-vm) - _JavaScript_
 - [eEVM](https://github.com/microsoft/eevm) - _C++_
-- [Hyperledger Burrow](https://github.com/hyperledger/burrow) - _Go_
 
 ## Dalsza lektura {#further-reading}
 

--- a/src/content/translations/pt-br/developers/docs/evm/index.md
+++ b/src/content/translations/pt-br/developers/docs/evm/index.md
@@ -65,8 +65,6 @@ Todos os [clientes Ethereum](/developers/docs/nodes-and-clients/#execution-clien
 - [evmone](https://github.com/ethereum/evmone) - _C++_
 - [ethereumjs-vm](https://github.com/ethereumjs/ethereumjs-vm) - _JavaScript_
 - [eEVM](https://github.com/microsoft/eevm) - _C++_
-- [Hyperledger Burrow](https://github.com/hyperledger/burrow) - _Go_
-- [hevm](https://github.com/dapphub/dapptools/tree/master/src/hevm) - _Haskell_
 
 ## Leitura adicional {#further-reading}
 

--- a/src/content/translations/ro/developers/docs/evm/index.md
+++ b/src/content/translations/ro/developers/docs/evm/index.md
@@ -65,8 +65,6 @@ Toți [clienții Ethereum](/developers/docs/nodes-and-clients/#execution-clients
 - [evmone](https://github.com/ethereum/evmone) - _C++_
 - [ethereumjs-vm](https://github.com/ethereumjs/ethereumjs-vm) - _JavaScript_
 - [eEVM](https://github.com/microsoft/eevm) - _C++_
-- [Hyperledger Burrow](https://github.com/hyperledger/burrow) - _Go_
-- [hevm](https://github.com/dapphub/dapptools/tree/master/src/hevm) - _Haskell_
 
 ## Referințe suplimentare {#further-reading}
 

--- a/src/content/translations/ru/developers/docs/evm/index.md
+++ b/src/content/translations/ru/developers/docs/evm/index.md
@@ -65,7 +65,6 @@ EVM работает как [стековая машина](https://wikipedia.or
 - [evmone](https://github.com/ethereum/evmone) — _C++_
 - [ethereumjs-vm](https://github.com/ethereumjs/ethereumjs-vm) — _JavaScript_
 - [eEVM](https://github.com/microsoft/eevm) — _C++_
-- [Hyperledger Burrow](https://github.com/hyperledger/burrow) — _Go_
 
 ## Дополнительные ресурсы {#further-reading}
 

--- a/src/content/translations/tr/developers/docs/evm/index.md
+++ b/src/content/translations/tr/developers/docs/evm/index.md
@@ -65,7 +65,6 @@ Tüm [Ethereum istemcileri](/developers/docs/nodes-and-clients/#execution-client
 - [evmone](https://github.com/ethereum/evmone) - _C++_
 - [ethereumjs-vm](https://github.com/ethereumjs/ethereumjs-vm) - _JavaScript_
 - [eEVM](https://github.com/microsoft/eevm) - _C++_
-- [Hyperledger Burrow](https://github.com/hyperledger/burrow) - _Go_
 
 ## Daha Fazla Bilgi {#further-reading}
 

--- a/src/content/translations/zh/developers/docs/evm/index.md
+++ b/src/content/translations/zh/developers/docs/evm/index.md
@@ -65,7 +65,6 @@ EVM 的所有实现都必须遵守以太坊黄皮书中描述的规范。
 - [evmone](https://github.com/ethereum/evmone) - _C++_
 - [ethereumjs-vm](https://github.com/ethereumjs/ethereumjs-vm) - _JavaScript_
 - [eEVM](https://github.com/microsoft/eevm) - _C++_
-- [Hyperledger Burrow](https://github.com/hyperledger/burrow) - _Go_
 
 ## 延伸阅读 {#further-reading}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In #7408, it was highlighted that Hyperledger Burrow has been deprecated. This PR removes the non-English mentions of Hyperledger Burrow.

## Related Issue

#7408 - Original issue
#7413 - Issue to add to deprecated software page