### PR TITLE
Fix partial active links

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -124,7 +124,7 @@ const LinkWrapper: React.FC<IProps> = ({
       to={to}
       as={IntlLink}
       language={language}
-      isPartiallyActive={isPartiallyActive}
+      partiallyActive={isPartiallyActive}
       activeStyle={{ color: theme.colors.primary }}
       whiteSpace={isGlossary ? "nowrap" : "normal"}
       {...commonProps}


### PR DESCRIPTION
We were using the incorrect propname to apply the active link styles. It name is `partiallyActive`.