### PR TITLE
Change translation in TranslationBanner see in english text

### DIFF
--- a/src/components/TranslationBanner.tsx
+++ b/src/components/TranslationBanner.tsx
@@ -104,7 +104,7 @@ const TranslationBanner: React.FC<IProps> = ({
                   color="#333333"
                   language="en"
                 >
-                  <Translation id="translation-banner-button-see-english" />
+                  See English
                 </ButtonLink>
               </Box>
             )}

--- a/src/intl/ar/common.json
+++ b/src/intl/ar/common.json
@@ -249,7 +249,6 @@
   "translation-banner-body-update": "هناك نسخة جديدة من هذه الصفحة لكنها باللغة الإنجليزية فقط الآن. ساعدنا في ترجمة أحدث نسخة.",
   "translation-banner-button-join-translation-program": "انضمام إلى برنامج الترجمة",
   "translation-banner-button-learn-more": "معرفة المزيد",
-  "translation-banner-button-see-english": "عرض المحتوى بالإنجليزية",
   "translation-banner-button-translate-page": "ترجمة الصفحة",
   "translation-banner-title-new": "المساعدة في ترجمة هذه الصفحة",
   "translation-banner-title-update": "المساعدة في تحديث هذه الصفحة",

--- a/src/intl/az/common.json
+++ b/src/intl/az/common.json
@@ -214,7 +214,6 @@
   "translation-banner-body-update": "Bu səhifənin yeni versiyası var, lakin hazırda yalnız ingilis dilindədir. Ən son versiyanı tərcümə etməkdə bizə kömək edin.",
   "translation-banner-button-join-translation-program": "Tərcümə Proqramına Qoşul",
   "translation-banner-button-learn-more": "Daha ətraflı",
-  "translation-banner-button-see-english": "İngiliscə bax",
   "translation-banner-button-translate-page": "Səhifəni tərcümə Et",
   "translation-banner-title-new": "Bu səhifəni tərcümə et",
   "translation-banner-title-update": "Bu səhifəni yeniləməyimizə kömək et",

--- a/src/intl/bg/common.json
+++ b/src/intl/bg/common.json
@@ -229,7 +229,6 @@
   "translation-banner-body-update": "Има нова версия на тази страница, но все още е само на английски език. Помогнете ни да преведем последната версия.",
   "translation-banner-button-join-translation-program": "Присъединете се към програмата за преводи",
   "translation-banner-button-learn-more": "Научи повече",
-  "translation-banner-button-see-english": "Вижте на английски език",
   "translation-banner-button-translate-page": "Преведете страницата",
   "translation-banner-title-new": "Помогнете с превода на тази страница",
   "translation-banner-title-update": "Помогнете да обновим тази страница",

--- a/src/intl/bn/common.json
+++ b/src/intl/bn/common.json
@@ -191,7 +191,6 @@
   "translation-banner-body-update": "এই পৃষ্ঠাটির একটি নতুন ভার্সন আছে, কিন্তু এটি এই মুহূর্তে শুধুমাত্র ইংরেজিতেই দেখানো হয়েছে। এর লেটেস্ট ভার্সনটি অনুবাদ করতে আমাদের সাহায্য করুন।",
   "translation-banner-button-join-translation-program": "অনুবাদ কর্মসূচিতে যোগ দিন",
   "translation-banner-button-learn-more": "আরও জানুন",
-  "translation-banner-button-see-english": "ইংরেজিতে দেখুন",
   "translation-banner-button-translate-page": "পেজ অনুবাদ করুন",
   "translation-banner-title-new": "এই পৃষ্ঠাটি অনুবাদ করতে সাহায্য করুন",
   "translation-banner-title-update": "এই পৃষ্ঠাটি আপডেট করতে সাহায্য করুন",

--- a/src/intl/cs/common.json
+++ b/src/intl/cs/common.json
@@ -240,7 +240,6 @@
   "translation-banner-body-update": "K dispozici je nová verze této stránky, ale v současné době je pouze v angličtině. Pomozte nám přeložit nejnovější verzi.",
   "translation-banner-button-join-translation-program": "Zapojte se do překladatelského programu",
   "translation-banner-button-learn-more": "Více informací",
-  "translation-banner-button-see-english": "Zobrazit angličtinu",
   "translation-banner-button-translate-page": "Přeložit stránku",
   "translation-banner-title-new": "Pomozte s překladem této stránky",
   "translation-banner-title-update": "Pomozte s aktualizací této stránky",

--- a/src/intl/da/common.json
+++ b/src/intl/da/common.json
@@ -240,7 +240,6 @@
   "translation-banner-body-update": "Der er en ny version af siden, men den er kun på engelsk lige nu. Hjælp os med at oversætte den nyeste version.",
   "translation-banner-button-join-translation-program": "Deltag i Oversættelsesprogrammet",
   "translation-banner-button-learn-more": "Læs mere",
