### PR TITLE
Update index.md

### DIFF
--- a/src/content/developers/docs/blocks/index.md
+++ b/src/content/developers/docs/blocks/index.md
@@ -124,6 +124,7 @@ The `execution_payload` itself contains the following (notice this is identical 
 | `withdrawals`      | list of withdrawal objects                                          |
 
 The `withdrawals` list contains `withdrawal` objects structured in the following way:
+
 | Field              | Description                                                         |
 | :----------------- | :------------------------------------------------------------------ |
 | `address`          | account address that has withdrawn                                  |


### PR DESCRIPTION
The `withdrawals` header was somehow missing a carriage return, causing the table that follows not to display as markdown

## Description

Added a carriage return to fix markdown issues (that did not appear during preview!)
