### PR TITLE
Added Nethermind in Security Audit Services

### DIFF
--- a/src/content/developers/docs/smart-contracts/testing/index.md
+++ b/src/content/developers/docs/smart-contracts/testing/index.md
@@ -227,6 +227,10 @@ Formal verification is considered important for smart contracts because it helps
 
 - [Website](https://www.openzeppelin.com/security-audits)
 
+**Nethermind** - _Solidity and Cairo auditing services, ensuring the integrity of smart contracts and the safety of users across Ethereum and Starknet._
+
+- [Website](https://nethermind.io/smart-contracts-audits)
+
 ### Bug bounty platforms {#bug-bounty-platforms}
 
 **Immunefi** - _Bug bounty platform for smart contracts and DeFi projects, where security researchers review code, disclose vulnerabilities, get paid, and make crypto safer._


### PR DESCRIPTION
Added Nethermind in Security Audit Services.

## Description

I added Nethermind as a service provider for Smart Contract Audits in Ethereum and Starknet.

## Related Issue

This is similar to PR #9617, which added Nethermind to the [Security Page](https://ethereum.org/en/developers/docs/smart-contracts/security/#smart-contract-security-resources-for-developers) but not to the [Testing Page](https://ethereum.org/en/developers/docs/smart-contracts/testing/#smart-contract-auditing-services).