-  "translation-banner-button-see-english": "Se engelsk",
   "translation-banner-button-translate-page": "Oversæt siden",
   "translation-banner-title-new": "Hjælp med at oversætte denne side",
   "translation-banner-title-update": "Hjælp med at opdatere denne side",

--- a/src/intl/de/common.json
+++ b/src/intl/de/common.json
@@ -249,7 +249,6 @@
   "translation-banner-body-update": "Es gibt eine neue Version dieser Seite, aber im Moment ist sie nur auf Englisch verfügbar. Helfen Sie mit, die neueste Version zu übersetzen.",
   "translation-banner-button-join-translation-program": "Treten Sie dem Übersetzungsprogramm bei",
   "translation-banner-button-learn-more": "Weitere Informationen",
-  "translation-banner-button-see-english": "In Englisch",
   "translation-banner-button-translate-page": "Seite übersetzen",
   "translation-banner-title-new": "Helfen Sie mit, diese Seite zu übersetzen",
   "translation-banner-title-update": "Helfen Sie mit, diese Seite zu aktualisieren",

--- a/src/intl/el/common.json
+++ b/src/intl/el/common.json
@@ -208,7 +208,6 @@
   "translation-banner-body-update": "Υπάρχει μια νέα έκδοση αυτής της σελίδας, αλλά αυτήν τη στιγμή είναι μόνο στα αγγλικά. Βοηθήστε μας να μεταφράσουμε την πιο πρόσφατη έκδοση.",
   "translation-banner-button-join-translation-program": "Εγγραφείτε στο πρόγραμμα μετάφρασης",
   "translation-banner-button-learn-more": "Μάθετε περισσότερα",
-  "translation-banner-button-see-english": "Δείτε στα αγγλικά",
   "translation-banner-button-translate-page": "Μετάφραση σελίδας",
   "translation-banner-title-new": "Βοηθήστε στη μετάφραση αυτής της σελίδας",
   "translation-banner-title-update": "Βοηθήστε στην ενημέρωση αυτής της σελίδας",

--- a/src/intl/en/common.json
+++ b/src/intl/en/common.json
@@ -251,7 +251,6 @@
   "translation-banner-body-update": "There’s a new version of this page but it’s only in English right now. Help us translate the latest version.",
   "translation-banner-button-join-translation-program": "Join Translation Program",
   "translation-banner-button-learn-more": "Learn more",
-  "translation-banner-button-see-english": "See English",
   "translation-banner-button-translate-page": "Translate page",
   "translation-banner-title-new": "Help translate this page",
   "translation-banner-title-update": "Help update this page",

--- a/src/intl/es/common.json
+++ b/src/intl/es/common.json
@@ -249,7 +249,6 @@
   "translation-banner-body-update": "Disponemos de una nueva versión de esta página, pero solo está en inglés por ahora. Ayúdenos a traducir la última versión.",
   "translation-banner-button-join-translation-program": "Únase al programa de traducción",
   "translation-banner-button-learn-more": "Más información",
-  "translation-banner-button-see-english": "Ver en inglés",
   "translation-banner-button-translate-page": "Traducir la página",
   "translation-banner-title-new": "Ayúdenos a traducir esta página.",
   "translation-banner-title-update": "Ayúdenos a actualizar esta página.",

--- a/src/intl/fa/common.json
+++ b/src/intl/fa/common.json
@@ -249,7 +249,6 @@
   "translation-banner-body-update": "نسخه جدیدی از این صفحه موجود است اما در حال حاضر فقط به زبان انگلیسی است. برای ترجمه آخرین نسخه به ما کمک کنید.",
   "translation-banner-button-join-translation-program": "به برنامه‌ی ترجمه ما ملحق شوید",
   "translation-banner-button-learn-more": "بیشتر بدانید",
-  "translation-banner-button-see-english": "انگلیسی را ببینید",
   "translation-banner-button-translate-page": "ترجمه صفحه",
   "translation-banner-title-new": "کمک به ترجمه این صفحه",
   "translation-banner-title-update": "کمک برای به روز رسانی این صفحه",

--- a/src/intl/fi/common.json
+++ b/src/intl/fi/common.json
@@ -214,7 +214,6 @@
   "translation-banner-body-update": "Tästä sivusta on uusi versio, mutta se on tällä hetkellä vain englanniksi. Auta meitä kääntämään uusin versio.",
   "translation-banner-button-join-translation-program": "Liity käännösprojektiin",
   "translation-banner-button-learn-more": "Opi lisää",
-  "translation-banner-button-see-english": "Näytä englanniksi",
   "translation-banner-button-translate-page": "Käännä sivu",
   "translation-banner-title-new": "Auta kääntämään tämä sivu",
   "translation-banner-title-update": "Auta päivittämään tämä sivu",

--- a/src/intl/fr/common.json
+++ b/src/intl/fr/common.json
@@ -240,7 +240,6 @@
   "translation-banner-body-update": "Il existe une nouvelle version de cette page, mais seulement en anglais pour le moment. Aidez-nous à traduire la dernière version.",
   "translation-banner-button-join-translation-program": "Rejoindre le programme de traduction",
   "translation-banner-button-learn-more": "En savoir plus",
