### PR TITLE
remove deprecated or non existent faucets for L2

### DIFF
--- a/src/content/developers/docs/networks/index.md
+++ b/src/content/developers/docs/networks/index.md
@@ -92,7 +92,7 @@ Goerli is testnet for testing of validating and staking. The Goerli network is o
 
 To launch a Validator on Goerli testnet, use ethstaker's ["cheap goerli validator" launchpad](https://goerli.launchpad.ethstaker.cc/en/).
 
-#### Rinkeby _(long-term support)_ {#rinkeby}
+#### Rinkeby _(deprecated)_ {#rinkeby}
 
 _Note: [the Rinkeby testnet is deprecated](https://blog.ethereum.org/2022/11/30/ropsten-shutdown-announcement) and will no longer receive protocol upgrades. Please consider migrating your applications to Sepolia._
 
@@ -115,9 +115,7 @@ A testnet for [Arbitrum](https://arbitrum.io/).
 
 ##### Faucets
 
-- [FaucETH](https://fauceth.komputing.org) (multi-Chain faucet without the need for social account)
 - [Chainlink faucet](https://faucets.chain.link/)
-- [Paradigm faucet](https://faucet.paradigm.xyz/)
 
 #### Optimistic Goerli {#optimistic-goerli}
 
@@ -125,7 +123,6 @@ A testnet for [Optimism](https://www.optimism.io/).
 
 ##### Faucets
 
-- [FaucETH](https://fauceth.komputing.org) (multi-Chain faucet without the need for social account)
 - [Paradigm faucet](https://faucet.paradigm.xyz/)
 - [Coinbase Wallet Faucet | Optimism Goerli](https://coinbase.com/faucets/optimism-goerli-faucet)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Remove deprecated faucets for layer 2 testnets
