### PR TITLE
Fix feedback widget copy

### DIFF
--- a/src/components/FeedbackWidget.tsx
+++ b/src/components/FeedbackWidget.tsx
@@ -171,7 +171,7 @@ const FeedbackWidget: React.FC<FeedbackWidgetProps> = ({ location = "" }) => {
                 alignItems="center"
                 display={{ base: "none", lg: isExpanded ? "flex" : "none" }}
               >
-                <Translation id="feedback-card-prompt-page" />
+                <Translation id="feedback-widget-prompt" />
               </Text>
             </ScaleFade>
           )}

--- a/src/components/FeedbackWidget.tsx
+++ b/src/components/FeedbackWidget.tsx
@@ -104,7 +104,6 @@ const FeedbackWidget: React.FC<FeedbackWidgetProps> = ({ location = "" }) => {
 
   const handleClose = (): void => {
     setIsOpen(false)
-    setIsExpanded(false)
     trackCustomEvent({
       eventCategory: `FeedbackWidget toggled`,
       eventAction: `Clicked`,
@@ -113,6 +112,7 @@ const FeedbackWidget: React.FC<FeedbackWidgetProps> = ({ location = "" }) => {
   }
   const handleOpen = (): void => {
     setIsOpen(true)
+    setIsExpanded(false)
     trackCustomEvent({
       eventCategory: `FeedbackWidget toggled`,
       eventAction: `Clicked`,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

On the feedback widget we switch tenses, "Was this page helpful?" slides out, then the pop-up shows "Is this page helpful?". This PR fixes that so that 'Is this page helpful?' is used consistently on the feedback widget.

https://user-images.githubusercontent.com/62268199/202189898-75371f9c-77c8-4312-98a2-06ec3a528e9e.mov

