### PR TITLE
Fix quizzes extra redirect

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -256,10 +256,6 @@
     "toPath": "/en/roadmap"
   },
   {
-    "fromPath": "/quizzes",
-    "toPath": "/en/quizzes/"
-  },
-  {
     "fromPath": "/*/upgrades",
     "toPath": "/:splat/roadmap"
   },


### PR DESCRIPTION
Currently, we have the following warning on the build:
```
warn There are routes that match both page and redirect. Pages take precedence over redirects so the redirect will not work:
 - page: "/quizzes/" and redirect: "/quizzes" -> "/en/quizzes/"
```

## Description

Removes `/quizzes` => `/en/quizzes` redirect from `redirects.json` since that rule is already generated automatically by the code in `gatsby-node.ts`.