### PR TITLE
Add Hacken and Hackenproof

### DIFF
--- a/src/content/developers/docs/smart-contracts/security/index.md
+++ b/src/content/developers/docs/smart-contracts/security/index.md
@@ -494,11 +494,15 @@ If you plan on querying an on-chain oracle for asset prices, consider using one 
 
 - **[Runtime Verification](https://runtimeverification.com/)** - _Security company specializing in formal modeling and verification of smart contracts._
 
+- **[Hacken](https://hacken.io)** - _Web3 cybersecurity auditor bringing the 360-degree approach to blockchain security._
+
 ### Bug bounty platforms {#bug-bounty-platforms}
 
 - **[Immunefi](https://immunefi.com/)** - _Bug bounty platform for smart contracts and DeFi projects, where security researchers review code, disclose vulnerabilities, get paid, and make crypto safer._
 
 - **[HackerOne](https://www.hackerone.com/)** - _Vulnerability coordination and bug bounty platform that connects businesses with penetration testers and cybersecurity researchers._
+
+- **[HackenProof](https://hackenproof.com/)** - _Expert bug bounty platform where blockchain projects only pay for verified, relevant and in-scope bug reports._
 
 ### Publications of known smart contract vulnerabilities and exploits {#common-smart-contract-vulnerabilities-and-exploits}
 

--- a/src/content/developers/docs/smart-contracts/security/index.md
+++ b/src/content/developers/docs/smart-contracts/security/index.md
@@ -502,7 +502,7 @@ If you plan on querying an on-chain oracle for asset prices, consider using one 
 
 - **[HackerOne](https://www.hackerone.com/)** - _Vulnerability coordination and bug bounty platform that connects businesses with penetration testers and cybersecurity researchers._
 
-- **[HackenProof](https://hackenproof.com/)** - _Expert bug bounty platform where blockchain projects only pay for verified, relevant and in-scope bug reports._
+- **[HackenProof](https://hackenproof.com/)** - _Expert bug bounty platform for crypto projects (DeFi, Smart Contracts, Wallets, CEX and more), where security professionals provide triage services and researchers get paid for relevant, verified bug reports._
 
 ### Publications of known smart contract vulnerabilities and exploits {#common-smart-contract-vulnerabilities-and-exploits}
 


### PR DESCRIPTION
Added Hacken (https://hacken.io/) to the Smart contract auditing services list;
Added HackenProof (https://hackenproof.com/) to the Bug bounty platforms list.

Description
Updating the Smart contract auditing services list; Updating the Bug bounty platforms list.

Related Issue
Related to issue https://github.com/ethereum/ethereum-org-website/issues/8543