### PR TITLE
Updated Wallet Link

### DIFF
--- a/src/data/wallets/wallet-data.ts
+++ b/src/data/wallets/wallet-data.ts
@@ -347,7 +347,7 @@ const walletData: WalletData[] = [
     name: "Portis",
     image_name: "portis",
     brand_color: "#ffffff",
-    url: "https://portis.io",
+    url: "https://www.portis.io",
     wallet_live_date: "Nov, 2018",
     active_development_team: true,
     languages_supported: ["en"],


### PR DESCRIPTION
on https://ethereum.org/en/wallets/find-wallet/ the link to Portis.io directs to https://portis.io/.

As we can see, https://portis.io has not configured the SSL certificate correctly when accessing directly without the  'www' subdomain. The looks unsecure to the visitor, so I have fixed the link to use the 'www' subdomain.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixing the external link to look more secure for the visitor.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
