### PR TITLE
fix: code flag for emoji visualization in the community events sectio…

### DIFF
--- a/src/data/community-meetups.json
+++ b/src/data/community-meetups.json
@@ -1,7 +1,7 @@
 [
   {
     "title": "Ethereum Ecuador",
-    "emoji": ":flag_ec:",
+    "emoji": ":ec:",
     "location": "Ecuador",
     "link": "https://www.eventbrite.com/o/ethereum-ecuador-64512134823"
   },
@@ -17,9 +17,9 @@
     "location": "Sydney",
     "link": "https://www.meetup.com/BokkyPooBahs-Ethereum-Workshop/"
   },
-   {
+  {
     "title": "Web3Mi",
-    "emoji": ":ita:",
+    "emoji": ":it:",
     "location": "Milan",
     "link": "https://www.eventbrite.it/o/web3mi-52766466683"
   },


### PR DESCRIPTION
Changelog:

- "emoji" field of the json community-meetups for Ecuador and Milan updated

## Description

Updated the country code to display the flag using the "emoji" field of the json community-meetups for Ecuador and Milan.

## Related Issue
you can find this issue in the following link: https://ethereum.org/en/community/events/

before this PR: 
<img width="779" alt="image" src="https://user-images.githubusercontent.com/791301/235694654-caab49ab-f158-479b-b742-ae4d759153fa.png">

<img width="789" alt="image" src="https://user-images.githubusercontent.com/791301/235694760-098fcd79-ee8a-47eb-9dbd-2e6dd8472aa0.png">

after this PR:
<img width="637" alt="image" src="https://user-images.githubusercontent.com/791301/235695218-4d13ff9f-4d88-4874-924e-3995f44136f4.png">
<img width="602" alt="image" src="https://user-images.githubusercontent.com/791301/235695349-400d112d-14b4-42f4-b773-5d257835d19d.png">
