### PR TITLE
fix(TableOfContents): export `Item` type-sig from index file

### DIFF
--- a/src/components/TableOfContents/index.tsx
+++ b/src/components/TableOfContents/index.tsx
@@ -23,6 +23,8 @@ import Mobile from "./TableOfContentsMobile"
 import ItemsList from "./ItemsList"
 import { getCustomId, Item, outerListProps } from "./utils"
 
+export { Item }
+
 export interface IProps extends BoxProps {
   items: Array<Item>
   maxDepth?: number


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This addresses type errors in template files where the `Item` type originally imported from the `TableOfContents` component was no longer recognized. This comes from the restructuring of the component into multiple files where the type now resides in a utils file.

This PR exports the type through the index file of the component to retain the imports in the templates.

<!--- Describe your changes in detail -->

## Related Issue
N/A
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
