### PR TITLE
fix discord invite link on translation program resources page

### DIFF
--- a/src/content/contributing/translation-program/resources/index.md
+++ b/src/content/contributing/translation-program/resources/index.md
@@ -44,7 +44,7 @@ To keep up-to-date with the latest Translation Program progress, you can follow 
 
 ## Office hours for translators {#office-hours}
 
-We have office hours for translators on the second Wednesday of every month. These are held in the #office-hours voice channel on the [ethereum.org Discord](https://discord.gg/geKhWjtF), where you can also find the exact times and additional details.
+We have office hours for translators on the second Wednesday of every month. These are held in the #office-hours voice channel on the [ethereum.org Discord](https://discord.gg/Sfz7jqpBWU), where you can also find the exact times and additional details.
 
 Office hours allow our translators to ask questions about the translation process, provide feedback on the program, share their ideas, or just chat with the core ethereum.org team.
 Finally, we want to use these calls to communicate recent developments with the Translation Program and share key tips and instructions with our contributors.

--- a/src/content/contributing/translation-program/resources/index.md
+++ b/src/content/contributing/translation-program/resources/index.md
@@ -44,7 +44,7 @@ To keep up-to-date with the latest Translation Program progress, you can follow 
 
 ## Office hours for translators {#office-hours}
 
-We have office hours for translators on the second Wednesday of every month. These are held in the #office-hours voice channel on the [ethereum.org Discord](https://discord.gg/Sfz7jqpBWU), where you can also find the exact times and additional details.
+We have office hours for translators on the second Wednesday of every month. These are held in the #office-hours voice channel on the [ethereum.org Discord](/discord/), where you can also find the exact times and additional details.
 
 Office hours allow our translators to ask questions about the translation process, provide feedback on the program, share their ideas, or just chat with the core ethereum.org team.
 Finally, we want to use these calls to communicate recent developments with the Translation Program and share key tips and instructions with our contributors.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

https://ethereum.org/en/contributing/translation-program/resources/#office-hours affected page. 

For the changes, I generated a discord invite link that will not expire, redirecting to #office-hours-voice channel.
<img width="392" alt="image" src="https://github.com/ethereum/ethereum-org-website/assets/56709653/bbbc572a-303e-4904-8d42-78bb38486664">

Expected behavior on clicking the invite link is to redirect to #office-hours-voice channel.
<img width="1429" alt="image" src="https://github.com/ethereum/ethereum-org-website/assets/56709653/f7fd7c75-8ef8-4e44-a64c-0a86e7c2c9fd">

Code change is to replace the invalid discord invite link https://discord.gg/geKhWjtF with a valid one https://discord.gg/Sfz7jqpBWU

## Related Issue

Closes #10530 

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
