### PR TITLE
fix(theme/tag): increase label line-height for multi-line

### DIFF
--- a/src/@chakra-ui/gatsby-plugin/components/Tag/index.ts
+++ b/src/@chakra-ui/gatsby-plugin/components/Tag/index.ts
@@ -15,9 +15,11 @@ const { Tag: tagTheme } = theme.components
 const baseStyleContainer = defineMergeStyles(tagTheme.baseStyle?.container, {
   border: "1px",
   borderColor: "transparent",
+  boxSizing: "border-box",
   gap: 1,
   borderRadius: "full",
   px: 2,
+  py: 0.5,
   minH: 8,
   fontWeight: 300,
   "&:any-link": {
@@ -35,7 +37,7 @@ const baseStyleLabel = defineStyle({
   fontSize: "xs",
   textTransform: "uppercase",
   textAlign: "center",
-  lineHeight: 1,
+  lineHeight: 1.6,
 })
 
 const baseStyleCloseButton = defineStyle({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Increases line-height of the `Tag` component to account for multi-line text.

Also adds padding adjustments to accommodate the fix.
<!--- Describe your changes in detail -->

Screenshot from Storybook
![image](https://github.com/ethereum/ethereum-org-website/assets/65234762/43c62f1b-0dc8-45b0-bf98-f0cfc17ca176)

## Related Issue
Closes #10265 
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
