### PR TITLE
Update template from `Staking` to `staking` in German md files

### DIFF
--- a/src/content/translations/de/staking/pools/index.md
+++ b/src/content/translations/de/staking/pools/index.md
@@ -2,7 +2,7 @@
 title: Pool-Staking
 description: Eine Übersicht darüber, wie man mit ETH-Pool-Staking beginnen kann
 lang: de
-template: Staking
+template: staking
 emoji: ":money_with_wings:"
 image: ../../../../../assets/staking/leslie-pool.png
 alt: Leslie, das Nashorn, wie es im Pool schwimmt.

--- a/src/content/translations/de/staking/saas/index.md
+++ b/src/content/translations/de/staking/saas/index.md
@@ -2,7 +2,7 @@
 title: Staking als Service
 description: Eine Übersicht darüber, wie man mit gepooltem ETH-Staking beginnen kann
 lang: de
-template: Staking
+template: staking
 emoji: ":money_with_wings:"
 image: ../../../../../assets/staking/leslie-saas.png
 alt: Leslie, das in den Wolken schwebende Nashorn.

--- a/src/content/translations/de/staking/solo/index.md
+++ b/src/content/translations/de/staking/solo/index.md
@@ -2,7 +2,7 @@
 title: Solo-Staking Ihrer ETH
 description: Ein Überblick darüber, wie Sie mit dem Solo-Staking Ihrer ETH beginnen können
 lang: de
-template: Staking
+template: staking
 emoji: ":money_with_wings:"
 image: ../../../../../assets/staking/leslie-solo.png
 alt: Leslie das Nashorn auf ihrem eigenen Computerchip.


### PR DESCRIPTION
## Description

Fixes incorrect template name. `Staking` does not exist. It was replaced by `staking`.