### PR TITLE
[feat] Add video explainer to staking withdrawals

### DIFF
--- a/src/content/staking/withdrawals/index.md
+++ b/src/content/staking/withdrawals/index.md
@@ -67,6 +67,12 @@ Withdrawal functionality will be enabled through a two-part simultaneous network
 
 Whether a given validator is eligible for a withdrawal or not is determined by the state of the validator account itself. No user input is needed at any given time to determine whether an account should have a withdrawal initiated or not—the entire process is done automatically by the consensus layer on a continuous loop.
 
+### More of a visual learner? {#visual-learner}
+
+Check out this explanation of Ethereum staking withdrawals by Finematics:
+
+<YouTube id="RwwU3P9n3uo" />
+
 ### Validator "sweeping" {#validator-sweeping}
 
 When a validator is scheduled to propose the next block, it is required to build a withdrawal queue, of up to 16 eligible withdrawals. This is done by originally starting with validator index 0, determining if there is an eligible withdrawal for this account per the rules of the protocol, and adding it to the queue if there is. The validator set to propose the following block will pick up where the last one left off, progressing in order indefinitely.


### PR DESCRIPTION
## Description
- Embeds YouTube video of new [Finematics explainer](https://www.youtube.com/watch?v=RwwU3P9n3uo) for Staking Withdrawals

<img width="1348" alt="image" src="https://user-images.githubusercontent.com/54227730/224975964-d7b3b726-9a4e-4c18-a61a-b57089a6ef0c.png">

## Related Issue
- #9248