### PR TITLE
Remove EthHub Link on sidechains developer docs

### DIFF
--- a/src/content/developers/docs/scaling/sidechains/index.md
+++ b/src/content/developers/docs/scaling/sidechains/index.md
@@ -67,7 +67,6 @@ Multiple projects provide implementations of sidechains that you can integrate i
 
 ## Further reading {#further-reading}
 
-- [EthHub on sidechains](https://docs.ethhub.io/ethereum-roadmap/layer-2-scaling/sidechains/)
 - [Scaling Ethereum dapps through Sidechains](https://medium.com/loom-network/dappchains-scaling-ethereum-dapps-through-sidechains-f99e51fff447) _Feb 8, 2018 - Georgios Konstantopoulos_
 
 _Know of a community resource that helped you? Edit this page and add it!_


### PR DESCRIPTION
## Description

Remove EthHub link as resource is being sunset.

ethereum.org resource covers all the points raised on EthHub

## Related Issue

#8862 
