### PR TITLE
correct spelling on Proof of Stake rewards page

### DIFF
--- a/src/content/developers/docs/consensus-mechanisms/pos/rewards-and-penalties/index.md
+++ b/src/content/developers/docs/consensus-mechanisms/pos/rewards-and-penalties/index.md
@@ -58,7 +58,7 @@ Block proposers receive `8 / 64 * base_reward` for **each valid attestation** in
 
 So far we have considered perfectly well-behaved validators, but what about validators that do not make timely head, source and target votes or do so slowly?
 
-The penalties for missing the target and source votes are equal to the rewards the attestor would have received had they submitted them. This means that instead of having the reward added to their balance, they have an equal value removed from their balance. There is no penalty for missign the head vote (i.e. head votes are only rewarded, never penalized). There is no penalty associated with the `inclusion_delay` - the reward will simply not be added to the validator's balance. There is also no penalty for failing to propose a block.
+The penalties for missing the target and source votes are equal to the rewards the attestor would have received had they submitted them. This means that instead of having the reward added to their balance, they have an equal value removed from their balance. There is no penalty for missing the head vote (i.e. head votes are only rewarded, never penalized). There is no penalty associated with the `inclusion_delay` - the reward will simply not be added to the validator's balance. There is also no penalty for failing to propose a block.
 
 Read more about rewards and penalties in the [consensus specs](https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/beacon-chain.md). Rewards and penalties were adjusted in the Bellatrix upgrade - watch Danny Ryan and Vitalik discuss this in this [Peep an EIP video](https://www.youtube.com/watch?v=iaAEGs1DMgQ).
 


### PR DESCRIPTION
`There is no penalty for missign the head vote` --> `There is no penalty for missing the head vote`

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
