### PR TITLE
Change launchpad link to mainnet in page-staking.json

### DIFF
--- a/src/intl/en/page-staking.json
+++ b/src/intl/en/page-staking.json
@@ -156,7 +156,7 @@
   "page-staking-section-comparison-requirements-title": "Requirements",
   "page-staking-section-comparison-solo-requirements-li1": "You must deposit 32 ETH",
   "page-staking-section-comparison-solo-requirements-li2": "Maintain hardware that runs both an Ethereum execution client and consensus client while connected to the internet",
-  "page-staking-section-comparison-solo-requirements-li3": "The <a href=\"https://goerli.launchpad.ethereum.org\" target=\"_blank\">Staking Launchpad</a> will walk you through the process and hardware requirements",
+  "page-staking-section-comparison-solo-requirements-li3": "The <a href=\"https://launchpad.ethereum.org\" target=\"_blank\">Staking Launchpad</a> will walk you through the process and hardware requirements",
   "page-staking-section-comparison-saas-requirements-li1": "Deposit 32 ETH and generate your keys with assistance",
   "page-staking-section-comparison-saas-requirements-li2": "Store your keys securely",
   "page-staking-section-comparison-saas-requirements-li3": "The rest is taken care of, though specific services will vary",


### PR DESCRIPTION
Change launchpad link to mainnet in page-staking.json. This will be helpful so people do not deposit real ETH to Görli.