### PR TITLE
Fix link overlay in `CardList`

### DIFF
--- a/src/components/CardList.tsx
+++ b/src/components/CardList.tsx
@@ -7,6 +7,7 @@ import {
   LinkBox,
   LinkOverlay,
   StackProps,
+  useColorModeValue,
 } from "@chakra-ui/react"
 
 import { ImageProp } from "../types"
@@ -50,6 +51,8 @@ const Card = (props: CardListItem & Omit<StackProps, "title" | "id">) => {
   const isLink = !!link
   const isExternal = url.isExternal(link || "")
 
+  const descriptionColor = useColorModeValue("gray.500", "gray.400")
+
   return (
     <CardContainer {...rest}>
       {image && <Box as={GatsbyImage} image={image} alt={alt} minW="20px" />}
@@ -69,7 +72,7 @@ const Card = (props: CardListItem & Omit<StackProps, "title" | "id">) => {
           <Box>{title}</Box>
         )}
 
-        <Box fontSize="sm" mb={0} opacity={0.6}>
+        <Box fontSize="sm" mb={0} color={descriptionColor}>
           {description}
         </Box>
       </Flex>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Due to CSS stacking context, the description text in the `Card` component of `CardList` is rendered on top of the pseudo element rendered by `LinkOverlay`, because the component for this text applies the `opacity` prop with a value less than 1 which puts it higher in the z-stack than the `zIndex={0}` rendered by the overlay.

This results in an area above the description text where you would not be able to access the anchor element to click.

This PR converts the `opacity` prop to the `color` prop.

In addition, adds `useColorModeValue` to ensure the color of this text in both light and dark mode meets the color contrast requirements for accessibility.

## Related Issue

N/A

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
