### PR TITLE
Update Lido trustless indicator

### DIFF
--- a/src/data/staking-products.json
+++ b/src/data/staking-products.json
@@ -650,7 +650,7 @@
       ],
       "isFoss": true,
       "hasBugBounty": true,
-      "isTrustless": false,
+      "isTrustless": true,
       "hasPermissionlessNodes": false,
       "pctMajorityClient": 42.83,
       "platforms": ["Browser", "Wallet"],


### PR DESCRIPTION
## Description
IIRC, the Lido "Trustless" indicator was marked false due to `0x00` withdrawal credentials that had not been updated. This has reportedly been completed now (cc: @isidorosp), with request to update field value. PR flips the `isTrustless` boolean for Lido to `true`


Note, ongoing discussion in #6452 regarding potentially redefining that category, but this PR does not address anything related to changing the definition.

## Related Issue
Reported on Discord