### PR TITLE
Fix table overflow caused by VisuallyHidden width on external Links

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -135,9 +135,7 @@ const Link: React.FC<IProps> = ({
       >
         <>
           {children}
-          <VisuallyHidden className="visually-hidden">
-            (opens in a new tab)
-          </VisuallyHidden>
+          <VisuallyHidden>(opens in a new tab)</VisuallyHidden>
           {!hideArrow && (
             <Box as="span" ml={0.5} mr={1.5} aria-hidden>
               ↗

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -135,7 +135,9 @@ const Link: React.FC<IProps> = ({
       >
         <>
           {children}
-          <VisuallyHidden>(opens in a new tab)</VisuallyHidden>
+          <VisuallyHidden className="visually-hidden">
+            (opens in a new tab)
+          </VisuallyHidden>
           {!hideArrow && (
             <Box as="span" ml={0.5} mr={1.5} aria-hidden>
               ↗

--- a/src/components/MarkdownTable.tsx
+++ b/src/components/MarkdownTable.tsx
@@ -14,6 +14,9 @@ const MarkdownTable: React.FC<IProps> = ({ children }) => (
           borderColor: "border",
           whiteSpace: "nowrap",
         },
+        ".chakra-link .visually-hidden": {
+          width: "0px",
+        },
       }}
     >
       {children}

--- a/src/components/MarkdownTable.tsx
+++ b/src/components/MarkdownTable.tsx
@@ -6,16 +6,13 @@ export interface IProps {
 }
 
 const MarkdownTable: React.FC<IProps> = ({ children }) => (
-  <Box my={8} overflowX="auto">
+  <Box position="relative" my={8} overflowX="auto">
     <Table
       sx={{
         th: {
           borderBottom: "1px solid",
           borderColor: "border",
           whiteSpace: "nowrap",
-        },
-        ".chakra-link .visually-hidden": {
-          width: "0px",
         },
       }}
     >


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Noticed in #10120: the energy consumption has a horizontal scroll under ~680px caused by the table ([also visible in prod](https://ethereum.org/en/energy-consumption/)).

- The `VisuallyHidden` component within the `Link` component is causing the issue.
- Looks like the 1px width of the `VisuallyHidden` component is causing the overflow scroll not to work correctly, causing a horizontal scroll. 
- When I delete it the `VisuallyHidden` component or add `width: 0px` to it, it does not overflow

Suspect this might be a bug in Chakra itself 🤔?

### A11Y

I tested the a11y of this with the width set to 0px, and it works as expected using VoiceOver/JAWs screen readers. However, I isolated this change to links within markdown tables incase there are unintended consequences I'm not aware of...

cc: @TylerAPfledderer @pettinarip 

## Related Issue

#10120

Fixes: https://github.com/ethereum/ethereum-org-website/issues/10174
