### PR TITLE
Update index.md

### DIFF
--- a/src/content/developers/tutorials/uniswap-v2-annotated-code/index.md
+++ b/src/content/developers/tutorials/uniswap-v2-annotated-code/index.md
@@ -1816,14 +1816,14 @@ This function returns the reserves of the two tokens that the pair exchange has.
     }
 ```
 
-This function gives you the amount of token B you'll get in return for token A if there is no fee involved. This calculation takes into account that the transfer changes the exchange rate.
+This function returns the number of tokens B that need to be added to add token A, while keeping the price the same. It is used when adding liquidity.
 
 ```solidity
     // given an input amount of an asset and pair reserves, returns the maximum output amount of the other asset
     function getAmountOut(uint amountIn, uint reserveIn, uint reserveOut) internal pure returns (uint amountOut) {
 ```
 
-The `quote` function above works great if there is no fee to use the pair exchange. However, if there is a 0.3% exchange fee the amount you actually get is lower. This function calculates the amount after the exchange fee.
+This function returns the number of tokens redeemed, while keeping the liquidity constant. This function calculates the amount after the exchange fee.
 
 ```solidity
 


### PR DESCRIPTION
The original description of quote and getAmountOut was wrong. The difference between the two is not whether the transaction fee is considered or not. quote function considers the price to remain constant, while getAmountOut function considers the liquidity to remain constant, the scenarios and mathematical formulas based on which they are used are different.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
