### PR TITLE
Add labels to any event PR

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -29,3 +29,6 @@
   - src/pages/*
   - src/pages-conditional/*
   - src/content/**/*
+
+"event :date:":
+  - src/data/community-events.json


### PR DESCRIPTION
## Description

To better organise PRs, this adds an event label to PRs that add to the community-events JSON file.