### PR TITLE
Fix roadmap page overflow in mobile [Fixes #9824]

### DIFF
--- a/src/templates/roadmap.tsx
+++ b/src/templates/roadmap.tsx
@@ -256,6 +256,7 @@ const MobileButtonDropdown = styled(StyledButtonDropdown)`
 
 const Container = styled.div`
   position: relative;
+  overflow-x: hidden;
 `
 
 const HeroContainer = styled.div`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The issue of horizontal scrolling caused by overflow on the x-axis in mobile view on the roadmap page has been resolved. The overflow is no longer visible and has been hidden.

## Related Issue

[Ethereum roadmap page: Overflow along x-axis #9824 ](https://github.com/ethereum/ethereum-org-website/issues/9824)

Fixes #9824
