### PR TITLE
Removed broken link and fixed incorrect id in url

### DIFF
--- a/src/content/whitepaper/index.md
+++ b/src/content/whitepaper/index.md
@@ -509,7 +509,7 @@ The concept of an arbitrary state transition function as implemented by the Ethe
 10. [Colored coins whitepaper](https://docs.google.com/a/buterin.com/document/d/1AnkP_cVZTCMLIzw4DvsW6M8Q2JC0lIzrTLuoWu2z1BE/edit)
 11. [Mastercoin whitepaper](https://github.com/mastercoin-MSC/spec)
 12. [Decentralized autonomous corporations, Bitcoin Magazine](http://bitcoinmagazine.com/7050/bootstrapping-a-decentralized-autonomous-corporation-part-i/)
-13. [Simplified payment verification](https://en.bitcoin.it/wiki/Scalability#Simplifiedpaymentverification)
+13. [Simplified payment verification](https://en.bitcoin.it/wiki/Scalability#Simplified_payment_verification)
 14. [Merkle trees](https://wikipedia.org/wiki/Merkle_tree)
 15. [Patricia trees](https://wikipedia.org/wiki/Patricia_tree)
 16. [GHOST](https://eprint.iacr.org/2013/881.pdf)
@@ -517,7 +517,6 @@ The concept of an arbitrary state transition function as implemented by the Ethe
 18. [Mike Hearn on Smart Property at Turing Festival](http://www.youtube.com/watch?v=Pu4PAMFPo5Y)
 19. [Ethereum RLP](https://github.com/ethereum/wiki/wiki/%5BEnglish%5D-RLP)
 20. [Ethereum Merkle Patricia trees](https://github.com/ethereum/wiki/wiki/%5BEnglish%5D-Patricia-Tree)
-21. [Peter Todd on Merkle sum trees](http://sourceforge.net/p/bitcoin/mailman/message/31709140/)
 
 _For history of the whitepaper, see [this wiki](https://github.com/ethereum/wiki/blob/old-before-deleting-all-files-go-to-wiki-wiki-instead/old-whitepaper-for-historical-reference.md)._
 

--- a/src/content/whitepaper/index.md
+++ b/src/content/whitepaper/index.md
@@ -517,6 +517,7 @@ The concept of an arbitrary state transition function as implemented by the Ethe
 18. [Mike Hearn on Smart Property at Turing Festival](http://www.youtube.com/watch?v=Pu4PAMFPo5Y)
 19. [Ethereum RLP](https://github.com/ethereum/wiki/wiki/%5BEnglish%5D-RLP)
 20. [Ethereum Merkle Patricia trees](https://github.com/ethereum/wiki/wiki/%5BEnglish%5D-Patricia-Tree)
+21. [Peter Todd on Merkle sum trees] (https://web.archive.org/web/20140623061815/http://sourceforge.net/p/bitcoin/mailman/message/31709140/)
 
 _For history of the whitepaper, see [this wiki](https://github.com/ethereum/wiki/blob/old-before-deleting-all-files-go-to-wiki-wiki-instead/old-whitepaper-for-historical-reference.md)._
 

--- a/src/content/whitepaper/index.md
+++ b/src/content/whitepaper/index.md
@@ -517,7 +517,7 @@ The concept of an arbitrary state transition function as implemented by the Ethe
 18. [Mike Hearn on Smart Property at Turing Festival](http://www.youtube.com/watch?v=Pu4PAMFPo5Y)
 19. [Ethereum RLP](https://github.com/ethereum/wiki/wiki/%5BEnglish%5D-RLP)
 20. [Ethereum Merkle Patricia trees](https://github.com/ethereum/wiki/wiki/%5BEnglish%5D-Patricia-Tree)
-21. [Peter Todd on Merkle sum trees] (https://web.archive.org/web/20140623061815/http://sourceforge.net/p/bitcoin/mailman/message/31709140/)
+21. [Peter Todd on Merkle sum trees](https://web.archive.org/web/20140623061815/http://sourceforge.net/p/bitcoin/mailman/message/31709140/)
 
 _For history of the whitepaper, see [this wiki](https://github.com/ethereum/wiki/blob/old-before-deleting-all-files-go-to-wiki-wiki-instead/old-whitepaper-for-historical-reference.md)._
 


### PR DESCRIPTION
Removed link on line 520 which was broken - http://sourceforge.net/p/bitcoin/mailman/message/31709140/.

Edited the url of the wikipedia to reflect the correct scroll to it for Simplified Payment Verification.
From https://en.bitcoin.it/wiki/Scalability#Simplifiedpaymentverification to https://en.bitcoin.it/wiki/Scalability#Simplified_payment_verification

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
1. Fixing a broken link to a resource which is no longer available. 
2. Editing the url of a link to make the id instantly accessible.
## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
1. Visit the link titled Peter Todd on Merkle sum trees on point 21 of Further Reading: http://sourceforge.net/p/bitcoin/mailman/message/31709140/
It is no longer accessible.
2. Visit the link titled Simplified payment verification on point 13 of further reading: https://en.bitcoin.it/wiki/Scalability#Simplified_payment_verification. The scroll to ID is incorrect and it opens the top of the page, which makes the link appear incorrect initially for the user.
<!--- Please link to the issue here: -->
