### PR TITLE
Migrate `OrderedList` to Chakra

### DIFF
--- a/src/components/OrderedList.tsx
+++ b/src/components/OrderedList.tsx
@@ -1,54 +1,65 @@
 // Libraries
 import React from "react"
-import styled from "@emotion/styled"
+import {
+  Box,
+  ListItem,
+  OrderedList as ChakraOrderedList,
+  SystemStyleObject,
+} from "@chakra-ui/react"
 
 export interface IProps {
   listData: Array<React.ReactNode>
   className?: string
 }
 
-// Styles
-const Content = styled.div`
-  margin-bottom: 1.45rem;
-
-  ol {
-    list-style: none;
-    counter-reset: li-counter;
-    padding-left: 2rem;
-    margin-bottom: 0;
-  }
-  ol li {
-    margin: 0 0 1rem 0;
-    counter-increment: li-counter;
-    position: relative;
-  }
-  ol li::before {
-    content: counter(li-counter);
-    position: absolute;
-    top: -2px; /* adjusts circle + number up and down */
-    left: -3rem;
-    width: 35px;
-    aspect-ratio: 1;
-    height: 2rem;
-    padding-top: 7px; /* adjusts number up and down */
-    line-height: 100%;
-    border-radius: 50%;
-    background: ${({ theme }) => theme.colors.grayBackground};
-    text-align: center;
-  }
-`
+/**
+ * The custom ordered list numbers in a solid circular background
+ */
+const liCustomType: SystemStyleObject = {
+  content: `counter(li-counter)`,
+  position: "absolute",
+  top: "-2px", // adjusts circle + number up and down
+  left: "-3rem",
+  width: "35px",
+  aspectRatio: "1",
+  height: "2rem",
+  pt: "7px", // adjusts number up and down,
+  lineHeight: "100%",
+  borderRadius: "50%",
+  background: "grayBackground",
+  textAlign: "center",
+}
 
 // `listData` should be a list of strings, or HTML components
 // ex: [<p>string<p>] or ['string']
 const OrderedList: React.FC<IProps> = ({ listData, className }) => {
   return (
-    <Content className={className}>
-      <ol>
+    <Box mb="1.45rem" className={className}>
+      <ChakraOrderedList
+        styleType="none"
+        pl="2rem"
+        mb="0"
+        sx={{
+          counterReset: "li-counter",
+        }}
+      >
         {listData.map((data, idx) => {
-          return <li key={idx}>{data}</li>
+          return (
+            <ListItem
+              key={idx}
+              m="0 0 1rem 0"
+              position="relative" // For the custom list types
+              sx={{
+                counterIncrement: "li-counter",
+              }}
+              _before={liCustomType}
+            >
+              {data}
+            </ListItem>
+          )
         })}
-      </ol>
-    </Content>
+      </ChakraOrderedList>
+    </Box>
   )
 }
 

--- a/src/components/OrderedList.tsx
+++ b/src/components/OrderedList.tsx
@@ -37,8 +37,9 @@ const OrderedList: React.FC<IProps> = ({ listData, className }) => {
     <Box mb="1.45rem" className={className}>
       <ChakraOrderedList
         styleType="none"
-        pl="2rem"
+        pl={8}
         mb="0"
+        ms="1.45rem"
         sx={{
           counterReset: "li-counter",
         }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This migrates the [OrderedList](https://github.com/ethereum/ethereum-org-website/blob/dev/src/components/OrderedList.tsx)

For @pettinarip: In terms of completely replacing it with just using Chakra's `OrderedList`, I believe this component could be retained. Despite it being primitive in the logic, it is used in at least two places on the site with specific styling, unless there is interest in eventually creating styling variants.

There is an alternative approach that comes to mind, but I'll hear your feedback and thoughts first. 😃 

## Related Issue

#6374
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
