### PR TITLE
Fix stakes width issues on xl

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -137,7 +137,6 @@ const Layout: React.FC<IProps> = ({
                 flexFlow="column"
                 maxW={{
                   lg: lightTheme.variables.maxPageWidth,
-                  xl: "100%",
                 }}
               >
                 <ZenMode>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -137,6 +137,7 @@ const Layout: React.FC<IProps> = ({
                 flexFlow="column"
                 maxW={{
                   lg: lightTheme.variables.maxPageWidth,
+                  xl: "100%",
                 }}
               >
                 <ZenMode>

--- a/src/pages/staking/index.tsx
+++ b/src/pages/staking/index.tsx
@@ -34,6 +34,7 @@ const HeroStatsWrapper = styled.div`
   align-items: center;
   background: ${({ theme }) => theme.colors.layer2Gradient};
   padding-bottom: 2rem;
+  width: 100%;
 `
 
 const Page = styled.div`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Stake page hero banner is not showing fullwidth in xl screens
<!--- Describe your changes in detail -->

## Related Issue
#9307 

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
