### PR TITLE
Polygon Hermez no longer exists and link is non-functional, should be renamed to Polygon zkEVM 

### DIFF
--- a/src/content/developers/docs/scaling/zk-rollups/index.md
+++ b/src/content/developers/docs/scaling/zk-rollups/index.md
@@ -238,7 +238,7 @@ Projects working on zkEVMs include:
 
 - **[Scroll](https://scroll.io/blog/zkEVM)** - _Scroll is a tech-driven company working on building a native zkEVM Layer 2 Solution for Ethereum._
 
-- **[Polygon Hermez](https://docs.hermez.io/Hermez_1.0/about/scalability/)** - _Hermez 2.0 is a decentralized ZK Rollup on the Ethereum mainnet working on a zero-knowledge Ethereum Virtual Machine (zkEVM) that executes Ethereum transactions in a transparent way, including smart contracts with zero-knowledge-proof validations._
+- **[Polygon zkEVM](https://docs.hermez.io/zkEVM/zkProver/Verifiable-Computations/Fibonacci/)** - _Hermez 2.0 is a decentralized ZK Rollup on the Ethereum mainnet working on a zero-knowledge Ethereum Virtual Machine (zkEVM) that executes Ethereum transactions in a transparent way, including smart contracts with zero-knowledge-proof validations._
 
 ## Further reading on ZK-rollups reading {#further-reading-on-zk-rollups}
 

--- a/src/content/developers/docs/scaling/zk-rollups/index.md
+++ b/src/content/developers/docs/scaling/zk-rollups/index.md
@@ -238,7 +238,7 @@ Projects working on zkEVMs include:
 
 - **[Scroll](https://scroll.io/blog/zkEVM)** - _Scroll is a tech-driven company working on building a native zkEVM Layer 2 Solution for Ethereum._
 
-- **[Polygon Hermez](https://docs.hermez.io/zkEVM/architecture/introduction/)** - _Hermez 2.0 is a decentralized ZK Rollup on the Ethereum mainnet working on a zero-knowledge Ethereum Virtual Machine (zkEVM) that executes Ethereum transactions in a transparent way, including smart contracts with zero-knowledge-proof validations._
+- **[Polygon Hermez](https://docs.hermez.io/Hermez_1.0/about/scalability/)** - _Hermez 2.0 is a decentralized ZK Rollup on the Ethereum mainnet working on a zero-knowledge Ethereum Virtual Machine (zkEVM) that executes Ethereum transactions in a transparent way, including smart contracts with zero-knowledge-proof validations._
 
 ## Further reading on ZK-rollups reading {#further-reading-on-zk-rollups}
 

--- a/src/content/developers/docs/scaling/zk-rollups/index.md
+++ b/src/content/developers/docs/scaling/zk-rollups/index.md
@@ -238,7 +238,7 @@ Projects working on zkEVMs include:
 
 - **[Scroll](https://scroll.io/blog/zkEVM)** - _Scroll is a tech-driven company working on building a native zkEVM Layer 2 Solution for Ethereum._
 
-- **[Polygon zkEVM](https://docs.hermez.io/zkEVM/zkProver/Verifiable-Computations/Fibonacci/)** - _Hermez 2.0 is a decentralized ZK Rollup on the Ethereum mainnet working on a zero-knowledge Ethereum Virtual Machine (zkEVM) that executes Ethereum transactions in a transparent way, including smart contracts with zero-knowledge-proof validations._
+- **[Polygon zkEVM](https://polygon.technology/solutions/polygon-zkevm)** - _is a decentralized ZK Rollup on the Ethereum mainnet working on a zero-knowledge Ethereum Virtual Machine (zkEVM) that executes Ethereum transactions in a transparent way, including smart contracts with zero-knowledge-proof validations._
 
 ## Further reading on ZK-rollups reading {#further-reading-on-zk-rollups}
 


### PR DESCRIPTION
Polygon Hermez no longer exists and link is non-functional, should be renamed to Polygon zkEVM [Fixes #9263]

<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR resolves the link error and changes the description:
https://docs.hermez.io/zkEVM/architecture/introduction
https://polygon.technology/solutions/polygon-zkevm

## Screenshot:
![image](https://i.imgur.com/L1Kx7oh.png)

Old version here:
https://github.com/0xPolygonHermez/zkevm-doc/blob/feature/merge-hermez-1.0-docs/mkdocs/docs/zkEVM/architecture/introduction.md or
https://docs.hermez.io/zkEVM/zkProver/Verifiable-Computations/Fibonacci

Updated similar version: https://wiki.polygon.technology/docs/zkEVM/zkProver/mfibonacci-example

## Related Issue

Fixes #9263
