### PR TITLE
Fixed typo 'uprade' -> 'upgrade'

### DIFF
--- a/src/intl/en/page-what-is-ethereum.json
+++ b/src/intl/en/page-what-is-ethereum.json
@@ -85,7 +85,7 @@
   "page-what-is-ethereum-criminal-activity-desc-3": "“The use of cryptocurrencies for illicit activities seems to comprise only a small part of the overall cryptocurrency economy, and it appears to be comparatively smaller than the amount of illicit funds involved in traditional finance.”",
   "page-what-is-ethereum-energy-title": "What about Ethereum's energy consumption?",
   "page-what-is-ethereum-energy-desc-1": "On September 15, 2022, Ethereum went through The Merge upgrade which transitioned Ethereum from proof-of-work to proof-of-stake.",
-  "page-what-is-ethereum-energy-desc-2": "The Merge was Ethereum's biggest uprade and reduced the energy consumption required to secure Ethereum by <b>99.95%</b>, creating a <b>more secure network for a much smaller carbon cost</b>. Ethereum is now a low-carbon blockchain while boosting its security and scalability.",
+  "page-what-is-ethereum-energy-desc-2": "The Merge was Ethereum's biggest upgrade and reduced the energy consumption required to secure Ethereum by <b>99.95%</b>, creating a <b>more secure network for a much smaller carbon cost</b>. Ethereum is now a low-carbon blockchain while boosting its security and scalability.",
   "page-what-is-ethereum-more-on-energy-consumption": "More on energy consumption",
   "page-what-is-ethereum-energy-consumption-chart-legend": "Annual Energy Consumption in TWh/yr",
   "energy-consumption-chart-youtube-label": "YouTube",


### PR DESCRIPTION
#Fix typo on 'What is Ethereum' page

## Description

Describe the bug
There is a typo on the 'What is Ethereum' page, specifically:
The Merge was Ethereum's biggest uprade...

'uprade' should be changed to 'upgrade'

## Related Issue

#9387 
