### PR TITLE
♻️ Propose a 'clearer' python code for RLP encoding page

### DIFF
--- a/src/content/developers/docs/data-structures-and-encoding/rlp/index.md
+++ b/src/content/developers/docs/data-structures-and-encoding/rlp/index.md
@@ -43,27 +43,27 @@ In code, this is:
 ```python
 def rlp_encode(input):
     if isinstance(input,str):
-        if len(input) == 1 and ord(input) < 0x80: return input
-        else: return encode_length(len(input), 0x80) + input
-    elif isinstance(input,list):
+        if len(input) == 1 and ord(input) < 0x80: 
+            return input
+        return encode_length(len(input), 0x80) + input
+    elif isinstance(input, list):
         output = ''
-        for item in input: output += rlp_encode(item)
+        for item in input: 
+            output += rlp_encode(item)
         return encode_length(len(output), 0xc0) + output
 
-def encode_length(L,offset):
+def encode_length(L, offset):
     if L < 56:
          return chr(L + offset)
     elif L < 256**8:
          BL = to_binary(L)
          return chr(len(BL) + offset + 55) + BL
-    else:
-         raise Exception("input too long")
+     raise Exception("input too long")
 
 def to_binary(x):
     if x == 0:
         return ''
-    else:
-        return to_binary(int(x / 256)) + chr(x % 256)
+    return to_binary(int(x / 256)) + chr(x % 256)
 ```
 
 ## Examples {#examples}
@@ -137,8 +137,7 @@ def decode_length(input):
         lenOfListLen = prefix - 0xf7
         listLen = to_integer(substr(input, 1, lenOfListLen))
         return (1 + lenOfListLen, listLen, list)
-    else:
-        raise Exception("input does not conform to RLP encoding form")
+    raise Exception("input does not conform to RLP encoding form")
 
 def to_integer(b):
     length = len(b)
@@ -146,8 +145,7 @@ def to_integer(b):
         raise Exception("input is null")
     elif length == 1:
         return ord(b[0])
-    else:
-        return ord(substr(b, -1)) + to_integer(substr(b, 0, -1)) * 256
+    return ord(substr(b, -1)) + to_integer(substr(b, 0, -1)) * 256
 ```
 
 ## Further reading {#further-reading}


### PR DESCRIPTION
Re-wrote some part of the python code on the page RLP encoding for a better understandinhg.

## Description

What I propose is to remove useless `else`; IDK if removing them is againts the **explicit is better than implicit** doctrine; I will let you judge.

Also, some `for` and `if` condition where wrote in one line, which is not really visible when you are know python and even other languages.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
