### PR TITLE
chore: add ETHMobile Miami to community-events.json

### DIFF
--- a/src/data/community-events.json
+++ b/src/data/community-events.json
@@ -198,6 +198,15 @@
     "endDate": "2023-04-02"
   },
   {
+    "title": "ETH Miami/ ETH Mobile",
+    "to": "https://www.ethmiami.ooo/",
+    "sponsor": null,
+    "location": "Hybrid",
+    "description": " We are Ethereum Miami. Joined the Road to DevCon and launched ETH Mobile at main stage of ETH Denver",
+    "startDate": "2023-09-15th",
+    "endDate": "2023-09-17th"
+  },
+  {
     "title": "ETHcon Korea",
     "to": "https://ethcon.kr/",
     "sponsor": null,

--- a/src/data/community-events.json
+++ b/src/data/community-events.json
@@ -202,7 +202,7 @@
     "to": "https://www.ethmiami.ooo/",
     "sponsor": null,
     "location": "Hybrid",
-    "description": " We are Ethereum Miami. Joined the Road to DevCon and launched ETH Mobile at main stage of ETH Denver",
+    "description": "We are Ethereum Miami. Joined the Road to DevCon and launched ETH Mobile at main stage of ETH Denver",
     "startDate": "2023-09-15",
     "endDate": "2023-09-17th"
   },

--- a/src/data/community-events.json
+++ b/src/data/community-events.json
@@ -198,7 +198,7 @@
     "endDate": "2023-04-02"
   },
   {
-    "title": "ETH Miami/ ETH Mobile",
+    "title": "ETHMobile Miami",
     "to": "https://www.ethmiami.ooo/",
     "sponsor": null,
     "location": "Hybrid",

--- a/src/data/community-events.json
+++ b/src/data/community-events.json
@@ -198,13 +198,13 @@
     "endDate": "2023-04-02"
   },
   {
-    "title": "ETHMobile Miami",
+    "title": "ETH Miami",
     "to": "https://www.ethmiami.ooo/",
     "sponsor": null,
     "location": "Hybrid",
     "description": "We are Ethereum Miami. Joined the Road to DevCon and launched ETH Mobile at main stage of ETH Denver",
     "startDate": "2023-09-15",
-    "endDate": "2023-09-17th"
+    "endDate": "2023-09-17"
   },
   {
     "title": "ETHcon Korea",

--- a/src/data/community-events.json
+++ b/src/data/community-events.json
@@ -203,7 +203,7 @@
     "sponsor": null,
     "location": "Hybrid",
     "description": " We are Ethereum Miami. Joined the Road to DevCon and launched ETH Mobile at main stage of ETH Denver",
-    "startDate": "2023-09-15th",
+    "startDate": "2023-09-15",
     "endDate": "2023-09-17th"
   },
   {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Adding ETH Mobile to the calendar of communities around the world. We are the local Ethereum Miami chapter. Also, we have received funding from EF Ecosystem Support in the past as well as for Road To DevCon 2022. 

www.ethmiami.ooo
www.ethmobile.io

<!--- Describe your changes in detail -->

"title": "ETH Miami/ ETH Mobile",
    "to": "https://www.ethmiami.ooo/",
    "sponsor": null,
    "location": "Hybrid",
    "description": " We are Ethereum Miami. Joined the Road to DevCon and launched ETH Mobile.",
    "startDate": "2023-09-15th",
    "endDate": "2023-09-17th"

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
