### PR TITLE
Ensure consistent spelling of 'ZK-rollup'

### DIFF
--- a/src/content/contributing/style-guide/index.md
+++ b/src/content/contributing/style-guide/index.md
@@ -95,6 +95,7 @@ When introducing an unfamiliar acronym, spell out the full term, and put the acr
 **For example:**
 
 "Ethereum, like Bitcoin, currently uses a consensus protocol called **proof-of-work (PoW)**."
+"**Zero-knowledge rollups (ZK-rollups)** are layer 2 scaling solutions."
 
 ### Consistency {#consistency}
 

--- a/src/content/contributing/style-guide/index.md
+++ b/src/content/contributing/style-guide/index.md
@@ -95,6 +95,7 @@ When introducing an unfamiliar acronym, spell out the full term, and put the acr
 **For example:**
 
 "Ethereum, like Bitcoin, currently uses a consensus protocol called **proof-of-work (PoW)**."
+
 "**Zero-knowledge rollups (ZK-rollups)** are layer 2 scaling solutions."
 
 ### Consistency {#consistency}


### PR DESCRIPTION
Ensure consistent spelling of 'ZK-rollup'

## Description

Ensure consistent spelling of 'ZK-rollup' by adding the correct speling to the guidelines

## Related Issue
#7908
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
