### PR TITLE
Add Hong Kong community 852dev.xyz to Community Meetups

### DIFF
--- a/src/data/community-meetups.json
+++ b/src/data/community-meetups.json
@@ -1,5 +1,11 @@
 [
   {
+    "title": "852dev.xyz",
+    "emoji": ":hong_kong:",
+    "location": "Hong Kong",
+    "link": "https://twitter.com/852devxyz"
+  },
+  {
     "title": "Ethereum Ecuador",
     "emoji": ":ec:",
     "location": "Ecuador",


### PR DESCRIPTION
## Description

The original Ethereum Hong Kong meetup group has been inactive for recent years. We want to propose adding another local developer meetup group 852dev.xyz, which focuses also on web3 technologies and often hosts blockchain-related seminars, onto the list.