### PR TITLE
fix nonsensical wording [Fixes #9927]

### DIFF
--- a/src/content/staking/withdrawals/index.md
+++ b/src/content/staking/withdrawals/index.md
@@ -53,7 +53,7 @@ Providing a withdrawal address is required before _any_ funds can be transferred
 
 Users looking to exit staking entirely and withdraw their full balance back must also sign and broadcast a "voluntary exit" message with validator keys which will start the process of exiting from staking. This is done with your validator client and submitted to your beacon node, and does not require gas.
 
-The process of a validator exiting from staking takes variable amounts of time, depending on how many others are exiting at the same time. Once complete, this account will no longer be responsible for performing validator network duties, is no longer eligible for rewards, and no longer has their ETH "at stake". At this time the account with be marked as fully “withdrawable”.
+The process of a validator exiting from staking takes variable amounts of time, depending on how many others are exiting at the same time. Once complete, this account will no longer be responsible for performing validator network duties, is no longer eligible for rewards, and no longer has their ETH "at stake". At this time the account will be marked as fully “withdrawable”.
 
 Once an account is flagged as "withdrawable", and withdrawal credentials have been provided, there is nothing more a user needs to do aside from wait. Accounts are automatically and continuously swept by block proposers for eligible exited funds, and your account balance will be transferred in full (also known as a "full withdrawal") during the next <a href="#validator-sweeping" customEventOptions={{ eventCategory: "Anchor link", eventAction: "Exiting staking entirely (sweep)", eventName: "click" }}>sweep</a>.
 


### PR DESCRIPTION
Resolves typo on Staking Withdrawals page described in [#9927](https://github.com/ethereum/ethereum-org-website/issues/9927)
## Description
I changed the word 'with' to 'will' in the following sentence to help it make sense:

`At this time the account with be marked as fully “withdrawable”.`

## Related Issue
[#9927](https://github.com/ethereum/ethereum-org-website/issues/9927)
