### PR TITLE
Migrate `ExpandableInfo` to Chakra

### DIFF
--- a/src/components/ExpandableInfo.tsx
+++ b/src/components/ExpandableInfo.tsx
@@ -68,8 +68,8 @@ const ExpandableInfo = forwardRef<IProps, "div">(
         border="1px solid"
         borderColor="border"
         borderRadius="2px"
-        p="1.5rem"
-        mb="1rem"
+        p={6}
+        mb={4}
         spacing="0"
         background={background ?? "background"}
         position="relative"
@@ -85,25 +85,25 @@ const ExpandableInfo = forwardRef<IProps, "div">(
         <Stack
           justify="space-between"
           align="center"
-          gap={{ base: "2rem", md: "3rem" }}
+          gap={{ base: 8, md: 12 }}
           flexDirection={{ base: "column", md: "row" }}
           width="full"
         >
           {image && <GatsbyImage image={image} alt="" />}
-          <HStack gap="3rem" width="full">
-            <Box mr="1rem">
+          <HStack gap={12} width="full">
+            <Box mr={4}>
               <HStack
                 width="full"
-                m="1rem 0"
+                my={4}
                 sx={{
                   img: {
-                    mr: "1.5rem",
+                    mr: 6,
                   },
                 }}
               >
                 <Heading
-                  mt="0rem"
-                  mb="0.5rem"
+                  mt="0"
+                  mb={1}
                   fontSize={{ base: "2xl", md: "2rem" }}
                   fontWeight="600"
                   lineHeight="1.4"
@@ -146,10 +146,10 @@ const ExpandableInfo = forwardRef<IProps, "div">(
         >
           <Box
             color="text"
-            mt="2rem"
+            mt={8}
             borderTop="1px solid"
             borderColor="border"
-            paddingTop="1.5rem"
+            paddingTop={6}
           >
             {children}
           </Box>

--- a/src/components/ExpandableInfo.tsx
+++ b/src/components/ExpandableInfo.tsx
@@ -6,7 +6,6 @@ import {
   Center,
   ChakraProps,
   Collapse,
-  forwardRef,
   Heading,
   HStack,
   Icon,
@@ -28,135 +27,129 @@ export interface IProps extends ChakraProps {
   className?: string
 }
 
-const ExpandableInfo = forwardRef<IProps, "div">(
-  (
-    {
-      image,
-      title,
-      contentPreview,
-      children,
-      background,
-      forceOpen,
-      className,
-      ...rest
+const ExpandableInfo: React.FC<IProps> = ({
+  image,
+  title,
+  contentPreview,
+  children,
+  background,
+  forceOpen,
+  className,
+  ...rest
+}) => {
+  const { isOpen, getButtonProps, getDisclosureProps } = useDisclosure({
+    defaultIsOpen: forceOpen,
+  })
+
+  const chevronFlip = {
+    collapsed: {
+      rotate: 0,
+      transition: {
+        duration: 0.1,
+      },
     },
-    ref
-  ) => {
-    const { isOpen, getButtonProps, getDisclosureProps } = useDisclosure({
-      defaultIsOpen: forceOpen,
-    })
-
-    const chevronFlip = {
-      collapsed: {
-        rotate: 0,
-        transition: {
-          duration: 0.1,
-        },
+    expanded: {
+      rotate: 180,
+      transition: {
+        duration: 0.4,
       },
-      expanded: {
-        rotate: 180,
-        transition: {
-          duration: 0.4,
+    },
+  }
+
+  const animateToggle = isOpen ? "expanded" : "collapsed"
+
+  return (
+    <VStack
+      border="1px solid"
+      borderColor="border"
+      borderRadius="2px"
+      p={6}
+      mb={4}
+      spacing="0"
+      background={background ?? "background"}
+      position="relative"
+      _hover={{
+        "& img": {
+          transform: "scale(1.08)",
+          transition: "transform 0.1s",
         },
-      },
-    }
-
-    const animateToggle = isOpen ? "expanded" : "collapsed"
-
-    return (
-      <VStack
-        border="1px solid"
-        borderColor="border"
-        borderRadius="2px"
-        p={6}
-        mb={4}
-        spacing="0"
-        background={background ?? "background"}
-        position="relative"
-        _hover={{
-          "& img": {
-            transform: "scale(1.08)",
-            transition: "transform 0.1s",
-          },
-        }}
-        ref={ref}
-        {...rest}
+      }}
+      {...rest}
+    >
+      <Stack
+        justify="space-between"
+        align="center"
+        gap={{ base: 8, md: 12 }}
+        flexDirection={{ base: "column", md: "row" }}
+        width="full"
       >
-        <Stack
-          justify="space-between"
-          align="center"
-          gap={{ base: 8, md: 12 }}
-          flexDirection={{ base: "column", md: "row" }}
-          width="full"
-        >
-          {image && <GatsbyImage image={image} alt="" />}
-          <HStack gap={12} width="full">
-            <Box mr={4}>
-              <HStack
-                width="full"
-                my={4}
-                sx={{
-                  img: {
-                    mr: 6,
-                  },
-                }}
-              >
-                <Heading
-                  mt="0"
-                  mb={1}
-                  fontSize={{ base: "2xl", md: "2rem" }}
-                  fontWeight="600"
-                  lineHeight="1.4"
-                >
-                  {title}
-                </Heading>
-              </HStack>
-              <Text color="text200" mb="0">
-                {contentPreview}
-              </Text>
-            </Box>
-          </HStack>
-          {!forceOpen && (
-            <Center
-              as={motion.div}
-              variants={chevronFlip}
-              animate={animateToggle}
-              initial={false}
-              {...getButtonProps()}
-              width={{ base: "full", md: "5rem" }}
-              minHeight={{ base: "full", md: "10rem" }}
-              cursor="pointer"
-              _hover={{
-                "& svg": {
-                  transform: "scale(1.25)",
-                  transition: "transform 0.1s",
+        {image && <GatsbyImage image={image} alt="" />}
+        <HStack gap={12} width="full">
+          <Box mr={4}>
+            <HStack
+              width="full"
+              my={4}
+              sx={{
+                img: {
+                  mr: 6,
                 },
               }}
             >
-              <Icon as={MdExpandMore} boxSize="initial" size="36" />
-            </Center>
-          )}
-        </Stack>
-        <Collapse
-          {...getDisclosureProps()}
-          in={isOpen}
-          startingHeight="0"
-          endingHeight="100%"
-          initial={false}
-        >
-          <Box
-            color="text"
-            mt={8}
-            borderTop="1px solid"
-            borderColor="border"
-            paddingTop={6}
-          >
-            {children}
+              <Heading
+                mt="0"
+                mb={1}
+                fontSize={{ base: "2xl", md: "2rem" }}
+                fontWeight="600"
+                lineHeight="1.4"
+              >
+                {title}
+              </Heading>
+            </HStack>
+            <Text color="text200" mb="0">
+              {contentPreview}
+            </Text>
           </Box>
-        </Collapse>
-      </VStack>
-    )
-  }
-)
+        </HStack>
+        {!forceOpen && (
+          <Center
+            as={motion.div}
+            variants={chevronFlip}
+            animate={animateToggle}
+            initial={false}
+            {...getButtonProps()}
+            width={{ base: "full", md: "5rem" }}
+            minHeight={{ base: "full", md: "10rem" }}
+            cursor="pointer"
+            _hover={{
+              "& svg": {
+                transform: "scale(1.25)",
+                transition: "transform 0.1s",
+              },
+            }}
+          >
+            <Icon as={MdExpandMore} boxSize="initial" size="36" />
+          </Center>
+        )}
+      </Stack>
+      <Collapse
+        {...getDisclosureProps()}
+        in={isOpen}
+        startingHeight="0"
+        endingHeight="100%"
+        initial={false}
+      >
+        <Box
+          color="text"
+          mt={8}
+          borderTop="1px solid"
+          borderColor="border"
+          paddingTop={6}
+        >
+          {children}
+        </Box>
+      </Collapse>
+    </VStack>
+  )
+}
 
 export default ExpandableInfo

--- a/src/components/ExpandableInfo.tsx
+++ b/src/components/ExpandableInfo.tsx
@@ -1,216 +1,155 @@
-import React, { ReactNode, useState } from "react"
-import styled from "@emotion/styled"
-import { motion } from "framer-motion"
+import React, { ReactNode } from "react"
 import { GatsbyImage, IGatsbyImageData } from "gatsby-plugin-image"
+import {
+  BackgroundProps,
+  Box,
+  Center,
+  ChakraProps,
+  Collapse,
+  forwardRef,
+  Heading,
+  HStack,
+  Icon,
+  Stack,
+  Text,
+  useDisclosure,
+  VStack,
+} from "@chakra-ui/react"
+import { motion } from "framer-motion"
+import { MdExpandMore } from "react-icons/md"
 
-import Icon from "./Icon"
-
-const Card = styled.div<{
-  background: string
-}>`
-  border: 1px solid ${({ theme }) => theme.colors.border};
-  border-radius: 2px;
-  padding: 1.5rem;
-  display: flex;
-  flex-direction: column;
-  margin-bottom: 1rem;
-  background: ${({ background, theme }) =>
-    background ? theme.colors[background] : theme.colors.background};
-  &:hover {
-    img {
-      transform: scale(1.08);
-      transition: transform 0.1s;
-    }
-  }
-`
-
-const Content = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 3rem;
-  @media (max-width: ${({ theme }) => theme.breakpoints.m}) {
-    gap: 2rem;
-    flex-direction: column;
-  }
-`
-
-const TitleContent = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 3rem;
-  width: 100%;
-`
-
-const Title = styled.h2`
-  margin-top: 0rem;
-  margin-bottom: 0.5rem;
-`
-
-const TextPreview = styled.p`
-  font-weight: 400;
-  color: ${(props) => props.theme.colors.text200};
-  margin-bottom: 0rem;
-`
-
-const Text = styled(motion.div)`
-  font-size: 16px;
-  font-weight: 400;
-  color: ${(props) => props.theme.colors.text};
-  margin-top: 2rem;
-  border-top: 1px solid ${(props) => props.theme.colors.border};
-  padding-top: 1.5rem;
-`
-
-const Question = styled.div`
-  margin-right: 1rem;
-`
-
-const Header = styled.div`
-  display: flex;
-  width: 100%;
-  margin: 1rem 0;
-  align-items: center;
-  img {
-    margin-right: 1.5rem;
-  }
-`
-
-const ButtonContainer = styled(motion.div)`
-  display: flex;
-  width: 5rem;
-  justify-content: center;
-  align-items: center;
-  min-height: 10rem;
-  cursor: pointer;
-  @media (max-width: ${({ theme }) => theme.breakpoints.m}) {
-    min-height: 100%;
-    height: 100%;
-    width: 100%;
-    margin: 0;
-  }
-  &:hover {
-    svg {
-      transform: scale(1.25);
-      transition: transform 0.1s;
-    }
-  }
-`
-
-export interface IProps {
+export interface IProps extends ChakraProps {
   children?: React.ReactNode
   image?: IGatsbyImageData
   title: ReactNode
   contentPreview: ReactNode
-  background: string
-  forceOpen: boolean
+  background: BackgroundProps["background"]
+  forceOpen?: boolean
   className?: string
 }
 
-const ExpandableInfo: React.FC<IProps> = ({
-  image,
-  title,
-  contentPreview,
-  children,
-  background,
-  forceOpen,
-  className,
-}) => {
-  const [isVisible, setIsVisible] = useState(forceOpen)
-  const expandCollapse = {
-    collapsed: {
-      height: 0,
-      transition: {
-        when: "afterChildren",
+const ExpandableInfo = forwardRef<IProps, "div">(
+  (
+    {
+      image,
+      title,
+      contentPreview,
+      children,
+      background,
+      forceOpen,
+      className,
+      ...rest
+    },
+    ref
+  ) => {
+    const { isOpen, getButtonProps, getDisclosureProps } = useDisclosure({
+      defaultIsOpen: forceOpen,
+    })
+
+    const chevronFlip = {
+      collapsed: {
+        rotate: 0,
+        transition: {
+          duration: 0.1,
+        },
       },
-    },
-    expanded: {
-      height: "100%",
-      transition: {
-        when: "beforeChildren",
+      expanded: {
+        rotate: 180,
+        transition: {
+          duration: 0.4,
+        },
       },
-    },
-  }
-  const chevronFlip = {
-    collapsed: {
-      rotate: 0,
-      transition: {
-        duration: 0.1,
-      },
-    },
-    expanded: {
-      rotate: 180,
-      transition: {
-        duration: 0.4,
-      },
-    },
-  }
-  const showHide = {
-    collapsed: {
-      display: "none",
-    },
-    expanded: {
-      display: "inline-block",
-    },
-  }
-  const fadeInOut = {
-    collapsed: {
-      opacity: 0,
-      transition: {
-        duration: 0.1,
-      },
-    },
-    expanded: {
-      opacity: 1,
-      transition: {
-        duration: 0.4,
-      },
-    },
-  }
-  return (
-    <Card background={background} className={className}>
-      <Content>
-        {image && <GatsbyImage image={image} alt="" />}
-        <TitleContent>
-          <Question>
-            <Header>
-              <Title>{title}</Title>
-            </Header>
-            <TextPreview>{contentPreview}</TextPreview>
-          </Question>
-        </TitleContent>
-        {!forceOpen && (
-          <ButtonContainer
-            variants={chevronFlip}
-            animate={isVisible ? "expanded" : "collapsed"}
-            initial={false}
-            onClick={() => setIsVisible(!isVisible)}
-          >
-            <Icon name="chevronDown" size="36" />
-          </ButtonContainer>
-        )}
-      </Content>
-      <motion.div
-        variants={expandCollapse}
-        animate={isVisible ? "expanded" : "collapsed"}
-        initial={false}
+    }
+
+    const animateToggle = isOpen ? "expanded" : "collapsed"
+
+    return (
+      <VStack
+        border="1px solid"
+        borderColor="border"
+        borderRadius="2px"
+        p="1.5rem"
+        mb="1rem"
+        spacing="0"
+        background={background ?? "background"}
+        position="relative"
+        _hover={{
+          "& img": {
+            transform: "scale(1.08)",
+            transition: "transform 0.1s",
+          },
+        }}
+        ref={ref}
+        {...rest}
       >
-        <motion.div
-          variants={showHide}
-          animate={isVisible ? "expanded" : "collapsed"}
+        <Stack
+          justify="space-between"
+          gap={{ base: "2rem", md: "3rem" }}
+          flexDirection={{ base: "column", md: "row" }}
+          width="full"
+        >
+          {image && <GatsbyImage image={image} alt="" />}
+          <HStack gap="3rem" width="full">
+            <Box mr="1rem">
+              <HStack
+                width="full"
+                m="1rem 0"
+                sx={{
+                  img: {
+                    mr: "1.5rem",
+                  },
+                }}
+              >
+                <Heading mt="0rem" mb="0.5rem" size="md" fontWeight="600">
+                  {title}
+                </Heading>
+              </HStack>
+              <Text color="text200" mb="0">
+                {contentPreview}
+              </Text>
+            </Box>
+          </HStack>
+          {!forceOpen && (
+            <Center
+              as={motion.div}
+              variants={chevronFlip}
+              animate={animateToggle}
+              initial={false}
+              {...getButtonProps()}
+              width={{ base: "full", md: "5rem" }}
+              minHeight={{ base: "full", md: "10rem" }}
+              cursor="pointer"
+              _hover={{
+                "& svg": {
+                  transform: "scale(1.25)",
+                  transition: "transform 0.1s",
+                },
+              }}
+            >
+              <Icon as={MdExpandMore} boxSize="initial" size="36" />
+            </Center>
+          )}
+        </Stack>
+        <Collapse
+          {...getDisclosureProps()}
+          in={isOpen}
+          startingHeight="0"
+          endingHeight="100%"
           initial={false}
         >
-          <Text
-            variants={fadeInOut}
-            animate={isVisible ? "expanded" : "collapsed"}
-            initial={false}
+          <Box
+            color="text"
+            mt="2rem"
+            borderTop="1px solid"
+            borderColor="border"
+            paddingTop="1.5rem"
           >
             {children}
-          </Text>
-        </motion.div>
-      </motion.div>
-    </Card>
-  )
-}
+          </Box>
+        </Collapse>
+      </VStack>
+    )
+  }
+)
 
 export default ExpandableInfo

--- a/src/components/ExpandableInfo.tsx
+++ b/src/components/ExpandableInfo.tsx
@@ -100,7 +100,13 @@ const ExpandableInfo = forwardRef<IProps, "div">(
                   },
                 }}
               >
-                <Heading mt="0rem" mb="0.5rem" size="md" fontWeight="600">
+                <Heading
+                  mt="0rem"
+                  mb="0.5rem"
+                  fontSize={{ base: "2xl", md: "2rem" }}
+                  fontWeight="600"
+                  lineHeight="1.4"
+                >
                   {title}
                 </Heading>
               </HStack>

--- a/src/components/ExpandableInfo.tsx
+++ b/src/components/ExpandableInfo.tsx
@@ -84,6 +84,7 @@ const ExpandableInfo = forwardRef<IProps, "div">(
       >
         <Stack
           justify="space-between"
+          align="center"
           gap={{ base: "2rem", md: "3rem" }}
           flexDirection={{ base: "column", md: "row" }}
           width="full"

--- a/src/pages/run-a-node.tsx
+++ b/src/pages/run-a-node.tsx
@@ -171,15 +171,6 @@ const Highlight = styled(Content)<{ backgroundColor: string }>`
 
 const SoftwareHighlight = styled(Highlight)``
 
-const StyledExpandableInfo = styled(ExpandableInfo)`
-  width: 90%;
-  align-self: center;
-  @media (max-width: ${({ theme }) => theme.breakpoints.m}) {
-    margin: 0;
-    width: 100%;
-  }
-`
-
 const ColumnFill = styled.div`
   line-height: 2;
   box-sizing: border-box;
@@ -536,7 +527,10 @@ const RunANodePage = ({ data }: PageProps<Queries.RunANodePageQuery>) => {
       </Content>
 
       <FlexContent>
-        <StyledExpandableInfo
+        <ExpandableInfo
+          alignSelf="center"
+          width={{ base: "full", md: "90%" }}
+          mb={{ base: 0, md: 4 }}
           image={getImage(data.impact)!}
           title={<Translation id="page-run-a-node-who-title" />}
           contentPreview={<Translation id="page-run-a-node-who-preview" />}
@@ -555,7 +549,7 @@ const RunANodePage = ({ data }: PageProps<Queries.RunANodePageQuery>) => {
           <StrongParagraph>
             <Translation id="page-run-a-node-who-copy-bold" />
           </StrongParagraph>
-        </StyledExpandableInfo>
+        </ExpandableInfo>
       </FlexContent>
 
       <Content>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This migrates the [ExpandableInfo](https://github.com/ethereum/ethereum-org-website/blob/dev/src/components/ExpandableInfo.tsx)

[Per discussion in Discord](https://discordapp.com/channels/714888181740339261/1003686202257449111/1027648992416383117), there was the question about using the `Accordion` prop for this component, but did not make sense to do so for accessibility because of it's current usage as only a forced-open iteration on a single page. So going by the existing functionality was considered the best course of action.

See comments below for explanation on certain Chakra additions.

## Related Issue

#6374
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
