### PR TITLE
Include IPFS hashes as external link possibility

### DIFF
--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -2,7 +2,7 @@ const HASH_PATTERN = /^#.*/
 const isHashLink = (href: string): boolean => HASH_PATTERN.test(href)
 
 export const isExternal = (href: string): boolean =>
-  href.includes("http") || href.includes("mailto:")
+  href.includes("http") || href.includes("mailto:") || href.includes("ipfs")
 
 export const isHash = (href: string): boolean => isHashLink(href)
 


### PR DESCRIPTION
External links can also be IPFS hashes, noticeable through "ipfs://" for the base layer protocol itself or "ipfs" somewhere within a public gateway link. Since Ethereum and IPFS go hand in hand when it comes to decentralized storage, we should recognize IPFS hashes as valid links to prepare ethereum.org for years to come when IPFS adoption will inevitably increase.