### PR TITLE
Revert "Chromatic job - change event for the workflow"

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -5,7 +5,11 @@ name: Chromatic Publish and Testing
 
 # Event for the workflow
 on:
-  push:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - ready_for_review
     paths:
       # Only run on file changes in any of these paths
       - "src/components/**/*"


### PR DESCRIPTION
Reverts ethereum/ethereum-org-website#10224

The `push` event change didn't work as expected. PRs coming from forked repos are not triggering the chromatic workflow. Its only being triggered by local branches.