### PR TITLE
Fixed error related to Arbitrum Nova description

### DIFF
--- a/src/content/social-networks/index.md
+++ b/src/content/social-networks/index.md
@@ -80,7 +80,7 @@ Reddit has [touted Community Points](https://cointelegraph.com/news/reddit-to-re
 
 The program is already live, with the r/CryptoCurrency subreddit [running its version of Community Points called "Moons"](https://www.reddit.com/r/CryptoCurrency/wiki/moons_wiki). Per the official description, Moons "reward posters, commenters, and moderators for their contributions to the subreddit." Because these tokens are on the blockchain (users receive them in wallets), they are independent of Reddit and cannot be taken away. 
 
-After concluding a beta phase on the Rinkeby testnet, Reddit Community Points are now on [Arbitrum Nova](https://nova.arbitrum.io/), a blockchain that combines properties of a [validium](/developers/docs/scaling/validium/) and an [optimistic rollup](/developers/docs/scaling/optimistic-rollups/). Besides using Community Points to unlock special features, users can also trade them for fiat on exchanges. Also, the amount of Community Points a user owns determines their influence on the decision-making process within the community. 
+After concluding a beta phase on the Rinkeby testnet, Reddit Community Points are now on [Arbitrum Nova](https://nova.arbitrum.io/), a blockchain that combines properties of a [sidechain](/developers/docs/scaling/sidechains/) and an [optimistic rollup](/developers/docs/scaling/optimistic-rollups/). Besides using Community Points to unlock special features, users can also trade them for fiat on exchanges. Also, the amount of Community Points a user owns determines their influence on the decision-making process within the community. 
 
 ### Twitter {#twitter}
 


### PR DESCRIPTION
The previous edit described Arbitrum Nova as a cross between a validium and an optimistic rollup, which is incorrect--the Arbitrum Nova chain only posts proofs of data availability to Ethereum, not proofs of validity (as validiums do). I've chosen to describe it as a cross between a sidechain and an optimistic rollup instead, as that feels more accurate.

<!--- Provide a general summary of your changes in the Title above -->