### PR TITLE
fix extra margin in `languages.tsx`

### DIFF
--- a/src/pages/languages.tsx
+++ b/src/pages/languages.tsx
@@ -15,9 +15,7 @@ import { TranslationKey } from "../utils/translations"
 import { CardItem as LangItem } from "../components/SharedStyledComponents"
 import Icon from "../components/Icon"
 
-const StyledPage = styled(Page)`
-  margin-top: 4rem;
-`
+const StyledPage = styled(Page)``
 
 const ContentContainer = styled.div``
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

there's too much margin on top in `languages page`
<img width="958" alt="Screenshot 2023-03-17 154502" src="https://user-images.githubusercontent.com/74294202/226083974-72996bbb-4f78-470a-9c28-670e3a5931bb.png">

after my changes
<img width="960" alt="Screenshot 2023-03-18 092635" src="https://user-images.githubusercontent.com/74294202/226083986-40b4446f-e10d-48d7-97dd-7dd2c3737225.png">



## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
