### PR TITLE
a11y(link): update indicators for external links

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -5,6 +5,7 @@ import {
   Link as ChakraLink,
   LinkProps,
   useTheme,
+  VisuallyHidden,
 } from "@chakra-ui/react"
 import { navigate as gatsbyNavigate } from "gatsby"
 import { LocalizedLink as IntlLink } from "gatsby-theme-i18n"
@@ -114,6 +115,7 @@ const Link: React.FC<IProps> = ({
         {...commonProps}
       >
         {children}
+        <VisuallyHidden>(opens in a new tab)</VisuallyHidden>
         {!hideArrow && (
           <Box as="span" ml={0.5} mr={1.5} aria-hidden>
             ↗

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,5 +1,11 @@
 import React from "react"
-import { Icon, Link as ChakraLink, LinkProps, useTheme } from "@chakra-ui/react"
+import {
+  Box,
+  Icon,
+  Link as ChakraLink,
+  LinkProps,
+  useTheme,
+} from "@chakra-ui/react"
 import { navigate as gatsbyNavigate } from "gatsby"
 import { LocalizedLink as IntlLink } from "gatsby-theme-i18n"
 import { NavigateOptions } from "@reach/router"
@@ -94,11 +100,6 @@ const Link: React.FC<IProps> = ({
       <ChakraLink
         href={to}
         isExternal
-        _after={{
-          content: !hideArrow ? '"↗"' : undefined,
-          ml: 0.5,
-          mr: 1.5,
-        }}
         onClick={(e) => {
           // only track events on external links
           if (!isExternal) {
@@ -113,6 +114,11 @@ const Link: React.FC<IProps> = ({
         {...commonProps}
       >
         {children}
+        {!hideArrow && (
+          <Box as="span" ml={0.5} mr={1.5} aria-hidden>
+            ↗
+          </Box>
+        )}
       </ChakraLink>
     )
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Moves the external link icon in the `Link` component from the after pseudo to a child element. This allows for the icon to be hidden from screen readers.

Also adds hidden indicator text that the link will open a new tab. This dissolves possible confusion for a blind user on where they are at in the browser. (Are they still on the website to be able to go back a page, or someplace else? It might not always be clear depending on the link text.)
<!--- Describe your changes in detail -->

## Related Issue
#8877
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->