### PR TITLE
added DeSci SF '22 to community events

### DIFF
--- a/src/data/community-events.json
+++ b/src/data/community-events.json
@@ -1,5 +1,14 @@
 [
   {
+    "title": "DeSci SF",
+    "to": "http://www.descisf.xyz/",
+    "sponsor": "Weavechain, Bacalhau, Foresight Institute, Bio.xyz, Fleming Protocol, Frontier DAO, Women of Desci",
+    "location": "PianoFight, 144 Taylor St, San Francisco, CA 94102",
+    "description": "DeSci SF 22 is a chance for the community to learn about what we are working on, find ways to collaborate, make new friends, and maintain meaningful connections in the DeSci Ecosystem. We've aligned with ETH SF, SF Blockchain Week, and SF Tech Week to make the most of these exciting events bringing Web3 communities together.",
+    "startDate": "2022-11-03",
+    "endDate": "2022-11-03"
+  },
+  {
     "title": "ETHVietnam",
     "to": "https://www.eth-vietnam.com/",
     "sponsor": null,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Weavechain is hosting DeSci SF '22 along with other sponsors, and we wanted to list our event on the Ethereum website to help increase exposure to DeSci researchers, builders, and enthusiasts if they're in the area to attend!

<!--- Describe your changes in detail -->

## Added entry with information to DeSci SF '22, happening on Nov 3. 

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
