### PR TITLE
fix: clarified wording regarding slasher rewards

### DIFF
--- a/src/content/developers/docs/consensus-mechanisms/pos/rewards-and-penalties/index.md
+++ b/src/content/developers/docs/consensus-mechanisms/pos/rewards-and-penalties/index.md
@@ -52,7 +52,7 @@ These weights sum to 64. The reward is calculated as the sum of the applicable w
 
 An additional reward is added to incentivize rapid attestations. This is the `inclusion_delay_reward`. This has a value equal to the `base_reward` multiplied by `1/delay` where `delay` is the number of slots separating the block proposal and attestation. For example, if the attestation is submitted within one slot of the block proposal the attestor receives `base_reward * 1/1 == base_reward`. If the attestation arrives in the next slot, the attestor received `base_reward * 1/2` and so on.
 
-Block proposers receive `8 / 64 * base_reward` for **each valid attestation** included in the block, so the actual value of the reward scales with the number of attesting validators. Block proposers can also increase their reward by including evidence of misbehavior by other validators in their proposed block. These rewards are the "carrots" that encourage validator honesty. A block proposer which includes slashing will be rewarded with the `slashed_validators_effective_balance / 512`.
+Block proposers receive `8 / 64 * base_reward` for **each valid attestation** included in the block, so the actual value of the reward scales with the number of attesting validators. Block proposers can also increase their reward by including evidence of misbehavior by other validators in their proposed block. These rewards are the "carrots" that encourage validator honesty. There is also a reward for a block proposer reporting validators that should be slashed, equal to 1/512 * effective balance for each slashed validator, `slashed_validators_effective_balance / 512`.
 
 ### Penalties {#penalties}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
"A block proposer which includes slashing will be rewarded with the `slashed_validators_effective_balance / 512`." is less descriptive and more vague than "There is also a reward for a block proposer reporting validators that should be slashed, equal to 1/512 * effective balance for each slashed validator, `slashed_validators_effective_balance / 512`."

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/ethereum/ethereum-org-website/issues/8937
