### PR TITLE
Fix typo in gasper developer docs

### DIFF
--- a/src/content/developers/docs/consensus-mechanisms/pos/gasper/index.md
+++ b/src/content/developers/docs/consensus-mechanisms/pos/gasper/index.md
@@ -49,4 +49,4 @@ LMD-GHOST stands for "latest message-driven greedy heaviest observed sub-tree". 
 ## Further Reading {#further-reading}
 
 - [Gasper: Combining GHOST and Casper](https://arxiv.org/pdf/2003.03052.pdf)
-- [Capser the Friendly Finality Gadget](https://arxiv.org/pdf/1710.09437.pdf)
+- [Casper the Friendly Finality Gadget](https://arxiv.org/pdf/1710.09437.pdf)


### PR DESCRIPTION
Fixes typo in `developers/docs/consensus-mechanisms/pos/gasper/`