### PR TITLE
refactor(code-modal): use chakra modal with custom variant

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -205,6 +205,7 @@ const config: GatsbyConfig = {
       options: {
         resetCSS: true,
         isUsingColorMode: true,
+        portalZIndex: 1001,
       },
     },
     // Source assets

--- a/src/@chakra-ui/gatsby-plugin/components/Modal.ts
+++ b/src/@chakra-ui/gatsby-plugin/components/Modal.ts
@@ -23,9 +23,8 @@ export const Modal: ComponentStyleConfig = {
         borderBottom: "1px solid",
         textTransform: "uppercase",
         fontWeight: "normal",
-        fontSize: "1rem",
-        fontFamily:
-          'SFMono-Regular, Consolas, "Roboto Mono", "Droid Sans Mono", "Liberation Mono", Menlo, Courier, monospace',
+        fontSize: "md",
+        fontFamily: "monospace",
       },
       closeButton: {
         padding: 0,
@@ -33,11 +32,11 @@ export const Modal: ComponentStyleConfig = {
         height: "24px",
         borderRadius: 0,
         color: "rgb(178, 178, 178)",
-        fontSize: "0.875rem",
+        fontSize: "sm",
         margin: 0,
-        top: "1rem",
-        right: "1rem",
-        bottom: "1rem",
+        top: 4,
+        right: 4,
+        bottom: 4,
       },
       body: {
         padding: 0,

--- a/src/@chakra-ui/gatsby-plugin/components/Modal.ts
+++ b/src/@chakra-ui/gatsby-plugin/components/Modal.ts
@@ -1,0 +1,47 @@
+import { StyleFunctionProps } from "@chakra-ui/react"
+import type { ComponentStyleConfig } from "@chakra-ui/theme"
+
+export const Modal: ComponentStyleConfig = {
+  variants: {
+    code: (props: StyleFunctionProps) => ({
+      overlay: {
+        bg: "rgba(0, 0, 0, 0.7)",
+      },
+      dialog: {
+        maxW: "100vw",
+        marginTop: "auto",
+        marginBottom: 0,
+        maxHeight: "50%",
+        borderRadius: 0,
+      },
+      header: {
+        bg:
+          props.colorMode === "dark" ? "rgb(25, 25, 25)" : "rgb(247, 247, 247)",
+        borderColor:
+          props.colorMode == "dark" ? "rgb(242, 242, 242)" : "rgb(51, 51, 51)",
+        borderTop: "1px solid",
+        borderBottom: "1px solid",
+        textTransform: "uppercase",
+        fontWeight: "normal",
+        fontSize: "1rem",
+        fontFamily:
+          'SFMono-Regular, Consolas, "Roboto Mono", "Droid Sans Mono", "Liberation Mono", Menlo, Courier, monospace',
+      },
+      closeButton: {
+        padding: 0,
+        width: "24px",
+        height: "24px",
+        borderRadius: 0,
+        color: "rgb(178, 178, 178)",
+        fontSize: "0.875rem",
+        margin: 0,
+        top: "1rem",
+        right: "1rem",
+        bottom: "1rem",
+      },
+      body: {
+        padding: 0,
+      },
+    }),
+  },
+}

--- a/src/@chakra-ui/gatsby-plugin/components/index.ts
+++ b/src/@chakra-ui/gatsby-plugin/components/index.ts
@@ -1,3 +1,4 @@
 export * from "./Link"
 export * from "./Button"
 export * from "./Tag"
+export * from "./Modal"

--- a/src/@chakra-ui/gatsby-plugin/theme.ts
+++ b/src/@chakra-ui/gatsby-plugin/theme.ts
@@ -35,6 +35,8 @@ const theme: ThemeOverride = {
     heading:
       "system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica, Arial, sans-serif",
     body: "system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica, Arial, sans-serif",
+    monospace:
+      "SFMono-Regular, Consolas, 'Roboto Mono', 'Droid Sans Mono', 'Liberation Mono', Menlo, Courier, monospace",
   },
   styles,
   ...foundations,

--- a/src/components/CodeModal.tsx
+++ b/src/components/CodeModal.tsx
@@ -1,90 +1,17 @@
-import React, { useRef } from "react"
-import styled from "@emotion/styled"
-import { motion } from "framer-motion"
+import React from "react"
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalCloseButton,
+} from "@chakra-ui/react"
 
-import Icon from "./Icon"
-import { useOnClickOutside } from "../hooks/useOnClickOutside"
 import { useKeyPress } from "../hooks/useKeyPress"
-
-const StyledOverlay = styled(motion.div)`
-  position: fixed;
-  background: rgba(0, 0, 0, 0.7);
-  will-change: opacity;
-  top: 0;
-  bottom: 0;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 100%;
-`
-
-const ModalContainer = styled.div`
-  top: 0px;
-  left: 0px;
-  right: 0px;
-  position: fixed;
-  z-index: 1002;
-  cursor: pointer;
-  width: 100%;
-  height: 100%;
-  border-top: 1px solid ${(props) => props.theme.colors.text};
-`
-
-const StyledModal = styled.div`
-  position: relative;
-  height: auto;
-  cursor: auto;
-  max-height: 100%;
-  max-width: 600px;
-  background: ${(props) => props.theme.colors.codeBackground};
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  box-shadow: rgba(0, 0, 0, 0.16) 0px 2px 4px 0px;
-  width: 100%;
-`
-
-const ModalContent = styled.div`
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-`
-
-const ModalClose = styled.div`
-  position: absolute;
-  top: 0;
-  right: 0;
-  width: 100%;
-  margin-top: -1px;
-  border-top: 1px solid ${(props) => props.theme.colors.text};
-  border-bottom: 1px solid ${(props) => props.theme.colors.text};
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  background: ${(props) => props.theme.colors.ednBackground};
-`
-
-const Title = styled.div`
-  margin-left: 1.5rem;
-  text-transform: uppercase;
-  font-family: ${(props) => props.theme.fonts.monospace};
-`
-
-const ModalCloseIcon = styled(Icon)`
-  cursor: pointer;
-  margin: 1rem;
-`
-
-const Overlay = ({ isActive }) => (
-  <StyledOverlay
-    initial={false}
-    animate={{ opacity: isActive ? 1 : 0, zIndex: isActive ? 1001 : -1 }}
-    transition={{ duration: 0.2 }}
-  />
-)
 
 export interface IProps {
   children?: React.ReactNode
-  className?: string
   isOpen: boolean
   setIsOpen: (isOpen: boolean) => void
   title: string
@@ -92,34 +19,28 @@ export interface IProps {
 
 const CodeModal: React.FC<IProps> = ({
   children,
-  className,
   isOpen,
   setIsOpen,
   title,
 }) => {
-  const ref = useRef<HTMLInputElement>(null)
-
-  // Close modal on outside clicks & `Escape` keypress
-  useOnClickOutside(ref, () => setIsOpen(false))
   useKeyPress(`Escape`, () => setIsOpen(false))
 
   return (
-    <div className={className}>
-      <Overlay isActive={isOpen} />
-      {isOpen && (
-        <ModalContainer className="modal-component-container">
-          <StyledModal className="modal-component" ref={ref}>
-            <ModalContent className="modal-component-content">
-              {children}
-            </ModalContent>
-            <ModalClose onClick={() => setIsOpen(false)}>
-              <Title>{title}</Title>
-              <ModalCloseIcon name="close" />
-            </ModalClose>
-          </StyledModal>
-        </ModalContainer>
-      )}
-    </div>
+    <Modal
+      isOpen={isOpen}
+      blockScrollOnMount={false}
+      scrollBehavior="inside"
+      variant="code"
+      onClose={() => setIsOpen(false)}
+    >
+      <ModalOverlay zIndex={1001} />
+      <ModalContent>
+        <ModalHeader>{title}</ModalHeader>
+        <ModalCloseButton />
+
+        <ModalBody>{children}</ModalBody>
+      </ModalContent>
+    </Modal>
   )
 }
 

--- a/src/components/CodeModal.tsx
+++ b/src/components/CodeModal.tsx
@@ -28,12 +28,11 @@ const CodeModal: React.FC<IProps> = ({
   return (
     <Modal
       isOpen={isOpen}
-      blockScrollOnMount={false}
       scrollBehavior="inside"
       variant="code"
       onClose={() => setIsOpen(false)}
     >
-      <ModalOverlay zIndex={1001} />
+      <ModalOverlay />
       <ModalContent>
         <ModalHeader>{title}</ModalHeader>
         <ModalCloseButton />

--- a/src/components/CodeModal.tsx
+++ b/src/components/CodeModal.tsx
@@ -7,9 +7,6 @@ import {
   ModalBody,
   ModalCloseButton,
 } from "@chakra-ui/react"
-
-import { useKeyPress } from "../hooks/useKeyPress"
-
 export interface IProps {
   children?: React.ReactNode
   isOpen: boolean
@@ -23,8 +20,6 @@ const CodeModal: React.FC<IProps> = ({
   setIsOpen,
   title,
 }) => {
-  useKeyPress(`Escape`, () => setIsOpen(false))
-
   return (
     <Modal
       isOpen={isOpen}


### PR DESCRIPTION
## Description

Migrates `CodeModal` component from `emotion` to `chakra-ui`.

> To do this change, I had to use the `modal` component from chakra-ui and adjust the zIndex of portals to `1001`  (by default, it's `40`) because the modal overlay was behind the header of the website (`z-index: 1000`).
> 
> The result's pretty close to the original, but it has some little differences (really minimal) to preserve most of the default values of chakra.

## Related Issue

https://github.com/ethereum/ethereum-org-website/issues/6374
