### PR TITLE
Handle SVGs / PNGs in Crowdin import script

### DIFF
--- a/src/scripts/crowdin-import.ts
+++ b/src/scripts/crowdin-import.ts
@@ -50,7 +50,7 @@ const USER_SELECTION: UserSelectionObject = {
   es: [],
   fa: [],
   fi: [],
-  fr: [1, 2, 3, 4, 5, 7],
+  fr: [],
   gl: [],
   gu: [],
   hi: [],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- We recently added SVG files to Crowdin.
- When pulling in the updates from Crowdin, the script was trying to open the SVG files as if they were folders and erroring out.
- This PR adds a check for other file types (SVGs/PNGs) to the `scrapeDirectory` function
