### PR TITLE
Fix typo in how-to-use-tellor-as-your-oracle

### DIFF
--- a/src/content/developers/tutorials/how-to-use-tellor-as-your-oracle/index.md
+++ b/src/content/developers/tutorials/how-to-use-tellor-as-your-oracle/index.md
@@ -62,7 +62,7 @@ constructor(address payable _tellorAddress) UsingTellor(_tellorAddress) public {
 
 function setBtcPrice() public {
     bytes memory _b = abi.encode("SpotPrice",abi.encode("btc","usd"));
-    bytes32 _queryID = keccak256(_b);
+    bytes32 _queryId = keccak256(_b);
 
     uint256 _timestamp;
     bytes _value;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request fixes a small typo in the how-to-use-tellor-as-your-oracle guide. In the BTC/USD Example section, on line 65, _queryID is used instead of _queryId.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
