### PR TITLE
Fix math % multiplication typo

### DIFF
--- a/src/content/developers/docs/gas/index.md
+++ b/src/content/developers/docs/gas/index.md
@@ -69,7 +69,7 @@ The base fee is calculated by a formula that compares the size of the previous b
 | 7            |          30M |        12.5% |       180.2 gwei |
 | 8            |          30M |        12.5% |       202.7 gwei |
 
-Relative to the pre-London gas auction market, this transaction-fee-mechanism change causes fee prediction to be more reliable. Following the table above - to create a transaction on block number 9, a wallet will let the user know with certainty that the **maximum base fee** to be added to the next block is `current base fee * 12.5%` or `202.7 gwei * 12.5% = 228.1 gwei`.
+Relative to the pre-London gas auction market, this transaction-fee-mechanism change causes fee prediction to be more reliable. Following the table above - to create a transaction on block number 9, a wallet will let the user know with certainty that the **maximum base fee** to be added to the next block is `current base fee * 112.5%` or `202.7 gwei * 112.5% = 228.1 gwei`.
 
 It's also important to note it is unlikely we will see extended spikes of full blocks because of the speed at which the base fee increases proceeding a full block.
 


### PR DESCRIPTION
Fix percentage calculations.

## Description

When we want to increase 100 by 10%, we should calculate `100 * 110%` not `100 * 10%` as in example :)

## Related Issue
None
