### PR TITLE
fix(Search/utils): update semantic syntax for highlighted search results

### DIFF
--- a/src/components/Search/utils.ts
+++ b/src/components/Search/utils.ts
@@ -133,7 +133,7 @@ export const getSearchModalStyles = (): SystemStyleObject => ({
       py: 3,
     },
     '&[aria-selected="true"] a': {
-      "--docsearch-hit-active-color": "colors.background",
+      "--docsearch-hit-active-color": "colors.background.base",
       bg: "primary.hover",
       boxShadow: `4px 4px 0 0 var(--eth-colors-primary-light)`,
       borderColor: "transparent",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes text color for highlighted search results where the semantic token used was not up-to-date, resulting in a typo.
