### PR TITLE
Fixed empty buttons in feedback widget [Fixes #7876]

### DIFF
--- a/src/components/FeedbackWidget.tsx
+++ b/src/components/FeedbackWidget.tsx
@@ -123,7 +123,6 @@ const ButtonContainer = styled.div`
   width: 100%;
   * {
     flex: 1;
-    color: ${({ theme }) => theme.colors.white};
     font-weight: 700;
   }
 `


### PR DESCRIPTION
## Description
* The button content of our feedback widget looked empty in light-mode (because the text color was also white). 
* I removed one line in ButtonContainer, this makes the text color the same as the theme color (blue in light-mode, orange in dark-mode). 

## Related Issue
* Related to #7876 
