### PR TITLE
Correct hreflang for Filipino (ph -> fil)

### DIFF
--- a/i18n/config.json
+++ b/i18n/config.json
@@ -249,7 +249,7 @@
   },
   {
     "code": "ph",
-    "hrefLang": "ph",
+    "hrefLang": "fil",
     "name": "Filipino",
     "localName": "Filipino",
     "langDir": "ltr",


### PR DESCRIPTION
Fixes #8016

<!--- Provide a general summary of your changes in the Title above -->

## Description

Wrong hreflang code as per Google's web.dev

Correct code is fil as per [List of ISO 639-1 codes](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)

<!--- Describe your changes in detail -->

## Related Issue

#8016 

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: #8016 -->
