### PR TITLE
Remove OpenEthereum from "Nodes and clients" page

### DIFF
--- a/src/content/developers/docs/nodes-and-clients/index.md
+++ b/src/content/developers/docs/nodes-and-clients/index.md
@@ -271,13 +271,12 @@ Snap sync is the latest approach to syncing a client, pioneered by the Geth team
 
 [More on snap sync](https://github.com/ethereum/devp2p/blob/master/caps/snap.md)
 
-| Client       | Disk size (fast sync) | Disk size (full archive) |
-| ------------ | --------------------- | ------------------------ |
-| Geth         | 400GB+                | 6TB+                     |
-| OpenEthereum | 280GB+                | 6TB+                     |
-| Nethermind   | 500GB+                | 12TB+                    |
-| Besu         | 750GB+                | 5TB+                     |
-| Erigon       | N/A                   | 1TB+                     |
+| Client     | Disk size (fast sync) | Disk size (full archive) |
+| ---------- | --------------------- | ------------------------ |
+| Geth       | 400GB+                | 6TB+                     |
+| Nethermind | 500GB+                | 12TB+                    |
+| Besu       | 750GB+                | 5TB+                     |
+| Erigon     | N/A                   | 1TB+                     |
 
 #### Optimistic sync {#optimistic-sync}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Removed OpenEthereum from "Nodes and clients" page

There is a note added in this PR https://github.com/ethereum/ethereum-org-website/commit/2440b9e8d5a23415ea52d2368471fc413225db88 that OpenEthereum client is deprecated.

I've also removed it from the list of clients in  "SYNCHRONIZATION MODES" section.

## Related Issue
Resolve ethereum/ethereum-org-website#6389

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
