### PR TITLE
Update bug_report.yaml to use template text instead of placeholder

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -15,7 +15,7 @@ body:
     attributes:
       label: To reproduce
       description: Steps to reproduce the behavior
-      placeholder: |
+      value: |
         1. Go to '...'
         2. Click on '...'
         3. Scroll down to '...'


### PR DESCRIPTION
Replaced placeholder text with template text in bug issue template

## Description

Currently, the bug issue template uses placeholder text to describe a bug. Now, it has been updated to template text that can be edited.

<!--- Describe your changes in detail -->

## Related Issue

(Replace placeholder text with template text) https://github.com/ethereum/ethereum-org-website/issues/8029
