### PR TITLE
Fix hidden close icon when menu is shown [mobile]

### DIFF
--- a/src/components/Nav/useNav.ts
+++ b/src/components/Nav/useNav.ts
@@ -266,7 +266,6 @@ export const useNav = ({ path }: { path: string }) => {
   let mobileLinkSections = cloneDeep(linkSections)
   const toggleMenu = (): void => {
     setIsMenuOpen((prev) => !prev)
-    document.documentElement.style.overflowY = isMenuOpen ? "scroll" : "hidden"
   }
 
   const searchRef = useRef<HTMLButtonElement>(null)


### PR DESCRIPTION
There is currently an error on `dev` when the menu is shown in mobile.

1. On mobile, visit the home page and scroll down a bit
2. Open the menu
3. ERROR: The close icon on the top-right corner is not visible

## Description

Removes manual overflow hide logic when the menu is shown.
