### PR TITLE
Fix spacing in roadmap page [Fixes #9804]

### DIFF
--- a/src/templates/roadmap.tsx
+++ b/src/templates/roadmap.tsx
@@ -268,6 +268,7 @@ const HeroContainer = styled.div`
     max-height: 100%;
     padding-left: 0;
     padding-right: 0;
+    margin-bottom: 2em;
   }
 `
 
@@ -409,7 +410,7 @@ const RoadmapPage = ({
               <Title>{mdx.frontmatter.title}</Title>
               <Text>{mdx.frontmatter.description}</Text>
               {mdx?.frontmatter?.buttons && (
-                <Wrap spacing={2}>
+                <Wrap spacing={2} marginBottom={4}>
                   {mdx.frontmatter.buttons.map((button, idx) => {
                     if (button?.to) {
                       return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Added margin to the wrapper containing header buttons 
- Added margin between header and main text in mobile view


## Related Issue

[ Roadmap pages: UI bugs on mobile #9804 ](https://github.com/ethereum/ethereum-org-website/issues/9804)
