### PR TITLE
Update development networks content

### DIFF
--- a/src/content/developers/docs/development-networks/index.md
+++ b/src/content/developers/docs/development-networks/index.md
@@ -57,7 +57,7 @@ Some consensus clients have built-in tools for spinning up local beacon chains f
 
 ### Public Ethereum Test-chains {#public-beacon-testchains}
 
-There are also two maintained public test implementations of Ethereum—Goerli and Sepolia. The recommended testnet with long-term support is Goerli, which anyone is free to validate on. Sepolia is a newer, smaller chain also expected to be maintained for the foreseeable future, with a permissioned validator set (meaning there is no general access to new validators on this testnet). The Ropsten chain is expected to be deprecated in Q4 2022, and the Rinkeby chain is expected to be deprecated in Q2/Q3 2023.
+There are also two maintained public test implementations of Ethereum: Goerli and Sepolia. The recommended testnet with long-term support is Goerli, which anyone is free to validate on. Sepolia is a newer, smaller chain also expected to be maintained for the foreseeable future, with a permissioned validator set (meaning there is no general access to new validators on this testnet). The Ropsten chain is expected to be deprecated in Q4 2022, and the Rinkeby chain is expected to be deprecated in Q2/Q3 2023.
 
 - [Goerli Staking Launchpad](https://goerli.launchpad.ethereum.org/)
 - [Ropsten, Rinkeby & Kiln Deprecation Announcement](https://blog.ethereum.org/2022/06/21/testnet-deprecation)

--- a/src/content/developers/docs/development-networks/index.md
+++ b/src/content/developers/docs/development-networks/index.md
@@ -2,7 +2,6 @@
 title: Development Networks
 description: An overview of development networks and the tools available to help build Ethereum applications.
 lang: en
-preMergeBanner: true
 ---
 
 When building an Ethereum application with smart contracts, you'll want to run it on a local network to see how it works before deploying it.
@@ -22,7 +21,7 @@ Development networks are essentially Ethereum clients (implementations of Ethere
 You _could_ [run a node](/developers/docs/nodes-and-clients/#running-your-own-node) but since development networks are purpose-built for development, they often come packed with convenient features like:
 
 - Deterministically seeding your local blockchain with data (e.g. accounts with ETH balances)
-- Instantly mining blocks with each transaction it receives, in order and with no delay
+- Instantly producing blocks with each transaction it receives, in order and with no delay
 - Enhanced debugging and logging functionality
 
 ## Available tools {#available-projects}
@@ -50,7 +49,7 @@ Hardhat Network comes built-in with Hardhat, an Ethereum development environment
 
 ### Local Beacon Chains {#local-beacon-chains}
 
-Some consensus clients have built-in tools for spinning up local Beacon chains for testing purposes. Instructions for Lighthouse, Nimbus and Lodestar are available:
+Some consensus clients have built-in tools for spinning up local beacon chains for testing purposes. Instructions for Lighthouse, Nimbus and Lodestar are available:
 
 - [Local testnet using Lodestar](https://chainsafe.github.io/lodestar/usage/local/)
 - [Local testnet using Lighthouse](https://lighthouse-book.sigmaprime.io/setup.html#local-testnets)
@@ -58,10 +57,10 @@ Some consensus clients have built-in tools for spinning up local Beacon chains f
 
 ### Public Ethereum Test-chains {#public-beacon-testchains}
 
-There are also three current public test implementations of Ethereum. The recommended testnet with long-term support is Goerli. Sepolia is also expected to be maintained for the foreseeable future, but the validator set is permissioned meaning there is no general access to new validators on this testnet. The Ropsten chain is expected to be deprecated.
+There are also two maintained public test implementations of Ethereum—Goerli and Sepolia. The recommended testnet with long-term support is Goerli, which anyone is free to validate on. Sepolia is a newer, smaller chain also expected to be maintained for the foreseeable future, with a permissioned validator set (meaning there is no general access to new validators on this testnet). The Ropsten chain is expected to be deprecated in Q4 2022, and the Rinkeby chain is expected to be deprecated in Q2/Q3 2023.
 
 - [Goerli Staking Launchpad](https://goerli.launchpad.ethereum.org/)
-- [Ropsten Staking Launchpad](https://ropsten.launchpad.ethereum.org/)
+- [Ropsten, Rinkeby & Kiln Deprecation Announcement](https://blog.ethereum.org/2022/06/21/testnet-deprecation)
 
 ## Further reading {#further-reading}
 


### PR DESCRIPTION
## Description
Updates content of "development networks" dev docs page to remove Ropsten launchpad link, update "miner" terminology, and link out to the blog post about testnet deprecation.

## Related Issue
#7075