### PR TITLE
Link beacon chain explainer to archive.org copy

### DIFF
--- a/src/components/BeaconChainActions.tsx
+++ b/src/components/BeaconChainActions.tsx
@@ -124,7 +124,7 @@ const BeaconChainActions: React.FC = () => {
         intl
       ),
       description: "Ethos.dev",
-      link: "https://ethos.dev/beacon-chain/",
+      link: "https://web.archive.org/web/20220719213551/https://ethos.dev/beacon-chain/",
     },
     {
       title: translateMessageId(

--- a/src/components/ShardChainsList.tsx
+++ b/src/components/ShardChainsList.tsx
@@ -45,7 +45,7 @@ const ShardChainsList: React.FC<IProps> = () => {
         "page-upgrade-article-author-ethos-dev",
         intl
       ),
-      link: "https://ethos.dev/beacon-chain/",
+      link: "https://web.archive.org/web/20220719213551/https://ethos.dev/beacon-chain/",
     },
     {
       title: translateMessageId(

--- a/src/content/community/grants/staking-community-grants/index.md
+++ b/src/content/community/grants/staking-community-grants/index.md
@@ -240,7 +240,7 @@ title="How can I learn more about Eth2?">
 - [Eth2 Overview](/eth2/) – _ethereum.org_
 - [The beacon chain](/upgrades/beacon-chain/) – _ethereum.org_
 - The Genesis of a Beacon Chain — Ben Edgington [https://hackmd.io/@benjaminion/genesis](https://hackmd.io/@benjaminion/genesis)
-- The Beacon Chain Ethereum 2.0 explainer — [https://ethos.dev/beacon-chain/](https://ethos.dev/beacon-chain/)
+- The Beacon Chain Ethereum 2.0 explainer — [https://ethos.dev/beacon-chain/](https://web.archive.org/web/20220719213551/https://ethos.dev/beacon-chain/)
 - [The State of Eth2](https://blog.ethereum.org/2020/06/02/the-state-of-eth2-june-2020/) _– Danny Ryan_
 - ['Intro to Eth2 & Staking for Beginners'](https://www.youtube.com/watch?v=tpkpW031RCI) - Superphiz
 - [https://old.reddit.com/r/ethstaker/wiki/studymaster](https://old.reddit.com/r/ethstaker/wiki/studymaster)

--- a/src/content/developers/docs/consensus-mechanisms/pos/index.md
+++ b/src/content/developers/docs/consensus-mechanisms/pos/index.md
@@ -64,7 +64,7 @@ Overall, proof-of-stake, as it is implemented on Ethereum, has been demonstrated
 - [Proof of Stake FAQ](https://vitalik.ca/general/2017/12/31/pos_faq.html) _Vitalik Buterin_
 - [What is Proof of Stake](https://consensys.net/blog/blockchain-explained/what-is-proof-of-stake/) _ConsenSys_
 - [What Proof of Stake Is And Why It Matters](https://bitcoinmagazine.com/culture/what-proof-of-stake-is-and-why-it-matters-1377531463) _Vitalik Buterin_
-- [The Beacon Chain Ethereum 2.0 explainer you need to read first](https://ethos.dev/beacon-chain/) _Ethos.dev_
+- [The Beacon Chain Ethereum 2.0 explainer you need to read first](https://web.archive.org/web/20220719213551/https://ethos.dev/beacon-chain/) _Ethos.dev_
 - [Why Proof of Stake (Nov 2020)](https://vitalik.ca/general/2020/11/06/pos2020.html) _Vitalik Buterin_
 - [Proof of Stake: How I Learned to Love Weak Subjectivity](https://blog.ethereum.org/2014/11/25/proof-stake-learned-love-weak-subjectivity/) _Vitalik Buterin_
 - [Proof-of-stake Ethereum attack and defense](https://mirror.xyz/jmcook.eth/YqHargbVWVNRQqQpVpzrqEQ8IqwNUJDIpwRP7SS5FXs)


### PR DESCRIPTION
Use Internet Archive copy for the moment