### PR TITLE
Force /discord/ invite path links to full url

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -17,6 +17,7 @@ import { Lang } from "../utils/languages"
 import { trackCustomEvent, MatomoEventOptions } from "../utils/matomo"
 import * as url from "../utils/url"
 import { Direction } from "../types"
+import { SITE_URL, DISCORD_PATH } from "../constants"
 
 export interface IBaseProps {
   to?: string
@@ -63,8 +64,10 @@ const Link: React.FC<IProps> = ({
 
   // TODO: in the next PR we are going to deprecate the `to` prop and just use `href`
   // this is to support the ButtonLink component which uses the `to` prop
-  const to = (toProp ?? href)!
+  let to = (toProp ?? href)!
 
+  const isDiscordInvite = url.isDiscordInvite(to)
+  if (isDiscordInvite) to = new URL(DISCORD_PATH, SITE_URL).href
   const isExternal = url.isExternal(to)
   const isHash = url.isHash(to)
   const isGlossary = url.isGlossary(to)

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,5 @@
+export const SITE_URL = "https://ethereum.org" as const
+export const DISCORD_PATH = "/discord/" as const
 export const GATSBY_FUNCTIONS_PATH = process.env.GATSBY_FUNCTIONS_PATH || "/api"
 
 // Quiz Hub

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,5 +1,10 @@
+import { DISCORD_PATH } from "../constants"
+
 const HASH_PATTERN = /^#.*/
 const isHashLink = (href: string): boolean => HASH_PATTERN.test(href)
+
+export const isDiscordInvite = (href: string): boolean =>
+  href.includes(DISCORD_PATH) && !href.includes("http")
 
 export const isExternal = (href: string): boolean =>
   href.includes("http") || href.includes("mailto:") || href.includes("ipfs")


### PR DESCRIPTION
## Description
- Updates the link component to force links to `/discord/` to use the full `https://ethereum.org/discord/` path. The former is being treated as an internal link and not triggering the desired redirect until a user refreshes the page at that path. By using the full path, it triggers the proper redirect for the Discord invite link.
- I saw two options here, one where we require editors to use the full path when linking out to this path, or another where we just add logic to the `Link` component to check for this relative path (`/discord/`) and update accordingly.
- I went with the second option here and have added a check for this path in `Link`, and then adjusting the string to the full path if it matches.

Thank you to @megatheikal for reporting! And my apologies, this got brought up earlier while going through feedback as a team and I went ahead and put together a patch. It wasn't until now that I noticed your request to work on this, so I do apologize... Didn't mean to steamroll. 

## Preview link
https://ethereumorgwebsitedev01-discordinvite.gatsbyjs.io/en/contributing/translation-program/how-to-translate/#find-document -> Discord link

## Related Issue
- Fixes #10205