### PR TITLE
change references to `Dagger Hashamoto` to `Dagger Hashimoto`

### DIFF
--- a/src/content/contributing/translation-program/content-buckets/index.md
+++ b/src/content/contributing/translation-program/content-buckets/index.md
@@ -182,7 +182,7 @@ Below is a breakdown of the website pages each content bucket contains.
 - [Network adresses](/developers/docs/networking-layer/network-addresses/)
 - [Simple serialize](/developers/docs/data-structures-and-encoding/ssz/)
 - [Mining algorithms](/developers/docs/consensus-mechanisms/pow/mining-algorithms/)
-- [Dagger-Hashamoto](/developers/docs/consensus-mechanisms/pow/mining-algorithms/dagger-hashamoto/)
+- [Dagger-Hashimoto](/developers/docs/consensus-mechanisms/pow/mining-algorithms/dagger-hashimoto/)
 - [Ethash](/developers/docs/consensus-mechanisms/pow/mining-algorithms/ethash/)
 - [Gasper](/developers/docs/consensus-mechanisms/pos/gasper/)
 - [Weak subjectivity](/developers/docs/consensus-mechanisms/pos/weak-subjectivity/)

--- a/src/content/translations/it/developers/docs/consensus-mechanisms/pow/mining-algorithms/ethash/index.md
+++ b/src/content/translations/it/developers/docs/consensus-mechanisms/pow/mining-algorithms/ethash/index.md
@@ -8,7 +8,7 @@ lang: it
    Ethash era l'algoritmo di mining di proof-of-work di Ethereum. Il proof-of-work è stato ora **interamente disattivato** ed Ethereum è ora protetto usando invece il [proof-of-stake](/developers/docs/consensus-mechanisms/pos). Leggi di più su <a href="/upgrades/merge/">La Fusione</a>, sul <a href="/developers/docs/consensus-mechanisms/pos/">proof-of-stake</a> e sullo <a href="/staking/">staking</a>. Questa pagina è per interesse storico!  
 </InfoBanner>
 
