### PR TITLE
Remove EthHub link on DeFi page

### DIFF
--- a/src/content/defi/index.md
+++ b/src/content/defi/index.md
@@ -339,7 +339,6 @@ DeFi is an open-source movement. The DeFi protocols and applications are all ope
 
 ### DeFi articles {#defi-articles}
 
-- [What is Decentralized Finance?](https://docs.ethhub.io/built-on-ethereum/open-finance/what-is-open-finance/) – _ETHHub, updated regularly_
 - [A beginner's guide to DeFi](https://blog.coinbase.com/a-beginners-guide-to-decentralized-finance-defi-574c68ff43c4) – _Sid Coelho-Prabhu, January 6 2020_
 
 ### Videos {#videos}


### PR DESCRIPTION
## Description

Remove EthHUub link which is being sunset.

The EthHub DeFi resources are largely revolving around specific implementations rather than concepts. ethereum.org has greater details regarding the concepts. Propose to add EthHub examples to the ethereum.org dapps [page](https://ethereum.org/en/dapps/?category=finance) if still relevant. To be tracked under https://github.com/ethereum/ethereum-org-website/issues/9146 instead with regards to adding dapps.

## Related Issue

#8862 
