### PR TITLE
Fix improper tag nesting - causing SSR hydration issue

### DIFF
--- a/src/components/StatsBoxGrid/GridItem.tsx
+++ b/src/components/StatsBoxGrid/GridItem.tsx
@@ -164,7 +164,7 @@ export const GridItem: React.FC<IGridItemProps> = ({ metric, dir }) => {
           )}
         </>
       )}
-      <Text
+      <Box
         position="absolute"
         bottom="8%"
         fontSize={{ base: "max(8.8vw, 48px)", lg: "min(4.4vw, 4rem)" }}
@@ -176,7 +176,7 @@ export const GridItem: React.FC<IGridItemProps> = ({ metric, dir }) => {
         textOverflow="ellipsis"
       >
         {value}
-      </Text>
+      </Box>
     </Flex>
   )
 }


### PR DESCRIPTION
We have invalid DOM nesting here. I'm changing the wrapping `Text` to a `Box`.

![image](https://user-images.githubusercontent.com/468158/211055605-bf07b7fa-259f-45db-9f12-42d2ab13eda3.png)
