### PR TITLE
Fix the random selection title in block proposal page

### DIFF
--- a/src/content/developers/docs/consensus-mechanisms/pos/block-proposal/index.md
+++ b/src/content/developers/docs/consensus-mechanisms/pos/block-proposal/index.md
@@ -14,7 +14,7 @@ Block proposal is part of the proof-of-stake protocol. To help understand this p
 
 Validator accounts propose blocks. Validator accounts are managed by node operators who run validator software as part of their execution and consensus clients and have deposited at least 32 ETH into the deposit contract. However, each validator is only occasionally responsible for proposing a block. Ethereum measures time in slots and epochs. Each slot is twelve seconds, and 32 slots (6.4 minutes) make up an epoch. Every slot is an opportunity to add a new block on Ethereum.
 
-### Random selection {#random-selection}
+### Random selection {#random-selection}
 
 A single validator is pseudo-randomly chosen to propose a block in each slot. There is no such thing as true randomness in a blockchain because if each node generated genuinely random numbers, they couldn't come to consensus. Instead, the aim is to make the validator selection process unpredictable. The randomness is achieved on Ethereum using an algorithm called RANDAO that mixes a hash from the block proposer with a seed that gets updated every block. This value is used to select a specific validator from the total validator set. The validator selection is fixed four epochs in advance as a way to protect against certain kinds of seed manipulation.
 


### PR DESCRIPTION
Fixes the `Random selection` section title that was incorrectly displayed on the [website](https://ethereum.org/en/developers/docs/consensus-mechanisms/pos/block-proposal/#who-produces-blocks).

### Before the fix
![image](https://user-images.githubusercontent.com/42520800/212573379-27823782-554e-42f3-8714-191285cdcd58.png)

### After the fix
![image](https://user-images.githubusercontent.com/42520800/212573394-c7db2bf7-128a-4c2d-a4e8-bc0bc164921b.png)

## Description

It seems that there was incorrect spacing in the markdown of the page which caused the incorrect display of the title for the section.
