### PR TITLE
refactor: update storybook config and theme util

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -3,13 +3,7 @@ const { propNames } = require("@chakra-ui/react")
 const { babelConfig } = require("./babel-storybook-config")
 
 module.exports = {
-  stories: [
-    {
-      directory: "../src/components",
-      titlePrefix: "Components",
-      files: "**/*.stories.tsx",
-    },
-  ],
+  stories: ["../src/components/**/*.stories.tsx"],
   addons: [
     "@storybook/addon-links",
     "@storybook/addon-essentials",
@@ -86,8 +80,5 @@ module.exports = {
         return !(isStyledSystemProp || isHTMLElementProp)
       },
     },
-  },
-  docs: {
-    autodocs: true,
   },
 }

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -31,9 +31,13 @@ export const parameters = {
       date: /Date$/,
     },
   },
+  backgrounds: {
+    disable: true,
+  },
   chakra: {
     theme,
   },
+  layout: "centered",
   // Modify viewport selection to match Chakra breakpoints (or custom breakpoints)
   viewport: {
     viewports: chakraBreakpointArray.reduce((prevVal, currVal) => {

--- a/src/@chakra-ui/gatsby-plugin/components/components.utils.ts
+++ b/src/@chakra-ui/gatsby-plugin/components/components.utils.ts
@@ -65,8 +65,8 @@ export {
  * @param styleObjs - The following style objects to be merged
  */
 export function defineMergeStyles(
-  defaultTheming?: SystemStyleObject,
-  ...styleObjs: SystemStyleObject[] | undefined[]
-) {
+  defaultTheming?: SystemStyleObject | unknown,
+  ...styleObjs: SystemStyleObject[] | unknown[]
+): Record<string, SystemStyleObject> {
   return merge(defaultTheming, ...styleObjs)
 }


### PR DESCRIPTION
- Update Storybook config to do the following:
  - Set the `stories` option in `.storybook/main.js` to only point to where the story files are located and not up global prefixed titles for the sidebar. Rely only on declaring the structure via the component stories for now.
  - Disable autodocs so that docs should only be added on a component-by-component basis with custom markdown
  - Disable the backgrounds toggle in `.storybook/preview.js`. This is a color mode toggle for the background of the component preview. However, the Chakra UI addon has it's own toggle that is connected to the Chakra provider and needs to be prioritized.
  - Set the `layout` option in `.storybook/preview.js` to `centered` so each rendered preview is in the center of the window. Only override this as needed in the story files.

- In the theme config `component.utils` file, updates the type signature of `defineMergeStyles` to allow for instances of objects imported from the default theming without type errors regarding object mismatch.
