### PR TITLE
index.md

### DIFF
--- a/src/content/developers/docs/consensus-mechanisms/index.md
+++ b/src/content/developers/docs/consensus-mechanisms/index.md
@@ -36,7 +36,7 @@ Like Bitcoin, Ethereum once used a **proof-of-work (PoW)** based consensus proto
 
 #### Block creation {#pow-block-creation}
 
-Miners compete to create new blocks filled with processed transactions. The winner shares the new block with the rest of the network and earns some freshly minted ETH. The race is won by the computer which is able to solve a math puzzle fastest. This produces the cryptographic link between the current block and the block that went before. Solving this puzzle is the work in "proof-of-work". The the canonical chain is then determined by a fork-choice rule that selects the set of blocks that have had the most work done to mine them.
+Miners compete to create new blocks filled with processed transactions. The winner shares the new block with the rest of the network and earns some freshly minted ETH. The race is won by the computer which is able to solve a math puzzle fastest. This produces the cryptographic link between the current block and the block that went before. Solving this puzzle is the work in "proof-of-work". The canonical chain is then determined by a fork-choice rule that selects the set of blocks that have had the most work done to mine them.
 
 #### Security {#pow-security}
 


### PR DESCRIPTION
There were 2 " The the " on line no 39 in the documentation section of Block creation {#pow-block-creation}. I fixed the dual "The" into 1 "The". Kindly merge this PR. It will fix the grammar mistake, and the documentation will look good. Thank you!

<!--- Provide a general summary of your changes in the Title above -->

## Description
I was reading the consensus-mechanisms on ethereum.org. Then I stumbled upon this grammar mistake and I thought I should make a pull request and submit this issue as it creates a hurdle in my learning/reading experience.
<!--- Describe your changes in detail -->

## Related Issue
 Typo in Consensus-mechanisms/Block creation {#pow-block-creation} Line no 39. #9030 

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