-  "translation-banner-button-see-english": "Voir l'anglais",
   "translation-banner-button-translate-page": "Traduire la page",
   "translation-banner-title-new": "Aider à traduire cette page",
   "translation-banner-title-update": "Aider à mettre à jour cette page",

--- a/src/intl/gl/common.json
+++ b/src/intl/gl/common.json
@@ -214,7 +214,6 @@
   "translation-banner-body-update": "Existe unha nova versión desta páxina, pero polo momento só existe en inglés. Axúdenos a traducir a versión máis recente.",
   "translation-banner-button-join-translation-program": "Únase ao proxecto de tradución",
   "translation-banner-button-learn-more": "Máis info",
-  "translation-banner-button-see-english": "Ver en inglés",
   "translation-banner-button-translate-page": "Traducir páxina",
   "translation-banner-title-new": "Axude a traducir esta páxina",
   "translation-banner-title-update": "Axude a actualizar esta páxina",

--- a/src/intl/gu/common.json
+++ b/src/intl/gu/common.json
@@ -249,7 +249,6 @@
   "translation-banner-body-update": "આ પેજનું નવું સંસ્કરણ છે પરંતુ તે હમણાં અંગ્રેજીમાં જ છે. નવીનતમ સંસ્કરણનો અનુવાદ કરવામાં અમારી મદદ કરો.",
   "translation-banner-button-join-translation-program": "અનુવાદ કાર્યક્રમમાં જોડાઓ",
   "translation-banner-button-learn-more": "વધુ શીખો",
-  "translation-banner-button-see-english": "અંગ્રેજી જુઓ",
   "translation-banner-button-translate-page": "પેજનો અનુવાદ કરો",
   "translation-banner-title-new": "આ પેજનો અનુવાદ કરવામાં મદદ કરો",
   "translation-banner-title-update": "આ પેજને અપડેટ કરવામાં મદદ કરો",

--- a/src/intl/hi/common.json
+++ b/src/intl/hi/common.json
@@ -249,7 +249,6 @@
   "translation-banner-body-update": "इस पृष्ठ का एक नया संस्करण है लेकिन अभी यह केवल अंग्रेजी में है। नवीनतम संस्करण का अनुवाद करने में हमारी सहायता करें।",
   "translation-banner-button-join-translation-program": "अनुवाद कार्यक्रम में शामिल हों",
   "translation-banner-button-learn-more": "अधिक जानें",
-  "translation-banner-button-see-english": "अंग्रेजी में देखें",
   "translation-banner-button-translate-page": "पृष्ठ का अनुवाद करें",
   "translation-banner-title-new": "इस पृष्ठ का अनुवाद करने में मदद करें",
   "translation-banner-title-update": "इस पृष्ठ को अपडेट करने में मदद करें",

--- a/src/intl/hr/common.json
+++ b/src/intl/hr/common.json
@@ -240,7 +240,6 @@
   "translation-banner-body-update": "Postoji nova verzija ove stranice, ali trenutačno samo na engleskom. Pomozite nam prevesti najnoviju verziju.",
   "translation-banner-button-join-translation-program": "Pridružite se projektu prevođenja",
   "translation-banner-button-learn-more": "Saznajte više",
-  "translation-banner-button-see-english": "Pogledajte engleski",
   "translation-banner-button-translate-page": "Prevedi stranicu",
   "translation-banner-title-new": "Pomozite prevesti ovu stranicu",
   "translation-banner-title-update": "Pomozite ažurirati ovu stranicu",

--- a/src/intl/hu/common.json
+++ b/src/intl/hu/common.json
@@ -250,7 +250,6 @@
   "translation-banner-body-update": "Az oldal új verziója jelenleg csak angolul érhető el. Segítsen nekünk a fordításban.",
   "translation-banner-button-join-translation-program": "Csatlakozzon a fordítási programhoz",
   "translation-banner-button-learn-more": "Bővebben",
-  "translation-banner-button-see-english": "Lásd angolul",
   "translation-banner-button-translate-page": "Oldal fordítása",
   "translation-banner-title-new": "Segítsen lefordítani ezt az oldalt",
   "translation-banner-title-update": "Segítsen frissíteni ezt az oldalt",

--- a/src/intl/id/common.json
+++ b/src/intl/id/common.json
@@ -240,7 +240,6 @@
   "translation-banner-body-update": "Terdapat versi baru halaman ini namun sementara ini hanya dalam bahasa Inggris. Bantu kami menerjemahkan versi terkini.",
   "translation-banner-button-join-translation-program": "Gabung ke program penerjemahan",
   "translation-banner-button-learn-more": "Pelajari lebih lanjut",
-  "translation-banner-button-see-english": "Lihat Bahasa Inggris",
   "translation-banner-button-translate-page": "Terjemahkan halaman",
   "translation-banner-title-new": "Bantu menerjemahkan halaman ini",
   "translation-banner-title-update": "Bantu memperbarui halaman ini",

