### PR TITLE
Add Infura Sepolia Faucet #9820

### DIFF
--- a/src/content/developers/docs/networks/index.md
+++ b/src/content/developers/docs/networks/index.md
@@ -60,6 +60,7 @@ The Sepolia network uses a permissioned validator set. It's fairly new, meaning 
 - [FaucETH](https://fauceth.komputing.org)
 - [Coinbase Wallet Faucet | Sepolia](https://coinbase.com/faucets/ethereum-sepolia-faucet)
 - [Alchemy Sepolia faucet](https://sepoliafaucet.com/)
+- [Infura Sepolia faucet](https://www.infura.io/faucet)
 
 #### Goerli _(long-term support)_ {#goerli}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Infura just released a Sepolia Testnet Faucet that lets you claim 0.5 Sepolia ETH per day, for free. It's super easy to use, just visit https://www.infura.io/faucet, sign in to your Infura account, enter your wallet address, and claim.

Sepolia Testnet is an important tool for testing your smart contracts before deploying them on mainnet environments. With our Testnet Faucet, you can easily catch bugs and reduce the cost of deploying tests on mainnet.

<!--- Describe your changes in detail -->

Add Infura Sepolia Testnet Faucet #9820

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
