### PR TITLE
Adding PyChain 2022 to Python resources page

### DIFF
--- a/src/content/developers/docs/programming-languages/python/index.md
+++ b/src/content/developers/docs/programming-languages/python/index.md
@@ -83,6 +83,10 @@ The following Ethereum-based projects use tools mentioned on this page. The rela
 - [Ethereum Python Community Discord](https://discord.gg/9zk7snTfWe) for Web3.py and other Python framework discussion
 - [Vyper Discord](<[https://discord.gg/9zk7snTfWe](https://discord.gg/SdvKC79cJk)>) for Vyper smart contract programming disucssion
 
+## Events
+
+- [PyChain 2022 virtual conference](https://www.pychain.org/) - virtual event to introduce blockchain to Python developers and share the practices across community boundaries
+
 ## Other aggregated lists {#other-aggregated-lists}
 
 The Vyper wiki has an [incredible list of resources for Vyper](https://github.com/ethereum/vyper/wiki/Vyper-tools-and-resources)

--- a/src/content/developers/docs/programming-languages/python/index.md
+++ b/src/content/developers/docs/programming-languages/python/index.md
@@ -85,7 +85,7 @@ The following Ethereum-based projects use tools mentioned on this page. The rela
 
 ## Events
 
-- [PyChain 2022 virtual conference](https://www.pychain.org/) - virtual event to introduce blockchain to Python developers and share the practices across community boundaries
+- [PyChain 2022](https://www.pychain.org/) - a virtual conference to introduce blockchain to Python developers and share practices across community boundaries
 
 ## Other aggregated lists {#other-aggregated-lists}
 


### PR DESCRIPTION
Adding PyChain 2022 to Ethereum Python resources page.

## Description

I am one of the organizers of PyChain 2022, the first-ever Pythonic blockchain developer conference. We are setting up this virtual event to introduce blockchain to more Python developers and share the best practices across different blockchain community boundaries.