### PR TITLE
chore: update example network IDs

### DIFF
--- a/src/content/developers/docs/apis/json-rpc/index.md
+++ b/src/content/developers/docs/apis/json-rpc/index.md
@@ -202,11 +202,10 @@ None
 `String` - The current network id.
 
 The full list of current network IDs is available at [chainlist.org](https://chainlist.org). Some common ones are:
-`1`: Ethereum Mainnet
-`2`: Morden testnet (now deprecated)
-`3`: Ropsten testnet
-`4`: Rinkeby testnet
-`5`: Goerli testnet
+
+- `1`: Ethereum Mainnet
+- `5`: Goerli testnet
+- `11155111`: Sepolia testnet
 
 **Example**
 


### PR DESCRIPTION
## Description

Currently, [the `net_version` return example paragraph](https://ethereum.org/en/developers/docs/apis/json-rpc/#net_version) reads like this:

![image](https://github.com/ethereum/ethereum-org-website/assets/29699850/a1883f22-57dc-4e3c-b5b0-349036d97cd4)

This PR makes 2 updates to this paragraph:
- Removes [deprecated testnets](https://blog.ethereum.org/2022/06/21/testnet-deprecation) and adds Sepolia as an example
- Updates the list into a bulleted list for easier readability