### PR TITLE
Remove EthHub Link from ZK-roll ups developer docs

### DIFF
--- a/src/content/developers/docs/scaling/zk-rollups/index.md
+++ b/src/content/developers/docs/scaling/zk-rollups/index.md
@@ -244,7 +244,6 @@ Projects working on zkEVMs include:
 
 - [What Are Zero-Knowledge Rollups?](https://coinmarketcap.com/alexandria/glossary/zero-knowledge-rollups)
 - [What are zero-knowledge rollups?](https://alchemy.com/blog/zero-knowledge-rollups)
-- [EthHub on ZK-rollups](https://docs.ethhub.io/ethereum-roadmap/layer-2-scaling/zk-rollups/)
 - [STARKs vs SNARKs](https://consensys.net/blog/blockchain-explained/zero-knowledge-proofs-starks-vs-snarks/)
 - [What is a zkEVM?](https://www.alchemy.com/overviews/zkevm)
 - [Intro to zkEVM](https://hackmd.io/@yezhang/S1_KMMbGt)


### PR DESCRIPTION
<!--- Describe your changes in detail -->

Removed link to EthHub which is being sunset.

The ethereum.org zk-rollup page is more comprehensive and easier to reason with. EthHub's resource assumes knowledge of plasma chains but the industry has since moved towards a roll-up centric framework (i.e. newer users are more familiar with rollups instead of plasma). Propose to remove link

## Related issue 

#8862 
