### PR TITLE
Scry Oracle Infrastructure support

### DIFF
--- a/src/content/developers/docs/oracles/index.md
+++ b/src/content/developers/docs/oracles/index.md
@@ -404,6 +404,8 @@ There are multiple oracle applications you can integrate into your Ethereum dapp
 
 **[Dos.Network](https://dos.network/)** - _DOS Network is a decentralized oracle service network to boost blockchain usability with real-world data and computation power._
 
+**[Scry Protocol](https://docs.scry.finance/)** - _Scry allows for developers to self-deploy high-scale oracles using custom signer sets for arbitrary APIs to any EVM without any code needed. Fully decentralized and permissionless including nodes, front end and contracts._
+
 ## Further reading {#further-reading}
 
 **Articles**


### PR DESCRIPTION
## Description

Requesting an update to have Scry in the oracles. The platform is the ONLY oracle infrastructure that allows devs to self deploy their own oracles with custom signers for the oracles data, with high scale feed batching, open source front end and nodes, permissionless feed updates, any API and historical onchain lookup for feeds.

Most projects have some token and decentralization theatre, this project has 0 token relience, can be forked free for the front end and self hosted, the nodes are fully self hosted, and the setup is simple for any dev in <15m for >100 feeds on any EVM.

## Related Issue
https://github.com/ethereum/ethereum-org-website/issues/9418
