### PR TITLE
Add EnvWarningBanner PoC

### DIFF
--- a/src/components/EnvWarningBanner.tsx
+++ b/src/components/EnvWarningBanner.tsx
@@ -3,10 +3,8 @@ import { FlexProps } from "@chakra-ui/react"
 import InfoBanner from "./InfoBanner"
 import Translation from "./Translation"
 
-export interface IProps extends FlexProps {}
-
-const EnvWarningBanner: React.FC<IProps> = () => (
-  <InfoBanner isWarning>
+const EnvWarningBanner: React.FC<FlexProps> = ({ ...flexProps }) => (
+  <InfoBanner isWarning {...flexProps}>
     <Translation id="page-tutorials-env-banner" />
   </InfoBanner>
 )

--- a/src/components/EnvWarningBanner.tsx
+++ b/src/components/EnvWarningBanner.tsx
@@ -1,0 +1,14 @@
+import React from "react"
+import { FlexProps } from "@chakra-ui/react"
+import InfoBanner from "./InfoBanner"
+import Translation from "./Translation"
+
+export interface IProps extends FlexProps {}
+
+const EnvWarningBanner: React.FC<IProps> = () => (
+  <InfoBanner isWarning>
+    <Translation id="page-tutorials-env-banner" />
+  </InfoBanner>
+)
+
+export default EnvWarningBanner

--- a/src/content/developers/tutorials/how-to-write-and-deploy-an-nft/index.md
+++ b/src/content/developers/tutorials/how-to-write-and-deploy-an-nft/index.md
@@ -235,9 +235,7 @@ Your `.env` should now look like this:
 
 To actually connect these to our code, we’ll reference these variables in our hardhat.config.js file in step 13.
 
-<InfoBanner isWarning>
-Don't commit <code>.env</code>! Please make sure never to share or expose your <code>.env</code> file with anyone, as you are compromising your secrets in doing so. If you are using version control, add your <code>.env</code> to a <a href="https://git-scm.com/docs/gitignore">gitignore</a> file.
-</InfoBanner>
+<EnvWarningBanner />
 
 ## Step 12: Install Ethers.js {#install-ethers}
 

--- a/src/intl/en/page-developers-tutorials.json
+++ b/src/intl/en/page-developers-tutorials.json
@@ -24,5 +24,6 @@
   "page-tutorial-intermediate": "Intermediate",
   "page-tutorial-advanced": "Advanced",
   "page-find-wallet-try-removing": "Try removing a feature or two",
-  "page-find-wallet-clear": "Clear filters"
+  "page-find-wallet-clear": "Clear filters",
+  "page-tutorials-env-banner": "Don't commit <code>.env</code>! Please make sure never to share or expose your <code>.env</code> file with anyone, as you are compromising your secrets in doing so. If you are using version control, add your <code>.env</code> to a <a href=\"https://git-scm.com/docs/gitignore\">gitignore</a> file."
 }

--- a/src/templates/tutorial.tsx
+++ b/src/templates/tutorial.tsx
@@ -11,6 +11,7 @@ import Codeblock from "../components/Codeblock"
 import TutorialMetadata from "../components/TutorialMetadata"
 import FileContributors from "../components/FileContributors"
 import InfoBanner from "../components/InfoBanner"
+import EnvWarningBanner from "../components/EnvWarningBanner"
 import Link from "../components/Link"
 import MarkdownTable from "../components/MarkdownTable"
 import PageMetadata from "../components/PageMetadata"
@@ -132,6 +133,7 @@ const components = {
   table: MarkdownTable,
   ButtonLink,
   InfoBanner,
+  EnvWarningBanner,
   Card,
   Divider,
   SectionNav,


### PR DESCRIPTION
## Description

Proposing we remove individual warnings about `.env` safety in Tutorial files with a reusable component.

**Why?**

1. Reduces duplicate work for translators
2. More maintainable (allows us to refine component/message to increase effectiveness)
3. Can be dropped anywhere we're telling people to use `.env` files, increasing developer safety
4. Allows us to remove many HTML tags (`<code>` and `<a>` tags) across our tutorial markdown pages, improving maintenance during Crowdin import process

The current banner is used in many places, but really should be in more places to avoid people getting by poor env hygiene:

<img width="1168" alt="Screenshot 2023-05-04 at 14 30 29" src="https://user-images.githubusercontent.com/62268199/236219931-36f462d1-e8de-4304-83de-b5990e748ab1.png">


## Related Issue

#10126 