### PR TITLE
Add code contribution tag to myself

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -9325,7 +9325,8 @@
       "profile": "https://sebastiansupreme.eth.link",
       "contributions": [
         "ideas",
-        "translation"
+        "translation",
+        "code"
       ]
     },
     {


### PR DESCRIPTION
Add code tag to myself because of my previously merged contribution (https://github.com/ethereum/ethereum-org-website/pull/8401).

Dear reviewer, please instruct the bot to add the "code" tag to me and close this PR afterward without merging it.
