### PR TITLE
update copy for goerli and sepolia testnets

### DIFF
--- a/src/content/developers/docs/networks/index.md
+++ b/src/content/developers/docs/networks/index.md
@@ -36,6 +36,13 @@ ETH on testnets has no real value; therefore, there are no markets for testnet E
 
 Goerli is a proof-of-stake testnet. Goerli will be maintained long term, and is recommended for stakers to test protocol upgrades and developers who want to interact with a large existing state. Before its testnet merge, Goerli was a proof-of-authority testnet.
 
+[Notable properties](https://blog.ethereum.org/2022/06/21/testnet-deprecation):
+
+- Open validator sets allowing stakers to test network upgrades and learn how to run a validator
+- Large state, useful for testing complex smart contract interactions
+- Longer to sync and requires more storage to run a node
+- More applications deployed
+
 - [Website](https://goerli.net/)
 - [GitHub](https://github.com/goerli/testnet)
 - [Etherscan](https://goerli.etherscan.io)
@@ -50,6 +57,12 @@ Goerli is a proof-of-stake testnet. Goerli will be maintained long term, and is 
 #### Sepolia {#sepolia}
 
 Sepolia is a proof-of-stake testnet. Sepolia will be maintained long term, and is recommended for users and developers who want a lighter weight chain to sync to and interact with.. Before undergoing The Merge in June 2022, Sepolia was a proof-of-work testnet.
+
+[Notable properties](https://blog.ethereum.org/2022/06/21/testnet-deprecation):
+
+- Closed validator set, controlled by client and testing teams
+- Newer testnet, which means less applications have been deployed on it compared to other testnets
+- Fast to sync and running a node requires minimal disk space
 
 - [Website](https://sepolia.dev/)
 - [GitHub](https://github.com/goerli/sepolia)

--- a/src/content/developers/docs/networks/index.md
+++ b/src/content/developers/docs/networks/index.md
@@ -56,7 +56,7 @@ Goerli is a proof-of-stake testnet. Goerli will be maintained long term, and is 
 
 #### Sepolia {#sepolia}
 
-Sepolia is a proof-of-stake testnet. Sepolia will be maintained long term, and is recommended for users and developers who want a lighter weight chain to sync to and interact with.. Before undergoing The Merge in June 2022, Sepolia was a proof-of-work testnet.
+Sepolia is a proof-of-stake testnet. Sepolia will be maintained long-term, and is recommended for users and developers who want a lighter-weight chain to sync to and interact with. Before undergoing The Merge in June 2022, Sepolia was a proof-of-work testnet.
 
 [Notable properties](https://blog.ethereum.org/2022/06/21/testnet-deprecation):
 

--- a/src/content/developers/docs/networks/index.md
+++ b/src/content/developers/docs/networks/index.md
@@ -34,7 +34,7 @@ ETH on testnets has no real value; therefore, there are no markets for testnet E
 
 #### Goerli {#goerli}
 
-Goerli is a proof-of-stake testnet. It is expected to be maintained long-term as a stable testnet for application developers. Before its testnet merge, Goerli was a proof-of-authority testnet.
+Goerli is a proof-of-stake testnet. Goerli will be maintained long term, and is recommended for stakers to test protocol upgrades and developers who want to interact with a large existing state. Before its testnet merge, Goerli was a proof-of-authority testnet.
 
 - [Website](https://goerli.net/)
 - [GitHub](https://github.com/goerli/testnet)
@@ -49,7 +49,7 @@ Goerli is a proof-of-stake testnet. It is expected to be maintained long-term as
 
 #### Sepolia {#sepolia}
 
-Sepolia is a proof-of-stake testnet. Although Sepolia is still running, it is not currently planned to be maintained long-term. Before undergoing The Merge in June 2022, Sepolia was a proof-of-work testnet.
+Sepolia is a proof-of-stake testnet. Sepolia will be maintained long term, and is recommended for users and developers who want a lighter weight chain to sync to and interact with.. Before undergoing The Merge in June 2022, Sepolia was a proof-of-work testnet.
 
 - [Website](https://sepolia.dev/)
 - [GitHub](https://github.com/goerli/sepolia)

--- a/src/content/developers/docs/networks/index.md
+++ b/src/content/developers/docs/networks/index.md
@@ -34,7 +34,7 @@ ETH on testnets has no real value; therefore, there are no markets for testnet E
 
 #### Goerli {#goerli}
 
-Goerli is a proof-of-stake testnet. Goerli will be maintained long term, and is recommended for stakers to test protocol upgrades and developers who want to interact with a large existing state. Before its testnet merge, Goerli was a proof-of-authority testnet.
+Goerli is a proof-of-stake testnet. Goerli will be maintained long-term, and is recommended for stakers to test protocol upgrades and developers who want to interact with a large existing state. Before its testnet merge, Goerli was a proof-of-authority testnet.
 
 [Notable properties](https://blog.ethereum.org/2022/06/21/testnet-deprecation):
 


### PR DESCRIPTION
## Description
- Update the copy on goerli and sepolia testnets to soften the language and talk about the differences.
- Reflects information in EF blog post: https://blog.ethereum.org/2022/06/21/testnet-deprecation

context: https://twitter.com/austingriffith/status/1587935771259858946

## Fixes
- Fixes https://github.com/ethereum/ethereum-org-website/issues/8467
