### PR TITLE
fix(TableOfContents): declare import type with `Item`

### DIFF
--- a/src/components/TableOfContents/index.tsx
+++ b/src/components/TableOfContents/index.tsx
@@ -22,7 +22,7 @@ import Translation from "../Translation"
 
 import Mobile from "./TableOfContentsMobile"
 import ItemsList from "./ItemsList"
-import { getCustomId, Item, outerListProps } from "./utils"
+import { getCustomId, type Item, outerListProps } from "./utils"
 import { trackCustomEvent } from "../../utils/matomo"
 
 export { Item }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Although #9959 was created to properly export the `Item` type signature from `TableOfContents` to be used throughout the project, the following warning still appeared in the console:
```
warn ./src/components/TableOfContents/index.tsx
export 'Item' (reexported as 'Item') was not found in './utils' (possible exports: customIdRegEx, emojiRegEx, getCustomId, outerListProps, slugify, trimmedTitle)
```

The warning throws because Gatsby is assuming that `Item` is some object or function, when it is actually a type signature. Declaring the import with `import type` gives a safe-guard to the warning and any future similar cases.

## Related Issue
N/A
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
