### PR TITLE
add missing translation strings for quiz titles

### DIFF
--- a/src/intl/en/learn-quizzes.json
+++ b/src/intl/en/learn-quizzes.json
@@ -306,5 +306,7 @@
   "h005-c-explanation": "Eth1 was the original name given to the execution layer, not the consensus layer.",
   "h005-d-label": "Staking",
   "h005-d-explanation": "Staking is depositing ETH into a smart contract to help secure the chain.",
-  "page-assets-merge": "The Merge"
+  "page-assets-merge": "The Merge",
+  "security": "Security",
+  "page-what-is-ethereum-what-is-ether": "What is ether?"
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Adds translation strings for `security` and `page-what-is-ethereum-what-is-ether` to `learn-quizzes.json`
