### PR TITLE
update JSON rpc documentation to add eth_chainId (EIP 695)

### DIFF
--- a/src/content/developers/docs/apis/json-rpc/index.md
+++ b/src/content/developers/docs/apis/json-rpc/index.md
@@ -370,7 +370,7 @@ None
 
 **Returns**
 
-`DATA`, integer of the current chain id.
+`chainId`, hexadecimal value as a string representing the integer of the current chain id.
 
 **Example**
 

--- a/src/content/developers/docs/apis/json-rpc/index.md
+++ b/src/content/developers/docs/apis/json-rpc/index.md
@@ -360,6 +360,31 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_coinbase","params":[],"id":6
 }
 ```
 
+## eth_chainId {#eth_chainId}
+
+Returns the chain ID used for signing replay-protected transactions.
+
+**Parameters**
+
+None
+
+**Returns**
+
+`DATA`, integer of the current chain id.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":67}'
+// Result
+{
+  "id":67,
+  "jsonrpc": "2.0",
+  "result": "0x1"
+}
+```
+
 ### eth_mining {#eth_mining}
 
 Returns `true` if client is actively mining new blocks.


### PR DESCRIPTION
Add a eth_chainId section in JSON rpc documentation

## Description

The JSON RPC documentation lacks the eth_chainId method from [EIP 695](https://eips.ethereum.org/EIPS/eip-695), so I added a section inside json_rpc index.md to show how to use it

## Related Issue

None
