### PR TITLE
Fixed spelling mistake in adding desci projects page

### DIFF
--- a/src/content/contributing/adding-desci-projects/index.md
+++ b/src/content/contributing/adding-desci-projects/index.md
@@ -1,6 +1,6 @@
 ---
 title: Adding DeSci projects
-description: The policy we use when adding a links to projects on the DeAci page on ethereum.org
+description: The policy we use when adding a links to projects on the DeSci page on ethereum.org
 lang: en
 sidebar: true
 ---


### PR DESCRIPTION
Changed word "DeAci" to "DeSci"

## Description

Fixed spelling mistake in description of the "Adding Desci Projects" page, under contributions
