### PR TITLE
fix table out of size issue

### DIFF
--- a/src/components/MarkdownTable.tsx
+++ b/src/components/MarkdownTable.tsx
@@ -6,12 +6,7 @@ export interface IProps {
 }
 
 const MarkdownTable: React.FC<IProps> = ({ children }) => (
-  <Box
-    my={8}
-    sx={{
-      overflowX: "auto",
-    }}
-  >
+  <Box my={8} overflowX="auto">
     <Table
       sx={{
         th: {

--- a/src/components/MarkdownTable.tsx
+++ b/src/components/MarkdownTable.tsx
@@ -6,7 +6,12 @@ export interface IProps {
 }
 
 const MarkdownTable: React.FC<IProps> = ({ children }) => (
-  <Box my={8}>
+  <Box
+    my={8}
+    sx={{
+      overflowX: "auto",
+    }}
+  >
     <Table
       sx={{
         th: {


### PR DESCRIPTION
Fixed table overflowing on https://ethereum.org/en/developers/docs/evm/opcodes/ page. 

Fixes #8320

<img width="773" alt="Screenshot 2022-10-23 at 10 40 55 PM" src="https://user-images.githubusercontent.com/41188167/197407229-0a0c5628-0868-41a4-9430-d42c4f95aee7.png">
