### PR TITLE
Support setting env vars in win envs

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "babel-loader": "^8.3.0",
     "babel-preset-gatsby": "^2.23.0",
     "chromatic": "^6.19.9",
+    "cross-env": "^7.0.3",
     "github-slugger": "^1.3.0",
     "gray-matter": "^4.0.3",
     "husky": "^4.2.5",
@@ -122,8 +123,8 @@
   "scripts": {
     "postinstall": "yarn theme",
     "build": "gatsby build",
-    "build:lambda": "NODE_OPTIONS=--openssl-legacy-provider netlify-lambda build src/lambda --config=./webpack.lambda.js",
-    "build:10gb": "NODE_OPTIONS=--max-old-space-size=10240 gatsby build",
+    "build:lambda": "cross-env NODE_OPTIONS=--openssl-legacy-provider netlify-lambda build src/lambda --config=./webpack.lambda.js",
+    "build:10gb": "cross-env NODE_OPTIONS=--max-old-space-size=10240 gatsby build",
     "clean": "gatsby clean",
     "crowdin-clean": "rm -rf .crowdin && mkdir .crowdin",
     "crowdin-import": "ts-node src/scripts/crowdin-import.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7987,6 +7987,13 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-fetch@^3.1.5:
   version "3.1.6"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.6.tgz#bae05aa31a4da760969756318feeee6e70f15d6c"
@@ -8005,7 +8012,7 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
`yarn build` is failing in Windows envs.

## Description

Adds `cross-env` as a dev dep to support setting env vars in Windows computers.