### PR TITLE
fix: invalid link 'incentive layer' and 'LMD-GHOST' [ #9866]

### DIFF
--- a/src/content/developers/docs/consensus-mechanisms/pos/attack-and-defense/index.md
+++ b/src/content/developers/docs/consensus-mechanisms/pos/attack-and-defense/index.md
@@ -8,7 +8,7 @@ Thieves and saboteurs are constantly seeking opportunities to attack Ethereum’
 
 ## Prerequisites {#prerequisites}
 
-Some basic knowledge of [proof-of-stake](/developers/docs/consensus-mechanisms/pos/) is required. Also, it will be helpful to have a basic understanding of Ethereum's [incentive layer](/docs/consensus-mechanisms/pos/rewards-and-penalties) and fork-choice algorithm, [LMD-GHOST](/docs/consensus-mechanisms/pos/gasper).
+Some basic knowledge of [proof-of-stake](/developers/docs/consensus-mechanisms/pos/) is required. Also, it will be helpful to have a basic understanding of Ethereum's [incentive layer](/developers/docs/consensus-mechanisms/pos/rewards-and-penalties) and fork-choice algorithm, [LMD-GHOST](/developers/docs/consensus-mechanisms/pos/gasper).
 
 ## What do attackers want? {#what-do-attackers-want}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

added the missing developer slug to the 'incentive layer' and 'LMD-GHOST' links on the 'Consensus Mechanisms - Proof of Stake: Attack and Defense' [page](https://ethereum.org/en/developers/docs/consensus-mechanisms/pos/attack-and-defense/#prerequisites).

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->  Invalid link 'incentive layer' and 'LMD-GHOST' #9866
