### PR TITLE
Fix incorrect spelling of 'YouTube' on client diversity developer doc

### DIFF
--- a/src/content/developers/docs/nodes-and-clients/client-diversity/index.md
+++ b/src/content/developers/docs/nodes-and-clients/client-diversity/index.md
@@ -104,7 +104,7 @@ Several dashboards give real-time client diversity statistics for the execution 
 - [Importance of client diversity](https://our.status.im/the-importance-of-client-diversity/)
 - [List of Ethereum node services](https://ethereumnodes.com/)
 - ["Five Whys" of the client diversity problem](https://notes.ethereum.org/@afhGjrKfTKmksTOtqhB9RQ/BJGj7uh08)
-- [Ethereum Diversity and How to Solve For It (Youtube)](https://www.youtube.com/watch?v=1hZgCaiqwfU)
+- [Ethereum Diversity and How to Solve For It (YouTube)](https://www.youtube.com/watch?v=1hZgCaiqwfU)
 - [clientdiversity.org](https://clientdiversity.org/)
 
 ## Related topics {#related-topics}


### PR DESCRIPTION
Fix inconsistent spelling of YouTube

<!--- Provide a general summary of your changes in the Title above -->

The spelling of YouTube is inconsistent.
There is an instance of spelling as 'Youtube' on the website which should be correctly written as YouTube.

<!--- Describe your changes in detail -->

https://github.com/ethereum/ethereum-org-website/issues/8393

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
