### PR TITLE
Add DeFiRate.com as a resource for DeFi information

### DIFF
--- a/src/content/defi/index.md
+++ b/src/content/defi/index.md
@@ -179,7 +179,6 @@ To be able to do the above example in the traditional finance world, you'd need 
 You can earn interest on your crypto by lending it and see your funds grow in real time. Right now interest rates are much higher than what you're likely to get at your local bank (if you're lucky enough to be able to access one). Here's an example:
 
 - You want to lend your 100 Dai, a [stablecoin](/stablecoins/).
-- You choose to lend with Aave, after checking [live crypto lending rates](https://defirate.com/lend) across DeFi platforms.
 - You receive 100 Aave Dai (aDai) which is a token that represents your loaned Dai.
 - Your aDai will increase based on the interest rates and you can see your balance growing in your wallet. Dependent on the APR, your wallet balance will read something like 100.1234 after a few days or even hours!
 - You can withdraw an amount of regular Dai that's equal to your aDai balance at any time.
@@ -333,10 +332,10 @@ DeFi is an open-source movement. The DeFi protocols and applications are all ope
 
 ### DeFi data {#defi-data}
 
-- [DeFi Rate](https://defirate.com/)
 - [DeFi Pulse](https://defipulse.com/)
 - [DeFi Prime](https://defiprime.com/)
 - [DeFi Llama](https://defillama.com/)
+- [DeFi Rate](https://defirate.com/)
 
 ### DeFi articles {#defi-articles}
 

--- a/src/content/defi/index.md
+++ b/src/content/defi/index.md
@@ -178,7 +178,7 @@ To be able to do the above example in the traditional finance world, you'd need 
 
 You can earn interest on your crypto by lending it and see your funds grow in real time. Right now interest rates are much higher than what you're likely to get at your local bank (if you're lucky enough to be able to access one). Here's an example:
 
-- You want to lend your 100 Dai, a [stablecoin](/stablecoins/).
+- You lend your 100 Dai, a [stablecoin](/stablecoins/), to a product like Aave.
 - You receive 100 Aave Dai (aDai) which is a token that represents your loaned Dai.
 - Your aDai will increase based on the interest rates and you can see your balance growing in your wallet. Dependent on the APR, your wallet balance will read something like 100.1234 after a few days or even hours!
 - You can withdraw an amount of regular Dai that's equal to your aDai balance at any time.

--- a/src/content/defi/index.md
+++ b/src/content/defi/index.md
@@ -178,7 +178,8 @@ To be able to do the above example in the traditional finance world, you'd need 
 
 You can earn interest on your crypto by lending it and see your funds grow in real time. Right now interest rates are much higher than what you're likely to get at your local bank (if you're lucky enough to be able to access one). Here's an example:
 
-- You lend your 100 Dai, a [stablecoin](/stablecoins/), to a product like Aave.
+- You want to lend your 100 Dai, a [stablecoin](/stablecoins/).
+- You choose to lend with Aave, after checking [live crypto lending rates](https://defirate.com/lend) across DeFi platforms.
 - You receive 100 Aave Dai (aDai) which is a token that represents your loaned Dai.
 - Your aDai will increase based on the interest rates and you can see your balance growing in your wallet. Dependent on the APR, your wallet balance will read something like 100.1234 after a few days or even hours!
 - You can withdraw an amount of regular Dai that's equal to your aDai balance at any time.
@@ -332,6 +333,7 @@ DeFi is an open-source movement. The DeFi protocols and applications are all ope
 
 ### DeFi data {#defi-data}
 
+- [DeFi Rate](https://defirate.com/)
 - [DeFi Pulse](https://defipulse.com/)
 - [DeFi Prime](https://defiprime.com/)
 - [DeFi Llama](https://defillama.com/)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds https://defirate.com as a source of DeFi information, particularly lending data.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #8065
