### PR TITLE
Refactor `CallToContribute` component

### DIFF
--- a/src/components/CallToContribute.tsx
+++ b/src/components/CallToContribute.tsx
@@ -1,4 +1,4 @@
-import { Flex, Heading, Icon, Text } from "@chakra-ui/react"
+import { Flex, Heading, Icon, Show, Text, useToken } from "@chakra-ui/react"
 import { FaGithub } from "react-icons/fa"
 import React, { ReactNode } from "react"
 import Link from "./Link"
@@ -20,85 +20,95 @@ const DescriptionParagraph = ({ children }: ChildOnlyType) => (
   </Text>
 )
 
-const CallToContribute: React.FC<IProps> = ({ editPath }) => (
-  <Flex
-    bg="ednBackground"
-    align="center"
-    mt={8}
-    border="1px"
-    borderColor="primary"
-    borderRadius="base"
-    boxShadow="inset 0 -2px 0 0 var(--eth-colors-primary400)"
-  >
+const CallToContribute: React.FC<IProps> = ({ editPath }) => {
+  /**
+   * TODO: After completion of the UI migration,
+   * Remove this and pass the token value directly
+   * into the `above` prop of `Show`
+   */
+  const largeBp = useToken("breakpoints", "lg")
+
+  return (
     <Flex
-      direction="column"
-      flexGrow={1}
-      flexShrink={1}
-      flexBasis="50%"
-      p={4}
-      color="text"
-      textAlign={{ base: "center", lg: "left" }}
-      display={{ base: "none", lg: "flex" }}
+      bg="ednBackground"
+      align="center"
+      mt={8}
+      border="1px"
+      borderColor="primary"
+      borderRadius="base"
+      boxShadow="inset 0 -2px 0 0 var(--eth-colors-primary400)"
     >
-      ░░░░░░░░░▄░░░░░░░░░░░░░░▄░░░░ ░░░░░░░░▌▒█░░░░░░░░░░░▄▀▒▌░░░
-      ░░░░░░░░▌▒▒█░░░░░░░░▄▀▒▒▒▐░░░ ░░░░░░░▐▄▀▒▒▀▀▀▀▄▄▄▀▒▒▒▒▒▐░░░
-      ░░░░░▄▄▀▒░▒▒▒▒▒▒▒▒▒█▒▒▄█▒▐░░░ ░░░▄▀▒▒▒░░░▒▒▒░░░▒▒▒▀██▀▒▌░░░
-      ░░▐▒▒▒▄▄▒▒▒▒░░░▒▒▒▒▒▒▒▀▄▒▒▌░░ ░░▌░░▌█▀▒▒▒▒▒▄▀█▄▒▒▒▒▒▒▒█▒▐░░
-      ░▐░░░▒▒▒▒▒▒▒▒▌██▀▒▒░░░▒▒▒▀▄▌░ ░▌░▒▄██▄▒▒▒▒▒▒▒▒▒░░░░░░▒▒▒▒▌░
-      ▀▒▀▐▄█▄█▌▄░▀▒▒░░░░░░░░░░▒▒▒▐░ ▐▒▒▐▀▐▀▒░▄▄▒▄▒▒▒▒▒▒░▒░▒░▒▒▒▒▌
-      ▐▒▒▒▀▀▄▄▒▒▒▄▒▒▒▒▒▒▒▒░▒░▒░▒▒▐░ ░▌▒▒▒▒▒▒▀▀▀▒▒▒▒▒▒░▒░▒░▒░▒▒▒▌░
-      ░▐▒▒▒▒▒▒▒▒▒▒▒▒▒▒░▒░▒░▒▒▄▒▒▐░░ ░░▀▄▒▒▒▒▒▒▒▒▒▒▒░▒░▒░▒▄▒▒▒▒▌░░
-      ░░░░▀▄▒▒▒▒▒▒▒▒▒▒▄▄▄▀▒▒▒▒▄▀░░░ ░░░░░░▀▄▄▄▄▄▄▀▀▀▒▒▒▒▒▄▄▀░░░░░
-      ░░░░░░░░░▒▒▒▒▒▒▒▒▒▒▀▀░░░░░░░░
-    </Flex>
-    <Flex
-      direction="column"
-      flexGrow={1}
-      flexShrink={1}
-      flexBasis="50%"
-      p={4}
-      color="text"
-      textAlign={{ base: "center", lg: "left" }}
-    >
-      <Heading
-        as="h2"
-        fontFamily="monospace"
-        textTransform="uppercase"
-        bg="border"
-        p={1}
-        fontSize="2rem"
-        lineHeight={1.4}
+      <Show above={largeBp}>
+        <Flex
+          direction="column"
+          flexGrow={1}
+          flexShrink={1}
+          flexBasis="50%"
+          p={4}
+          color="text"
+          textAlign={{ base: "center", lg: "left" }}
+        >
+          ░░░░░░░░░▄░░░░░░░░░░░░░░▄░░░░ ░░░░░░░░▌▒█░░░░░░░░░░░▄▀▒▌░░░
+          ░░░░░░░░▌▒▒█░░░░░░░░▄▀▒▒▒▐░░░ ░░░░░░░▐▄▀▒▒▀▀▀▀▄▄▄▀▒▒▒▒▒▐░░░
+          ░░░░░▄▄▀▒░▒▒▒▒▒▒▒▒▒█▒▒▄█▒▐░░░ ░░░▄▀▒▒▒░░░▒▒▒░░░▒▒▒▀██▀▒▌░░░
+          ░░▐▒▒▒▄▄▒▒▒▒░░░▒▒▒▒▒▒▒▀▄▒▒▌░░ ░░▌░░▌█▀▒▒▒▒▒▄▀█▄▒▒▒▒▒▒▒█▒▐░░
+          ░▐░░░▒▒▒▒▒▒▒▒▌██▀▒▒░░░▒▒▒▀▄▌░ ░▌░▒▄██▄▒▒▒▒▒▒▒▒▒░░░░░░▒▒▒▒▌░
+          ▀▒▀▐▄█▄█▌▄░▀▒▒░░░░░░░░░░▒▒▒▐░ ▐▒▒▐▀▐▀▒░▄▄▒▄▒▒▒▒▒▒░▒░▒░▒▒▒▒▌
+          ▐▒▒▒▀▀▄▄▒▒▒▄▒▒▒▒▒▒▒▒░▒░▒░▒▒▐░ ░▌▒▒▒▒▒▒▀▀▀▒▒▒▒▒▒░▒░▒░▒░▒▒▒▌░
+          ░▐▒▒▒▒▒▒▒▒▒▒▒▒▒▒░▒░▒░▒▒▄▒▒▐░░ ░░▀▄▒▒▒▒▒▒▒▒▒▒▒░▒░▒░▒▄▒▒▒▒▌░░
+          ░░░░▀▄▒▒▒▒▒▒▒▒▒▒▄▄▄▀▒▒▒▒▄▀░░░ ░░░░░░▀▄▄▄▄▄▄▀▀▀▒▒▒▒▒▄▄▀░░░░░
+          ░░░░░░░░░▒▒▒▒▒▒▒▒▒▒▀▀░░░░░░░░
+        </Flex>
+      </Show>
+      <Flex
+        direction="column"
+        flexGrow={1}
+        flexShrink={1}
+        flexBasis="50%"
+        p={4}
+        color="text"
+        textAlign={{ base: "center", lg: "left" }}
       >
-        <Translation id="page-calltocontribute-title" />
-      </Heading>
-      <DescriptionParagraph>
-        <Translation id="page-calltocontribute-desc-1" />
-      </DescriptionParagraph>
-      <DescriptionParagraph>
-        <Translation id="page-calltocontribute-desc-2" />
-      </DescriptionParagraph>
-      <DescriptionParagraph>
-        <Translation id="page-calltocontribute-desc-3" />{" "}
-        <Link to="https://www.notion.so/efdn/Writer-template-4b40d196cde7422ca6a2091de33550bd">
-          <Translation id="page-calltocontribute-link" />
-        </Link>
-      </DescriptionParagraph>
-      <DescriptionParagraph>
-        <Translation id="page-calltocontribute-desc-4" />{" "}
-        <Link to="https://discord.gg/CetY6Y4">
-          <Translation id="page-calltocontribute-link-2" />
-        </Link>{" "}
-      </DescriptionParagraph>
-      <ButtonLink
-        to={editPath}
-        leftIcon={
-          <Icon fill="background" w={6} h={6} as={FaGithub} name="github" />
-        }
-      >
-        <Translation id="page-calltocontribute-span" />
-      </ButtonLink>
+        <Heading
+          as="h2"
+          fontFamily="monospace"
+          textTransform="uppercase"
+          bg="border"
+          p={1}
+          fontSize="2rem"
+          lineHeight={1.4}
+        >
+          <Translation id="page-calltocontribute-title" />
+        </Heading>
+        <DescriptionParagraph>
+          <Translation id="page-calltocontribute-desc-1" />
+        </DescriptionParagraph>
+        <DescriptionParagraph>
+          <Translation id="page-calltocontribute-desc-2" />
+        </DescriptionParagraph>
+        <DescriptionParagraph>
+          <Translation id="page-calltocontribute-desc-3" />{" "}
+          <Link to="https://www.notion.so/efdn/Writer-template-4b40d196cde7422ca6a2091de33550bd">
+            <Translation id="page-calltocontribute-link" />
+          </Link>
+        </DescriptionParagraph>
+        <DescriptionParagraph>
+          <Translation id="page-calltocontribute-desc-4" />{" "}
+          <Link to="https://discord.gg/CetY6Y4">
+            <Translation id="page-calltocontribute-link-2" />
+          </Link>{" "}
+        </DescriptionParagraph>
+        <ButtonLink
+          to={editPath}
+          leftIcon={
+            <Icon fill="background" w={6} h={6} as={FaGithub} name="github" />
+          }
+        >
+          <Translation id="page-calltocontribute-span" />
+        </ButtonLink>
+      </Flex>
     </Flex>
-  </Flex>
-)
+  )
+}
 
 export default CallToContribute

