### PR TITLE
add kraken to cex-layer-2-support

### DIFF
--- a/src/data/layer-2/cex-layer-2-support.json
+++ b/src/data/layer-2/cex-layer-2-support.json
@@ -22,5 +22,11 @@
     "supports_withdrawals": ["Arbitrum", "Optimism"],
     "supports_deposits": ["Arbitrum", "Optimism"],
     "url": "https://www.huobi.com/"
+  },
+  {
+    "name": "Kraken",
+    "supports_withdrawals": ["Arbitrum"],
+    "supports_deposits": ["Arbitrum"],
+    "url": "https://www.kraken.com/"
   }
 ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Kraken recently [enabled withdrawals and deposits for Arbitrum](https://blog.kraken.com/post/17590/eth-deposits-and-withdrawals-available-on-arbitrum/?utm_source=Social&utm_medium=Twitter&utm_campaign=Eth+on+Arb). Adds data for this to `cex-layer-2-support` for layer-2 page.
