### PR TITLE
Updated MEV and Me Link

### DIFF
--- a/src/content/developers/docs/mev/index.md
+++ b/src/content/developers/docs/mev/index.md
@@ -210,7 +210,7 @@ Some projects, such as MEV Boost, use the Builder API as part of an overall stru
 ## Further reading {#further-reading}
 
 - [What Is Miner-Extractable Value (MEV)?](https://blog.chain.link/what-is-miner-extractable-value-mev/)
-- [MEV and Me](https://research.paradigm.xyz/MEV)
+- [MEV and Me]([https://research.paradigm.xyz/MEV](https://www.paradigm.xyz/2021/02/mev-and-me))
 - [Ethereum is a Dark Forest](https://www.paradigm.xyz/2020/08/ethereum-is-a-dark-forest/)
 - [Escaping the Dark Forest](https://samczsun.com/escaping-the-dark-forest/)
 - [Flashbots: Frontrunning the MEV Crisis](https://medium.com/flashbots/frontrunning-the-mev-crisis-40629a613752)


### PR DESCRIPTION
Replaced the MEV and ME Link as the old link was linking to a snapshot of the [Internet Archive's Wayback Machine](https://archive.org/web/). 

## Description

Replaced https://research.paradigm.xyz/MEV with https://www.paradigm.xyz/2021/02/mev-and-me

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
