### PR TITLE
Document the `defaultBlock` options `safe` and `finalized`

### DIFF
--- a/src/content/developers/docs/apis/json-rpc/index.md
+++ b/src/content/developers/docs/apis/json-rpc/index.md
@@ -75,6 +75,8 @@ The following options are possible for the defaultBlock parameter:
 - `HEX String` - an integer block number
 - `String "earliest"` for the earliest/genesis block
 - `String "latest"` - for the latest mined block
+- `String "safe"` - for the latest safe head block
+- `String "finalized"` - for the latest finalized block
 - `String "pending"` - for the pending state/transactions
 
 ## Examples


### PR DESCRIPTION
Post-merge, the `defaultBlock` parameter accepts the options `safe` and `finalized`.

Details: https://blog.ethereum.org/2021/11/29/how-the-merge-impacts-app-layer
