### PR TITLE
replace ETHGlobal Istanbul with Lisbon

### DIFF
--- a/src/data/community-events.json
+++ b/src/data/community-events.json
@@ -63,6 +63,15 @@
     "endDate": "2023-04-25"
   },
   {
+    "title": "ETHGlobal Lisbon",
+    "to": "https://ethglobal.com/events/lisbon",
+    "sponsor": null,
+    "location": "Lisbon, Portugal",
+    "description": "ETHGlobal Lisbon replaces ETHGlobal Istanbul",
+    "startDate": "2023-05-12",
+    "endDate": "2023-05-14"
+  },
+  {
     "title": "EDCON 2023",
     "to": "https://edcon.io/",
     "sponsor": null,
@@ -70,15 +79,6 @@
     "description": "EDCON is a non-profit annual global conference committed to serving the Ethereum ecosystem in boosting the communication and interaction of Ethereum communities worldwide",
     "startDate": "2023-05-19",
     "endDate": "2023-05-23"
-  },
-  {
-    "title": "ETHGlobal Istanbul",
-    "to": "https://ethglobal.com/events/istanbul",
-    "sponsor": null,
-    "location": "Istanbul, Turkey",
-    "description": "Get hype to build the future of web3 with thousands of developers and creatives in one of the oldest cities in the world, let's hack in Istanbul.",
-    "startDate": "2023-05-26",
-    "endDate": "2023-05-28"
   },
   {
     "title": "ETH Belgrade 2023",


### PR DESCRIPTION
ETHGlobal announced that Lisbon replaces Istanbul
https://ethglobal.medium.com/updates-to-the-2023-ethglobal-hackathon-season-1d2a9d418c91

ETHGlobal Istanbul is now expected later in the year.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
replace ETHGlobal Istanbul with Lisbon as per ETHGlobal announcement

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#9707 
