### PR TITLE
Add Protocol Berg to Community Events List

### DIFF
--- a/src/data/community-events.json
+++ b/src/data/community-events.json
@@ -277,5 +277,14 @@
     "description": "ETHAccra is a 3-day hackathon striving to educate young generations of web3 developers and builders.",
     "startDate": "2023-09-07",
     "endDate": "2023-09-09"
+  },
+  {
+    "title": "Protocol Berg",
+    "to": "https://protocol.berlin/",
+    "sponsor": null,
+    "location": "Berlin, Germany",
+    "description": "The decentralized protocol and infrastructure conference. Protocol Berg is a one-day technical conference for protocol/system/network engineers, decentralized-infrastructure administrators, researchers, and other curious minds from different ecosystems.",
+    "startDate": "2023-09-15",
+    "endDate": "2023-09-15"
   }
 ]


### PR DESCRIPTION
## Description

Adding Protocol Berg (https://protocol.berlin/) to the community events lists!

I couldn't find a logic (alphabetical or by date) in the list so I added it to the bottom - let me know if that was incorrect.
