### PR TITLE
remove function that does'nt exist [fixed #7468]

### DIFF
--- a/src/content/developers/docs/standards/tokens/erc-4626/index.md
+++ b/src/content/developers/docs/standards/tokens/erc-4626/index.md
@@ -161,14 +161,6 @@ function totalSupply() public view returns (uint256)
 
 Returns the total number of unredeemed vault shares in circulation.
 
-#### balanceOfUnderlying {#balanceofunderlying}
-
-```solidity
-function balanceOfUnderlying(address owner) public view returns (uint256)
-```
-
-This function returns the total amount of underlying tokens held in the vault for `owner`.
-
 #### balanceOf {#balanceof}
 
 ```solidity


### PR DESCRIPTION
ERC4626 page incorrectly displays a function that didn't make the final cut

## Description
removed the function

## Related Issue

issue #7468 
