### PR TITLE
[patch] ethpool icon key name

### DIFF
--- a/src/components/Staking/StakingProductsCardGrid.tsx
+++ b/src/components/Staking/StakingProductsCardGrid.tsx
@@ -73,7 +73,7 @@ const getIconFromName = (
     dappnode: StakingDappnodeGlyphIcon,
     docker: DockerIcon,
     defaultOpenSource: DefaultOpenSourceGlyphIcon,
-    ethpools: EthpoolGlyphIcon,
+    ethpool: EthpoolGlyphIcon,
     kiln: KilnGlyphIcon,
     lido: LidoGlyphIcon,
     rocketPool: RocketPoolGlyphIcon,


### PR DESCRIPTION
## Description
- Patches the key name for ethpool icon

## Related Issue
<img width="1449" alt="image" src="https://user-images.githubusercontent.com/54227730/230729978-1c5446eb-18a8-4b2d-b43a-43e2c58f8fcd.png">

## Preview link
https://ethereumorgwebsitedev01-patchethpoolicon.gatsbyjs.io/en/staking/saas/#saas-providers

## Fix screenshot
<img width="1444" alt="image" src="https://user-images.githubusercontent.com/54227730/230729944-79fe494d-67a7-450b-b822-9f99ee7afe82.png">