--- a/src/intl/ig/common.json
+++ b/src/intl/ig/common.json
@@ -188,7 +188,6 @@
   "translation-banner-body-update": "Enwere udi ohuru nke peeji a mana o no naani na asusu Bekee ugbu a. Nyere anyi aka tugharia nke kachasi ohuru.",
   "translation-banner-button-join-translation-program": "Sonye mmemme ntughari asusu",
   "translation-banner-button-learn-more": "Mutakwuo",
-  "translation-banner-button-see-english": "Lee Bekee",
   "translation-banner-button-translate-page": "Tugharia peeji",
   "translation-banner-title-new": "Nye aka tugharia asusu peeji a",
   "translation-banner-title-update": "Nye aka tinye ozi ohuru na peeji a",

--- a/src/intl/it/common.json
+++ b/src/intl/it/common.json
@@ -249,7 +249,6 @@
   "translation-banner-body-update": "C'è una nuova versione di questa pagina, ma al momento è solo in inglese. Aiutaci a tradurre l'ultima versione.",
   "translation-banner-button-join-translation-program": "Partecipa al programma di traduzione",
   "translation-banner-button-learn-more": "Scopri di più",
-  "translation-banner-button-see-english": "Visualizza in inglese",
   "translation-banner-button-translate-page": "Traduci la pagina",
   "translation-banner-title-new": "Aiuta a tradurre questa pagina",
   "translation-banner-title-update": "Aiuta ad aggiornare questa pagina",

--- a/src/intl/ja/common.json
+++ b/src/intl/ja/common.json
@@ -249,7 +249,6 @@
   "translation-banner-body-update": "このページの新しいバージョンがありますが、現在は英語のみです。最新バージョンの翻訳にご協力ください。",
   "translation-banner-button-join-translation-program": "翻訳プロジェクトへの参加",
   "translation-banner-button-learn-more": "もっと詳しく",
-  "translation-banner-button-see-english": "英語を見る",
   "translation-banner-button-translate-page": "ページを翻訳する",
   "translation-banner-title-new": "このページの翻訳を行う",
   "translation-banner-title-update": "このページの翻訳を行う",

--- a/src/intl/ka/common.json
+++ b/src/intl/ka/common.json
@@ -247,7 +247,6 @@
   "translation-banner-body-update": "ეს გვერდის ახალი ვერსიაა, ამიტომ ის, ამჟამად, მხოლოდ ინგლისურ ენაზეა. დაგვეხმარეთ ახალი ვერსიის თარგმნაში.",
   "translation-banner-button-join-translation-program": "შეუერთდით თარგმნის პროგრამას",
   "translation-banner-button-learn-more": "გაიგე მეტი",
-  "translation-banner-button-see-english": "ნახე ინგლისურად",
   "translation-banner-button-translate-page": "გვერდის გადათარგმნა",
   "translation-banner-title-new": "დაგვეხმარე გვერდის გადათარგმნაში",
   "translation-banner-title-update": "დაგვეხმარე ამ გვერდის განახლებაში",

--- a/src/intl/kk/common.json
+++ b/src/intl/kk/common.json
@@ -240,7 +240,6 @@
   "translation-banner-body-update": "Бұл беттің жаңарақ нұсқасы бар, бірақ ол ағылшын тілінде ғана қолжетімді. Соңғы нұсқасын аударуға көмектесіңіз.",
   "translation-banner-button-join-translation-program": "Аударма бағдарламасына қосылу",
   "translation-banner-button-learn-more": "Көбірек білу",
-  "translation-banner-button-see-english": "Ағылшын тіліндегі нұсқасын көру",
   "translation-banner-button-translate-page": "Бетті аудару",
   "translation-banner-title-new": "Бұл бетті аударуға көмектесіңіз",
   "translation-banner-title-update": "Бұл бетті жаңартуға көмектесіңіз",

--- a/src/intl/km/common.json
+++ b/src/intl/km/common.json
@@ -249,7 +249,6 @@
   "translation-banner-body-update": "មានកំណែថ្មីនៃទំព័រនេះ ប៉ុន្តែវាជាភាសាអង់គ្លេសឥឡូវនេះ។ ជួយយើងបកប្រែកំណែចុងក្រោយបំផុត។",
   "translation-banner-button-join-translation-program": "ចូលរួមកម្មវិធីបកប្រែ",
   "translation-banner-button-learn-more": "ស្វែង​យល់​បន្ថែម",
-  "translation-banner-button-see-english": "មើលជាភាសាអង់គ្លេស",
   "translation-banner-button-translate-page": "បកប្រែទំព័រ",
   "translation-banner-title-new": "ជួយបកប្រែទំព័រនេះ",
   "translation-banner-title-update": "ជួយអាប់ដេតទំព័រនេះ",

--- a/src/intl/ko/common.json
+++ b/src/intl/ko/common.json
@@ -247,7 +247,6 @@
   "translation-banner-body-update": "이 페이지의 새로운 버전이 있지만 현재는 영어로만 제공됩니다. 최신 버전의 번역을 도와 주세요.",
   "translation-banner-button-join-translation-program": "번역 프로그램 참여하기",
   "translation-banner-button-learn-more": "자세히 알아보기",
