### PR TITLE
Fix the URL for Ethereum Madrid meetup

### DIFF
--- a/src/data/community-meetups.json
+++ b/src/data/community-meetups.json
@@ -171,7 +171,7 @@
     "title": "Ethereum Madrid",
     "emoji": ":es:",
     "location": "Madrid",
-    "link": "https://ethereummadrid.com/"
+    "link": "https://www.meetup.com/ethereum-madrid/"
   },
   {
     "title": "Geneva DevChain",


### PR DESCRIPTION
Just change the link for Ethereum Madrid meetup as asked by the organizers.

## Description

The organizers of the meetup prefer to use meetup.com link instead of the ethereum madrid website, it is also more consistent and therefore more intuitive for users visiting the link, as most of the meetup links on this page point to meetup.com


## Related Issue

No additional relevant info to add
