### PR TITLE
Update a Dapp Link

### DIFF
--- a/src/pages-conditional/dapps.tsx
+++ b/src/pages-conditional/dapps.tsx
@@ -1039,7 +1039,7 @@ const DappsPage = ({
         "page-dapps-dapp-description-cryptopunks",
         intl
       ),
-      link: "https://www.larvalabs.com/cryptopunks",
+      link: "https://cryptopunks.app/",
       image: getImage(data.cryptopunks),
       alt: translateMessageId("page-dapps-cryptopunks-logo-alt", intl),
     },


### PR DESCRIPTION
## Update a Dapp Link
Updated the CryptoPunks link since, after the acquisition of Yuga Labs, the web app will soon be moving from "https://www.larvalabs.com/cryptopunks" to "https://cryptopunks.app/" (note for example that, by selecting a CryptoPunks, you will already be redirected to the new site) 🆕