### PR TITLE
docs: fix typos

### DIFF
--- a/src/content/contributing/translation-program/content-buckets/index.md
+++ b/src/content/contributing/translation-program/content-buckets/index.md
@@ -237,7 +237,7 @@ Below is a breakdown of the website pages each content bucket contains.
 - [Patricia Merkle Trees](/developers/docs/data-structures-and-encoding/patricia-merkle-trie/)
 - [Data structures and encoding](/developers/docs/data-structures-and-encoding/)
 - [Recursive-length prefix (RLP) serialization](/developers/docs/data-structures-and-encoding/rlp/)
-- [Network adresses](/developers/docs/networking-layer/network-addresses/)
+- [Network addresses](/developers/docs/networking-layer/network-addresses/)
 - [Simple serialize](/developers/docs/data-structures-and-encoding/ssz/)
 - [Mining algorithms](/developers/docs/consensus-mechanisms/pow/mining-algorithms/)
 - [Dagger-Hashimoto](/developers/docs/consensus-mechanisms/pow/mining-algorithms/dagger-hashimoto/)

--- a/src/content/developers/docs/nodes-and-clients/bootnodes/index.md
+++ b/src/content/developers/docs/nodes-and-clients/bootnodes/index.md
@@ -22,7 +22,7 @@ When you start up a node it should log your [enode](/developers/docs/networking-
 
 The enode is usually regenerated on every restart, so make sure to look at your client's documentation on how to generate a persistent enode for your bootnode.
 
-In order to be a good bootnode it's a good idea to increase the maximum number of peers that can connect to it. Running a bootnode with many peers will increase the bandwith requirement significantly.
+In order to be a good bootnode it's a good idea to increase the maximum number of peers that can connect to it. Running a bootnode with many peers will increase the bandwidth requirement significantly.
 
 ## Available bootnodes {#available-bootnodes}
 


### PR DESCRIPTION
Hey :wave:,

This PR will fix :

1 typo in `src/content/contributing/translation-program/content-buckets/index.md`
1 typo in `src/content/developers/docs/nodes-and-clients/bootnodes/index.md`


Best!