--- a/src/components/CallToContribute.tsx
+++ b/src/components/CallToContribute.tsx
@@ -14,6 +14,20 @@ export type ChildOnlyType = {
   children: ReactNode
 }
 
+const ContentColumn = ({ children }: ChildOnlyType) => (
+  <Flex
+    direction="column"
+    flexGrow={1}
+    flexShrink={1}
+    flexBasis="50%"
+    p={4}
+    color="text"
+    textAlign={{ base: "center", lg: "left" }}
+  >
+    {children}
+  </Flex>
+)
+
 const DescriptionParagraph = ({ children }: ChildOnlyType) => (
   <Text lineHeight="140%" color="text" fontFamily="monospace">
     {children}
@@ -39,15 +53,7 @@ const CallToContribute: React.FC<IProps> = ({ editPath }) => {
       boxShadow="inset 0 -2px 0 0 var(--eth-colors-primary400)"
     >
       <Show above={largeBp}>
-        <Flex
-          direction="column"
-          flexGrow={1}
-          flexShrink={1}
-          flexBasis="50%"
-          p={4}
-          color="text"
-          textAlign={{ base: "center", lg: "left" }}
-        >
+        <ContentColumn>
           ░░░░░░░░░▄░░░░░░░░░░░░░░▄░░░░ ░░░░░░░░▌▒█░░░░░░░░░░░▄▀▒▌░░░
           ░░░░░░░░▌▒▒█░░░░░░░░▄▀▒▒▒▐░░░ ░░░░░░░▐▄▀▒▒▀▀▀▀▄▄▄▀▒▒▒▒▒▐░░░
           ░░░░░▄▄▀▒░▒▒▒▒▒▒▒▒▒█▒▒▄█▒▐░░░ ░░░▄▀▒▒▒░░░▒▒▒░░░▒▒▒▀██▀▒▌░░░
@@ -58,17 +64,9 @@ const CallToContribute: React.FC<IProps> = ({ editPath }) => {
           ░▐▒▒▒▒▒▒▒▒▒▒▒▒▒▒░▒░▒░▒▒▄▒▒▐░░ ░░▀▄▒▒▒▒▒▒▒▒▒▒▒░▒░▒░▒▄▒▒▒▒▌░░
           ░░░░▀▄▒▒▒▒▒▒▒▒▒▒▄▄▄▀▒▒▒▒▄▀░░░ ░░░░░░▀▄▄▄▄▄▄▀▀▀▒▒▒▒▒▄▄▀░░░░░
           ░░░░░░░░░▒▒▒▒▒▒▒▒▒▒▀▀░░░░░░░░
-        </Flex>
+        </ContentColumn>
       </Show>
-      <Flex
-        direction="column"
-        flexGrow={1}
-        flexShrink={1}
-        flexBasis="50%"
-        p={4}
-        color="text"
-        textAlign={{ base: "center", lg: "left" }}
-      >
+      <ContentColumn>
         <Heading
           as="h2"
           fontFamily="monospace"
@@ -106,7 +104,7 @@ const CallToContribute: React.FC<IProps> = ({ editPath }) => {
         >
           <Translation id="page-calltocontribute-span" />
         </ButtonLink>
-      </Flex>
+      </ContentColumn>
     </Flex>
   )
 }

--- a/src/components/CallToContribute.tsx
+++ b/src/components/CallToContribute.tsx
@@ -1,6 +1,6 @@
 import { Flex, Heading, Icon, Text } from "@chakra-ui/react"
 import { FaGithub } from "react-icons/fa"
-import React from "react"
+import React, { ReactNode } from "react"
 import Link from "./Link"
 import ButtonLink from "./ButtonLink"
 
@@ -9,6 +9,16 @@ import Translation from "./Translation"
 export interface IProps {
   editPath: string
 }
+
+export type ChildOnlyType = {
+  children: ReactNode
+}
+
+const DescriptionParagraph = ({ children }: ChildOnlyType) => (
+  <Text lineHeight="140%" color="text" fontFamily="monospace">
+    {children}
+  </Text>
+)
 
 const CallToContribute: React.FC<IProps> = ({ editPath }) => (
   <Flex
@@ -61,24 +71,24 @@ const CallToContribute: React.FC<IProps> = ({ editPath }) => (
       >
         <Translation id="page-calltocontribute-title" />
       </Heading>
-      <Text lineHeight="140%" color="text" fontFamily="monospace">
+      <DescriptionParagraph>
         <Translation id="page-calltocontribute-desc-1" />
-      </Text>
-      <Text lineHeight="140%" color="text" fontFamily="monospace">
+      </DescriptionParagraph>
+      <DescriptionParagraph>
         <Translation id="page-calltocontribute-desc-2" />
-      </Text>
-      <Text lineHeight="140%" color="text" fontFamily="monospace">
+      </DescriptionParagraph>
+      <DescriptionParagraph>
         <Translation id="page-calltocontribute-desc-3" />{" "}
         <Link to="https://www.notion.so/efdn/Writer-template-4b40d196cde7422ca6a2091de33550bd">
           <Translation id="page-calltocontribute-link" />
         </Link>
-      </Text>
-      <Text lineHeight="140%" color="text" fontFamily="monospace">
+      </DescriptionParagraph>
+      <DescriptionParagraph>
         <Translation id="page-calltocontribute-desc-4" />{" "}
         <Link to="https://discord.gg/CetY6Y4">
           <Translation id="page-calltocontribute-link-2" />
         </Link>{" "}
-      </Text>
+      </DescriptionParagraph>
       <ButtonLink
         to={editPath}
         leftIcon={


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Refactor `CallToContribute` post Chakra migration.
<!--- Describe your changes in detail -->
- Create `ContentColumn` reusable component for the image and the content.
- Use the `Show` component to only show the image above the `lg` breakpoint (see additional information below).
- Create `DescriptionParagraph` reusable component for the content paragraphs.

## Related Issue
N/A
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Additional Information
As of this PR, the Chakra UI migration is not complete. If I were to do the following with `Show`:

```tsx
<Show above="lg">
```

The token value would not be recognized. This is due to the under the hood functionality of `Show` using the `useTheme` hook from Chakra. `useTheme` looks through the emotion package to retrieve theme values from the Context, and I believe it is receiving the old theme config instead of the Chakra config. Indeed there is no issue when applying Chakra's token values in the style props (I believe it has to do with how the theme config is acquired different from `useTheme`)

`useToken` solves this issue temporarily until the complete merge occurs.