### PR TITLE
DPoS Link Change

### DIFF
--- a/src/content/developers/docs/scaling/sidechains/index.md
+++ b/src/content/developers/docs/scaling/sidechains/index.md
@@ -18,7 +18,7 @@ Sidechains are independent blockchains, with different histories, development ro
 One of the qualities that make sidechains unique (i.e., different from Ethereum) is the consensus algorithm used. Sidechains don't rely on Ethereum for consensus and can choose alternative consensus protocols that suit their needs. Some examples of consensus algorithms used on sidechains include:
 
 - [Proof-of-authority](https://wikipedia.org/wiki/Proof_of_authority)
-- [Delegated proof-of-stake](https://en.bitcoinwiki.org/wiki/DPoS)
+- [Delegated proof-of-stake](https://en.bitcoin.it/wiki/Delegated_proof_of_stake)
 - [Byzantine fault tolerance](https://decrypt.co/resources/byzantine-fault-tolerance-what-is-it-explained).
 
 Like Ethereum, sidechains have validating nodes that verify and process transactions, produce blocks, and store the blockchain state. Validators are also responsible for maintaining consensus across the network and securing it against malicious attacks.


### PR DESCRIPTION
The link https://en.bitcoinwiki.org/wiki/DPoS just redirects to https://bitcoin.org/. Switching to https://en.bitcoin.it/wiki/Delegated_proof_of_stake

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This is just a simple change to fix a broken link for DPoS which is going to the wrong page now.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
