### PR TITLE
ci: Add Workflow for ChromaticUI Visual Regression Testing

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -16,6 +16,7 @@ on:
       - "src/pages/**/*"
       - "src/pages-conditional/**/*"
       - "src/templates/**/*"
+      - "src/@chakra-ui/gatsby-plugin/**/*"
 
 # List of jobs
 jobs:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,42 @@
+# .github/workflows/chromatic.yml
+
+# Workflow name
+name: Chromatic Publish and Testing
+
+# Event for the workflow
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - ready_for_review
+    paths:
+      # Only run on file changes in any of these paths
+      - "src/components/**/*"
+      - "src/pages/**/*"
+      - "src/pages-conditional/**/*"
+      - "src/templates/**/*"
+
+# List of jobs
+jobs:
+  chromatic-deployment:
+    # Operating System
+    runs-on: ubuntu-latest
+    # Job steps
+    steps:
+      # 👇 Version 2 of the action
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # 👈 Required to retrieve git history
+      - name: Install deps
+        # 👇 Install dependencies with the same package manager used in the project (replace it as needed), e.g. yarn, npm, pnpm
+        run: yarn
+      - name: Publish to Chromatic
+        # 👇 Adds Chromatic as a step in the workflow
+        uses: chromaui/action@v1
+        # Options required for Chromatic's GitHub Action
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          # 👇 Only fail if Storybook contains stories that error
+          exitZeroOnChanges: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
This PR adds the Github action to automate Chromatic UI's visual regression testing in conjunction with StorybookJS. 

The workflow is customized for the specific usage of this project with the following expectations:
- Action to be triggered only if there are file changes within the `components`, `pages`, `pages-conditional`, and `templates` directories (subject to be altered later as needed)
- Testing only fails if errors exist in story files.
- Reliance on ensuring that the steps generated by this action in the PR checks are to be reviewed and accepted before merge, and that if any change is denied within the Chromatic dashboard by a reviewer, that it should fail the check and prevent the PR from being merged.

Along with comments given by me to note anything specific in the file or questions, please provide further feedback on any additions or alterations.

## Related issue

#8490