### PR TITLE
refactor: postmergebanner to chakra

### DIFF
--- a/src/components/Banners/PostMergeBanner.tsx
+++ b/src/components/Banners/PostMergeBanner.tsx
@@ -3,14 +3,14 @@ import BannerNotification from "../BannerNotification"
 import Translation from "../Translation"
 
 import { TranslationKey } from "../../utils/translations"
-import { Flex, Text } from "@chakra-ui/react"
+import { Center, Text } from "@chakra-ui/react"
 
 export interface IProps {
   translationString: TranslationKey
 }
 
 const PostMergeBanner: React.FC<IProps> = ({ translationString }) => (
-  <Flex
+  <Center
     as={BannerNotification}
     shouldShow={true}
     zIndex={1}
@@ -25,7 +25,7 @@ const PostMergeBanner: React.FC<IProps> = ({ translationString }) => (
     <Text maxW="100ch" m={0} p={0}>
       <Translation id={translationString} />
     </Text>
-  </Flex>
+  </Center>
 )
 
 export default PostMergeBanner

--- a/src/components/Banners/PostMergeBanner.tsx
+++ b/src/components/Banners/PostMergeBanner.tsx
@@ -14,7 +14,6 @@ const PostMergeBanner: React.FC<IProps> = ({ translationString }) => (
     as={BannerNotification}
     shouldShow={true}
     zIndex={1}
-    justifyContent="center"
     textAlign="center"
     sx={{
       a: {

--- a/src/components/Banners/PostMergeBanner.tsx
+++ b/src/components/Banners/PostMergeBanner.tsx
@@ -1,35 +1,31 @@
 import React from "react"
-import styled from "@emotion/styled"
 import BannerNotification from "../BannerNotification"
 import Translation from "../Translation"
 
 import { TranslationKey } from "../../utils/translations"
-
-const StyledBannerNotification = styled(BannerNotification)`
-  display: flex;
-  z-index: 1;
-  justify-content: center;
-  p {
-    max-width: 100ch;
-    margin: 0;
-    padding: 0;
-  }
-  a {
-    text-decoration: underline;
-  }
-  text-align: center;
-`
+import { Flex, Text } from "@chakra-ui/react"
 
 export interface IProps {
   translationString: TranslationKey
 }
 
 const PostMergeBanner: React.FC<IProps> = ({ translationString }) => (
-  <StyledBannerNotification shouldShow={true}>
-    <p>
+  <Flex
+    as={BannerNotification}
+    shouldShow={true}
+    zIndex={1}
+    justifyContent="center"
+    textAlign="center"
+    sx={{
+      a: {
+        "text-decoration": "underline",
+      },
+    }}
+  >
+    <Text maxW="100ch" m={0} p={0}>
       <Translation id={translationString} />
-    </p>
-  </StyledBannerNotification>
+    </Text>
+  </Flex>
 )
 
 export default PostMergeBanner


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Migrates `PostMergeBanner` component from `emotion` to `chakra-ui`

## Related Issue
#8632
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
