### PR TITLE
Fix bullet points misalign in staking - saas providers

### DIFF
--- a/src/components/Staking/StakingProductsCardGrid.tsx
+++ b/src/components/Staking/StakingProductsCardGrid.tsx
@@ -140,6 +140,10 @@ const Item = styled.li`
   font-size: 0.75rem;
   line-height: 0.875rem;
   letter-spacing: 0.04em;
+
+  p {
+    margin: 1rem auto 1rem 0;
+  }
 `
 
 const Cta = styled(PaddedDiv)`


### PR DESCRIPTION
Fix the bullet point for <p/> tag misalignment in issue #7866

## Description

add `margin: 1rem auto 1rem 0` into p tag as suggested

## Related Issue
#7866 
