### PR TITLE
Patch intl key-value namespace

### DIFF
--- a/src/content/staking/withdrawals/index.md
+++ b/src/content/staking/withdrawals/index.md
@@ -13,7 +13,7 @@ summaryPoints:
   - Validators who fully exit staking will receive their remaining balance
 ---
 
-<UpgradeStatus dateKey="page-upgrades-withdrawals">
+<UpgradeStatus dateKey="page-staking-withdrawals-when">
   Staking withdrawals will be enabled through the Shanghai/Capella upgrade. This Ethereum network upgrade is expected to take place in the first half of 2023. <a href="#when" customEventOptions={{ eventCategory: "Anchor link", eventAction: "When's it shipping?", eventName: "click" }}>More below</a>
 </UpgradeStatus>
 

--- a/src/intl/en/page-staking.json
+++ b/src/intl/en/page-staking.json
@@ -1,4 +1,5 @@
 {
+  "page-staking-withdrawals-when": "Q1/Q2 2023",
   "page-staking-image-alt": "Image of the Rhino mascot for the staking launchpad.",
   "page-staking-benefits-1-title": "Earn rewards",
   "page-staking-benefits-1-description": "Rewards are given for actions that help the network reach consensus. You'll get rewards for running software that properly batches transactions into new blocks and checks the work of other validators because that's what keeps the chain running securely.",

--- a/src/intl/en/page-upgrades.json
+++ b/src/intl/en/page-upgrades.json
@@ -5,7 +5,6 @@
   "page-upgrades-merge-date": "September 2022",
   "page-upgrades-shards-date": "~2023",
   "page-upgrades-pbs": "Not imminent - expect 2024/25",
-  "page-upgrades-withdrawals": "Q1/Q2 2023",
   "page-upgrades-post-merge-banner-tutorial-ood": "This tutorial is out of date after the merge and may not work. Please raise a PR if you would like to contribute.",
   "page-upgrades-post-merge-banner-governance-ood": "Some content on this page is out-of-date after the merge. Please raise a PR if you would like to contribute.",
   "page-upgrades-upgrades-guide": "Guide to Ethereum upgrades",


### PR DESCRIPTION
## Description
- Moves dateKey to `page-staking.json` namespace to fix broken translation component

## Related Issue
None filed
https://ethereum.org/en/staking/withdrawals
<img width="1024" alt="image" src="https://user-images.githubusercontent.com/54227730/224235811-10e093a1-de86-424f-a967-62a35f45b568.png">

With patch:
<img width="1016" alt="image" src="https://user-images.githubusercontent.com/54227730/224236006-ed533d99-8419-452a-b91f-6e9259b57493.png">

