### PR TITLE
minor edit in docs to correspond to post-Merge reality

### DIFF
--- a/src/content/developers/docs/nodes-and-clients/index.md
+++ b/src/content/developers/docs/nodes-and-clients/index.md
@@ -8,7 +8,7 @@ sidebarDepth: 2
 
 Ethereum is a distributed network of computers (known as nodes) running software that can verify blocks and transaction data. The software application, known as a client, must be run on your computer to turn it into an Ethereum node.
 
-**Note: it is still possible to run an execution client on its own. However, this will no longer be possible after [The Merge](/upgrades/merge). After The Merge, both execution and consensus clients must be run together in order for a user to gain access to the Ethereum network. Some testnets (Kiln, Ropsten, Sepolia, and Goerli) have already been through their versions of The Merge, meaning execution clients alone are already insufficient for accessing those networks unless they are coupled to a consensus client that can keep track of the head of the chain.**
+**Note: it is not possible to run an execution client on its own anymore. After [The Merge](/upgrades/merge), both execution and consensus clients must be run together in order for a user to gain access to the Ethereum network.**
 
 ## Prerequisites {#prerequisites}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Update NB on the https://ethereum.org/en/developers/docs/nodes-and-clients page to reflect that it is not possible to run an execution client without a consensus client.

## Related Issue
https://github.com/ethereum/ethereum-org-website/issues/7700
https://github.com/ethereum/ethereum-org-website/issues/7401