-  "translation-banner-button-see-english": "영어로 보기",
   "translation-banner-button-translate-page": "페이지 번역하기",
   "translation-banner-title-new": "이 페이지 번역 돕기",
   "translation-banner-title-update": "이 페이지 업데이트 돕기",

--- a/src/intl/lt/common.json
+++ b/src/intl/lt/common.json
@@ -214,7 +214,6 @@
   "translation-banner-body-update": "Jau yra nauja šio puslapio versija, bet kol kas tik anglų kalba. Padėkite mums išversti naujausią versiją.",
   "translation-banner-button-join-translation-program": "Prisijungti prie vertimo programos",
   "translation-banner-button-learn-more": "Sužinokite daugiau",
-  "translation-banner-button-see-english": "Rodyti anglų kalba",
   "translation-banner-button-translate-page": "Išversti puslapį",
   "translation-banner-title-new": "Padėkite išversti šį puslapį",
   "translation-banner-title-update": "Padėkite atnaujinti šį puslapį",

--- a/src/intl/ml/common.json
+++ b/src/intl/ml/common.json
@@ -227,7 +227,6 @@
   "translation-banner-body-update": "ഈ പേജിന്റെ ഒരു പുതിയ പതിപ്പുണ്ട്, പക്ഷേ ഇത് ഇപ്പോൾ ഇംഗ്ലീഷിൽ മാത്രമേ ഉള്ളൂ. ഈ ഏറ്റവും പുതിയ പതിപ്പ് വിവർത്തനം ചെയ്യാൻ ഞങ്ങളെ സഹായിക്കൂ.",
   "translation-banner-button-join-translation-program": "വിവർത്തന പ്രോഗ്രാമിൽ ചേരൂ",
   "translation-banner-button-learn-more": "കൂടുതല്‍ അറിയൂ",
-  "translation-banner-button-see-english": "ഇംഗ്ലീഷ് കാണൂ",
   "translation-banner-button-translate-page": "പേജ് വിവര്‍ത്തനം ചെയ്യൂ",
   "translation-banner-title-new": "ഈ പേജ് വിവർത്തനം ചെയ്യാൻ സഹായിക്കൂ",
   "translation-banner-title-update": "ഈ പേജ് അപ്ഡേറ്റ് ചെയ്യാന്‍ സഹായിക്കൂ",

--- a/src/intl/mr/common.json
+++ b/src/intl/mr/common.json
@@ -247,7 +247,6 @@
   "translation-banner-body-update": "या पृष्ठाची नवीन आवृत्ती आहे परंतु ती आत्ता केवळ इंग्रजीमध्ये आहे. नवीनतम आवृत्ती अनुवादित करण्यात आमची मदत करा.",
   "translation-banner-button-join-translation-program": "भाषांतर कार्यक्रमात सामील व्हा",
   "translation-banner-button-learn-more": "अधिक जाणून घ्या",
-  "translation-banner-button-see-english": "इंग्रजी पहा",
   "translation-banner-button-translate-page": "पृष्ठाचे भाषांतर करा",
   "translation-banner-title-new": "या पृष्ठाचे भाषांतर करण्यात मदत करा",
   "translation-banner-title-update": "हे पृष्ठ अद्यतनित करण्यात मदत करा",

--- a/src/intl/ms/common.json
+++ b/src/intl/ms/common.json
@@ -214,7 +214,6 @@
   "translation-banner-body-update": "Terdapat versi baru untuk halaman ini tetapi ianya hanya didapati dalam Bahasa Inggeris buat masa ini. Bantu kami untuk menterjemahkan versi terkini.",
   "translation-banner-button-join-translation-program": "Sertai program terjemahan",
   "translation-banner-button-learn-more": "Ketahui lebih lanjut",
-  "translation-banner-button-see-english": "Lihat Bahasa Inggeris",
   "translation-banner-button-translate-page": "Halaman terjemahan",
   "translation-banner-title-new": "Bantu menterjemahkan halaman ini",
   "translation-banner-title-update": "Bantu mengemas kini halaman ini",

--- a/src/intl/nb/common.json
+++ b/src/intl/nb/common.json
@@ -188,7 +188,6 @@
   "translation-banner-body-update": "Det finnes en ny versjon av denne siden, men den er bare på engelsk akkurat nå. Hjelp oss å oversette den nyeste versjonen.",
   "translation-banner-button-join-translation-program": "Delta i oversettelsesprogram",
   "translation-banner-button-learn-more": "Finn ut mer",
-  "translation-banner-button-see-english": "Se på engelsk",
   "translation-banner-button-translate-page": "Oversett side",
   "translation-banner-title-new": "Hjelp med å oversette denne siden",
   "translation-banner-title-update": "Hjelp med å oppdatere denne siden",

