### PR TITLE
nonce field is missing from transaction information in transactions page 

### DIFF
--- a/src/content/developers/docs/transactions/index.md
+++ b/src/content/developers/docs/transactions/index.md
@@ -27,6 +27,7 @@ A submitted transaction includes the following information:
 
 - `recipient` – the receiving address (if an externally-owned account, the transaction will transfer value. If a contract account, the transaction will execute the contract code)
 - `signature` – the identifier of the sender. This is generated when the sender's private key signs the transaction and confirms the sender has authorized this transaction
+- `nonce` - a sequencially incrementing counter which indicate the transaction number from the account 
 - `value` – amount of ETH to transfer from sender to recipient (in WEI, a denomination of ETH)
 - `data` – optional field to include arbitrary data
 - `gasLimit` – the maximum amount of gas units that can be consumed by the transaction. Units of gas represent computational steps


### PR DESCRIPTION
adding Nonce as it is also part of the transaction which gets validated along with the transaction

## Description
Nonce is added in the transaction information section.

## Related Issue
[Issue link #7609](https://github.com/ethereum/ethereum-org-website/issues/7609#issue-1353469978)
