### PR TITLE
Intl reorg script - new line at the end of the files

### DIFF
--- a/src/scripts/reorgIntlFiles.ts
+++ b/src/scripts/reorgIntlFiles.ts
@@ -1,4 +1,5 @@
 import fs from "fs"
+import os from "os"
 import path from "path"
 import walkdir from "walkdir"
 import _ from "lodash"
@@ -43,7 +44,7 @@ async function reorgIntl() {
       if (!_.isEmpty(translations)) {
         fs.writeFileSync(
           path.join(sourcePath, language, ns),
-          JSON.stringify(translations, null, 2)
+          JSON.stringify(translations, null, 2) + os.EOL
         )
       }
     })


### PR DESCRIPTION
## Description

Prettier will format the json files with a new line at the end of each file.

Currently the script doesn't add that new line automatically, so it will create a bunch of git differences every time you run the script. To avoid having that problem, we add that extra line to the script to do the same as prettier.