--- a/src/intl/nl/common.json
+++ b/src/intl/nl/common.json
@@ -249,7 +249,6 @@
   "translation-banner-body-update": "Er is een nieuwe versie van deze pagina, maar die is momenteel alleen in het Engels. Help ons de nieuwste versie te vertalen.",
   "translation-banner-button-join-translation-program": "Deelnemen aan vertaalteam",
   "translation-banner-button-learn-more": "Meer informatie",
-  "translation-banner-button-see-english": "Bekijk in het Engels",
   "translation-banner-button-translate-page": "Pagina vertalen",
   "translation-banner-title-new": "Help deze pagina te vertalen",
   "translation-banner-title-update": "Help deze pagina bij te werken",

--- a/src/intl/ph/common.json
+++ b/src/intl/ph/common.json
@@ -247,7 +247,6 @@
   "translation-banner-body-update": "May bagong bersyon ng page na ito ngunit nasa English lang ito ngayon. Tulungan kaming isalin ang pinakabagong bersyon.",
   "translation-banner-button-join-translation-program": "Sumali sa Translation Program",
   "translation-banner-button-learn-more": "Matuto pa",
-  "translation-banner-button-see-english": "Tingnan ang English",
   "translation-banner-button-translate-page": "I-translate ang page",
   "translation-banner-title-new": "Tumulong na i-translate ang page na ito",
   "translation-banner-title-update": "Tumulong paunlarin ang pahina",

--- a/src/intl/pl/common.json
+++ b/src/intl/pl/common.json
@@ -249,7 +249,6 @@
   "translation-banner-body-update": "Dostępna jest nowsza wersja tej strony, ale tylko w języku angielskim. Pomóż nam przetłumaczyć najnowszą wersję.",
   "translation-banner-button-join-translation-program": "Dołącz do zespołu tłumaczeniowego",
   "translation-banner-button-learn-more": "Dowiedz się więcej",
-  "translation-banner-button-see-english": "Zobacz wersję po angielsku",
   "translation-banner-button-translate-page": "Przetłumacz stronę",
   "translation-banner-title-new": "Pomóż w przetłumaczeniu tej strony",
   "translation-banner-title-update": "Pomóż nam zaktualizować tę stronę",

--- a/src/intl/pt-br/common.json
+++ b/src/intl/pt-br/common.json
@@ -249,7 +249,6 @@
   "translation-banner-body-update": "Há uma nova versão desta página mas, no momento, ela está apenas em inglês. Ajude-nos a traduzir a última versão.",
   "translation-banner-button-join-translation-program": "Participar do programa de tradução",
   "translation-banner-button-learn-more": "Saiba mais",
-  "translation-banner-button-see-english": "Visualizar em inglês",
   "translation-banner-button-translate-page": "Traduzir página",
   "translation-banner-title-new": "Ajude a traduzir esta página",
   "translation-banner-title-update": "Ajude a atualizar esta página",

--- a/src/intl/pt/common.json
+++ b/src/intl/pt/common.json
@@ -240,7 +240,6 @@
   "translation-banner-body-update": "Existe uma nova versão desta página, mas por enquanto só existe em inglês. Ajude-nos a traduzir a versão mais recente.",
   "translation-banner-button-join-translation-program": "Participe no projeto de tradução",
   "translation-banner-button-learn-more": "Saiba mais",
-  "translation-banner-button-see-english": "Ver em inglês",
   "translation-banner-button-translate-page": "Traduzir página",
   "translation-banner-title-new": "Ajude a traduzir esta página",
   "translation-banner-title-update": "Ajude a atualizar esta página",

--- a/src/intl/ro/common.json
+++ b/src/intl/ro/common.json
@@ -247,7 +247,6 @@
   "translation-banner-body-update": "Există o nouă versiune a acestei pagini, dar este doar în limba engleză pentru moment. Ajutați-ne să traducem versiunea cea mai recentă.",
   "translation-banner-button-join-translation-program": "Înscrieți-vă în programul de traducere",
   "translation-banner-button-learn-more": "Aflați mai multe",
-  "translation-banner-button-see-english": "Afișați versiunea în limba engleză",
   "translation-banner-button-translate-page": "Traduceți pagina",
   "translation-banner-title-new": "Ajutați-ne să traducem această pagină",
   "translation-banner-title-update": "Ajutați-ne să actualizăm această pagină",

--- a/src/intl/ru/common.json
+++ b/src/intl/ru/common.json
@@ -249,7 +249,6 @@
   "translation-banner-body-update": "Есть новая версия этой страницы, но пока только на английском языке. Помогите нам перевести последнюю версию.",
   "translation-banner-button-join-translation-program": "Присоединиться к программе перевода",
   "translation-banner-button-learn-more": "Подробнее",
-  "translation-banner-button-see-english": "См. английский",
   "translation-banner-button-translate-page": "Перевести страницу",
   "translation-banner-title-new": "Помогите перевести эту страницу",
   "translation-banner-title-update": "Помогите обновить эту страницу",

