### PR TITLE
Fixed listing policy links to GH issue templates

### DIFF
--- a/src/content/contributing/adding-developer-tools/index.md
+++ b/src/content/contributing/adding-developer-tools/index.md
@@ -56,6 +56,6 @@ Unless products are specifically ordered otherwise, such as alphabetically, prod
 
 If you want to add a developer tool to ethereum.org and it meets the criteria, create an issue on GitHub.
 
-<ButtonLink to="https://github.com/ethereum/ethereum-org-website/issues/new?assignees=&labels=Type%3A+Feature&template=suggest_dev_tool.md&title=">
+<ButtonLink to="https://github.com/ethereum/ethereum-org-website/issues/new?assignees=&labels=Type%3A+Feature&template=suggest_dev_tool.yaml&title=Suggest+a+developer+tool">
   Create issue
 </ButtonLink>

--- a/src/content/contributing/adding-glossary-terms/index.md
+++ b/src/content/contributing/adding-glossary-terms/index.md
@@ -23,4 +23,4 @@ New glossary terms will be assessed by the following criteria:
 
 ## Add your term {#how-decisions-about-the-site-are-made}
 
-If you want to add a glossary term to ethereum.org and it meets the criteria, [create an issue on GitHub](https://github.com/ethereum/ethereum-org-website/issues/new?template=suggest_glossary_term.md).
+If you want to add a glossary term to ethereum.org and it meets the criteria, [create an issue on GitHub](https://github.com/ethereum/ethereum-org-website/issues/new?template=suggest_glossary_term.yaml&title=Suggest+a+glossary+term).

--- a/src/content/contributing/adding-layer-2s/index.md
+++ b/src/content/contributing/adding-layer-2s/index.md
@@ -8,7 +8,7 @@ lang: en
 
 We want to make sure we list the best resources possible so users can navigate the layer 2 space in a safe and confident manner.
 
-Anyone is free to suggest adding a layer 2 on ethereum.org. If there's a layer 2 that we have missed, **[please suggest it](https://github.com/ethereum/ethereum-org-website/issues/new?&template=suggest_layer2.md)!**
+Anyone is free to suggest adding a layer 2 on ethereum.org. If there's a layer 2 that we have missed, **[please suggest it](https://github.com/ethereum/ethereum-org-website/issues/new?&template=suggest_layer2.yaml)!**
 
 We currently list L2s on the following pages:
 
@@ -90,6 +90,6 @@ _We do not consider other scaling solutions that don't use Ethereum for data ava
 
 If you want to add a layer 2 to ethereum.org, create an issue on GitHub.
 
-<ButtonLink to="https://github.com/ethereum/ethereum-org-website/issues/new?&template=suggest_layer2.md">
+<ButtonLink to="https://github.com/ethereum/ethereum-org-website/issues/new?&template=suggest_layer2.yaml">
   Create an issue
 </ButtonLink>

--- a/src/content/contributing/adding-products/index.md
+++ b/src/content/contributing/adding-products/index.md
@@ -97,7 +97,7 @@ As is the fluid nature of Ethereum, teams and products come and go and innovatio
 - ensure that all wallets and dapps listed still fulfil our criteria
 - verify there aren't products that have been suggested that meet more of our criteria than the ones currently listed
 
-You can help with this by checking and letting us know. [Create an issue](https://github.com/ethereum/ethereum-org-website/issues/new?assignees=&labels=Type%3A+Feature&template=feature_request.md&title=) or send an email to [website@ethereum.org](mailto:website@ethereum.org)
+You can help with this by checking and letting us know. [Create an issue](https://github.com/ethereum/ethereum-org-website/issues/new?assignees=&labels=Type%3A+Feature&template=feature_request.yaml&title=) or send an email to [website@ethereum.org](mailto:website@ethereum.org)
 
 _We're also investigating options for voting so the community can indicate their preferences and highlight the best products out there for us to recommend._
 

--- a/src/content/contributing/content-resources/index.md
+++ b/src/content/contributing/content-resources/index.md
@@ -27,6 +27,6 @@ Learning resources will be assessed by the following criteria:
 
 If you want to add a content resource to ethereum.org and it meets the criteria, create an issue on GitHub.
 
-<ButtonLink to="https://github.com/ethereum/ethereum-org-website/issues/new?assignees=&labels=Type%3A+Feature&template=feature_request.md&title=">
+<ButtonLink to="https://github.com/ethereum/ethereum-org-website/issues/new?assignees=&labels=Type%3A+Feature&template=feature_request.yaml&title=">
   Create an issue
 </ButtonLink>

--- a/src/content/contributing/design-principles/index.md
+++ b/src/content/contributing/design-principles/index.md
@@ -90,4 +90,4 @@ You can see our design principles in action [across our site](/).
 
 While these principles are focused on the ethereum.org website, we hope that many of them are representative of the values of the Ethereum ecosystem overall (e.g. you can see influence from the [principles of the Ethereum Whitepaper](https://github.com/ethereum/wiki/wiki/White-Paper#philosophy)). Maybe you even want to incorporate some of them into your own project!
 
-Let us know your thoughts on [Discord server](https://discord.gg/CetY6Y4) or by [creating an issue](https://github.com/ethereum/ethereum-org-website/issues/new?assignees=&labels=Type%3A+Feature&template=feature_request.md&title=).
+Let us know your thoughts on [Discord server](https://discord.gg/CetY6Y4) or by [creating an issue](https://github.com/ethereum/ethereum-org-website/issues/new?assignees=&labels=Type%3A+Feature&template=feature_request.yaml&title=).

--- a/src/content/contributing/index.md
+++ b/src/content/contributing/index.md
@@ -29,7 +29,7 @@ The ethereum.org website, like Ethereum more broadly, is an open-source project.
   _– Add an exchange to our [exchange finder](/get-eth/#country-picker)_
 - [Improve our research](https://www.notion.so/efdn/Ethereum-org-User-Persona-Memo-b44dc1e89152457a87ba872b0dfa366c)
   _– Let us know your feedback on our research or contribute your own_
-- [Request a feature](https://github.com/ethereum/ethereum-org-website/issues/new?assignees=&labels=Type%3A+Feature&template=feature_request.md&title=)
+- [Request a feature](https://github.com/ethereum/ethereum-org-website/issues/new?assignees=&labels=Type%3A+Feature&template=feature_request.yaml&title=)
   _– Let us know about any ideas you have for a new feature or design_
 - [Add a glossary term](/contributing/adding-glossary-terms)
   _– Help us continue to expand the Ethereum [glossary](/glossary/)_

--- a/src/pages-conditional/dapps.tsx
+++ b/src/pages-conditional/dapps.tsx
@@ -1294,7 +1294,7 @@ const DappsPage = ({
             </div>
             <AddDappButton
               variant="outline"
-              to="https://github.com/ethereum/ethereum-org-website/issues/new?assignees=&labels=Type%3A+Feature&template=suggest_dapp.md&title="
+              to="https://github.com/ethereum/ethereum-org-website/issues/new?assignees=&labels=Type%3A+Feature&template=suggest_dapp.yaml&title="
             >
               <Translation id="page-dapps-add-button" />
             </AddDappButton>

--- a/src/pages/developers/tutorials.tsx
+++ b/src/pages/developers/tutorials.tsx
@@ -338,7 +338,7 @@ const TutorialsPage = ({
             </p>
             <GithubButton
               variant="outline"
-              to="https://github.com/ethereum/ethereum-org-website/issues/new?assignees=&labels=Type%3A+Feature&template=suggest_tutorial.md&title="
+              to="https://github.com/ethereum/ethereum-org-website/issues/new?assignees=&labels=Type%3A+Feature&template=suggest_tutorial.yaml&title=Suggest+a+tutorial"
             >
               <GithubIcon name="github" />{" "}
               <span>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

After Updating GH issue templates to yml files, all the links on our listing policy page were broken. Fixed all the listing policy links to GH issue templates.
<!--- Describe your changes in detail -->

## Related Issue

Fixes #9291 

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
