### PR TITLE
Updated broken discord link to a persistent link

### DIFF
--- a/src/content/community/online/index.md
+++ b/src/content/community/online/index.md
@@ -28,7 +28,7 @@ Hundreds of thousands of Ethereum enthusiasts gather in these online forums to s
 <SocialListItem socialIcon="discord"><Link to="https://discord.io/ethstaker">EthStaker Discord</Link> - community oriented around offering project management support to Ethereum development</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/CetY6Y4">Ethereum.org website team</Link> - stop by and chat ethereum.org web development and design with the team and folks from the community</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ZH5aXDgWEU">Web3 University</Link> - community focused on learning web3 development </SocialListItem>
-<SocialListItem socialIcon="discord"><Link to="https://discord.gg/G4vVhQu3">Matos Discord</Link> - web3 creators community where builders, industrial figureheads, and Ethereum enthusiasts hang out. we're passioned about web3 development, design, and culture. come build with us.</SocialListItem>
+<SocialListItem socialIcon="discord"><Link to="https://discord.matos.club/">Matos Discord</Link> - web3 creators community where builders, industrial figureheads, and Ethereum enthusiasts hang out. we're passioned about web3 development, design, and culture. come build with us.</SocialListItem>
 <SocialListItem socialIcon="webpage"><Link to="https://gitter.im/ethereum/solidity/">Solidity Gitter</Link> - chat for solidity development (Gitter)</SocialListItem>
 <SocialListItem socialIcon="webpage"><Link to="https://matrix.to/#/#ethereum_solidity:gitter.im">Solidity Matrix</Link> - chat for solidity development (Matrix)</SocialListItem>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updated the current discord link (which did expire in 7 days) to a [persistent link](https://discord.matos.club/) that never expires.

## Related Issue

Fixes this (already merged) [PR](https://github.com/ethereum/ethereum-org-website/pull/7397) before it is shipped to production.

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
