### PR TITLE
Add Diligence Fuzzing to Dynamic analysis tools #9917

### DIFF
--- a/src/content/developers/docs/smart-contracts/testing/index.md
+++ b/src/content/developers/docs/smart-contracts/testing/index.md
@@ -202,7 +202,7 @@ Formal verification is considered important for smart contracts because it helps
 - [GitHub](https://github.com/trailofbits/manticore)
 - [Documentation](https://github.com/trailofbits/manticore/wiki)
 
-**Diligence Fuzzing** - _A holistic fuzzing tool, powered by the Harvey fuzzing engine, that can automatically execute millions of inputs on a smart contract and generate unit and system tests for you._
+**Diligence Fuzzing** - _A holistic fuzzing tool that can automatically execute millions of inputs on a smart contract and generate unit and system tests for you which is powered by the Harvey fuzzing engine._
 
 - [Website](https://consensys.net/diligence/fuzzing/)
 - [Documentation](https://fuzzing-docs.diligence.tools/)

--- a/src/content/developers/docs/smart-contracts/testing/index.md
+++ b/src/content/developers/docs/smart-contracts/testing/index.md
@@ -197,18 +197,24 @@ Formal verification is considered important for smart contracts because it helps
 
 - [GitHub](https://github.com/crytic/echidna/)
 
-**Harvey** - _Automated fuzzing tool useful for detecting property violations in smart contract code._
-
-- [Website](https://consensys.net/diligence/fuzzing/)
-
 **Manticore** - _Dynamic symbolic execution framework for analyzing EVM bytecode._
 
 - [GitHub](https://github.com/trailofbits/manticore)
 - [Documentation](https://github.com/trailofbits/manticore/wiki)
 
+**Diligence Fuzzing** - _A holistic fuzzing tool, powered by the Harvey fuzzing engine, that can automatically execute millions of inputs on a smart contract and generate unit and system tests for you._
+
+- [Website](https://consensys.net/diligence/fuzzing/)
+- [Documentation](https://fuzzing-docs.diligence.tools/)
+
+**Diligence Scribble** - _Scribble is a specification language and runtime verification tool that allows you to annotate smart contracts with properties that allow you to automatically test smart contracts with tools such as Diligence Fuzzing._
+
+- [Website](https://consensys.net/diligence/scribble/)
+- [Documentation](https://docs.scribble.codes/)
+
 ### Smart contract auditing services {#smart-contract-auditing-services}
 
-**ConsenSys Diligence** - _Smart contract auditing service helping projects across the blockchain ecosystem ensure their protocols are ready for launch and built to protect users._
+**Consensys Diligence** - _Smart contract auditing service helping projects across the blockchain ecosystem ensure their protocols are ready for launch and built to protect users._
 
 - [Website](https://consensys.net/diligence/)
 

--- a/src/content/developers/docs/smart-contracts/testing/index.md
+++ b/src/content/developers/docs/smart-contracts/testing/index.md
@@ -207,7 +207,7 @@ Formal verification is considered important for smart contracts because it helps
 - [Website](https://consensys.net/diligence/fuzzing/)
 - [Documentation](https://fuzzing-docs.diligence.tools/)
 
-**Diligence Scribble** - _Scribble is a specification language and runtime verification tool that allows you to annotate smart contracts with properties that allow you to automatically test smart contracts with tools such as Diligence Fuzzing._
+**Diligence Scribble** - _Scribble is a specification language and runtime verification tool that allows you to annotate smart contracts with properties that allow you to automatically test the contracts with tools such as Diligence Fuzzing or MythX._
 
 - [Website](https://consensys.net/diligence/scribble/)
 - [Documentation](https://docs.scribble.codes/)

--- a/src/content/developers/docs/smart-contracts/testing/index.md
+++ b/src/content/developers/docs/smart-contracts/testing/index.md
@@ -214,7 +214,7 @@ Formal verification is considered important for smart contracts because it helps
 
 ### Smart contract auditing services {#smart-contract-auditing-services}
 
-**Consensys Diligence** - _Smart contract auditing service helping projects across the blockchain ecosystem ensure their protocols are ready for launch and built to protect users._
+**ConsenSys Diligence** - _Smart contract auditing service helping projects across the blockchain ecosystem ensure their protocols are ready for launch and built to protect users._
 
 - [Website](https://consensys.net/diligence/)
 


### PR DESCRIPTION
Updated the [Dynamic Analysis Tools section of the Smart Contracts Testing page ](https://ethereum.org/en/developers/docs/smart-contracts/testing/#dynamic-analysis-tools) to update the entry for the Harvey fuzzing engine to reflect the updated Consensys Fuzzing project.

## Description

- Add links to docs for Scribble and Fuzzing for developers
- Updated description
- Replaced listing for Harvey with the updated projects
- Removed the camelcase "S" from ConsenSys to Consensys b/c of change in branding

## Related Issue

https://github.com/ethereum/ethereum-org-website/issues/9917
