### PR TITLE
Added Alchemy's new Sepolia Faucet

### DIFF
--- a/src/content/developers/docs/networks/index.md
+++ b/src/content/developers/docs/networks/index.md
@@ -53,12 +53,13 @@ The Sepolia network uses a permissioned validator set. It's fairly new, meaning 
 - [Etherscan](https://sepolia.etherscan.io)
 
 ##### Faucets
-- [Alchemy Sepolia faucet](https://sepoliafaucet.com/)
+
 - [Grabteeth](https://grabteeth.xyz/)
 - [PoW faucet](https://sepolia-faucet.pk910.de/)
 - [Sepolia faucet](https://faucet.sepolia.dev/)
 - [FaucETH](https://fauceth.komputing.org)
 - [Coinbase Wallet Faucet | Sepolia](https://coinbase.com/faucets/ethereum-sepolia-faucet)
+- [Alchemy Sepolia faucet](https://sepoliafaucet.com/)
 
 #### Goerli _(long-term support)_ {#goerli}
 

--- a/src/content/developers/docs/networks/index.md
+++ b/src/content/developers/docs/networks/index.md
@@ -77,11 +77,11 @@ Goerli is testnet for testing of validating and staking. The Goerli network is o
 
 ##### Faucets
 
-- [Paradigm faucet](https://faucet.paradigm.xyz/)
-- [Alchemy Goerli Faucet](https://goerlifaucet.com/)
 - [Grabteeth](https://grabteeth.xyz/)
 - [PoW faucet](https://goerli-faucet.pk910.de/)
 - [Goerli faucet](https://faucet.goerli.mudit.blog/)
+- [Paradigm faucet](https://faucet.paradigm.xyz/)
+- [Alchemy Goerli Faucet](https://goerlifaucet.com/)
 - [All That Node Goerli Faucet](https://www.allthatnode.com/faucet/ethereum.dsrv)
 
 To launch a Validator on Goerli testnet, use ethstaker's ["cheap goerli validator" launchpad](https://goerli.launchpad.ethstaker.cc/en/).

--- a/src/content/developers/docs/networks/index.md
+++ b/src/content/developers/docs/networks/index.md
@@ -53,7 +53,7 @@ The Sepolia network uses a permissioned validator set. It's fairly new, meaning 
 - [Etherscan](https://sepolia.etherscan.io)
 
 ##### Faucets
-
+- [Alchemy Sepolia faucet](https://sepoliafaucet.com/)
 - [Grabteeth](https://grabteeth.xyz/)
 - [PoW faucet](https://sepolia-faucet.pk910.de/)
 - [Sepolia faucet](https://faucet.sepolia.dev/)
@@ -77,11 +77,11 @@ Goerli is testnet for testing of validating and staking. The Goerli network is o
 
 ##### Faucets
 
+- [Paradigm faucet](https://faucet.paradigm.xyz/)
+- [Alchemy Goerli Faucet](https://goerlifaucet.com/)
 - [Grabteeth](https://grabteeth.xyz/)
 - [PoW faucet](https://goerli-faucet.pk910.de/)
 - [Goerli faucet](https://faucet.goerli.mudit.blog/)
-- [Paradigm faucet](https://faucet.paradigm.xyz/)
-- [Alchemy Goerli Faucet](https://goerlifaucet.com/)
 - [All That Node Goerli Faucet](https://www.allthatnode.com/faucet/ethereum.dsrv)
 
 To launch a Validator on Goerli testnet, use ethstaker's ["cheap goerli validator" launchpad](https://goerli.launchpad.ethstaker.cc/en/).


### PR DESCRIPTION
Hey there - adding Alchemy's newly launched Sepolia Faucet to offer devs resources like this as they build. Also given the unfortunate Goerli ETH shortage, I moved up Paradigm and Alchemy's faucets as they have consistently provided free testETH and we want to help developers find available supply.