### PR TITLE
remove unneeded translation key and updated use

### DIFF
--- a/src/data/quizzes/index.ts
+++ b/src/data/quizzes/index.ts
@@ -8,7 +8,7 @@ const quizzes: RawQuizzes = {
     questions: ["a001", "a002", "a003", "a004", "a005"],
   },
   "what-is-ether": {
-    title: "page-what-is-ethereum-what-is-ether",
+    title: "what-is-ether",
     questions: ["b001", "b002", "b003", "b004"],
   },
   web3: {

--- a/src/intl/en/common.json
+++ b/src/intl/en/common.json
@@ -138,7 +138,6 @@
   "page-developers-aria-label": "Developers' Menu",
   "page-index-meta-title": "Home",
   "page-last-updated": "Page last updated",
-  "page-what-is-ethereum-what-is-ether": "What is ether?",
   "pbs": "Proposer-builder separation",
   "pools": "Pooled staking",
   "privacy-policy": "Privacy policy",


### PR DESCRIPTION
removed page-what-is-ethereum-what-is-ether from common.js
updated key to what-is-ether for learn quizzes
