### PR TITLE
Update existing glossary term #8163

### DIFF
--- a/src/content/glossary/index.md
+++ b/src/content/glossary/index.md
@@ -219,7 +219,8 @@ The economics of cryptocurrencies.
 
 ### DAG {#dag}
 
-DAG stands for Directed Acyclic Graph. It is a data structure composed of nodes and links between them. Ethereum uses a DAG in its [proof-of-work](#pow) algorithm, [Ethash](#ethash).
+DAG stands for Directed Acyclic Graph. It is a data structure composed of nodes and links between them. Previous to The 
+Merge,  Ethereum used a DAG in its [proof-of-work](#pow) algorithm, [Ethash](#ethash).
 
 ### Dapp {#dapp}
 

--- a/src/content/glossary/index.md
+++ b/src/content/glossary/index.md
@@ -219,8 +219,7 @@ The economics of cryptocurrencies.
 
 ### DAG {#dag}
 
-DAG stands for Directed Acyclic Graph. It is a data structure composed of nodes and links between them. Previous to The 
-Merge,  Ethereum used a DAG in its [proof-of-work](#pow) algorithm, [Ethash](#ethash).
+DAG stands for Directed Acyclic Graph. It is a data structure composed of nodes and links between them. Before The Merge, Ethereum used a DAG in its [proof-of-work](#pow) algorithm, [Ethash](#ethash), but is no longer used in [proof-of-stake](#pos).
 
 ### Dapp {#dapp}
 


### PR DESCRIPTION
Term name
DAG

Term definition
DAG stands for Directed Acyclic Graph. It is a data structure composed of nodes and links between them. Previous to The Merge, Ethereum used a DAG in its [proof-of-work](https://ethereum.org/en/glossary/#pow) algorithm, [Ethash](https://ethereum.org/en/glossary/#ethash).

Sources, if any (please do not submit copywrited content without appropriate approval)
No response

Ethereum.org links
No response

Additional context
As it stands today, it might cause confusion for new and existing users, given that it states in present form that Etherum "uses a DAG in its proof-of-work algorithm", which is no longer the case.
