### PR TITLE
isLangRightToLeft function not using language config setting

### DIFF
--- a/src/utils/translations.ts
+++ b/src/utils/translations.ts
@@ -1,10 +1,15 @@
 import type { Lang } from "./languages"
 import type { Direction } from "../types"
 
+import i18nConfigs from "../../i18n/config.json"
+
 export type TranslationKey = string
 
 export const isLangRightToLeft = (lang: Lang): boolean => {
-  return lang === "ar" || lang === "fa"
+  const langConfig = i18nConfigs.filter(
+    (language) => language.hrefLang === lang
+  )
+  return langConfig[0].langDir === "rtl"
 }
 
 export const getDirection = (lang?: Lang): Direction => {

--- a/src/utils/translations.ts
+++ b/src/utils/translations.ts
@@ -7,7 +7,7 @@ export type TranslationKey = string
 
 export const isLangRightToLeft = (lang: Lang): boolean => {
   const langConfig = i18nConfigs.filter(
-    (language) => language.hrefLang === lang
+    (language) => language.code === lang
   )
   return langConfig[0].langDir === "rtl"
 }

--- a/src/utils/translations.ts
+++ b/src/utils/translations.ts
@@ -6,9 +6,11 @@ import i18nConfigs from "../../i18n/config.json"
 export type TranslationKey = string
 
 export const isLangRightToLeft = (lang: Lang): boolean => {
-  const langConfig = i18nConfigs.filter(
-    (language) => language.code === lang
-  )
+  const langConfig = i18nConfigs.filter((language) => language.code === lang)
+
+  if (!langConfig.length)
+    throw new Error("Language code not found in isLangRightToLeft")
+
   return langConfig[0].langDir === "rtl"
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Fixes the `isLangRightToLeft` function to use a languages config for lang direction instead of being hardcoded values for langauges.

## Related Issue
Fixes https://github.com/ethereum/ethereum-org-website/issues/10258
