### PR TITLE
[UI] Banner Notification: migrate component to chakra ui

### DIFF
--- a/src/components/BannerNotification.tsx
+++ b/src/components/BannerNotification.tsx
@@ -1,9 +1,6 @@
 import React from "react"
-import styled from "@emotion/styled"
-
-export interface IStyledBanner {
-  shouldShow: boolean
-}
+import { Flex, useMediaQuery } from "@chakra-ui/react"
+import { lightTheme as oldTheme } from "../theme"
 
 export interface IProps {
   children?: React.ReactNode
@@ -11,31 +8,36 @@ export interface IProps {
   className?: string
 }
 
-const Banner = styled.div<IStyledBanner>`
-  display: ${(props) => (props.shouldShow ? `flex` : `none`)};
-  width: 100%;
-  background-color: ${(props) => props.theme.colors.primary};
-  color: ${(props) => props.theme.colors.background};
-  padding: 1rem 2rem;
-  border-bottom: 1px solid ${(props) => props.theme.colors.primary};
-
-  a {
-    color: ${(props) => props.theme.colors.background} !important;
-  }
-
-  @media (min-width: ${(props) => props.theme.breakpoints.l}) {
-    max-width: ${(props) => props.theme.variables.maxPageWidth};
-  }
-`
-
 const BannerNotification: React.FC<IProps> = ({
   children,
   className,
   shouldShow = false,
-}) => (
-  <Banner shouldShow={shouldShow} className={className}>
-    {children}
-  </Banner>
-)
+}) => {
+  const [isLGScreen] = useMediaQuery(`min-width: ${oldTheme.breakpoints.l}`)
+
+  return (
+    <>
+      {shouldShow && (
+        <Flex
+          className={className}
+          maxW={isLGScreen ? oldTheme.variables.maxPageWidth : "100%"}
+          w="100%"
+          py="4"
+          px="8"
+          bg="primary"
+          color="background"
+          borderBottom="1px solid primary"
+          sx={{
+            a: {
+              color: "background",
+            },
+          }}
+        >
+          {children}
+        </Flex>
+      )}
+    </>
+  )
+}
 
 export default BannerNotification


### PR DESCRIPTION
## Description
The component has been migrated to chakra ui. 
The emotion styled component has been removed from the file

---

### Usage of Chakra:
- There was a nested styling in the Banner component and it has been refactored in the `sx` attribute of chakra-ui.
- Using the useMediaQuery hook from chakra ui for the min-width media query used in pure css

### Before
**_Large screen_**
<img width="1161" alt="image" src="https://user-images.githubusercontent.com/16734238/189427054-df2e1718-5cde-4dce-8605-ee5053f1c44a.png">

**_Small screen_**
<img width="882" alt="image" src="https://user-images.githubusercontent.com/16734238/189426998-2c161053-9ec8-4247-b93f-d5e9c663c5c5.png">

---

### After:
**_Large screen_**
<img width="1171" alt="image" src="https://user-images.githubusercontent.com/16734238/189426742-bd30aac8-4721-40d5-9850-1c6d76a7b02a.png">

**_Small screen_**
<img width="882" alt="image" src="https://user-images.githubusercontent.com/16734238/189426807-e18380ff-82f8-48e4-a5ef-94c2b251c166.png">


Once the first migration is validated, I'll make all the missing PRs for the assigned components.

---

## Related Issue
Refs: #6374
