### PR TITLE
Updated a mistranslated sentence in line 18 + typos.

### DIFF
--- a/src/content/translations/pl/developers/docs/standards/tokens/erc-721/index.md
+++ b/src/content/translations/pl/developers/docs/standards/tokens/erc-721/index.md
@@ -15,7 +15,7 @@ Niewymienne tokeny (NFT) służą do identyfikacji czegoś lub kogoś w unikalny
 
 ERC-721 wprowadza standard dla NFT, innymi słowy ten typ tokena jest unikalny i może mieć różną wartość niż inny token z tego samego inteligentnego kontraktu, być może ze względu na jego wiek, rzadkość, a nawet coś innego, jak jego wygląd. Czekaj, wizualnie?
 
-Tak! Wszystkie NFT mają zmienną `uint256` o nazwie `tokenId`, więc dla każdeego kontraktu ERC-721, para `contract address, uint256 tokenId` musi być unikatowa globalnie. Powiedział, że aplikacja zdecentralizowana może mieć „konwerter”, który używa `tokenId` jako danych wejściowych i wyświetla obraz czegoś fajnego, takiego jak zombie, broń, umiejętności lub niesamowite kociaki!
+Tak! Wszystkie NFT mają zmienną `uint256` o nazwie `tokenId`, więc dla każdego kontraktu ERC-721, para `contract address, uint256 tokenId` musi być unikatowa globalnie. Dzięki temu zdecentralizowana aplikacja może mieć „konwerter”, który używa `tokenId` jako danych wejściowych i wyświetla obraz czegoś fajnego, takiego jak zombie, broń, umiejętności lub niesamowite kociaki!
 
 ## Warunki wstępne {#prerequisites}
 


### PR DESCRIPTION
The sentence in line 18 has been mistranslated. The sentence will sound more natural in Polish upon the change.


## Description

1. The sentence in line 18 (more specifically, the phrase "That said,") was mistranslated. I've made it more readable in Polish.

2. Changed the typo in "każdeego" - it should be "każdego".

3. Changed "aplikacja zdecentralizowana" to "zdecentralizowana aplikacja" - sounds more natural.

