### PR TITLE
Change markdown links to anchor links

### DIFF
--- a/src/content/developers/docs/consensus-mechanisms/pow/mining-algorithms/index.md
+++ b/src/content/developers/docs/consensus-mechanisms/pow/mining-algorithms/index.md
@@ -5,7 +5,7 @@ lang: en
 ---
 
 <InfoBanner emoji=":wave:">
-    Proof-of-work is no longer underlying Ethereum's consensus mechanism, meaning mining has been switched off. Instead, Ethereum is secured by validators who stake ETH. You can start staking your ETH today. Read more on [The Merge](/upgrades/merge/), [proof-of-stake](/developers/docs/consensus-mechanisms/pos/), and [staking](/staking/). This page is for historical interest only.
+Proof-of-work is no longer underlying Ethereum's consensus mechanism, meaning mining has been switched off. Instead, Ethereum is secured by validators who stake ETH. You can start staking your ETH today. Read more on <a href='/upgrades/merge/'>The Merge</a>, <a href='/developers/docs/consensus-mechanisms/pos/'>proof-of-stake</a>, and <a href='/staking/'>staking</a>. This page is for historical interest only.
 </InfoBanner>
 
 Ethereum mining used an algorithm known as Ethash. The fundamental idea of the algorithm is that a miner tries to find a nonce input using brute force computation so that the resulting hash is smaller than a threshold determined by the calculated difficulty. This difficulty level can be dynamically adjusted, allowing block production to happen at a regular interval.

--- a/src/content/developers/docs/consensus-mechanisms/pow/mining/index.md
+++ b/src/content/developers/docs/consensus-mechanisms/pow/mining/index.md
@@ -5,7 +5,7 @@ lang: en
 ---
 
 <InfoBanner emoji=":wave:">
-    Proof-of-work is no longer underlying Ethereum's consensus mechanism, meaning mining has been switched off. Instead, Ethereum is secured by validators who stake ETH. You can start staking your ETH today. Read more on [The Merge](/upgrades/merge/), [proof-of-stake](/developers/docs/consensus-mechanisms/pos/), and [staking](/staking/). This page is for historical interest only.
+Proof-of-work is no longer underlying Ethereum's consensus mechanism, meaning mining has been switched off. Instead, Ethereum is secured by validators who stake ETH. You can start staking your ETH today. Read more on <a href='/upgrades/merge/'>The Merge</a>, <a href='/developers/docs/consensus-mechanisms/pos/'>proof-of-stake</a>, and <a href='/staking/'>staking</a>. This page is for historical interest only.
 </InfoBanner>
 
 ## Prerequisites {#prerequisites}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Sorry for the repeated requests for review. I have been trying to fix the markdown links (https://github.com/ethereum/ethereum-org-website/pull/8130), but it seems that in some cases they do not work at the build, so the broken links in the production version have not been fixed. I have approached this in a different way, so please check it out.

## Related Issue

https://github.com/ethereum/ethereum-org-website/pull/8130

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
