### PR TITLE
Fix markdown link display

### DIFF
--- a/src/content/developers/docs/consensus-mechanisms/pow/mining-algorithms/index.md
+++ b/src/content/developers/docs/consensus-mechanisms/pow/mining-algorithms/index.md
@@ -5,12 +5,9 @@ lang: en
 ---
 
 <InfoBanner emoji=":wave:">
-
-Proof-of-work is no longer underlying Ethereum's consensus mechanism, meaning mining has been switched off. Instead, Ethereum is secured by validators who stake ETH. You can start staking your ETH today. Read more on [The Merge](/upgrades/merge/), [proof-of-stake](/developers/docs/consensus-mechanisms/pos/), and [staking](/staking/). This page is for historical interest only.
-
+    Proof-of-work is no longer underlying Ethereum's consensus mechanism, meaning mining has been switched off. Instead, Ethereum is secured by validators who stake ETH. You can start staking your ETH today. Read more on [The Merge](/upgrades/merge/), [proof-of-stake](/developers/docs/consensus-mechanisms/pos/), and [staking](/staking/). This page is for historical interest only.
 </InfoBanner>
- 
- 
+
 Ethereum mining used an algorithm known as Ethash. The fundamental idea of the algorithm is that a miner tries to find a nonce input using brute force computation so that the resulting hash is smaller than a threshold determined by the calculated difficulty. This difficulty level can be dynamically adjusted, allowing block production to happen at a regular interval.
 
 ## Prerequisites {#prerequisites}

--- a/src/content/developers/docs/consensus-mechanisms/pow/mining/index.md
+++ b/src/content/developers/docs/consensus-mechanisms/pow/mining/index.md
@@ -5,7 +5,7 @@ lang: en
 ---
 
 <InfoBanner emoji=":wave:">
-   Proof-of-work is no longer underlying Ethereum's consensus mechanism, meaning mining has been switched off. Instead, Ethereum is secured by validators who stake ETH. You can start staking your ETH today. Read more on [The Merge](/upgrades/merge/), [proof-of-stake](/developers/docs/consensus-mechanisms/pos/), and [staking](/staking/). This page is for historical interest.
+    Proof-of-work is no longer underlying Ethereum's consensus mechanism, meaning mining has been switched off. Instead, Ethereum is secured by validators who stake ETH. You can start staking your ETH today. Read more on [The Merge](/upgrades/merge/), [proof-of-stake](/developers/docs/consensus-mechanisms/pos/), and [staking](/staking/). This page is for historical interest only.
 </InfoBanner>
 
 ## Prerequisites {#prerequisites}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
fix: #7905 

- Fix link
- Add spacing above the callout
- The wording is also aligned

### before
<img width="716" alt="スクリーンショット 2022-10-02 1 02 36" src="https://user-images.githubusercontent.com/701242/193418038-ae8c318a-ca35-4a91-a29d-5ad212c3ff9f.png">

<img width="702" alt="スクリーンショット 2022-10-02 1 02 44" src="https://user-images.githubusercontent.com/701242/193418033-dfe067e1-c444-45b6-824e-2f19bdaa2aa7.png">

### after

<img width="741" alt="スクリーンショット 2022-10-02 1 03 09" src="https://user-images.githubusercontent.com/701242/193418025-8b51417d-041a-4cce-a638-8f3f81354abd.png">

<img width="710" alt="スクリーンショット 2022-10-02 1 02 06" src="https://user-images.githubusercontent.com/701242/193418044-0c173e1a-40c2-4055-beaf-a7a2f691a04d.png">


## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
