### PR TITLE
Fix GitHub issue template syntax [Fixes #9760]

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -68,7 +68,9 @@ body:
     attributes:
       label: Would you like to work on this issue?
       options:
-        - "Yes"
-        - "No"
+        - label: Yes
+          required: false
+        - label: No
+          required: false
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -68,9 +68,9 @@ body:
     attributes:
       label: Would you like to work on this issue?
       options:
-        - label: Yes
+        - label: "Yes"
           required: false
-        - label: No
+        - label: "No"
           required: false
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -38,9 +38,9 @@ body:
     attributes:
       label: Would you like to work on this issue?
       options:
-        - label: Yes
+        - label: "Yes"
           required: false
-        - label: No
+        - label: "No"
           required: false
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -38,7 +38,9 @@ body:
     attributes:
       label: Would you like to work on this issue?
       options:
-        - "Yes"
-        - "No"
+        - label: Yes
+          required: false
+        - label: No
+          required: false
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/suggest_dapp.yaml
+++ b/.github/ISSUE_TEMPLATE/suggest_dapp.yaml
@@ -101,7 +101,9 @@ body:
     attributes:
       label: Would you like to work on this issue?
       options:
-        - "Yes"
-        - "No"
+        - label: Yes
+          required: false
+        - label: No
+          required: false
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/suggest_dapp.yaml
+++ b/.github/ISSUE_TEMPLATE/suggest_dapp.yaml
@@ -101,9 +101,9 @@ body:
     attributes:
       label: Would you like to work on this issue?
       options:
-        - label: Yes
+        - label: "Yes"
           required: false
-        - label: No
+        - label: "No"
           required: false
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/suggest_dev_tool.yaml
+++ b/.github/ISSUE_TEMPLATE/suggest_dev_tool.yaml
@@ -69,9 +69,9 @@ body:
     attributes:
       label: Would you like to work on this issue?
       options:
-        - label: Yes
+        - label: "Yes"
           required: false
-        - label: No
+        - label: "No"
           required: false
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/suggest_dev_tool.yaml
+++ b/.github/ISSUE_TEMPLATE/suggest_dev_tool.yaml
@@ -69,7 +69,9 @@ body:
     attributes:
       label: Would you like to work on this issue?
       options:
-        - "Yes"
-        - "No"
+        - label: Yes
+          required: false
+        - label: No
+          required: false
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/suggest_exchange.yaml
+++ b/.github/ISSUE_TEMPLATE/suggest_exchange.yaml
@@ -58,7 +58,9 @@ body:
     attributes:
       label: Would you like to work on this issue?
       options:
-        - "Yes"
-        - "No"
+        - label: Yes
+          required: false
+        - label: No
+          required: false
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/suggest_exchange.yaml
+++ b/.github/ISSUE_TEMPLATE/suggest_exchange.yaml
@@ -58,9 +58,9 @@ body:
     attributes:
       label: Would you like to work on this issue?
       options:
-        - label: Yes
+        - label: "Yes"
           required: false
-        - label: No
+        - label: "No"
           required: false
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/suggest_glossary_term.yaml
+++ b/.github/ISSUE_TEMPLATE/suggest_glossary_term.yaml
@@ -50,9 +50,9 @@ body:
     attributes:
       label: Would you like to work on this issue?
       options:
-        - label: Yes
+        - label: "Yes"
           required: false
-        - label: No
+        - label: "No"
           required: false
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/suggest_glossary_term.yaml
+++ b/.github/ISSUE_TEMPLATE/suggest_glossary_term.yaml
@@ -46,11 +46,13 @@ body:
       label: Additional context
       description: Add any other context or screenshots about the feature request here
   - type: checkboxes
-    id: exchange_work_on
+    id: glossary_work_on
     attributes:
       label: Would you like to work on this issue?
       options:
-        - "Yes"
-        - "No"
+        - label: Yes
+          required: false
+        - label: No
+          required: false
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/suggest_layer2.yaml
+++ b/.github/ISSUE_TEMPLATE/suggest_layer2.yaml
@@ -151,11 +151,13 @@ body:
       label: Is there a block explorer?
       description: Are there block explorers for the network? Please share URLs.
   - type: checkboxes
-    id: exchange_work_on
+    id: layer_2_work_on
     attributes:
       label: Would you like to work on this issue?
       options:
-        - "Yes"
-        - "No"
+        - label: Yes
+          required: false
+        - label: No
+          required: false
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/suggest_layer2.yaml
+++ b/.github/ISSUE_TEMPLATE/suggest_layer2.yaml
@@ -155,9 +155,9 @@ body:
     attributes:
       label: Would you like to work on this issue?
       options:
-        - label: Yes
+        - label: "Yes"
           required: false
-        - label: No
+        - label: "No"
           required: false
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/suggest_staking_product.yaml
+++ b/.github/ISSUE_TEMPLATE/suggest_staking_product.yaml
@@ -198,9 +198,9 @@ body:
     attributes:
       label: Would you like to work on this issue?
       options:
-        - label: Yes
+        - label: "Yes"
           required: false
-        - label: No
+        - label: "No"
           required: false
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/suggest_staking_product.yaml
+++ b/.github/ISSUE_TEMPLATE/suggest_staking_product.yaml
@@ -194,11 +194,13 @@ body:
       label: Social media links
       description: List available social media links. ie. Discord, Twitter, Telegram, Reddit
   - type: checkboxes
-    id: exchange_work_on
+    id: staking_product_work_on
     attributes:
       label: Would you like to work on this issue?
       options:
-        - "Yes"
-        - "No"
+        - label: Yes
+          required: false
+        - label: No
+          required: false
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/suggest_tutorial.yaml
+++ b/.github/ISSUE_TEMPLATE/suggest_tutorial.yaml
@@ -63,11 +63,13 @@ body:
       label: "For tutorials hosted elsewhere: URL to tutorial"
       description: Please paste the URL to your tutorial
   - type: checkboxes
-    id: exchange_work_on
+    id: tutorial_work_on
     attributes:
       label: Would you like to work on this issue?
       options:
-        - "Yes"
-        - "No"
+        - label: Yes
+          required: false
+        - label: No
+          required: false
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/suggest_tutorial.yaml
+++ b/.github/ISSUE_TEMPLATE/suggest_tutorial.yaml
@@ -67,9 +67,9 @@ body:
     attributes:
       label: Would you like to work on this issue?
       options:
-        - label: Yes
+        - label: "Yes"
           required: false
-        - label: No
+        - label: "No"
           required: false
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/suggest_wallet.yaml
+++ b/.github/ISSUE_TEMPLATE/suggest_wallet.yaml
@@ -295,11 +295,13 @@ body:
       label: Does the wallet have any integrated tools not mentioned above?
       description: Please provide any information about extra features this wallet has that we may have missed in the above criteria. (e.g. privacy features, transaction batching, etc).
   - type: checkboxes
-    id: exchange_work_on
+    id: wallet_work_on
     attributes:
       label: Would you like to work on this issue?
       options:
-        - "Yes"
-        - "No"
+        - label: Yes
+          required: false
+        - label: No
+          required: false
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/suggest_wallet.yaml
+++ b/.github/ISSUE_TEMPLATE/suggest_wallet.yaml
@@ -299,9 +299,9 @@ body:
     attributes:
       label: Would you like to work on this issue?
       options:
-        - label: Yes
+        - label: "Yes"
           required: false
-        - label: No
+        - label: "No"
           required: false
     validations:
       required: true


### PR DESCRIPTION
## Description
- Updates attribute option syntax for issue templates to use `label: <string>` and `required: <bool>` syntax
- Ensures all templates are using a unique ID for "Would you like to work on this issue?" question

## Related Issue
- [Fixes #9760]