--- a/src/intl/se/common.json
+++ b/src/intl/se/common.json
@@ -247,7 +247,6 @@
   "translation-banner-body-update": "Det finns en ny version av den här sidan, men den finns bara på engelska just nu. Hjälp oss att översätta den senaste versionen.",
   "translation-banner-button-join-translation-program": "Gå med i översättningsprogrammet",
   "translation-banner-button-learn-more": "Lär dig mer",
-  "translation-banner-button-see-english": "Visa på engelska",
   "translation-banner-button-translate-page": "Översätt sidan",
   "translation-banner-title-new": "Hjälp till att översätta denna sida",
   "translation-banner-title-update": "Hjälp till att uppdatera den här sidan",

--- a/src/intl/sk/common.json
+++ b/src/intl/sk/common.json
@@ -214,7 +214,6 @@
   "translation-banner-body-update": "K dispozícii je nová verzia tejto stránky. V súčasnosti je však len v angličtine. Pomôžte nám s prekladom najnovšej verzie.",
   "translation-banner-button-join-translation-program": "Zapojte sa do prekladateľského programu",
   "translation-banner-button-learn-more": "Ďalšie informácie",
-  "translation-banner-button-see-english": "Zobraziť v angličtine",
   "translation-banner-button-translate-page": "Preložiť stránku",
   "translation-banner-title-new": "Pomôžte s prekladom tejto stránky",
   "translation-banner-title-update": "Pomôžte nám aktualizovať túto stránku",

--- a/src/intl/sl/common.json
+++ b/src/intl/sl/common.json
@@ -240,7 +240,6 @@
   "translation-banner-body-update": "Na voljo je nova različica te strani, vendar je zaenkrat samo v angleščini. Pomagajte nam prevesti najnovejšo različico.",
   "translation-banner-button-join-translation-program": "Pridružite se programu prevajanja",
   "translation-banner-button-learn-more": "Več informacij",
-  "translation-banner-button-see-english": "Oglejte si angleško različico",
   "translation-banner-button-translate-page": "Prevedi stran",
   "translation-banner-title-new": "Pomagajte prevesti to stran",
   "translation-banner-title-update": "Pomagajte posodobiti to stran",

--- a/src/intl/sr/common.json
+++ b/src/intl/sr/common.json
@@ -244,7 +244,6 @@
   "translation-banner-body-update": "Postoji novija verzija ove stranice ali je trenutno dostupna samo na engleskom. Pomozite nam da prevedemo poslednju verziju.",
   "translation-banner-button-join-translation-program": "Priključi se programu prevođenja",
   "translation-banner-button-learn-more": "Saznaj više",
-  "translation-banner-button-see-english": "Pogledaj na engleskom",
   "translation-banner-button-translate-page": "Prevedi stranicu",
   "translation-banner-title-new": "Pomozi da se ova stranica prevede",
   "translation-banner-title-update": "Pomozi da se ova stranica ažurira",

--- a/src/intl/sw/common.json
+++ b/src/intl/sw/common.json
@@ -227,7 +227,6 @@
   "translation-banner-body-update": "Kuna toleo jipya la ukurasa huu ila liko kwenye Kiingereza tu hivi sasa. Tusaidie kutafsiri toleo jipya zaidi.",
   "translation-banner-button-join-translation-program": "Jiunge na mpango wa kutafsiri",
   "translation-banner-button-learn-more": "Pata maelezo zaidi",
-  "translation-banner-button-see-english": "Angalia Kiingereza",
   "translation-banner-button-translate-page": "Tafsiri ukurasa",
   "translation-banner-title-new": "Saidia kutafsiri ukurasa huu",
   "translation-banner-title-update": "Saidia kusasisha ukurasa huu",

--- a/src/intl/ta/common.json
+++ b/src/intl/ta/common.json
@@ -247,7 +247,6 @@
   "translation-banner-body-update": "தற்போது இப்பக்கத்திற்கான புதிய பதிப்பு ஆங்கிலத்தில் மட்டுமே உள்ளது. சமீபத்திய பதிப்பினை மொழிபெயர்க்க உதவுங்கள்.",
   "translation-banner-button-join-translation-program": "மொழிபெயர்ப்புத் திட்டத்தில் சேருங்கள்",
   "translation-banner-button-learn-more": "மேலும் அறிக",
-  "translation-banner-button-see-english": "ஆங்கிலத்தில் காட்டு",
   "translation-banner-button-translate-page": "பக்கத்தை மொழிபெயர்",
   "translation-banner-title-new": "இந்தப் பக்கத்தை மொழிபெயர்க்க உதவி செய்யுங்கள்",
   "translation-banner-title-update": "இப்பக்கத்தினைப் புதுப்பிக்க உதவுங்கள்",

--- a/src/intl/th/common.json
+++ b/src/intl/th/common.json
@@ -249,7 +249,6 @@
   "translation-banner-body-update": "มีเวอร์ชันใหม่ของหน้านี้ แต่ตอนนี้เป็นภาษาอังกฤษเท่านั้น ช่วยเราแปลเวอร์ชันล่าสุด",
   "translation-banner-button-join-translation-program": "เข้าร่วมกับโครงการการแปล",
   "translation-banner-button-learn-more": "เรียนรู้เพิ่มเติม",
