### PR TITLE
Upgrade staking data for Atlas upgrade

### DIFF
--- a/src/data/staking-products.json
+++ b/src/data/staking-products.json
@@ -8,21 +8,39 @@
       "url": "https://rocketpool.net/node-operators",
       "audits": [
         {
-          "name": "Sigma Prime",
+          "name": "Sigma Prime - May 2021",
           "url": "https://rocketpool.net/files/sigma-prime-audit.pdf"
         },
         {
-          "name": "Consensys Diligence",
+          "name": "Sigma Prime - Nov 2021",
+          "url": "https://rocketpool.net/files/sigma-prime-fix-review.pdf"
+        },
+        {
+          "name": "Sigma Prime - Redstone, June 2022",
+          "url": "https://rocketpool.net/files/sigma-prime-audit-redstone.pdf"
+        },
+        {
+          "name": "Sigma Prime - Atlas, Dec 2022",
+          "url": "https://rocketpool.net/files/sigma-prime-atlas-v1.2.pdf"
+        },
+        {
+          "name": "Consensys Diligence - 2021",
           "url": "https://consensys.net/diligence/audits/2021/04/rocketpool/"
         },
         {
-          "name": "Trail of Bits",
+          "name": "Consensys Diligence - Redstone, June 2022",
+          "url": "https://rocketpool.net/files/consensys-audit-redstone.pdf"
+        },
+        {
+          "name": "Consensys Diligence - Atlas, Jan 2023",
+          "url": "https://rocketpool.net/files/consensys-diligence-atlas-v1.2.pdf"
+        },
+        {
+          "name": "Trail of Bits - Sept 2021",
           "url": "https://github.com/trailofbits/publications/blob/master/reviews/RocketPool.pdf"
         }
       ],
-      "minEth": 16,
-      "additionalStake": "10",
-      "additionalStakeUnit": "% RPL",
+      "minEth": 10.4,
       "tokens": [
         {
           "name": "Rocket Pool ETH",
@@ -88,7 +106,7 @@
       "launchDate": "2020-12-01",
       "url": "https://dappnode.io",
       "audits": [],
-      "minEth": 32,
+      "minEth": 10.4,
       "isFoss": true,
       "hasBugBounty": false,
       "isTrustless": true,
@@ -198,9 +216,7 @@
       "launchDate": "2018-12-01",
       "url": "https://ava.do/",
       "audits": [],
-      "minEth": 16,
-      "additionalStake": "10",
-      "additionalStakeUnit": "% RPL",
+      "minEth": 10.4,
       "isFoss": true,
       "hasBugBounty": false,
       "isTrustless": true,
@@ -287,9 +303,6 @@
       "launchDate": "2018-12-01",
       "url": "https://ava.do/",
       "audits": [],
-      "minEth": 16,
-      "additionalStake": "10",
-      "additionalStakeUnit": "% RPL",
       "isFoss": true,
       "hasBugBounty": false,
       "isTrustless": true,

--- a/src/data/staking-products.json
+++ b/src/data/staking-products.json
@@ -560,15 +560,35 @@
       "url": "https://rocketpool.net/",
       "audits": [
         {
-          "name": "Sigma Prime",
+          "name": "Sigma Prime - May 2021",
           "url": "https://rocketpool.net/files/sigma-prime-audit.pdf"
         },
         {
-          "name": "Consensys Diligence",
+          "name": "Sigma Prime - Nov 2021",
+          "url": "https://rocketpool.net/files/sigma-prime-fix-review.pdf"
+        },
+        {
+          "name": "Sigma Prime - Redstone, June 2022",
+          "url": "https://rocketpool.net/files/sigma-prime-audit-redstone.pdf"
+        },
+        {
+          "name": "Sigma Prime - Atlas, Dec 2022",
+          "url": "https://rocketpool.net/files/sigma-prime-atlas-v1.2.pdf"
+        },
+        {
+          "name": "Consensys Diligence - 2021",
           "url": "https://consensys.net/diligence/audits/2021/04/rocketpool/"
         },
         {
-          "name": "Trail of Bits",
+          "name": "Consensys Diligence - Redstone, June 2022",
+          "url": "https://rocketpool.net/files/consensys-audit-redstone.pdf"
+        },
+        {
+          "name": "Consensys Diligence - Atlas, Jan 2023",
+          "url": "https://rocketpool.net/files/consensys-diligence-atlas-v1.2.pdf"
+        },
+        {
+          "name": "Trail of Bits - Sept 2021",
           "url": "https://github.com/trailofbits/publications/blob/master/reviews/RocketPool.pdf"
         }
       ],


### PR DESCRIPTION
## Description
Rocket Pool recently underwent the Atlas upgrade bringing the minimum stake (for a node operator) from 16 ETH + 10% in RPL (17.6 ETH min), to 8 ETH + 30% in RPL (10.4 ETH min). DAppNode has also released the ability to use Rocket Pool in their UI, similar to Avado.

- Updates the Rocket Pool audit information since Atlas
- Updates the min ETH required to 10.4 (8 ETH + 2.4 ETH worth of RPL for collateral) for Rocket Pool CLI node tool
- Updates min ETH required to the same for Avado and DAppNode, both of which offer a GUI for the Rocket Pool stack