### PR TITLE
Removing banner from bug bounty page

### DIFF
--- a/src/pages/bug-bounty.tsx
+++ b/src/pages/bug-bounty.tsx
@@ -445,8 +445,6 @@ const BugBountiesPage = ({
         title={t("page-upgrades-bug-bounty-meta-title")}
         description={t("page-upgrades-bug-bounty-meta-description")}
       />
-      {/* TODO: Remove April 6 */}
-      <BugBountyBanner />
       <Content>
         <HeroCard>
           <HeroContainer>


### PR DESCRIPTION
## Description

As the multiplier is no longer active for the bounty page, it's being removed. This will be reactivated at the next hard fork.