### PR TITLE
Update `TranslationChartImage` (Post Chakra Migration)

### DIFF
--- a/src/components/TranslationChartImage.tsx
+++ b/src/components/TranslationChartImage.tsx
@@ -1,6 +1,5 @@
 import React from "react"
-import { Flex, Image } from "@chakra-ui/react"
-import { useColorMode } from "@chakra-ui/react"
+import { Image, useColorModeValue } from "@chakra-ui/react"
 import { useStaticQuery, graphql } from "gatsby"
 import { GatsbyImage } from "gatsby-plugin-image"
 import { getImage } from "../utils/image"
@@ -8,9 +7,6 @@ import { getImage } from "../utils/image"
 export interface IProps {}
 
 const TranslationChartImage: React.FC<IProps> = () => {
-  const { colorMode } = useColorMode()
-  const isDarkTheme = colorMode === "dark"
-
   const data = useStaticQuery(graphql`
     {
       pageviewsLight: file(
@@ -40,7 +36,7 @@ const TranslationChartImage: React.FC<IProps> = () => {
     }
   `)
 
-  const ethImage = isDarkTheme ? data.pageviewsDark : data.pageviewsLight
+  const ethImage = useColorModeValue(data.pageviewsLight, data.pageviewsDark)
 
   return (
     <Flex justifyContent="center" objectFit="contain">

--- a/src/components/TranslationChartImage.tsx
+++ b/src/components/TranslationChartImage.tsx
@@ -13,24 +13,14 @@ const TranslationChartImage: React.FC<IProps> = () => {
         relativePath: { eq: "translation-program/pageviews-light.png" }
       ) {
         childImageSharp {
-          gatsbyImageData(
-            height: 500
-            layout: FIXED
-            placeholder: BLURRED
-            quality: 100
-          )
+          gatsbyImageData(height: 500, placeholder: BLURRED, quality: 100)
         }
       }
       pageviewsDark: file(
         relativePath: { eq: "translation-program/pageviews-dark.png" }
       ) {
         childImageSharp {
-          gatsbyImageData(
-            height: 500
-            layout: FIXED
-            placeholder: BLURRED
-            quality: 100
-          )
+          gatsbyImageData(height: 500, placeholder: BLURRED, quality: 100)
         }
       }
     }

--- a/src/components/TranslationChartImage.tsx
+++ b/src/components/TranslationChartImage.tsx
@@ -29,15 +29,13 @@ const TranslationChartImage: React.FC<IProps> = () => {
   const ethImage = useColorModeValue(data.pageviewsLight, data.pageviewsDark)
 
   return (
-    <Flex justifyContent="center" objectFit="contain">
-      <Image
-        as={GatsbyImage}
-        image={getImage(ethImage)!}
-        alt=""
-        fit="contain"
-        minW="263px"
-      />
-    </Flex>
+    <Image
+      as={GatsbyImage}
+      image={getImage(ethImage)!}
+      alt=""
+      fit="contain"
+      minW="263px"
+    />
   )
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Current behavior of the `TranslationChartImage` is not responsive in mobile screens. Overflow scrolling is not applied.
![Screen Shot 2022-11-13 at 23 58 39](https://user-images.githubusercontent.com/65234762/201578729-e25dff13-5e75-4071-81c3-bc6f08a36dbc.png)

New behavior...
- Remove the `layout` option in the query, so the value is set back to the default of `CONSTRAINT`
- Remove wrapper component, as it is no longer needed

![Screen Shot 2022-11-14 at 00 17 49](https://user-images.githubusercontent.com/65234762/201581188-afab6a41-a479-4b18-94d9-90b33646bef7.png)

The additional refactoring replaces `useColorMode` with `useColorModeValue` for retrieving the images asset paths.

## Related Issue

N/A

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
