### PR TITLE
Update min. requirements for SSD from 1TB to 2TB

### DIFF
--- a/src/content/developers/docs/nodes-and-clients/run-a-node/index.md
+++ b/src/content/developers/docs/nodes-and-clients/run-a-node/index.md
@@ -89,14 +89,14 @@ All clients support major operating systems - Linux, MacOS, Windows. This means 
 
 - CPU with 2+ cores
 - 8 GB RAM
-- 700GB free disk space
+- 2TB SSD
 - 10+ MBit/s bandwidth
 
 ##### Recommended specifications
 
 - Fast CPU with 4+ cores
 - 16 GB+ RAM
-- Fast SSD with 1+TB
+- Fast SSD with 2+TB
 - 25+ MBit/s bandwidth
 
 The sync mode and client you choose will affect space requirements, but we've estimated the disk space you'll need for each client below.


### PR DESCRIPTION
- Many client pairs require more than 1TB today (e.g. Teku + Besu require +1.1GB)

- EthStaker has been recommending 2TB since before the merge: https://www.reddit.com/r/ethstaker/comments/rizos9/hardware_for_staking_2022_edition/

- eth.org itself recommends 2TB here: https://ethereum.org/en/run-a-node/#build-your-own

- As of right now the verkle trie migration will require ELs to temporarily store a copy of both the merkle patricia tree and verkle trie. Currently that would be just under 2TB, but depending on how soon the verkle trie upgrade is launched (unlikely before Q1 2024), it could pass 2TB in the meantime. (This could be mitigated if state expiry / EIP 4444 is launched in the interim.)

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
