### PR TITLE
Fix broken link on wallets page

### DIFF
--- a/src/pages-conditional/wallets.tsx
+++ b/src/pages-conditional/wallets.tsx
@@ -209,7 +209,7 @@ const articles = [
   {
     title: <Translation id="page-wallets-keys-to-safety" />,
     description: <Translation id="page-wallets-blog" />,
-    link: "https://blog.coinbase.com/the-keys-to-keeping-your-crypto-safe-96d497cce6cf",
+    link: "https://www.coinbase.com/learn/crypto-basics/how-to-secure-crypto",
   },
   {
     title: <Translation id="page-wallets-how-to-store" />,


### PR DESCRIPTION
The respective article has been moved from coinbase blog to learn.

## Description
Changed the broken link from : https://blog.coinbase.com/the-keys-to-keeping-your-crypto-safe-96d497cce6cf 
to : https://www.coinbase.com/learn/crypto-basics/how-to-secure-crypto as it has been moved by coinbase.

## Related Issue
Issue: https://github.com/ethereum/ethereum-org-website/issues/8559
