### PR TITLE
Fix broken link on online community page

### DIFF
--- a/src/content/community/online/index.md
+++ b/src/content/community/online/index.md
@@ -36,6 +36,7 @@ Hundreds of thousands of Ethereum enthusiasts gather in these online forums to s
 <SocialListItem socialIcon="youtube"><Link to="https://www.youtube.com/c/EthereumFoundation">Ethereum Foundation</Link> - Keep up to date with the latest from the Ethereum Foundation</SocialListItem>
 <SocialListItem socialIcon="twitter"><Link to="https://twitter.com/ethereum">@ethereum</Link> - Offical account of the Ethereum Foundation</SocialListItem>
 <SocialListItem socialIcon="twitter"><Link to="https://twitter.com/ethdotorg">@ethdotorg</Link> - The portal to Ethereum, built for our growing global community</SocialListItem>
+<SocialListItem socialIcon="webpage"><Link to="https://hive.one/c/ethereum?page=1">List of influential Ethereum twitter accounts</Link></SocialListItem>
 
 <Divider />
 

--- a/src/content/community/online/index.md
+++ b/src/content/community/online/index.md
@@ -36,7 +36,6 @@ Hundreds of thousands of Ethereum enthusiasts gather in these online forums to s
 <SocialListItem socialIcon="youtube"><Link to="https://www.youtube.com/c/EthereumFoundation">Ethereum Foundation</Link> - Keep up to date with the latest from the Ethereum Foundation</SocialListItem>
 <SocialListItem socialIcon="twitter"><Link to="https://twitter.com/ethereum">@ethereum</Link> - Offical account of the Ethereum Foundation</SocialListItem>
 <SocialListItem socialIcon="twitter"><Link to="https://twitter.com/ethdotorg">@ethdotorg</Link> - The portal to Ethereum, built for our growing global community</SocialListItem>
-<SocialListItem socialIcon="webpage"><Link to="https://hive.one/c/Ethereum?page=1">List of influential Ethereum twitter accounts</Link></SocialListItem>
 
 <Divider />
 


### PR DESCRIPTION
The following external list item is broken - List of influential Ethereum twitter accounts (List of influential Ethereum twitter accounts) - https://hive.one/c/Ethereum?page=1

I removed as it points to a Server 500 error at destination page

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Visit the link titled  List of influential Ethereum twitter accounts - https://hive.one/c/Ethereum?page=1
at https://ethereum.org/en/community/online/#youtube-and-twitter


## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
