### PR TITLE
Chore: remove extra `Item` type export in `TableOfContents`

### DIFF
--- a/src/components/TableOfContents/index.tsx
+++ b/src/components/TableOfContents/index.tsx
@@ -23,9 +23,6 @@ import Mobile from "./TableOfContentsMobile"
 import ItemsList from "./ItemsList"
 import { getCustomId, Item, outerListProps } from "./utils"
 
-// For use in pages and templates
-export { Item }
-
 export interface IProps extends BoxProps {
   items: Array<Item>
   maxDepth?: number


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This removes an extra type export of `Item` from the main `TableOfContents` file, as it is already exported from [utils.ts](https://github.com/ethereum/ethereum-org-website/blob/efa2d964d6715db1e1b5700ae6a513ade0f54faf/src/components/TableOfContents/utils.ts#L27-L30)
