### PR TITLE
Create issue process

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -63,3 +63,12 @@ body:
       value: |
         **Want to contribute?**
         We love contributions from the Ethereum community! Please comment on an issue if you're interested in helping out with a PR.
+  - type: checkboxes
+    id: bug_report_work_on
+    attributes:
+      label: Would you like to work on this issue?
+      options:
+        - "Yes"
+        - "No"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -33,6 +33,12 @@ body:
     attributes:
       value: |
         **Want to contribute?**
-  - type: markdown
+  - type: checkboxes
+    id: feature_request_work_on
     attributes:
-      value: We love contributions from the Ethereum community! Please comment on an issue if you're interested in helping out with a PR.
+      label: Would you like to work on this issue?
+      options:
+        - "Yes"
+        - "No"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/suggest_dapp.yaml
+++ b/.github/ISSUE_TEMPLATE/suggest_dapp.yaml
@@ -96,3 +96,12 @@ body:
       description: Is usage globally accessible, or do you have restrictions?
     validations:
       required: true
+  - type: checkboxes
+    id: dapp_work_on
+    attributes:
+      label: Would you like to work on this issue?
+      options:
+        - "Yes"
+        - "No"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/suggest_dev_tool.yaml
+++ b/.github/ISSUE_TEMPLATE/suggest_dev_tool.yaml
@@ -64,3 +64,12 @@ body:
     attributes:
       label: Additional context
       description: Add any other context or screenshots about the dev tool here
+  - type: checkboxes
+    id: dev_tools_work_on
+    attributes:
+      label: Would you like to work on this issue?
+      options:
+        - "Yes"
+        - "No"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/suggest_exchange.yaml
+++ b/.github/ISSUE_TEMPLATE/suggest_exchange.yaml
@@ -53,3 +53,12 @@ body:
     attributes:
       label: Do you have any extra information?
       description: Add any more info that may make a stronger case for listing this exchange. Consider years of operation, size of company, financial backing etc
+  - type: checkboxes
+    id: exchange_work_on
+    attributes:
+      label: Would you like to work on this issue?
+      options:
+        - "Yes"
+        - "No"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/suggest_glossary_term.yaml
+++ b/.github/ISSUE_TEMPLATE/suggest_glossary_term.yaml
@@ -45,3 +45,12 @@ body:
     attributes:
       label: Additional context
       description: Add any other context or screenshots about the feature request here
+  - type: checkboxes
+    id: exchange_work_on
+    attributes:
+      label: Would you like to work on this issue?
+      options:
+        - "Yes"
+        - "No"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/suggest_layer2.yaml
+++ b/.github/ISSUE_TEMPLATE/suggest_layer2.yaml
@@ -150,3 +150,12 @@ body:
     attributes:
       label: Is there a block explorer?
       description: Are there block explorers for the network? Please share URLs.
+  - type: checkboxes
+    id: exchange_work_on
+    attributes:
+      label: Would you like to work on this issue?
+      options:
+        - "Yes"
+        - "No"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/suggest_staking_product.yaml
+++ b/.github/ISSUE_TEMPLATE/suggest_staking_product.yaml
@@ -193,3 +193,12 @@ body:
     attributes:
       label: Social media links
       description: List available social media links. ie. Discord, Twitter, Telegram, Reddit
+  - type: checkboxes
+    id: exchange_work_on
+    attributes:
+      label: Would you like to work on this issue?
+      options:
+        - "Yes"
+        - "No"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/suggest_tutorial.yaml
+++ b/.github/ISSUE_TEMPLATE/suggest_tutorial.yaml
@@ -62,3 +62,12 @@ body:
     attributes:
       label: "For tutorials hosted elsewhere: URL to tutorial"
       description: Please paste the URL to your tutorial
+  - type: checkboxes
+    id: exchange_work_on
+    attributes:
+      label: Would you like to work on this issue?
+      options:
+        - "Yes"
+        - "No"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/suggest_wallet.yaml
+++ b/.github/ISSUE_TEMPLATE/suggest_wallet.yaml
@@ -294,3 +294,12 @@ body:
     attributes:
       label: Does the wallet have any integrated tools not mentioned above?
       description: Please provide any information about extra features this wallet has that we may have missed in the above criteria. (e.g. privacy features, transaction batching, etc).
+  - type: checkboxes
+    id: exchange_work_on
+    attributes:
+      label: Would you like to work on this issue?
+      options:
+        - "Yes"
+        - "No"
+    validations:
+      required: true

--- a/.github/workflows/issue-triage-label.yml
+++ b/.github/workflows/issue-triage-label.yml
@@ -1,0 +1,21 @@
+name: Label issues for triage
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["needs-triage"]
+            })

--- a/docs/github-issue-triage-process.md
+++ b/docs/github-issue-triage-process.md
@@ -2,7 +2,7 @@
 
 This documentation outlines the current process for how issues are triaged for the ethereum.org GitHub repository.
 
-## Issue created process
+## Issue creation process
 
 Whenever a new issue is opened, it will automatically be labeled with a `needs-triage` label. The `needs-triage` label means that the core team needs to look at the issue, and nobody should work on it yet to avoid unnecessary work. This label will be removed after the issue has been triaged by a core contributor.
 

--- a/docs/github-issue-triage-process.md
+++ b/docs/github-issue-triage-process.md
@@ -1,0 +1,25 @@
+# GitHub issue triage process
+
+This documentation outlines the current process for how issues are triaged for the ethereum.org GitHub repository.
+
+## Issue created process
+
+Whenever a new issue is opened, it will automatically be labeled with a `needs-triage` label. The `needs-triage` label means that the core team needs to look at the issue, and nobody should work on it yet to avoid unnecessary work. This label will be removed after the issue has been triaged by a core contributor.
+
+## Triage process
+
+The core team will review issues with the `needs-triage` label within 5 days. In order for an issue to be considered triaged, one of the following will need to happen:
+
+1. The issue will be closed if it is not needed, a duplicate, or spam.
+2. If an issue needs more discussion, the `GH grooming` tag will be added, and the issue will be discussed next GitHub grooming. After this call, action items will be recorded and the issue will be considered triaged.
+3. The issue is labeled with the appropriate tags for work needed (ex: `design required`, `dev required`, etc.) and open it up for assignment. More on this below.
+
+After an issue has been triaged, the `needs-triage` label will be removed from the issue.
+
+## Assignment process
+
+After an issue has been triaged, it is ready to be assigned to someone to work on. Priority for assignment will be given in the following order:
+
+1. A core team member
+2. The person who opened the issue if they want to be assigned
+3. Anyone in the community. A `help-wanted` tag will be added to the issue in this case.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- adds documentation on issue process
- adds question for each issue template asking if the person who creates the issue wants to contribute
- adds workflow to label every issue opened with `needs-triage` label
- adds information that links out to process documentation in README

## Related Issue
https://github.com/ethereum/ethereum-org-website/issues/9059