### PR TITLE
Refactor: Apply `AspectRatio` to iframe in "Attack and Defense" page

### DIFF
--- a/src/@chakra-ui/gatsby-plugin/styles.ts
+++ b/src/@chakra-ui/gatsby-plugin/styles.ts
@@ -58,12 +58,6 @@ const styles = {
     "li > p": {
       "margin-bottom": "calc(1.45rem / 2)",
     },
-    // YouTube embeds
-    iframe: {
-      display: "block",
-      maxWidth: "560px",
-      margin: "32px 0",
-    },
     // should be replace by the usage of https://chakra-ui.com/docs/components/heading
     // also, the media queries defined on each of these heading tags are bearly used
     "h1,h2,h3,h4,h5,h6": {

--- a/src/components/YouTube.tsx
+++ b/src/components/YouTube.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Box } from "@chakra-ui/react"
+import { AspectRatio } from "@chakra-ui/react"
 
 /**
  * @param {id} ID of the YouTube video
@@ -22,10 +22,8 @@ const YouTube: React.FC<IProps> = ({ id, start = "0", title = "YouTube" }) => {
   const baseUrl = "https://www.youtube.com/embed/"
   const src = baseUrl + id + startQuery
   return (
-    <Box as="figure" display="block" my={4}>
+    <AspectRatio as="figure" maxW="560px" ratio={16 / 9} my={8}>
       <iframe
-        width="100%"
-        height="315"
         src={src}
         frameBorder="0"
         title={title}
@@ -37,8 +35,8 @@ const YouTube: React.FC<IProps> = ({ id, start = "0", title = "YouTube" }) => {
       gyroscope;
       picture-in-picture"
         allowFullScreen
-      ></iframe>
-    </Box>
+      />
+    </AspectRatio>
   )
 }
 

--- a/src/content/developers/docs/consensus-mechanisms/pos/attack-and-defense/index.md
+++ b/src/content/developers/docs/consensus-mechanisms/pos/attack-and-defense/index.md
@@ -65,7 +65,12 @@ A more sophisticated attack can split the honest validator set into discrete gro
 
 **Bouncing attacks** are similar. Votes are again withheld by the attacking validators. Instead of releasing the votes to keep an even split between two forks, they use their votes at opportune moments to justify checkpoints that alternate between fork A and fork B. This flip-flopping of justification between two forks prevents there from being pairs of justified source and target checkpoints that can be finalized on either chain, halting finality.
 
-<iframe title="vimeo-player" src="https://player.vimeo.com/video/637529564?h=25bfe1321e" width="640" height="360" frameborder="0" allowfullscreen></iframe>
+import { AspectRatio } from '@chakra-ui/react'
+
+<AspectRatio ratio={ 16 / 9 } maxWidth="560px" my={8}>
+
+  <iframe title="vimeo-player" src="https://player.vimeo.com/video/637529564?h=25bfe1321e" frameborder="0" allowfullscreen />
+</AspectRatio>
 
 Both bouncing and balancing attacks rely upon the attacker having very fine control over message timing across the network, which is unlikely. Nevertheless, defenses are built into the protocol in the form of additional weighting given to prompt messages compared to slow ones. This is known as [proposer-weight boosting](https://github.com/ethereum/consensus-specs/pull/2730). To defend against bouncing attacks the fork-choice algorithm was updated so that the latest justified checkpoint can only switch to that of an alternative chain during the [first 1/3 of the slots in each epoch](https://ethresear.ch/t/prevention-of-bouncing-attack-on-ffg/6114). This condition prevents the attacker from saving up votes to deploy later - the fork choice algorithm simply stays loyal to the checkpoint it chose in the first 1/3 of the epoch during which time most honest validators would have voted.
 

--- a/src/content/developers/docs/consensus-mechanisms/pos/attack-and-defense/index.md
+++ b/src/content/developers/docs/consensus-mechanisms/pos/attack-and-defense/index.md
@@ -65,12 +65,7 @@ A more sophisticated attack can split the honest validator set into discrete gro
 
 **Bouncing attacks** are similar. Votes are again withheld by the attacking validators. Instead of releasing the votes to keep an even split between two forks, they use their votes at opportune moments to justify checkpoints that alternate between fork A and fork B. This flip-flopping of justification between two forks prevents there from being pairs of justified source and target checkpoints that can be finalized on either chain, halting finality.
 
-import { AspectRatio } from '@chakra-ui/react'
-
-<AspectRatio ratio={ 16 / 9 } maxWidth="560px" my={8}>
-
-  <iframe title="vimeo-player" src="https://player.vimeo.com/video/637529564?h=25bfe1321e" frameborder="0" allowfullscreen />
-</AspectRatio>
+<YouTube id="xcPxwhrg3Ao"/>
 
 Both bouncing and balancing attacks rely upon the attacker having very fine control over message timing across the network, which is unlikely. Nevertheless, defenses are built into the protocol in the form of additional weighting given to prompt messages compared to slow ones. This is known as [proposer-weight boosting](https://github.com/ethereum/consensus-specs/pull/2730). To defend against bouncing attacks the fork-choice algorithm was updated so that the latest justified checkpoint can only switch to that of an alternative chain during the [first 1/3 of the slots in each epoch](https://ethresear.ch/t/prevention-of-bouncing-attack-on-ffg/6114). This condition prevents the attacker from saving up votes to deploy later - the fork choice algorithm simply stays loyal to the checkpoint it chose in the first 1/3 of the epoch during which time most honest validators would have voted.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Adds Chakra's `AspectRatio` component to wrap the embedded iframe used in the PoS [Attack and Defense](https://ethereum.org/en/developers/docs/consensus-mechanisms/pos/attack-and-defense/#reorgs) page (under the "reorgs" section).

## Related Issue
N/A
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
