### PR TITLE
pt-br: fixed mobile color mode button name

### DIFF
--- a/src/intl/pt-br/common.json
+++ b/src/intl/pt-br/common.json
@@ -169,7 +169,7 @@
   "learn-menu": "Menu Aprendizagem",
   "learn-more": "Saiba mais",
   "less": "Menos",
-  "light-mode": "Leve",
+  "light-mode": "Claro",
   "listing-policy-disclaimer": "Os produtos listados nesta página não são avais oficiais e são fornecidos apenas para fins informativos. Se você quiser adicionar um produto ou fornecer feedback sobre as políticas, faça uma consulta no GitHub.",
   "listing-policy-raise-issue-link": "Fazer uma consulta",
   "live-help": "Ajuda ao vivo",


### PR DESCRIPTION
## Description

changed menu mobile light mode button string from "leve" to "claro"

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
