### PR TITLE
fix: incorrect formating of sub-header

### DIFF
--- a/src/content/developers/docs/consensus-mechanisms/pos/block-proposal/index.md
+++ b/src/content/developers/docs/consensus-mechanisms/pos/block-proposal/index.md
@@ -14,7 +14,7 @@ Block proposal is part of the proof-of-stake protocol. To help understand this p
 
 Validator accounts propose blocks. Validator accounts are managed by node operators who run validator software as part of their execution and consensus clients and have deposited at least 32 ETH into the deposit contract. However, each validator is only occasionally responsible for proposing a block. Ethereum measures time in slots and epochs. Each slot is twelve seconds, and 32 slots (6.4 minutes) make up an epoch. Every slot is an opportunity to add a new block on Ethereum.
 
-### Random selection {#random-selection}
+### Random selection {#random-selection}
 
 A single validator is pseudo-randomly chosen to propose a block in each slot. There is no such thing as true randomness in a blockchain because if each node generated genuinely random numbers, they couldn't come to consensus. Instead, the aim is to make the validator selection process unpredictable. The randomness is achieved on Ethereum using an algorithm called RANDAO that mixes a hash from the block proposer with a seed that gets updated every block. This value is used to select a specific validator from the total validator set. The validator selection is fixed four epochs in advance as a way to protect against certain kinds of seed manipulation.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently the subheader does not render. 

 `### Random selection {#random-selection}` gets displayed as paragraph text erroneously.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/ethereum/ethereum-org-website/issues/8934
