### PR TITLE
[Fix] Bad redirect from /upgrades/shard-chains/ 

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -205,7 +205,7 @@
   },
   {
     "fromPath": "/upgrades/shard-chains/",
-    "toPath": "/en/upgrades/sharding/"
+    "toPath": "/en/roadmap/danksharding/"
   },
   {
     "fromPath": "/*/eth2/staking/",

--- a/redirects.json
+++ b/redirects.json
@@ -204,6 +204,10 @@
     "toPath": "/:splat/upgrades/sharding/"
   },
   {
+    "fromPath": "/upgrades/shard-chains/",
+    "toPath": "/en/upgrades/sharding/"
+  },
+  {
     "fromPath": "/*/eth2/staking/",
     "toPath": "/:splat/staking/"
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Adds default redirect for `/upgrades/shard-chains` so that it redirects to `/en/upgrades/sharding`

## Related Issue
Fixes https://github.com/ethereum/ethereum-org-website/issues/9067
