### PR TITLE
Update prysm's --execution-endpoint.

### DIFF
--- a/src/content/developers/docs/nodes-and-clients/run-a-node/index.md
+++ b/src/content/developers/docs/nodes-and-clients/run-a-node/index.md
@@ -368,7 +368,7 @@ Prysm comes with script which allows easy automatic installation. Details can be
 ./prysm.sh beacon-chain \
     --mainnet
     --datadir /data/ethereum  \
-    --http-web3provider=http://localhost:8551  \
+    --execution-endpoint=http://localhost:8551  \
     --jwt-secret=/path/to/jwtsecret
 ```
 


### PR DESCRIPTION
--http-web3provider has been renamed to --execution-endpoint.

Reference release notes: https://github.com/prysmaticlabs/prysm/releases/tag/v3.0.0

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
