### PR TITLE
Guides Pages Updates

### DIFF
--- a/src/content/guides/how-to-register-an-ethereum-account/index.md
+++ b/src/content/guides/how-to-register-an-ethereum-account/index.md
@@ -6,9 +6,9 @@ lang: en
 
 # How to "register" an Ethereum account
 
-Anyone can create an Ethereum account for free with a specific type of app commonly known as a wallet. Wallets hold the keys that let you hold, send and receive crypto. You can also connect to projects on Ethereum that will let you trade NFTs, exchange coins, access games, unlock Defi and much more.
+Anyone can create an Ethereum account for free with a specific type of app commonly known as a wallet. Wallets create and secure the keys that let you hold, send and receive crypto. You can also connect to projects on Ethereum that will let you trade NFTs, exchange tokens, access games, and much more.
 
-Unlike traditional account registrations you may be used to, creating an Ethereum account is done privately and without asking permission. Accounts are controlled by keys that your wallet software helps you create, and are not issued by a third party, nor stored in a central registry.
+Unlike opening a new account with a company, creating an Ethereum account is done freely, privately and without asking permission. Accounts are controlled by keys that your wallet software helps you create, and are not issued by a third party, nor stored in a central registry.
 
 ## Step 1: Browse our list of wallets
 
@@ -49,11 +49,11 @@ Once you have saved your recovery phrase you should see your wallet dashboard wi
 
 ### Are my wallet and my Ethereum account the same?
 
-No, wallets have the ability to create a new Ethereum account, but the account lives on Ethereum and wallets connect to it. So if you lose your wallet you can still recover your account with the recovery phrase.
+No, just like online banking you can have many different accounts all stored in one wallet application. Your 12 or 24 word phrase secures them all: it is like the seed of a big tree (which is why you must keep it safe). Each branch of the tree holds a key, and every key is one of your accounts. If you lose access to the wallet (i.e. your tree gets cut down), you can always restore all your different accounts using other software and the same seed (which will always grow the same tree).
 
 ### Can I send bitcoin to an Ethereum address, or ether to a Bitcoin address?
 
