### PR TITLE
add classes to selectors_exclude to ignore new chakra way of doing links

### DIFF
--- a/.github/workflows/docsearchConfig.json
+++ b/.github/workflows/docsearchConfig.json
@@ -1,5 +1,5 @@
 {
-  "index_name": "dev-ethereum-org",
+  "index_name": "prod-ethereum-org",
   "start_urls": [
     {
       "url": "https://ethereum.org/(?P<lang>.*?)/developers/tutorials/",
@@ -112,7 +112,7 @@
       "default_value": "en"
     }
   },
-  "selectors_exclude": ["aside", "nav", "footer", ".header-anchor"],
+  "selectors_exclude": ["aside", "nav", "footer", "style"],
   "strip_chars": " .,;:#",
   "custom_settings": {
     "attributesForFaceting": ["lang", "content"],

--- a/.github/workflows/docsearchConfig.json
+++ b/.github/workflows/docsearchConfig.json
@@ -1,5 +1,5 @@
 {
-  "index_name": "prod-ethereum-org",
+  "index_name": "dev-ethereum-org",
   "start_urls": [
     {
       "url": "https://ethereum.org/(?P<lang>.*?)/developers/tutorials/",
@@ -112,7 +112,7 @@
       "default_value": "en"
     }
   },
-  "selectors_exclude": ["aside", "nav", "footer"],
+  "selectors_exclude": ["aside", "nav", "footer", ".header-anchor"],
   "strip_chars": " .,;:#",
   "custom_settings": {
     "attributesForFaceting": ["lang", "content"],

--- a/.github/workflows/docsearchConfigScript.js
+++ b/.github/workflows/docsearchConfigScript.js
@@ -42,7 +42,7 @@ var config = {
       default_value: "en",
     },
   },
-  selectors_exclude: ["aside", "nav", "footer"],
+  selectors_exclude: ["aside", "nav", "footer", ".header-anchor", ".before"],
   strip_chars: " .,;:#",
   custom_settings: {
     attributesForFaceting: ["lang", "content"],

--- a/.github/workflows/docsearchConfigScript.js
+++ b/.github/workflows/docsearchConfigScript.js
@@ -42,7 +42,7 @@ var config = {
       default_value: "en",
     },
   },
-  selectors_exclude: ["aside", "nav", "footer", ".header-anchor"],
+  selectors_exclude: ["aside", "nav", "footer", "style"],
   strip_chars: " .,;:#",
   custom_settings: {
     attributesForFaceting: ["lang", "content"],

--- a/.github/workflows/docsearchConfigScript.js
+++ b/.github/workflows/docsearchConfigScript.js
@@ -2,7 +2,7 @@ const fs = require("fs")
 const translations = require("../../src/utils/languages").default
 
 var config = {
-  index_name: "dev-ethereum-org",
+  index_name: "prod-ethereum-org",
   start_urls: [
     {
       url: "https://ethereum.org/(?P<lang>.*?)/developers/tutorials/",

--- a/.github/workflows/docsearchConfigScript.js
+++ b/.github/workflows/docsearchConfigScript.js
@@ -2,7 +2,7 @@ const fs = require("fs")
 const translations = require("../../src/utils/languages").default
 
 var config = {
-  index_name: "prod-ethereum-org",
+  index_name: "dev-ethereum-org",
   start_urls: [
     {
       url: "https://ethereum.org/(?P<lang>.*?)/developers/tutorials/",
@@ -42,7 +42,7 @@ var config = {
       default_value: "en",
     },
   },
-  selectors_exclude: ["aside", "nav", "footer", ".header-anchor", ".before"],
+  selectors_exclude: ["aside", "nav", "footer", ".header-anchor"],
   strip_chars: " .,;:#",
   custom_settings: {
     attributesForFaceting: ["lang", "content"],


### PR DESCRIPTION
## Description
- During the migration to Chakra, there were some new classes and pseudo elements that have been added to headers that we need to ignore now.
- https://docsearch.algolia.com/docs/legacy/config-file/#selectors_exclude-optional

<img width="1920" alt="Screen Shot 2022-09-13 at 5 11 35 AM" src="https://user-images.githubusercontent.com/15589226/189886769-7ac7c646-c1cf-4982-be93-af2580ba3aa1.png">
