### PR TITLE
Add 'merge-complete' community translations

### DIFF
--- a/src/intl/de/common.json
+++ b/src/intl/de/common.json
@@ -184,6 +184,7 @@
   "matcha-logo": "Matcha-Logo",
   "medalla-data-challenge": "Die Medalla-Datenherausforderung",
   "merge": "Zusammenführen",
+  "merge-complete": "Die Fusion ist abgeschlossen! Willkommen in einem neuen, grüneren Ethereum!",
   "more": "Mehr",
   "more-info": "Mehr Info",
   "nav-beginners": "Anfänger",

--- a/src/intl/el/common.json
+++ b/src/intl/el/common.json
@@ -166,6 +166,7 @@
   "matcha-logo": "Λογότυπο Matcha",
   "medalla-data-challenge": "Πρόκληση δεδομένων Medalla",
   "merge": "Συγχώνευση",
+  "merge-complete": "Η Συγχώνευση ολοκληρώθηκε! Καλωσήρθατε σε ένα πιο πράσινο Ethereum.",
   "more": "Περισσότερα",
   "more-info": "Περισσότερες πληροφορίες",
   "nav-beginners": "Αρχάριοι",

--- a/src/intl/es/common.json
+++ b/src/intl/es/common.json
@@ -184,6 +184,7 @@
   "matcha-logo": "Logo de Matcha",
   "medalla-data-challenge": "Reto de datos Medalla",
   "merge": "Fusión",
+  "merge-complete": "¡La fusión está completa! Bienvenido a un nuevo Ethereum más verde.",
   "more": "Más",
   "more-info": "Más información",
   "nav-beginners": "Principiantes",

--- a/src/intl/fr/common.json
+++ b/src/intl/fr/common.json
@@ -184,6 +184,7 @@
   "matcha-logo": "Logo Matcha",
   "medalla-data-challenge": "Défi de données Medalla",
   "merge": "Fusionner",
+  "merge-complete": "La fusion s'est produite ! Bienvenue dans un Ethereum plus vert.",
   "more": "Plus",
   "more-info": "Plus d'infos",
   "nav-beginners": "Débutants",

--- a/src/intl/hi/common.json
+++ b/src/intl/hi/common.json
@@ -184,6 +184,7 @@
   "matcha-logo": "Matcha लोगो",
   "medalla-data-challenge": "Medalla डेटा चुनौती",
   "merge": "मर्ज करें",
+  "merge-complete": "मर्ज पूरा हो गया है! एक नए हरित Ethereum में आपका स्वागत है।",
   "more": "अधिक",
   "more-info": "अधिक जानकारी",
   "nav-beginners": "नई शुरुआत",

--- a/src/intl/id/common.json
+++ b/src/intl/id/common.json
@@ -184,6 +184,7 @@
   "matcha-logo": "Logo Matcha",
   "medalla-data-challenge": "Tantangan data Medalla",
   "merge": "Gabungkan",
+  "merge-complete": "Penggabungan telah selesai!  Selamat datang di Ethereum baru yang lebih hijau.",
   "more": "Lebih Banyak",
   "more-info": "Info lebih lanjut",
   "nav-beginners": "Pemula",

--- a/src/intl/it/common.json
+++ b/src/intl/it/common.json
@@ -184,6 +184,7 @@
   "matcha-logo": "Logo di Matcha",
   "medalla-data-challenge": "Medalla data challenge",
   "merge": "Fusione",
+  "merge-complete": "La fusione è completa! Benvenuti in un nuovo Ethereum più verde.",
   "more": "Altro",
   "more-info": "Maggiori informazioni",
   "nav-beginners": "Principianti",

--- a/src/intl/ja/common.json
+++ b/src/intl/ja/common.json
@@ -184,6 +184,7 @@
   "matcha-logo": "Matcha ロゴ",
   "medalla-data-challenge": "Medallaデータチャレンジ",
   "merge": "マージ",
+  "merge-complete": "マージ完了! より環境に優しくなったイーサリアムへようこそ。",
   "more": "もっと見る",
   "more-info": "詳細",
   "nav-beginners": "初心者",

--- a/src/intl/ko/common.json
+++ b/src/intl/ko/common.json
@@ -184,6 +184,7 @@
   "matcha-logo": "Matcha 로고",
   "medalla-data-challenge": "Medalla 데이터 문제",
   "merge": "병합",
+  "merge-complete": "머지가 완료되었습니다! 친환경적인 새로운 이더리움의 세계에 오신 것을 환영합니다.",
   "more": "더 보기",
   "more-info": "상세 정보",
   "nav-beginners": "입문자",

--- a/src/intl/nl/common.json
+++ b/src/intl/nl/common.json
@@ -184,6 +184,7 @@
   "matcha-logo": "Matcha-logo",
   "medalla-data-challenge": "Medalla-gegevensuitdaging",
   "merge": "Samenvoegen",
