### PR TITLE
Moved up Block explorers section; added Dune section

### DIFF
--- a/src/content/developers/docs/data-and-analytics/index.md
+++ b/src/content/developers/docs/data-and-analytics/index.md
@@ -31,9 +31,7 @@ Using [GraphQL](https://graphql.org/), developers can query any of the curated o
 
 ## Dune Analytics {#dune-analytics}
 
-[Dune Analytics](https://dune.com/) pre-processes blockchain data into relational database (PostgreSQL and DatabricksSQL) tables, allows users to query blockchain data using SQL and build dashboards based on query results. On-chain data are organized into 4 raw tables: `blocks`, `transactions`, (event)  `logs` and (call) `traces`. Popular contracts and protocols have been decoded and each have their own set of event and call tables. Those event and call tables are processed further and organized into abstraction tables by the type of protocols, for example, dex, lending, stablecoins, etc.
-
-Besides the Ethereum Mainnet, Dune support Arbitrum, Avalanche, BNB Chain, xDAI, Optimism, and Polygon. Solana support is provided by the new Dune v2 query engine. Dune users can create public queries and dashboard free of charge; besides creating private queries and dashboards, paid users can download query results in CSV format. Dune doesn't yet provide API access.
+[Dune Analytics](https://dune.com/) pre-processes blockchain data into relational database (PostgreSQL and DatabricksSQL) tables, allows users to query blockchain data using SQL and build dashboards based on query results. On-chain data are organized into 4 raw tables: `blocks`, `transactions`, (event)  `logs` and (call) `traces`. Popular contracts and protocols have been decoded, and each has its own set of event and call tables. Those event and call tables are processed further and organized into abstraction tables by the type of protocols, for example, dex, lending, stablecoins, etc.
 
 ## Further Reading {#further-reading}
 

--- a/src/content/developers/docs/data-and-analytics/index.md
+++ b/src/content/developers/docs/data-and-analytics/index.md
@@ -17,20 +17,27 @@ You should understand the basic concept of [Block Explorers](/developers/docs/da
 
 In terms of architectural fundamentals, understanding what an [API](https://www.wikipedia.org/wiki/API) and [REST](https://www.wikipedia.org/wiki/Representational_state_transfer) are, even in theory.
 
-## The Graph {#the-graph}
-
-The [Graph Network](https://thegraph.com/) is a decentralized indexing protocol for organizing blockchain data. Instead of building and managing off-chain and centralized data stores to aggregate on-chain data, with The Graph, developers can build serverless applications that run entirely on public infrastructure.
-
-Using [GraphQL](https://graphql.org/), developers can query any of the curated open APIs, known as sub-graphs, to acquire the necessary information they need to drive their dapp. By querying these indexed sub-graphs, Reports and dapps not only get performance and scalability benefits but also the built in accuracy provided by network consensus. As new improvements and/or sub-graphs are added to the network, your projects can rapidly iterate to take advantage of these enhancements.
-
 ## Block explorers {#block-explorers}
 
 Many [Block Explorers](/developers/docs/data-and-analytics/block-explorers/) offer [RESTful](https://www.wikipedia.org/wiki/Representational_state_transfer) [API](https://www.wikipedia.org/wiki/API) gateways that will provide developers visibility into real-time data on blocks, transactions, miners, accounts, and other on-chain activity.
 
 Developers can then process and transform this data to give their users unique insights and interactions with the [blockchain](/glossary/#blockchain).
 
+## The Graph {#the-graph}
+
+The [Graph Network](https://thegraph.com/) is a decentralized indexing protocol for organizing blockchain data. Instead of building and managing off-chain and centralized data stores to aggregate on-chain data, with The Graph, developers can build serverless applications that run entirely on public infrastructure.
+
+Using [GraphQL](https://graphql.org/), developers can query any of the curated open APIs, known as sub-graphs, to acquire the necessary information they need to drive their dapp. By querying these indexed sub-graphs, Reports and dapps not only get performance and scalability benefits but also the built in accuracy provided by network consensus. As new improvements and/or sub-graphs are added to the network, your projects can rapidly iterate to take advantage of these enhancements.
+
+## Dune Analytics {#dune-analytics}
+
+[Dune Analytics](https://dune.com/) pre-processes blockchain data into relational database (PostgreSQL and DatabricksSQL) tables, allows users to query blockchain data using SQL and build dashboards based on query results. On-chain data are organized into 4 raw tables: `blocks`, `transactions`, (event)  `logs` and (call) `traces`. Popular contracts and protocols have been decoded and each have their own set of event and call tables. Those event and call tables are processed further and organized into abstraction tables by the type of protocols, for example, dex, lending, stablecoins, etc.
+
+Besides the Ethereum Mainnet, Dune support Arbitrum, Avalanche, BNB Chain, xDAI, Optimism, and Polygon. Solana support is provided by the new Dune v2 query engine. Dune users can create public queries and dashboard free of charge; besides creating private queries and dashboards, paid users can download query results in CSV format. Dune doesn't yet provide API access.
+
 ## Further Reading {#further-reading}
 
 - [Graph Network Overview](https://thegraph.com/docs/en/about/network/)
 - [Graph Query Playground](https://thegraph.com/explorer/subgraph/graphprotocol/graph-network-mainnet?version=current)
 - [API code examples on EtherScan](https://etherscan.io/apis#contracts)
+- [Dune Basics](https://docs.dune.com/#dune-basics) 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Moved `Block explorers` section to be ahead of The Graph section because it is one of the prerequisites.
- Added a section for Dune Analytics, another representative approach to on-chain data analytics that is different from the Graph protocol

## Related Issue

None

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
