### PR TITLE
fix(content): use correct "nodes and clients" anchor url on "Networking layer" page

### DIFF
--- a/src/content/developers/docs/networking-layer/index.md
+++ b/src/content/developers/docs/networking-layer/index.md
@@ -15,7 +15,7 @@ After [The Merge](/upgrades/merge/), there will be two parts of client software 
 
 ## Prerequisites {#prerequisites}
 
-Some knowledge of Ethereum [nodes and clients](/src/content/developers/docs/nodes-and-clients/) will be helpful for understanding this page.
+Some knowledge of Ethereum [nodes and clients](/developers/docs/nodes-and-clients/) will be helpful for understanding this page.
 
 ## The Execution Layer {#execution-layer}
 


### PR DESCRIPTION
## Description

Fixes the broken "nodes and clients" link on the [Networking layer page](https://ethereum.org/en/developers/docs/networking-layer/).

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