-  "translation-banner-button-see-english": "ดูภาษาอังกฤษ",
   "translation-banner-button-translate-page": "แปลหน้านี้",
   "translation-banner-title-new": "ช่วยแปลหน้านี้",
   "translation-banner-title-update": "ช่วยอัปเดตหน้านี้",

--- a/src/intl/tr/common.json
+++ b/src/intl/tr/common.json
@@ -249,7 +249,6 @@
   "translation-banner-body-update": "Bu sayfanın yeni bir sürümü vardır ancak şu anda yalnızca İngilizce'dir. Son sürümü çevirmemize yardımcı ol.",
   "translation-banner-button-join-translation-program": "Çeviri programına katıl",
   "translation-banner-button-learn-more": "Daha fazla bilgi edin",
-  "translation-banner-button-see-english": "İngilizce'yi gör",
   "translation-banner-button-translate-page": "Sayfayı çevir",
   "translation-banner-title-new": "Bu sayfanın çevirisine yardım edin",
   "translation-banner-title-update": "Bu sayfanın güncellenmesine yardım edin",

--- a/src/intl/uk/common.json
+++ b/src/intl/uk/common.json
@@ -249,7 +249,6 @@
   "translation-banner-body-update": "Ми оновили контент на цій сторінці, але наразі нова версія доступна лише англійською мовою. Допоможіть нам її перекласти.",
   "translation-banner-button-join-translation-program": "Приєднатися до програми перекладів",
   "translation-banner-button-learn-more": "Докладніше",
-  "translation-banner-button-see-english": "Читати англійською",
   "translation-banner-button-translate-page": "Перекласти сторінку",
   "translation-banner-title-new": "Допоможіть перекласти цю сторінку",
   "translation-banner-title-update": "Допоможіть оновити цю сторінку",

--- a/src/intl/uz/common.json
+++ b/src/intl/uz/common.json
@@ -247,7 +247,6 @@
   "translation-banner-body-update": "Bu sahifaning yangi versiyasi mavjud, ammo hozirda faqat ingliz tilida. Oxirgi versiyasini tarjima qilishda yordam bering.",
   "translation-banner-button-join-translation-program": "Tarjima dasturiga qo'shiling",
   "translation-banner-button-learn-more": "Ko'proq ma'lumot olish",
-  "translation-banner-button-see-english": "Ingliz tilida ko'ring",
   "translation-banner-button-translate-page": "Sahifani tarjima qilish",
   "translation-banner-title-new": "Bu sahifani tarjima qilishga yordam bering",
   "translation-banner-title-update": "Bu sahifani yangilashga yordam bering",

--- a/src/intl/vi/common.json
+++ b/src/intl/vi/common.json
@@ -249,7 +249,6 @@
   "translation-banner-body-update": "Đã có phiên bản mới của trang này nhưng chỉ hiển thị tiếng Anh. Hãy giúp chúng tôi dịch phiên bản mới nhất.",
   "translation-banner-button-join-translation-program": "Tham gia chương trình dịch",
   "translation-banner-button-learn-more": "Tìm hiểu thêm",
-  "translation-banner-button-see-english": "Xem tiếng Anh",
   "translation-banner-button-translate-page": "Dịch trang",
   "translation-banner-title-new": "Giúp dịch trang này",
   "translation-banner-title-update": "Giúp cập nhật trang này",

--- a/src/intl/zh-tw/common.json
+++ b/src/intl/zh-tw/common.json
@@ -249,7 +249,6 @@
   "translation-banner-body-update": "本頁面內容已有新版本，但目前僅提供英文。協助我們翻譯最新內容。",
   "translation-banner-button-join-translation-program": "加入翻譯計畫",
   "translation-banner-button-learn-more": "了解更多",
-  "translation-banner-button-see-english": "查看英文",
   "translation-banner-button-translate-page": "翻譯本頁面",
   "translation-banner-title-new": "協助翻譯本頁面",
   "translation-banner-title-update": "協助更新本頁面",

--- a/src/intl/zh/common.json
+++ b/src/intl/zh/common.json
@@ -249,7 +249,6 @@
   "translation-banner-body-update": "本页面有新版本，但现在只有英文版。请帮助我们翻译最新版本。",
   "translation-banner-button-join-translation-program": "加入翻译计划",
   "translation-banner-button-learn-more": "查看更多",
-  "translation-banner-button-see-english": "查看英文",
   "translation-banner-button-translate-page": "翻译页面",
   "translation-banner-title-new": "帮助翻译此页面",
   "translation-banner-title-update": "帮助更新此页面",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`See English` button text should be in English in all languages. It will help english users who is landing in a unknown regional language web reference. 
<!--- Describe your changes in detail -->
Removed the translation key `translation-banner-button-see-english` from all language files. Hard coded the button text `See English` instead.

## Related Issue
#9309 

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
