### PR TITLE
fix(theme/Button): remove border color for solid variant

### DIFF
--- a/src/@chakra-ui/gatsby-plugin/components/Button.ts
+++ b/src/@chakra-ui/gatsby-plugin/components/Button.ts
@@ -38,6 +38,7 @@ const baseStyle = defineStyle((props) => ({
 const variantSolid = defineStyle({
   color: "background.base",
   bg: "primary.base",
+  borderColor: "transparent",
   _hover: {
     color: "background.base",
     bg: "primary.hover",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
With only the solid variant of the Button theme updates with the new DS, a border color still renders via the default `currentColor`, which does not match the background color. Make color `transparent` instead.
<!--- Describe your changes in detail -->

## Related Issue
N/A
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
