### PR TITLE
Update Hello World Smart Contract tutorial to use Sepoila testnet

### DIFF
--- a/src/content/developers/tutorials/hello-world-smart-contract/index.md
+++ b/src/content/developers/tutorials/hello-world-smart-contract/index.md
@@ -16,7 +16,7 @@ If you are new to blockchain development and don’t know where to start, or if 
 > 
 > For the entirety of this guide, the Goerli test network is being used for creating and deploying a smart contract. However, please note that the Ethereum Foundation has announced that [Goerli will soon be deprecated](https://www.alchemy.com/blog/goerli-faucet-deprecation).
 > 
-> We therefore recommend you to use the [Sepolia](https://www.alchemy.com/overviews/sepolia-testnet) testnet as Alchemy has full Sepolia support and a free [Sepolia faucet](https://sepoliafaucet.com/) also.
+> We recommend you to use the [Sepolia](https://www.alchemy.com/overviews/sepolia-testnet) and [Sepolia faucet](https://sepoliafaucet.com/) for this tutorial.
 
 In [part 2](https://docs.alchemy.com/docs/interacting-with-a-smart-contract) of this tutorial we’ll go through how we can interact with our smart contract once it’s deployed here, and in [part 3](https://docs.alchemy.com/docs/submitting-your-smart-contract-to-etherscan) we’ll cover how to publish it on Etherscan.
 

--- a/src/content/developers/tutorials/hello-world-smart-contract/index.md
+++ b/src/content/developers/tutorials/hello-world-smart-contract/index.md
@@ -10,6 +10,14 @@ published: 2021-03-31
 
 If you are new to blockchain development and don’t know where to start, or if you just want to understand how to deploy and interact with smart contracts, this guide is for you. We will walk through creating and deploying a simple smart contract on the Goerli test network using a virtual wallet [MetaMask](https://metamask.io/), [Solidity](https://docs.soliditylang.org/en/v0.8.0/), [Hardhat](https://hardhat.org/), and [Alchemy](https://alchemyapi.io/eth) (don’t worry if you don’t understand what any of this means yet, we will explain it).
 
+> **Warning**
+> 
+> 🚧 Deprecation Notice
+> 
+> For the entirety of this guide, the Goerli test network is being used for creating and deploying a smart contract. However, please note that the Ethereum Foundation has announced that [Goerli will soon be deprecated](https://www.alchemy.com/blog/goerli-faucet-deprecation).
+> 
+> We therefore recommend you to use the [Sepolia](https://www.alchemy.com/overviews/sepolia-testnet) testnet as Alchemy has full Sepolia support and a free [Sepolia faucet](https://sepoliafaucet.com/) also.
+
 In [part 2](https://docs.alchemy.com/docs/interacting-with-a-smart-contract) of this tutorial we’ll go through how we can interact with our smart contract once it’s deployed here, and in [part 3](https://docs.alchemy.com/docs/submitting-your-smart-contract-to-etherscan) we’ll cover how to publish it on Etherscan.
 
 If you have questions at any point feel free to reach out in the [Alchemy Discord](https://discord.gg/gWuC7zB)!


### PR DESCRIPTION
Hello Ethereum team, I'm Opemipo and I work at Alchemy and because of the updating Goerli deprecation, you are adding Sepolia b/c we want to make sure that developers reading these tutorials (originally uploaded by Alchemy) have the latest, best tools to build with.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

I added a Deprecation notice about Goerli and suggested Sepolia as the most recommended test network to work with. I did not change Goerli in the body of the guide, it's up to the developers to do that since I made a recommendation about using Sepolia.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
