### PR TITLE
Add Hardhat+Solidity VSCode extension

### DIFF
--- a/src/content/developers/docs/ides/index.md
+++ b/src/content/developers/docs/ides/index.md
@@ -61,6 +61,7 @@ Most established IDEs have built plugins to enhance the Ethereum development exp
 ## Plugins and extensions {#plugins-extensions}
 
 - [solidity](https://marketplace.visualstudio.com/items?itemName=JuanBlanco.solidity) - Ethereum Solidity Language for Visual Studio Code
+- [Solidity + Hardhat for VS Code](https://marketplace.visualstudio.com/items?itemName=NomicFoundation.hardhat-solidity) - Solidity and Hardhat support by the Hardhat team
 - [Prettier Solidity](https://github.com/prettier-solidity/prettier-plugin-solidity) - Code formatter using prettier
 
 ## Further reading {#further-reading}


### PR DESCRIPTION
## Description

Added the Hardhat VSCode extension. I normally would've added it last, but I think it makes sense to have the VSCode extensions grouped, otherwise the list is like "VSCode extension, formatter, VSCode extension".

## Related Issue

No issue.