### PR TITLE
Adding BlockSplit to the list of Ethereum events

### DIFF
--- a/src/data/community-events.json
+++ b/src/data/community-events.json
@@ -78,7 +78,16 @@
     "location": "Podgorica, Montenegro",
     "description": "EDCON is a non-profit annual global conference committed to serving the Ethereum ecosystem in boosting the communication and interaction of Ethereum communities worldwide",
     "startDate": "2023-05-19",
-    "endDate": "2023-05-23"
+    "endDate": "2023-05-23"  
+  },
+  {
+    "title": "BlockSplit",
+    "to": "https://www.blocksplit.net",
+    "sponsor": null,
+    "location": "Split, Croatia",
+    "description": "BlockSplit is the oldest web3 conference in the South-East Europe, taking place since 2018 and attracting over 600 attendees from all around the world.",
+    "startDate": "2023-05-23",
+    "endDate": "2023-05-24"
   },
   {
     "title": "ETH Belgrade 2023",


### PR DESCRIPTION
I'd like to propose adding BlockSplit to the list of Ethereum events. More than two-thirds of BlockSplit's content have historically been dedicated to Ethereum. Majority of our sponsors are Ethereum businesses. We have always held multiple full day Ethereum workshops for developers. Besides that, we are last year's grantees of Ethereum Foundation ESP.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
