### PR TITLE
Fix Translation Banner appearing on English pages

### DIFF
--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -98,12 +98,15 @@ const checkIsPageOutdated = async (
 
   const joinedFilepath = filePath.join("-")
   const srcPath = path.resolve(`src/intl/${lang}/page-${joinedFilepath}.json`)
-  const englishPath = path.resolve(`src/intl/en/page-${joinedFilepath}.json`)
+  const englishPath = path.resolve(
+    `src/intl/${defaultLanguage}/page-${joinedFilepath}.json`
+  )
 
   // If no file exists, default to english
   if (!fs.existsSync(srcPath)) {
     return {
-      isOutdated: true,
+      // Consider always defaultLanguage paths as updated
+      isOutdated: lang !== defaultLanguage,
       isContentEnglish: true,
     }
   } else {


### PR DESCRIPTION
English pages should never display the Translation Banner as they are always updated.

## Description

Fixes the logic inside the `checkIsPageOutdated` function to always return English paths as updated.
