### PR TITLE
refactor(eth-video): apply `useColorModeValue` for video source

### DIFF
--- a/src/components/EthVideo.tsx
+++ b/src/components/EthVideo.tsx
@@ -1,6 +1,5 @@
 import React from "react"
-import { useTheme } from "@emotion/react"
-import { Box } from "@chakra-ui/react"
+import { Box, useColorModeValue } from "@chakra-ui/react"
 
 import darkVideo from "../assets/ethereum-hero-dark.mp4"
 import lightVideo from "../assets/ethereum-hero-light.mp4"
@@ -11,10 +10,9 @@ export interface IProps {
 }
 
 const EthVideo: React.FC<IProps> = ({ className, videoSrc }) => {
-  const theme = useTheme()
-  const isDarkTheme = theme.isDark
+  const videoFile = useColorModeValue(lightVideo, darkVideo)
 
-  const src = videoSrc ? videoSrc : isDarkTheme ? darkVideo : lightVideo
+  const src = videoSrc ? videoSrc : videoFile
 
   return (
     <Box className={className}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Replace dark mode check from emotion with `useColorModeValue` hook from Chakra.

This provides a way to not use a nested ternary to determine what source to use, while returning a local video asset based on color mode if no `videoSrc` provided.

## Related Issue
None
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
