### PR TITLE
Fix twemoji cdn issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "react": "^18.0.0",
     "react-countdown": "^2.3.2",
     "react-dom": "^18.0.0",
-    "react-emoji-render": "^1.2.4",
+    "react-emoji-render": "^2.0.1",
     "react-helmet": "^6.1.0",
     "react-icons": "^4.3.1",
     "react-instantsearch-dom": "^6.32.0",

--- a/src/components/Emoji.tsx
+++ b/src/components/Emoji.tsx
@@ -1,10 +1,10 @@
 import React from "react"
 import { Box, HTMLChakraProps } from "@chakra-ui/react"
-import { Twemoji, Props } from "react-emoji-render"
+import { Twemoji, BaseProps } from "react-emoji-render"
 
 import { IS_DEV } from "../utils/env"
 
-export interface IProps extends HTMLChakraProps<"span">, Props {}
+export interface IProps extends HTMLChakraProps<"span">, BaseProps {}
 
 const Emoji = (props: IProps) => {
   return (

--- a/src/content/translations/it/developers/tutorials/how-to-view-nft-in-metamask/index.md
+++ b/src/content/translations/it/developers/tutorials/how-to-view-nft-in-metamask/index.md
@@ -32,7 +32,7 @@ Una volta sulla rete di Ropsten, seleziona la scheda "Oggetti collezionabili" a 
 
 ![Come trovare l'hash della tua transazione e l'ID del token ERC-721](./findNFTEtherscan.png)
 
-È possibile che tu debba ricaricare un paio di volte per vedere il tuo NFT — ma ci sarà <Emoji text="" size={1} />!
+È possibile che tu debba ricaricare un paio di volte per vedere il tuo NFT — ma ci sarà <Emoji text="😄" size={1} />!
 
 ![Come caricare il tuo NFT su MetaMask](./findNFTMetamask.gif)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10752,11 +10752,6 @@ embla-carousel@7.0.1:
   resolved "https://registry.yarnpkg.com/embla-carousel/-/embla-carousel-7.0.1.tgz#51bb13f6a12cd455c9435c770efc85322d73a976"
   integrity sha512-+beEwrdj+FGyiz9a/prfj4IAG6CWDSRYUB3c+FKf17WUq5OxxKg5BVDF5FWcvC3EX6n8wFKQGXjkB3obnWZM8Q==
 
-emoji-regex@^6.4.1:
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.5.1.tgz#9baea929b155565c11ea41c6626eaa65cef992c2"
-  integrity sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ==
-
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
@@ -18319,13 +18314,13 @@ react-element-to-jsx-string@^14.3.4:
     is-plain-object "5.0.0"
     react-is "17.0.2"
 
-react-emoji-render@^1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/react-emoji-render/-/react-emoji-render-1.2.4.tgz#fa3542a692e1eed3236f0f12b8e3a61b2818e2c2"
-  integrity sha512-AqktVXV38uDpgf02BoCXrzLYFsHAsxfdWwjrLexSJ22l1JgB01y1KejjxW/zTuCzod6O7BZfiMS866LEEfMHmA==
+react-emoji-render@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/react-emoji-render/-/react-emoji-render-2.0.1.tgz#c02fb00f4421762e31a9a4c367068b3cdf2edaa2"
+  integrity sha512-SKtsdwgEf2BFNiE9y4UBFZBWjkRcyWmhMprVly52+J77/zxThcfaQ3sCA0+2LtGJIRMpm4DGWSvyLg72fd1rXQ==
   dependencies:
     classnames "^2.2.5"
-    emoji-regex "^6.4.1"
+    emoji-regex "^8.0.0"
     lodash.flatten "^4.4.0"
     prop-types "^15.5.8"
     string-replace-to-array "^1.0.1"


### PR DESCRIPTION
## Description

Bump `react-emoji-render` to include [fix on cdn](https://github.com/tommoor/react-emoji-render/pull/107).

## Related Issue

Fixes #9135
