### PR TITLE
Remove ETHMalaysia from Ethereum events

### DIFF
--- a/src/data/community-events.json
+++ b/src/data/community-events.json
@@ -673,14 +673,5 @@
     "description": "Join ETHMiami during Art Basel Miami 2022.",
     "startDate": "2022-11-28",
     "endDate": "2022-12-4"
-  },
-  {
-    "title": "ETHMalaysia 2023",
-    "to": "http://ethmalaysia.com",
-    "sponsor": null,
-    "location": "Kuala Lumpur Convention Centre, Malaysia",
-    "description": "ETHMalaysia is the first Ethereum Innovation Festival in Southeast Asia that consists of a conference, a hackathon and fun Web3 themed activities.",
-    "startDate": "2023-5-5",
-    "endDate": "2023-5-7"
   }
 ]


### PR DESCRIPTION
## Description

Remove ETHMalaysia from the list of Ethereum events on https://ethereum.org/en/community/events/, as it's been cancelled
More details here: http://ethmalaysia.com/

## Related Issue

No related issue, it's been highlighted that the event was cancelled a while ago, and should be removed from the events page
