### PR TITLE
fix: fix dead link to UMA Optimistic Oracle

### DIFF
--- a/src/content/developers/docs/oracles/index.md
+++ b/src/content/developers/docs/oracles/index.md
@@ -392,7 +392,7 @@ There are multiple oracle applications you can integrate into your Ethereum dapp
 
 **[Witnet](https://witnet.io/)** - _Witnet is a permissionless, decentralized, and censorship-resistant oracle helping smart contracts to react to real world events with strong crypto-economic guarantees._
 
-**[UMA Oracle](https://umaproject.org/products/optimistic-oracle)** - _UMA's optimistic oracle allows smart contracts to quickly and receive any kind of data for different applications, including insurance, financial derivatives, and prediction market._
+**[UMA Oracle](https://uma.xyz/#builder)** - _UMA's optimistic oracle allows smart contracts to quickly and receive any kind of data for different applications, including insurance, financial derivatives, and prediction markets._
 
 **[Tellor](https://tellor.io/)** - _Tellor is a transparent and permissionless oracle protocol for your smart contract to easily get any data whenever it needs it._
 

--- a/src/content/developers/docs/oracles/index.md
+++ b/src/content/developers/docs/oracles/index.md
@@ -392,7 +392,7 @@ There are multiple oracle applications you can integrate into your Ethereum dapp
 
 **[Witnet](https://witnet.io/)** - _Witnet is a permissionless, decentralized, and censorship-resistant oracle helping smart contracts to react to real world events with strong crypto-economic guarantees._
 
-**[UMA Oracle](https://uma.xyz/#builder)** - _UMA's optimistic oracle allows smart contracts to quickly and receive any kind of data for different applications, including insurance, financial derivatives, and prediction markets._
+**[UMA Oracle](https://uma.xyz)** - _UMA's optimistic oracle allows smart contracts to quickly and receive any kind of data for different applications, including insurance, financial derivatives, and prediction markets._
 
 **[Tellor](https://tellor.io/)** - _Tellor is a transparent and permissionless oracle protocol for your smart contract to easily get any data whenever it needs it._
 


### PR DESCRIPTION
## Description

The link to UMA's Optimistic Oracle page is dead. This updates the link and fixes a minor typo.

## Related Issue

N/A
