### PR TITLE
Add EIPs included in Paris upgrade to History section

### DIFF
--- a/src/content/history/index.md
+++ b/src/content/history/index.md
@@ -38,6 +38,13 @@ The Paris upgrade was triggered by the proof-of-work blockchain passing a [termi
 
 - [Read the Paris upgrade specification](https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/paris.md)
 
+<ExpandableCard title="Paris EIPs" contentPreview="Official improvements included in this upgrade.">
+
+- [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675) – _Upgrade consensus to Proof-of-Stake_
+- [EIP-4399](https://eips.ethereum.org/EIPS/eip-4399) – _Supplant DIFFICULTY opcode with PREVRANDAO_
+
+</ExpandableCard>
+
 ---
 
 ### Bellatrix {#bellatrix}


### PR DESCRIPTION
Adds the EIPs included in the Paris upgrade to the ethereum.org website's history section. 

## Description

Adds a card under the Paris upgrade section on the History page with links to EIP's 3675 and 4399 [included therein](https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/paris.md).