-No you cannot as bitcoin and ether exists on two separate networks (i.e. different blockchains), each with their own bookkeeping models and address formats. There are many EVM (Ethereum Virtual Machine) compatible tokens & blockchains that you can use with your Ethereum address.
+No you cannot. Bitcoin and ether exist on two separate networks (i.e. different blockchains), each with their own bookkeeping models and address formats. There have been various attempts to bridge the two different networks, of which the most active one is currently [Wrapped bitcoin or WBTC](https://www.bitcoin.com/get-started/what-is-wbtc/). This is not an endorsement, as WBTC is a custodial solution (meaning a single group of people controls certain critical functions) and is provided here for informational purposes only.
 
 ### If I own an ETH address, do I own the same address on other blockchains?
 
@@ -61,8 +61,8 @@ You can use the same address on all EVM compatible blockchains (if you have the 
 
 ### Is having my own wallet safer than keeping my funds on an exchange?
 
-Yes, this is a much safer option because nobody else will have access to your funds. There are unfortunately many examples of failed exchanges that filed for bankruptcy resulting in users' losing their savings which were being held in custody. Hacks, frozen accounts or blocked withdrawals are some other common risks. Owning a wallet (with a recovery phrase) is the best way to safeguard your assets. Nonetheless, a poorly backed up recovery phrase potentially exposes you to more risks as compared to having your keys managed by an exchange. Make sure to store your recovery phrase well.
+Yes, this is a much safer option because nobody else will have access to your funds. There are unfortunately many examples of failed exchanges that filed for bankruptcy resulting in users' losing their savings which were being held in custody. Hacks, frozen accounts, or blocked withdrawals are some other common risks. Owning a wallet (with a recovery phrase) is the best way to safeguard your assets. Nonetheless, a poorly backed up recovery phrase potentially exposes you to more risks as compared to having your keys managed by an exchange. Make sure to store your recovery phrase well.
 
 ### If I lose my phone/hardware wallet, do I need to use the same wallet app again to recover the lost funds?
 
-No, you can use almost any wallet as the recovery process is largely standardized whereby only knowledge of the recovery phrase is required. You will have to enter the recovery phrase into any new wallet app, it can be a different app from the one you used before. It is almost impossible to recover lost funds without the recovery phrase.
+No, you can use almost any wallet as the recovery process is largely standardized. This means that you can put the same 12 or 24 word phrase into most wallets and they will restore your same account. Be careful if you ever need to do this: it is best to make sure you are not connected to the internet when recovering your wallet so that your recovery phrase is not accidentally leaked. It is often impossible to recover lost funds without the recovery phrase.

--- a/src/content/guides/how-to-revoke-token-access/index.md
+++ b/src/content/guides/how-to-revoke-token-access/index.md
@@ -41,9 +41,9 @@ If you do not know which contract to choose, you can revoke all of them. It won'
 
 Once you click on revoke, you should see a new transaction suggestion in your wallet. This is to be expected. You will have to pay the fee for the cancellation to be successful. Depending on the network this can take from a minute to several to be processed.
 
-We advise to refresh the revoking tool after few minutes and connect your wallet again to double check if revoked contract has disappeared from the list.
+We advise you to refresh the revoking tool after a few minutes and connect your wallet again to double check if the revoked contract has disappeared from the list.
 
-<mark>We recommend you never allow projects unlimited access to your tokens and revoke all token allowance access regularly. Revoking token access will never result in loss of funds.</mark>
+<mark>We recommend you never allow projects unlimited access to your tokens and revoke all token allowance access regularly. Revoking token access should never result in a loss of funds, especially if you use the tools listed above.</mark>
 
  <br />
 

--- a/src/content/guides/how-to-swap-tokens/index.md
+++ b/src/content/guides/how-to-swap-tokens/index.md
@@ -6,7 +6,7 @@ lang: en
 
 # How to swap tokens
 
-Tired of searching for an exchange that lists all your favorite tokens? You can swap most of the tokens using decentralized exchanges.
+Are you tired of searching for an exchange that lists all your favorite tokens? You can swap most of the tokens using decentralized exchanges.
 
 A token swap involves the exchange of two different assets that exist on the Ethereum network, for example swapping ETH for DAI (an ERC-20 token). The process is very fast and cheap. You will need to have a crypto wallet to swap tokens.
 
@@ -23,6 +23,8 @@ Some popular exchanges are:
 - [Sushiswap](https://www.sushi.com/swap)
 - [1Inch](https://app.1inch.io/#/1/unified/swap/ETH/DAI)
 - [Curve](https://curve.fi/#/ethereum/swap)
+
+If you'd like to learn more about what DeFi is and how these new kinds of exchanges work, we can recommend the [Kernel Library](https://library.kernel.community/Topic+-+DeFi/Topic+-+DeFi).
 
 ## 2. Select the pair of tokens you wish to swap
 

--- a/src/content/guides/how-to-use-a-bridge/index.md
+++ b/src/content/guides/how-to-use-a-bridge/index.md
@@ -6,7 +6,7 @@ lang: en
 
 # How to bridge tokens to layer 2
 
-If everyone always uses Ethereum, it can get slow and expensive. One solution to this is to create new "layers": i.e. different networks which operate in similar ways to Ethereum itself. These so-called Layer 2s help reduce congestion and cost on Ethereum by processing many more transactions at lower fees, and only storing the result of these on Ethereum every so often. As such, these layers 2s enable us to transact with increased speed and decreased costs. Many popular crypto projects are moving to layer 2s because of these benefits. The simplest way to move tokens from Ethereum to layer 2 is to use a bridge.
+If there is a lot of traffic on Ethereum, it can become expensive. One solution to this is to create new "layers": i.e. different networks which operate in similar ways to Ethereum itself. These so-called Layer 2s help reduce congestion and cost on Ethereum by processing many more transactions at lower fees, and only storing the result of these on Ethereum every so often. As such, these layers 2s enable us to transact with increased speed and decreased costs. Many popular crypto projects are moving to layer 2s because of these benefits. The simplest way to move tokens from Ethereum to layer 2 is to use a bridge.
 
 **Prerequisite:**
 

--- a/src/content/guides/how-to-use-a-bridge/index.md
+++ b/src/content/guides/how-to-use-a-bridge/index.md
@@ -6,7 +6,7 @@ lang: en
 
 # How to bridge tokens to layer 2
 
-Layer 2s are scaling solutions for Ethereum which allow users to transact with increased speed and decreased costs. Many popular crypto projects are moving to layer 2s because of these benefits. The simplest way to move tokens from Ethereum to layer 2 is to use a bridge project.
+If everyone always uses Ethereum, it can get slow and expensive. One solution to this is to create new "layers": i.e. different networks which operate in similar ways to Ethereum itself. These so-called Layer 2s help reduce congestion and cost on Ethereum by processing many more transactions at lower fees, and only storing the result of these on Ethereum every so often. As such, these layers 2s enable us to transact with increased speed and decreased costs. Many popular crypto projects are moving to layer 2s because of these benefits. The simplest way to move tokens from Ethereum to layer 2 is to use a bridge.
 
 **Prerequisite:**
 

--- a/src/content/guides/how-to-use-a-wallet/index.md
+++ b/src/content/guides/how-to-use-a-wallet/index.md
@@ -16,14 +16,16 @@ You should see a dashboard that will likely show your balance and contain button
 
 Do you want to receive crypto into your wallet?
 
-Each Ethereum account has its own receiving address which is a unique sequence of numbers and letters. The address functions like a bank account number. Ethereum addresses will always start with “0x”.
+Each Ethereum account has its own receiving address which is a unique sequence of numbers and letters. The address functions like a bank account number. Ethereum addresses will always start with “0x”. You can share this address with anyone: it is safe to do so.
 
-You need to provide the sender with your receiving address. Many wallet apps let you copy to clipboard the address or show a QR code to scan for easier usage. Avoid typing any Ethereum address manually. This is unsafe, and can easily lead to clerical errors and lost funds.
+Your address (which is sometimes called a "public key") is like your home address: you need to tell people what it is so they can find you. It is safe to do this, because you can still lock your front door with another key only you control so that no-one can get in, even if they know where you live.
 
-This is a general pattern, and different apps may vary or use different language. It should also be similar process if you are trying to send your funds from an exchange.
+You need to provide whoever wants to send you money with your public address. Many wallet apps let you copy your address or show a QR code to scan for easier usage. Avoid typing any Ethereum address manually. This can easily lead to clerical errors and lost funds.
+
+Different apps may vary or use different language, but they should take you through a similar process if you are trying to transfer funds.
 
 1. Open your wallet app.
-2. Click on "Receive" or similarly worded option on the dashboard
+2. Click on "Receive" (or similarly worded option).
 3. Copy your Ethereum address to clipboard.
 4. Provide the sender with your receiving Ethereum address.
 
@@ -31,21 +33,21 @@ This is a general pattern, and different apps may vary or use different language
 
 Would you like to send ETH to another wallet?
 
-1. Prepare the receiving address and the network of the recipient.
-2. Open your wallet app.
-3. Click on a “Send” button on the dashboard of your wallet or similarly worded alternative.
-4. Enter the receiving address or scan a QR code with your camera so that you don’t have to write the address manually.
+1. Open your wallet app.
+2. Get the receiving address and make sure you are connected to the same network as the recipient.
+3. Enter the receiving address or scan a QR code with your camera so that you don’t have to write the address manually.
+4. Click on a “Send” button in your wallet (or a similarly worded alternative).
 
 ![Send field for crypto address](./send.png)
 <br/>
 
 5. Many assets, like DAI or USDC, exist on multiple networks. When transferring crypto tokens, make sure that the recipient is using the same network as you are, since these are not interchangeable.
-6. Ensure that your wallet has sufficient ETH to cover the transaction fee which varies depending on network conditions. Most wallets will automatically add the suggested fee to the transaction which you can then confirm.
-7. Once your transaction is processed, the corresponding crypto amount will show up in the recipient’s account. This might take anywhere from a few seconds to a few minutes depending on network transaction prioritisation.
+6. Ensure that your wallet has sufficient ETH to cover the transaction fee, which varies depending on network conditions. Most wallets will automatically add the suggested fee to the transaction which you can then confirm.
+7. Once your transaction is processed, the corresponding crypto amount will show up in the recipient’s account. This might take anywhere from a few seconds to a few minutes depending on how much the network is currently being used.
 
 ## Connecting to projects
 
-Your address represents you on all Ethereum projects. You will not need to register individually on any project. Once you have a wallet, you can connect to any Ethereum project without any additional information. No emails or any other personal information are needed.
+Your address will be the same in all Ethereum projects. You do not need to register individually on any project. Once you have a wallet, you can connect to any Ethereum project without any additional information. No emails or any other personal information are needed.
 
 1. Visit any project’s website.
 2. If the project's landing page is just a static description of the project, you should be able to click on an "Open the App" button in the menu which will navigate you to the actual web app.
@@ -57,7 +59,7 @@ Your address represents you on all Ethereum projects. You will not need to regis
 
 ![Selecting from a list of wallets to connect with](./connect2.png)
 
-5. Confirm the signature request in your wallet to establish the connection. Do note that signing this message should not require spending any ETH.
+5. Confirm the signature request in your wallet to establish the connection. **Signing this message should not require spending any ETH**.
 6. That's it! Start using the app. You can find some interesting projects on our [dApps page](/dapps/#explore).
    <br />
 
@@ -80,8 +82,8 @@ Yes you can use the same address on multiple devices. Wallets are technically on
 
 ### I have not received the crypto, where can I check the status of a transaction?
 
-You can use [block explorers](https://ethereum.org/en/developers/docs/data-and-analytics/block-explorers/) to see the status of any transaction in real time. All you need to do is to search your wallet address or the ID of the transaction.
+You can use [block explorers](/developers/docs/data-and-analytics/block-explorers/) to see the status of any transaction in real time. All you need to do is to search your wallet address or the ID of the transaction.
 
 ### Can I cancel or return transactions?
 
-No, once a transaction is confirmed, you can not cancel the transaction.
+No, once a transaction is confirmed, you cannot cancel the transaction.

--- a/src/content/guides/index.md
+++ b/src/content/guides/index.md
@@ -6,13 +6,13 @@ lang: en
 
 # Ethereum guides
 
-Do you want to start your Ethereum journey? It can be confusing to use and understand new technology. Our practical guides will teach you how to get started step-by-step.
+Do you want to start your Ethereum journey? There's a whole community of us exploring together many different ways to use and understand Ethereum. Ethereum is not a corporation with a script-bound helpdesk: it is a living group of people interested in building better worlds. These practical guides will help you learn how to get started and where to find us.
 
 ## Getting started
 
-1. [How to "register" an Ethereum account](/guides/how-to-register-an-ethereum-account/) - You will learn that you need a wallet app and the guide will show you where to find one.
+1. [How to "register" an Ethereum account](/guides/how-to-register-an-ethereum-account/) - Anyone can create a wallet for free. This guide will show you where to begin.
 
-2. [How to use a wallet](/guides/how-to-use-a-wallet/) - An introduction to basic features of any wallet and how to use them.
+2. [How to use a wallet](/guides/how-to-use-a-wallet/) - An introduction to the basic features of any wallet and how to use them.
 
 ## Security basics
 
@@ -22,4 +22,8 @@ Do you want to start your Ethereum journey? It can be confusing to use and under
 
 1. [How to bridge tokens to layer 2](/guides/how-to-use-a-bridge/) - Are Ethereum transactions too costly? Consider moving to Ethereum scaling solutions called layer 2s.
 
-2. [How to swap tokens](/guides/how-to-swap-tokens/) - Do you want to exchange your tokens for a different one? A simple guide how to do that.
+2. [How to swap tokens](/guides/how-to-swap-tokens/) - Do you want to exchange your tokens for a different one? This simple guide will show you how to do that.
+
+## Decentralized Thinking Skills
+
+Once you've got a wallet and have used a few of its features, you can understand more about Ethereum by asking, "_why_ does this matter?" What makes money valuable if no-one controls it? What is trust? Does this contribute to freedom? What kinds of new governance and organizational structures does Ethereum enable? These questions, and more, are explored freely in communities like [Kernel](https://www.kernel.community/).

--- a/src/pages-conditional/dapps.tsx
+++ b/src/pages-conditional/dapps.tsx
@@ -776,7 +776,7 @@ const DappsPage = ({
     {
       title: "SuperRare",
       description: t("page-dapps-dapp-description-superrare"),
-      link: "https://www.superrare.co",
+      link: "https://www.superrare.com",
       image: getImage(data.superrare),
       alt: t("page-dapps-superrare-logo-alt"),
     },


### PR DESCRIPTION
## Description

This PR continues work on updating copy across the e.org website. In this case, the focus is specifically the `Guides` section under the `Learn` tab. I have edited the copy, added just one link to Kernel, and generally tried to keep cutting away for clarity and brevity, while not sacrificing accuracy.

## Related Issue

#9869 

## Notes

It seems like a previous fix I made has been reverted on `dev`, so this corrects #9924 again.
