### PR TITLE
Remove errored values from fee calculation

### DIFF
--- a/src/pages/layer-2.tsx
+++ b/src/pages/layer-2.tsx
@@ -171,7 +171,11 @@ interface L2DataResponse {
 }
 
 interface FeeDataResponse {
-  data: Array<{ id: string; results: { feeTransferEth: number } }>
+  data: Array<{
+    id: string
+    results: { feeTransferEth: number }
+    errors?: { [key: string]: string }
+  }>
 }
 
 const Layer2Page = ({ data }: PageProps<Queries.Layer2PageQuery>) => {
@@ -229,7 +233,9 @@ const Layer2Page = ({ data }: PageProps<Queries.Layer2PageQuery>) => {
         )
 
         // filtering out L2's we arent listing
-        const feeData = feeDataResponse.data.filter((l2) => l2.id !== "hermez")
+        const feeData = feeDataResponse.data.filter(
+          (l2) => l2.id !== "hermez" && !l2.errors
+        )
 
         const feeAverage =
           feeData.reduce(


### PR DESCRIPTION
## Description
- Filters out L2 API results that come with an error—avoids using these values as "$0 fees" in the calculation

Note, this calculation still has issues with equal weighting of the networks (as opposed to weighting by TVL or tx volume), and the API results are only giving values for a few of the less utilized networks, which leads to a fairly misleading and inaccurate result here.

This PR simply patches the fact that `null` values were being included as "$0 fees", but does not address the other issues. As an alternative to this patch, I would also not be against removal of this metric until a more suitable API is investigated.

## Related Issue
From Discord