### PR TITLE
Fix broken links in Particia Merkle Trie page

### DIFF
--- a/src/content/developers/docs/data-structures-and-encoding/patricia-merkle-trie/index.md
+++ b/src/content/developers/docs/data-structures-and-encoding/patricia-merkle-trie/index.md
@@ -179,7 +179,7 @@ Now, we build such a trie with the following key/value pairs in the underlying D
     hashE:    [ <17>, [ <>, <>, <>, <>, <>, <>, [ <35>, 'coin' ], <>, <>, <>, <>, <>, <>, <>, <>, <>, 'puppy' ] ]
 ```
 
-When one node is referenced inside another node, what is included is `H(rlp.encode(x))`, where `H(x) = keccak256(x) if len(x) >= 32 else x` and `rlp.encode` is the [RLP](/fundamentals/rlp) encoding function.
+When one node is referenced inside another node, what is included is `H(rlp.encode(x))`, where `H(x) = keccak256(x) if len(x) >= 32 else x` and `rlp.encode` is the [RLP](/developers/docs/data-structures-and-encoding/rlp) encoding function.
 
 Note that when updating a trie, one needs to store the key/value pair `(keccak256(x), x)` in a persistent lookup table _if_ the newly-created node has length >= 32. However, if the node is shorter than that, one does not need to store anything, since the function f(x) = x is reversible.
 

--- a/src/content/translations/it/developers/docs/data-structures-and-encoding/patricia-merkle-trie/index.md
+++ b/src/content/translations/it/developers/docs/data-structures-and-encoding/patricia-merkle-trie/index.md
@@ -179,7 +179,7 @@ Ora, costruiamo un trie di questo tipo con le seguenti coppie chiave/valore nel 
     hashE:    [ <17>, [ <>, <>, <>, <>, <>, <>, [ <35>, 'coin' ], <>, <>, <>, <>, <>, <>, <>, <>, <>, 'puppy' ] ]
 ```
 
-Quando in un nodo si fa riferimento a un altro nodo, viene inserito `H(rlp.encode(x))`, dove `H(x) = keccak256(x) if len(x) >= 32 else x` e `rlp.encode` è la funzione di codifica [RLP](/fundamentals/rlp).
+Quando in un nodo si fa riferimento a un altro nodo, viene inserito `H(rlp.encode(x))`, dove `H(x) = keccak256(x) if len(x) >= 32 else x` e `rlp.encode` è la funzione di codifica [RLP](/developers/docs/data-structures-and-encoding/rlp).
 
 Nota che, aggiornando un trie, si deve memorizzare la coppia chiave/valore `(keccak256(x), x)` in una tabella di ricerca persistente _se_ il nodo appena creato ha una lunghezza >= 32. Se invece il nodo è inferiore a questo valore, non è necessario memorizzare nulla, poiché la funzione f(x) = x è reversibile.
 

--- a/src/content/translations/zh/developers/docs/data-structures-and-encoding/patricia-merkle-trie/index.md
+++ b/src/content/translations/zh/developers/docs/data-structures-and-encoding/patricia-merkle-trie/index.md
@@ -179,7 +179,7 @@ sidebarDepth: 2
     hashE:    [ <17>, [ <>, <>, <>, <>, <>, <>, [ <35>, 'coin' ], <>, <>, <>, <>, <>, <>, <>, <>, <>, 'puppy' ] ]
 ```
 
-当一个节点在另一个节点中被引用时，包含的是 `H(rlp.encode(x))`，其中 `H(x) = keccak256(x) if len(x) > > = 32 else x` 和 `rlp.encode` 是[递归长度前缀](/fundamentals/rlp)编码函数。
+当一个节点在另一个节点中被引用时，包含的是 `H(rlp.encode(x))`，其中 `H(x) = keccak256(x) if len(x) > > = 32 else x` 和 `rlp.encode` 是[递归长度前缀](/developers/docs/data-structures-and-encoding/rlp)编码函数。
 
 请注意，更新前缀树时，*如果*新创建节点的长度 >= 32，则需要将键/值对 `(keccak256(x), x)` 存储在一个持久的查询表中。 然而，如果节点比这短，则不需要存储任何数据，因为函数 f(x) = x 是可逆的。
 


### PR DESCRIPTION
## Description

Change broken link from `/fundamentals/rlp` to `/developers/docs/data-structures-and-encoding/rlp`

## Related Issue

Fix #7944 
