### PR TITLE
Fix broken link in 'Data availability' page in the docs

### DIFF
--- a/src/content/developers/docs/data-availability/index.md
+++ b/src/content/developers/docs/data-availability/index.md
@@ -93,7 +93,7 @@ However, on-chain data availability places bottlenecks on scalability. Monolithi
 
 ### Off-chain data availability {#off-chain-data-availability}
 
-Off-chain data availability systems move data storage off the blockchain: block producers don't publish transaction data on-chain, but provide a cryptographic commitment to prove the availability of the data. This is a method used by [modular blockchains](https://celestia.org/learn/basics-of-modular-blockchains/), where the chain manages some tasks, such as transaction execution and consensus, and offloads others (e.g., data availability) to another layer.
+Off-chain data availability systems move data storage off the blockchain: block producers don't publish transaction data on-chain, but provide a cryptographic commitment to prove the availability of the data. This is a method used by [modular blockchains](https://celestia.org/learn/basics-of-modular-blockchains/modular-and-monolithic-blockchains/), where the chain manages some tasks, such as transaction execution and consensus, and offloads others (e.g., data availability) to another layer.
 
 Many scaling solutions adopt a modular approach by separating data availability from consensus and execution, as this is considered the ideal way to scale blockchains without increasing node requirements. For example, [validiums](/developers/docs/scaling/validium/) and [plasma](/developers/docs/scaling/plasma/) use off-chain storage to reduce the amount of data posted on-chain.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes a broken link in the [Data availability](https://ethereum.org/en/developers/docs/data-availability/) page. The broken link in question is https://celestia.org/learn/basics-of-modular-blockchains/ which was replaced with its updated link https://celestia.org/learn/basics-of-modular-blockchains/modular-and-monolithic-blockchains/


<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
