### PR TITLE
Updates merge impact on ether issuance page [Closes #7873]

### DIFF
--- a/src/content/upgrades/merge/issuance/index.md
+++ b/src/content/upgrades/merge/issuance/index.md
@@ -26,8 +26,6 @@ title="ETH issuance tldr">
 
 </Card>
 
-<!-- How ETH gets issued changed at the time of The Merge, which occurred in September 2022. Previously, new ETH was issued from two sources: the execution layer (i.e. Mainnet) and the consensus layer (i.e. Beacon Chain). Since The Merge, issuance on the execution layer is now zero. Let's break this down. -->
-
 ## Pre-merge (historical) {#pre-merge}
 
 ### Execution layer issuance {#el-issuance-pre-merge}

--- a/src/content/upgrades/merge/issuance/index.md
+++ b/src/content/upgrades/merge/issuance/index.md
@@ -32,7 +32,7 @@ title="ETH issuance tldr">
 
 ### Execution layer issuance {#el-issuance-pre-merge}
 
-Under proof-of-work, miners only interacted with the execution layer and were rewarded with block rewards if they were the first miner to solve the next block. Since the [Constantinople upgrade](/history/#constantinople) in 2019 this reward had been 2 ETH per block. Miners were also rewarded for publishing [ommer](/glossary/#ommer) blocks, which were valid blocks that don't end up in the longest/canonical chain. These rewards maxed out at 1.75 ETH per ommer, and were _in addition to_ the reward issued from the canonical block. The process of mining is an economically intensive activity, which historically required high levels of ETH issuance to sustain.
+Under proof-of-work, miners only interacted with the execution layer and were rewarded with block rewards if they were the first miner to solve the next block. Since the [Constantinople upgrade](/history/#constantinople) in 2019 this reward had been 2 ETH per block. Miners were also rewarded for publishing [ommer](/glossary/#ommer) blocks, which were valid blocks that didn't end up in the longest/canonical chain. These rewards maxed out at 1.75 ETH per ommer, and were _in addition to_ the reward issued from the canonical block. The process of mining was an economically intensive activity, which historically required high levels of ETH issuance to sustain.
 
 ### Consensus layer issuance {#cl-issuance-pre-merge}
 

--- a/src/content/upgrades/merge/issuance/index.md
+++ b/src/content/upgrades/merge/issuance/index.md
@@ -128,6 +128,6 @@ So, for example, if `X` (daily ETH issuance) rises to 1800 based on total ETH st
 
 ## Further reading {#further-reading}
 
-- [The Merge](/history/merge/)
+- [The Merge](/upgrades/merge/)
 - [Ultrasound.money](https://ultrasound.money/) - _Dashboards available to visualize ETH issuance and burn in real-time_
 - [Charting Ethereum Issuance](https://www.attestant.io/posts/charting-ethereum-issuance/) - _Jim McDonald 2020_

--- a/src/content/upgrades/merge/issuance/index.md
+++ b/src/content/upgrades/merge/issuance/index.md
@@ -1,10 +1,14 @@
 ---
-title: How The Merge impacts ETH supply
-description: Breakdown on how The Merge will impact ETH supply
+title: How The Merge impacted ETH supply
+description: Breakdown on how The Merge impacted ETH supply
 lang: en
 ---
 
-# How The Merge impacts ETH supply {#how-the-merge-impacts-ETH-supply}
+# How The Merge impacted ETH supply {#how-the-merge-impacts-ETH-supply}
+
+The Merge represented the Ethereum networks transition from proof-of-work to proof-of-stake which occurred in September 2022. The way ETH is issued underwent changes at time of that transition. Previously, new ETH was issued from two sources: the execution layer (i.e. Mainnet) and the consensus layer (i.e. Beacon Chain). Since The Merge, issuance on the execution layer is now zero. Let's break this down.
+
+## Components of ETH issuance {#components-of-eth-issuance}
 
 We can break the supply of ETH into two primary forces: issuance, and burn.
 
@@ -14,88 +18,89 @@ The **issuance** of ETH is the process of creating ETH that did not previously e
 emoji=":chart_decreasing:"
 title="ETH issuance tldr">
 
-- Mining rewards ~13,000 ETH/day pre-merge
-- Staking rewards ~1,600 ETH/day pre-merge
-- **After The Merge, only the ~1,600 ETH per day will remain, dropping total new ETH issuance by ~90%**
-- The burn: At an average gas price of at least 16 gwei, at least 1,600 ETH is burned every day, which effectively brings net ETH inflation to zero or less post-merge.
+- Before transitioning to proof-of-stake, miners were issued approximately 13,000 ETH/day
+- Stakers are issued approximately 1,700 ETH/day, based on about 14 million total ETH staked
+- The exact staking issuance fluctuates based on the total amount of ETH staked
+- **Since The Merge, only the ~1,700 ETH/day remains, dropping total new ETH issuance by ~88%**
+- The burn: This fluctuate according to network demand. _If_ an average gas price of at least 17 gwei is observed for a given day, this effectively offsets the ~1,700 ETH that is issued to validators and brings net ETH inflation to zero or less for that day.
 
 </Card>
 
-How ETH gets issued will change at the time of The Merge. Currently, new ETH is issued from two sources: the execution layer (i.e. Mainnet) and the consensus layer (i.e. Beacon Chain). After The Merge, issuance from the execution layer will go to zero. Let's break this down.
+<!-- How ETH gets issued changed at the time of The Merge, which occurred in September 2022. Previously, new ETH was issued from two sources: the execution layer (i.e. Mainnet) and the consensus layer (i.e. Beacon Chain). Since The Merge, issuance on the execution layer is now zero. Let's break this down. -->
 
-[More on The Merge](/upgrades/merge/)
-
-## Pre-merge {#pre-merge}
+## Pre-merge (historical) {#pre-merge}
 
 ### Execution layer issuance {#el-issuance-pre-merge}
 
-Under proof-of-work, miners only interact with the execution layer and are rewarded with block rewards if they are the first miner to solve the next block. Since the [Constantinople upgrade](/history/#constantinople) in 2019 this reward has been 2 ETH per block. Miners are also rewarded for publishing [ommer](/glossary/#ommer) blocks, which are valid blocks that don't end up in the longest/canonical chain. These rewards max out at 1.75 ETH per ommer, and are _in addition to_ the reward issued from the canonical block. Mining is an economically intensive activity, requiring high levels of ETH issuance to sustain.
+Under proof-of-work, miners only interacted with the execution layer and were rewarded with block rewards if they were the first miner to solve the next block. Since the [Constantinople upgrade](/history/#constantinople) in 2019 this reward had been 2 ETH per block. Miners were also rewarded for publishing [ommer](/glossary/#ommer) blocks, which were valid blocks that don't end up in the longest/canonical chain. These rewards maxed out at 1.75 ETH per ommer, and were _in addition to_ the reward issued from the canonical block. The process of mining is an economically intensive activity, which historically required high levels of ETH issuance to sustain.
 
 ### Consensus layer issuance {#cl-issuance-pre-merge}
 
-The [Beacon Chain](/history/#beacon-chain-genesis) went live in 2020. Instead of miners, it is secured by validators using proof-of-stake. This chain was bootstrapped by Ethereum users depositing ETH one-way into a smart contract on Mainnet, which the Beacon Chain listens to, crediting the user with an equal amount on the new chain. Until The Merge happens, the Beacon Chain's validators are not processing transactions and are essentially coming to consensus on the state of the validator pool itself.
+The [Beacon Chain](/history/#beacon-chain-genesis) went live in 2020. Instead of miners, it is secured by validators using proof-of-stake. This chain was bootstrapped by Ethereum users depositing ETH one-way into a smart contract on Mainnet (the execution layer), which the Beacon Chain listens to, crediting the user with an equal amount of ETH on the new chain. Until The Merge happened, the Beacon Chain's validators were not processing transactions and were essentially coming to consensus on the state of the validator pool itself.
 
-Validators on the Beacon Chain are rewarded with ETH for attesting to the state of the chain and proposing blocks. Rewards (or penalties) are calculated and distributed at each epoch (every 6.4 minutes) based on validator performance. The validator rewards are **significantly** less than the miner rewards issued on proof-of-work (2 ETH every ~13.5 seconds), as operating a validating node is not an economically intense activity and thus does not require or warrant as high a reward.
+Validators on the Beacon Chain are rewarded with ETH for attesting to the state of the chain and proposing blocks. Rewards (or penalties) are calculated and distributed at each epoch (every 6.4 minutes) based on validator performance. Validator rewards are **significantly** less than the mining rewards that were previously issued under proof-of-work (2 ETH every ~13.5 seconds), as operating a validating node is not an economically intense activity and thus does not require or warrant as high a reward.
 
 ### Pre-merge issuance breakdown {#pre-merge-issuance-breakdown}
 
-Total ETH supply: **~119,300,000 ETH** (as of Q2 2022)
+<!-- Total ETH supply: **~119,300,000 ETH** (as of Q2 2022, prior to The Merge) -->
+
+Total ETH supply: **~120,520,000 ETH** (at time of The Merge in September 2022)
 
 **Execution layer issuance:**
 
-- Estimating at 2.08 ETH per 13.3 seconds\*: **~4,930,000** ETH issued in a year
-- Currently inflating at **~4.13%** (4.93M per year / 119.3M total)
+- Was estimated at 2.08 ETH per 13.3 seconds\*: **~4,930,000** ETH issued in a year
+- Resulted in an inflation rate of **approximately 4.09%** (4.93M per year / 120.5M total)
 - \*This includes the 2 ETH per canonical block, plus an average of 0.08 ETH over time from ommer blocks. Also uses 13.3 seconds, the baseline block time target without any influence from a [difficulty bomb](/glossary/#difficulty-bomb). ([See source](https://bitinfocharts.com/ethereum/))
 
 **Consensus layer issuance:**
 
-- Using 13,000,000 total ETH staked, the rate of ETH issuance is ~1600 ETH/day ([See source](https://ultrasound.money/))
-- Results in **~584,000** ETH issued in a year
-- Currently inflating at **~0.49%** (584K per year / 119.3M total)
+- Using 14,000,000 total ETH staked, the rate of ETH issuance is approximately 1700 ETH/day ([See source](https://ultrasound.money/))
+- Results in **~620,500** ETH issued in a year
+- Resulted in inflation rate of **approximately 0.52%** (620.5K per year / 119.3M total)
 
 <InfoBanner>
-<strong>Total annual issuance rate: ~4.62%</strong> (4.13% + 0.49%)<br/><br/>
-<strong>~89.4%</strong> of the issuance is going to miners on the execution layer (4.13 / 4.62 * 100)<br/><br/>
-<strong>~10.6%</strong> is being issued to stakers on the consensus layer (0.49 / 4.62 * 100)
+<strong>Total annualized issuance rate (pre-merge): ~4.61%</strong> (4.09% + 0.52%)<br/><br/>
+<strong>~88.7%</strong> of the issuance was going to miners on the execution layer (4.09 / 4.61 * 100)<br/><br/>
+<strong>~11.3%</strong> was being issued to stakers on the consensus layer (0.52 / 4.61 * 100)
 </InfoBanner>
 
-## Post-merge {#post-merge}
+## Post-merge (present day) {#post-merge}
 
 ### Execution layer issuance {#el-issuance-post-merge}
 
-Execution layer issuance after The Merge will be zero. Proof-of-work will no longer be valid under the rules of consensus. All execution layer activity will be included in "beacon blocks", which are published and attested to by proof-of-stake validators.
+Execution layer issuance since The Merge is zero. Proof-of-work is no longer a valid means of block production under the upgraded rules of consensus. All execution layer activity is packaged into "beacon blocks", which are published and attested to by proof-of-stake validators. Rewards for attesting-to and publishing beacon blocks are accounted for separately on the consensus layer.
 
 ### Consensus layer issuance {#cl-issuance-post-merge}
 
-Consensus layer issuance will continue as before The Merge, with small rewards for validators who attest to and propose blocks. Validator rewards will continue to accrue to _validator balances_ that are managed within the consensus layer. These are separate Ethereum accounts to the accounts we're used to on Mainnet, and until the Shanghai upgrade funds from validator accounts will not be withdrawable/transferrable. This means that although new ETH is still being issued, 100% of it will be locked from the market until this upgrade occurs. When the Shanghai upgrade is rolled out, this ETH will become available.
+Consensus layers issuance continues today as it did prior to The Merge, with small rewards for validators who attest to and propose blocks. Validator rewards continue to accrue to _validator balances_ that are managed within the consensus layer. These are separate Ethereum accounts to the accounts we're used to on Mainnet, and until the upcoming Shanghai upgrade funds from validator accounts will not be withdrawable/transferrable. This means that although new ETH is still being issued, 100% remains locked from the market until this upgrade occurs. When the Shanghai upgrade is rolled out, this ETH will become available.
 
-When validator withdrawals are enabled, stakers will be incentivized to remove their _earnings/rewards (balance over 32 ETH)_ as these funds are otherwise not contributing to their stake weight (which maxes as 32).
+When validator withdrawals are enabled, stakers will be incentivized to remove their _earnings/rewards (balance over 32 ETH)_ as these funds are otherwise not contributing to their stake weight (which maxes at 32).
 
-Stakers may also choose to exit and withdraw their entire validator balance. To ensure Ethereum is stable, the number of validators leaving simultaneously is capped. Only six validators may exit in a given epoch (6.4 minute period) depending on the total ETH staked at the time. This decreases to as low as four as more validators withdraw to intentionally prevent large destabilizing amounts of staked ETH from leaving at once.
+After withdraw functionality is enabled, stakers may also choose to exit and withdraw their entire validator balance. To ensure Ethereum is stable, the number of validators leaving simultaneously is capped. Only six validators may exit in a given epoch (6.4 minute period) depending on the total ETH staked at the time. This decreases to as low as four as more validators withdraw to intentionally prevent large destabilizing amounts of staked ETH from leaving at once.
 
 ### Post-merge inflation breakdown {#post-merge-inflation-breakdown}
 
-- Total ETH supply: **~119,300,000 ETH** (as of Q2 2022)
+- Total ETH supply: **~120,520,000 ETH** (at time of The Merge in September 2022)
 - Execution layer issuance: **0**
-- Consensus layer issuance: Same as above, **~0.49%** annual issuance rate (with 13 million ETH staked)
-- Total annual issuance rate: **~0.49%**
+- Consensus layer issuance: Same as above, **~0.52%** annualized issuance rate (with 14 million total ETH staked)
 
 <InfoBanner>
-Total annual issuance rate: <strong>~0.49%</strong><br/><br/>
-Net reduction in annual ETH issuance: <strong>~89.4%</strong> (0.49% / 4.62% * 100)
+Total annualized issuance rate: <strong>~0.52%</strong><br/><br/>
+Net reduction in annual ETH issuance: <strong>~88.7%</strong> ((4.61% - 0.52%) / 4.61% * 100)
 </InfoBanner>
 
 ## <Emoji text=":fire:" size="1" /> The burn {#the-burn}
 
-The opposite force to ETH issuance is the rate at which ETH is burned. For a transaction to execute on Ethereum, a minimum fee (known as a `base fee`) must be paid, which fluctuates continuously depending on network activity. The fee is paid in ETH and is _required_ for the transaction to be considered valid. This fee gets _burned_ during the transaction process, removing it from circulation.
+The opposite force to ETH issuance is the rate at which ETH is burned. For a transaction to execute on Ethereum, a minimum fee (known as a "base fee") must be paid, which fluctuates continuously (block-to-block) depending on network activity. The fee is paid in ETH and is _required_ for the transaction to be considered valid. This fee gets _burned_ during the transaction process, removing it from circulation.
 
 <InfoBanner>
-Fee burning went live with <a href="/history/#london">the London upgrade</a> in August 2021, and will continue after the Merge.
+Fee burning went live with <a href="/history/#london">the London upgrade</a> in August 2021, and remains unchanged since The Merge.
 </InfoBanner>
 
-On top of the fee burn implemented by the London upgrade, validators can also incur penalties for being offline, or worse, they can be slashed for breaking specific rules that threaten network security. These penalties result in a reduction of ETH from that validator's balance, which is not directly rewarded to any other account, effectively burning it from circulation.
+On top of the fee burn implemented by the London upgrade, validators can also incur penalties for being offline, or worse, they can be slashed for breaking specific rules that threaten network security. These penalties result in a reduction of ETH from that validator's balance, which is not directly rewarded to any other account, effectively burning/removing it from circulation.
 
 ## Further reading {#further-reading}
 
+- [The Merge](/history/merge/)
 - [Ultrasound.money](https://ultrasound.money/) - _Dashboards available to visualize ETH issuance and burn in real-time_
 - [Charting Ethereum Issuance](https://www.attestant.io/posts/charting-ethereum-issuance/) - _Jim McDonald 2020_

--- a/src/content/upgrades/merge/issuance/index.md
+++ b/src/content/upgrades/merge/issuance/index.md
@@ -99,6 +99,33 @@ Fee burning went live with <a href="/history/#london">the London upgrade</a> in 
 
 On top of the fee burn implemented by the London upgrade, validators can also incur penalties for being offline, or worse, they can be slashed for breaking specific rules that threaten network security. These penalties result in a reduction of ETH from that validator's balance, which is not directly rewarded to any other account, effectively burning/removing it from circulation.
 
+### Calculating average gas price for deflation {#calculating-average-gas-price-for-deflation}
+
+As discussed above, the amount of ETH issued in a given day is dependent upon the total ETH staked. At time of writing, this is approximately 1700 ETH/day.
+
+To determine the average gas price required to completely offset this issuance in a given 24-hour period, we'll start by calculating the total number of blocks in a day:
+
+- `1 block / 12 seconds = 5 blocks/minute`
+- `(5 blocks/minute) * (60 minutes/hour) * (24 hours/day) = 7200 blocks/day`
+
+Each block targets `15x10^6 gas/block` ([more on gas](/developers/docs/gas/)). Using this, we can solve for the average gas price (in units of gwei/gas) required to offset issuance, given a total daily ETH issuance of 1700 ETH:
+
+- `7200 blocks/day * 15x10^6 gas/block * Y gwei/gas * 1 ETH/ 10^9 gwei = 1700 ETH/day`
+
+Solving for `Y`:
+
+- `Y = (1700(10^9))/(7200 * 15(10^6)) = (1700(10^3)/(7200 * 15)) = 16 gwei` (rounding to only two significant digits)
+
+Another way to rearrange this last step would be to replace `1700` with a variable `X` that represents the daily ETH issuance, and to simplify the rest to:
+
+- `Y = (X(10^3)/(7200 * 15)) = X/108`
+
+We can simplify and write this as a function of `X`:
+
+- `f(X) = X/108` where `X` is daily ETH issuance, and `f(X)` represents the gwei/gas price required to offset all of the newly issued ETH.
+
+So, for example, if `X` (daily ETH issuance) rises to 1800 based on total ETH staked, `f(X)` (gwei required to offset all of the issuance) would then be `17 gwei` (using 2 significant digits)
+
 ## Further reading {#further-reading}
 
 - [The Merge](/history/merge/)


### PR DESCRIPTION
## Description
- Updates the "How The Merge impacted ETH supply" page located at [`/upgrades/merge/issuance`](https://ethereum.org/en/upgrades/merge/issuance)
- This copy update intentionally keeps the comparison to a pre-merge PoW world, so users have a comparison from what the issuance is now compared to what is was prior to The Merge. 
- Adds a section on "Calculating average gas price for deflation" which dives into some math surrounding how to calculate the average gas price needed to completely offset the issuance.

## Related Issue
- [Closes #7873]
- #7075

Note, PR #7921 was also put up to address updated ETH issuance, but removes the comparison to pre-merge Ethereum. After some discussion and given this page is located at `/upgrades/merge/issuance`, recommending we table that PR for now and plan to create a separate subpage located underneath the `/eth` path as noted in [this comment](https://github.com/ethereum/ethereum-org-website/pull/7921#issuecomment-1282785148) such as `/eth/issuance`.

Another note, in the future it would be nice to have issue #7653 addressed to enable displaying these mathematical expressions in a more appropriate manner. If/when that issue is completed, we should circle back to this content and update these expressions to use Latex mathematical expressions instead of code snippets. 

## Preview link
- https://ethereumorgwebsitedev01-postmergeissuance.gtsb.io/en/upgrades/merge/issuance