### PR TITLE
Request to add Zeeve in Enterprise resources

### DIFF
--- a/src/content/enterprise/index.md
+++ b/src/content/enterprise/index.md
@@ -66,6 +66,7 @@ Some collaborative efforts to make Ethereum enterprise friendly have been made b
 - [Tenderly](https://tenderly.co) _a Web3 development platform that provides debugging, observability, and infrastructure building blocks for developing, testing, monitoring, and operating smart contracts_
 - [Unibright](https://unibright.io/) _a team of blockchain specialists, architects, developers and consultants with 20+ years of experience in business processes and integration_
 - [Zero Services GmbH](https://www.zeroservices.eu/) _provider of managed services spread across co-locations in Europe and Asia. Operates & monitors your nodes securely and reliably_
+- [Zeeve](https://www.zeeve.io/) _provides a range of products and tools for building on Ethereum, also infrastructure and APIs for Enterprise Web3 applications._
 
 ### Tooling and libraries {#tooling-and-libraries}
 


### PR DESCRIPTION
Hi there, 
I came across your enterprise developer resource listing for ethereum and found that Zeeve is not listed there. I take this opportunity to bring to your attention that Zeeve has been one of the most popular no code web3 platforms for enterprises and has been providing RPC node hosting services. Hereby, i request you to add Zeeve to your directory for Node as a Service.  Zeeve is a cloud-based platform for managing and deploying applications. It provides a comprehensive set of features for developers to quickly and easily deploy their applications to the cloud. Zeeve offers a range of features, including automated deployment of   applications to the cloud of your choice, monitoring of applications, automated security and compliance and so on.  We believe that Zeeve is an excellent addition to the Github directory and would be a great resource for developers looking to quickly and easily deploy their decentralized applications to the cloud. Thank you for your time and consideration.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
