### PR TITLE
Fix a typo in the "Hooks" section

### DIFF
--- a/src/content/developers/docs/standards/tokens/erc-1155/index.md
+++ b/src/content/developers/docs/standards/tokens/erc-1155/index.md
@@ -23,7 +23,7 @@ To better understand this page, we recommend you first read about [token standar
 - [Batch Transfer](#batch_transfers): Transfer multiple assets in a single call.
 - [Batch Balance](#batch_balance): Get the balances of multiple assets in a single call.
 - [Batch Approval](#batch_approval): Approve all tokens to an address.
-- [Hooks](#recieve_hook): Receive tokens hook.
+- [Hooks](#receive_hook): Receive tokens hook.
 - [NFT Support](#nft_support): If supply is only 1, treat it as NFT.
 - [Safe Transfer Rules](#safe_transfer_rule): Set of rules for secure transfer.
 


### PR DESCRIPTION
## Description

This commit will fix a typo in a broken link.

- `#recieve_hook` => `#receive_hook`

## Related Issue

