### PR TITLE
migrate GitStars component to chakra-ui [Fixes #8049]

### DIFF
--- a/src/components/GitStars.tsx
+++ b/src/components/GitStars.tsx
@@ -1,52 +1,9 @@
 import React from "react"
-import styled from "@emotion/styled"
-import Emoji from "./OldEmoji"
-import Icon from "./Icon"
+import { Icon, Text, Center, Flex } from "@chakra-ui/react"
+import { FaGithub } from "react-icons/fa"
+import Emoji from "./Emoji"
 import Link from "./Link"
 
-const Container = styled(Link)`
-  float: right;
-  display: flex;
-  text-decoration: none;
-  border-radius: 4px;
-  border: 1px solid ${(props) => props.theme.colors.lightBorder};
-  color: ${(props) => props.theme.colors.text};
-  &:hover {
-    text-decoration: none;
-    box-shadow: 0 0 1px ${(props) => props.theme.colors.primary};
-  }
-  &:hover path {
-    fill: ${(props) => props.theme.colors.primary};
-  }
-  background: ${(props) => props.theme.colors.lightBorder};
-`
-
-const Pill = styled.div`
-  text-align: center;
-`
-
-const StyledIcon = styled(Icon)`
-  margin: 0.25rem;
-`
-
-const GlyphPill = styled(Pill)`
-  display: flex;
-  align-items: center;
-  width: 36px;
-  justify-content: space-between;
-  margin: 0 0.325rem;
-  path {
-    fill: ${(props) => props.theme.colors.text};
-  }
-  float: left;
-  font-size: ${(props) => props.theme.fontSizes.s};
-`
-
-const Text = styled.div`
-  padding: 0 0.325rem;
-  font-size: 0.8125rem;
-  background: ${(props) => props.theme.colors.searchBackgroundEmpty};
-`
 export interface GitHubRepo {
   stargazerCount: number
   url: string
@@ -65,21 +22,47 @@ const GitStars: React.FC<IProps> = ({ gitHubRepo, className, hideStars }) => {
   while (rgx.test(starsString)) {
     starsString = starsString.replace(rgx, "$1,$2")
   }
-  if (hideStars) {
-    return (
-      <Container className={className} to={gitHubRepo.url} hideArrow={true}>
-        <StyledIcon name="github" size="16px" />
-      </Container>
-    )
-  }
+
   return (
-    <Container className={className} to={gitHubRepo.url} hideArrow={true}>
-      <GlyphPill>
-        <Icon name="github" size="16px" />
-        <Emoji text=":star:" size={1} />
-      </GlyphPill>
-      <Text>{starsString}</Text>
-    </Container>
+    <Link className={className} to={gitHubRepo.url} hideArrow={true}>
+      <Flex
+        background="lightBorder"
+        textDecoration="none"
+        border="1px solid"
+        borderColor="lightBorder"
+        borderRadius="4px"
+        float="right"
+        color="text"
+        _hover={{
+          boxShadow: "0 0 1px",
+          path: { fill: "primary" },
+        }}
+      >
+        {hideStars ? (
+          <Icon as={FaGithub} m="4px" />
+        ) : (
+          <>
+            <Center
+              w="36px"
+              justifyContent="space-between"
+              fontSize="s"
+              mx="0.325rem"
+            >
+              <Icon as={FaGithub} />
+              <Emoji text=":star:" />
+            </Center>
+            <Text
+              fontSize="0.8125rem"
+              px="0.325rem"
+              my="0"
+              background="searchBackgroundEmpty"
+            >
+              {starsString}
+            </Text>
+          </>
+        )}
+      </Flex>
+    </Link>
   )
 }
 

--- a/src/components/GitStars.tsx
+++ b/src/components/GitStars.tsx
@@ -30,16 +30,16 @@ const GitStars: React.FC<IProps> = ({ gitHubRepo, className, hideStars }) => {
         textDecoration="none"
         border="1px solid"
         borderColor="lightBorder"
-        borderRadius="4px"
+        borderRadius="base"
         float="right"
         color="text"
         _hover={{
-          boxShadow: "0 0 1px",
+          boxShadow: "0 0 1px var(--eth-colors-primary)",
           path: { fill: "primary" },
         }}
       >
         {hideStars ? (
-          <Icon as={FaGithub} m="4px" />
+          <Icon as={FaGithub} m={1} />
         ) : (
           <>
             <Center


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Update Github icon, star Emoji, and GitStars component styling to use chakra-ui rather than emotion styling according to [chakra-migration-guide.md](https://github.com/ethereum/ethereum-org-website/blob/dev/docs/chakra-migration-guide.md).

## Preview locally

Follow docs/api-keys.md step 1 to get a personal access token to add `GATSBY_GITHUB_TOKEN_READ_ONLY` to the .env file. You need this token to query [Github's graphql api](https://api.github.com/graphql) for github star counts. Then follow overall readme instructions to run the frontend locally.

hideStars: false
http://localhost:8000/en/developers/local-environment/

hideStars: true
http://localhost:8000/en/upgrades/get-involved/

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/ethereum/ethereum-org-website/issues/8049
