### PR TITLE
Update Ommer Description & EthHub Link [Fixes #8862]

### DIFF
--- a/src/content/developers/docs/consensus-mechanisms/pow/mining/index.md
+++ b/src/content/developers/docs/consensus-mechanisms/pow/mining/index.md
@@ -58,7 +58,7 @@ Every transaction is mined (included in a new block and propagated for the first
 
 ## Ommer (uncle) blocks {#ommer-blocks}
 
-Block mining on proof-of-work was probabilistic, meaning sometimes two valid blocks were published simultaneously due to network latency. In this case, the protocol had to determine the longest (and therefore most "valid") chain while ensuring fairness towards miners by partially rewarding the unincluded valid block proposed by the miner. This encouraged further decentralization of the network as smaller miners, who might face greater latency, could still generate returns via [ommer](/glossary/#ommer) block rewards.
+Block mining on proof-of-work was probabilistic, meaning sometimes two valid blocks were published simultaneously due to network latency. In this case, the protocol had to determine the longest (and therefore most "valid") chain while ensuring fairness towards miners by partially rewarding the unincluded valid block proposed. This encouraged further decentralization of the network as smaller miners, who might face greater latency, could still generate returns via [ommer](/glossary/#ommer) block rewards.
 
 The term "ommer" is the preferred gender-neutral term for the sibling of a parent block, but this is also sometimes referred to as an "uncle". **Since Ethereum's move to proof-of-stake, ommer blocks are no longer mined** as only one proposer is elected in each slot. You can see this change by viewing the [historical chart](https://ycharts.com/indicators/ethereum_uncle_rate) of the ommer blocks mined.
 

--- a/src/content/developers/docs/consensus-mechanisms/pow/mining/index.md
+++ b/src/content/developers/docs/consensus-mechanisms/pow/mining/index.md
@@ -56,6 +56,12 @@ The following provides an overview of how transactions were mined in Ethereum pr
 
 Every transaction is mined (included in a new block and propagated for the first time) once, but executed and verified by every participant in the process of advancing the canonical EVM state. This highlights one of the central mantras of blockchain: **Don’t trust, verify**.
 
+## Ommer (Uncle) Blocks
+
+As block mining under proof-of-work was probabilistic, there exists a non-zero chance that two valid blocks may have been published at the same time due to network latency. In this case, the protocol still has to determine the longest (and hence most "valid") chain while still ensuring fairness towards the miners by partially rewarding the unincluded valid block proposed by the miner. This encourages further decentralization of the network as smaller miners, who might face greater latency, are still able to generate a return via [ommer](https://ethereum.org/en/glossary/#ommer) block rewards.
+
+The term "ommer" is the preferred gender-neutral term for the sibling of a parent block, but this is also sometimes referred to as an "uncle". **Since Ethereum's move to proof-of-stake, ommer blocks are no longer mined** as only one proposer is elected in each slot. You can see this change by viewing the [historical chart](https://ycharts.com/indicators/ethereum_uncle_rate) of the ommer blocks mined.
+
 ## A visual demo {#a-visual-demo}
 
 Watch Austin walk you through mining and the proof-of-work blockchain.
@@ -70,7 +76,7 @@ Ethereum Mainnet only ever used one mining algorithm - ['Ethash'](/developers/do
 
 ## Further reading {#further-reading}
 
-- [What does it mean to mine Ethereum?](https://docs.ethhub.io/using-ethereum/mining/) _EthHub_
+- [What does it mean to mine Ethereum?](https://web.archive.org/web/20220917012350/https://docs.ethhub.io/using-ethereum/mining/) _EthHub (Archived)_
 
 ## Related topics {#related-topics}
 

--- a/src/content/developers/docs/consensus-mechanisms/pow/mining/index.md
+++ b/src/content/developers/docs/consensus-mechanisms/pow/mining/index.md
@@ -58,7 +58,7 @@ Every transaction is mined (included in a new block and propagated for the first
 
 ## Ommer (uncle) blocks {#ommer-blocks}
 
-As block mining under proof-of-work was probabilistic, sometimes two valid blocks were published simultaneously due to network latency. In this case, the protocol had to determine the longest (and therefore most "valid") chain while ensuring fairness towards miners by partially rewarding the unincluded valid block proposed by the miner. This encouraged further decentralization of the network as smaller miners, who might face greater latency, could still generate returns via [ommer](/glossary/#ommer) block rewards.
+Block mining on proof-of-work was probabilistic, meaning sometimes two valid blocks were published simultaneously due to network latency. In this case, the protocol had to determine the longest (and therefore most "valid") chain while ensuring fairness towards miners by partially rewarding the unincluded valid block proposed by the miner. This encouraged further decentralization of the network as smaller miners, who might face greater latency, could still generate returns via [ommer](/glossary/#ommer) block rewards.
 
 The term "ommer" is the preferred gender-neutral term for the sibling of a parent block, but this is also sometimes referred to as an "uncle". **Since Ethereum's move to proof-of-stake, ommer blocks are no longer mined** as only one proposer is elected in each slot. You can see this change by viewing the [historical chart](https://ycharts.com/indicators/ethereum_uncle_rate) of the ommer blocks mined.
 

--- a/src/content/developers/docs/consensus-mechanisms/pow/mining/index.md
+++ b/src/content/developers/docs/consensus-mechanisms/pow/mining/index.md
@@ -56,9 +56,9 @@ The following provides an overview of how transactions were mined in Ethereum pr
 
 Every transaction is mined (included in a new block and propagated for the first time) once, but executed and verified by every participant in the process of advancing the canonical EVM state. This highlights one of the central mantras of blockchain: **Don’t trust, verify**.
 
-## Ommer (Uncle) Blocks
+## Ommer (uncle) blocks {#ommer-blocks}
 
-As block mining under proof-of-work was probabilistic, there exists a non-zero chance that two valid blocks may have been published at the same time due to network latency. In this case, the protocol still has to determine the longest (and hence most "valid") chain while still ensuring fairness towards the miners by partially rewarding the unincluded valid block proposed by the miner. This encourages further decentralization of the network as smaller miners, who might face greater latency, are still able to generate a return via [ommer](https://ethereum.org/en/glossary/#ommer) block rewards.
+As block mining under proof-of-work was probabilistic, sometimes two valid blocks were published simultaneously due to network latency. In this case, the protocol had to determine the longest (and therefore most "valid") chain while ensuring fairness towards miners by partially rewarding the unincluded valid block proposed by the miner. This encouraged further decentralization of the network as smaller miners, who might face greater latency, could still generate returns via [ommer](/glossary/#ommer) block rewards.
 
 The term "ommer" is the preferred gender-neutral term for the sibling of a parent block, but this is also sometimes referred to as an "uncle". **Since Ethereum's move to proof-of-stake, ommer blocks are no longer mined** as only one proposer is elected in each slot. You can see this change by viewing the [historical chart](https://ycharts.com/indicators/ethereum_uncle_rate) of the ommer blocks mined.
 


### PR DESCRIPTION
## Description

Edit page as EthHub is being sunset.

As Ethereum has switched to PoS, the included EthHub link still maintains its relevancy as a historical archive. As such, updated EthHub link to point to the [web archive snapshot on 17/09/22](https://web.archive.org/web/20220917012350/https://docs.ethhub.io/using-ethereum/mining/). Additionally, added a section on ommer blocks to give further context to readers that might have come across the "uncle" term when Ethereum was still under PoW.

## Related Issue

Fixes #8862 
