### PR TITLE
Fix theme toggle button text in mobile [Fixes #9822]

### DIFF
--- a/src/components/Nav/Mobile.tsx
+++ b/src/components/Nav/Mobile.tsx
@@ -329,9 +329,9 @@ const MobileNavMenu: React.FC<IProps> = ({
           </BottomItemText>
         </BottomItem>
         <BottomItem onClick={toggleTheme}>
-          <Icon name={isDarkTheme ? "darkTheme" : "lightTheme"} />
+          <Icon name={!isDarkTheme ? "darkTheme" : "lightTheme"} />
           <BottomItemText>
-            <Translation id={isDarkTheme ? "dark-mode" : "light-mode"} />
+            <Translation id={!isDarkTheme ? "dark-mode" : "light-mode"} />
           </BottomItemText>
         </BottomItem>
         <BottomItem onClick={handleClick}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Theme toggle button in sidebar navigation now shows expected label and icon. 
- Label "Dark" and moon icon when the theme is set to light
- Label "Light" and sun icon when the theme is set to dark

## Related Issue

[Theme switch button issue on small screen sizes #9822](https://github.com/ethereum/ethereum-org-website/issues/9822)