### PR TITLE
the `type` field in `eth_getTransactionReceipt` should return a QUANTITY

### DIFF
--- a/src/content/developers/docs/apis/json-rpc/index.md
+++ b/src/content/developers/docs/apis/json-rpc/index.md
@@ -1219,7 +1219,7 @@ params: ["0x85d995eba9763907fdf35cd2034144dd9d53ce32cbec21349d4b12823c6860c5"]
 - `contractAddress `: `DATA`, 20 Bytes - The contract address created, if the transaction was a contract creation, otherwise `null`.
 - `logs`: `Array` - Array of log objects, which this transaction generated.
 - `logsBloom`: `DATA`, 256 Bytes - Bloom filter for light clients to quickly retrieve related logs.
-- `type`: `DATA` - integer of the transaction type, `0x00` for legacy transactions, `0x01` for access list types, `0x02` for dynamic fees.
+- `type`: `QUANTITY` - integer of the transaction type, `0x0` for legacy transactions, `0x1` for access list types, `0x2` for dynamic fees.
   It also returns _either_ :
 - `root` : `DATA` 32 bytes of post-transaction stateroot (pre Byzantium)
 - `status`: `QUANTITY` either `1` (success) or `0` (failure)


### PR DESCRIPTION
Run this (with your own RPC URL or Infura ID):

```
curl -H 'Content-Type: application/json' --data '{"jsonrpc":"2.0","method": "eth_getTransactionByHash", "params": [ "0xc088a442d8b412a48ba4a677b19d5b59bb1f8ebc1fbe66eb72fff1699f62f470" ],"id":1}' https://mainnet.infura.io/v3/<INFURA ID>
```

and it should return:

```
{"jsonrpc":"2.0","id":1,"result":{"accessList":[],"blockHash":"0x58b75e6c12d3b26c5a3c804f71a7118f458d4b5bcbf81eb08a0a1340fbd1318f","blockNumber":"0x10101cd","chainId":"0x1","from":"0x95222290dd7278aa3ddd389cc1e1d165cc4bafe5","gas":"0x7530","gasPrice":"0x4e4f9efc6","hash":"0xc088a442d8b412a48ba4a677b19d5b59bb1f8ebc1fbe66eb72fff1699f62f470","input":"0x","maxFeePerGas":"0x4e4f9efc6","maxPriorityFeePerGas":"0x0","nonce":"0x29548","r":"0x7e460941cfcb2447f601cb99447be92aecddd7ef3d6b1d3146cdf1ffaf64bfc5","s":"0x6cc6f59e4021d3e7550c21a9bc00b75ed43d2dbfb9d0f03e6986f7af85434947","to":"0xe688b84b23f322a994a53dbf8e15fa82cdb71127","transactionIndex":"0x66","type":"0x2","v":"0x0","value":"0x2dcae87d436027"}}
```

Notice the `type` is `0x2`, which is a `QUANTITY` representation.