### PR TITLE
Add missing header ID on zk page

### DIFF
--- a/src/content/zero-knowledge-proofs.md
+++ b/src/content/zero-knowledge-proofs.md
@@ -5,7 +5,7 @@ lang: en
 sidebar: true
 ---
 
-## What are zero-knowledge proofs?
+## What are zero-knowledge proofs? {#what-are-zk-proofs}
 
 A zero-knowledge proof is a way of proving the validity of a statement without revealing the statement itself. The ‘prover’ is the party trying to prove a claim, while the ‘verifier’ is responsible for validating the claim.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a missing header ID on zk page, which was throwing a warning during builds

<img width="831" alt="Screenshot 2022-09-23 at 13 10 25" src="https://user-images.githubusercontent.com/62268199/191957163-2b2a91b6-3648-4528-a218-cc640ec1e67d.png">


