### PR TITLE
Fix `isOutdated` flag

### DIFF
--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -210,13 +210,13 @@ export const createPages: GatsbyNode<any, Context>["createPages"] = async ({
         edges {
           node {
             fields {
-              isOutdated
               slug
               relativePath
             }
             frontmatter {
               lang
               template
+              isOutdated
             }
           }
         }
@@ -314,7 +314,7 @@ export const createPages: GatsbyNode<any, Context>["createPages"] = async ({
         language,
         languagesToFetch: [language],
         slug,
-        isOutdated: !!node.fields.isOutdated,
+        isOutdated: !!node.frontmatter?.isOutdated,
         isDefaultLang: language === defaultLanguage,
         relativePath,
         // gatsby i18n plugin


### PR DESCRIPTION
Currently, we are trying to get the `isOutdated` flag from `node.fields` which is incorrect and for some reason that defaults to `true`. So, all pages that doesn't have `isOutdated` set, will be marked as outdated.

Here you can see an example where the page [is not set as outdated](https://github.com/ethereum/ethereum-org-website/blob/move-upgrades-pages/src/content/translations/es/web3/index.md) (is undefined) but the `isOutdated` is defaulting to `true`, https://ethereum.org/es/web3/

## Description

This PR query that flag from the frontmatter, where the `isOutdated` is declared.

Here is an example where we are setting that flag on the md files: https://github.com/ethereum/ethereum-org-website/blob/dev/src/content/translations/hu/developers/docs/gas/index.md