### PR TITLE
Redirects in browser

### DIFF
--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -4,7 +4,7 @@ import path from "path"
 import util from "util"
 import child_process from "child_process"
 import { createFilePath } from "gatsby-source-filesystem"
-import type { GatsbyNode } from "gatsby"
+import type { GatsbyNode, Actions } from "gatsby"
 
 import type { Context } from "./src/types"
 
@@ -27,6 +27,7 @@ const commonRedirectProps = {
   isPermanent: true,
   ignoreCase: true,
   force: true,
+  redirectInBrowser: true,
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR enables the `redirectInBrowser` flag in Gatsby to also redirect the user to the correct destination on the client side.

## Related Issue

#9951
