### PR TITLE
docs(applying-storybook): update storybook docs for v7

### DIFF
--- a/docs/applying-storybook.md
+++ b/docs/applying-storybook.md
@@ -18,20 +18,20 @@ It's as easy as running `yarn storybook` to boot up a dedicated localhost to see
 
 ## Setting up a component's stories
 
+> 🚨 NOTE: This project has version 7, which is currently still in beta. The following documentation outlines preferences in setup as it relates to this version. You can refer to the [7.0 beta docs](https://storybook.js.org/docs/7.0/react/get-started/introduction) if you need any additional details
+
 A Storybook "story" is an instance of a component in a certain state or with certain parameters applied to show an alternative version of the component.
 
-Each component will only need one file containing all the stories, and should follow the naming convention of the component.
+Each component will only need one file containing all the stories.
 
-So for the component `ExpandableCard.tsx`, the stories file will be named `ExpandableCard.stories.tsx`.
-
-The stories file will reside with each component. So the base folder structure in `src` will look like this:
+The stories file will reside with each component as simply `stories.tsx`. So the base folder structure in `src` will look like this:
 
 ```
 src/
 └── components/
     └── ComponentA/
         ├── index.tsx
-        ├── ComponentA.stories.tsx
+        ├── stories.tsx
         └── // Any other files as applicable (utils, child components, useHook, etc.)
 ```
 
@@ -40,45 +40,58 @@ The initial structure of each story file will look something like this (in types
 ```tsx
 import ComponentA from "."
 
-export default {
-  title: "ComponentA", // Generates the nav structure in the Storybook server
-} as ComponentMeta<typeof ComponentA>
+type ComponentAType = typeof ComponentA
 
-export const Basic = () => <ComponentA />
+const meta: Meta<ComponentAType> {
+  title: "ComponentA", // Generates the nav structure in the Storybook server
+  component: ComponentA
+}
+
+export default meta
+type Story = StoryObj<ComponentAType>;
+
+export const Basic: Story = {
+  render: () => <ComponentA />
+}
 ```
 
-Should the component accept props on all or some renders, a template can be created.
+We will maintain this structure for every story file, regardless of simplicity.
+
+Should the component accept props on all or some renders, you can provide an `args` prop for each story and supply the necessary data. And if there is children, use the `render` prop to pass the args and supply children elements.
 
 Let's say for a `Button` component with different style variants...
 
 ```tsx
 import Button from "."
 
-export default {
+type ButtonType = typeof Button
+
+const meta: Meta<ButtonType> {
   title: "Button",
-} as ComponentMeta<typeof Button>
-
-const Template: ComponentStory<typeof Button> = (args) => (
-  <ComponentA {...args} />
-)
-
-export const Solid = Template.bind({})
-Solid.args = {
-  variant: "solid",
-  children: "A Button", // Assuming the `children` prop takes text content only
+  component: Button
 }
 
-export const Outline = Template.bind({})
-Outline.args = {
-  variant: "outline",
-  children: "A Button", // Assuming the `children` prop takes text content only
+export default meta
+type Story = StoryObj<ButtonType>;
+
+export const Solid: Story = {
+  render: (args) => <Button {...args}>A Button</Button>,
+  args: {
+    variant: 'solid',
+  }
+}
+export const Outline: Story = {
+  render: (args) => <Button {...args}>A Button</Button>,
+  args: {
+    variant: 'outline',
+  }
 }
 
 /**
  * For practical purposes, if you are displaying different "variants",
  * they should be shown under one story, so they can be seen side-by-side in the GUI
  * for reviewers to easily compare.
- * This can be done for various sizes or other like alterations
+ * This can also be done for various sizes or other like alterations
  */
 
 // Assuming `solid` is the default variant in the Chakra theme config
@@ -92,3 +105,24 @@ export const Variants = () => (
 ```
 
 As you go and make adjustments to the component itself or it's variant styles, Storybook will hot reload and those changes will appear in the stories that emphasize them.
+
+## Storybook Dashboard
+
+The dashboard where you view each story has a number of different addons available to check the story thoroughly.
+
+Outlined below are each area going from left to right in the selections.
+
+| Sidebar above the preview                | Dashboard below the preview                                                                                                                                                                                                                                                |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1. Rerender preview                      | 1. Controls - allows you to interact with a component’s args (inputs) dynamically. Experiment with alternate configurations of the component to discover edge cases. See [Controls addon docs](https://storybook.js.org/docs/7.0/react/essentials/controls)                |
+| 2. Zoom In                               | 2. Actions (if applicable) - help you verify interactions produce the correct outputs via callbacks. See [Actions addon docs](https://storybook.js.org/docs/7.0/react/essentials/actions)                                                                                  |
+| 3. Zoom Out                              | 3. Interactions (if applicable) - In conjunction with the `play` function in a story object, this section allows you to simulate user interactions after the story renders. See [Interactions addon docs](https://storybook.js.org/docs/7.0/react/essentials/interactions) |
+| 4. Reset Zoom                            | 4. Accessibility provides visual A11y results for each story.<br><br>**NOTE**: To check accessibility for light and dark mode, you will need to toggle the mode, then rerender the preview to update the results.                                                          |
+| 5. Change background                     |
+| 6. Apply grid to preview                 |
+| 7. Change viewport size                  |
+| 8. Enable measuring of elements on hover |
+| 9. Apply element outlines to preview     |
+| 10. A11y Visualization Simulator         |
+| 11. Set layout direction (left or right) |
+| 12. Toggle color mode                    |


### PR DESCRIPTION
_This is an update for #9546 to provide better direction in implementation for Storybook for components._

This PR updates the [applying-storybook.md](https://github.com/ethereum/ethereum-org-website/blob/dev/docs/applying-storybook.md) in the docs directory of the project to be inline with Storybook v7

- Updates codeblocks and notation for the new Story Object syntax
- Adds a quick ref table for the different selections in the UI Dashboard