### PR TITLE
add note to eth_protocolVersion in RPC-API

### DIFF
--- a/src/content/developers/docs/apis/json-rpc/index.md
+++ b/src/content/developers/docs/apis/json-rpc/index.md
@@ -271,7 +271,7 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"net_peerCount","params":[],"id":
 
 ### eth_protocolVersion {#eth_protocolversion}
 
-Returns the current Ethereum protocol version.
+Returns the current Ethereum protocol version. Note that this method is [not available in Geth](https://github.com/ethereum/go-ethereum/pull/22064#issuecomment-788682924).
 
 **Parameters**
 


### PR DESCRIPTION

## Description

Adds note to the method description for `eth_protocolVersion` explaining that it is not available in Geth. This is in response to some user feedback. Currently geth.ethereum.org links to this page for the `eth` namespace definition rather than listing out the methods. However, this specific method is not actually available in geth, although
 it is available in other clients.

