### PR TITLE
Improve QuizSummary copy

### DIFF
--- a/src/components/Quiz/QuizSummary.tsx
+++ b/src/components/Quiz/QuizSummary.tsx
@@ -98,7 +98,7 @@ const QuizSummary: React.FC<IProps> = ({
           <Flex>
             <Text {...valueStyles}>{questionCount}</Text>
             <Text {...labelStyles}>
-              <Translation id="total" />
+              <Translation id="questions" />
             </Text>
           </Flex>
         )}

--- a/src/intl/en/learn-quizzes.json
+++ b/src/intl/en/learn-quizzes.json
@@ -23,7 +23,6 @@
   "start": "Start",
   "submit-answer": "Submit answer",
   "test-your-knowledge": "Test your Ethereum knowledge",
-  "total": "Total",
   "try-again": "Try again",
   "using-ethereum": "Using Ethereum",
   "using-ethereum-description": "Delve into the real-world applications of Ethereum and uncover how this revolutionary blockchain platform is reshaping industries. This is a great way to make sure you understand things well enough before you start using cryptocurrencies actively.",

--- a/src/intl/pt-br/learn-quizzes.json
+++ b/src/intl/pt-br/learn-quizzes.json
@@ -7,7 +7,6 @@
   "share-results": "Compartilhar resultados",
   "submit-answer": "Enviar a resposta",
   "test-your-knowledge": "Teste seus conhecimentos",
-  "total": "Total",
   "try-again": "Tente novamente",
   "a001-prompt": "A maior diferença entre Ethereum e Bitcoin é:",
   "a001-a-label": "O Ethereum não permite que você faça pagamentos para outras pessoas",

--- a/src/intl/zh/learn-quizzes.json
+++ b/src/intl/zh/learn-quizzes.json
@@ -7,7 +7,6 @@
   "share-results": "分享成绩",
   "submit-answer": "提交答案",
   "test-your-knowledge": "检验掌握的知识",
-  "total": "总计",
   "try-again": "重试",
   "a001-prompt": "以太坊和比特币之间最大的差异是：",
   "a001-a-label": "以太坊不允许用户向他人付款",


### PR DESCRIPTION
## Description

The current quiz summary is a little confusing, as it isn't entirely clear what 'Total' means.

![image](https://github.com/ethereum/ethereum-org-website/assets/62268199/f1219bc7-5d1c-4322-9078-1be3ad8d83ff)

- To make this clearer, we can switch 'Total' with 'Questions'.
- We already have a 'questions' string in the JSON file, so simply replaced the string and removed the unused JSON keys

## Related Issue
#10320
