### PR TITLE
Fix typo in SSZ documentation

### DIFF
--- a/src/content/developers/docs/data-structures-and-encoding/ssz/index.md
+++ b/src/content/developers/docs/data-structures-and-encoding/ssz/index.md
@@ -146,5 +146,5 @@ The hash of (8,9) should equal hash (4), which hashes with 5 to produce 2, which
 - [Upgrading Ethereum: SSZ](https://eth2book.info/altair/part2/building_blocks/ssz)
 - [Upgrading Ethereum: Merkleization](https://eth2book.info/altair/part2/building_blocks/merkleization)
 - [SSZ implementations](https://github.com/ethereum/consensus-specs/issues/2138)
-- [SSZ calcuator](https://simpleserialize.com/)
+- [SSZ calculator](https://simpleserialize.com/)
 - [SSZ.dev](https://www.ssz.dev/)


### PR DESCRIPTION
## Description

* `calcuator` -> `calculator` under [`Further reading` section](https://ethereum.org/en/developers/docs/data-structures-and-encoding/ssz/#further-reading)

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
