### PR TITLE
Request to add Zeeve in Private ethereum

### DIFF
--- a/src/content/enterprise/private-ethereum/index.md
+++ b/src/content/enterprise/private-ethereum/index.md
@@ -27,3 +27,4 @@ Some collaborative efforts to make Ethereum enterprise friendly have been put to
 - [Hyperledger Burrow](https://www.hyperledger.org/projects/hyperledger-burrow) _modular blockchain client with a permissioned smart contract interpreter partially developed to the specification of the Ethereum Virtual Machine (EVM)_
 - [Kaleido](https://kaleido.io/) _full-stack platform for building and running cross-cloud, hybrid enterprise ecosystems_
 - [Quorum](https://consensys.net/quorum/) _an Ethereum-based open source enterprise blockchain platform with advanced enterprise grade features enabling privacy, permissioning and performance_
+[Zeeve](https://www.zeeve.io/) _provides a range of products and tools for building on Ethereum, also infrastructure and APIs for Enterprise Web3 applications._


### PR DESCRIPTION
Hi there, 
I came across your private ethereum listing for ethereum and found that Zeeve is not listed there. I take this opportunity to bring to your attention that Zeeve has been one of the most popular no code web3 platforms for enterprises and has been providing RPC node hosting services. Hereby, i request you to add Zeeve to your directory for Node as a Service.  Zeeve is a cloud-based platform for managing and deploying applications. It provides a comprehensive set of features for developers to quickly and easily deploy their applications to the cloud. Zeeve offers a range of features, including automated deployment of   applications to the cloud of your choice, monitoring of applications, automated security and compliance and so on.  We believe that Zeeve is an excellent addition to the Github directory and would be a great resource for developers looking to quickly and easily deploy their decentralized applications to the cloud. Thank you for your time and consideration.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
