### PR TITLE
adds more prominent links to desci listing policy

### DIFF
--- a/src/content/contributing/index.md
+++ b/src/content/contributing/index.md
@@ -39,6 +39,7 @@ The ethereum.org website, like Ethereum more broadly, is an open-source project.
   _- Add a layer 2 to a relevant page_
 - [Add a staking product or service](/contributing/adding-staking-products/) - _Add a project that helps facilitate solo staking, pooled staking, or staking as a service_
 - [Add a wallet](/contributing/adding-wallets/) _- Add a wallet for the [find wallets page](/wallets/find-wallet/)._
+- [Suggest a project for our DeSci page](https://ethereum.org/en/contributing/adding-desci-projects/) - _Add a project built on Ethereum that contributes to decentralized science_
 
 _Any questions?_ 🤔 Reach out on our [Discord server](https://discord.gg/CetY6Y4)
 

--- a/src/content/contributing/index.md
+++ b/src/content/contributing/index.md
@@ -39,7 +39,7 @@ The ethereum.org website, like Ethereum more broadly, is an open-source project.
   _- Add a layer 2 to a relevant page_
 - [Add a staking product or service](/contributing/adding-staking-products/) - _Add a project that helps facilitate solo staking, pooled staking, or staking as a service_
 - [Add a wallet](/contributing/adding-wallets/) _- Add a wallet for the [find wallets page](/wallets/find-wallet/)._
-- [Suggest a project for our DeSci page](https://ethereum.org/en/contributing/adding-desci-projects/) - _Add a project built on Ethereum that contributes to decentralized science_
+- [Suggest a project for our DeSci page](/contributing/adding-desci-projects/) - _Add a project built on Ethereum that contributes to decentralized science_
 
 _Any questions?_ 🤔 Reach out on our [Discord server](https://discord.gg/CetY6Y4)
 

--- a/src/content/desci/index.md
+++ b/src/content/desci/index.md
@@ -113,6 +113,8 @@ Explore projects and join the DeSci community.
 - [CureDAO: Community-Owned Precision Health Platform](https://docs.curedao.org/)
 - [IdeaMarkets: enabling decentralized scientifc credibility](https://ideamarket.io/)
 
+We welcome suggestions for new projects to list - please take a look at our [listing policy](https://ethereum.org/en/contributing/adding-desci-projects/) to get started!
+
 ## Further reading {#further-reading}
 
 - [DeSci Wiki by Jocelynn Pearl and Ultrarare](https://docs.google.com/document/d/1aQC6zn-eXflSmpts0XGE7CawbUEHwnL6o-OFXO52PTc/edit#)

--- a/src/content/desci/index.md
+++ b/src/content/desci/index.md
@@ -113,7 +113,7 @@ Explore projects and join the DeSci community.
 - [CureDAO: Community-Owned Precision Health Platform](https://docs.curedao.org/)
 - [IdeaMarkets: enabling decentralized scientifc credibility](https://ideamarket.io/)
 
-We welcome suggestions for new projects to list - please take a look at our [listing policy](https://ethereum.org/en/contributing/adding-desci-projects/) to get started!
+We welcome suggestions for new projects to list - please look at our [listing policy](/contributing/adding-desci-projects/) to get started!
 
 ## Further reading {#further-reading}
 


### PR DESCRIPTION
## Description

DeSci listing policy was previously added to the site but it wasn't obvious where it could be found. This PR adds some more prominent links in the `contributing` and `desci` pages.

