### PR TITLE
Disable text selection of example ETH address

### DIFF
--- a/src/pages/get-eth.tsx
+++ b/src/pages/get-eth.tsx
@@ -134,6 +134,10 @@ const CodeBox = styled.div`
   border-radius: 4px;
   padding: 0.5rem;
   margin-bottom: 1.5rem;
+  -webkit-user-select: none;  
+  -moz-user-select: none;    
+  -ms-user-select: none;      
+  user-select: none;
   @media (max-width: ${(props) => props.theme.breakpoints.l}) {
     flex-direction: column-reverse;
   }


### PR DESCRIPTION
In page https://ethereum.org/en/get-eth/ we have an example public ETH address, where we mark this as an example address only. 

![eth-do-not-copy](https://user-images.githubusercontent.com/38789408/195968664-800a4ae8-18ea-4a2b-82e0-270c60252fd7.png)

My PR adds 3 lines of simple css to the CodeBox class in this page which will disable the copying of text in the browser, to ensure the user cannot copy this ETH address by mistake.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
