### PR TITLE
Add missing question mark on DID header

### DIFF
--- a/src/content/decentralized-identity/index.md
+++ b/src/content/decentralized-identity/index.md
@@ -17,7 +17,7 @@ However, traditional identity management systems have long relied on centralized
 
 To solve these problems, we have decentralized identity systems built on public blockchains like Ethereum. Decentralized identity allows individuals to manage their identity-related information. With decentralized identity solutions, _you_ can create identifiers and claim and hold your attestations without relying on central authorities, like service providers or governments.
 
-## What is identity {#what-is-identity}
+## What is identity? {#what-is-identity}
 
 Identity means an individual's sense of self, defined by unique characteristics. Identity refers to being an _individual_, i.e., a distinct human entity. Identity could also refer to other non-human entities, such as an organization or authority.
 


### PR DESCRIPTION
## Description
Noticed that we're missing a question mark from the "What is identity" header on the DID page; this PR corrects it to make it consistent with the remainder of the page.

## Related Issue
None filed