### PR TITLE
Fix broken use case hero images in non-English languages

### DIFF
--- a/src/content/translations/de/decentralized-identity/index.md
+++ b/src/content/translations/de/decentralized-identity/index.md
@@ -5,7 +5,7 @@ lang: de
 template: use-cases
 emoji: ":id:"
 sidebarDepth: 2
-image: ../../assets/eth-gif-cat.png
+image: ../../../../assets/eth-gif-cat.png
 summaryPoint1: Traditionelle Identitätssysteme haben die Ausgabe, Wartung und Kontrolle Ihrer Identifikatoren zentralisiert.
 summaryPoint2: Eine dezentralisierte Identität beseitigt die Abhängigkeit von zentralisierten Dritten.
 summaryPoint3: Dank Krypto haben Benutzer jetzt die Werkzeuge, um ihre eigenen Identifikatoren und Bescheinigungen wieder auszugeben, zu halten und zu kontrollieren.

--- a/src/content/translations/de/social-networks/index.md
+++ b/src/content/translations/de/social-networks/index.md
@@ -5,7 +5,7 @@ lang: de
 template: use-cases
 emoji: ":mega:"
 sidebarDepth: 2
-image: ../../assets/ethereum-learn.png
+image: ../../../../assets/ethereum-learn.png
 summaryPoint1: Blockchain-basierte Plattformen für soziale Interaktionen und Content-Erstellung und -Verteilung.
 summaryPoint2: Dezentralisierte Social-Media-Netzwerke schützen die Privatsphäre der Benutzer und erhöhen Datensicherheit.
 summaryPoint3: Token und NFTs erschaffen neue Wege zur Monetarisierung von Inhalten.

--- a/src/content/translations/es/decentralized-identity/index.md
+++ b/src/content/translations/es/decentralized-identity/index.md
@@ -5,7 +5,7 @@ lang: es
 template: use-cases
 emoji: ":id:"
 sidebarDepth: 2
-image: ../../assets/eth-gif-cat.png
+image: ../../../../assets/eth-gif-cat.png
 summaryPoint1: Los sistemas tradicionales de identidad han centralizado la emisión, mantenimiento y control de sus identificadores.
 summaryPoint2: La identidad descentralizada elimina la dependencia de terceras partes centralizadas.
 summaryPoint3: Gracias a la criptografía, los usuarios tienen ahora las herramientas para emitir, retener y controlar sus propios identificadores y certificaciones.

--- a/src/content/translations/es/social-networks/index.md
+++ b/src/content/translations/es/social-networks/index.md
@@ -5,7 +5,7 @@ lang: es
 template: use-cases
 emoji: ":mega:"
 sidebarDepth: 2
-image: ../../assets/ethereum-learn.png
+image: ../../../../assets/ethereum-learn.png
 summaryPoint1: Plataformas basadas en la cadena de bloques para interacción social, creación y distribución de contenidos.
 summaryPoint2: Las redes sociales descentralizadas protegen la privacidad del usuario y mejoran la seguridad de los datos.
 summaryPoint3: Tókenes y NFT crean nuevas formas de monetizar contenido.

--- a/src/content/translations/it/dao/index.md
+++ b/src/content/translations/it/dao/index.md
@@ -5,7 +5,7 @@ lang: it
 template: use-cases
 emoji: ":handshake:"
 sidebarDepth: 3
-image: ../../assets/use-cases/dao-2.png
+image: ../../../../assets/use-cases/dao-2.png
 alt: Rappresentazione di una votazione DAO su una proposta.
 summaryPoint1: Comunità di proprietà dei membri senza leadership centralizzata.
 summaryPoint2: Un modo sicuro per collaborare con sconosciuti su Internet.

--- a/src/content/translations/it/decentralized-identity/index.md
+++ b/src/content/translations/it/decentralized-identity/index.md
@@ -5,7 +5,7 @@ lang: it
 template: use-cases
 emoji: ":id:"
 sidebarDepth: 2
-image: ../../assets/eth-gif-cat.png
+image: ../../../../assets/eth-gif-cat.png
 summaryPoint1: I sistemi d'identità tradizionali hanno centralizzato l'emissione, manutenzione e controllo dei tuoi identificativi.
 summaryPoint2: L'identità decentralizzata rende possibile non fare affidamento su terze parti centralizzate.
 summaryPoint3: Grazie alle cripto, gli utenti hanno ora nuovamente gli strumenti per emettere, detenere e controllare i propri identificativi e attestazioni.

--- a/src/content/translations/it/defi/index.md
+++ b/src/content/translations/it/defi/index.md
@@ -4,7 +4,7 @@ description: Una panoramica sulla DeFi in Ethereum
 lang: it
 template: use-cases
 emoji: ":money_with_wings:"
