### PR TITLE
Fix `ButtonLink` styles

### DIFF
--- a/src/components/ButtonLink.tsx
+++ b/src/components/ButtonLink.tsx
@@ -12,15 +12,21 @@ const ButtonLink: React.FC<IProps> = ({ children, isSecondary, ...props }) => {
    *  Prevent React warning that does not recognize `isSecondary` on DOM
    *  while still sending prop to the theme config
    */
-  const styles = useStyleConfig("Button", { ...props, isSecondary })
+  const styles = useStyleConfig("Button", {
+    ...props,
+    isSecondary,
+  })
 
   return (
     <Button
       as={Link}
-      textDecoration="none"
       activeStyle={{}}
       // `styles` object sent to `sx` prop per convention
-      sx={styles}
+      sx={{
+        ...styles,
+        textDecoration: "none",
+        _hover: { ...styles["_hover"], textDecoration: "none" },
+      }}
       {...props}
     >
       {children}


### PR DESCRIPTION
Due to [recent DS implementation changes on the Button component](https://github.com/ethereum/ethereum-org-website/pull/10315), we need to override the underlined text decoration inherited from the Link component.

## Description

Overrides the link text decoration styles.

Before (hovered):
![image](https://github.com/ethereum/ethereum-org-website/assets/468158/44c3efe5-e9e2-4539-838f-d9c75479fd9e)

Now (hovered):
![image](https://github.com/ethereum/ethereum-org-website/assets/468158/1fcf462c-0fcd-4278-839e-cc4f7b21a6d3)