### PR TITLE
Add docsearch:description meta tag

### DIFF
--- a/src/components/PageMetadata.tsx
+++ b/src/components/PageMetadata.tsx
@@ -200,6 +200,10 @@ const PageMetadata: React.FC<IProps> = ({
           property: `og:site_name`,
           content: `ethereum.org`,
         },
+        {
+          name: `docsearch:description`,
+          content: desc,
+        },
       ].concat(meta)}
     >
       <script type="application/ld+json">


### PR DESCRIPTION
## Description
- Adds a `meta` tag for `docsearch:description` to gain access to the current metadata description for each page via Algolia DocSearch
- About: https://docsearch.algolia.com/docs/required-configuration/#introduce-global-information-as-meta-tags