### PR TITLE
Fix typo in node comparison table

### DIFF
--- a/src/content/developers/docs/nodes-and-clients/node-architecture/index.md
+++ b/src/content/developers/docs/nodes-and-clients/node-architecture/index.md
@@ -45,7 +45,7 @@ Node operators can add a validator to their consensus clients by depositing 32 E
 
 | Execution Client                                   | Consensus Client                                                 | Validator                    |
 | -------------------------------------------------- | ---------------------------------------------------------------- | ---------------------------- |
-| Gossips transactions over its p2p network          | Gossips blocks and attestations overs its p2p network            | Proposes blocks              |
+| Gossips transactions over its p2p network          | Gossips blocks and attestations over its p2p network             | Proposes blocks              |
 | Executes/re-executes transactions                  | Runs the fork choice algorithm                                   | Accrues rewards/penalties    |
 | Verifies incoming state changes                    | Keeps track of the head of the chain                             | Makes attestations           |
 | Manages state and receipts tries                   | Manages the Beacon state (contains consensus and execution info) | Requires 32 ETH to be staked |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed a typo: overs --> over.

## Related Issue

N/A
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
