### PR TITLE
Fix read address aloud functionality [#7690]

### DIFF
--- a/src/pages/staking/deposit-contract.tsx
+++ b/src/pages/staking/deposit-contract.tsx
@@ -229,9 +229,9 @@ const DepositContractPage = ({
     // Create textToSpeechRequest
     let speech = new SpeechSynthesisUtterance()
     speech.lang = "en-US"
-    speech.text = DEPOSIT_CONTRACT_ADDRESS.split("").join(" ")
+    speech.text = DEPOSIT_CONTRACT_ADDRESS.split("").join(",")
     speech.volume = 1
-    speech.rate = 0.5
+    speech.rate = 1
     speech.pitch = 1
     // Add event listeners
     // Explicity set state in listener callback


### PR DESCRIPTION
Fixed the read address aloud issue in #7690

## Description

We were using the Web Speech API and setting the [SpeechSynthesisUtterance.text](https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesisUtterance/text) to DEPOSIT_CONTRACT_ADDRESS.split("").join(" ")

When following a number the letter 'C' is read as 'degrees Celsius' and the letter 'F' as 'degrees Fahrenheit'.

I have added commas between the characters so that each character is read separately

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
