### PR TITLE
Adjust QuizWidget block margins [Fixes #10693]

### DIFF
--- a/src/components/Quiz/QuizWidget.tsx
+++ b/src/components/Quiz/QuizWidget.tsx
@@ -309,12 +309,13 @@ const QuizWidget: React.FC<IProps> = ({
 
   // Render QuizWidget component
   return (
-    <Flex width="full" direction="column" alignItems="center">
+    <Flex width="full" direction="column" alignItems="center" my={16}>
       {/* Hide heading if quiz is not in Learning Quizzes Hub page */}
       {isStandaloneQuiz && (
         <Heading
           as="h2"
           mb={12}
+          mt={0}
           textAlign="center"
           scrollBehavior="smooth"
           scrollMarginTop={24}


### PR DESCRIPTION
## Description

Margins on QuizWidget were collapsing causing the widget to not have proper vertical margins. 

- Removes top margin on H2 title
- Add vertical margins to the flex container

## Screenshot

<img width="851" alt="image" src="https://github.com/ethereum/ethereum-org-website/assets/54227730/9f361e6c-4f36-4e2c-87d5-a969ce08e565">

## Related Issue
- Fixes #10693 