### PR TITLE
Fix broken DAppNode url

### DIFF
--- a/src/content/developers/docs/nodes-and-clients/run-a-node/index.md
+++ b/src/content/developers/docs/nodes-and-clients/run-a-node/index.md
@@ -135,7 +135,7 @@ Multiple user-friendly projects aim to improve the experience of setting up a cl
 
 Below are a few projects which can help you install and control clients just with a few clicks:
 
-- [DappNode](https://docs.dappnode.io/get-started/installation/custom-hardware/installation/overview/) - DappNode doesn't come only with a machine from a vendor. The software, the actual node launcher and control center with many features can be used on arbitrary hardware.
+- [DappNode](https://docs.dappnode.io/user/quick-start/first-steps/) - DappNode doesn't come only with a machine from a vendor. The software, the actual node launcher and control center with many features can be used on arbitrary hardware.
 - [eth-docker](https://eth-docker.net/) - Automated setup using Docker focused on easy and secure staking, requires basic terminal and Docker knowledge, recommended for a bit more advanced users.
 - [Stereum](https://stereum.net/ethereum-node-setup/) - Launcher for installing clients on a remote server via SSH connection with a GUI setup guide, control center, and many other features.
 - [NiceNode](https://www.nicenode.xyz/) - Launcher with a straightforward user experience to run a node on your computer. Just choose clients and start them with a few clicks. Still in development.


### PR DESCRIPTION
Existing DAppNode url is broken, change to "First steps with Dappnode" docs

## Description

The DappNode docs link [here](https://ethereum.org/en/developers/docs/nodes-and-clients/run-a-node/#automatized-setup) links to a page that says: 
```
Oh oh... You probably weren't looking for this.

We've changed the documentation to serve you better and we might have broken this link.
```

The original URL mentions "custom hardware" but I couldn't find that page in the existing docs, so I pointed it to a general First steps doc. 

## Related Issue
[Issue link](https://github.com/ethereum/ethereum-org-website/issues/9380)