### PR TITLE
chore: fixed anchor Data availability committee

### DIFF
--- a/src/content/developers/docs/scaling/validium/index.md
+++ b/src/content/developers/docs/scaling/validium/index.md
@@ -84,7 +84,7 @@ Data availability managers in validium attest to the availability of data for of
 
 Validiums differ in their approach to data availability management. Some rely on trusted parties to store state data, while others use randomly assigned validators for the task.
 
-#### Data availability committee (DAC) {#data-availability-committee)
+#### Data availability committee (DAC) {#data-availability-committee}
 
 To guarantee the availability of off-chain data, some validium solutions appoint a group of trusted entities, collectively known as a data availability committee (DAC), to store copies of the state and provide proof of data availability. DACs are easier to implement and require less coordination since membership is low.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

 `Data availability committee` heading parenthesis was wrong (ended in **)** instead of **}** ) which resulted the anchor link appearing in the text.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
