### PR TITLE
+ community code of conduct

### DIFF
--- a/src/content/community/code-of-conduct/index.md
+++ b/src/content/community/code-of-conduct/index.md
@@ -1,0 +1,75 @@
+---
+title: Code of conduct
+description: The basic standards that we strive for across ethereum.org spaces.
+lang: en
+---
+
+## Mission
+
+To develop and maintain the most comprehensive and accessible knowledge hub for Ethereum.
+
+## Values
+
+The [Ethereum.org](http://Ethereum.org) community strives to be:
+
+- educational, intended to help everyone to understand Ethereum
+- inclusive
+- accessible
+- community-driven
+- focused on Ethereum’s underlying technology and use-cases
+- focused on Ethereum concepts and design principles
+
+## What we are not
+
+- The Ethereum Foundation website
+- A platform for promoting investments or profiteering of any kind
+- A platform for elevating or endorsing individual projects or organizations
+- A DEX, CEX or any other form of financial platform
+- A platform that gives financial or legal advice of any kind
+
+## Code-of-conduct
+
+### Pledge
+
+Open participation is core to the [ethereum.org](http://ethereum.org) ethos. We are a website and community maintained by thousands of contributors and this is only possible if we maintain a welcoming participatory environment. To this end, contributors to this site pledge to maintain a harassment-free environment for all participants across all ethereum.org platforms and community spaces. The ethereum.org community welcomes and values anyone who wants to participate in a constructive and friendly way, regardless of age, disability, ethnicity, sex characteristics, gender identity, level of experience, area of expertise, education, socio-economic status, nationality, personal appearance, race, religion or any other dimension of diversity.
+
+### Scope
+
+This Code of Conduct applies to all [ethereum.org](http://ethereum.org) spaces (such as Github, Discord, Figma Crowdin, Twitter and other online platforms), and it also applies when the community is represented in real-world public spaces such as at meetups, conferences and events.
+
+### Our standards
+
+Examples of behaviour that contributes to creating a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting and/or empathetically providing constructive criticism
+- Acting calmly and professionally when resolving conflicts or disagreements
+- Showing empathy and tolerance towards other community members
+- Encouraging and amplifying new voices in the community
+
+Examples of unacceptable behavior by participants include:
+
+- Physical violence, threatening physical violence or encouraging of physical violence of any kind
+- Using sexualized language or imagery or imposing unwelcome sexual attention
+- Impersonating another individual or otherwise dishonestly claiming affiliation with some individual or organization.
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Harrassing other community members in public or private channels
+- Publishing others’ private information, such as a physical or electronic addresses, without explicit permission
+- Social engineering, scamming or otherwise manipulating other community members
+- Promoting investments, tokens, projects or anything else for personal monetary or non-monetary gain
+- Spamming servers with off-topic content
+- Disregarding requests or warnings from community moderators
+- Engaging in other conduct which could reasonably be considered inappropriate in a professional setting
+
+### Reporting
+
+Violations of the code of conduct will normally be visible to the community as we try to do everything in open, public channels, allowing community members to self police.
+
+However, if something happens that you feel needs attention, you can raise it with someone who has a moderation role (e.g. discord guide) so that they can help investigate and execute the appropriate response.
+
+When reporting, please try to include as much detail as you can, including specific examples and timestamps where possible. This will help to ensure a fair outcome.
+
+### Enforcement
+
+Depending on the severity, people who violate the code of conduct can receive warnings, temporary bans or permanent bans from [ethereum.org](http://ethereum.org) platforms.

--- a/src/content/community/code-of-conduct/index.md
+++ b/src/content/community/code-of-conduct/index.md
@@ -4,13 +4,13 @@ description: The basic standards that we strive for across ethereum.org spaces.
 lang: en
 ---
 
-## Mission
+## Mission {#mission}
 
 To develop and maintain the most comprehensive and accessible knowledge hub for Ethereum.
 
-## Values
+## Values {#values}
 
-The [Ethereum.org](http://Ethereum.org) community strives to be:
+The ethereum.org community strives to be:
 
 - educational, intended to help everyone to understand Ethereum
 - inclusive
@@ -19,7 +19,7 @@ The [Ethereum.org](http://Ethereum.org) community strives to be:
 - focused on Ethereum’s underlying technology and use-cases
 - focused on Ethereum concepts and design principles
 
-## What we are not
+## What we are not {#what-we-are-not}
 
 - The Ethereum Foundation website
 - A platform for promoting investments or profiteering of any kind
@@ -27,17 +27,17 @@ The [Ethereum.org](http://Ethereum.org) community strives to be:
 - A DEX, CEX or any other form of financial platform
 - A platform that gives financial or legal advice of any kind
 
-## Code-of-conduct
+## Code of conduct {#code-of-conduct}
 
-### Pledge
+### Pledge {#pledge}
 
-Open participation is core to the [ethereum.org](http://ethereum.org) ethos. We are a website and community maintained by thousands of contributors and this is only possible if we maintain a welcoming participatory environment. To this end, contributors to this site pledge to maintain a harassment-free environment for all participants across all ethereum.org platforms and community spaces. The ethereum.org community welcomes and values anyone who wants to participate in a constructive and friendly way, regardless of age, disability, ethnicity, sex characteristics, gender identity, level of experience, area of expertise, education, socio-economic status, nationality, personal appearance, race, religion or any other dimension of diversity.
+Open participation is core to the ethereum.org ethos. We are a website and community maintained by thousands of contributors, and this is only possible if we maintain a welcoming, participatory environment. To this end, contributors to this site pledge to maintain a harassment-free environment for all participants across all ethereum.org platforms and community spaces. The ethereum.org community welcomes and values anyone who wants to participate in a constructive and friendly way, regardless of age, disability, ethnicity, sex characteristics, gender identity, level of experience, area of expertise, education, socio-economic status, nationality, personal appearance, race, religion or any other dimension of diversity.
 
-### Scope
+### Scope {#scope}
 
-This Code of Conduct applies to all [ethereum.org](http://ethereum.org) spaces (such as Github, Discord, Figma Crowdin, Twitter and other online platforms), and it also applies when the community is represented in real-world public spaces such as at meetups, conferences and events.
+This Code of Conduct applies to all ethereum.org spaces (such as GitHub, Discord, Figma Crowdin, Twitter and other online platforms), and it also applies when the community is represented in real-world public spaces such as at meetups, conferences and events.
 
-### Our standards
+### Our standards {#our-standards}
 
 Examples of behaviour that contributes to creating a positive environment include:
 
@@ -54,22 +54,22 @@ Examples of unacceptable behavior by participants include:
 - Using sexualized language or imagery or imposing unwelcome sexual attention
 - Impersonating another individual or otherwise dishonestly claiming affiliation with some individual or organization.
 - Trolling, insulting/derogatory comments, and personal or political attacks
-- Harrassing other community members in public or private channels
-- Publishing others’ private information, such as a physical or electronic addresses, without explicit permission
+- Harassing other community members in public or private channels
+- Publishing others’ private information, such as a physical or electronic address, without explicit permission
 - Social engineering, scamming or otherwise manipulating other community members
 - Promoting investments, tokens, projects or anything else for personal monetary or non-monetary gain
 - Spamming servers with off-topic content
 - Disregarding requests or warnings from community moderators
 - Engaging in other conduct which could reasonably be considered inappropriate in a professional setting
 
-### Reporting
+### Reporting {#reporting}
 
-Violations of the code of conduct will normally be visible to the community as we try to do everything in open, public channels, allowing community members to self police.
+Violations of the code of conduct will normally be visible to the community as we try to do everything in open, public channels, allowing community members to self-police.
 
 However, if something happens that you feel needs attention, you can raise it with someone who has a moderation role (e.g. discord guide) so that they can help investigate and execute the appropriate response.
 
-When reporting, please try to include as much detail as you can, including specific examples and timestamps where possible. This will help to ensure a fair outcome.
+When reporting, please include as much detail as possible, including specific examples and timestamps. This will help to ensure a fair outcome.
 
-### Enforcement
+### Enforcement {#enforcement}
 
-Depending on the severity, people who violate the code of conduct can receive warnings, temporary bans or permanent bans from [ethereum.org](http://ethereum.org) platforms.
+Depending on the severity, people who violate the code of conduct can receive warnings, temporary bans or permanent bans from ethereum.org communities.

--- a/src/content/community/get-involved/index.md
+++ b/src/content/community/get-involved/index.md
@@ -8,6 +8,8 @@ lang: en
 
 The Ethereum community includes people of many different backgrounds and skillsets. Whether you’re a developer, an artist, or an accountant, there are ways to get involved. Here’s a list of suggestions that might help you get started.
 
+Start by reading about the ethereum.org mission and values in our [code of conduct](/community/code-of-conduct).
+
 ## Developers <Emoji text=":computer:" size={1} />‍ {#developers}
 
 - Learn about and try Ethereum at [ethereum.org/developers/](/developers/)
@@ -122,3 +124,6 @@ The Ethereum ecosystem is on a mission to fund public goods and impactful projec
 - [ΜΓΔ](https://metagammadelta.com/) (Meta Gamma Delta) [@metagammadelta](https://twitter.com/metagammadelta) - _Women-led projects_
 - [MolochDAO](https://molochdao.com) [@MolochDAO](https://twitter.com/MolochDAO) - _Community focused on funding Ethereum development_
 - [Raid Guild](https://raidguild.org) [@RaidGuild](https://twitter.com/RaidGuild) - _Collective of Web3 builders_
+
+
+Please remember to abide by the ethereum.org [code of conduct](/community/code-of-conduct) whenever and however you contribute to ethereum.org!

--- a/src/content/contributing/index.md
+++ b/src/content/contributing/index.md
@@ -65,6 +65,7 @@ Before contributing, make sure you're familiar with:
 - the evolving [vision of ethereum.org](/about/)
 - our [design principles](/contributing/design-principles/)
 - our [style guide](/contributing/style-guide/)
+- our [code of conduct](/community/code-of-conduct)
 
 ## How decisions about the site are made {#how-decisions-about-the-site-are-made}
 


### PR DESCRIPTION
## Description

A new code of conduct for the ethereum.org project spaces was workshoppped by volunteers from the ethereum.org discord. This PR adds it to the website under `/community`.
