### PR TITLE
Correcting wrong EDCON URL

### DIFF
--- a/src/data/community-events.json
+++ b/src/data/community-events.json
@@ -46,7 +46,7 @@
   },
   {
     "title": "EDCON 2023",
-    "to": "edcon.io",
+    "to": "https://edcon.io/",
     "sponsor": null,
     "location": "Podgorica, Montenegro",
     "description": "EDCON is a non-profit annual global conference committed to serving the Ethereum ecosystem in boosting the communication and interaction of Ethereum communities worldwide",


### PR DESCRIPTION
changing edcon.io to https://edcon.io/

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