+  "merge-complete": "De Merge is compleet! Welkom bij een nieuw groener Ethereum.",
   "more": "Meer",
   "more-info": "Meer info",
   "nav-beginners": "Beginners",

--- a/src/intl/pl/common.json
+++ b/src/intl/pl/common.json
@@ -184,6 +184,7 @@
   "matcha-logo": "Logo Matcha",
   "medalla-data-challenge": "Wyzwanie z danymi Medalla",
   "merge": "Połącz",
+  "merge-complete": "Merge jest gotowy! Witajcie w nowym, bardziej zielonym Ethereum.",
   "more": "Więcej",
   "more-info": "Więcej informacji",
   "nav-beginners": "Początkujący",

--- a/src/intl/pt-br/common.json
+++ b/src/intl/pt-br/common.json
@@ -184,6 +184,7 @@
   "matcha-logo": "Logotipo da Matcha",
   "medalla-data-challenge": "Desafio de dados Medalla",
   "merge": "Integração",
+  "merge-complete": "A Fusão está completa! Bem-vindo a uma nova Ethereum mais verde.",
   "more": "Mais",
   "more-info": "Mais informações",
   "nav-beginners": "Principiantes",

--- a/src/intl/pt/common.json
+++ b/src/intl/pt/common.json
@@ -184,6 +184,7 @@
   "matcha-logo": "Logótipo da Matcha",
   "medalla-data-challenge": "Desafio de dados Medalla",
   "merge": "Fundir",
+  "merge-complete": "A fusão está completa! Bem-vindo a um novo Ethereum mais verde.",
   "more": "Mais",
   "more-info": "Mais informação",
   "nav-beginners": "Principiantes",

--- a/src/intl/ru/common.json
+++ b/src/intl/ru/common.json
@@ -184,6 +184,7 @@
   "matcha-logo": "Логотип Matcha",
   "medalla-data-challenge": "Конкурс данных Medalla",
   "merge": "Объединение",
+  "merge-complete": "Слияние завершено! Добро пожаловать в новый экологичный Ethereum.",
   "more": "Больше",
   "more-info": "Подробнее",
   "nav-beginners": "Начинающим",

--- a/src/intl/sw/common.json
+++ b/src/intl/sw/common.json
@@ -172,6 +172,7 @@
   "matcha-logo": "Nembo ya Matcha",
   "medalla-data-challenge": "Changamoto ya data ya Medella",
   "merge": "Unganisha",
+  "merge-complete": "Muungano umekamilika! Karibu kwenye Ethereum inayojali mazingira.",
   "more": "Zaidi",
   "more-info": "Habari zaidi",
   "nav-beginners": "Wanaoanza",

--- a/src/intl/tr/common.json
+++ b/src/intl/tr/common.json
@@ -188,6 +188,7 @@
   "matcha-logo": "Matcha logosu",
   "medalla-data-challenge": "Medalla veri yarışması",
   "merge": "Birleşme",
+  "merge-complete": "(Ethereum birleşmesi) tamamlandı! Daha yeşil bir Ethereum’a hoşgeldiniz.",
   "more": "Daha fazlası",
   "more-info": "Daha fazla bilgi",
   "nav-beginners": "Yeni başlayanlar",

--- a/src/intl/vi/common.json
+++ b/src/intl/vi/common.json
@@ -184,6 +184,7 @@
   "matcha-logo": "Logo Matcha",
   "medalla-data-challenge": "Thử thách dữ liệu Medalla",
   "merge": "Gộp",
+  "merge-complete": "Hợp nhất đã hoàn tất! Chào mừng bạn đến với kỷ nguyên xanh mới của Ethereum.",
   "more": "Xem thêm",
   "more-info": "Thông tin chi tiết",
   "nav-beginners": "Người mới bắt đầu",

--- a/src/intl/zh/common.json
+++ b/src/intl/zh/common.json
@@ -184,6 +184,7 @@
   "matcha-logo": "Matcha徽标",
   "medalla-data-challenge": "Medalla 数据挑战赛",
   "merge": "合并",
+  "merge-complete": "大合并业已完成！欢迎进入一个崭新的、更加绿色环保的以太坊",
   "more": "更多",
   "more-info": "更多信息",
   "nav-beginners": "初学者",


### PR DESCRIPTION
## Description

Adds community translations for the 'merge-complete' string (i.e. `"merge-complete": "The Merge is complete! Welcome to a new greener Ethereum."`) for the following 18 languages:

- Swahili
- Chinese simplified
- Korean
- Greek
- Dutch
- Japanese
- Russian
- Portuguese Brazilian
- Turkish
- Portuguese
- Polish
- French
- German
- Italian
- Hindi
- Vietnamese
- Spanish
- Indonesian