### PR TITLE
Add missing line continuation for lighthouse launch command

### DIFF
--- a/src/content/developers/docs/nodes-and-clients/run-a-node/index.md
+++ b/src/content/developers/docs/nodes-and-clients/run-a-node/index.md
@@ -321,7 +321,7 @@ When starting a Beacon Node on a testnet, you can save significant syncing time 
 Before running Lighthouse, learn more on how to install and configure it in [Lighthouse Book](https://lighthouse-book.sigmaprime.io/installation.html).
 
 ```
-lighthouse beacon_node
+lighthouse beacon_node \
     --network mainnet \
     --datadir /data/ethereum \
     --http \


### PR DESCRIPTION
## Description
Add missing line continuation for lighthouse launch command. The multi-line command does not have line continuation for the first line and therefore would fail.