### PR TITLE
Remove EthHub Link [Fixes #8862]

### DIFF
--- a/src/content/developers/docs/scaling/optimistic-rollups/index.md
+++ b/src/content/developers/docs/scaling/optimistic-rollups/index.md
@@ -259,7 +259,6 @@ Multiple implementations of Optimistic rollups exist that you can integrate into
 
 - [How do optimistic rollups work (The Complete guide)](https://www.alchemy.com/overviews/optimistic-rollups)
 - [Everything you need to know about Optimistic Rollup](https://research.paradigm.xyz/rollups)
-- [EthHub on optimistic rollups](https://docs.ethhub.io/ethereum-roadmap/layer-2-scaling/optimistic_rollups/)
 - [The Essential Guide to Arbitrum](https://newsletter.banklesshq.com/p/the-essential-guide-to-arbitrum)
 - [How does Optimism's Rollup really work?](https://research.paradigm.xyz/optimism)
 - [OVM Deep Dive](https://medium.com/ethereum-optimism/ovm-deep-dive-a300d1085f52)


### PR DESCRIPTION
## Description

Remove EthHub link as resource is being sunset.

Ethereum.org is more comprehensive and reflects developments in the optimistic rollup space since the EThHub resource was created. Propose to remove link.

## Related Issue

Fixed #8862 