-image: ../../assets/use-cases/defi.png
+image: ../../../../assets/use-cases/defi.png
 alt: Logo di Eth in mattoncini Lego.
 sidebarDepth: 3
 summaryPoint1: Un'alternativa globale e aperta all'attuale sistema finanziario.

--- a/src/content/translations/it/social-networks/index.md
+++ b/src/content/translations/it/social-networks/index.md
@@ -5,7 +5,7 @@ lang: it
 template: use-cases
 emoji: ":mega:"
 sidebarDepth: 2
-image: ../../assets/ethereum-learn.png
+image: ../../../../assets/ethereum-learn.png
 summaryPoint1: Piattaforme basate sulla blockchain per l'interazione sociale e la creazione e distribuzione di contenuti.
 summaryPoint2: I social network decentralizzati proteggono la privacy dell'utente e migliorano la sicurezza dei dati.
 summaryPoint3: Token e NFT creano nuovi modi per monetizzare i contenuti.

--- a/src/content/translations/pt-br/decentralized-identity/index.md
+++ b/src/content/translations/pt-br/decentralized-identity/index.md
@@ -5,7 +5,7 @@ lang: pt-br
 template: use-cases
 emoji: ":id:"
 sidebarDepth: 2
-image: ../../assets/eth-gif-cat.png
+image: ../../../../assets/eth-gif-cat.png
 summaryPoint1: Os sistemas de identidade tradicionais centralizaram a emissão, manutenção e controle de seus identificadores.
 summaryPoint2: A identidade descentralizada elimina a dependência de terceiros centralizados.
 summaryPoint3: Graças à criptografia, os usuários agora têm as ferramentas para emitir, manter e controlar seus próprios identificadores e atestações novamente.

--- a/src/content/translations/pt-br/defi/index.md
+++ b/src/content/translations/pt-br/defi/index.md
@@ -4,7 +4,7 @@ description: Uma visão geral do DeFi na Ethereum
 lang: pt-br
 template: use-cases
 emoji: ":money_with_wings:"
-image: ../../assets/use-cases/defi.png
+image: ../../../../assets/use-cases/defi.png
 alt: Um logotipo Eth feito de blocos de lego.
 sidebarDepth: 2
 summaryPoint1: Uma alternativa global e aberta ao sistema financeiro atual.

--- a/src/content/translations/pt-br/social-networks/index.md
+++ b/src/content/translations/pt-br/social-networks/index.md
@@ -5,7 +5,7 @@ lang: pt-br
 template: use-cases
 emoji: ":mega:"
 sidebarDepth: 2
-image: ../../assets/ethereum-learn.png
+image: ../../../../assets/ethereum-learn.png
 summaryPoint1: Plataformas baseadas em blockchain para interação social, criação e distribuição de conteúdo.
 summaryPoint2: As redes de mídia social descentralizadas protegem a privacidade do usuário e aumentam a segurança dos dados.
 summaryPoint3: Tokens e NFTs criam formas de monetizar conteúdo.

--- a/src/content/translations/zh/decentralized-identity/index.md
+++ b/src/content/translations/zh/decentralized-identity/index.md
@@ -5,7 +5,7 @@ lang: zh
 template: use-cases
 emoji: ":id:"
 sidebarDepth: 2
-image: ../../assets/eth-gif-cat.png
+image: ../../../../assets/eth-gif-cat.png
 summaryPoint1: 传统身份系统有权对您的身份标识进行发布、维护和控制。
 summaryPoint2: 去中心化身份消除了对中心化第三方的依赖。
 summaryPoint3: 多亏了加密技术，用户现在拥有了再次发布、持有和控制其自身身份标识和身份证明的工具。

--- a/src/content/translations/zh/social-networks/index.md
+++ b/src/content/translations/zh/social-networks/index.md
@@ -5,7 +5,7 @@ lang: zh
 template: use-cases
 emoji: ":mega:"
 sidebarDepth: 2
-image: ../../assets/ethereum-learn.png
+image: ../../../../assets/ethereum-learn.png
 summaryPoint1: 基于区块链的社交互动与内容平台的创建和分配。
 summaryPoint2: 去中心化社交媒体网络可保护用户隐私并增强数据安全性。
 summaryPoint3: 代币和非同质化代币创造了一种将内容货币化的新方法。


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Some non-English pages were using the English path for their frontmatter image, causing the image to 404 and not show.

E.g. using `../../assets/use-cases/dao-2.png` (which only works for English files) instead of `../../../../assets/use-cases/dao-2.png` (which is required for all non-English languages)

This PR fixes these for use case pages.
