### PR TITLE
Fix broken header on Blog translation page

### DIFF
--- a/src/content/contributing/translation-program/blog-translations/index.md
+++ b/src/content/contributing/translation-program/blog-translations/index.md
@@ -22,7 +22,7 @@ Anyone can contribute to translating the EF blog. If you want to get involved, k
 
 </InfoBanner>
 
-### Join the blog translations project in Crowdin {#join-crowdin}
+### Join the blog translations project in Crowdin {#join-crowdin}
 
 You'll need to log in to your Crowdin account or sign up if you don’t already have one. All that is required to sign up is an e-mail account and password.
 


### PR DESCRIPTION
## Description

Fix broken header on the Blog translations subpage

<img width="807" alt="Screenshot 2022-08-24 at 20 23 51" src="https://user-images.githubusercontent.com/37338979/186494575-bf295888-3720-4114-9fe2-0d08611a36a9.png">

## Related Issue

None
