### PR TITLE
Fix: Replace `div` with fragment in `tutorial` template

### DIFF
--- a/src/templates/tutorial.tsx
+++ b/src/templates/tutorial.tsx
@@ -174,7 +174,7 @@ const TutorialPage = ({
   const hideEditButton = !!mdx.frontmatter.hideEditButton
   const absoluteEditPath = `${editContentUrl}${relativePath}`
   return (
-    <div>
+    <>
       {showPostMergeBanner && (
         <PostMergeBanner
           translationString={postMergeBannerTranslationString!}
@@ -213,7 +213,7 @@ const TutorialPage = ({
           />
         )}
       </Page>
-    </div>
+    </>
   )
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Currently, there is both left and right overflow on tutorial pages, which use the `tutorial.tsx` template:
![Screen Shot 2022-12-20 at 11 39 02](https://user-images.githubusercontent.com/65234762/208718988-ce6a27eb-edee-40ae-abbe-d010296222f4.png)

This issue points to the `div` element wrapping all the content in the `tutorial.tsx` template. The flexbox applied to `main` in the `Layout.tsx` is stretching this `div` past the browser window. Replacing this `div` with a React fragment resolves the global overflow issues for the tutorial pages, and retains the styling in `Layout` to prevent creating other bugs.

This seems to only impact the tutorial pages and no other templates.

## Related Issue

N/A

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
