### PR TITLE
Adds staking survey banner to staking pages [Closes #8654]

### DIFF
--- a/src/components/Staking/StakingSurveyBanner.tsx
+++ b/src/components/Staking/StakingSurveyBanner.tsx
@@ -1,0 +1,15 @@
+import React from "react"
+import BannerNotification from "../BannerNotification"
+import Link from "../Link"
+
+const StakingSurveyBanner: React.FC = () => (
+  <BannerNotification shouldShow>
+    Researchers with EthStaker and the Ethereum Foundation are looking for
+    anonymous feedback from stakers.
+    <Link ms={2} to="https://stakingsurvey.paperform.co/">
+      Take a quick survey here
+    </Link>
+  </BannerNotification>
+)
+
+export default StakingSurveyBanner

--- a/src/components/Staking/StakingSurveyBanner.tsx
+++ b/src/components/Staking/StakingSurveyBanner.tsx
@@ -1,14 +1,17 @@
 import React from "react"
 import BannerNotification from "../BannerNotification"
 import Link from "../Link"
+import { Text } from "@chakra-ui/react"
 
 const StakingSurveyBanner: React.FC = () => (
   <BannerNotification shouldShow>
-    Researchers with EthStaker and the Ethereum Foundation are looking for
-    anonymous feedback from stakers.
-    <Link ms={2} to="https://stakingsurvey.paperform.co/">
-      Take a quick survey here
-    </Link>
+    <Text m={0} textAlign="center">
+      Researchers with EthStaker and the Ethereum Foundation are looking for
+      anonymous feedback from stakers.{" "}
+      <Link to="https://stakingsurvey.paperform.co/">
+        Take a quick survey here
+      </Link>
+    </Text>
   </BannerNotification>
 )
 

--- a/src/pages/staking/index.tsx
+++ b/src/pages/staking/index.tsx
@@ -20,6 +20,7 @@ import {
 import FeedbackCard from "../../components/FeedbackCard"
 import ExpandableCard from "../../components/ExpandableCard"
 import StakingStatsBox from "../../components/Staking/StakingStatsBox"
+import StakingSurveyBanner from "../../components/Staking/StakingSurveyBanner"
 import StakingHierarchy from "../../components/Staking/StakingHierarchy"
 import StakingHomeTableOfContents from "../../components/Staking/StakingHomeTableOfContents"
 import StakingCommunityCallout from "../../components/Staking/StakingCommunityCallout"
@@ -344,6 +345,7 @@ const StakingPage = ({
         description={translateMessageId("page-staking-meta-description", intl)}
       />
       <HeroStatsWrapper>
+        <StakingSurveyBanner />
         <PageHero content={heroContent} />
         <StakingStatsBox />
       </HeroStatsWrapper>

--- a/src/templates/staking.tsx
+++ b/src/templates/staking.tsx
@@ -46,6 +46,7 @@ import StakingHowSoloWorks from "../components/Staking/StakingHowSoloWorks"
 import StakingConsiderations from "../components/Staking/StakingConsiderations"
 import StakingCommunityCallout from "../components/Staking/StakingCommunityCallout"
 import StakingGuides from "../components/Staking/StakingGuides"
+import StakingSurveyBanner from "../components/Staking/StakingSurveyBanner"
 
 import { isLangRightToLeft, TranslationKey } from "../utils/translations"
 import { Context } from "../types"
@@ -403,6 +404,7 @@ const StakingPage = ({
 
   return (
     <Container>
+      <StakingSurveyBanner />
       <HeroContainer>
         <TitleCard>
           <Breadcrumbs slug={location.pathname} />


### PR DESCRIPTION
## Description
- Adds a banner linking out to the staking survey noted in issue #8654
- Banner added to /staking and all three subpages via the `staking` template

@Rodrigolvc Feel free to suggest alterations to the wording here

## Related Issue
- [Closes #8654]