### PR TITLE
Updated remix-deploy to reflect correct Enviroment

### DIFF
--- a/src/content/developers/tutorials/deploying-your-first-smart-contract/index.md
+++ b/src/content/developers/tutorials/deploying-your-first-smart-contract/index.md
@@ -72,9 +72,10 @@ You can choose to select the “Auto compile” option so the contract will alwa
 
 Then navigate to the deploy and run transactions screen:
 
-![The deploy icon in the Remix toolbar](./remix-deploy.png)
+![The deploy icon in the Remix toolbar](https://user-images.githubusercontent.com/1228667/204576317-10491b6e-c9a9-44bf-adae-9d74a815fefe.png)
 
-Once you are on the "deploy and run" transactions screen, double check that your contract name appears and click on Deploy. As you can see on the top of the page, the current environment is “JavaScript VM” that means that we’ll deploy and interact with our smart contract on a local test blockchain to be able to test faster and without any fees.
+
+Once you are on the "deploy and run" transactions screen, double check that your contract name appears and click on Deploy. As you can see on the top of the page, the current environment is “Remix VM (London)” that means that we’ll deploy and interact with our smart contract on a local test blockchain to be able to test faster and without any fees.
 
 ![The deploy button in the Remix solidity compiler](./remix-deploy-button.png)
 

--- a/src/content/developers/tutorials/deploying-your-first-smart-contract/index.md
+++ b/src/content/developers/tutorials/deploying-your-first-smart-contract/index.md
@@ -74,7 +74,6 @@ Then navigate to the deploy and run transactions screen:
 
 ![The deploy icon in the Remix toolbar](https://user-images.githubusercontent.com/1228667/204576317-10491b6e-c9a9-44bf-adae-9d74a815fefe.png)
 
-
 Once you are on the "deploy and run" transactions screen, double check that your contract name appears and click on Deploy. As you can see on the top of the page, the current environment is “Remix VM (London)” that means that we’ll deploy and interact with our smart contract on a local test blockchain to be able to test faster and without any fees.
 
 ![The deploy button in the Remix solidity compiler](./remix-deploy-button.png)


### PR DESCRIPTION
Changed references from "Javascript VM" to the currently supported "Remix VM (London)" show in Remix

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
