### PR TITLE
Update StaFi permissionless flag [Fixes #9740]

### DIFF
--- a/src/data/staking-products.json
+++ b/src/data/staking-products.json
@@ -707,7 +707,7 @@
       "isFoss": true,
       "hasBugBounty": false,
       "isTrustless": false,
-      "hasPermissionlessNodes": false,
+      "hasPermissionlessNodes": true,
       "pctMajorityClient": null,
       "platforms": ["Browser"],
       "ui": ["GUI"],


### PR DESCRIPTION
## Description
Updates StaFi `hasPermissionlessNodes` flag to `true`, in response to #9740

## Related Issue
- Fixes #9740