### PR TITLE
Replace EthHub sample with ConsenSys on ethereum.org style guide

### DIFF
--- a/src/content/contributing/style-guide/index.md
+++ b/src/content/contributing/style-guide/index.md
@@ -315,12 +315,12 @@ When citing articles from a specific author or organization, use the article's n
 <--- Good --->
 
 - [A rollup-centric ethereum roadmap](https://ethereum-magicians.org/t/a-rollup-centric-ethereum-roadmap/4698) — _Vitalik Buterin_
-- [The History of Ethereum Testnets](https://consensys.net/blog/news/the-history-of-ethereum-testnets/) – _Consensys_
+- [The History of Ethereum Testnets](https://consensys.net/blog/news/the-history-of-ethereum-testnets/) – _ConsenSys_
 
 <--- Bad--->
 
 - [A rollup-centric ethereum roadmap by Vitalik Buterin](https://ethereum-magicians.org/t/a-rollup-centric-ethereum-roadmap/4698)
-- [Consensys on The History of Ethereum Testnets](https://consensys.net/blog/news/the-history-of-ethereum-testnets/) – _Consensys_
+- [ConsenSys on The History of Ethereum Testnets](https://consensys.net/blog/news/the-history-of-ethereum-testnets/) – _ConsenSys_
 ```
 
 ## Anything else? {#anything-else}

--- a/src/content/contributing/style-guide/index.md
+++ b/src/content/contributing/style-guide/index.md
@@ -315,12 +315,12 @@ When citing articles from a specific author or organization, use the article's n
 <--- Good --->
 
 - [A rollup-centric ethereum roadmap](https://ethereum-magicians.org/t/a-rollup-centric-ethereum-roadmap/4698) — _Vitalik Buterin_
-- [Oracles](https://docs.ethhub.io/built-on-ethereum/oracles/what-are-oracles/) – _EthHub_
+- [The History of Ethereum Testnets](https://consensys.net/blog/news/the-history-of-ethereum-testnets/) – _Consensys_
 
 <--- Bad--->
 
 - [A rollup-centric ethereum roadmap by Vitalik Buterin](https://ethereum-magicians.org/t/a-rollup-centric-ethereum-roadmap/4698)
-- [EthHub on Oracles](https://docs.ethhub.io/built-on-ethereum/oracles/what-are-oracles/) – _EthHub_
+- [Consensys on The History of Ethereum Testnets](https://consensys.net/blog/news/the-history-of-ethereum-testnets/) – _Consensys_
 ```
 
 ## Anything else? {#anything-else}


### PR DESCRIPTION
## Description
Update sample link as EthHub resource is being sunset. Sample has been changed to a generic Consensys [article](https://consensys.net/blog/news/the-history-of-ethereum-testnets/) as this is another well-known resource for Ethereum related content.

## Related Issue
#8862 
