### PR TITLE
Fix: height of homeIcon svg

### DIFF
--- a/src/components/Nav/index.tsx
+++ b/src/components/Nav/index.tsx
@@ -108,6 +108,7 @@ const HomeLogoNavLink = styled(Link)`
 
 const HomeLogo = styled(HomeIcon)`
   width: 22px;
+  height: 35px;
   opacity: 0.85;
   &:hover {
     opacity: 1;


### PR DESCRIPTION
## Issue
When tab navigating, this was the resulting selection box. This zone was also all clickable, potentially interfering with other content.
<img width="789" alt="image" src="https://user-images.githubusercontent.com/54227730/184459966-30688d22-4f1d-463f-b3d9-cd5f1f2739cd.png">
Svg is missing a height property.

## Fix Description
- Capped height of svg keeping ratio of original svg size. 
<img width="823" alt="image" src="https://user-images.githubusercontent.com/54227730/184460044-82f7d6b9-b787-4003-80f2-e3e190bb6c5f.png">
