### PR TITLE
fix(Button): fix onClick prop call override

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -12,13 +12,13 @@ export interface IProps extends ButtonProps {
   isSecondary?: boolean
 }
 
-const Button: React.FC<IProps> = ({ toId, isSecondary, ...props }) => {
+const Button: React.FC<IProps> = ({ toId, isSecondary, onClick, ...props }) => {
   const handleOnClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     if (toId) {
       scrollIntoView(toId)
     }
 
-    props.onClick?.(e)
+    onClick?.(e)
   }
 
   /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix issue where the `onClick` prop was being called in a custom handler of the local `Button` component and being passed straight to the render, thereby overriding the custom handler.
<!--- Describe your changes in detail -->

## Related Issue
N/A
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
