### PR TITLE
Fix unstyled links living in the JSON files [Fixes #8547]

### DIFF
--- a/src/@chakra-ui/gatsby-plugin/styles.ts
+++ b/src/@chakra-ui/gatsby-plugin/styles.ts
@@ -19,6 +19,10 @@ const styles = {
       bg: mode("white", "gray.700")(props),
       lineHeight: "1.6rem",
     },
+    a: {
+      color: "primary",
+      textDecoration: "underline",
+    },
     // should be replace with https://chakra-ui.com/docs/components/text
     p: {
       margin: "0px 0px 1.45rem",


### PR DESCRIPTION
## Description

Recover the [old global styles for the `a` tag](https://github.com/ethereum/ethereum-org-website/blob/v4.0.0/src/theme.ts#L416) to temporarily fix the unstyled links we have on the JSON files.

Note: these global styles are going to soon be removed on the #8406 PR by fixing the root problem which is using our chakra `Link` component on the translation files.

## Related Issue

#8547