### PR TITLE
Resolved Typo in Documentation

### DIFF
--- a/src/content/developers/docs/nodes-and-clients/node-architecture/index.md
+++ b/src/content/developers/docs/nodes-and-clients/node-architecture/index.md
@@ -37,7 +37,7 @@ The consensus client does not participate in attesting to or proposing blocks - 
 
 ## Validators {#validators}
 
-Node operators can add a validator to their consensus clients if 32 ETH is the deposit contract. The validator client comes bundled with the consensus client and can be added to a node at any time. The validator handles attestations and block proposals. They enable a node to accrue rewards or lose ETH via penalties or slashing. Running the validator software also makes a node eligible to be selected to propose a new block.
+Node operators can add a validator to their consensus clients by depositing 32 ETH in the deposit contract. The validator client comes bundled with the consensus client and can be added to a node at any time. The validator handles attestations and block proposals. They enable a node to accrue rewards or lose ETH via penalties or slashing. Running the validator software also makes a node eligible to be selected to propose a new block.
 
 [More on staking](/staking/).
 


### PR DESCRIPTION
I found a typo in the Ethereum documentation.

## Description

This commit will resolve a typo issue in the documentation.

## Related Issue

No related issue.
