### PR TITLE
Withdrawals page updates

### DIFF
--- a/src/components/ExpandableCard.tsx
+++ b/src/components/ExpandableCard.tsx
@@ -22,6 +22,7 @@ export interface IProps {
   contentPreview?: ReactNode
   title: ReactNode
   svg?: typeof Icon
+  eventAction?: string
   eventCategory?: string
   eventName?: string
 }
@@ -31,12 +32,13 @@ const ExpandableCard: React.FC<IProps> = ({
   contentPreview,
   title,
   svg: Svg,
+  eventAction = "Clicked",
   eventCategory = "",
   eventName = "",
 }) => {
   const [isVisible, setIsVisible] = useState(false)
   const matomo = {
-    eventAction: `Clicked`,
+    eventAction,
     eventCategory: `ExpandableCard${eventCategory}`,
     eventName,
   }

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -65,8 +65,14 @@ const Link: React.FC<IProps> = ({
   const isStatic = url.isStatic(to)
   const isPdf = url.isPdf(to)
 
-  const eventOptions: EventOptions = {
+  const externalLinkEvent: EventOptions = {
     eventCategory: `External link`,
+    eventAction: `Clicked`,
+    eventName: to,
+  }
+
+  const hashLinkEvent: EventOptions = {
+    eventCategory: `Hash link`,
     eventAction: `Clicked`,
     eventName: to,
   }
@@ -81,7 +87,21 @@ const Link: React.FC<IProps> = ({
   // See https://github.com/gatsbyjs/gatsby/issues/21909
   if (isHash) {
     return (
-      <ChakraLink href={to} {...commonProps}>
+      <ChakraLink
+        href={to}
+        onClick={(e) => {
+          // only track events on external links and hash links
+          if (!isHash) {
+            return
+          }
+
+          e.stopPropagation()
+          trackCustomEvent(
+            customEventOptions ? customEventOptions : hashLinkEvent
+          )
+        }}
+        {...commonProps}
+      >
         {children}
       </ChakraLink>
     )
@@ -100,14 +120,14 @@ const Link: React.FC<IProps> = ({
           mr: 1.5,
         }}
         onClick={(e) => {
-          // only track events on external links
+          // only track events on external links and hash links
           if (!isExternal) {
             return
           }
 
           e.stopPropagation()
           trackCustomEvent(
-            customEventOptions ? customEventOptions : eventOptions
+            customEventOptions ? customEventOptions : externalLinkEvent
           )
         }}
         {...commonProps}

--- a/src/components/Staking/ShanghaiCapella.tsx
+++ b/src/components/Staking/ShanghaiCapella.tsx
@@ -75,6 +75,10 @@ const ShanghaiCapella: FC<IProps> = (props) => {
               to="https://zhejiang.launchpad.ethereum.org/withdrawals"
               mt="auto"
               hideArrow
+              whiteSpace="normal"
+              textAlign="center"
+              h="fit-content"
+              py={3}
             >
               Test your setup on Zhejiang launchpad
               {/* TODO: Update once Withdrawals page merged to Goerli/Mainnet branches */}

--- a/src/components/Staking/ShanghaiCapella.tsx
+++ b/src/components/Staking/ShanghaiCapella.tsx
@@ -76,7 +76,7 @@ const ShanghaiCapella: FC<IProps> = (props) => {
               mt="auto"
               hideArrow
             >
-              Test your setup on Zhejiang{" "}
+              Test your setup on Zhejiang launchpad
               {/* TODO: Update once Withdrawals page merged to Goerli/Mainnet branches */}
             </ButtonLink>
           </>

--- a/src/components/Staking/WithdrawalCredentials.tsx
+++ b/src/components/Staking/WithdrawalCredentials.tsx
@@ -5,7 +5,7 @@ import { Button, Flex, Input, Spinner, Text } from "@chakra-ui/react"
 import CopyToClipboard from "../CopyToClipboard"
 import Emoji from "../Emoji"
 import Link from "../Link"
-import InfoBanner from "../InfoBanner"
+import { trackCustomEvent } from "../../utils/matomo"
 
 interface Validator {
   validatorIndex: number
@@ -25,6 +25,11 @@ const WithdrawalCredentials: FC<IProps> = () => {
   const [validator, setValidator] = useState<Validator | null>(null)
 
   const checkWithdrawalCredentials = async (isTestnet: boolean = false) => {
+    trackCustomEvent({
+      eventCategory: `Validator index`,
+      eventAction: `Verify on ${isTestnet ? "Goerli" : "Mainnet"}`,
+      eventName: `click`,
+    })
     setHasError(false)
     setIsLoading((prev) => ({
       ...prev,

--- a/src/components/Staking/WithdrawalsTabComparison.tsx
+++ b/src/components/Staking/WithdrawalsTabComparison.tsx
@@ -13,68 +13,82 @@ import {
 import WithdrawalCredentials from "./WithdrawalCredentials"
 import ButtonLink from "../ButtonLink"
 import Link from "../Link"
+import { trackCustomEvent } from "../../utils/matomo"
 
 interface IProps {}
-const WithdrawalsTabComparison: React.FC<IProps> = () => (
-  <Tabs>
-    <TabList>
-      <Tab>Current stakers</Tab>
-      <Tab>New stakers (not yet deposited)</Tab>
-    </TabList>
+const WithdrawalsTabComparison: React.FC<IProps> = () => {
+  const handleMatomoEvent = (name: string): void => {
+    trackCustomEvent({
+      eventCategory: `Staker tabs`,
+      eventAction: name,
+      eventName: `click`,
+    })
+  }
+  return (
+    <Tabs>
+      <TabList>
+        <Tab onClick={() => handleMatomoEvent("Current stakers")}>
+          Current stakers
+        </Tab>
+        <Tab onClick={() => handleMatomoEvent("New stakers")}>
+          New stakers (not yet deposited)
+        </Tab>
+      </TabList>
 
-    <TabPanels>
-      <TabPanel>
-        <Heading as="h3">Current stakers</Heading>
-        <UnorderedList>
-          <ListItem>
-            Some users may have provided a withdrawal address when initially
-            setting up their staking deposit—these users have nothing more they
-            need to do
-          </ListItem>
-          <ListItem>
-            The majority of stakers did not provide a withdrawal address on
-            initial deposit, and will need to update their withdrawal
-            credentials. The{" "}
-            <Link href="https://zhejiang.launchpad.ethereum.org/withdrawals">
-              Zhejiang Testnet Launchpad
-            </Link>{" "}
-            has instructions on when and how to do this
-          </ListItem>
-        </UnorderedList>
-        <Text fontWeight="bold">
-          You can enter your validator index number here to see if you still
-          need to update your credentials{" "}
-          <Text as="span" fontWeight="normal">
-            (this can be found in your client logs):
+      <TabPanels>
+        <TabPanel>
+          <Heading as="h3">Current stakers</Heading>
+          <UnorderedList>
+            <ListItem>
+              Some users may have provided a withdrawal address when initially
+              setting up their staking deposit—these users have nothing more
+              they need to do
+            </ListItem>
+            <ListItem>
+              The majority of stakers did not provide a withdrawal address on
+              initial deposit, and will need to update their withdrawal
+              credentials. The{" "}
+              <Link href="https://zhejiang.launchpad.ethereum.org/withdrawals">
+                Zhejiang Testnet Launchpad
+              </Link>{" "}
+              has instructions on when and how to do this
+            </ListItem>
+          </UnorderedList>
+          <Text fontWeight="bold">
+            You can enter your validator index number here to see if you still
+            need to update your credentials{" "}
+            <Text as="span" fontWeight="normal">
+              (this can be found in your client logs):
+            </Text>
           </Text>
-        </Text>
 
-        <WithdrawalCredentials />
-      </TabPanel>
+          <WithdrawalCredentials />
+        </TabPanel>
 
-      <TabPanel>
-        <Heading as="h3">New stakers (not yet deposited)</Heading>
-        <UnorderedList>
-          <ListItem>
-            By default, new stakers looking to automatically enable reward
-            payments and withdrawal functionality should provide an Ethereum
-            withdrawal address they control when generating their validator keys
-            using the Staking Deposit CLI tool
-          </ListItem>
-          <ListItem>
-            This is not required at time of deposit, but will prevent the need
-            to update these keys at a later date to unlock your funds
-          </ListItem>
-        </UnorderedList>
-        <Text fontWeight="bold">
-          The Staking Launchpad will guide you through staking onboarding.
-        </Text>
-        <ButtonLink to="https://launchpad.ethereum.org/" hideArrow>
-          Visit Staking Launchpad
-        </ButtonLink>
-      </TabPanel>
-    </TabPanels>
-  </Tabs>
-)
+        <TabPanel>
+          <Heading as="h3">New stakers (not yet deposited)</Heading>
+          <UnorderedList>
+            <ListItem>
+              By default, new stakers looking to automatically enable reward
+              payments and withdrawal functionality should provide an Ethereum
+              withdrawal address they control when generating their validator
+              keys using the Staking Deposit CLI tool
+            </ListItem>
+            <ListItem>
+              This is not required at time of deposit, but will prevent the need
+              to update these keys at a later date to unlock your funds
+            </ListItem>
+          </UnorderedList>
+          <Text fontWeight="bold">
+            The Staking Launchpad will guide you through staking onboarding.
+          </Text>
+          <ButtonLink to="https://launchpad.ethereum.org/" hideArrow>
+            Visit Staking Launchpad
+          </ButtonLink>
+        </TabPanel>
+      </TabPanels>
+    </Tabs>
+  )
+}
 
 export default WithdrawalsTabComparison

--- a/src/content/history/index.md
+++ b/src/content/history/index.md
@@ -66,8 +66,7 @@ This consensus layer upgrade brings the ability for stakers who did not provide 
 
 The upgrade also provides automatic account sweeping functionality, which continuously processes validator accounts for any available rewards payments or full withdrawals.
 
-<!-- - [More on staking withdrawals](/staking/withdrawals/). -->
-
+- [More on staking withdrawals](/staking/withdrawals/).
 - [Read the Capella upgrade specifications](https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/)
 
 <Divider />

--- a/src/content/staking/withdrawals/index.md
+++ b/src/content/staking/withdrawals/index.md
@@ -116,40 +116,86 @@ As you see this slows down as more validators are on the network. An increase in
 
 ## Frequently asked questions {#faq}
 
-<ExpandableCard title="Once I have provided a withdrawal address, can I change it to an alternative withdrawal address?">
-No, the process to provide withdrawal credentials is a one-time process, and cannot be changed once submitted.
-</ExpandableCard>
+<ExpandableCard
+title="Once I have provided a withdrawal address, can I change it to an alternative withdrawal address?"
+eventCategory="FAQ"
+eventAction="Once I have provided a withdrawal address, can I change it to an alternative withdrawal address?"
+eventName="read more"
 
-<ExpandableCard title="Why can a withdrawal address only be set once?">
-By setting an execution layer withdrawal address the withdrawal credentials for that validator have permanently been changed. This means the old credentials will no longer work, and the new credentials direct to an execution layer account.
+> No, the process to provide withdrawal credentials is a one-time process, and cannot be changed once submitted.
+> </ExpandableCard>
+
+<ExpandableCard
+title="Why can a withdrawal address only be set once?"
+eventCategory="FAQ"
+eventAction="Why can a withdrawal address only be set once?"
+eventName="read more"
+
+> By setting an execution layer withdrawal address the withdrawal credentials for that validator have permanently been changed. This means the old credentials will no longer work, and the new credentials direct to an execution layer account.
 
 Withdrawal addresses can be either a smart contract (controlled by its code), or an externally owned account (EOA, controlled by its private key). Currently these accounts have no way to communicate a message back to the consensus layer that would signal a change of validator credentials, and adding this functionality would add unnecessary complexity to the protocol.
 
 As an alternative to changing the withdrawal address for a particular validator, users may choose to set a smart contract as their withdrawal address which could handle key rotating, such as a Safe. Users who set their funds to their own EOA can perform a full exit to withdrawal all of their staked funds, and then re-stake using new credentials.
 </ExpandableCard>
 
-<ExpandableCard title="What if I participate in liquid staking derivatives or pooled staking">
+<ExpandableCard
+title="What if I participate in liquid staking derivatives or pooled staking"
+eventCategory="FAQ"
+eventAction="What if I participate in liquid staking derivatives or pooled staking"
+eventName="read more"
+
+>
+
 <p>If you are part of a <a href="/staking/pools/">staking pool</a> or hold liquid staking derivatives, you should check with your provider for more details about how staking withdrawals will affect your arrangement, as each service operates differently.</p>
 <p>In general, users will likely have nothing they need to do, and these services will no longer be limited by the inability to withdrawal rewards or exit validator funds after this upgrade.</p>
 <p>This means that users can now decide to redeem their underlying staked ETH, or change which staking provider they utilize. If a particular pool is getting too large, funds can be exited and redeemed, and re-staked with a <a href="https://pools.invis.cloud">smaller provider</a>. Or, if you’ve accumulated enough ETH you could <a href="/staking/solo/">stake from home</a>.</p>
 </ExpandableCard>
 
-<ExpandableCard title="Do reward payments (partial withdrawals) happen automatically?">
+<ExpandableCard
+title="Do reward payments (partial withdrawals) happen automatically?"
+eventCategory="FAQ"
+eventAction="Do reward payments (partial withdrawals) happen automatically?"
+eventName="read more"
+
+>
+
 <p>Yes, as long as your validator has provided a withdrawal address. This must be provided once to enable any withdrawals, then reward payments will be automatically triggered every few days with each validator sweep.</p>
 </ExpandableCard>
 
-<ExpandableCard title="Do full withdrawals happen automatically?">
+<ExpandableCard
+title="Do full withdrawals happen automatically?"
+eventCategory="FAQ"
+eventAction="Do full withdrawals happen automatically?"
+eventName="read more"
+
+>
+
 <p>No, if your validator is still active on the network, a full withdrawal will not happen automatically. This requires manually initiating a voluntary exit.</p>
 <p>Once a validator has completed the exiting process, and assuming the account has withdrawal credentials, the remaining balance will <em>then</em> be withdrawn during the next validator sweep.</p>
 </ExpandableCard>
 
-<ExpandableCard title="How can I withdrawal a custom amount?">
+<ExpandableCard
+title="How can I withdrawal a custom amount?"
+eventCategory="FAQ"
+eventAction="How can I withdrawal a custom amount?"
+eventName="read more"
+
+>
+
 <p>Withdrawals are designed to be pushed automatically, transferring any ETH that is not actively contributing to stake. This includes full balances for accounts </p>
 <p>It is not possible to manually request specific amounts of ETH to be withdrawn.</p>
 </ExpandableCard>
 
 <!-- TODO: Switch link to Mainnet once available -->
-<ExpandableCard title="I operate a validator, where can I find more information on preparing?">
+
+<ExpandableCard
+title="I operate a validator, where can I find more information on preparing?"
+eventCategory="FAQ"
+eventAction="I operate a validator, where can I find more information on preparing?"
+eventName="read more"
+
+>
+
 <p>Validator operators are recommended to visit the <a href="https://zhejiang.launchpad.ethereum.org/withdrawals/">Staking Launchpad Withdrawals (Zhejiang Testnet)</a> page where you'll find more details about how to be prepared, timing of events, and more details about how withdrawals function.</p>
 </ExpandableCard>
 

--- a/src/content/staking/withdrawals/index.md
+++ b/src/content/staking/withdrawals/index.md
@@ -102,13 +102,13 @@ Expanding this calculation, we can estimate the time it will take to process a g
 
 <TableContainer>
 
-| Number of withdrawals | Time to complete |
-| :-------------------: | :--------------: |
-|        400,000        |     3.5 days     |
-|        500,000        |     4.3 days     |
-|        600,000        |     5.2 days     |
-|        700,000        |     6.1 days     |
-|        800,000        |     7.0 days     |
+| Withdrawals |   Time   |
+| :---------: | :------: |
+|   400,000   | 3.5 days |
+|   500,000   | 4.3 days |
+|   600,000   | 5.2 days |
+|   700,000   | 6.1 days |
+|   800,000   | 7.0 days |
 
 </TableContainer>
 

--- a/src/content/staking/withdrawals/index.md
+++ b/src/content/staking/withdrawals/index.md
@@ -14,7 +14,7 @@ summaryPoints:
 ---
 
 <UpgradeStatus dateKey="page-upgrades-withdrawals">
-  Staking withdrawals will be enabled through the Shanghai/Capella upgrade. This Ethereum network upgrade is expected to take place in the first half of 2023. <a href="#when">More below</a>
+  Staking withdrawals will be enabled through the Shanghai/Capella upgrade. This Ethereum network upgrade is expected to take place in the first half of 2023. <a href="#when" customEventOptions={{ eventCategory: "Anchor link", eventAction: "When's it shipping?", eventName: "click" }}>More below</a>
 </UpgradeStatus>
 
 The Shanghai/Capella upgrade enables **staking withdrawals** on Ethereum, allowing people to unlock ETH staking rewards. Reward payments will automatically and regularly be sent to a provided withdrawal address linked to each validator. Users can also exit staking entirely, unlocking their full validator balance.
@@ -55,7 +55,7 @@ Users looking to exit staking entirely and withdraw their full balance back must
 
 The process of a validator exiting from staking takes variable amounts of time, depending on how many others are exiting at the same time. Once complete, this account will no longer be responsible for performing validator network duties, is no longer eligible for rewards, and no longer has their ETH "at stake". At this time the account with be marked as fully “withdrawable”.
 
-Once an account is flagged as "withdrawable", and withdrawal credentials have been provided, there is nothing more a user needs to do aside from wait. Accounts are automatically and continuously swept by block proposers for eligible exited funds, and your account balance will be transferred in full (also known as a "full withdrawal") during the next [sweep](#validator-sweeping).
+Once an account is flagged as "withdrawable", and withdrawal credentials have been provided, there is nothing more a user needs to do aside from wait. Accounts are automatically and continuously swept by block proposers for eligible exited funds, and your account balance will be transferred in full (also known as a "full withdrawal") during the next <a href="#validator-sweeping" customEventOptions={{ eventCategory: "Anchor link", eventAction: "Exiting staking entirely (sweep)", eventName: "click" }}>sweep</a>.
 
 ## When are staking withdrawals enabled? {#when}
 

--- a/src/content/staking/withdrawals/index.md
+++ b/src/content/staking/withdrawals/index.md
@@ -120,18 +120,16 @@ As you see this slows down as more validators are on the network. An increase in
 title="Once I have provided a withdrawal address, can I change it to an alternative withdrawal address?"
 eventCategory="FAQ"
 eventAction="Once I have provided a withdrawal address, can I change it to an alternative withdrawal address?"
-eventName="read more"
-
-> No, the process to provide withdrawal credentials is a one-time process, and cannot be changed once submitted.
-> </ExpandableCard>
+eventName="read more">
+No, the process to provide withdrawal credentials is a one-time process, and cannot be changed once submitted.
+</ExpandableCard>
 
 <ExpandableCard
 title="Why can a withdrawal address only be set once?"
 eventCategory="FAQ"
 eventAction="Why can a withdrawal address only be set once?"
-eventName="read more"
-
-> By setting an execution layer withdrawal address the withdrawal credentials for that validator have permanently been changed. This means the old credentials will no longer work, and the new credentials direct to an execution layer account.
+eventName="read more">
+By setting an execution layer withdrawal address the withdrawal credentials for that validator have permanently been changed. This means the old credentials will no longer work, and the new credentials direct to an execution layer account.
 
 Withdrawal addresses can be either a smart contract (controlled by its code), or an externally owned account (EOA, controlled by its private key). Currently these accounts have no way to communicate a message back to the consensus layer that would signal a change of validator credentials, and adding this functionality would add unnecessary complexity to the protocol.
 
@@ -142,9 +140,7 @@ As an alternative to changing the withdrawal address for a particular validator,
 title="What if I participate in liquid staking derivatives or pooled staking"
 eventCategory="FAQ"
 eventAction="What if I participate in liquid staking derivatives or pooled staking"
-eventName="read more"
-
->
+eventName="read more">
 
 <p>If you are part of a <a href="/staking/pools/">staking pool</a> or hold liquid staking derivatives, you should check with your provider for more details about how staking withdrawals will affect your arrangement, as each service operates differently.</p>
 <p>In general, users will likely have nothing they need to do, and these services will no longer be limited by the inability to withdrawal rewards or exit validator funds after this upgrade.</p>
@@ -155,9 +151,7 @@ eventName="read more"
 title="Do reward payments (partial withdrawals) happen automatically?"
 eventCategory="FAQ"
 eventAction="Do reward payments (partial withdrawals) happen automatically?"
-eventName="read more"
-
->
+eventName="read more">
 
 <p>Yes, as long as your validator has provided a withdrawal address. This must be provided once to enable any withdrawals, then reward payments will be automatically triggered every few days with each validator sweep.</p>
 </ExpandableCard>
@@ -166,9 +160,7 @@ eventName="read more"
 title="Do full withdrawals happen automatically?"
 eventCategory="FAQ"
 eventAction="Do full withdrawals happen automatically?"
-eventName="read more"
-
->
+eventName="read more">
 
 <p>No, if your validator is still active on the network, a full withdrawal will not happen automatically. This requires manually initiating a voluntary exit.</p>
 <p>Once a validator has completed the exiting process, and assuming the account has withdrawal credentials, the remaining balance will <em>then</em> be withdrawn during the next validator sweep.</p>
@@ -178,9 +170,7 @@ eventName="read more"
 title="How can I withdrawal a custom amount?"
 eventCategory="FAQ"
 eventAction="How can I withdrawal a custom amount?"
-eventName="read more"
-
->
+eventName="read more">
 
 <p>Withdrawals are designed to be pushed automatically, transferring any ETH that is not actively contributing to stake. This includes full balances for accounts </p>
 <p>It is not possible to manually request specific amounts of ETH to be withdrawn.</p>
@@ -192,9 +182,7 @@ eventName="read more"
 title="I operate a validator, where can I find more information on preparing?"
 eventCategory="FAQ"
 eventAction="I operate a validator, where can I find more information on preparing?"
-eventName="read more"
-
->
+eventName="read more">
 
 <p>Validator operators are recommended to visit the <a href="https://zhejiang.launchpad.ethereum.org/withdrawals/">Staking Launchpad Withdrawals (Zhejiang Testnet)</a> page where you'll find more details about how to be prepared, timing of events, and more details about how withdrawals function.</p>
 </ExpandableCard>

--- a/src/content/staking/withdrawals/index.md
+++ b/src/content/staking/withdrawals/index.md
@@ -102,13 +102,13 @@ Expanding this calculation, we can estimate the time it will take to process a g
 
 <TableContainer>
 
-| Withdrawals |   Time   |
-| :---------: | :------: |
-|   400,000   | 3.5 days |
-|   500,000   | 4.3 days |
-|   600,000   | 5.2 days |
-|   700,000   | 6.1 days |
-|   800,000   | 7.0 days |
+| Number of withdrawals | Time to complete |
+| :-------------------: | :--------------: |
+|        400,000        |     3.5 days     |
+|        500,000        |     4.3 days     |
+|        600,000        |     5.2 days     |
+|        700,000        |     6.1 days     |
+|        800,000        |     7.0 days     |
 
 </TableContainer>
 

--- a/src/templates/staking.tsx
+++ b/src/templates/staking.tsx
@@ -322,7 +322,7 @@ const TableContainer: FC<BoxProps> = (props) => (
         borderSpacing: "1rem 0",
       },
       th: {
-        whiteSpace: "normal",
+        whiteSpace: "break-spaces",
         textAlign: "center",
       },
     }}

--- a/src/templates/staking.tsx
+++ b/src/templates/staking.tsx
@@ -322,7 +322,7 @@ const TableContainer: FC<BoxProps> = (props) => (
         borderSpacing: "1rem 0",
       },
       th: {
-        whiteSpace: "break-spaces",
+        whiteSpace: "break-spaces !important",
         textAlign: "center",
       },
     }}

--- a/src/templates/staking.tsx
+++ b/src/templates/staking.tsx
@@ -321,6 +321,10 @@ const TableContainer: FC<BoxProps> = (props) => (
         borderCollapse: "separate",
         borderSpacing: "1rem 0",
       },
+      th: {
+        whiteSpace: "normal",
+        textAlign: "center",
+      },
     }}
     {...props}
   />


### PR DESCRIPTION
## Description
- Few bug patches an fix-ups related to the new /staking/withdrawals page
- Enables matomo event tracking for internal hash links
- Adds matomo tracking to contents of withdrawals page, including custom hash link events taking advantage of the modification to the `Link` component.

## Preview link
https://ethereumorgwebsitedev01-withdrawalsv2.gatsbyjs.io/en/staking/withdrawals/

## Related Issue
- #9101
- Fixes #9456 