### PR TITLE
Added link to PoW faucet to the network page

### DIFF
--- a/src/content/developers/docs/networks/index.md
+++ b/src/content/developers/docs/networks/index.md
@@ -63,6 +63,7 @@ Sepolia is a proof-of-stake testnet, and is the recommended default testnet for 
 
 - [Sepolia faucet](https://faucet.sepolia.dev/)
 - [FaucETH](https://fauceth.komputing.org)
+- [Sepolia PoW Faucet](https://sepolia-faucet.pk910.de/)
 
 #### Goerli {#goerli}
 
@@ -77,6 +78,7 @@ Goerli is a proof-of-stake testnet, and is the recommended default testnet for t
 - [Goerli faucet](https://faucet.goerli.mudit.blog/)
 - [Alchemy Goerli Faucet](https://goerlifaucet.com/)
 - [All That Node Goerli Faucet](https://www.allthatnode.com/faucet/ethereum.dsrv)
+- [Goerli PoW Faucet](https://goerli-faucet.pk910.de/)
 
 To launch a Validator on Goerli testnet, use ethstaker's ["cheap goerli validator" launchpad](https://goerli.launchpad.ethstaker.cc/en/).
 

--- a/src/content/translations/de/developers/docs/networks/index.md
+++ b/src/content/translations/de/developers/docs/networks/index.md
@@ -51,6 +51,7 @@ Ein Proof-of-Authority-Testnetz, das über verschiedene Clients hinweg funktioni
 - [Görli faucet](https://faucet.goerli.mudit.blog/)
 - [Chainlink faucet](https://faucets.chain.link/)
 - [Alchemy Goerli Faucet](https://goerlifaucet.com/)
+- [Goerli PoW Faucet](https://goerli-faucet.pk910.de/)
 
 #### Kintsugi {#kintsugi}
 

--- a/src/content/translations/es/developers/docs/networks/index.md
+++ b/src/content/translations/es/developers/docs/networks/index.md
@@ -51,6 +51,7 @@ Una red de prueba con prueba de autoridad que funciona entre los clientes.
 - [Faucet Görli](https://faucet.goerli.mudit.blog/)
 - [Faucet Chainlink](https://faucets.chain.link/)
 - [Alchemy Goerli Faucet](https://goerlifaucet.com/)
+- [Goerli PoW Faucet](https://goerli-faucet.pk910.de/)
 
 #### Kintsugi {#kintsugi}
 

--- a/src/content/translations/fa/developers/docs/networks/index.md
+++ b/src/content/translations/fa/developers/docs/networks/index.md
@@ -51,6 +51,7 @@ lang: fa
 - [فاست Görli](https://faucet.goerli.mudit.blog/)
 - [فاست Chainlink](https://faucets.chain.link/)
 - [Alchemy Goerli Faucet](https://goerlifaucet.com/)
+- [Goerli PoW Faucet](https://goerli-faucet.pk910.de/)
 
 #### Kintsugi {#kintsugi}
 

--- a/src/content/translations/fr/developers/docs/networks/index.md
+++ b/src/content/translations/fr/developers/docs/networks/index.md
@@ -51,6 +51,7 @@ Réseau de test de preuve d'autorité qui fonctionne entre les clients.
 - [Robinet Görli](https://faucet.goerli.mudit.blog/)
 - [Robinet Chainlink](https://faucets.chain.link/)
 - [Alchemy Goerli Faucet](https://goerlifaucet.com/)
+- [Goerli PoW Faucet](https://goerli-faucet.pk910.de/)
 
 #### Kintsugi {#kintsugi}
 

--- a/src/content/translations/id/developers/docs/networks/index.md
+++ b/src/content/translations/id/developers/docs/networks/index.md
@@ -51,6 +51,7 @@ Testnet bukti otoritas yang berfungsi di seluruh klien.
 - [Keran Görli](https://faucet.goerli.mudit.blog/)
 - [Keran Chainlink](https://faucets.chain.link/)
 - [Alchemy Goerli Faucet](https://goerlifaucet.com/)
+- [Goerli PoW Faucet](https://goerli-faucet.pk910.de/)
 
 #### Kintsugi {#kintsugi}
 

--- a/src/content/translations/it/developers/docs/networks/index.md
+++ b/src/content/translations/it/developers/docs/networks/index.md
@@ -45,6 +45,7 @@ Goerli è una rete di prova Proof of Stake. Si prevede che sarà mantenuta a lun
 - [Faucet Goerli](https://faucet.goerli.mudit.blog/)
 - [Faucet Chainlink](https://faucets.chain.link/)
 - [Faucet Alchemy Goerli](https://goerlifaucet.com/)
+- [Goerli PoW Faucet](https://goerli-faucet.pk910.de/)
 
 #### Sepolia {#sepolia}
 
@@ -59,6 +60,7 @@ Sepolia è una rete di prova Proof of Stake. Sebbene Sepolia sia ancora in funzi
 
 - [Faucet Sepolia](https://faucet.sepolia.dev/)
 - [FaucETH](https://fauceth.komputing.org)
+- [Sepolia PoW Faucet](https://sepolia-faucet.pk910.de/)
 
 #### Ropsten _(deprecata)_ {#ropsten}
 

--- a/src/content/translations/ja/developers/docs/networks/index.md
+++ b/src/content/translations/ja/developers/docs/networks/index.md
@@ -45,6 +45,7 @@ Goerli (ゴエリ)はプルーフ・オブ・ステークのテストネット�
 - [Goerli faucet](https://faucet.goerli.mudit.blog/)
 - [Chainlink faucet](https://faucets.chain.link/)
 - [Alchemy Goerli Faucet](https://goerlifaucet.com/)
+- [Goerli PoW Faucet](https://goerli-faucet.pk910.de/)
 
 #### Sepolia (セポリア) {#sepolia}
 
@@ -59,6 +60,7 @@ Sepolia (セポリア)は、プルーフ・オブ・ステークのテストネ�
 
 - [Sepolia faucet](https://faucet.sepolia.dev/)
 - [FaucETH](https://fauceth.komputing.org)
+- [Sepolia PoW Faucet](https://sepolia-faucet.pk910.de/)
 
 #### Ropsten (ロプステン) _(非推奨)_ {#ropsten}
 

--- a/src/content/translations/pt-br/developers/docs/networks/index.md
+++ b/src/content/translations/pt-br/developers/docs/networks/index.md
@@ -45,6 +45,7 @@ Goerli é uma rede de testes de prova de participação. É esperado que ela sej
 - [Torneira Goerli](https://faucet.goerli.mudit.blog/)
 - [Torneira Chainlink](https://faucets.chain.link/)
 - [Torneira Alchemy Goerli](https://goerlifaucet.com/)
+- [Torneira PoW Goerli](https://goerli-faucet.pk910.de/)
 
 #### Sepolia {#sepolia}
 
@@ -59,6 +60,7 @@ Sepolia é uma rede de teste de prova de participação. Embora a Sepolia ainda 
 
 - [Torneira Sepolia](https://faucet.sepolia.dev/)
 - [FaucETH](https://fauceth.komputing.org)
+- [Torneira PoW Faucet](https://sepolia-faucet.pk910.de/)
 
 #### Ropsten _(obsoleta)_ {#ropsten}
 

--- a/src/content/translations/ro/developers/docs/networks/index.md
+++ b/src/content/translations/ro/developers/docs/networks/index.md
@@ -51,6 +51,7 @@ Un testnet bazat pe dovada-autorității care funcționează la nivelul tuturor 
 - [Faucet-ul Görli](https://faucet.goerli.mudit.blog/)
 - [Chainlink faucet](https://faucets.chain.link/)
 - [Alchemy Goerli Faucet](https://goerlifaucet.com/)
+- [Goerli PoW Faucet](https://goerli-faucet.pk910.de/)
 
 #### Kintsugi {#kintsugi}
 

--- a/src/content/translations/ru/developers/docs/networks/index.md
+++ b/src/content/translations/ru/developers/docs/networks/index.md
@@ -51,6 +51,7 @@ ETH в тестовых сетях не имеет реальной стоимо
 - [Görli кран](https://faucet.goerli.mudit.blog/)
 - [Кран Chainlink](https://faucets.chain.link/)
 - [Кран Alchemy Goerli](https://goerlifaucet.com/)
+- [Кран PoW Goerli](https://goerli-faucet.pk910.de/)
 
 #### Kintsugi {#kintsugi}
 

--- a/src/content/translations/tr/developers/docs/networks/index.md
+++ b/src/content/translations/tr/developers/docs/networks/index.md
@@ -51,6 +51,7 @@ Test ağlarındaki ETH'nin gerçek bir değeri yoktur; bu nedenle, test ağı ET
 - [Görli musluk](https://faucet.goerli.mudit.blog/)
 - [Chainlink musluğu](https://faucets.chain.link/)
 - [Alchemy Goerli Musluğu](https://goerlifaucet.com/)
+- [PoW Goerli Musluğu](https://goerli-faucet.pk910.de/)
 
 #### Kintsugi {#kintsugi}
 

--- a/src/content/translations/zh/developers/docs/networks/index.md
+++ b/src/content/translations/zh/developers/docs/networks/index.md
@@ -45,6 +45,7 @@ Goerli 是一个权益证明测试网。 它有望得到长期维护，作为面
 - [Goerli 水龙头](https://faucet.goerli.mudit.blog/)
 - [Chainlink 水龙头](https://faucets.chain.link/)
 - [Alchemy Goerli 水龙头](https://goerlifaucet.com/)
+- [PoW Goerli 水龙头](https://goerli-faucet.pk910.de/)
 
 #### Sepolia {#sepolia}
 
@@ -59,6 +60,7 @@ Sepolia 是一个权益证明测试网。 尽管 Sepolia 仍在运行，但目�
 
 - [Sepolia 水龙头](https://faucet.sepolia.dev/)
 - [FaucETH](https://fauceth.komputing.org)
+- [PoW Sepolia 水龙头](https://sepolia-faucet.pk910.de/)
 
 #### Ropsten*（已弃用）* {#ropsten}
 


### PR DESCRIPTION
I've added 2 links to my PoW Faucet to the network page. 
One for the sepolia testnet:  https://sepolia-faucet.pk910.de/ 
And one for goerli testnet:  https://goerli-faucet.pk910.de/

## Description

Both faucets are free to use, but require some mining work to prevent bot mass requests. 
They're active for about a year now and heavily used by the community. 
Mining is not used for any profit, neither does the faucet offer paid options. (and will never do so)

Code is open source and on github: https://github.com/pk910/PoWFaucet

