### PR TITLE
Updated button colour in theme.ts for better accessibility (light mode)

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -2,7 +2,7 @@ import { mix } from "polished"
 
 const white = "#ffffff"
 const black = "#000000"
-const primaryLight = "#1c1cff"
+const primaryLight = "#1718A5"
 const primaryDark = "#ff7324"
 const success = "#109e62"
 const fail = "#b80000"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
# Better colour contrast for primary button (light mode)

## Description
The primary button colour in light mode is changed from Hex code: 1C1CF5 to Hex code: 1718A5.


<!--- Describe your changes in detail -->
## Reason for change
1. Provides better contrast against the background by a contrast ratio of 3 points. - Improved accessibility
2. It uses the colour from the colour pallet used in the website illustrations.- Coherent visual design system



## WCAG check
### Current colour
The contrast ratio for the **current primary colour** (light mode) Hex code: 1C1CF5 against soft-orange background (from 'A fairer financial system' panel)
- Contrast ratio: 6.76
- WCAG check: AA pass
<img width="318" alt="image" src="https://user-images.githubusercontent.com/109195419/198684085-3df41f72-3db6-427f-a7cb-5314af3cfe96.png">

### Changed colour
The contrast ratio for the **suggested primary colour** (light mode) Hex code: 1718A5 against the same background
- Contrast ratio: 10.02
- WCAG check: AAA pass
<img width="319" alt="image" src="https://user-images.githubusercontent.com/109195419/198684944-9679deba-a4b4-421a-903a-766bfcc71be7.png">


## Steps to reproduce 
1. Go to the Ethereum homepage
2. Access light mode
3. Check the Contrast ratio for the Primary button.
<img width="1395" alt="image" src="https://user-images.githubusercontent.com/109195419/199495397-a0702f0d-2654-493a-981b-6195f9abfe6b.png">


## Link to issue
https://github.com/ethereum/ethereum-org-website/issues/8398

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
