### PR TITLE
fix: small typo/grammar issue

### DIFF
--- a/src/content/developers/docs/consensus-mechanisms/pos/keys/index.md
+++ b/src/content/developers/docs/consensus-mechanisms/pos/keys/index.md
@@ -4,7 +4,7 @@ description: An explanation of keys used in Ethereum's proof-of-stake consensus 
 lang: en
 ---
 
-Ethereum secures user's assets using public-private key cryptography. The public key is used as the basis for an Ethereum address—that is, it is visible to the general public and used as a unique identifier. The private (or 'secret') key should only ever be accessible to an account owner. The private key is used to 'sign' transactions and data so that cryptography can prove that the holder approves some action of a specific private key.
+Ethereum secures user assets using public-private key cryptography. The public key is used as the basis for an Ethereum address—that is, it is visible to the general public and used as a unique identifier. The private (or 'secret') key should only ever be accessible to an account owner. The private key is used to 'sign' transactions and data so that cryptography can prove that the holder approves some action of a specific private key.
 
 Ethereum's keys are generated using [elliptic-curve cryptography](https://en.wikipedia.org/wiki/Elliptic-curve_cryptography).
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Small typo/grammar issue: "Ethereum secures user's assets using public-private key cryptography." -> "Ethereum secures user assets using public-private key cryptography."

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/ethereum/ethereum-org-website/issues/8898