### PR TITLE
fix the checbox static white color check on all themes

### DIFF
--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -11,7 +11,7 @@ const CustomIcon = (props: CheckboxIconProps) => {
     <Icon
       viewBox="0 0 24 24"
       fill="none"
-      stroke="white"
+      stroke="buttonColor"
       strokeWidth="2px"
       w="100%"
       h="100%"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix the checkbox button using static `white` colour for both dark/light theme. Converted the property to read from variable.
<!--- Describe your changes in detail -->

## Related Issue

#9327 

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Local Evidence:
**Dark** 
<img width="398" alt="Screenshot 2023-01-31 at 1 05 04 pm" src="https://user-images.githubusercontent.com/26359740/215641274-44862c06-8d2d-4796-9b1c-81e4581365ef.png">




**Light**
<img width="425" alt="Screenshot 2023-01-31 at 1 04 57 pm" src="https://user-images.githubusercontent.com/26359740/215641285-ca5625a5-9852-4b3f-8b38-e059ab396879.png">

