### PR TITLE
Spike: refactor ExpandableCard to work with md translations

### DIFF
--- a/src/components/ExpandableCard.tsx
+++ b/src/components/ExpandableCard.tsx
@@ -1,11 +1,5 @@
 // Libraries
-import React, { ComponentType, ReactNode, SVGProps, useState } from "react"
-
-// Components
-import Translation from "./Translation"
-
-// Utils
-import { trackCustomEvent } from "../utils/matomo"
+import React, { ReactNode } from "react"
 import {
   Accordion,
   AccordionButton,
@@ -15,13 +9,17 @@ import {
   Heading,
   Icon,
   Text,
+  useAccordionItemState,
 } from "@chakra-ui/react"
+
+// Components
+import Translation from "./Translation"
+
+// Utils
+import { trackCustomEvent } from "../utils/matomo"
 
 export interface IProps {
   children?: React.ReactNode
-  contentPreview?: ReactNode
-  title: ReactNode
-  svg?: typeof Icon
   eventAction?: string
   eventCategory?: string
   eventName?: string
@@ -29,20 +27,18 @@ export interface IProps {
 
 const ExpandableCard: React.FC<IProps> = ({
   children,
-  contentPreview,
-  title,
-  svg: Svg,
   eventAction = "Clicked",
   eventCategory = "",
   eventName = "",
 }) => {
-  const [isVisible, setIsVisible] = useState(false)
   const matomo = {
     eventAction,
     eventCategory: `ExpandableCard${eventCategory}`,
     eventName,
   }
-  const onClick = () => {
+
+  const onChange = (expandedIndex: number) => {
+    const isExpanded = expandedIndex === 0
     // Card will not collapse if clicking on a link or selecting text
     if (
       window.getSelection()?.toString().length === 0 &&
@@ -50,13 +46,14 @@ const ExpandableCard: React.FC<IProps> = ({
         "ExternalLink"
       )
     ) {
-      !isVisible && trackCustomEvent(matomo)
-      setIsVisible(!isVisible)
+      isExpanded && trackCustomEvent(matomo)
     }
   }
 
   return (
     <Accordion
+      allowToggle
+      onChange={onChange}
       border="1px solid"
       borderColor="border"
       borderRadius="sm"
@@ -68,83 +65,101 @@ const ExpandableCard: React.FC<IProps> = ({
         backgroundColor: "ednBackground",
       }}
       borderBottomWidth="0"
-      index={isVisible ? [0] : []}
     >
       <AccordionItem borderTopWidth="0" flex="1">
-        <Heading as="h3" m={0}>
-          <AccordionButton
-            width="100%"
-            p={6}
-            flex="1"
-            onClick={onClick}
-            _hover={{
-              backgroundColor: "ednBackground",
-            }}
-          >
-            <Box
-              display="flex"
-              width="100%"
-              alignItems="center"
-              flexDir={{ base: "column", sm: "row" }}
-              textAlign="start"
-            >
-              <Box
-                marginBottom={{ base: 2, sm: 0 }}
-                marginRight={{ base: 0, sm: 4 }}
-              >
-                <Box
-                  display="flex"
-                  alignItems="center"
-                  sx={{
-                    svg: { marginRight: "1.5rem" },
-                  }}
-                  my="4"
-                >
-                  {!!Svg && <Svg />}
-                  <Text fontSize="xl" fontWeight="semibold" flex="1" m="0">
-                    {title}
-                  </Text>
-                </Box>
-                <Text
-                  fontSize="sm"
-                  color="text200"
-                  marginBottom="0"
-                  width="fit-content"
-                >
-                  {contentPreview}
-                </Text>
-              </Box>
-              <Text
-                fontSize="md"
-                color="primary"
-                ml={{ base: undefined, sm: "auto" }}
-                mt="auto"
-                mb="auto"
-              >
-                <Translation id={isVisible ? "less" : "more"} />
-              </Text>
-            </Box>
-          </AccordionButton>
-        </Heading>
-        <AccordionPanel
-          paddingX="6"
-          paddingBottom="6"
-          paddingTop="0"
-          onClick={onClick}
-        >
-          <Box
-            fontSize="md"
-            color="text"
-            paddingTop="6"
-            borderTop="1px solid"
-            borderColor="border"
-          >
-            {children}
-          </Box>
-        </AccordionPanel>
+        {children}
       </AccordionItem>
     </Accordion>
   )
 }
+
+export interface IPreviewProps {
+  children?: React.ReactNode
+  title: ReactNode
+  svg?: typeof Icon
+}
+
+export const ExpandableCardPreview = ({
+  children,
+  title,
+  svg: Svg,
+}: IPreviewProps) => {
+  const { isOpen } = useAccordionItemState()
+
+  return (
+    <Heading as="h3" m={0}>
+      <AccordionButton
+        width="100%"
+        p={6}
+        flex="1"
+        _hover={{
+          backgroundColor: "ednBackground",
+        }}
+      >
+        <Box
+          display="flex"
+          width="100%"
+          alignItems="center"
+          flexDir={{ base: "column", sm: "row" }}
+          textAlign="start"
+        >
+          <Box
+            marginBottom={{ base: 2, sm: 0 }}
+            marginRight={{ base: 0, sm: 4 }}
+          >
+            <Box
+              display="flex"
+              alignItems="center"
+              sx={{
+                svg: { marginRight: "1.5rem" },
+              }}
+              my="4"
+            >
+              {!!Svg && <Svg />}
+              <Text fontSize="xl" fontWeight="semibold" flex="1" m="0">
+                {title}
+              </Text>
+            </Box>
+            <Text
+              fontSize="sm"
+              color="text200"
+              marginBottom="0"
+              width="fit-content"
+            >
+              {children}
+            </Text>
+          </Box>
+          <Text
+            fontSize="md"
+            color="primary"
+            ml={{ base: undefined, sm: "auto" }}
+            mt="auto"
+            mb="auto"
+          >
+            <Translation id={isOpen ? "less" : "more"} />
+          </Text>
+        </Box>
+      </AccordionButton>
+    </Heading>
+  )
+}
+
+export interface IContentProps {
+  children?: React.ReactNode
+}
+
+export const ExpandableCardContent = ({ children }: IContentProps) => (
+  <AccordionPanel px={6} pb={6} pt={0}>
+    <Box
+      fontSize="md"
+      color="text"
+      pt={6}
+      borderTop="1px solid"
+      borderColor="border"
+    >
+      {children}
+    </Box>
+  </AccordionPanel>
+)
 
 export default ExpandableCard

--- a/src/content/history/index.md
+++ b/src/content/history/index.md
@@ -9,13 +9,17 @@ sidebarDepth: 1
 
 A timeline of all the major milestones, forks, and updates to the Ethereum blockchain.
 
-<ExpandableCard title="What are forks?" contentPreview="Changes to the rules of the Ethereum protocol which often include planned technical upgrades.">
-
-Forks are when major technical upgrades or changes need to be made to the network – they typically stem from [Ethereum Improvement Proposals (EIPs)](/eips/) and change the "rules" of the protocol.
+<ExpandableCard>
+  <ExpandableCardPreview title="What are forks?">
+    Changes to the rules of the Ethereum protocol which often include planned technical upgrades.
+  </ExpandableCardPreview>
+  <ExpandableCardContent>
+  Forks are when major technical upgrades or changes need to be made to the network – they typically stem from [Ethereum Improvement Proposals (EIPs)](/eips/) and change the "rules" of the protocol.
 
 When upgrades are needed in traditional, centrally-controlled software, the company will just publish a new version for the end-user. Blockchains work differently because there is no central ownership. [Ethereum clients](/developers/docs/nodes-and-clients/) must update their software to implement the new fork rules. Plus block creators (miners in a proof-of-work world, validators in a proof-of-stake world) and nodes must create blocks and validate against the new rules. [More on consensus mechanisms](/developers/docs/consensus-mechanisms/)
 
 These rule changes may create a temporary split in the network. New blocks could be produced according to the new rules or the old ones. Forks are usually agreed upon ahead of time so that clients adopt the changes in unison and the fork with the upgrades becomes the main chain. However, in rare cases, disagreements over forks can cause the network to permanently split – most notably the creation of Ethereum Classic with the [DAO fork](#dao-fork).
+</ExpandableCardContent>
 </ExpandableCard>
 
 Skip straight to information about some of the particularly important past upgrades: [The Beacon Chain](/roadmap/beacon-chain/); [The Merge](/roadmap/merge/); and [EIP-1559](#london)

--- a/src/pages/bug-bounty.tsx
+++ b/src/pages/bug-bounty.tsx
@@ -22,7 +22,10 @@ import CardList from "../components/CardList"
 import Breadcrumbs from "../components/Breadcrumbs"
 import ButtonLink from "../components/ButtonLink"
 import PageMetadata from "../components/PageMetadata"
-import ExpandableCard from "../components/ExpandableCard"
+import ExpandableCard, {
+  ExpandableCardContent,
+  ExpandableCardPreview,
+} from "../components/ExpandableCard"
 import FeedbackCard from "../components/FeedbackCard"
 import { getImage } from "../utils/image"
 
@@ -777,95 +780,117 @@ const BugBountiesPage = ({
         </Center>
         <Faq>
           <LeftColumn>
-            <ExpandableCard
-              title={t("bug-bounty-faq-q1-title")}
-              contentPreview={t("bug-bounty-faq-q1-contentPreview")}
-            >
-              <Text>
-                <Translation id="bug-bounty-faq-q1-content-1" />
-              </Text>
-              <Text>
-                <Translation id="bug-bounty-faq-q1-content-2" />
-              </Text>
-              <Text>
-                <Translation id="bug-bounty-faq-q1-content-3" />
-              </Text>
-              <Text>
-                <Translation id="bug-bounty-faq-q1-content-4" />
-              </Text>
-              <Text>
-                <Translation id="bug-bounty-faq-q1-content-5" />
-              </Text>
-              <Text>
-                <Translation id="bug-bounty-faq-q1-content-6" />
-              </Text>
-              <Text>
-                <Translation id="bug-bounty-faq-q1-content-7" />
-              </Text>
+            <ExpandableCard>
+              <ExpandableCardPreview title={t("bug-bounty-faq-q1-title")}>
+                <Translation id="bug-bounty-faq-q1-contentPreview" />
+              </ExpandableCardPreview>
+              <ExpandableCardContent>
+                <Text>
+                  <Translation id="bug-bounty-faq-q1-content-1" />
+                </Text>
+                <Text>
+                  <Translation id="bug-bounty-faq-q1-content-2" />
+                </Text>
+                <Text>
+                  <Translation id="bug-bounty-faq-q1-content-3" />
+                </Text>
+                <Text>
+                  <Translation id="bug-bounty-faq-q1-content-4" />
+                </Text>
+                <Text>
+                  <Translation id="bug-bounty-faq-q1-content-5" />
+                </Text>
+                <Text>
+                  <Translation id="bug-bounty-faq-q1-content-6" />
+                </Text>
+                <Text>
+                  <Translation id="bug-bounty-faq-q1-content-7" />
+                </Text>
+              </ExpandableCardContent>
             </ExpandableCard>
-            <ExpandableCard
-              title={t("bug-bounty-faq-q2-title")}
-              contentPreview={t("bug-bounty-faq-q2-contentPreview")}
-            >
-              <Text>
-                <Translation id="bug-bounty-faq-q2-content-1" />
-              </Text>
+
+            <ExpandableCard>
+              <ExpandableCardPreview title={t("bug-bounty-faq-q2-title")}>
+                <Translation id="bug-bounty-faq-q2-contentPreview" />
+              </ExpandableCardPreview>
+              <ExpandableCardContent>
+                <Text>
+                  <Translation id="bug-bounty-faq-q2-content-1" />
+                </Text>
+              </ExpandableCardContent>
             </ExpandableCard>
-            <ExpandableCard
-              title={t("bug-bounty-faq-q3-title")}
-              contentPreview={t("bug-bounty-faq-q3-contentPreview")}
-            >
-              <Text>
-                <Translation id="bug-bounty-faq-q3-content-1" />
-              </Text>
+
+            <ExpandableCard>
+              <ExpandableCardPreview title={t("bug-bounty-faq-q3-title")}>
+                <Translation id="bug-bounty-faq-q3-contentPreview" />
+              </ExpandableCardPreview>
+              <ExpandableCardContent>
+                <Text>
+                  <Translation id="bug-bounty-faq-q3-content-1" />
+                </Text>
+              </ExpandableCardContent>
             </ExpandableCard>
-            <ExpandableCard
-              title={t("bug-bounty-faq-q4-title")}
-              contentPreview={t("bug-bounty-faq-q4-contentPreview")}
-            >
-              <Text>
-                <Translation id="bug-bounty-faq-q4-content-1" />
-              </Text>
+
+            <ExpandableCard>
+              <ExpandableCardPreview title={t("bug-bounty-faq-q4-title")}>
+                <Translation id="bug-bounty-faq-q4-contentPreview" />
+              </ExpandableCardPreview>
+              <ExpandableCardContent>
+                <Text>
+                  <Translation id="bug-bounty-faq-q4-content-1" />
+                </Text>
+              </ExpandableCardContent>
             </ExpandableCard>
           </LeftColumn>
           <RightColumn>
-            <ExpandableCard
-              title={t("bug-bounty-faq-q5-title")}
-              contentPreview={t("bug-bounty-faq-q5-contentPreview")}
-            >
-              <Text>
-                <Translation id="bug-bounty-faq-q5-content-1" />
-              </Text>
+            <ExpandableCard>
+              <ExpandableCardPreview title={t("bug-bounty-faq-q5-title")}>
+                <Translation id="bug-bounty-faq-q5-contentPreview" />
+              </ExpandableCardPreview>
+              <ExpandableCardContent>
+                <Text>
+                  <Translation id="bug-bounty-faq-q5-content-1" />
+                </Text>
+              </ExpandableCardContent>
             </ExpandableCard>
-            <ExpandableCard
-              title={t("bug-bounty-faq-q6-title")}
-              contentPreview={t("bug-bounty-faq-q6-contentPreview")}
-            >
-              <Text>
-                <Translation id="bug-bounty-faq-q6-content-1" />
-              </Text>
-              <Text>
-                <Translation id="bug-bounty-faq-q6-content-2" />
-              </Text>
+
+            <ExpandableCard>
+              <ExpandableCardPreview title={t("bug-bounty-faq-q6-title")}>
+                <Translation id="bug-bounty-faq-q6-contentPreview" />
+              </ExpandableCardPreview>
+              <ExpandableCardContent>
+                <Text>
+                  <Translation id="bug-bounty-faq-q6-content-1" />
+                </Text>
+                <Text>
+                  <Translation id="bug-bounty-faq-q6-content-2" />
+                </Text>
+              </ExpandableCardContent>
             </ExpandableCard>
-            <ExpandableCard
-              title={t("bug-bounty-faq-q7-title")}
-              contentPreview={t("bug-bounty-faq-q7-contentPreview")}
-            >
-              <Text>
-                <Translation id="bug-bounty-faq-q7-content-1" />
-              </Text>
+
+            <ExpandableCard>
+              <ExpandableCardPreview title={t("bug-bounty-faq-q7-title")}>
+                <Translation id="bug-bounty-faq-q7-contentPreview" />
+              </ExpandableCardPreview>
+              <ExpandableCardContent>
+                <Text>
+                  <Translation id="bug-bounty-faq-q7-content-1" />
+                </Text>
+              </ExpandableCardContent>
             </ExpandableCard>
-            <ExpandableCard
-              title={t("bug-bounty-faq-q8-title")}
-              contentPreview={t("bug-bounty-faq-q8-contentPreview")}
-            >
-              <Text>
-                <Translation id="bug-bounty-faq-q8-content-1" />
-              </Text>
-              <Link to="https://ethereum.org/security_at_ethereum.org.asc">
-                <Translation id="bug-bounty-faq-q8-PGP-key" />
-              </Link>
+
+            <ExpandableCard>
+              <ExpandableCardPreview title={t("bug-bounty-faq-q8-title")}>
+                <Translation id="bug-bounty-faq-q8-contentPreview" />
+              </ExpandableCardPreview>
+              <ExpandableCardContent>
+                <Text>
+                  <Translation id="bug-bounty-faq-q8-content-1" />
+                </Text>
+                <Link to="https://ethereum.org/security_at_ethereum.org.asc">
+                  <Translation id="bug-bounty-faq-q8-PGP-key" />
+                </Link>
+              </ExpandableCardContent>
             </ExpandableCard>
           </RightColumn>
         </Faq>

--- a/src/templates/static.tsx
+++ b/src/templates/static.tsx
@@ -27,7 +27,10 @@ import Logo from "../components/Logo"
 import MeetupList from "../components/MeetupList"
 import PageMetadata from "../components/PageMetadata"
 import RandomAppList from "../components/RandomAppList"
-import ExpandableCard from "../components/ExpandableCard"
+import ExpandableCard, {
+  ExpandableCardPreview,
+  ExpandableCardContent,
+} from "../components/ExpandableCard"
 import TableOfContents from "../components/TableOfContents"
 import Translation from "../components/Translation"
 import SectionNav from "../components/SectionNav"
@@ -194,6 +197,8 @@ const components = {
   Emoji,
   DocLink,
   ExpandableCard,
+  ExpandableCardPreview,
+  ExpandableCardContent,
   CardContainer,
   GhostCard,
   UpcomingEventsList,


### PR DESCRIPTION
**DO NOT MERGE**

----

Currently, the custom attrs that are set in a react component, do not show up in Crowdin for translations.

For example,
```tsx
// https://github.com/ethereum/ethereum-org-website/blob/dev/src/content/history/index.md
<ExpandableCard title="title" contentPreview="preview content">
  ...content
</ExpandableCard>
```
The attr `contentPreview` can't be translated in Crowdin.

## Description

Adds a refactor to the `ExpandableCard` to accept the preview content as a child component.

```tsx
// new proposal: removes the `contentPreview` attr
<ExpandableCard>
  <ExpandableCardPreview title="title">
    preview content
  </ExpandableCardPreview>

  <ExpandableCardContent>
    content
  </ExpandableCardContent>
</ExpandableCard>
```

You can see these changes on:
- A react page (/bug-bounty): https://ethereumorgwebsitedev01-expandablecardintl.gatsbyjs.io/en/bug-bounty/
- A md page (/history): https://ethereumorgwebsitedev01-expandablecardintl.gatsbyjs.io/en/history/

**Note:** if this test is accepted, the new structure for `ExpandableCard` will be applied to the rest of the codebase.
