### PR TITLE
Added `from` key to transaction information

### DIFF
--- a/src/content/developers/docs/transactions/index.md
+++ b/src/content/developers/docs/transactions/index.md
@@ -26,7 +26,7 @@ A submitted transaction includes the following information:
 - `from` – the address of the sender, that will be signing the transaction. This will be an externally-owned account as contract accounts cannot send transactions. 
 - `recipient` – the receiving address (if an externally-owned account, the transaction will transfer value. If a contract account, the transaction will execute the contract code)
 - `signature` – the identifier of the sender. This is generated when the sender's private key signs the transaction and confirms the sender has authorized this transaction
-- `nonce` - a sequencially incrementing counter which indicates the transaction number from the account
+- `nonce` - a sequentially incrementing counter which indicates the transaction number from the account
 - `value` – amount of ETH to transfer from sender to recipient (in WEI, a denomination of ETH)
 - `data` – optional field to include arbitrary data
 - `gasLimit` – the maximum amount of gas units that can be consumed by the transaction. Units of gas represent computational steps

--- a/src/content/developers/docs/transactions/index.md
+++ b/src/content/developers/docs/transactions/index.md
@@ -23,6 +23,7 @@ Transactions require a fee and must be included in a validated block. To make th
 
 A submitted transaction includes the following information:
 
+- `from` – the address of the sender, that will be signing the transaction. This will be an externally-owned account as contract accounts cannot send transactions. 
 - `recipient` – the receiving address (if an externally-owned account, the transaction will transfer value. If a contract account, the transaction will execute the contract code)
 - `signature` – the identifier of the sender. This is generated when the sender's private key signs the transaction and confirms the sender has authorized this transaction
 - `nonce` - a sequencially incrementing counter which indicates the transaction number from the account


### PR DESCRIPTION
added the `from` key and its description as `the address of the sender, that will be signing the transaction. This will be an externally-owned account as contract accounts cannot send transactions.`

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

<img width="640" alt="image" src="https://user-images.githubusercontent.com/60383339/212958624-53a4ebf8-ab8e-458f-896d-a4253e4ed86d.png">

The `from` key in this sample transaction object has not been included in the descriptions.

<img width="656" alt="image" src="https://user-images.githubusercontent.com/60383339/212958894-35c34277-c485-41f6-8dc2-060c4f9d459b.png">
