### PR TITLE
Fix energy consumption chart translations

### DIFF
--- a/src/intl/de/page-about.json
+++ b/src/intl/de/page-about.json
@@ -22,5 +22,15 @@
   "page-about-p-6": "Aufgaben, die wir in der Wartscheschlange haben, um sie als nächstes zu implementieren.",
   "page-about-p-7": "Kürzlich abgeschlossene Aufgaben.",
   "page-about-p-8": "Haben Sie eine Idee wie man ethereum.org verbessern kann? Wir würden uns freuen, mit dir zusammenzuarbeiten!",
-  "page-what-is-ethereum-energy-consumption-chart-legend": "Jährlicher Energieverbrauch in TWh/Jahr"
+  "page-what-is-ethereum-energy-consumption-chart-legend": "Jährlicher Energieverbrauch in TWh/Jahr",
+  "energy-consumption-chart-youtube-label": "YouTube",
+  "energy-consumption-chart-gold-mining-galaxy-label": "Goldförderung (Galaxy Digital)",
+  "energy-consumption-chart-global-data-centers-label": "Globale Rechenzentren",
+  "energy-consumption-chart-gold-mining-cbeci-label": "Goldabbau (CBECI)",
+  "energy-consumption-chart-btc-pow-label": "BTC PoW",
+  "energy-consumption-chart-netflix-label": "Netflix",
+  "energy-consumption-chart-eth-pow-label": "ETH PoW",
+  "energy-consumption-chart-gaming-us-label": "Gaming in den USA",
+  "energy-consumption-chart-paypal-label": "PayPal",
+  "energy-consumption-chart-eth-pos-label": "ETH PoS"
 }

--- a/src/intl/en/page-about.json
+++ b/src/intl/en/page-about.json
@@ -23,5 +23,15 @@
   "page-about-p-7": "Recently completed tasks.",
   "page-about-p-8": "Do you have an idea for how to improve ethereum.org? We'd love to collaborate with you!",
   "page-what-is-ethereum-energy-consumption-chart-legend": "Annual Energy Consumption in TWh/yr",
-  "page-upgrades-post-merge-banner-governance-ood": "Some content on this page is out-of-date after the merge. Please raise a PR if you would like to contribute."
+  "page-upgrades-post-merge-banner-governance-ood": "Some content on this page is out-of-date after the merge. Please raise a PR if you would like to contribute.",
+  "energy-consumption-chart-youtube-label": "YouTube",
+  "energy-consumption-chart-gold-mining-galaxy-label": "Gold mining (Galaxy Digital)",
+  "energy-consumption-chart-global-data-centers-label": "Global data centers",
+  "energy-consumption-chart-gold-mining-cbeci-label": "Gold mining (CBECI)",
+  "energy-consumption-chart-btc-pow-label": "BTC PoW",
+  "energy-consumption-chart-netflix-label": "Netflix",
+  "energy-consumption-chart-eth-pow-label": "ETH PoW",
+  "energy-consumption-chart-gaming-us-label": "Gaming in the US",
+  "energy-consumption-chart-paypal-label": "PayPal",
+  "energy-consumption-chart-eth-pos-label": "ETH PoS"
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes translations on the energy consumption chart: https://ethereum.org/en/energy-consumption/

Adding the translations in the `page-about` namespace as is the one used for the `static` template (the template used for this page).

## Related Issue

#9843