### PR TITLE
New Meetup added: UrbeTalks Ethereum Meetup

### DIFF
--- a/src/data/community-meetups.json
+++ b/src/data/community-meetups.json
@@ -358,5 +358,11 @@
     "emoji": ":taiwan:",
     "location": "Taipei",
     "link": "https://www.meetup.com/taipei-ethereum-meetup/"
+  },
+  {
+    "title": "UrbeTalks Ethereum Meetup",
+    "emoji": ":it:",
+    "location": "Rome, Italy",
+    "link": "https://www.youtube.com/@urbetalks381"
   }
 ]


### PR DESCRIPTION
With this PR we'd like to add the UrbeTalks monthly meetup in the "Ethereum Meetups" section. UrbeTalks is hosted by the builders' community [@urbeeth](https://twitter.com/urbeeth) in Rome, Italy. This monthly event features 5 talks by 5 community members. Each speaker has 10 minutes to talk about a web3-related topic. The topics often tell about the experience of builders working in web3. All talks are recorded and updated to Urbe.eth Youtube channel (https://www.youtube.com/@urbetalks381/)
