### PR TITLE
Fix typo in Security - #use-hardware-wallet

### DIFF
--- a/src/content/security/index.md
+++ b/src/content/security/index.md
@@ -137,7 +137,7 @@ By screenshotting your seed phrases or private keys, you risk syncing them to th
 
 ### Use a hardware wallet {#use-hardware-wallet}
 
-A hardware wallet provides offline storage for private keys. They are considered the most secure wallet option for storing your private keys: your private key touches the internet and stays completely local on your device.
+A hardware wallet provides offline storage for private keys. They are considered the most secure wallet option for storing your private keys: your private key never touches the internet and stays completely local on your device.
 
 Keeping private keys offline massively reduces the risk of being hacked, even if a hacker gets control of your computer.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Hi everyone! I think there might be a typo on the [Use a hardware wallet](https://ethereum.org/en/security/#use-hardware-wallet) section of the [Security](https://ethereum.org/en/security) page:

> They are considered the most secure wallet option for storing your private keys: your private key touches the internet and stays completely local on your device.

Should be:
> They are considered the most secure wallet option for storing your private keys: your private key **never** touches the internet and stays completely local on your device.

Unless I misunderstood this paragraph?

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
