### PR TITLE
Add CFI and EOF to glossary

### DIFF
--- a/src/content/glossary/index.md
+++ b/src/content/glossary/index.md
@@ -195,6 +195,10 @@ Ethereum's consensus layer is the network of [consensus clients](#consensus-clie
 
 The block validation rules that full nodes follow to stay in consensus with other nodes. Not to be confused with [consensus](#consensus).
 
+### Considered for Inclusion (CFI) {#cfi}
+
+A Core [EIP](#eip) which is not yet active on Mainnet, and client developers are generally positive towards the idea. Assuming it meets all the requirements for mainnet inclusion, it could potentially be included in a network upgrade (not necessarily the next one).
+
 ### Constantinople fork {#constantinople-fork}
 
 The second part of the [Metropolis](#metropolis) stage, originally planned for mid-2018. Expected to include a switch to a hybrid [proof-of-work](#pow)/[proof-of-stake](#pos) consensus algorithm, among other changes.

--- a/src/content/glossary/index.md
+++ b/src/content/glossary/index.md
@@ -409,6 +409,10 @@ A stack-based virtual machine that executes [bytecode](#bytecode). In Ethereum, 
 
 A human-readable form of EVM [bytecode](#bytecode).
 
+### EVM Object Format (EOF) {#eof}
+
+A proposal ([EIP-3540](https://eips.ethereum.org/EIPS/eip-3540)) for an extensible and versioned container format for the EVM, with a once-off validation at deploy time. It brings the tangible benefit of code and data separation, and allows for easy introduction of a variety of changes in the future.
+
 <Divider />
 
 ## F {#section-f}

--- a/src/content/glossary/index.md
+++ b/src/content/glossary/index.md
@@ -409,10 +409,6 @@ A stack-based virtual machine that executes [bytecode](#bytecode). In Ethereum, 
 
 A human-readable form of EVM [bytecode](#bytecode).
 
-### EVM Object Format (EOF) {#eof}
-
-A proposal ([EIP-3540](https://eips.ethereum.org/EIPS/eip-3540)) for an extensible and versioned container format for the EVM, with a once-off validation at deploy time. It brings the tangible benefit of code and data separation, and allows for easy introduction of a variety of changes in the future.
-
 <Divider />
 
 ## F {#section-f}


### PR DESCRIPTION
## Description

Add CFI and EOF as entries in the glossary.

CFI for its relevance around EIP and network upgrade discussions, and EOF given it is under significant development and several related EIPs for EOF are CFI.
