### PR TITLE
Added Link to Popular NFT APIs in Further Reading

### DIFF
--- a/src/content/nft/index.md
+++ b/src/content/nft/index.md
@@ -345,6 +345,7 @@ Most NFTs are built using a consistent standard known as [ERC-721](/developers/d
 
 ## Further reading {#further-reading}
 
+- [Ethereum NFT APIs](https://www.alchemy.com/list-of/nft-apis-on-ethereum) - _Alchemy_
 - [Crypto art data](https://cryptoart.io/data) – Richard Chen, updated automatically
 - [OpenSea: the NFT Bible](https://opensea.io/blog/guides/non-fungible-tokens/) – _Devin Fizner, January 10 2020_
 - [A beginner's guide to NFTs](https://linda.mirror.xyz/df649d61efb92c910464a4e74ae213c4cab150b9cbcc4b7fb6090fc77881a95d) – _Linda Xie, January 2020_

--- a/src/content/nft/index.md
+++ b/src/content/nft/index.md
@@ -345,12 +345,12 @@ Most NFTs are built using a consistent standard known as [ERC-721](/developers/d
 
 ## Further reading {#further-reading}
 
-- [Ethereum NFT APIs](https://www.alchemy.com/list-of/nft-apis-on-ethereum) - _Alchemy_
 - [Crypto art data](https://cryptoart.io/data) – Richard Chen, updated automatically
 - [OpenSea: the NFT Bible](https://opensea.io/blog/guides/non-fungible-tokens/) – _Devin Fizner, January 10 2020_
 - [A beginner's guide to NFTs](https://linda.mirror.xyz/df649d61efb92c910464a4e74ae213c4cab150b9cbcc4b7fb6090fc77881a95d) – _Linda Xie, January 2020_
 - [Everything you need to know about the metaverse](https://foundation.app/blog/enter-the-metaverse) – _Foundation team, foundation.app_
 - [No, CryptoArtists Aren’t Harming the Planet](https://medium.com/superrare/no-cryptoartists-arent-harming-the-planet-43182f72fc61)
 - [Ethereum's energy consumption](/energy-consumption/)
+- [Ethereum NFT APIs](https://www.alchemy.com/list-of/nft-apis-on-ethereum) - _Alchemy_
 
 <QuizWidget quizKey="nfts" />


### PR DESCRIPTION
Hey!

Adding Alchemy's NFT APIs store as I’ve found it to be a useful web directory. It has information about respective NFT minting tools and their chains. Thought this would allow devs to play around and mint their own NFTs using the API directory, allowing them to better understand the rest of the article.
