### PR TITLE
Update backend doc with one addition node provider

### DIFF
--- a/src/content/developers/docs/apis/backend/index.md
+++ b/src/content/developers/docs/apis/backend/index.md
@@ -42,6 +42,11 @@ These libraries abstract away much of the complexity of interacting directly wit
 
 - [cloudflare-eth.com](https://cloudflare-eth.com)
 
+**Coinbase Cloud Node -** **_Blockchain Infrastructure API._**
+
+- [Node](https://www.coinbase.com/cloud/products/node)
+- [Documentation](https://docs.cloud.coinbase.com/node/reference/welcome-to-node)
+
 **DataHub by Figment -** **_Web3 API services with Ethereum Mainnet and testnets._**
 
 - [DataHub](https://www.figment.io/datahub)

--- a/src/content/developers/docs/apis/backend/index.md
+++ b/src/content/developers/docs/apis/backend/index.md
@@ -44,7 +44,7 @@ These libraries abstract away much of the complexity of interacting directly wit
 
 **Coinbase Cloud Node -** **_Blockchain Infrastructure API._**
 
-- [Node](https://www.coinbase.com/cloud/products/node)
+- [Coinbase Cloud Node](https://www.coinbase.com/cloud/products/node)
 - [Documentation](https://docs.cloud.coinbase.com/node/reference/welcome-to-node)
 
 **DataHub by Figment -** **_Web3 API services with Ethereum Mainnet and testnets._**


### PR DESCRIPTION
Added Coinbase Cloud as a node provider.

## Description

Coinbase Cloud now has a public offering as a Node Provider for Ethereum.
https://www.coinbase.com/blog/coinbase-cloud-launches-platform-for-web3-developers
This update is listing Coinbase Node as an alternative in the backend page : https://ethereum.org/en/developers/docs/apis/backend/

## Related Issue

This is a suggested addition tracked by Issue 
https://github.com/ethereum/ethereum-org-website/issues/8098
