### PR TITLE
Fixed #7817, Handle /txs response correctly for 'Number of transactions today'

### DIFF
--- a/src/pages-conditional/what-is-ethereum.tsx
+++ b/src/pages-conditional/what-is-ethereum.tsx
@@ -244,12 +244,12 @@ const WhatIsEthereumPage = ({
 
   const localeForStatsBoxNumbers = getLocaleForNumberFormat(intl.locale as Lang)
 
-  const txCount = useFetchStat<{
-    result: Array<{ unixTimeStamp: string; transactionCount: number }>
-  }>(
+  const txCount = useFetchStat<
+    Array<{ unixTimeStamp: string; transactionCount: number }>
+  >(
     `${GATSBY_FUNCTIONS_PATH}/txs`,
     (response) => {
-      return response.result
+      return response
         .map(({ unixTimeStamp, transactionCount }) => ({
           timestamp: parseInt(unixTimeStamp) * 1000, // unix milliseconds
           value: transactionCount,


### PR DESCRIPTION
## Description

"Number of transactions today" was calculated from [the result of `/txs`](https://ethereum.org/.netlify/functions/txs) ([src/lambda/txs.ts](https://github.com/ethereum/ethereum-org-website/blob/dev/src/lambda/txs.ts))
After ecf1791bf5ffae6c3edf756617ab07b7f212ea22 commit (included in v5.0.0), `.result` was handled in `/txs` already.
So there are no need to handle `.result` in [`src/pages-conditional/what-is-ethereum.tsx`](https://github.com/minhoryang/ethereum-org-website/blob/dev/src/pages-conditional/what-is-ethereum.tsx).

FYI, [`src/components/StatsBoxGrid.tsx`](https://github.com/ethereum/ethereum-org-website/blob/dev/src/components/StatsBoxGrid.tsx) was also using `/txs` and already patched this in 13 Jul  (https://github.com/ethereum/ethereum-org-website/commit/214600eb509ffa228af16fb24f3b939b9c91d995).

## Related Issue

#7817