### PR TITLE
Fix translation in learning quizzes

### DIFF
--- a/src/intl/en/learn-quizzes.json
+++ b/src/intl/en/learn-quizzes.json
@@ -305,5 +305,6 @@
   "h005-c-label": "Eth1",
   "h005-c-explanation": "Eth1 was the original name given to the execution layer, not the consensus layer.",
   "h005-d-label": "Sharding",
-  "h005-d-explanation": "Sharding is an update on the Ethereum roadmap related to scaling."
+  "h005-d-explanation": "Sharding is an update on the Ethereum roadmap related to scaling.",
+  "page-assets-merge": "The Merge"
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes "page-assets-merge" translation in the learning quizzes.
