### PR TITLE
Add LearnWeb3 to community support

### DIFF
--- a/src/content/community/support/index.md
+++ b/src/content/community/support/index.md
@@ -38,6 +38,7 @@ Looking for an Ethereum wallet? [Explore our full list of Ethereum wallets](/wal
 
 Building can be hard. Here are some development focused spaces with experienced Ethereum developers that are happy to help.
 
+- [LearnWeb3](https://learnweb3.io)
 - [Alchemy University](https://university.alchemy.com/#starter_code)
 - [CryptoDevs discord](https://discord.gg/Z9TA39m8Yu)
 - [Ethereum StackExchange](https://ethereum.stackexchange.com/)


### PR DESCRIPTION
## Description

LearnWeb3 was started in early 2022, and is the home to 80k+ developers who have been learning about web3 development. A lot of our students have won hackathons, gotten jobs, and built their own projects.

It would be great to add it here.
