### PR TITLE
Blockchain in developing countries link broken on learn page

### DIFF
--- a/src/pages/learn/index.tsx
+++ b/src/pages/learn/index.tsx
@@ -596,7 +596,7 @@ const LearnPage = ({ data }: PageProps<Queries.LearnPageQuery, Context>) => {
             </AdditionalReadingHeader>
             <DocsContainer>
               <DocLink
-                to="http://governance40.com/wp-content/uploads/2019/06/Blockchain-in-Developing-Countries.pdf"
+                to="https://web.archive.org/web/20220708092831/http://governance40.com/wp-content/uploads/2019/06/Blockchain-in-Developing-Countries.pdf"
                 isExternal
               >
                 <Translation id="more-on-ethereum-use-cases-link" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Replace `Blockchain in developing countries` link with a wayback machine link

## Related Issue
Fixes https://github.com/ethereum/ethereum-org-website/issues/8704
