### PR TITLE
fix(orderedlist): list points in layer2 page

### DIFF
--- a/src/components/OrderedList.tsx
+++ b/src/components/OrderedList.tsx
@@ -18,11 +18,10 @@ export interface IProps {
 const liCustomType: SystemStyleObject = {
   content: `counter(li-counter)`,
   position: "absolute",
-  top: "-5px", // adjusts circle + number up and down
+  top: "-3px", // adjusts circle + number up and down
   left: "-3rem",
-  width: "32px",
-  // aspectRatio: "1",
-  height: "1.5rem",
+  width: "34px",
+  height: "1.6rem",
   pt: "9px", // adjusts number up and down,
   lineHeight: "100%",
   borderRadius: "50%",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Made the points fit in center of the circle and fixed the oval shape to circular shape.

<!--- Describe your changes in detail -->
Earlier the numbers in points were not in center of the circle and circle was not in proper circle shape, it was in oval shape, fixed both of these problems.

## Related Issue
Bug report: L2 numbered list doesnt have aligned numbers: #9974

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
