### PR TITLE
Fix link to staking issue template

### DIFF
--- a/src/content/contributing/adding-staking-products/index.md
+++ b/src/content/contributing/adding-staking-products/index.md
@@ -8,7 +8,7 @@ lang: en
 
 We want to make sure we list the best resources possible while keeping users safe and confident.
 
-Anyone is free to suggest adding a staking products or service on ethereum.org. If there's one that we have missed, **[please suggest it]([https://github.com/ethereum/ethereum-org-website/issues/new?&template=suggest_staking_product.md](https://github.com/ethereum/ethereum-org-website/issues/new?assignees=&labels=feature+%3Asparkles%3A%2Ccontent+%3Afountain_pen%3A&template=suggest_staking_product.yaml&title=Suggest+a+staking+product+or+service))!**
+Anyone is free to suggest adding a staking products or service on ethereum.org. If there's one that we have missed, **[please suggest it](https://github.com/ethereum/ethereum-org-website/issues/new?assignees=&labels=feature+%3Asparkles%3A%2Ccontent+%3Afountain_pen%3A&template=suggest_staking_product.yaml&title=Suggest+a+staking+product+or+service)!**
 
 We currently list staking products and services on the following pages:
 
@@ -166,6 +166,6 @@ The code logic and weights for these criteria are currently contained in [this J
 
 If you want to add a staking product or service to ethereum.org, create an issue on GitHub.
 
-<ButtonLink to="[https://github.com/ethereum/ethereum-org-website/issues/new?&template=suggest_staking_product.md](https://github.com/ethereum/ethereum-org-website/issues/new?assignees=&labels=feature+%3Asparkles%3A%2Ccontent+%3Afountain_pen%3A&template=suggest_staking_product.yaml&title=Suggest+a+staking+product+or+service)">
+<ButtonLink to="https://github.com/ethereum/ethereum-org-website/issues/new?assignees=&labels=feature+%3Asparkles%3A%2Ccontent+%3Afountain_pen%3A&template=suggest_staking_product.yaml&title=Suggest+a+staking+product+or+service">
   Create an issue
 </ButtonLink>

--- a/src/content/contributing/adding-staking-products/index.md
+++ b/src/content/contributing/adding-staking-products/index.md
@@ -8,7 +8,7 @@ lang: en
 
 We want to make sure we list the best resources possible while keeping users safe and confident.
 
-Anyone is free to suggest adding a staking products or service on ethereum.org. If there's one that we have missed, **[please suggest it](https://github.com/ethereum/ethereum-org-website/issues/new?&template=suggest_staking_product.md)!**
+Anyone is free to suggest adding a staking products or service on ethereum.org. If there's one that we have missed, **[please suggest it]([https://github.com/ethereum/ethereum-org-website/issues/new?&template=suggest_staking_product.md](https://github.com/ethereum/ethereum-org-website/issues/new?assignees=&labels=feature+%3Asparkles%3A%2Ccontent+%3Afountain_pen%3A&template=suggest_staking_product.yaml&title=Suggest+a+staking+product+or+service))!**
 
 We currently list staking products and services on the following pages:
 
@@ -166,6 +166,6 @@ The code logic and weights for these criteria are currently contained in [this J
 
 If you want to add a staking product or service to ethereum.org, create an issue on GitHub.
 
-<ButtonLink to="https://github.com/ethereum/ethereum-org-website/issues/new?&template=suggest_staking_product.md">
+<ButtonLink to="[https://github.com/ethereum/ethereum-org-website/issues/new?&template=suggest_staking_product.md](https://github.com/ethereum/ethereum-org-website/issues/new?assignees=&labels=feature+%3Asparkles%3A%2Ccontent+%3Afountain_pen%3A&template=suggest_staking_product.yaml&title=Suggest+a+staking+product+or+service)">
   Create an issue
 </ButtonLink>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Current links lead to an empty issue template:
![Image 2023-01-24 at 4 27 36 PM](https://user-images.githubusercontent.com/8097623/214452532-0e850800-193a-4250-b2be-242723260ea1.jpg)

We want to link to the staking product template:
![Image 2023-01-24 at 4 29 15 PM](https://user-images.githubusercontent.com/8097623/214452723-b8632a33-01b8-4ff5-a3f4-d7b462c23d0d.jpg)

## Related Issue
None
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
