### PR TITLE
Refactor: Use `AspectRatio` in `Youtube` component

### DIFF
--- a/src/@chakra-ui/gatsby-plugin/styles.ts
+++ b/src/@chakra-ui/gatsby-plugin/styles.ts
@@ -58,12 +58,6 @@ const styles = {
     "li > p": {
       "margin-bottom": "calc(1.45rem / 2)",
     },
-    // YouTube embeds
-    iframe: {
-      display: "block",
-      maxWidth: "560px",
-      margin: "32px 0",
-    },
     // should be replace by the usage of https://chakra-ui.com/docs/components/heading
     // also, the media queries defined on each of these heading tags are bearly used
     "h1,h2,h3,h4,h5,h6": {

--- a/src/components/YouTube.tsx
+++ b/src/components/YouTube.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Box } from "@chakra-ui/react"
+import { AspectRatio } from "@chakra-ui/react"
 
 /**
  * @param {id} ID of the YouTube video
@@ -22,10 +22,8 @@ const YouTube: React.FC<IProps> = ({ id, start = "0", title = "YouTube" }) => {
   const baseUrl = "https://www.youtube.com/embed/"
   const src = baseUrl + id + startQuery
   return (
-    <Box as="figure" display="block" my={4}>
+    <AspectRatio as="figure" maxW="560px" ratio={16 / 9} my={8}>
       <iframe
-        width="100%"
-        height="315"
         src={src}
         frameBorder="0"
         title={title}
@@ -37,8 +35,8 @@ const YouTube: React.FC<IProps> = ({ id, start = "0", title = "YouTube" }) => {
       gyroscope;
       picture-in-picture"
         allowFullScreen
-      ></iframe>
-    </Box>
+      />
+    </AspectRatio>
   )
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Replaces `Box` component with a more robust `AspectRatio` component, which is primarily used for media elements. Adds enhanced sizing with aspect ratio equal, and equal existing sizing of the iframe in its current rendering.

It also creates a better render at mobile screen sizes.

### Before: 
![Screen Shot 2022-11-01 at 23 59 56](https://user-images.githubusercontent.com/65234762/199394071-e10cb0b1-3b44-4938-ae94-437aca7d08ef.png)

### After: 
![Screen Shot 2022-11-01 at 23 59 01](https://user-images.githubusercontent.com/65234762/199394093-8e3df585-7864-4dad-a085-a7d29662ae4d.png)


## Note: 
This makes the `iframe` styling in the styles file unnecessary.

## Related Issue
N/A

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
