### PR TITLE
Patch `zh` markdown link syntax

### DIFF
--- a/src/content/translations/zh/history/index.md
+++ b/src/content/translations/zh/history/index.md
@@ -11,11 +11,11 @@ sidebarDepth: 1
 
 <ExpandableCard title="什么是分叉？" contentPreview="Changes to the rules of the Ethereum protocol which often include planned technical upgrades.">
 
-分叉是需要对网络进行重大技术升级或更改时的变化——它们通常源自【以太坊改进建议（EIP）】(/eips/) ，并且更改以太坊协议的“规则”。
+分叉是需要对网络进行重大技术升级或更改时的变化——它们通常源自[以太坊改进建议（EIP）](/eips/) ，并且更改以太坊协议的“规则”。
 
-当传统的中心化软件需要升级时，公司会为终端用户发布新版本。 因为没有中心化所有权，区块链以不同的方式运作。 【以太坊客户端】(/developers/docs/nodes-and-clients/) 必须升级他们的软件来执行新的分叉规则。 直链区块创造者（POW 中的矿工，POS 中的验证者）和节点必须创造区块和按照新规则进行验证。 [关于共识机制的更多信息](/developers/docs/consenus-mechanisms/)
+当传统的中心化软件需要升级时，公司会为终端用户发布新版本。 因为没有中心化所有权，区块链以不同的方式运作。 [以太坊客户端](/developers/docs/nodes-and-clients/) 必须升级他们的软件来执行新的分叉规则。 直链区块创造者（POW 中的矿工，POS 中的验证者）和节点必须创造区块和按照新规则进行验证。 [关于共识机制的更多信息](/developers/docs/consenus-mechanisms/)
 
-这些规则更改可能会在网络中造成暂时的分叉。 新区块的产生，可以来自新规则，也可以来自旧规则。 分叉通常提前商定，以便让客户端能够采用 Unison 的升级，升级后的分叉链成为主链。 然而，在极少数情况下，对分叉的不同意见可能导致网络永久硬分叉——最为著名的是【DAO fork】(#dao-fork) 的分叉，产生了 Ethereum Classic（ETC-ETH）。
+这些规则更改可能会在网络中造成暂时的分叉。 新区块的产生，可以来自新规则，也可以来自旧规则。 分叉通常提前商定，以便让客户端能够采用 Unison 的升级，升级后的分叉链成为主链。 然而，在极少数情况下，对分叉的不同意见可能导致网络永久硬分叉——最为著名的是[DAO fork](#dao-fork) 的分叉，产生了 Ethereum Classic（ETC-ETH）。
 
 </ExpandableCard>
 

--- a/src/content/translations/zh/upgrades/merge/index.md
+++ b/src/content/translations/zh/upgrades/merge/index.md
@@ -95,7 +95,7 @@ id="developers">
 - 链上随机性的来源
 - _安全头_ 和 _最终区块_ 的概念
 
-更多信息，请查看 Tim Beiko 的这篇博客：【合并如何影响以太坊的应用层】(https://blog.ethereum.org/2021/11/29/how-the-merge-impacts-app-layer)。
+更多信息，请查看 Tim Beiko 的这篇博客：[合并如何影响以太坊的应用层](https://blog.ethereum.org/2021/11/29/how-the-merge-impacts-app-layer)。
 </ExpandableCard>
 
 ## 合并和能源消耗 {#merge-and-energy}


### PR DESCRIPTION
## Description
While reviewing translation imports, encountered some broken markdown link syntax on the `zh` translations. This patches them.

## Related Issue
None filed