### PR TITLE
Wrap InfoBanner in LightMode component

### DIFF
--- a/src/components/InfoBanner.tsx
+++ b/src/components/InfoBanner.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Flex, FlexProps, Text } from "@chakra-ui/react"
+import { Flex, FlexProps, LightMode, Text } from "@chakra-ui/react"
 import Emoji from "./Emoji"
 
 export interface IProps extends FlexProps {
@@ -23,45 +23,47 @@ const InfoBanner: React.FC<IProps> = ({
   ...props
 }) => {
   const banner = (
-    <Flex
-      align="center"
-      p={6}
-      borderRadius={"sm"}
-      maxW={shouldCenter ? "55rem" : "100%"}
-      sx={{
-        ":not(button)": {
-          color: "black300 !important",
-        },
-      }}
-      bg={isWarning ? "warning" : "infoBanner"}
-      direction={{ base: "column", sm: "row" }}
-      {...props}
-    >
-      {emoji && (
-        <Emoji
-          flexGrow="0"
-          flexShrink="0"
-          mr={{ base: 0, sm: 6 }}
-          mb={{ base: 2, sm: 0 }}
-          alignSelf={{ base: "flex-start", sm: "auto" }}
-          text={emoji}
-          fontSize="4xl"
-        />
-      )}
+    <LightMode>
       <Flex
-        display={{ base: "block", sm: shouldSpaceBetween ? "flex" : "block" }}
-        align={shouldSpaceBetween ? "center" : "auto"}
-        w={shouldSpaceBetween ? "100%" : "auto"}
-        justify={shouldSpaceBetween ? "space-between" : "auto"}
+        align="center"
+        p={6}
+        borderRadius={"sm"}
+        maxW={shouldCenter ? "55rem" : "100%"}
+        sx={{
+          ":not(button)": {
+            color: "black300 !important",
+          },
+        }}
+        bg={isWarning ? "warning" : "infoBanner"}
+        direction={{ base: "column", sm: "row" }}
+        {...props}
       >
-        {title && (
-          <Text fontSize="lg" fontWeight="700">
-            {title}
-          </Text>
+        {emoji && (
+          <Emoji
+            flexGrow="0"
+            flexShrink="0"
+            mr={{ base: 0, sm: 6 }}
+            mb={{ base: 2, sm: 0 }}
+            alignSelf={{ base: "flex-start", sm: "auto" }}
+            text={emoji}
+            fontSize="4xl"
+          />
         )}
-        {children}
+        <Flex
+          display={{ base: "block", sm: shouldSpaceBetween ? "flex" : "block" }}
+          align={shouldSpaceBetween ? "center" : "auto"}
+          w={shouldSpaceBetween ? "100%" : "auto"}
+          justify={shouldSpaceBetween ? "space-between" : "auto"}
+        >
+          {title && (
+            <Text fontSize="lg" fontWeight="700">
+              {title}
+            </Text>
+          )}
+          {children}
+        </Flex>
       </Flex>
-    </Flex>
+    </LightMode>
   )
   return shouldCenter ? <Flex justify="center">{banner}</Flex> : banner
 }


### PR DESCRIPTION
## Description
Background colors for `InfoBanner` are customized and not color-mode responsive, while the text is. This causes a clash of white text in dark mode on a light background.

PR forces use of "light" color mode settings at all times for all elements of the component, using the `LightMode` Chakra-UI component. Intended to be a patch until proper design adjustments implemented.

## Related Issue
None filed