### PR TITLE
Fix broken Alchemy link

### DIFF
--- a/src/pages/developers/learning-tools.tsx
+++ b/src/pages/developers/learning-tools.tsx
@@ -252,7 +252,7 @@ const LearningToolsPage = ({
     {
       name: "Alchemy University",
       description: "page-learning-tools-alchemy-university-description",
-      url: "https://university.alchemycom/",
+      url: "https://university.alchemy.com/",
       image: getImage(data.alchemyuniversity)!,
       alt: "page-learning-tools-alchemy-university-logo-alt",
       background: "#ffffff",


### PR DESCRIPTION
Bug fixed URL error mentioned in issue https://github.com/ethereum/ethereum-org-website/issues/9504

## Description

Fixed the URL from "alchemycom" to "alchemy.com".

## Related Issue #9504 