### PR TITLE
fix - etherscan.io redirection link [Fixes #8945]

### DIFF
--- a/src/content/developers/docs/data-and-analytics/index.md
+++ b/src/content/developers/docs/data-and-analytics/index.md
@@ -20,7 +20,7 @@ In terms of architectural fundamentals, understanding what an [API](https://www.
 
 Many [Block Explorers](/developers/docs/data-and-analytics/block-explorers/) offer [RESTful](https://www.wikipedia.org/wiki/Representational_state_transfer) [API](https://www.wikipedia.org/wiki/API) gateways that will provide developers visibility into real-time data on blocks, transactions, miners, accounts, and other on-chain activity.
 
-Developers can then process and transform this data to give their users unique insights and interactions with the [blockchain](/glossary/#blockchain). For example, [Etherscan](etherscan.io) provides execution and consensus data for every 12s slot.
+Developers can then process and transform this data to give their users unique insights and interactions with the [blockchain](/glossary/#blockchain). For example, [Etherscan](https://etherscan.io) provides execution and consensus data for every 12s slot.
 
 ## The Graph {#the-graph}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above  -->

## Description
updated working external redirection link for  https://etherscan.io/ portal.
for which: changed the url-src link in the mark-down file, as external links(not under ethereum.org domain) should start  with `https://` just like existing _wikipedia-api-src-url_ in md fle -> `https://www.wikipedia.org/wiki/API`

<!--- Describe your changes in detail -->

## Related Issue
#8945 

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
