### PR TITLE
Patch: remove confetti from homepage

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -195,9 +195,7 @@ const Layout: React.FC<IProps> = ({
                 </div>
               </BannerNotification>
               <SkipLinkAnchor id="main-content" />
-              {(isMergePage || isHomepage) && (
-                <Centered id="confetti-easter-egg" />
-              )}
+              {isMergePage && <Centered id="confetti-easter-egg" />}
               <MainContainer>
                 {shouldShowSideNav && (
                   <VisuallyHidden isHidden={isZenMode}>


### PR DESCRIPTION
## Description
Confetti hook on the homepage is causing a glitch on Apple mobile devices. Removing from homepage.

(Not experiencing this bug on The Merge page `/upgrades/merge`; leaving the confetti on this page for the time being)