### PR TITLE
feat: fixed broken link

### DIFF
--- a/src/pages/learn/index.tsx
+++ b/src/pages/learn/index.tsx
@@ -869,7 +869,7 @@ const LearnPage = ({ data }: PageProps<Queries.LearnPageQuery, Context>) => {
               </h3>
               <ul>
                 <li>
-                  <Link to="https://podcast.ethhub.io/">Into the Ether</Link>{" "}
+                  <Link to="https://open.spotify.com/show/2CNyWXgKVxTqTlmLhc8A5m?si=810b2aed1666408e">Into the Ether</Link>{" "}
                   <i>
                     <Translation id="ethhub-description" />
                   </i>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

All ethhub sites are not working, added Spotify podcast link of Into the Ether as replacement

## Related Issue
#9089 

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
