### PR TITLE
Change button style to Ethreum Website's default main button. Issue #10553

### DIFF
--- a/src/pages/run-a-node.tsx
+++ b/src/pages/run-a-node.tsx
@@ -250,7 +250,7 @@ const ButtonContainer = (props: ChildOnlyProp) => (
 
 const DappNodeButtonLink = (props: ComponentProps<typeof ButtonLink>) => (
   <ButtonLink
-    bg="#007dfc"
+    bg="#1c1cff"
     _hover={{ bg: "#0077be", boxShadow: "4px 4px 0 0 rgb(0 125 252 / 47%)" }}
     {...props}
   />
@@ -258,7 +258,7 @@ const DappNodeButtonLink = (props: ComponentProps<typeof ButtonLink>) => (
 
 const AvadoButtonLink = (props: ComponentProps<typeof ButtonLink>) => (
   <ButtonLink
-    bg="#37822e"
+    bg="#1c1cff"
     _hover={{ bg: "#2e6d2e", boxShadow: "4px 4px 0 0 rgb(55 130 46 / 47%)" }}
     {...props}
   />


### PR DESCRIPTION
Button style on the `run-a-node` page changed according to the theme of the Ethereum official website.

## Description

Previously it used to look like this:
![249156392-8750e1cb-14d5-498e-80ff-e30c30645c8d](https://github.com/ethereum/ethereum-org-website/assets/98945276/595b5728-dc49-4d9c-8fc0-1401b45fee61)

I fixed it to:
![image](https://github.com/ethereum/ethereum-org-website/assets/98945276/06d3d84c-67b3-441b-addc-6c5ddaeb0751)

## Related Issue

https://github.com/ethereum/ethereum-org-website/issues/10553
