### PR TITLE
Add pages for Contributor Funding Rounds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,6 @@ IGNORE_CONTENT=**/docs,**/tutorials
 
 # Used to avoid loading Matomo in our preview deploys
 IS_PREVIEW_DEPLOY=false
+
+# Contract address for current funding round through Gitcoin's Allo Protocol
+GATSBY_CURRENT_FUNDING_ROUND=

--- a/src/components/CurrentFundingRound.tsx
+++ b/src/components/CurrentFundingRound.tsx
@@ -1,0 +1,35 @@
+import React from "react"
+import { Text } from "@chakra-ui/react"
+import type { TextProps } from "@chakra-ui/react"
+import Link from "./Link"
+
+type RoundInterface = "explorer" | "builder"
+
+interface IProps extends TextProps {
+  roundInterface: RoundInterface
+}
+
+const CurrentFundingRound: React.FC<IProps> = ({
+  children,
+  roundInterface,
+}) => {
+  const contractAddress = process.env.GATSBY_CURRENT_FUNDING_ROUND
+  const href =
+    roundInterface === "explorer"
+      ? `https://explorer.gitcoin.co/#/round/10/${contractAddress}`
+      : roundInterface === "builder"
+      ? `https://builder.gitcoin.co/#/chains/10/rounds/${contractAddress}`
+      : ""
+  const addressRegEx = /^0x[0-9a-f]{40}$/
+  if (!contractAddress || !addressRegEx.test(contractAddress) || !href)
+    return (
+      <em>
+        <Text as="span" textStyle="italic">
+          (no funding round currently available)
+        </Text>
+      </em>
+    )
+  return <Link href={href}>{children}</Link>
+}
+
+export default CurrentFundingRound

--- a/src/content/contributing/funding-rounds/index.md
+++ b/src/content/contributing/funding-rounds/index.md
@@ -16,7 +16,7 @@ Ethereum.org is currently managed by a core team of ten full-time individuals, b
 
 Contributions to ethereum.org have increased significantly in frequency over the past five years. While the vast majority of these contributions have been on a voluntary basis, large portions of the site content **would not have been possible** without this community support, and the core team has been investigating measures to return value to impactful contributors.
 
-<InfoBanner emoji="❤️" mt="8">
+<InfoBanner emoji="❤️" my="8">
 The goal is to retroactively reward impactful work, while encouraging and creating incentive for everyone to contribute to public goods, including ethereum.org. And of course, to say <strong>thank you</strong>.
 </InfoBanner>
 
@@ -52,5 +52,3 @@ This prevents large donors from having disproportionate influence over the alloc
 If you've contributed to ethereum.org in the past and would like to apply for funding, or have benefited from ethereum.org and would like to help allocate funds to contributors, learn how to participate in the next funding round!
 
 <ButtonLink href="/contributing/funding-rounds/participating/" mt={8}>Learn how to participate</ButtonLink>
-
-<!-- TODO: Add information about timing, and how to find the (next) active round -->

