### PR TITLE
Chromatic job - change event for the workflow

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -5,11 +5,7 @@ name: Chromatic Publish and Testing
 
 # Event for the workflow
 on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - ready_for_review
+  push:
     paths:
       # Only run on file changes in any of these paths
       - "src/components/**/*"


### PR DESCRIPTION
Recently we have experienced weird scenarios where the UI Review for Chromatic is not triggered correctly on [some PRs](https://github.com/ethereum/ethereum-org-website/pull/10131).

## Description

Based on the [Chromatic docs](https://www.chromatic.com/docs/github-actions#recommended-configuration-for-build-events), they recommend using the `push` event on builds instead of `pull-request` (the one we are using atm).

The idea is to test how things go from now on with this change. If we face similar issues again, we will get in contact with the Chromatic team to check if there is anything else we are doing wrong.