### PR TITLE
fix formatting in eth_getTransaction output bullets

### DIFF
--- a/src/content/developers/docs/apis/json-rpc/index.md
+++ b/src/content/developers/docs/apis/json-rpc/index.md
@@ -1246,7 +1246,8 @@ params: ["0x85d995eba9763907fdf35cd2034144dd9d53ce32cbec21349d4b12823c6860c5"]
 - `logs`: `Array` - Array of log objects, which this transaction generated.
 - `logsBloom`: `DATA`, 256 Bytes - Bloom filter for light clients to quickly retrieve related logs.
 - `type`: `QUANTITY` - integer of the transaction type, `0x0` for legacy transactions, `0x1` for access list types, `0x2` for dynamic fees.
-  It also returns _either_ :
+
+It also returns _either_ :
 - `root` : `DATA` 32 bytes of post-transaction stateroot (pre Byzantium)
 - `status`: `QUANTITY` either `1` (success) or `0` (failure)
 


### PR DESCRIPTION
# before
![image](https://github.com/ethereum/ethereum-org-website/assets/7883777/154a1463-9d3b-4748-a7cc-b25c11225880)

# after
![image](https://github.com/ethereum/ethereum-org-website/assets/7883777/0a1ec088-42e9-4572-9ff1-d96308c2a66a)
