### PR TITLE
[Patch] ethonarm_22.04.00.img.zip sha256 checksum

### DIFF
--- a/src/content/developers/tutorials/run-node-raspberry-pi/index.md
+++ b/src/content/developers/tutorials/run-node-raspberry-pi/index.md
@@ -61,7 +61,7 @@ Download the Raspberry Pi image from [Ethereum on Arm](https://ethereumonarm-my.
 ```sh
 # From directory containing the downloaded image
 shasum -a 256 ethonarm_22.04.00.img.zip
-# Hash should output: 485cf36128ca60a41b5de82b5fee3ee46b7c479d0fc5dfa5b9341764414c4c57
+# Hash should output: fb497e8f8a7388b62d6e1efbc406b9558bee7ef46ec7e53083630029c117444f
 ```
 
 Note that images for Rock 5B and Odroid M1 boards are available at the Ethereum-on-Arm [downloads page](https://ethereum-on-arm-documentation.readthedocs.io/en/latest/quick-guide/download-and-install.html).


### PR DESCRIPTION
## Description
- Fixes sha256 hash for `ethonarm_22.04.00.img.zip` 
- https://ethereum-on-arm-documentation.readthedocs.io/en/latest/quick-guide/download-and-install.html#id2

## Related Issue
https://www.notion.so/efdn/change-instructions-in-tutorial-d512f287a0794751bef574569c97c3a6