### PR TITLE
chore: Update l2beat Risk assessment button URL

### DIFF
--- a/src/pages/layer-2.tsx
+++ b/src/pages/layer-2.tsx
@@ -697,7 +697,7 @@ const Layer2Page = ({ data }: PageProps<Queries.Layer2PageQuery>) => {
             <Translation id="layer-2-dyor-2" />
           </p>
           <p>
-            <ButtonLink to="https://l2beat.com/?view=risk">
+            <ButtonLink to="https://l2beat.com/scaling/risk">
               <Translation id="layer-2-dyor-3" />
             </ButtonLink>
           </p>


### PR DESCRIPTION
The URL to view the risk assessment of L2 chains is different. The old URL takes you to TVL tab.