### PR TITLE
fix the translate page button not showing the text

### DIFF
--- a/src/components/ButtonLink.tsx
+++ b/src/components/ButtonLink.tsx
@@ -7,7 +7,7 @@ export interface IProps extends ILinkProps, ButtonProps {}
 
 const ButtonLink: React.FC<IProps> = ({ children, ...props }) => {
   return (
-    <Button as={Link} textDecoration="none" {...props}>
+    <Button as={Link} textDecoration="none" activeStyle={{}} {...props}>
       {children}
     </Button>
   )

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -19,6 +19,7 @@ export interface IBaseProps {
   hideArrow?: boolean
   isPartiallyActive?: boolean
   customEventOptions?: EventOptions
+  activeStyle?: object
 }
 
 export interface IProps extends IBaseProps, LinkProps {
@@ -49,6 +50,7 @@ const Link: React.FC<IProps> = ({
   hideArrow = false,
   isPartiallyActive = true,
   customEventOptions,
+  activeStyle = null,
   ...restProps
 }) => {
   const theme = useTheme()
@@ -122,7 +124,7 @@ const Link: React.FC<IProps> = ({
       as={IntlLink}
       language={language}
       partiallyActive={isPartiallyActive}
-      activeStyle={{ color: theme.colors.primary }}
+      activeStyle={activeStyle ? activeStyle : { color: theme.colors.primary }}
       whiteSpace={isGlossary ? "nowrap" : "normal"}
       {...commonProps}
     >


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The language which loads to should be `en` as we are requesting the user to see the latest `en` version and seeking their help to translate the page. It will fix the empty text in the button issue as well.

Please advice, we should not load the `en` version on `Translate Page` click. So that I can make changes accordingly.

<!--- Describe your changes in detail -->

## Related Issue
#9312 #9313 

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
