### PR TITLE
Add context to testnets and re-order Goerli/Sepolia

### DIFF
--- a/src/content/developers/docs/networks/index.md
+++ b/src/content/developers/docs/networks/index.md
@@ -39,8 +39,16 @@ The two public proof-of-stake testnets (which client developers are maintaining 
 **[Sepolia](#sepolia) is the recommended default testnet for application development**.
 The Sepolia network uses a permissioned validator set. It's fairly new, meaning its state and history are both quite small. This means the network is quick to sync to and that running a node on it requires less storage. This is useful for users who want to quickly spin up a node and interact with the network directly.
 
+- Closed validator set, controlled by client & testing teams
+- New testnet, less applications deployed than other testnets 
+- Fast to sync and running a node requires minimal disk space
+
 **[Goerli](#goerli) is the recommended default testnet for testing of validating and staking**. 
 The Goerli network is open for users wanting to run a testnet validator. Stakers wanting to test protocol upgrades before they are deployed to mainnet should therefore use Goerli.
+
+- Open validator set, stakers can test network upgrades
+- Large state, useful for testing complex smart contract interactions 
+- Longer to sync and requires more storage to run a node
 
 #### Sepolia {#sepolia}
 

--- a/src/content/developers/docs/networks/index.md
+++ b/src/content/developers/docs/networks/index.md
@@ -32,6 +32,30 @@ Most testnets started by using a proof-of-authority consensus mechanism. This me
 
 ETH on testnets has no real value; therefore, there are no markets for testnet ETH. Since you need ETH to actually interact with Ethereum, most people get testnet ETH from faucets. Most faucets are webapps where you can input an address which you request ETH to be sent to.
 
+#### Which Testnet should I use?
+
+The two public proof-of-stake testnets (which client developers are maintaining post-merge) are Goerli and Sepolia. The Goerli network was merged with the Prater Beacon Chain testnet. The Sepolia network has been created to transition to proof-of-stake.
+
+**[Sepolia](#sepolia) is the recommended default testnet for application development**.
+The Sepolia network uses a permissioned validator set. It's fairly new, meaning its state and history are both quite small. This means the network is quick to sync to and that running a node on it requires less storage. This is useful for users who want to quickly spin up a node and interact with the network directly.
+
+**[Goerli](#goerli) is the recommended default testnet for testing of validating and staking**. 
+The Goerli network is open for users wanting to run a testnet validator. Stakers wanting to test protocol upgrades before they are deployed to mainnet should therefore use Goerli.
+
+#### Sepolia {#sepolia}
+
+Sepolia is a proof-of-stake testnet, and is the recommended default testnet for application development.
+
+- [Website](https://sepolia.dev/)
+- [GitHub](https://github.com/goerli/sepolia)
+- [Otterscan](https://sepolia.otterscan.io/)
+- [Etherscan](https://sepolia.etherscan.io)
+
+##### Sepolia faucets
+
+- [Sepolia faucet](https://faucet.sepolia.dev/)
+- [FaucETH](https://fauceth.komputing.org)
+
 #### Goerli {#goerli}
 
 Goerli is a proof-of-stake testnet, and is the recommended default testnet for testing of validating and staking.
@@ -48,20 +72,6 @@ Goerli is a proof-of-stake testnet, and is the recommended default testnet for t
 - [All That Node Goerli Faucet](https://www.allthatnode.com/faucet/ethereum.dsrv)
 
 To launch a Validator on Goerli testnet, use ethstaker's ["cheap goerli validator" launchpad](https://goerli.launchpad.ethstaker.cc/en/).
-
-#### Sepolia {#sepolia}
-
-Sepolia is a proof-of-stake testnet, and is the recommended default testnet for application development.
-
-- [Website](https://sepolia.dev/)
-- [GitHub](https://github.com/goerli/sepolia)
-- [Otterscan](https://sepolia.otterscan.io/)
-- [Etherscan](https://sepolia.etherscan.io)
-
-##### Sepolia faucets
-
-- [Sepolia faucet](https://faucet.sepolia.dev/)
-- [FaucETH](https://fauceth.komputing.org)
 
 #### Ropsten _(deprecated)_ {#ropsten}
 

--- a/src/content/developers/docs/networks/index.md
+++ b/src/content/developers/docs/networks/index.md
@@ -34,7 +34,7 @@ ETH on testnets has no real value; therefore, there are no markets for testnet E
 
 #### Which Testnet should I use?
 
-The two public proof-of-stake testnets (which client developers are maintaining post-merge) are Goerli and Sepolia. The Goerli network was merged with the Prater Beacon Chain testnet. The Sepolia network has been created to transition to proof-of-stake.
+The two public proof-of-stake testnets (which client developers are maintaining post-merge) are Goerli and Sepolia. The Goerli network was merged with the Prater Beacon Chain testnet. The Sepolia network was created to test the transition to proof-of-stake.
 
 **[Sepolia](#sepolia) is the recommended default testnet for application development**.
 The Sepolia network uses a permissioned validator set. It's fairly new, meaning its state and history are both quite small. This means the network is quick to sync to and that running a node on it requires less storage. This is useful for users who want to quickly spin up a node and interact with the network directly.


### PR DESCRIPTION
Adding more context to choose which public testnet to use.
Also re-ordering so Sepolia comes first (as default for app devs)  
