### PR TITLE
docs: remove a dead link to https://faucet.goerli.mudit.blog/

### DIFF
--- a/src/content/developers/docs/networks/index.md
+++ b/src/content/developers/docs/networks/index.md
@@ -84,7 +84,6 @@ Goerli is testnet for testing of validating and staking. The Goerli network is o
 - [QuickNode Goerli Faucet](https://faucet.quicknode.com/drip)
 - [Grabteeth](https://grabteeth.xyz/)
 - [PoW faucet](https://goerli-faucet.pk910.de/)
-- [Goerli faucet](https://faucet.goerli.mudit.blog/)
 - [Paradigm faucet](https://faucet.paradigm.xyz/)
 - [Alchemy Goerli Faucet](https://goerlifaucet.com/)
 - [All That Node Goerli Faucet](https://www.allthatnode.com/faucet/ethereum.dsrv)


### PR DESCRIPTION
The link https://faucet.goerli.mudit.blog/ in fucet for goerli faucets resources is dead
