### PR TITLE
Adding links to Kaleido services

### DIFF
--- a/src/content/developers/docs/storage/index.md
+++ b/src/content/developers/docs/storage/index.md
@@ -177,6 +177,12 @@ Proof-of-stake based:
 - [Documentation](https://docs.filebase.com/)
 - [GitHub](https://github.com/filebase)
 
+**Kaleido - _A blockchain-as-a-service platform with click-button IPFS Nodes_**
+
+- [Kaleido](https://kaleido.io/)
+- [Documentation](https://docs.kaleido.io/kaleido-services/ipfs/)
+- [GitHub](https://github.com/kaleido-io)
+
 ## Further reading {#further-reading}
 
 - [What Is Decentralized Storage?](https://coinmarketcap.com/alexandria/article/what-is-decentralized-storage-a-deep-dive-by-filecoin) - _CoinMarketCap_

--- a/src/content/enterprise/index.md
+++ b/src/content/enterprise/index.md
@@ -59,6 +59,7 @@ Some collaborative efforts to make Ethereum enterprise friendly have been made b
 - [EY OpsChain](https://blockchain.ey.com/products/contract-manager) _provides a procurement workflow by issuing RFQ’s, contracts, purchase orders, and invoices across your network of trusted business partners_
 - [Hyperledger Besu](https://www.hyperledger.org/use/besu) _an enterprise focused open-source Ethereum client developed under the Apache 2.0 license and written in Java_
 - [Infura](https://infura.io/) _scalable API access to the Ethereum and IPFS networks_
+- [Kaleido] (https://kaleido.io/) _an enterprise-focused development platform that offers simplified blockchain and digital asset applications_
 - [Provide](https://provide.services/) _infrastructure and APIs for Enterprise Web3 applications_
 - [QuickNode](https://www.quicknode.com/) _provides reliable and fast nodes with high-level APIs like NFT API, Token API, etc., while delivering a unified product suite and enterprise-grade solutions_
 - [Unibright](https://unibright.io/) _a team of blockchain specialists, architects, developers and consultants with 20+ years of experience in business processes and integration_


### PR DESCRIPTION
Added information about Kaleido's services to the enterprise ethereum page as well as the storage page

<!--- Provide a general summary of your changes in the Title above -->

## Description

Added links to the Enterprise Ethereum and Storage documentation pages regarding Kaleido's services.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/ethereum/ethereum-org-website/issues/8855#issue-1485271272