### PR TITLE
Fixing broken link and language on /backend page

### DIFF
--- a/src/content/developers/docs/apis/backend/index.md
+++ b/src/content/developers/docs/apis/backend/index.md
@@ -6,7 +6,7 @@ lang: en
 
 In order for a software application to interact with the Ethereum blockchain (i.e. read blockchain data and/or send transactions to the network), it must connect to an Ethereum node.
 
-For this purpose, every Ethereum client implements the [JSON-RPC](/developers/docs/apis/json-rpc/) specification, so there are a uniform set of [endpoints](/developers/docs/apis/json-rpc/#json-rpc-methods) that applications can rely on.
+For this purpose, every Ethereum client implements the [JSON-RPC](/developers/docs/apis/json-rpc/) specification, so there are a uniform set of [methods](/developers/docs/apis/json-rpc/#json-rpc-methods) that applications can rely on.
 
 If you want to use a specific programming language to connect with an Ethereum node, there are many convenience libraries within the ecosystem that make this much easier. With these libraries, developers can write intuitive, one-line methods to initialize JSON-RPC requests (under the hood) that interact with Ethereum.
 

--- a/src/content/developers/docs/apis/javascript/index.md
+++ b/src/content/developers/docs/apis/javascript/index.md
@@ -6,7 +6,7 @@ lang: en
 
 In order for a web app to interact with the Ethereum blockchain (i.e. read blockchain data and/or send transactions to the network), it must connect to an Ethereum node.
 
-For this purpose, every Ethereum client implements the [JSON-RPC](/developers/docs/apis/json-rpc/) specification, so there are a uniform set of [endpoints](/developers/docs/apis/json-rpc/endpoints/) that applications can rely on.
+For this purpose, every Ethereum client implements the [JSON-RPC](/developers/docs/apis/json-rpc/) specification, so there are a uniform set of [methods](/developers/docs/apis/json-rpc/#json-rpc-methods) that applications can rely on.
 
 If you want to use JavaScript to connect with an Ethereum node, it's possible to use vanilla JavaScript but several convenience libraries exist within the ecosystem that make this much easier. With these libraries, developers can write intuitive, one-line methods to initialize JSON RPC requests (under the hood) that interact with Ethereum.
 


### PR DESCRIPTION
Fixed the broken link to the JSON-RPC page in the backend page.



## Description
The link on the public website is broken. See : https://ethereum.org/en/developers/docs/apis/backend/ 
I also renamed endpoints to methods to align the language.
The GRPC endpoint is litteraly the URI where you can send you JSON-RPC requests. That previous language was confusing.
## Related Issue

This is a suggested addition tracked by Issue 
https://github.com/ethereum/ethereum-org-website/issues/8095
<!--- Please link to the issue here: https://github.com/ethereum/ethereum-org-website/issues/8095
-->
