### PR TITLE
fix: Fixed padding in What is Ethereum section

### DIFF
--- a/src/components/BannerGrid/index.tsx
+++ b/src/components/BannerGrid/index.tsx
@@ -67,7 +67,7 @@ export const BannerGridCell: React.FC<Props> = ({ children }) => {
 
   return (
     <Flex
-      px={12}
+      px={{ base: 0, md: 12 }}
       py={8}
       direction="column"
       borderTop="1px solid"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed padding for smaller screens

<img width="241" alt="image" src="https://github.com/ethereum/ethereum-org-website/assets/57575219/f4df55a7-c08c-46da-bf25-d6889f0934a7">

## Related Issue
Fixes #10217 

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
