### PR TITLE
Remove EthHub link from nodes and clients developer docs

### DIFF
--- a/src/content/developers/docs/nodes-and-clients/index.md
+++ b/src/content/developers/docs/nodes-and-clients/index.md
@@ -299,7 +299,6 @@ There is a lot of information about Ethereum clients on the internet. Here are f
 
 - [Ethereum 101 - Part 2 - Understanding Nodes](https://kauri.io/ethereum-101-part-2-understanding-nodes/48d5098292fd4f11b251d1b1814f0bba/a) _– Wil Barnes, 13 February 2019_
 - [Running Ethereum Full Nodes: A Guide for the Barely Motivated](https://medium.com/@JustinMLeroux/running-ethereum-full-nodes-a-guide-for-the-barely-motivated-a8a13e7a0d31) _– Justin Leroux, 7 November 2019_
-- [Running an Ethereum Node](https://docs.ethhub.io/using-ethereum/running-an-ethereum-node/) _– ETHHub, updated often_
 
 ## Related topics {#related-topics}
 


### PR DESCRIPTION
## Description

Remove link to EthHub link which is being sunset. Etherem.org contains more updated information hence propose removal to avoid confusion

## Related Issue

#8862 
