### PR TITLE
Deleting Tornado Cash from the DeFi section in Dapps

### DIFF
--- a/src/pages-conditional/dapps.tsx
+++ b/src/pages-conditional/dapps.tsx
@@ -745,16 +745,6 @@ const DappsPage = ({
 
   const payments = [
     {
-      title: "Tornado cash",
-      description: translateMessageId(
-        "page-dapps-dapp-description-tornado-cash",
-        intl
-      ),
-      link: "https://tornado.cash/",
-      image: getImage(data.tornado),
-      alt: translateMessageId("page-dapps-tornado-cash-logo-alt", intl),
-    },
-    {
       title: "Sablier",
       description: translateMessageId(
         "page-dapps-dapp-description-sablier",


### PR DESCRIPTION
As Tornado Cash is now **illegal** in the US, the website has been taken down, and the only way to get to Tornado Cash is through it’s IPFS hash. #7498 mentions this problem, but no action was taken after the issue was created. 