### PR TITLE
Update `#maxRedeem` description in `index.md`

### DIFF
--- a/src/content/developers/docs/standards/tokens/erc-4626/index.md
+++ b/src/content/developers/docs/standards/tokens/erc-4626/index.md
@@ -134,7 +134,7 @@ This function burns `shares` from `owner` and send exactly `assets` token from t
 function maxRedeem(address owner) public view returns (uint256)
 ```
 
-This function returns the maximum amount of shares that can be redeem from the `owner` balance through a [`redeem`](#redeem) call.
+This function returns the maximum amount of shares that can be redeemed from the `owner` balance through a [`redeem`](#redeem) call.
 
 #### previewRedeem {#previewredeem}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Update `#maxRedeem` description in `index.md` from "...that can be redeem from.." to "...that can be redeem**ed** from...".

## Description

The tense of the word "redeem" in the description should be in present perfect - "...that can be redeem from.." should be "...that can be redeem**ed** from...".
