### PR TITLE
Link to bordel.wtf in /upgrades/merge page fixed [Fixes #7834]

### DIFF
--- a/src/content/upgrades/merge/index.md
+++ b/src/content/upgrades/merge/index.md
@@ -118,9 +118,9 @@ The Merge comes with changes to consensus, which also includes changes related t
 For more information, check out this blog post by Tim Beiko on [How The Merge Impacts Ethereum’s Application Layer](https://blog.ethereum.org/2021/11/29/how-the-merge-impacts-app-layer/).
 </ExpandableCard>
 
-## What date is The Merge? {#wen-merge}
+## What date is The Merge? {#when-merge}
 
-The Merge is happening on 14/15th September. The precise timing depends upon how the network hash rate develops and it can be monitored at [bordel.wtf](bordel.wtf). The Merge will be triggered when the network passes a threshold accumulated difficulty, known as the TTD (terminal total difficulty). You can track total difficulty milestones using the [Nethermind TTD bot](https://explorer.forta.network/bot/0x5c2f5e0854ff24b425efc3a860953ee2923d9b0bc73ea86acd29d45d588e7bdc).
+The Merge is happening on 14/15th September. The precise timing depends upon how the network hash rate develops and it can be monitored at [bordel.wtf](https://bordel.wtf/). The Merge will be triggered when the network passes a threshold accumulated difficulty, known as the TTD (terminal total difficulty). You can track total difficulty milestones using the [Nethermind TTD bot](https://explorer.forta.network/bot/0x5c2f5e0854ff24b425efc3a860953ee2923d9b0bc73ea86acd29d45d588e7bdc).
 
 ## After The Merge {#after-the-merge}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed a link in "upgrades/merge/" page. Thin this page there is a heading  "What date is The Merge?" in this content a link to bordel.wtf was invalid without HTTPS or HTTP protocol as a result it was doing an internal redirect to the ethereum page only instead of redirecting to that domain.
I have added the HTTPS protocol to the URL from the markdown, which now redirects correctly.

The second issue was URL heading for that content was "upgrades/merge/#wen-merge" last id of that heading should be "#when-merge"  instead of "#wen-merge# I have also corrected that type

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
