### PR TITLE
Correct heading level on `eth_chainId`

### DIFF
--- a/src/content/developers/docs/apis/json-rpc/index.md
+++ b/src/content/developers/docs/apis/json-rpc/index.md
@@ -359,7 +359,7 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_coinbase","params":[],"id":6
 }
 ```
 
-## eth_chainId {#eth_chainId}
+### eth_chainId {#eth_chainId}
 
 Returns the chain ID used for signing replay-protected transactions.
 


### PR DESCRIPTION
I was seeing it rendered weirdly, and I found this mistake.

Here's what I was seeing:
Right side-bar:
![image](https://github.com/ethereum/ethereum-org-website/assets/7883777/9c74fa6b-9351-43ae-a44e-a5b7046249b8)
Body:
![image](https://github.com/ethereum/ethereum-org-website/assets/7883777/ebba8252-d7db-44bb-a70e-cff84ab0717a)

Furthermore, the link in the right side bar was doing nothing when I clicked it.

I was using Firefox 102.4.0esr (64-bit) on Debian Linux.