### PR TITLE
Change L2Beat API

### DIFF
--- a/src/lambda/l2beat.ts
+++ b/src/lambda/l2beat.ts
@@ -4,7 +4,7 @@ import type { HandlerResponse } from "@netlify/functions"
 
 export const lambda = async (): Promise<HandlerResponse> => {
   try {
-    const response = await axios.get(`https://l2beat.com/api/tvl.json`)
+    const response = await axios.get(`https://api.l2beat.com/api/tvl`)
     if (response.status < 200 || response.status >= 300) {
       return { statusCode: response.status, body: response.statusText }
     }

--- a/src/pages/layer-2.tsx
+++ b/src/pages/layer-2.tsx
@@ -186,11 +186,15 @@ const StatDivider = styled.div`
     margin: 2rem 0;
   }
 `
-
-interface L2DataResponse {
+interface L2DataResponseItem {
   daily: {
     data: Array<[string, number, number]>
   }
+}
+interface L2DataResponse {
+  layers2s: L2DataResponseItem
+  combined: L2DataResponseItem
+  bridges: L2DataResponseItem
 }
 
 interface FeeDataResponse {
@@ -214,6 +218,8 @@ const Layer2Page = ({ data }: PageProps<Queries.Layer2PageQuery>) => {
           `${GATSBY_FUNCTIONS_PATH}/l2beat`
         )
 
+        const dailyData = l2BeatData.layers2s.daily.data
+
         // formatted TVL from L2beat API formatted
         const TVL = new Intl.NumberFormat(localeForStatsBoxNumbers, {
           style: "currency",
@@ -221,13 +227,14 @@ const Layer2Page = ({ data }: PageProps<Queries.Layer2PageQuery>) => {
           notation: "compact",
           minimumSignificantDigits: 2,
           maximumSignificantDigits: 3,
-        }).format(l2BeatData.daily.data[l2BeatData.daily.data.length - 1][1])
+        }).format(dailyData[dailyData.length - 1][1])
+
         setTVL(`${TVL}`)
         // Calculate percent change ((new value - old value) / old value) *100)
         const percentage =
-          ((l2BeatData.daily.data[l2BeatData.daily.data.length - 1][1] -
-            l2BeatData.daily.data[l2BeatData.daily.data.length - 31][1]) /
-            l2BeatData.daily.data[l2BeatData.daily.data.length - 31][1]) *
+          ((dailyData[dailyData.length - 1][1] -
+            dailyData[dailyData.length - 31][1]) /
+            dailyData[dailyData.length - 31][1]) *
           100
         setL2PercentChange(
           percentage > 0


### PR DESCRIPTION
## Description
L2Beat changed its API URL and the response structure, so I modified the URL and adapted the calculations to work with the new structure of the response. They have 4 items on the JSON root; I assumed that what we need It's the data from `layers2s` key.

## Related Issue
https://github.com/ethereum/ethereum-org-website/issues/8143