### PR TITLE
Docs: Update Blocks page language & description [Fixes #9039]

### DIFF
--- a/src/content/developers/docs/blocks/index.md
+++ b/src/content/developers/docs/blocks/index.md
@@ -23,7 +23,7 @@ By spacing out commits, we give all network participants enough time to come to 
 
 To preserve the transaction history, blocks are strictly ordered (every new block created contains a reference to its parent block), and transactions within blocks are strictly ordered as well. Except in rare cases, at any given time, all participants on the network are in agreement on the exact number and history of blocks, and are working to batch the current live transaction requests into the next block.
 
-Once a block is put together by a randomly selected network validator, it is propagated to the rest of the network; all nodes add this block to the end of their blockchain, and a new validator is selected to create the next block. The exact block-assembly process and commitment/consensus process is currently specified by Ethereum’s “proof-of-stake” protocol.
+Once a block is put together by a randomly selected validator on the network, it is propagated to the rest of the network; all nodes add this block to the end of their blockchain, and a new validator is selected to create the next block. The exact block-assembly process and commitment/consensus process is currently specified by Ethereum’s “proof-of-stake” protocol.
 
 ## Proof-of-stake protocol {#proof-of-work-protocol}
 

--- a/src/content/developers/docs/blocks/index.md
+++ b/src/content/developers/docs/blocks/index.md
@@ -4,7 +4,7 @@ description: An overview of blocks in the Ethereum blockchain – their data str
 lang: en
 ---
 
-Blockchain data is grouped, processed and stored in blocks. To create a block, transactions are batched and combined with the hash of a previous block in the chain. This previous block hash reference links blocks together (in a chain) because hashes are cryptographically derived from the existing block data. As changes to any previously confirmed blocks will alter the derived hashes in subsequent blocks, network participants are easily able to invalidate blocks which diverge from actual network history.
+Blocks are batches of transactions with a hash of the previous block in the chain. This links blocks together (in a chain) because hashes are cryptographically derived from the block data. This prevents fraud, because one change in any block in history would invalidate all the following blocks as all subsequent hashes would change and everyone running the blockchain would notice.
 
 ## Prerequisites {#prerequisites}
 

--- a/src/content/developers/docs/blocks/index.md
+++ b/src/content/developers/docs/blocks/index.md
@@ -4,7 +4,7 @@ description: An overview of blocks in the Ethereum blockchain – their data str
 lang: en
 ---
 
-Blocks are batches of transactions with a hash of the previous block in the chain. This links blocks together (in a chain) because hashes are cryptographically derived from the block data. This prevents fraud, because one change in any block in history would invalidate all the following blocks as all subsequent hashes would change and everyone running the blockchain would notice.
+Blockchain data is grouped, processed and stored in blocks. To create a block, transactions are batched and combined with the hash of a previous block in the chain. This previous block hash reference links blocks together (in a chain) because hashes are cryptographically derived from the existing block data. As changes to any previously confirmed blocks will alter the derived hashes in subsequent blocks, network participants are easily able to invalidate blocks which diverge from actual network history.
 
 ## Prerequisites {#prerequisites}
 
@@ -23,7 +23,7 @@ By spacing out commits, we give all network participants enough time to come to 
 
 To preserve the transaction history, blocks are strictly ordered (every new block created contains a reference to its parent block), and transactions within blocks are strictly ordered as well. Except in rare cases, at any given time, all participants on the network are in agreement on the exact number and history of blocks, and are working to batch the current live transaction requests into the next block.
 
-Once a block is put together by some validator on the network, it is propagated to the rest of the network; all nodes add this block to the end of their blockchain, and a new validator is selected to create the next block. The exact block-assembly process and commitment/consensus process is currently specified by Ethereum’s “proof-of-stake” protocol.
+Once a block is put together by a randomly selected network validator, it is propagated to the rest of the network; all nodes add this block to the end of their blockchain, and a new validator is selected to create the next block. The exact block-assembly process and commitment/consensus process is currently specified by Ethereum’s “proof-of-stake” protocol.
 
 ## Proof-of-stake protocol {#proof-of-work-protocol}
 
@@ -31,7 +31,7 @@ Proof-of-stake means the following:
 
 - Validating nodes have to stake 32 ETH into a deposit contract as collateral against bad behavior. This helps protect the network because provably dishonest activity leads to some or all of that stake being destroyed.
 - In every slot (spaced twelve seconds apart) a validator is randomly selected to be the block proposer. They bundle transactions together, execute them and determine a new 'state'. They wrap this information into a block and pass it around to other validators.
-- Other validators who hear about a new block re-execute the transactions to ensure they agree with the proposed change to the global state. Assuming the block is valid they add it to their own database.
+- Other validators who hear about the new block re-execute the transactions to ensure they agree with the proposed change to the global state. Assuming the block is valid, they add it to their own database.
 - If a validator hears about two conflicting blocks for the same slot they use their fork-choice algorithm to pick the one supported by the most staked ETH.
 
 [More on proof-of-stake](/developers/docs/consensus-mechanisms/pos)
@@ -123,7 +123,9 @@ The `execution_payload` itself contains the following (notice this is identical 
 
 ## Block time {#block-time}
 
-Block time refers to the time separating blocks. In Ethereum, time is divided up into twelve second units called 'slots'. In each slot a single validator is selected to propose a block. Assuming all validators are online and fully functional there will be a block in every slot, meaning the block time is 12s. However, occasionally validators might be offline when called to propose a block, meaning slots can sometimes go empty. This is different to proof-of-work based systems where block times are probabilistic and tuned by the mining difficulty.
+Block time refers to the time separating blocks. In Ethereum, time is divided up into twelve second units called 'slots'. In each slot a single validator is selected to propose a block. Assuming all validators are online and fully functional there will be a block in every slot, meaning the block time is 12s. However, occasionally validators might be offline when called to propose a block, meaning slots can sometimes go empty.
+
+This implementation differs from proof-of-work based systems where block times are probabilistic and tuned by the protocol's target mining difficulty. Ethereum's [average block time](https://etherscan.io/chart/blocktime) is a perfect example of this whereby the transition from proof-of-work to proof-of-stake can be clearly inferred based on the consistency of the new 12s block time.
 
 ## Block size {#block-size}
 


### PR DESCRIPTION
## Description

- Edited introductory paragraph to aid understanding of block segmentation and linking of blocks
- Added details to Ethereum's [average block time](https://etherscan.io/chart/blocktime) to provide greater context on Ethereum's transition to PoS

## Related Issue

Fixes #9039 