--- a/src/content/contributing/funding-rounds/index.md
+++ b/src/content/contributing/funding-rounds/index.md
@@ -1,0 +1,56 @@
+---
+title: Contributor funding rounds
+description: Information hub about funding rounds for ethereum.org contributors
+lang: en
+---
+
+# Contributor funding rounds {#contributor-funding-rounds}
+
+The [ethereum.org website team](/about/), with sponsorship from the [Ethereum Foundation](https://ethereum.foundation), is excited to be running a series of funding rounds to give back and reward community members who have made impactful contributions!
+
+<ButtonLink href="/contributing/funding-rounds/participating/" mt={8}>How to participate</ButtonLink>
+
+## What for? {#what-for}
+
+Ethereum.org is currently managed by a core team of ten full-time individuals, but is comprised of contributions from **thousands of contributors** from all over the globe!
+
+Contributions to ethereum.org have increased significantly in frequency over the past five years. While the vast majority of these contributions have been on a voluntary basis, large portions of the site content **would not have been possible** without this community support, and the core team has been investigating measures to return value to impactful contributors.
+
+<InfoBanner emoji="❤️" mt="8">
+The goal is to retroactively reward impactful work, while encouraging and creating incentive for everyone to contribute to public goods, including ethereum.org. And of course, to say <strong>thank you</strong>.
+</InfoBanner>
+
+[How to become a contributor](/contributing/)
+
+## The challenge in deciding {#the-challenge-in-deciding}
+
+Deciding _which_ contributions are deserving of financial reward, and _how much_ they should receive, is _challenging_ and _subjective_.
+
+If a core team member finds a contribution valuable, this doesn't mean others did. Similarly, just because the core team did not appreciate the impact of a particular contribution, this doesn't mean that potentially hundreds of thousands of others didn't find immense value in the addition.
+
+## We need your help! {#we-need-your-help}
+
+We're taking ourselves out of the decision making, and allowing the community to decide. We need **signal and feedback** from the whole community to know which contributions have been most impactful! As such, ethereum.org will be utilizing Gitcoin's **Allo Protocol** to help distribute the funds in a more democratic way, optimizing for the most human impact.
+
+## Allo Protocol {#allo-protocol}
+
+Allo Protocol is a set of smart contracts that enable the democratic allocation and distribution of funds through the power of **quadratic funding **.
+
+In short, quadratic funding is a mechanism for donation matching that takes into consideration how many unique people are signaling support to a recipient, rather than solely the amount of money a that recipient raised. Donations to recipients are then matched with funds from the matching pool, proportional to number of unique contributors, and to a lesser extent, the amount of money raised.
+
+This prevents large donors from having disproportionate influence over the allocation of funds. A recipient with 100 small donations will receive significantly more matching funds at the end of the round than a project with a large donation from a single donor, even if the latter raised more money.
+
+- [Allo Protocol docs](https://docs.allo.gitcoin.co)
+- [WTFisQF.com](https://wtfisqf.com/)
+
+**WTF is Quadratic Funding in (100) sec (2020):**
+
+<YouTube id="HJljTtLnymE" />
+
+## Get started {#get-started}
+
+If you've either contributed to ethereum.org in the past and would like to apply for funding, or if you've benefited from ethereum.org in the past and would like to help allocate the funds, learn how to participate in the next funding round!
+
+<ButtonLink href="/contributing/funding-rounds/participating/" mt={8}>Learn how to participate</ButtonLink>
+
+<!-- TODO: Add information about timing, and how to find the (next) active round -->

--- a/src/content/contributing/funding-rounds/index.md
+++ b/src/content/contributing/funding-rounds/index.md
@@ -20,7 +20,7 @@ Contributions to ethereum.org have increased significantly in frequency over the
 The goal is to retroactively reward impactful work, while encouraging and creating incentive for everyone to contribute to public goods, including ethereum.org. And of course, to say <strong>thank you</strong>.
 </InfoBanner>
 
-[How to become a contributor](/contributing/)
+[Contributing to ethereum.org](/contributing/)
 
 ## The challenge in deciding {#the-challenge-in-deciding}
 
@@ -36,7 +36,7 @@ We're taking ourselves out of the decision making, and allowing the community to
 
 Allo Protocol is a set of smart contracts that enable the democratic allocation and distribution of funds through the power of **quadratic funding **.
 
-In short, quadratic funding is a mechanism for donation matching that takes into consideration how many unique people are signaling support to a recipient, rather than solely the amount of money a that recipient raised. Donations to recipients are then matched with funds from the matching pool, proportional to number of unique contributors, and to a lesser extent, the amount of money raised.
+In short, quadratic funding is a mechanism for donation matching that takes into consideration how many unique people are signaling support to a recipient, rather than solely the amount of money a recipient raised. Donations to recipients are then matched with funds from the matching pool, proportional to number of unique contributors, and to a lesser extent, the amount of money raised.
 
 This prevents large donors from having disproportionate influence over the allocation of funds. A recipient with 100 small donations will receive significantly more matching funds at the end of the round than a project with a large donation from a single donor, even if the latter raised more money.
 
@@ -49,7 +49,7 @@ This prevents large donors from having disproportionate influence over the alloc
 
 ## Get started {#get-started}
 
-If you've either contributed to ethereum.org in the past and would like to apply for funding, or if you've benefited from ethereum.org in the past and would like to help allocate the funds, learn how to participate in the next funding round!
+If you've contributed to ethereum.org in the past and would like to apply for funding, or have benefited from ethereum.org and would like to help allocate funds to contributors, learn how to participate in the next funding round!
 
 <ButtonLink href="/contributing/funding-rounds/participating/" mt={8}>Learn how to participate</ButtonLink>
 

--- a/src/content/contributing/funding-rounds/participating/allocating/index.md
+++ b/src/content/contributing/funding-rounds/participating/allocating/index.md
@@ -1,6 +1,6 @@
 ---
 title: Allocating funds during a funding round
-description:
+description: Instructions on how to participate as an allocator during a funding round
 lang: en
 ---
 
@@ -26,7 +26,7 @@ _Note that you’ll be required to sign multiple message with your wallet during
 
 <!-- TODO: Replace with a canonical list of ethereum.org grant rounds -->
 
-1. **Go to** [Ethereum.org Contributor Round](https://explorer.gitcoin.co/#/round/10/0x{round-contract-address})
+1. **Go to** <CurrentFundingRound roundInterface="explorer">Ethereum.org Contributor Round</CurrentFundingRound>
 2. **Connect Wallet**
 3. **Switch network** to Optimism
 4. **Browse contributors**

--- a/src/content/contributing/funding-rounds/participating/allocating/index.md
+++ b/src/content/contributing/funding-rounds/participating/allocating/index.md
@@ -1,0 +1,63 @@
+---
+title: Allocating funds during a funding round
+description:
+lang: en
+---
+
+# Allocating funds during a funding round {#allocating}
+
+The ethereum.org contributor funding rounds are being help using the **Allo Protocol**, which allows **anyone to help allocate funds** from a matching pool to the ethereum.org contributors listed. Once a funding round begins, you may make smalls donations of ETH or DAI (minimum of $1 USD worth) to any contribution you'd like to support.
+
+## Step 1: Gitcoin Passport (can be done ahead of time) {#step-1}
+
+To enhance the matching power of your contribution, you’ll need to provide some evidence that you’re only donating with one wallet.
+
+1. Go to [Gitcoin Passport](https://passport.gitcoin.co/#/)
+2. Sign-in with Ethereum
+3. Follow the setup process to add "stamps" to your passport. Each stamp will help increase your total passport score, which is used to determine your matching power.
+
+_Note that you’ll be required to sign multiple message with your wallet during setup, but **no gas (transaction fee) is required** for anything related to Gitcoin Passport setup._
+
+<InfoBanner emoji="🥸">
+<strong>Why is this necessary?</strong> Remember, the number of people donating to a project is weighted stronger than the value of donations received, so limiting each person to one wallet is important. If one person could easily pretend to be many (what’s known as a <a href="#sybil-resistance">Sybil attack</a>), it would greatly limit the effectiveness.
+</InfoBanner>
+
+## Step 2: Make allocations (once round has started) {#step-2}
+
+<!-- TODO: Replace with a canonical list of ethereum.org grant rounds -->
+
+1. **Go to** [Ethereum.org Contributor Round](https://explorer.gitcoin.co/#/round/10/0x{round-contract-address})
+2. **Connect Wallet**
+3. **Switch network** to Optimism
+4. **Browse contributors**
+   - Here is where you’ll be able to view all the submitted contributors to ethereum.org that are seeking funding. Clicking into each will provide a description of their contribution with supporting links and screenshots for you to understand their work.
+   - If you see a contribution that you believe is valuable, would like to support, or that you’ve already enjoyed the benefits of, you can add them to your shopping cart.
+5. **Checkout**
+
+   - When you’re satisfied with your selection, go to the shopping cart to finish your donations. Here you can adjust the final amounts you would like to donate for each project. You may choose to donate either ETH or DAI (on Optimism in either case).
+
+6. **Submit on chain**
+   - When you’re ready, you can submit your final donations via a transaction on Optimism (requires ETH on Optimism for transaction fee, plus additional ETH or DAI to cover your donations).
+
+## How much should I donate? {#how-much-should-i-donate}
+
+Donating the minimum of $1 is enough to signal your support for a contributor. You’re free to donate more to increase your signal, though the amount that will be matched per dollar drops as your donation increases.
+
+**Note that 100% of all donations go directly to the recipient Ethereum address.**
+
+## How do we know someone is "unique"? {#sybil-resistance}
+
+When one person pretends to be many, this is known as a "Sybil attack". Allo Protocol functions by placing higher importance on the number of donations from unique participants a project received, over the total donation amount. For this to work, "Sybil resistance" mechanisms must be used to make it difficult for individuals to participate in the round using multiple addresses.
+
+### Gitcoin Passport {#gitcoin-passport}
+
+Funding rounds will use the decentralized identifier system **Gitcoin Passport** to resist Sybil attacks. Gitcoin Passport gives you the ability to provide evidence that you are unique, based on other provable identifiers and attributions, providing a score for the quality and quantity of evidence provided. This score is used in conjunction with your donation to determine the matching weight of your vote.
+
+<InfoBanner emoji="🚨">
+To protect again Sybil attacks, connecting your Gitcoin Passport score <strong>is required</strong> to participate as an allocator for the ethereum.org funding rounds. 
+</InfoBanner>
+
+**Passport tips:**
+
+- Connecting web3 identifiers, such as an ENS, POAP history, token holdings, Proof of Humanity or DAO involvement, will provide your account with higher levels of matching, increasing with evidence from multiple categories
+- By connecting only web2 identifiers, such as Twitter, Discord, Facebook or Google, you will receive only a small increase to your Gitcoin Passport score, as these accounts are easier to spin up in large numbers

--- a/src/content/contributing/funding-rounds/participating/allocating/index.md
+++ b/src/content/contributing/funding-rounds/participating/allocating/index.md
@@ -6,7 +6,7 @@ lang: en
 
 # Allocating funds during a funding round {#allocating}
 
-The ethereum.org contributor funding rounds are being help using the **Allo Protocol**, which allows **anyone to help allocate funds** from a matching pool to the ethereum.org contributors listed. Once a funding round begins, you may make smalls donations of ETH or DAI (minimum of $1 USD worth) to any contribution you'd like to support.
+The ethereum.org contributor funding rounds are being held using the Gitcoin **Grants Stack**, which allows **anyone to help allocate funds** from a matching pool to the ethereum.org contributors listed. Once a funding round begins, you may make smalls donations of ETH or DAI (minimum of $1 USD worth) to any contributor you'd like to support.
 
 ## Step 1: Gitcoin Passport (can be done ahead of time) {#step-1}
 
@@ -14,46 +14,57 @@ To enhance the matching power of your contribution, you’ll need to provide som
 
 1. Go to [Gitcoin Passport](https://passport.gitcoin.co/#/)
 2. Sign-in with Ethereum
-3. Follow the setup process to add "stamps" to your passport. Each stamp will help increase your total passport score, which is used to determine your matching power.
+3. Follow the setup process to add "stamps" to your passport. Each stamp will help increase your Unique Humanity Score, which is used to determine your matching power.
+4. Check the indicator next to your score to ensure you have a "passing" score
 
 _Note that you’ll be required to sign multiple message with your wallet during setup, but **no gas (transaction fee) is required** for anything related to Gitcoin Passport setup._
 
-<InfoBanner emoji="🥸">
+<InfoBanner emoji="🥸" mt={8}>
 <strong>Why is this necessary?</strong> Remember, the number of people donating to a project is weighted stronger than the value of donations received, so limiting each person to one wallet is important. If one person could easily pretend to be many (what’s known as a <a href="#sybil-resistance">Sybil attack</a>), it would greatly limit the effectiveness.
 </InfoBanner>
+
+[Learn more about Gitcoin Passport](https://support.gitcoin.co/gitcoin-knowledge-base/gitcoin-passport/what-is-gitcoin-passport)
 
 ## Step 2: Make allocations (once round has started) {#step-2}
 
 <!-- TODO: Replace with a canonical list of ethereum.org grant rounds -->
 
-1. **Go to** <CurrentFundingRound roundInterface="explorer">Ethereum.org Contributor Round</CurrentFundingRound>
-2. **Connect Wallet**
-3. **Switch network** to Optimism
-4. **Browse contributors**
+1. **Get connected** to current funding round:
+
+   - Go to <CurrentFundingRound roundInterface="explorer">Ethereum.org Contributor Round</CurrentFundingRound>
+   - Connect Wallet
+   - Switch network to Optimism
+
+2. **Browse** contributors
+
    - Here is where you’ll be able to view all the submitted contributors to ethereum.org that are seeking funding. Clicking into each will provide a description of their contribution with supporting links and screenshots for you to understand their work.
    - If you see a contribution that you believe is valuable, would like to support, or that you’ve already enjoyed the benefits of, you can add them to your shopping cart.
-5. **Checkout**
+
+3. **Finalize** amounts
 
    - When you’re satisfied with your selection, go to the shopping cart to finish your donations. Here you can adjust the final amounts you would like to donate for each project. You may choose to donate either ETH or DAI (on Optimism in either case).
 
-6. **Submit on chain**
+4. **Submit** on chain
+
    - When you’re ready, you can submit your final donations via a transaction on Optimism (requires ETH on Optimism for transaction fee, plus additional ETH or DAI to cover your donations).
 
 ## How much should I donate? {#how-much-should-i-donate}
 
 Donating the minimum of $1 is enough to signal your support for a contributor. You’re free to donate more to increase your signal, though the amount that will be matched per dollar drops as your donation increases.
 
-**Note that 100% of all donations go directly to the recipient Ethereum address.**
+<InfoBanner>
+Note that <strong>100%</strong> of all donations go directly to the recipient Ethereum address.
+</InfoBanner>
 
 ## How do we know someone is "unique"? {#sybil-resistance}
 
-When one person pretends to be many, this is known as a "Sybil attack". Allo Protocol functions by placing higher importance on the number of donations from unique participants a project received, over the total donation amount. For this to work, "Sybil resistance" mechanisms must be used to make it difficult for individuals to participate in the round using multiple addresses.
+When one person pretends to be many, this is known as a "Sybil attack". Allo Protocol functions by placing higher importance on the _number of supporters_ of a project, over the _total donation amount_. For this to work, "Sybil resistance" mechanisms must be used to make it difficult for one person from appearing like a community of supporters.
 
 ### Gitcoin Passport {#gitcoin-passport}
 
 Funding rounds will use the decentralized identifier system **Gitcoin Passport** to resist Sybil attacks. Gitcoin Passport gives you the ability to provide evidence that you are unique, based on other provable identifiers and attributions, providing a score for the quality and quantity of evidence provided. This score is used in conjunction with your donation to determine the matching weight of your vote.
 
-<InfoBanner emoji="🚨">
+<InfoBanner emoji="🚨" isWarning>
 To protect again Sybil attacks, connecting your Gitcoin Passport score <strong>is required</strong> to participate as an allocator for the ethereum.org funding rounds. 
 </InfoBanner>
 

--- a/src/content/contributing/funding-rounds/participating/index.md
+++ b/src/content/contributing/funding-rounds/participating/index.md
@@ -1,0 +1,103 @@
+---
+title: Participating in a funding round
+description: Information on how to participate in a funding round as an ethereum.org contributor or as an allocator
+lang: en
+---
+
+# Participating in a funding round {#participating}
+
+There are two ways to participate: as an **ethereum.org contributor**, or as an **allocator**.
+
+## Ethereum.org contributors (2019-present) {#ethereumorg-contributors}
+
+Contributors to ethereum.org will have a period of time to apply for funding before a funding round starts. Anyone who meets the [eligibility criteria](#eligibility-criteria) are encouraged to apply during this time.
+
+Applications from ethereum.org contributors are accepted up until the funding round begins.
+
+Contributions can be from (but not limited to) any of the following categories:
+
+- <Emoji text="🌐" me={1} /> Translations
+- <Emoji text="📝" me={1} /> Content
+- <Emoji text="📖" me={1} /> Documentation
+- <Emoji text="📐" me={1} /> Design
+- <Emoji text="🐞" me={1} /> Bug reports
+- <Emoji text="👩‍💻" me={1} /> Code/development
+- <Emoji text="👨‍🦯" me={1} /> Accessibility
+- <Emoji text="🏛️" me={1} /> Infrastructure
+- <Emoji text="🔧" me={1} /> Tooling
+- <Emoji text="💿" me={1} /> Data
+- <Emoji text="🤝" me={1} /> Community
+
+### Eligibility criteria {#eligibility-criteria}
+
+- **Project** - A "project" refers to a contributor to the **ethereum.org website domain or subdomains**. Contributors ("projects") can apply as individuals or as collectives, noting only one Ethereum address will be used for payout.
+- **Completed work** - Contribution must have been performed in the past—funding is not intended for future/planned work.
+- **Evidence** - Must provide public link to clear evidence of contribution. This is both for the operating team, as well as for donors participating in a round to see.
+- **Financial disclosures** - Applicants who may have previously received funding for their work associated with a contribution are welcome to apply, but for the sake of transparency are required to disclose this amount publicly.
+- **Time period** - Contributions are currently allowed from any time since 2019, which marked the v1.0.1 release of the current code repository.
+- **Excluded parties**
+  - Round will be managed by members of the ethereum.org core team who are ineligible to receive matching funds.
+  - Full-time employees/contractors of the Ethereum Foundation are not eligible to receive matching funds.
+
+Eligibility criteria are subject to change, and disputes will be arbitrated by the ethereum.org core team. For questions reach out to us on [Discord](/discord/).
+
+<ButtonLink href="/contributing/funding-rounds/participating/registering/">Learn how to register</ButtonLink>
+
+## Allocators {#allocators}
+
+Once a funding round begins, **anyone** is allowed to help allocate the matching pool funds by signaling their support for the ethereum.org contributions listed. This is done by making a small donations of ETH or DAI (minimum of $1 USD worth) to any contribution you'd like to support.
+
+<ExpandableCard
+title="Wait, I have to pay for this?"
+contentPreview="Ethereum.org is using Allo Protocol by Gitcoin to execute funding rounds">
+Allo Protocol by Gitcoin utilizes a mechanism called "quadratic funding" to allocate funds democratically, optimizing for human impact.
+
+Your "donation" represents your vote in how the matching funds should be <em>allocated</em>.
+
+The funds in the matching pool are intended to be the main source of funding—donations by participants are meant to signal where they'd prefer the matching pool funds to be allocated, while keeping votes scarce (unlimited free votes would break the model).
+
+<p><a href="https://docs.allo.gitcoin.co/">More on Allo Protocol and quadratic funding</a></p>
+</ExpandableCard>
+
+<ExpandableCard
+title="How much do I need to spend?"
+contentPreview="$1 is the minimum—you can do more, but that will do">
+Quadratic funding cares more about <em>how many unique individuals</em> found a contribution valuable, and less about the total value that was donated to each project... a <strong>$1 donation is plenty</strong> (the minimum allowed per project by Allo Protocol), and can be matched by significantly more if others agree.
+
+You are welcome to strengthen your vote by donating more, but each additional dollar donated will have diminishing returns on the matching pool funds.
+</ExpandableCard>
+
+You can view all submitted contributions to see a summary of each. If you've found a contribution to be impactful, you're encouraged to show your support for this contributor to receive more matching funds by adding them to your shopping cart.
+
+When ready, users can checkout using the shopping cart by finalizing the amounts they'd like to donate before sending the funds using their wallet.
+
+<ButtonLink href="/contributing/funding-rounds/participating/allocating/">Learn how to allocate</ButtonLink>
+
+## What funds will I need? {#needed-funds}
+
+Rounds are being held using the Allo Protocol on the Optimism layer 2 rollup. As such you’ll need an Ethereum address with some ETH available _on Optimism_ to be used for transaction fees (gas).
+
+As an **ethereum.org contributor** looking to receive funding, you’ll need some ETH on Optimism for:
+
+1. Gas when registering yourself as a "project"
+2. Gas when applying to the funding round with your "project"
+
+As an **allocator**, you’ll need Optimism ETH for:
+
+1. Gas when submitting your donations
+2. Your donation itself (or optionally, you can use [DAI on Optimism](https://optimistic.etherscan.io/token/0xda10009cbd5d07dd0cecc66161fc93d7c9000da1) for this)
+
+<ExpandableCard
+title="How much will gas cost?"
+contentPreview="On Optimism, total fees should be anywhere from ~$0.25-$2">
+
+Total transaction fees for an ethereum.org contributor registering as a project should be under 0.001 ETH.
+
+Total fees for allocators will depend on number of contributors you’re supporting, but should in general be less than 0.002 ETH in total.
+</ExpandableCard>
+
+## When a round is over {#round-over}
+
+When a round is completed, the results will be calculated, reviewed, and then funds will be distributed based on the final results. Contributors who received donations will receive these donations and their associated portion of the matching pool to the Ethereum address provided during registration.
+
+For additional questions, reach out to us on [Discord](/discord/).

--- a/src/content/contributing/funding-rounds/participating/index.md
+++ b/src/content/contributing/funding-rounds/participating/index.md
@@ -69,13 +69,13 @@ You are welcome to strengthen your vote by donating more, but each additional do
 
 You can view all submitted contributions to see a summary of each. If you've found a contribution to be impactful, you're encouraged to show your support for this contributor to receive more matching funds by adding them to your shopping cart.
 
-When ready, users can checkout using the shopping cart by finalizing the amounts they'd like to donate before sending the funds using their wallet.
+When ready, you can checkout using the shopping cart by finalizing the amounts you'd like to donate before sending the funds using your wallet.
 
 <ButtonLink href="/contributing/funding-rounds/participating/allocating/">Learn how to allocate</ButtonLink>
 
 ## What funds will I need? {#needed-funds}
 
-Rounds are being held using the Allo Protocol on the Optimism layer 2 rollup. As such you’ll need an Ethereum address with some ETH available _on Optimism_ to be used for transaction fees (gas).
+Rounds are being held using the Allo Protocol on the Optimism layer 2 rollup, for on-chain transparency and inexpensive network fees. As such you’ll need an Ethereum address with some ETH available _on Optimism_ to be used for transaction fees (gas).
 
 As an **ethereum.org contributor** looking to receive funding, you’ll need some ETH on Optimism for:
 

--- a/src/content/contributing/funding-rounds/participating/index.md
+++ b/src/content/contributing/funding-rounds/participating/index.md
@@ -50,9 +50,9 @@ Once a funding round begins, **anyone** is allowed to help allocate the matching
 <ExpandableCard
 title="Wait, I have to pay for this?"
 contentPreview="Ethereum.org is using Allo Protocol by Gitcoin to execute funding rounds">
-Allo Protocol by Gitcoin utilizes a mechanism called "quadratic funding" to allocate funds democratically, optimizing for human impact.
+Allo Protocol by Gitcoin utilizes a mechanism called <strong>quadratic funding</strong> to allocate funds democratically, optimizing for human impact.
 
-Your "donation" represents your vote in how the matching funds should be <em>allocated</em>.
+Your donation represents your vote in how the matching funds should be <em>allocated</em>.
 
 The funds in the matching pool are intended to be the main source of funding—donations by participants are meant to signal where they'd prefer the matching pool funds to be allocated, while keeping votes scarce (unlimited free votes would break the model).
 
@@ -66,6 +66,8 @@ Quadratic funding cares more about <em>how many unique individuals</em> found a 
 
 You are welcome to strengthen your vote by donating more, but each additional dollar donated will have diminishing returns on the matching pool funds.
 </ExpandableCard>
+
+**Note that 100% of all donations go directly to the recipient Ethereum address.**
 
 You can view all submitted contributions to see a summary of each. If you've found a contribution to be impactful, you're encouraged to show your support for this contributor to receive more matching funds by adding them to your shopping cart.
 

--- a/src/content/contributing/funding-rounds/participating/index.md
+++ b/src/content/contributing/funding-rounds/participating/index.md
@@ -41,7 +41,7 @@ Contributions can be from (but not limited to) any of the following categories:
 
 Eligibility criteria are subject to change, and disputes will be arbitrated by the ethereum.org core team. For questions reach out to us on [Discord](/discord/).
 
-<ButtonLink href="/contributing/funding-rounds/participating/registering/">Learn how to register</ButtonLink>
+<ButtonLink href="/contributing/funding-rounds/participating/registering/">Learn how to register as a recipient</ButtonLink>
 
 ## Allocators {#allocators}
 
@@ -50,7 +50,7 @@ Once a funding round begins, **anyone** is allowed to help allocate the matching
 <ExpandableCard
 title="Wait, I have to pay for this?"
 contentPreview="Ethereum.org is using Allo Protocol by Gitcoin to execute funding rounds">
-Allo Protocol by Gitcoin utilizes a mechanism called <strong>quadratic funding</strong> to allocate funds democratically, optimizing for human impact.
+Allo Protocol is a suite of smart contracts that utilize a mechanism called <strong>quadratic funding</strong> to allocate funds democratically, optimizing for human impact.
 
 Your donation represents your vote in how the matching funds should be <em>allocated</em>.
 
@@ -62,22 +62,24 @@ The funds in the matching pool are intended to be the main source of funding—d
 <ExpandableCard
 title="How much do I need to spend?"
 contentPreview="$1 is the minimum—you can do more, but that will do">
-Quadratic funding cares more about <em>how many unique individuals</em> found a contribution valuable, and less about the total value that was donated to each project... a <strong>$1 donation is plenty</strong> (the minimum allowed per project by Allo Protocol), and can be matched by significantly more if others agree.
+Quadratic funding cares more about <em>how many unique individuals</em> found a contribution valuable, and less about the total value that was donated to each project... a <strong>$1 donation is plenty</strong> (the minimum allowed per project by the Allo Protocol), and can be matched by significantly more if others agree.
 
 You are welcome to strengthen your vote by donating more, but each additional dollar donated will have diminishing returns on the matching pool funds.
 </ExpandableCard>
-
-**Note that 100% of all donations go directly to the recipient Ethereum address.**
 
 You can view all submitted contributions to see a summary of each. If you've found a contribution to be impactful, you're encouraged to show your support for this contributor to receive more matching funds by adding them to your shopping cart.
 
 When ready, you can checkout using the shopping cart by finalizing the amounts you'd like to donate before sending the funds using your wallet.
 
+<InfoBanner my={8}>
+Note that <strong>100%</strong> of all donations go directly to the recipient Ethereum address.
+</InfoBanner>
+
 <ButtonLink href="/contributing/funding-rounds/participating/allocating/">Learn how to allocate</ButtonLink>
 
 ## What funds will I need? {#needed-funds}
 
-Rounds are being held using the Allo Protocol on the Optimism layer 2 rollup, for on-chain transparency and inexpensive network fees. As such you’ll need an Ethereum address with some ETH available _on Optimism_ to be used for transaction fees (gas).
+Rounds are being held using the Allo Protocol smart contracts for on-chain transparency, deployed to the Optimism layer 2 rollup for inexpensive network fees. As such you’ll need an Ethereum address with some ETH available _on Optimism_ to be used for transaction fees (gas).
 
 As an **ethereum.org contributor** looking to receive funding, you’ll need some ETH on Optimism for:
 
@@ -92,6 +94,8 @@ As an **allocator**, you’ll need Optimism ETH for:
 <ExpandableCard
 title="How much will gas cost?"
 contentPreview="On Optimism, total fees should be anywhere from ~$0.25-$2">
+
+Optimism has implemented the Bedrock upgrade, which has further reduced gas costs for users.
 
 Total transaction fees for an ethereum.org contributor registering as a project should be under 0.001 ETH.
 

--- a/src/content/contributing/funding-rounds/participating/index.md
+++ b/src/content/contributing/funding-rounds/participating/index.md
@@ -12,7 +12,7 @@ There are two ways to participate: as an **ethereum.org contributor**, or as an 
 
 Contributors to ethereum.org will have a period of time to apply for funding before a funding round starts. Anyone who meets the [eligibility criteria](#eligibility-criteria) are encouraged to apply during this time.
 
-Applications from ethereum.org contributors are accepted up until the funding round begins.
+Applications from ethereum.org contributors are accepted up until a funding round begins.
 
 Contributions can be from (but not limited to) any of the following categories:
 

--- a/src/content/contributing/funding-rounds/participating/index.md
+++ b/src/content/contributing/funding-rounds/participating/index.md
@@ -82,7 +82,7 @@ Rounds are being held using the Allo Protocol on the Optimism layer 2 rollup, fo
 As an **ethereum.org contributor** looking to receive funding, you’ll need some ETH on Optimism for:
 
 1. Gas when registering yourself as a "project"
-2. Gas when applying to the funding round with your "project"
+2. Gas when applying to a funding round with your "project"
 
 As an **allocator**, you’ll need Optimism ETH for:
 

--- a/src/content/contributing/funding-rounds/participating/registering/index.md
+++ b/src/content/contributing/funding-rounds/participating/registering/index.md
@@ -9,7 +9,7 @@ lang: en
 As an ethereum.org contributor looking to receive funding during a funding round, there are a couple things you'll need to do **before round allocations begin**:
 
 1. Creating a "project" for yourself
-1. Applying to the funding round
+1. Applying to a funding round
 
 ## Step 1: Creating a "project" for yourself {#step-1}
 
@@ -38,14 +38,14 @@ Follow along below, or check out the Gitcoin support docs, _[How to create a pro
 
 - Confirm your details, then "Save and Publish" to submit your transaction on Optimism (requires some ETH on Optimism for transaction fee)
 
-## Step 2: Applying to the round {#step-2}
+## Step 2: Applying to a round {#step-2}
 
 Once you have a project for yourself, you'll need to apply to an active round. Follow along here, or see the Gitcoin support docs, _[How to apply to a round in Explorer](https://support.gitcoin.co/gitcoin-knowledge-base/gitcoin-grants-program/project-owners/how-to-apply-to-a-round-in-explorer)_, for additional guidance.
 
 <!-- TODO: Figure out how to link to round(s) without manual updates here -->
 <!-- Explorer link: https://explorer.gitcoin.co/#/round/10/round-contract-address -->
 
-1. Go to [Gitcoin Builder for the current round](https://builder.gitcoin.co/#/chains/10/rounds/round-contract-address)
+1. Go to <CurrentFundingRound roundInterface="builder">Gitcoin Builder for the current round</CurrentFundingRound>
 2. Make sure you're connected to the same wallet used to create your project
 3. Review application period and round eligibility, then click **Apply** to continue
 4. Select your project from the list

--- a/src/content/contributing/funding-rounds/participating/registering/index.md
+++ b/src/content/contributing/funding-rounds/participating/registering/index.md
@@ -62,7 +62,7 @@ Once you have a project for yourself, you'll need to apply to an active round. F
 6. When finished, click **Preview Application** to continue to preview
 7. Review your application, then click **Submit**
 8. Once submitted, the entry cannot be changed. Please make sure everything is correct before proceeding. Clicking **Proceed** will submit your transaction on Optimism (requires some ETH on Optimism for transaction fee)
-   - To encrypt your data, you must also sign-in again with your wallet—this does not cost gas
+   - To encrypt your data, you must also sign-in again with your wallet—this does not cost additional gas
 
 <InfoBanner emoji="👷">
 After you’ve applied, you’re submission will enter the review process. You can view your project profile and the status of your application by going to <a href="https://builder.gitcoin.co/">Gitcoin Builder</a>.
@@ -71,3 +71,9 @@ After you’ve applied, you’re submission will enter the review process. You c
 ## Step 3: Spread the word! {#step-3}
 
 <Emoji text="📣" fontSize="3xl" me={2} /> Tell others about the round and make sure folks know you’ve applied! Encourage others to check out the round when it goes live and add their voice in how the funds are distributed.
+
+<!-- TODO: Consider a link with a prepared tweet -->
+
+Lastly, when round allocations begin, be sure to also participate as an allocator to get a say in how the funds are distributed!
+
+<ButtonLink href="/contributing/funding-rounds/participating/allocating/">Learn how to allocate</ButtonLink>

--- a/src/content/contributing/funding-rounds/participating/registering/index.md
+++ b/src/content/contributing/funding-rounds/participating/registering/index.md
@@ -1,0 +1,73 @@
+---
+title: Registering for funding as an ethereum.org contributor
+description: Instructions on how to get registered as a funding recipient and apply to a funding round
+lang: en
+---
+
+# Registering for funding as an ethereum.org contributor {#registering-for-funding}
+
+As an ethereum.org contributor looking to receive funding during a funding round, there are a couple things you'll need to do **before round allocations begin**:
+
+1. Creating a "project" for yourself
+1. Applying to the funding round
+
+## Step 1: Creating a "project" for yourself {#step-1}
+
+First, you'll need to register yourself as a "project" on Gitcoin. This process is about you, and _not yet_ about your contributions to ethereum.org—you'll get a chance to describe your contribution(s) and provide a receiving address in a later step.
+
+Follow along below, or check out the Gitcoin support docs, _[How to create a project in Builder](https://support.gitcoin.co/gitcoin-knowledge-base/gitcoin-grants-program/project-owners/how-to-create-a-project-in-builder)_, for additional guidance.
+
+1. Get connected:
+
+- Go to [Gitcoin Builder New Project](https://builder.gitcoin.co/#/projects/new)
+- Connect wallet
+- Switch network to **Optimism**
+
+2. Fill out project details:
+
+- _Project Name_ - This is your name, or whatever identifier others will recognize (if you’ve contributed as a team, you can use a team name here)
+- _Project Website_ - Link to a social profile, or your website
+- _Project Logo, Project Banner_ - _Optional_ avatar and banner images for your project profile page
+- _Project Description_ - Describe your interest in ethereum.org, and what potential impact could result from receiving funds
+
+3. Provide socials (optional):
+
+- If you’re contribution involved code contributions or anything on GitHub, it is recommended to provide this for clarity
+
+4. Preview and publish:
+
+- Confirm your details, then "Save and Publish" to submit your transaction on Optimism (requires some ETH on Optimism for transaction fee)
+
+## Step 2: Applying to the round {#step-2}
+
+Once you have a project for yourself, you'll need to apply to an active round. Follow along here, or see the Gitcoin support docs, _[How to apply to a round in Explorer](https://support.gitcoin.co/gitcoin-knowledge-base/gitcoin-grants-program/project-owners/how-to-apply-to-a-round-in-explorer)_, for additional guidance.
+
+<!-- TODO: Figure out how to link to round(s) without manual updates here -->
+<!-- Explorer link: https://explorer.gitcoin.co/#/round/10/round-contract-address -->
+
+1. Go to [Gitcoin Builder for the current round](https://builder.gitcoin.co/#/chains/10/rounds/round-contract-address)
+2. Make sure you're connected to the same wallet used to create your project
+3. Review application period and round eligibility, then click **Apply** to continue
+4. Select your project from the list
+5. **Fill out form details** - Required fields include:
+   - _Email address_
+   - _Funding sources_ - Must disclose any prior funding for work being submitted
+   - _Contribution description_
+     - This is your space to describe the contribution(s) you’ve made, and its impact... let people know why your contribution should be valued!
+     - **This field has rich-text support using markdown**, so don’t be afraid to express yourself, and make sure users can easily see what you’ve worked on
+     - This means you can also embed screenshots using URLs and additional links as needed, though you'll need a place to host these images (i.e. [GitHub](https://github.com), [Imgur](https://imgur.com/), etc.)
+     - You can preview your submission in the next step
+     - [Markdown cheat sheet](https://www.markdownguide.org/cheat-sheet/)
+   - _Primary contribution link_ - Link out to publicly available evidence of your contribution. This could be a link to contributions on GitHub, Crowdin, Discord, or directly to a page affected on ethereum.org. You may optionally provide additional URLs in the fields below, or in your contribution description.
+6. When finished, click **Preview Application** to continue to preview
+7. Review your application, then click **Submit**
+8. Once submitted, the entry cannot be changed. Please make sure everything is correct before proceeding. Clicking **Proceed** will submit your transaction on Optimism (requires some ETH on Optimism for transaction fee)
+   - To encrypt your data, you must also sign-in again with your wallet—this does not cost gas
+
+<InfoBanner emoji="👷">
+After you’ve applied, you’re submission will enter the review process. You can view your project profile and the status of your application by going to <a href="https://builder.gitcoin.co/">Gitcoin Builder</a>.
+</InfoBanner>
+
+## Step 3: Spread the word! {#step-3}
+
+<Emoji text="📣" fontSize="3xl" me={2} /> Tell others about the round and make sure folks know you’ve applied! Encourage others to check out the round when it goes live and add their voice in how the funds are distributed.

--- a/src/content/contributing/funding-rounds/participating/registering/index.md
+++ b/src/content/contributing/funding-rounds/participating/registering/index.md
@@ -1,6 +1,6 @@
 ---
 title: Registering for funding as an ethereum.org contributor
-description: Instructions on how to get registered as a funding recipient and apply to a funding round
+description: Instructions on how to get registered as a project and apply to a funding round as a recipient
 lang: en
 ---
 
@@ -17,24 +17,24 @@ First, you'll need to register yourself as a "project" using Gitcoin's Grant Sta
 
 Follow along below, or check out the Gitcoin support docs, _[How to create a project in Builder](https://support.gitcoin.co/gitcoin-knowledge-base/gitcoin-grants-program/project-owners/how-to-create-a-project-in-builder)_, for additional guidance.
 
-1. Get connected to Builder:
+1. **Get connected** to Gitcoin Builder:
 
    - Go to [Gitcoin Builder New Project](https://builder.gitcoin.co/#/projects/new)
    - Connect wallet
-   - Switch network to **Optimism**
+   - Switch network to Optimism
 
-2. Fill out project details:
+2. **Provide project details**:
 
    - _Project Name_ - This is your name, or whatever identifier others will recognize (if you’ve contributed as a team, you can use a team name here)
    - _Project Website_ - Link to your preferred social profile (or your own website if you have one)
    - _Project Logo, Project Banner (optional)_ - Avatar and banner images for your project profile
    - _Project Description_ - Describe your interest in ethereum.org, and what potential impact could result from receiving funds
 
-3. Provide socials _(optional)_:
+3. **Provide socials** _(optional)_:
 
    - If you’re contribution involved code contributions or anything on GitHub, it is recommended to provide this for clarity
 
-4. Preview and publish:
+4. **Preview and publish**:
 
    - Confirm your details, then "Save and Publish" to submit your transaction on Optimism (requires some ETH on Optimism for transaction fee)
 
@@ -45,13 +45,13 @@ Once you have a project for yourself, you'll need to apply to an active round. F
 <!-- TODO: Figure out how to link to round(s) without manual updates here -->
 <!-- Explorer link: https://explorer.gitcoin.co/#/round/10/round-contract-address -->
 
-1. Get connected to the round:
+1. **Get connected** to the funding round:
 
    - Go to <CurrentFundingRound roundInterface="explorer">Gitcoin Explorer for the current round</CurrentFundingRound>
    - Make sure you're connected to the same wallet used to create your project
    - Confirm network is on **Optimism**
 
-2. Start application
+2. **Start** application
 
    - Review application period and round eligibility
    - Click **Apply** to continue
@@ -61,7 +61,7 @@ Once you have a project for yourself, you'll need to apply to an active round. F
 There can be a delay after selecting your project. Give it a moment, and form details should be displayed beneath the selector. If you don't see anything after 30 seconds, try refreshing the page.
 </InfoBanner>
 
-3. Fill out contribution details - Required fields include:
+3. **Provide** contribution details - Required fields include:
 
    - _Email address_ - Not displayed publicly, used to contact you if there are any issues with your application
    - _Prior funding for work_ - Must disclose any prior funding for work being submitted, such as previous grant rounds—if none, simply write "none"
@@ -73,7 +73,7 @@ There can be a delay after selecting your project. Give it a moment, and form de
      - [Markdown cheat sheet](https://www.markdownguide.org/cheat-sheet/)
    - _Primary contribution link_ - Link out to publicly available evidence of your contribution. This could be a link to contributions on GitHub, Crowdin, Discord, or directly to a page affected on ethereum.org. You may optionally provide additional URLs in the fields provided, or in your contribution description.
 
-4. Preview and publish:
+4. **Preview and publish**:
 
    - Click **Preview Application** to see a preview of your submission
    - Use _Back to Editing_ " to make any changes, or click **Submit** if everything looks good
@@ -87,8 +87,6 @@ After you’ve applied, you’re submission will enter the review process. You c
 ## Step 3: Spread the word! {#step-3}
 
 <Emoji text="📣" fontSize="3xl" me={2} /> Tell others about the round and make sure folks know you’ve applied! Encourage others to check out the round when it goes live and add their voice in how the funds are distributed.
-
-<!-- TODO: Consider a link with a prepared tweet -->
 
 Lastly, when round allocations begin, be sure to also participate as an allocator _yourself_ to get a say in how the funds are distributed!
 

--- a/src/content/contributing/funding-rounds/participating/registering/index.md
+++ b/src/content/contributing/funding-rounds/participating/registering/index.md
@@ -13,30 +13,30 @@ As an ethereum.org contributor looking to receive funding during a funding round
 
 ## Step 1: Creating a "project" for yourself {#step-1}
 
-First, you'll need to register yourself as a "project" on Gitcoin. This process is about you, and _not yet_ about your contributions to ethereum.org—you'll get a chance to describe your contribution(s) and provide a receiving address in a later step.
+First, you'll need to register yourself as a "project" using Gitcoin's Grant Stack. This step is about you, and _not yet_ about your contributions to ethereum.org—you'll get a chance to describe your contribution(s) and provide a receiving address in a later step.
 
 Follow along below, or check out the Gitcoin support docs, _[How to create a project in Builder](https://support.gitcoin.co/gitcoin-knowledge-base/gitcoin-grants-program/project-owners/how-to-create-a-project-in-builder)_, for additional guidance.
 
-1. Get connected:
+1. Get connected to Builder:
 
-- Go to [Gitcoin Builder New Project](https://builder.gitcoin.co/#/projects/new)
-- Connect wallet
-- Switch network to **Optimism**
+   - Go to [Gitcoin Builder New Project](https://builder.gitcoin.co/#/projects/new)
+   - Connect wallet
+   - Switch network to **Optimism**
 
 2. Fill out project details:
 
-- _Project Name_ - This is your name, or whatever identifier others will recognize (if you’ve contributed as a team, you can use a team name here)
-- _Project Website_ - Link to a social profile, or your website
-- _Project Logo, Project Banner_ - _Optional_ avatar and banner images for your project profile page
-- _Project Description_ - Describe your interest in ethereum.org, and what potential impact could result from receiving funds
+   - _Project Name_ - This is your name, or whatever identifier others will recognize (if you’ve contributed as a team, you can use a team name here)
+   - _Project Website_ - Link to your preferred social profile (or your own website if you have one)
+   - _Project Logo, Project Banner (optional)_ - Avatar and banner images for your project profile
+   - _Project Description_ - Describe your interest in ethereum.org, and what potential impact could result from receiving funds
 
-3. Provide socials (optional):
+3. Provide socials _(optional)_:
 
-- If you’re contribution involved code contributions or anything on GitHub, it is recommended to provide this for clarity
+   - If you’re contribution involved code contributions or anything on GitHub, it is recommended to provide this for clarity
 
 4. Preview and publish:
 
-- Confirm your details, then "Save and Publish" to submit your transaction on Optimism (requires some ETH on Optimism for transaction fee)
+   - Confirm your details, then "Save and Publish" to submit your transaction on Optimism (requires some ETH on Optimism for transaction fee)
 
 ## Step 2: Applying to a round {#step-2}
 
@@ -45,23 +45,39 @@ Once you have a project for yourself, you'll need to apply to an active round. F
 <!-- TODO: Figure out how to link to round(s) without manual updates here -->
 <!-- Explorer link: https://explorer.gitcoin.co/#/round/10/round-contract-address -->
 
-1. Go to <CurrentFundingRound roundInterface="builder">Gitcoin Builder for the current round</CurrentFundingRound>
-2. Make sure you're connected to the same wallet used to create your project
-3. Review application period and round eligibility, then click **Apply** to continue
-4. Select your project from the list
-5. **Fill out form details** - Required fields include:
-   - _Email address_
-   - _Funding sources_ - Must disclose any prior funding for work being submitted
+1. Get connected to the round:
+
+   - Go to <CurrentFundingRound roundInterface="explorer">Gitcoin Explorer for the current round</CurrentFundingRound>
+   - Make sure you're connected to the same wallet used to create your project
+   - Confirm network is on **Optimism**
+
+2. Start application
+
+   - Review application period and round eligibility
+   - Click **Apply** to continue
+   - Select your project from the list
+
+<InfoBanner emoji="⏱️" my={8}>
+There can be a delay after selecting your project. Give it a moment, and form details should be displayed beneath the selector. If you don't see anything after 30 seconds, try refreshing the page.
+</InfoBanner>
+
+3. Fill out contribution details - Required fields include:
+
+   - _Email address_ - Not displayed publicly, used to contact you if there are any issues with your application
+   - _Prior funding for work_ - Must disclose any prior funding for work being submitted, such as previous grant rounds—if none, simply write "none"
    - _Contribution description_
-     - This is your space to describe the contribution(s) you’ve made, and its impact... let people know why your contribution should be valued!
+     - This is your space to describe the contribution(s) you’ve made, and its impact... _let people know why your contribution should be valued!_
      - **This field has rich-text support using markdown**, so don’t be afraid to express yourself, and make sure users can easily see what you’ve worked on
      - This means you can also embed screenshots using URLs and additional links as needed, though you'll need a place to host these images (i.e. [GitHub](https://github.com), [Imgur](https://imgur.com/), etc.)
      - You can preview your submission in the next step
      - [Markdown cheat sheet](https://www.markdownguide.org/cheat-sheet/)
-   - _Primary contribution link_ - Link out to publicly available evidence of your contribution. This could be a link to contributions on GitHub, Crowdin, Discord, or directly to a page affected on ethereum.org. You may optionally provide additional URLs in the fields below, or in your contribution description.
-6. When finished, click **Preview Application** to continue to preview
-7. Review your application, then click **Submit**
-8. Once submitted, the entry cannot be changed. Please make sure everything is correct before proceeding. Clicking **Proceed** will submit your transaction on Optimism (requires some ETH on Optimism for transaction fee)
+   - _Primary contribution link_ - Link out to publicly available evidence of your contribution. This could be a link to contributions on GitHub, Crowdin, Discord, or directly to a page affected on ethereum.org. You may optionally provide additional URLs in the fields provided, or in your contribution description.
+
+4. Preview and publish:
+
+   - Click **Preview Application** to see a preview of your submission
+   - Use _Back to Editing_ " to make any changes, or click **Submit** if everything looks good
+   - Once submitted, the entry **cannot be changed**. Please make sure everything is correct before proceeding. Clicking **Proceed** will submit your transaction on Optimism (requires some ETH on Optimism for transaction fee)
    - To encrypt your data, you must also sign-in again with your wallet—this does not cost additional gas
 
 <InfoBanner emoji="👷">
@@ -74,6 +90,6 @@ After you’ve applied, you’re submission will enter the review process. You c
 
 <!-- TODO: Consider a link with a prepared tweet -->
 
-Lastly, when round allocations begin, be sure to also participate as an allocator to get a say in how the funds are distributed!
+Lastly, when round allocations begin, be sure to also participate as an allocator _yourself_ to get a say in how the funds are distributed!
 
 <ButtonLink href="/contributing/funding-rounds/participating/allocating/">Learn how to allocate</ButtonLink>

--- a/src/templates/static.tsx
+++ b/src/templates/static.tsx
@@ -19,6 +19,7 @@ import Breadcrumbs from "../components/Breadcrumbs"
 import Card from "../components/Card"
 import Callout from "../components/Callout"
 import Contributors from "../components/Contributors"
+import CurrentFundingRound from "../components/CurrentFundingRound"
 import FeedbackCard from "../components/FeedbackCard"
 import InfoBanner from "../components/InfoBanner"
 import Link from "../components/Link"
@@ -207,6 +208,7 @@ const components = {
   EnergyConsumptionChart,
   QuizWidget,
   UpgradeStatus,
+  CurrentFundingRound,
 }
 
 const StaticPage = ({


### PR DESCRIPTION
Draft of new pages outlining funding round processes

## New pages
- `/contributing/funding-rounds/`
- `/contributing/funding-rounds/participating/`
- `/contributing/funding-rounds/participating/registering/`
- `/contributing/funding-rounds/participating/allocating/`

## Preview link
https://ethereumorgwebsitedev01-contributorfundingrounds.gatsbyjs.io/en/contributing/funding-rounds/