### PR TITLE
Fix sitemap output

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -70,6 +70,7 @@ const config: GatsbyConfig = {
     {
       resolve: `gatsby-plugin-sitemap`,
       options: {
+        output: "/sitemap",
         query: `{
           site {
             siteMetadata {


### PR DESCRIPTION
Currently https://ethereum.org/sitemap/sitemap-index.xml gives a 404 error.

## Description

Fix sitemap output config to be aligned with the robots file (defined in `gatsby-plugin-robots-txt`).
