### PR TITLE
replace "miner" with "validator" on gas page

### DIFF
--- a/src/content/developers/docs/gas/index.md
+++ b/src/content/developers/docs/gas/index.md
@@ -85,7 +85,9 @@ It's also important to note it is unlikely we will see extended spikes of full b
 
 Before the London Upgrade, miners would receive the total gas fee from any transaction included in a block.
 
-With the new base fee getting burned, the London Upgrade introduced a priority fee (tip) to incentivize miners to include a transaction in the block. Without tips, miners would find it economically viable to mine empty blocks, as they would receive the same block reward. Under normal conditions, a small tip provides miners a minimal incentive to include a transaction. For transactions that need to get preferentially executed ahead of other transactions in the same block, a higher tip will be necessary to attempt to outbid competing transactions.
+With the new base fee getting burned, the London Upgrade introduced a priority fee (tip) to incentivize miners to include a transaction in the block. Without tips, miners would find it economically viable to mine empty blocks, as they would receive the same block reward. Under normal conditions, a small tip provided miners a minimal incentive to include a transaction. For transactions that need to get preferentially executed ahead of other transactions in the same block, a higher tip was necessary to attempt to outbid competing transactions.
+
+Ethereum has since swapped it's proof-of-work based consensus mechanism for one based on proof-of-stake, but the base and priority fee and burning mechanism stayed the same. The only difference is in today's system miners are replaced with validators who secure the network by sending their ETH to a smart contract rather than proof-of-work mining.
 
 ### Max fee {#maxfee}
 
@@ -120,7 +122,7 @@ _Diagram adapted from [Ethereum EVM illustrated](https://takenobu-hs.github.io/d
 
 Gas limit refers to the maximum amount of gas you are willing to consume on a transaction. More complicated transactions involving [smart contracts](/developers/docs/smart-contracts/) require more computational work, so they require a higher gas limit than a simple payment. A standard ETH transfer requires a gas limit of 21,000 units of gas.
 
-For example, if you put a gas limit of 50,000 for a simple ETH transfer, the EVM would consume 21,000, and you would get back the remaining 29,000. However, if you specify too little gas, for example, a gas limit of 20,000 for a simple ETH transfer, the EVM will consume your 20,000 gas units attempting to fulfill the transaction, but it will not complete. The EVM then reverts any changes, but since the miner has already done 20k gas units worth of work, that gas is consumed.
+For example, if you put a gas limit of 50,000 for a simple ETH transfer, the EVM would consume 21,000, and you would get back the remaining 29,000. However, if you specify too little gas, for example, a gas limit of 20,000 for a simple ETH transfer, the EVM will consume your 20,000 gas units attempting to fulfill the transaction, but it will not complete. The EVM then reverts any changes, but since the validator has already done 20k gas units worth of work, that gas is consumed.
 
 ## Why can gas fees get so high? {#why-can-gas-fees-get-so-high}
 
@@ -136,7 +138,7 @@ Layer 2 scaling is a primary initiative to greatly improve gas costs, user exper
 
 ## Strategies for you to reduce gas costs {#strategies-for-you-to-reduce-gas-costs}
 
-If you are looking to reduce gas costs for your transactions, you can set a tip to indicate the priority level of your transaction. Miners will 'work on' and execute transactions that offer a higher tip per gas, as they get to keep the tips that you pay and will be less inclined to execute transactions with lower tips set.
+If you are looking to reduce gas costs for your transactions, you can set a tip to indicate the priority level of your transaction. Validators will 'work on' and execute transactions that offer a higher tip per gas, as they get to keep the tips that you pay and will be less inclined to execute transactions with lower tips set.
 
 If you want to monitor gas prices, so you can send your ETH for less, you can use many different tools such as:
 

--- a/src/content/developers/docs/gas/index.md
+++ b/src/content/developers/docs/gas/index.md
@@ -85,9 +85,9 @@ It's also important to note it is unlikely we will see extended spikes of full b
 
 Before the London Upgrade, miners would receive the total gas fee from any transaction included in a block.
 
-With the new base fee getting burned, the London Upgrade introduced a priority fee (tip) to incentivize miners to include a transaction in the block. Without tips, miners would find it economically viable to mine empty blocks, as they would receive the same block reward. Under normal conditions, a small tip provided miners a minimal incentive to include a transaction. For transactions that need to get preferentially executed ahead of other transactions in the same block, a higher tip was necessary to attempt to outbid competing transactions.
+With the new base fee getting burned, the London Upgrade introduced a priority fee (tip) to incentivize miners to include a transaction in the block. Without tips, miners would find it economically viable to mine empty blocks, as they would receive the same block reward. Under normal conditions, a small tip gave miners a minimal incentive to include a transaction. For transactions that needed to get preferentially executed ahead of other transactions in the same block, a higher tip was necessary to attempt to outbid competing transactions.
 
-Ethereum has since swapped it's proof-of-work based consensus mechanism for one based on proof-of-stake, but the base and priority fee and burning mechanism stayed the same. The only difference is in today's system miners are replaced with validators who secure the network by sending their ETH to a smart contract rather than proof-of-work mining.
+Ethereum has since swapped its proof-of-work-based consensus mechanism for one based on proof-of-stake, but the base fee, priority fee and burning mechanism stayed the same. The only difference is, in today's system, miners are replaced with validators who secure the network by sending their ETH to a smart contract rather than proof-of-work mining.
 
 ### Max fee {#maxfee}
 


### PR DESCRIPTION
Replaces "miner" with "validator" in several places on gas page.

Fixes #10430 (although note that the copy identified in the issue refers to the London upgrade which happened before The Merge, so miner is correct. Added a note about pow->pos beneath instead of swapping terms.