### PR TITLE
Fix typo, remove duplicate 'can'

### DIFF
--- a/src/content/decentralized-identity/index.md
+++ b/src/content/decentralized-identity/index.md
@@ -132,7 +132,7 @@ Decentralized identity has many potential use-cases:
 
 ### 1. Universal logins {#universal-dapp-logins}
 
-Decentralized identity can help replace password-based logins with [decentralized authentication](https://www.ibm.com/blogs/blockchain/2018/10/decentralized-identity-an-alternative-to-password-based-authentication/). Service providers can can issue attestations to users, which can be stored in an Ethereum wallet. An example attestation would be an [NFT](/nft/) granting the holder access to an online community.
+Decentralized identity can help replace password-based logins with [decentralized authentication](https://www.ibm.com/blogs/blockchain/2018/10/decentralized-identity-an-alternative-to-password-based-authentication/). Service providers can issue attestations to users, which can be stored in an Ethereum wallet. An example attestation would be an [NFT](/nft/) granting the holder access to an online community.
 
 A [Sign-In with Ethereum](https://login.xyz/) function would then enable servers to confirm the user's Ethereum account and fetch the required attestation from their account address. This means users can access platforms and websites without having to memorize long passwords and improves the online experience for users.
 


### PR DESCRIPTION
## Description

There was a duplicate 'can' in the article, therefore removed one 'can'.

## Related Issue

There is no related issue.