### PR TITLE
Change 'with' to 'for' for clarity

### DIFF
--- a/src/content/developers/tutorials/transfers-and-approval-of-erc-20-tokens-from-a-solidity-smart-contract/index.md
+++ b/src/content/developers/tutorials/transfers-and-approval-of-erc-20-tokens-from-a-solidity-smart-contract/index.md
@@ -13,7 +13,7 @@ address: "0x19dE91Af973F404EDF5B4c093983a7c6E3EC8ccE"
 
 In the previous tutorial we studied [the anatomy of an ERC-20 token in Solidity](/developers/tutorials/understand-the-erc-20-token-smart-contract/) on the Ethereum blockchain. In this article we’ll see how we can use a smart contract to interact with a token using the Solidity language.
 
-For this smart contract, we’ll create a really dummy decentralized exchange where a user can trade Ethereum with our newly deployed [ERC-20 token](/developers/docs/standards/tokens/erc-20/).
+For this smart contract, we’ll create a really dummy decentralized exchange where a user can trade Ethereum for our newly deployed [ERC-20 token](/developers/docs/standards/tokens/erc-20/).
 
 For this tutorial we’ll use the code we wrote in the previous tutorial as a base. Our DEX will instantiate an instance of the contract in its constructor and perform the operations of:
 


### PR DESCRIPTION
## Description

I'm changing "a user can trade Ethereum with our newly deployed ERC-20 token" to "a user can trade Ethereum _for_ our newly deployed ERC-20 token". It's a single, little word but it makes it much clearer.

In English we tend to say, "I'll trade my hat for that spade" and not "I'll trade my hat with that spade", which makes it sound like I'm using the spade to physically move the hat into someone else's possession. It's so subtle but when you're learning something completely new, you tend to analyse every word.

You could say, "a user can _buy_ Ethereum _with_ our newly deployed ERC-20 token" because you're buying it with ETH.

## Related Issue

N/A