### PR TITLE
Convert glossary link tags for `Đ` and `DAG` to lowercase

### DIFF
--- a/src/content/glossary/index.md
+++ b/src/content/glossary/index.md
@@ -211,11 +211,11 @@ The economics of cryptocurrencies.
 
 ## D {#section-d}
 
-### Đ {#D-with-stroke}
+### Đ {#d-with-stroke}
 
 Đ (D with stroke) is used in Old English, Middle English, Icelandic, and Faroese to stand for an uppercase letter “Eth”. It is used in words like ĐEV or Đapp (decentralized application), where the Đ is the Norse letter “eth”. The uppercase eth (Ð) is also used to symbolize the cryptocurrency Dogecoin. This is commonly seen in older Ethereum literature but is used less often today.
 
-### DAG {#DAG}
+### DAG {#dag}
 
 DAG stands for Directed Acyclic Graph. It is a data structure composed of nodes and links between them. Ethereum uses a DAG in its [proof of work](#proof-of-work) algorithm, [Ethash](#ethash).
 


### PR DESCRIPTION
Fix broken links from Table of Contents to definition. The links and hashes for all other items are lowercase and the generated urls are all lowercase. `#DAG` and `#D-with-stroke` were the only exceptions.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->


The generated links in the Glossary's table of contents does not directly link you to the definition.

1. Đ (`#d-with-stroke` , the actual link is `#D-with-stroke`)
2. DAG (`#dag`, the actual link is `#DAG`)

Example:

1. Đ
    2. The link in the TOC is: https://ethereum.org/en/glossary/#d-with-stroke
    3. The current direct link is: https://ethereum.org/en/glossary/#D-with-stroke
5. DAG
    6. The link in the TOC is: https://ethereum.org/en/glossary/#dag
    7. The current direct link is: https://ethereum.org/en/glossary/#DAG

Proposing to change the `#<LINK_NAME>` to lowercase, matching all other short links in the glossary.

Thanks!

## Related Issue

Closes #7678 
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
