### PR TITLE
Update DAppNode multi-client status

### DIFF
--- a/src/data/staking-products.json
+++ b/src/data/staking-products.json
@@ -93,7 +93,7 @@
       "hasBugBounty": false,
       "isTrustless": true,
       "isPermissionless": true,
-      "multiClient": false,
+      "multiClient": true,
       "easyClientSwitching": false,
       "platforms": ["Browser"],
       "ui": ["GUI"],


### PR DESCRIPTION
## Description
DAppNode has recently introduced the addition of web3signer, which has enabled multi-client support for consensus clients. With this, **Teku, Lighthouse and Prysm** are now supported for Mainnet through DAppNode.
<img width="881" alt="image" src="https://user-images.githubusercontent.com/54227730/185798385-59a25857-e718-40f5-b73e-110d60599ba2.png">
<img width="1256" alt="image" src="https://user-images.githubusercontent.com/54227730/185798466-ce010fcf-0d63-4edd-8077-2c658145ea0f.png">
Also:

- Geth/Nethermind execution clients on Mainnet
- Nimbus/Lighthouse/Teku/Prysm consensus clients on Prater
- Geth execution client, and also SSV on Goerli (formerly Prater)

This PR updated the `multiClient` flag to `true` for DAppNode, to update their indicator on the http://localhost:8000/en/staking/solo/#node-and-client-tools page

## Related Issue
None filed