### PR TITLE
Fix possible negative connotation of 'bank run' in code example

### DIFF
--- a/src/intl/en/page-index.json
+++ b/src/intl/en/page-index.json
@@ -39,7 +39,7 @@
   "page-index-developers-button": "Developer portal",
   "page-index-developers-code-examples": "Code examples",
   "page-index-developers-code-example-title-0": "Your own bank",
-  "page-index-developers-code-example-description-0": "You can build a bank run by logic you've programmed.",
+  "page-index-developers-code-example-description-0": "You can build a bank powered by logic you've programmed.",
   "page-index-developers-code-example-title-1": "Your own currency",
   "page-index-developers-code-example-description-1": "You can create tokens that you can transfer and use across applications.",
   "page-index-developers-code-example-title-2": "A JavaScript Ethereum wallet",


### PR DESCRIPTION
The phrase 'bank run' appears on the homepage. Even though of form noun-verb, it could be misinterpreted as noun-noun with the negative connotations of a [bank run](https://en.wikipedia.org/wiki/Bank_run).

## Description

Replace 'You can build a bank run by logic you've programmed.' with 'You can build a bank powered by logic you've programmed.'

## Related Issue

#10369 
