### PR TITLE
Add Chain Connect to access multiple RPC endpoints

### DIFF
--- a/src/content/developers/docs/nodes-and-clients/index.md
+++ b/src/content/developers/docs/nodes-and-clients/index.md
@@ -126,7 +126,7 @@ If you're more of a technical user, dive into more details and options on how to
 
 ## Alternatives {#alternatives}
 
-Setting up your own node can cost you time and resources but you don’t always need to run your own instance. In this case, you can use a third party API provider. For an overview of using these services, check out [nodes as a service](/developers/docs/nodes-and-clients/nodes-as-a-service/).
+Setting up your own node can cost you time and resources but you don’t always need to run your own instance. In this case, you can use a third party API provider. For an overview of using these services, check out [nodes as a service](/developers/docs/nodes-and-clients/nodes-as-a-service/). All the public RPC endpoints, often used by developers can be found on [Chain Connect](https://www.alchemy.com/chain-connect/chain/ethereum).
 
 If somebody runs an Ethereum node with a public API in your community, you can point your wallets to a community node via Custom RPC and gain more privacy than with some random trusted third party.
 


### PR DESCRIPTION
One place for developers to access multiple public and private RPC endpoints.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Chain Connect is a resource for the web3 community to explore RPC endpoints from various providers and connect to a range of blockchain and network nodes. Alchemy and DeveloperDAO maintain it.
This will help developers easily access and choose between multiple RPC endpoints.

P.S. - I work with Alchemy
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
