### PR TITLE
Corrected the spelling in doc. issue 7703

### DIFF
--- a/src/content/developers/docs/nodes-and-clients/index.md
+++ b/src/content/developers/docs/nodes-and-clients/index.md
@@ -256,7 +256,7 @@ Light client mode downloads all block headers, block data, and verifies some ran
 
 #### Snap sync {#snap-sync}
 
-Snap sync is the latest approach to syncing a client, pioneered by the Geth team. Using dynamic snapshots served by peers retrieves all the account and storage data without downloading intermediate trie nodes and then reconstructs the Merkle trie locally.
+Snap sync is the latest approach to syncing a client, pioneered by the Geth team. Using dynamic snapshots served by peers retrieves all the account and storage data without downloading intermediate trie nodes and then reconstructs the Merkle tree locally.
 
 - Fastest sync strategy, currently default in Ethereum mainnet
 - Saves a lot of disk usage and network bandwidth without sacrificing security


### PR DESCRIPTION
Spelling Mistake of 'tree'

Updates the spelling [Fixes #7703]

## Description

This PR is related to the issue 7703

## Related Issue

https://github.com/ethereum/ethereum-org-website/issues/7703
