### PR TITLE
fix: replace `disabled` with `isDisabled` for button components

### DIFF
--- a/src/components/Quiz/QuizWidget.tsx
+++ b/src/components/Quiz/QuizWidget.tsx
@@ -404,7 +404,7 @@ const QuizWidget: React.FC<IProps> = ({ quizKey, maxQuestions }) => {
                         currentQuestionAnswerChoice!
                       )
                     }
-                    disabled={!currentQuestionAnswerChoice}
+                    isDisabled={!currentQuestionAnswerChoice}
                   >
                     <Translation id="submit-answer" />
                   </Button>

--- a/src/components/Staking/WithdrawalCredentials.tsx
+++ b/src/components/Staking/WithdrawalCredentials.tsx
@@ -147,14 +147,14 @@ const WithdrawalCredentials: FC<IProps> = () => {
         >
           <Button
             onClick={() => checkWithdrawalCredentials()}
-            disabled={!inputValue.length}
+            isDisabled={!inputValue.length}
             isLoading={isLoading.mainnet}
           >
             Verify on Mainnet
           </Button>
           <Button
             onClick={() => checkWithdrawalCredentials(true)}
-            disabled={!inputValue.length}
+            isDisabled={!inputValue.length}
             variant="outline"
             isLoading={isLoading.testnet}
           >

--- a/src/pages/staking/deposit-contract.tsx
+++ b/src/pages/staking/deposit-contract.tsx
@@ -416,7 +416,7 @@ const DepositContractPage = ({
                     <Translation id="page-staking-deposit-contract-checkbox3" />
                   </Checkbox>
                   <CopyButton
-                    disabled={!isButtonEnabled}
+                    isDisabled={!isButtonEnabled}
                     leftIcon={<Emoji text=":eyes:" boxSize={4} />}
                     onClick={() =>
                       setState({ ...state, showAddress: !state.showAddress })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

When updating the Chakra UI dep, it introduced [a change in the `Button` component props](https://github.com/chakra-ui/chakra-ui/commit/0f376650efce9eb2d2cba3484ffe4e3a73364504) where `disabled` became `isDisabled`. This addresses that change.

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
