### PR TITLE
fix: inappropriate "mev" examples

### DIFF
--- a/src/content/developers/docs/mev/index.md
+++ b/src/content/developers/docs/mev/index.md
@@ -36,56 +36,6 @@ Rather than programming complex algorithms to detect profitable MEV opportunitie
 
 Flashbots is an independent project which extends execution clients with a service that allows searchers to submit MEV transactions to validators without revealing them to the public mempool. This prevents transactions from being frontrun by generalized frontrunners.
 
-## MEV examples {#mev-examples}
-
-MEV emerges on the blockchain in a few ways.
-
-### DEX arbitrage {#mev-examples-dex-arbitrage}
-
-[Decentralized exchange](/glossary/#dex) (DEX) arbitrage is the simplest and most well-known MEV opportunity. As a result, it is also the most competitive.
-
-It works like this: if two DEXes are offering a token at two different prices, someone can buy the token on the lower-priced DEX and sell it on the higher-priced DEX in a single, atomic transaction. Thanks to the mechanics of the blockchain, this is true, riskless arbitrage.
-
-[Here's an example](https://etherscan.io/tx/0x5e1657ef0e9be9bc72efefe59a2528d0d730d478cfc9e6cdd09af9f997bb3ef4) of a profitable arbitrage transaction where a searcher turned 1,000 ETH into 1,045 ETH by taking advantage of different pricing of the ETH/DAI pair on Uniswap vs. Sushiswap.
-
-### Liquidations {#mev-examples-liquidations}
-
-Lending protocol liquidations present another well-known MEV opportunity.
-
-Lending protocols like Maker and Aave require users to deposit some collateral (e.g. ETH). This deposited collateral is then used to then lend out to other users.
-
-Users can then borrow assets and tokens from others depending on what they need (e.g. you might borrow MKR if you want to vote in a MakerDAO governance proposal) up to a certain percentage of their deposited collateral. For example, if the borrowing amount is a maximum of 30%, a user who deposits 100 DAI into the protocol can borrow up to 30 DAI worth of another asset. The protocol determines the exact borrowing power percentage.
-
-As the value of a borrower's collateral fluctuates, so too does their borrowing power. If, due to market fluctuations, the value of borrowed assets exceeds say, 30% of the value of their collateral (again, the exact percentage is determined by the protocol), the protocol typically allows anyone to liquidate the collateral, instantly paying off the lenders (this is similar to how [margin calls](https://www.investopedia.com/terms/m/margincall.asp) work in traditional finance). If liquidated, the borrower usually has to pay a hefty liquidation fee, some of which goes to the liquidator — which is where the MEV opportunity comes in.
-
-Searchers compete to parse blockchain data as fast as possible to determine which borrowers can be liquidated and be the first to submit a liquidation transaction and collect the liquidation fee for themselves.
-
-### Sandwich trading {#mev-examples-sandwich-trading}
-
-Sandwich trading is another common method of MEV extraction.
-
-To sandwich, a searcher will watch the mempool for large DEX trades. For instance, suppose someone wants to buy 10,000 UNI with DAI on Uniswap. A trade of this magnitude will have a meaningful effect on the UNI/DAI pair, potentially significantly raising the price of UNI relative to DAI.
-
-A searcher can calculate the approximate price effect of this large trade on the UNI/DAI pair and execute an optimal buy order immediately _before_ the large trade, buying UNI cheaply, then execute a sell order immediately _after_ the large trade, selling it for the higher price caused by the large order.
-
-Sandwiching, however, is riskier as it isn't atomic (unlike DEX arbitrage, as described above) and is prone to a [salmonella attack](https://github.com/Defi-Cartel/salmonella).
-
-### NFT MEV {#mev-examples-nfts}
-
-MEV in the NFT space is an emergent phenomenon, and isn't necessarily profitable.
-
-However, since NFT transactions happen on the same blockchain shared by all other Ethereum transactions, searchers can use similar techniques as those used in traditional MEV opportunities in the NFT market too.
-
-For example, if there's a popular NFT drop and a searcher wants a certain NFT or set of NFTs, they can program a transaction such that they are the first in line to buy the NFT, or they can buy the entire set of NFTs in a single transaction. Or if an NFT is [mistakenly listed at a low price](https://www.theblockcrypto.com/post/113546/mistake-sees-69000-cryptopunk-sold-for-less-than-a-cent), a searcher can frontrun other purchasers and snap it up for cheap.
-
-One prominent example of NFT MEV occurred when a searcher spent $7 million to [buy](https://etherscan.io/address/0x650dCdEB6ecF05aE3CAF30A70966E2F395d5E9E5) every single Cryptopunk at the price floor. A blockchain researcher [explained on Twitter](https://twitter.com/IvanBogatyy/status/1422232184493121538) how the buyer worked with an MEV provider to keep their purchase secret.
-
-### The long tail {#mev-examples-long-tail}
-
-DEX arbitrage, liquidations, and sandwich trading are all very well-known MEV opportunities and are unlikely to be profitable for new searchers. However, there is a long tail of lesser known MEV opportunities (NFT MEV is arguably one such opportunity).
-
-Searchers who are just getting started may be able to find more success by searching for MEV in this longer tail. Flashbot's [MEV job board](https://github.com/flashbots/mev-job-board) lists some emerging opportunities.
-
 ## Effects of MEV {#effects-of-mev}
 
 MEV is not all bad — there are both positive and negative consequences to MEV on Ethereum.


### PR DESCRIPTION
Currently, a page on [ethereum.org](https://ethereum.org/en/developers/docs/mev/) defines MEV with an example of [Sandwhich Attack](https://ethereum.org/en/developers/docs/mev/#mev-examples-sandwich-trading). 

However, the included mentions and examples were nothing more than a state of having "potential profitability". By this logic, buying and selling any ERC20 should be on this list however, of course, that is not an example of genuine "MEV".

## Description

The original author of this section provided examples that are defined based on "running a transaction faster" and "finding money others didn't" rather than any level of miner inclusion or nuance and it is resulting in a significant amount of people believing that a sandwich attack is "MEV".

The term has been misappropriated to mean atomic instances of profit, which is not what MEV is. This PR removes the inclusion of the naive MEV examples to prevent further misdefinition and misunderstanding of what MEV is. The fact that Toxic Flow is not even included in this section is a visual display that things were fundamentally misunderstood at the time of writing.

There is potentially a discussion to be had about correcting the "definition" of MEV to reflect once again "miner extractable value" as it only recently took on the definition of "maximal" due to the lacking context and knowledge of those proposing and using the term.

The entire MEV page is currently baked with an immense set of inaccuracies not addressed in this PR.

> Is worth acknowledging that this misdefinition and misrepresentation does not only take place here but also in places like Chainlink marketing articles. This has become an ecosystem-wide misdefinition and misrepresentation, and addressing it here first would be wise.