### PR TITLE
Fix breadcrumb spacing in mobile view

### DIFF
--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -76,6 +76,8 @@ const Breadcrumbs: React.FC<IProps> = ({
       listProps={{
         m: 0,
         lineHeight: 1,
+        rowGap: 1.5,
+        flexWrap: "wrap"
       }}
       {...restProps}
     >


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

On smaller screen sizes, when breadcrumb text is big, the items are wrapped to next line instead of breaking each breadcrumb text in two

## Related Issue

[ Mobile breadcrumb navigation wrong spacing #9805 ](https://github.com/ethereum/ethereum-org-website/issues/9805)
