### PR TITLE
Fix broken link on the get-eth page

### DIFF
--- a/src/pages/get-eth.tsx
+++ b/src/pages/get-eth.tsx
@@ -229,7 +229,7 @@ const GetETHPage = ({ data }: PageProps<Queries.GetEthPageQuery>) => {
         "page-get-eth-article-keeping-crypto-safe",
         intl
       ),
-      link: "https://medium.com/the-coinbase-blog/the-keys-to-keeping-your-crypto-safe-96d497cce6cf",
+      link: "https://web.archive.org/web/20190716160333/https://blog.coinbase.com/the-keys-to-keeping-your-crypto-safe-96d497cce6cf?gi=548619266f28",
       description: "Coinbase",
     },
     {

--- a/src/pages/get-eth.tsx
+++ b/src/pages/get-eth.tsx
@@ -229,7 +229,7 @@ const GetETHPage = ({ data }: PageProps<Queries.GetEthPageQuery>) => {
         "page-get-eth-article-keeping-crypto-safe",
         intl
       ),
-      link: "https://blog.coinbase.com/the-keys-to-keeping-your-crypto-safe-96d497cce6cf",
+      link: "https://medium.com/the-coinbase-blog/the-keys-to-keeping-your-crypto-safe-96d497cce6cf",
       description: "Coinbase",
     },
     {


### PR DESCRIPTION
on page https://ethereum.org/en/get-eth/ under Community posts on security there is a broken link to a coinbase.com article titled 'the keys to keeping your crypto safe':

https://blog.coinbase.com/the-keys-to-keeping-your-crypto-safe-96d497cce6cf

Blog.coinbase.com subdomain has been redirected to coinbase.com/blog subdirectory. However this post is no longer available and couldn't be found on waybackmachine. I found the medium post for Philip Martin and linked this instead.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed broken coinbase.com link with the authors medium.com article.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
