### PR TITLE
fix(community guide): learnhub

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -112,7 +112,7 @@ const Footer: React.FC<IProps> = () => {
         },
         {
           to: `/learn/`,
-          text: t("guides-and-resources"),
+          text: t("learn-hub"),
         },
         {
           to: "/history/",

--- a/src/intl/en/common.json
+++ b/src/intl/en/common.json
@@ -87,7 +87,6 @@
   "get-started": "Get started",
   "grants": "Grants",
   "grant-programs": "Ecosystem Grant Programs",
-  "guides-and-resources": "Community guides and resources",
   "guides": "Guides",
   "guides-hub": "Guides hub",
   "history-of-ethereum": "History of Ethereum",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Changed **community guide and resources** in footer to **Learn Hub**.

<!--- Describe your changes in detail -->
Changed **community guide and resources** in footer to **Learn Hub**, and removed community-guide-and-resources **label** from the **common.js** file.

## Related Issue

Legacy link on the footer needs to change the label to "Learning hub" 

Fixes #10156

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
