### PR TITLE
modified StakingProductsCardGrid.tsx

### DIFF
--- a/src/components/Staking/StakingProductsCardGrid.tsx
+++ b/src/components/Staking/StakingProductsCardGrid.tsx
@@ -306,7 +306,6 @@ const StakingProductCard: React.FC<ICardProps> = ({
                 my={4}
                 ms="auto"
                 me={0}
-                py={2}
                 gap="1em"
                 alignItems="center"
               >


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Just removed py={2} from StakingProductCardGrid.tsx  line 309 to reduce spacing
## Description

<!--- Describe your changes in detail -->

## Related Issue
#8696

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
