### PR TITLE
Close button updated

### DIFF
--- a/src/components/Nav/Mobile.tsx
+++ b/src/components/Nav/Mobile.tsx
@@ -289,7 +289,7 @@ const MobileNavMenu: React.FC<IProps> = ({
           <GlyphButton 
           viewBox="0 0 24 40"
           pointerEvents={ isSearchOpen && isMenuOpen ? "none" : "auto"}
-          pointsAtZ={isSearchOpen ?"0":100}
+          pointsAtZ={ isSearchOpen ? 0 : 100 }
            >
             <motion.path
               variants={glyphPathVariants}

--- a/src/components/Nav/Mobile.tsx
+++ b/src/components/Nav/Mobile.tsx
@@ -52,7 +52,8 @@ const GlyphButton = styled.svg`
   height: 2.5rem;
   position: relative;
   stroke-width: 2px;
-  z-index: 100;
+  z-index: ${(props) => props.pointsAtZ};
+  pointer-events: ${(props) => props.pointerEvents};
   & > path {
     stroke: ${(props) => props.theme.colors.text};
     fill: none;
@@ -285,11 +286,15 @@ const MobileNavMenu: React.FC<IProps> = ({
       />
       <IconButton
         icon={
-          <GlyphButton viewBox="0 0 24 40">
+          <GlyphButton 
+          viewBox="0 0 24 40"
+          pointerEvents={isSearchOpen||isSearchOpen&&isMenuOpen ? "none" : "auto"}
+          pointsAtZ={isSearchOpen ?"0":100}
+           >
             <motion.path
               variants={glyphPathVariants}
               initial={false}
-              animate={isOpen ? "open" : "closed"}
+              animate={isMenuOpen ? "open" : "closed"}
             />
           </GlyphButton>
         }

--- a/src/components/Nav/Mobile.tsx
+++ b/src/components/Nav/Mobile.tsx
@@ -288,7 +288,7 @@ const MobileNavMenu: React.FC<IProps> = ({
         icon={
           <GlyphButton 
           viewBox="0 0 24 40"
-          pointerEvents={isSearchOpen||isSearchOpen&&isMenuOpen ? "none" : "auto"}
+          pointerEvents={ isSearchOpen && isMenuOpen ? "none" : "auto"}
           pointsAtZ={isSearchOpen ?"0":100}
            >
             <motion.path


### PR DESCRIPTION
-When the search bar is opened in a small or medium device, the Glyph Button animation is Not visible nor it is clickable

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue
when we open the website in the mobile form.
Open the search container the menu button turns into a cancel button which is not the requirement and hence a bug.

fixes:- https://github.com/ethereum/ethereum-org-website/issues/9275
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
