### PR TITLE
Represent Brussels on ethereum.org

### DIFF
--- a/src/data/community-events.json
+++ b/src/data/community-events.json
@@ -126,6 +126,15 @@
     "endDate": "2023-06-11"
   },
   {
+    "title": "ETHBrussels",
+    "to": "https://ethbrussels.com/",
+    "sponsor": null,
+    "location": "Brussels, Belgium",
+    "description": "ETHBrussels is a cozy hackathon in the capital of Europe. As part of the Brussels Blockchain Week, dozens of coders learn and devise local solutions on the Ethereum stack. Located in a coding school on top of the Brussels Central Station.",
+    "startDate": "2023-06-09",
+    "endDate": "2023-06-11"
+  },
+  {
     "title": "ETHGlobal Paris",
     "to": "https://ethglobal.com/events/paris2023",
     "sponsor": null,

--- a/src/data/community-meetups.json
+++ b/src/data/community-meetups.json
@@ -382,5 +382,11 @@
     "emoji": ":romania:",
     "location": "Timisoara",
     "link": "https://www.meetup.com/web3-timisoara/"
+  },
+  {
+    "title": "Crypto Wednesdays",
+    "emoji": ":belgium:",
+    "location": "Brussels",
+    "link": "https://dao.brussels/"
   }
 ]


### PR DESCRIPTION
Add ETHBrussels and the monthly Crypto Wednesdays (organized by DAO Brussels) to this page: https://ethereum.org/en/community/events/