### PR TITLE
Make Buttons in InfoBanner inherit color from theme

### DIFF
--- a/src/components/InfoBanner.tsx
+++ b/src/components/InfoBanner.tsx
@@ -29,7 +29,7 @@ const InfoBanner: React.FC<IProps> = ({
       borderRadius={"sm"}
       maxW={shouldCenter ? "55rem" : "100%"}
       sx={{
-        "*": {
+        ":not(button)": {
           color: "black300 !important",
         },
       }}


### PR DESCRIPTION
## Description

We were overriding the default colors in the InfoBanner because we kept the background color blue in both themes, but this introduced a bug where the button colors were wrong :) 

This PR fixes that bug.

![Screenshot 2023-05-05 at 10 30 13](https://user-images.githubusercontent.com/62268199/236426465-12d53d9f-d702-4cc3-a148-662b2a5ca102.png)



## Related Issue

#9642
