### PR TITLE
fix(learn-links): footer links order changed

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -99,6 +99,10 @@ const Footer: React.FC<IProps> = () => {
       title: t("learn"),
       links: [
         {
+          to: `/learn/`,
+          text: t("learn-hub"),
+        },
+        {
           to: `/what-is-ethereum/`,
           text: t("what-is-ethereum"),
         },
@@ -111,8 +115,24 @@ const Footer: React.FC<IProps> = () => {
           text: t("ethereum-wallets"),
         },
         {
-          to: `/learn/`,
-          text: t("learn-hub"),
+          text: t("ethereum-security"),
+          to: "/security/",
+        },
+        {
+          text: t("web3"),
+          to: "/web3/",
+        },
+        {
+          text: t("energy-consumption"),
+          to: "/energy-consumption/",
+        },
+        {
+          text: t("ethereum-roadmap"),
+          to: "/roadmap/",
+        },
+        {
+          to: "/eips/",
+          text: t("eips"),
         },
         {
           to: "/history/",
@@ -121,14 +141,6 @@ const Footer: React.FC<IProps> = () => {
         {
           to: "/whitepaper/",
           text: t("ethereum-whitepaper"),
-        },
-        {
-          text: t("ethereum-roadmap"),
-          to: "/roadmap/",
-        },
-        {
-          text: t("ethereum-security"),
-          to: "/security/",
         },
         {
           to: `/glossary/`,
@@ -145,18 +157,6 @@ const Footer: React.FC<IProps> = () => {
         {
           text: t("zero-knowledge-proofs"),
           to: "/zero-knowledge-proofs/",
-        },
-        {
-          text: t("energy-consumption"),
-          to: "/energy-consumption/",
-        },
-        {
-          text: t("web3"),
-          to: "/web3/",
-        },
-        {
-          to: "/eips/",
-          text: t("eips"),
         },
       ],
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changed the order of the links in the footer Section : **Learn**

<!--- Describe your changes in detail -->
Here is an sc preview after changes, **on left** final-website footer links order and **on right** header links order :
![preview-footer-links-order](https://github.com/ethereum/ethereum-org-website/assets/92221517/ab3fa3a5-94bc-4eef-80b7-fb7c055d5c4d)

## Related Issue
Feature request : Regarding the footer links order in Learn Section #10171 

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
