### PR TITLE
Increasing ChainSecurity's score on bug bounty leaderboard

### DIFF
--- a/src/data/execution-bounty-hunters.csv
+++ b/src/data/execution-bounty-hunters.csv
@@ -1,7 +1,7 @@
 username, name, score
 samczsun, "Sam Sun", 35000
 holiman, "Martin Holst Swende", 35500
-chainsecurity, "ChainSecurity", 21000
+chainsecurity, "ChainSecurity", 23000
 junorouse, "Juno Im", 20500
 uknowy, "Yoonho Kim (team Hithereum)", 20000
 johnyangk, "John Youngseok Yang (Software Platform Lab)", 20000


### PR DESCRIPTION
+2000 points for finding and reporting a vulnerability.
