### PR TITLE
Replace Kanye/Yeezy reference NFT with Nike/Jordans

### DIFF
--- a/src/content/nft/index.md
+++ b/src/content/nft/index.md
@@ -14,7 +14,7 @@ summaryPoint3: Powered by smart contracts on the Ethereum blockchain.
 
 NFTs are currently taking the digital art and collectibles world by storm. Digital artists are seeing their lives change thanks to huge sales to a new crypto-audience. And celebrities are joining in as they spot a new opportunity to connect with fans. But digital art is only one way to use NFTs. Really they can be used to represent ownership of any unique asset, like a deed for an item in the digital or physical realm.
 
-If Andy Warhol had been born in the late 90s, he probably would have minted Campbell's Soup as an NFT. It's only a matter of time before your favorite brand has a run of NFTs on Ethereum. And one day owning your car might be proved with an NFT.
+If Andy Warhol had been born in the late 90s, he probably would have minted Campbell's Soup as an NFT. It's only a matter of time before Nike puts a run of Jordans on Ethereum. And one day owning your car might be proved with an NFT.
 
 ## What's an NFT? {#what-are-nfts}
 

--- a/src/content/nft/index.md
+++ b/src/content/nft/index.md
@@ -14,7 +14,7 @@ summaryPoint3: Powered by smart contracts on the Ethereum blockchain.
 
 NFTs are currently taking the digital art and collectibles world by storm. Digital artists are seeing their lives change thanks to huge sales to a new crypto-audience. And celebrities are joining in as they spot a new opportunity to connect with fans. But digital art is only one way to use NFTs. Really they can be used to represent ownership of any unique asset, like a deed for an item in the digital or physical realm.
 
-If Andy Warhol had been born in the late 90s, he probably would have minted Campbell's Soup as an NFT. It's only a matter of time before Kanye puts a run of Yeezys on Ethereum. And one day owning your car might be proved with an NFT.
+If Andy Warhol had been born in the late 90s, he probably would have minted Campbell's Soup as an NFT. It's only a matter of time before your favorite brand has a run of NFTs on Ethereum. And one day owning your car might be proved with an NFT.
 
 ## What's an NFT? {#what-are-nfts}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Kanye West has recently made many antisemitic comments and has [taken pro-nazi stances publicly](https://www.mediamatters.org/infowars/rapper-ye-goes-unhinged-antisemitic-rant-infowars). Earlier in his career the examples on this page were about Kanye the artist and the popular brand of shoes (Yeezys) that he created and marketed. Now Kanye is much more divisive and is a more dangerous name to use as an example. His brand of shoes has also been dropped by Adidas, so, while it is possible he takes his brand to Ethereum next, we can do better than to associate Ethereum with someone who spouts hate so openly.

When people search to learn about NFTs and land on ethereum.org, for many seeing Kanye's name and brand as examples might turn them off of the rest of the educational content that the page has to offer.
<!--- Describe your changes in detail -->
I propose we use a generic example and have replaced the text with one in this PR.
## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
