### PR TITLE
Fix ordering of items in developer docs (gas) 

### DIFF
--- a/src/content/developers/docs/gas/index.md
+++ b/src/content/developers/docs/gas/index.md
@@ -32,10 +32,11 @@ In the transaction, the gas limit is 21,000 units, and the gas price is 200 gwei
 Total fee would have been: `Gas units (limit) * Gas price per unit`
 i.e `21,000 * 200 = 4,200,000 gwei` or 0.0042 ETH
 
-Let's say Jordan has to pay Taylor 1 ETH. In the transaction, the gas limit is 21,000 units and the base fee is 10 gwei. Jordan includes a tip of 2 gwei.
-
 ## After the London upgrade {#post-london}
 
+Let's say Jordan has to pay Taylor 1 ETH. In the transaction, the gas limit is 21,000 units and the base fee is 10 gwei. Jordan includes a tip of 2 gwei.
+
+Total fee would have been: `Gas units (limit) * (Base fee + Tip)`
 `21,000 * (10 + 2) = 252,000 gwei` or 0.000252 ETH.
 
 When Jordan sends the money, 1.000252 ETH will be deducted from Jordan's account.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changed the ordering of this [line](https://github.com/ethereum/ethereum-org-website/blob/dev/src/content/developers/docs/gas/index.md#after-the-london-upgrade-post-london)
Currently the example is split in 2 parts and the title is breaking that example. i.e The position of title is not appropriate.
With this change the example would make sense with the context and with the title.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first --> Documentation changes
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: --> #8034 
