### PR TITLE
Fix "develoeprs" typo in `beacon-chain/index.md`

### DIFF
--- a/src/content/upgrades/beacon-chain/index.md
+++ b/src/content/upgrades/beacon-chain/index.md
@@ -73,4 +73,4 @@ Sharding can only safely enter the Ethereum ecosystem with a proof-of-stake cons
 ## Further Reading
 
 - [More on Ethereum's future upgrades](/upgrades/vision)
-- [More of proof-of-stake](/develoeprs/docs/consensus-mechanisms/pos)
+- [More of proof-of-stake](/developers/docs/consensus-mechanisms/pos)


### PR DESCRIPTION
## Description

This simply replaces the `develoeprs` typo with `developers` across the codebase, but there only happens to be one case.
