### PR TITLE
Minor updates for nodes and clients page

### DIFF
--- a/src/content/developers/docs/nodes-and-clients/index.md
+++ b/src/content/developers/docs/nodes-and-clients/index.md
@@ -215,6 +215,10 @@ Implemented by Trinity. Works like fast sync but also downloads the data needed 
 - Syncs state first and enables you to query RPC in a few minutes.
 - Still in development and not fully reliable, background sync is slowed down and RPC responses might fail.
 
+Learn more in [Nimbus docs](https://nimbus.guide/)
+
+### Prysm (#prysm)
+
 Prysm is a full-featured, open source consensus client written in Go under the GPL-3.0 license. It features an optional webapp UI and prioritizes user experience, documentation, and configurability for both stake-at-home and institutional users.
 
 Visit [Prysm docs](https://docs.prylabs.network/docs/getting-started/) to learn more.

--- a/src/content/developers/docs/nodes-and-clients/index.md
+++ b/src/content/developers/docs/nodes-and-clients/index.md
@@ -217,7 +217,7 @@ Implemented by Trinity. Works like fast sync but also downloads the data needed 
 
 Learn more in [Nimbus docs](https://nimbus.guide/)
 
-### Prysm (#prysm)
+### Prysm {#prysm}
 
 Prysm is a full-featured, open source consensus client written in Go under the GPL-3.0 license. It features an optional webapp UI and prioritizes user experience, documentation, and configurability for both stake-at-home and institutional users.
 


### PR DESCRIPTION
Title was missing for Prysm section in consensus nodes. 
I've also added a link for Nimbus documentation.
