### PR TITLE
Add Swedish mapping to crowdin-import script

### DIFF
--- a/src/scripts/crowdin-import.ts
+++ b/src/scripts/crowdin-import.ts
@@ -136,6 +136,7 @@ const repoToCrowdinCode: { [key: string]: string } = {
   pt: "pt-PT",
   ml: "ml-IN",
   sr: "sr-CS",
+  se: "sv-SE",
 }
 /**
  * Names for each bucket in order, zero indexed.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The crowdin-import script was not working for Swedish because we didn't have the Crowdin lang-code (`sv-SE`) mapped to the one we use (`se`). This PR fixes that.