### PR TITLE
✏️ Fix typo in scaling/validium

### DIFF
--- a/src/content/developers/docs/scaling/validium/index.md
+++ b/src/content/developers/docs/scaling/validium/index.md
@@ -67,7 +67,7 @@ As an anti-censorship mechanism, the validium protocol allows users to withdraw 
 
 ### Batch submission {#batch-submission}
 
-After executing a batch of transactions, the operator submits the associated validity proof to the Lverifier contract and proposes a new state root to the main contract. If the proof is valid, the main contract updates the validium's state and finalizes the results of transactions in the batch.
+After executing a batch of transactions, the operator submits the associated validity proof to the verifier contract and proposes a new state root to the main contract. If the proof is valid, the main contract updates the validium's state and finalizes the results of transactions in the batch.
 
 Unlike a ZK-rollup, block producers on a validium are not required to publish transaction data for transaction batches (only block headers). This makes validium a purely off-chain scaling protocol, as opposed to "hybrid" scaling protocols (i.e., [layer 2](/layer-2/)) that publish state data on the main Ethereum chain as `calldata`.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix a typo in the `Batch submission` part.
<!--- Describe your changes in detail -->

Change the word `Lverifier` to `verifier` in the following sentence:

`
After executing a batch of transactions, the operator submits the associated validity proof to the Lverifier contract and proposes a new state root to the main contract.
`

## Related Issue

Not related to an issue.

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
