### PR TITLE
Update Dapps.tsx and SharedStyledComponents.tsx

### DIFF
--- a/src/components/SharedStyledComponents.tsx
+++ b/src/components/SharedStyledComponents.tsx
@@ -184,7 +184,7 @@ export const InfoGrid = styled.div`
   grid-template-columns: repeat(auto-fill, minmax(min(100%, 340px), 1fr));
   gap: 2rem;
   & > div {
-    height: fit-content;
+    height: auto;
     margin: 0;
     &:hover {
       transition: 0.1s;

--- a/src/components/SharedStyledComponents.tsx
+++ b/src/components/SharedStyledComponents.tsx
@@ -184,7 +184,7 @@ export const InfoGrid = styled.div`
   grid-template-columns: repeat(auto-fill, minmax(min(100%, 340px), 1fr));
   gap: 2rem;
   & > div {
-    height: auto;
+    height: fit-content;
     margin: 0;
     &:hover {
       transition: 0.1s;

--- a/src/pages-conditional/dapps.tsx
+++ b/src/pages-conditional/dapps.tsx
@@ -750,7 +750,7 @@ const DappsPage = ({
         "page-dapps-dapp-description-tornado-cash",
         intl
       ),
-      link: "https://tornado.cash/",
+      link: "https://tornadocash.eth.link/",
       image: getImage(data.tornado),
       alt: translateMessageId("page-dapps-tornado-cash-logo-alt", intl),
     },


### PR DESCRIPTION
### **Update dapps.tsx**

Updates the original Tornado.cash website which can no longer be accessed to an alternative Tornado cash website that works

![tornado cash](https://user-images.githubusercontent.com/89455475/185746610-48d01fdd-a0e5-4573-a22a-cc26e5936f98.png)

When clicking on the Tornado cash Dapps "go" button it links you to the original website (https://tornado.cash).  https://tornadocash.eth.link/ is the updated link that now works

---

### **Update SharedStyledComponents.tsx**


### Before:

Grids are not inline

height: fit-content;

![bfore](https://user-images.githubusercontent.com/89455475/185745589-7785362c-ccad-4588-bd84-4991be4c73cc.png)

---

### After:

Grids are inline 

height: auto;

![after](https://user-images.githubusercontent.com/89455475/185745604-68adea10-3912-425e-b0cb-a2c50773bd64.png)