### PR TITLE
Fix (`StablecoinAccordion`): change `color` prop in pills to `background`

### DIFF
--- a/src/components/StablecoinAccordion.tsx
+++ b/src/components/StablecoinAccordion.tsx
@@ -537,7 +537,7 @@ const StablecoinAccordion: React.FC<IProps> = () => {
               <Title>
                 <Translation id="page-stablecoins-accordion-swap-title" />
               </Title>
-              <StyledPill color="success100">
+              <StyledPill background="success100">
                 <Translation id="page-stablecoins-accordion-swap-pill" />
               </StyledPill>
             </Row>
@@ -724,7 +724,7 @@ const StablecoinAccordion: React.FC<IProps> = () => {
               <Title>
                 <Translation id="page-stablecoins-accordion-borrow-title" />
               </Title>
-              <StyledPill color="warning">
+              <StyledPill background="warning">
                 <Translation id="page-stablecoins-accordion-borrow-pill" />
               </StyledPill>
             </Row>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
In PR #8774 a bug was introduced to the `StableAccordion` component where the pills were not rendering the text color correctly.

This PR changes the `color` prop to the `StyledPill` instances to `background` which was changed in the `Pill` component. This ensures that the background of the `StyledPill`'s receives the passed in color and not the text.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes: #8923 