-[Ethash](https://github.com/ethereum/wiki/wiki/Ethash) è una versione modificata dell'algoritmo [Dagger-Hashimoto](/developers/docs/consensus-mechanisms/pow/mining-algorithms/dagger-hashamoto). Il proof-of-work di Ethash è [a elevato consumo di memoria](https://wikipedia.org/wiki/Memory-hard_function), cosa pensata per rendere l'algoritmo resistente agli ASIC. Gli ASIC di Ethash sono infine stati sviluppati, ma il mining della GPU è stata un'opzione ancora valida fino alla disattivazione del proof-of-work. Ethash è ancora usato per minare altre valute su altre reti di proof-of-work non di Ethereum.
+[Ethash](https://github.com/ethereum/wiki/wiki/Ethash) è una versione modificata dell'algoritmo [Dagger-Hashimoto](/developers/docs/consensus-mechanisms/pow/mining-algorithms/dagger-hashimoto). Il proof-of-work di Ethash è [a elevato consumo di memoria](https://wikipedia.org/wiki/Memory-hard_function), cosa pensata per rendere l'algoritmo resistente agli ASIC. Gli ASIC di Ethash sono infine stati sviluppati, ma il mining della GPU è stata un'opzione ancora valida fino alla disattivazione del proof-of-work. Ethash è ancora usato per minare altre valute su altre reti di proof-of-work non di Ethereum.
 
 ## Come funziona Ethash? {#how-does-ethash-work}
 

--- a/src/content/translations/it/developers/docs/consensus-mechanisms/pow/mining/index.md
+++ b/src/content/translations/it/developers/docs/consensus-mechanisms/pow/mining/index.md
@@ -64,7 +64,7 @@ Austin ti guiderà attraverso il mining e la blockchain basata sul proof-of-work
 
 ## L'algoritmo di mining {#mining-algorithm}
 
-La Rete principale di Ethereum ha sempre e solo usato un algoritmo di mining: ['Ethash'](/developers/docs/consensus-mechanisms/pow/mining/mining-algorithms/ethash). Ethash era il successore di un algoritmo di R&S originale, noto come ['Dagger-Hashamoto'](/developers/docs/consensus-mechanisms/pow/mining/mining-algorithms/dagger-hashamoto).
+La Rete principale di Ethereum ha sempre e solo usato un algoritmo di mining: ['Ethash'](/developers/docs/consensus-mechanisms/pow/mining/mining-algorithms/ethash). Ethash era il successore di un algoritmo di R&S originale, noto come ['Dagger-Hashimoto'](/developers/docs/consensus-mechanisms/pow/mining/mining-algorithms/dagger-hashimoto).
 
 [Maggiori informazioni sugli algoritmi di mining](/developers/docs/consensus-mechanisms/pow/mining-algorithms/).
 

--- a/src/content/translations/zh/developers/docs/consensus-mechanisms/pow/mining-algorithms/ethash/index.md
+++ b/src/content/translations/zh/developers/docs/consensus-mechanisms/pow/mining-algorithms/ethash/index.md
@@ -8,7 +8,7 @@ lang: zh
    Ethash 是以太坊的工作量证明挖矿算法。 工作量证明现在已经被 **完全关闭**，取而代之，以太坊现在使用 [proof-of-stake](/developers/docs/consensus-mechanisms/pos) 来保证安全。 阅读更多关于<a href="/upgrades/merge/">合并</a>、<a href="/developers/docs/consensus-mechanisms/pos/">权益证明</a>和<a href="/staking/">质押</a>的信息。 此页面是为了满足对历史的兴趣！  
 </InfoBanner>
 
-[Ethash](https://github.com/ethereum/wiki/wiki/Ethash) 是 [Dagger-Hashimoto](/developers/docs/consensus-mechanisms/pow/mining-algorithms/dagger-hashamoto) 算法的修改版。 Ethash 工作量证明是[内存密集型](https://wikipedia.org/wiki/Memory-hard_function)算法，这被认为使算法可抵御专用集成电路。 Ethash 专用集成电路最终被开发出来，但在工作量证明被关闭之前，图形处理单元挖矿仍然是一个可行的选择。 Ethash 仍然用于在其他非以太坊工作量证明网络上挖掘其他币。
+[Ethash](https://github.com/ethereum/wiki/wiki/Ethash) 是 [Dagger-Hashimoto](/developers/docs/consensus-mechanisms/pow/mining-algorithms/dagger-hashimoto) 算法的修改版。 Ethash 工作量证明是[内存密集型](https://wikipedia.org/wiki/Memory-hard_function)算法，这被认为使算法可抵御专用集成电路。 Ethash 专用集成电路最终被开发出来，但在工作量证明被关闭之前，图形处理单元挖矿仍然是一个可行的选择。 Ethash 仍然用于在其他非以太坊工作量证明网络上挖掘其他币。
 
 ## Ethash 是如何工作的？ {#how-does-ethash-work}
 

--- a/src/content/translations/zh/developers/docs/consensus-mechanisms/pow/mining/index.md
+++ b/src/content/translations/zh/developers/docs/consensus-mechanisms/pow/mining/index.md
@@ -64,7 +64,7 @@ lang: zh
 
 ## 挖矿算法 {#mining-algorithm}
 
-以太坊主网只使用过一种挖矿算法 - [“Ethash”](/developers/docs/consensus-mechanisms/pow/mining/mining-algorithms/ethash)。 Ethhash 是称为[“Dagger-Hashamoto”](/developers/docs/consensus-mechanisms/pow/mining/mining-algorithms/dagger-hashamoto)的最初研发挖矿算法的继承者。
+以太坊主网只使用过一种挖矿算法 - [“Ethash”](/developers/docs/consensus-mechanisms/pow/mining/mining-algorithms/ethash)。 Ethhash 是称为[“Dagger-Hashimoto”](/developers/docs/consensus-mechanisms/pow/mining/mining-algorithms/dagger-hashimoto)的最初研发挖矿算法的继承者。
 
 [有关挖矿算法的更多信息](/developers/docs/consensus-mechanisms/pow/mining-algorithms/)。
 

--- a/src/data/developer-docs-links.yaml
+++ b/src/data/developer-docs-links.yaml
@@ -64,8 +64,8 @@
                 - id: docs-nav-mining-algorithms
                   to: /developers/docs/consensus-mechanisms/pow/mining-algorithms/
                   items:
-                    - id: docs-nav-dagger-hashamoto
-                      to: /developers/docs/consensus-mechanisms/pow/mining-algorithms/dagger-hashamoto
+                    - id: docs-nav-dagger-hashimoto
+                      to: /developers/docs/consensus-mechanisms/pow/mining-algorithms/dagger-hashimoto
                     - id: docs-nav-ethash
                       to: /developers/docs/consensus-mechanisms/pow/mining-algorithms/ethash
         - id: docs-nav-proof-of-stake

--- a/src/intl/en/page-developers-docs.json
+++ b/src/intl/en/page-developers-docs.json
@@ -59,7 +59,7 @@
   "docs-nav-mev-description": "How value is extracted from the Ethereum blockchain beyond the block reward",
   "docs-nav-mining": "Mining",
   "docs-nav-mining-algorithms": "Mining algorithms",
-  "docs-nav-dagger-hashamoto": "Dagger-Hashamoto",
+  "docs-nav-dagger-hashimoto": "Dagger-Hashimoto",
   "docs-nav-ethash": "Ethash",
   "docs-nav-networks": "Networks",
   "docs-nav-networks-description": "Implementations of Ethereum including test networks",

--- a/src/intl/it/page-developers-docs.json
+++ b/src/intl/it/page-developers-docs.json
@@ -58,7 +58,7 @@
   "docs-nav-mev-description": "Come viene estratto il valore dalla blockchain Ethereum attraverso il blocco delle ricompense",
   "docs-nav-mining": "Mining",
   "docs-nav-mining-algorithms": "Algoritmi di mining",
-  "docs-nav-dagger-hashamoto": "Dagger-Hashamoto",
+  "docs-nav-dagger-hashimoto": "Dagger-Hashimoto",
   "docs-nav-ethash": "Ethash",
   "docs-nav-networks": "Reti",
   "docs-nav-networks-description": "Implementazioni di Ethereum compresi test di rete",

--- a/src/intl/zh/page-developers-docs.json
+++ b/src/intl/zh/page-developers-docs.json
@@ -58,7 +58,7 @@
   "docs-nav-mev-description": "从除了区块奖励之外的以太坊区块链中提取价值",
   "docs-nav-mining": "矿工",
   "docs-nav-mining-algorithms": "挖矿算法",
-  "docs-nav-dagger-hashamoto": "Dagger-Hashamoto 算法",
+  "docs-nav-dagger-hashimoto": "Dagger-Hashimoto 算法",
   "docs-nav-ethash": "Ethash",
   "docs-nav-networks": "网络",
   "docs-nav-networks-description": "部署以太坊，包括测试网络",


### PR DESCRIPTION
## Description
- Fixes any references of `Dagger Hashamoto` to `Dagger Hashimoto`

## Related Issue
Fixes: https://github.com/ethereum/ethereum-org-website/issues/8421
