### PR TITLE
Staking page StakingHierarchy safari

### DIFF
--- a/src/components/Staking/StakingHierarchy.tsx
+++ b/src/components/Staking/StakingHierarchy.tsx
@@ -144,7 +144,6 @@ const Line = () => {
       as="aside"
       gridColumn={1}
       gridRow="1 / 3"
-      boxSize="100%"
       position="relative"
       hideBelow={medBp}
       _after={{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Remove boxSize causing overflow and offset bug on Safari

## Related Issue
Fixes https://github.com/ethereum/ethereum-org-website/issues/10274
