### PR TITLE
Fix Broken Tornado Cash URL

### DIFF
--- a/src/pages-conditional/dapps.tsx
+++ b/src/pages-conditional/dapps.tsx
@@ -612,7 +612,7 @@ const DappsPage = ({
     {
       title: "Tornado cash",
       description: t("page-dapps-dapp-description-tornado-cash"),
-      link: "https://tornado.cash/",
+      link: "https://ipfs.io/ipns/tornadocash.eth/",
       image: getImage(data.tornado),
       alt: t("page-dapps-tornado-cash-logo-alt"),
     },


### PR DESCRIPTION
Fixed the link to Tornado Cash to the one they use in their [twitter bio](https://twitter.com/TornadoCash) as the current one no longer works.

## Description

Just changed a URL on a component :)

## Related Issue

Noticed it was broken so decided to fix it