### PR TITLE
fix: Markdown does not work in infobanner

### DIFF
--- a/src/content/developers/docs/consensus-mechanisms/pow/mining-algorithms/ethash/index.md
+++ b/src/content/developers/docs/consensus-mechanisms/pow/mining-algorithms/ethash/index.md
@@ -5,7 +5,7 @@ lang: en
 ---
 
 <InfoBanner emoji=":wave:">
-   Ethash was Ethereum's proof-of-work mining algorithm. Proof-of-work has now been **switched off entirely** and Ethereum is now secured using [proof-of-stake](/developers/docs/consensus-mechanisms/pos) instead. Read more on <a href="/upgrades/merge/">The Merge</a>, <a href="/developers/docs/consensus-mechanisms/pos/">proof-of-stake</a> and <a href="/staking/">staking</a>. This page is for historical interest!  
+   Ethash was Ethereum's proof-of-work mining algorithm. Proof-of-work has now been **switched off entirely** and Ethereum is now secured using <a href="/developers/docs/consensus-mechanisms/pos/">proof-of-stake</a> instead. Read more on <a href="/upgrades/merge/">The Merge</a>, <a href="/developers/docs/consensus-mechanisms/pos/">proof-of-stake</a> and <a href="/staking/">staking</a>. This page is for historical interest!  
 </InfoBanner>
 
 [Ethash](https://github.com/ethereum/wiki/wiki/Ethash) is a modified version of the [Dagger-Hashimoto](/developers/docs/consensus-mechanisms/pow/mining-algorithms/dagger-hashimoto) algorithm. Ethash proof-of-work is [memory hard](https://wikipedia.org/wiki/Memory-hard_function), which was thought to make the algorithm ASIC resistant. Ethash ASICs were eventually developed but GPU mining was still a viable option until proof-of-work was switched off. Ethash is still used to mine other coins on other non-Ethereum proof-of-work networks.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

THe documentation page about Ethash uses markdown in its infobanner, which is not rendered correctly. 

<!--- Describe your changes in detail -->

![image](https://user-images.githubusercontent.com/24369532/208303703-6de466e5-f13b-4344-8a32-1c0587fa8466.png)


## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
