### PR TITLE
Update index.md

### DIFF
--- a/src/content/developers/docs/scaling/optimistic-rollups/index.md
+++ b/src/content/developers/docs/scaling/optimistic-rollups/index.md
@@ -30,7 +30,7 @@ If the rollup batch remains unchallenged (i.e., all transactions are correctly e
 
 Optimistic rollups are [off-chain scaling solutions](/developers/docs/scaling/#off-chain-scaling) built to operate on top of Ethereum. Each optimistic rollup is managed by a set of smart contracts deployed on the Ethereum network. Optimistic rollups process transactions off the main Ethereum chain, but post off-chain transactions (in batches) to an on-chain rollup contract. Like the Ethereum blockchain, this transaction record is immutable and forms the "optimistic rollup chain."
 
-The architecure of an optimistic rollup comprises the following parts:
+The architecture of an optimistic rollup comprises the following parts:
 
 **On-chain contracts**: The optimistic rollups's operation is controlled by smart contracts running on Ethereum. This includes contracts that store rollup blocks, monitor state updates on the rollup, and track user deposits. In this sense Ethereum serves as the base layer or "layer 1" for optimistic rollups.
 


### PR DESCRIPTION
"The **architecure** of an optimistic rollup comprises the following parts:" architecture is misspelled 

Corrected to: 
"The architecture of an optimistic rollup comprises the following parts"

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
