### PR TITLE
add missing link in footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -123,6 +123,10 @@ const Footer: React.FC<IProps> = () => {
           to: "/web3/",
         },
         {
+          text: t("Smart contracts"),
+          to: "/smart-contracts/",
+        },
+        {
           text: t("energy-consumption"),
           to: "/energy-consumption/",
         },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Links from Learn section in the `footer` follow the same links and same order from Learn menu in Navbar, but the Smart Contracts link is missing from the `footer` list.

## Related Issue
#10201

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
