### PR TITLE
Add ERC-223 to token standards list at the Advanced Standards tab

### DIFF
--- a/src/content/developers/docs/standards/tokens/index.md
+++ b/src/content/developers/docs/standards/tokens/index.md
@@ -19,6 +19,7 @@ Many Ethereum development standards focus on token interfaces. These standards h
 Here are some of the most popular token standards on Ethereum:
 
 - [ERC-20](/developers/docs/standards/tokens/erc-20/) - A standard interface for fungible (interchangeable) tokens, like voting tokens, staking tokens or virtual currencies.
+- [ERC-223](/developers/docs/standards/tokens/erc-223/) - A fungible token standard with "transaction handling" model that makes token behave identical to Ether.
 - [ERC-721](/developers/docs/standards/tokens/erc-721/) - A standard interface for non-fungible tokens, like a deed for artwork or a song.
 - [ERC-777](/developers/docs/standards/tokens/erc-777/) - ERC-777 allows people to build extra functionality on top of tokens such as a mixer contract for improved transaction privacy or an emergency recover function to bail you out if you lose your private keys.
 - [ERC-1155](/developers/docs/standards/tokens/erc-1155/) - ERC-1155 allows for more efficient trades and bundling of transactions – thus saving costs. This token standard allows for creating both utility tokens (such as $BNB or $BAT) and Non-Fungible Tokens like CryptoPunks.

--- a/src/content/developers/docs/standards/tokens/index.md
+++ b/src/content/developers/docs/standards/tokens/index.md
@@ -19,7 +19,7 @@ Many Ethereum development standards focus on token interfaces. These standards h
 Here are some of the most popular token standards on Ethereum:
 
 - [ERC-20](/developers/docs/standards/tokens/erc-20/) - A standard interface for fungible (interchangeable) tokens, like voting tokens, staking tokens or virtual currencies.
-- [ERC-223](/developers/docs/standards/tokens/erc-223/) - A fungible token standard with "transaction handling" model that makes token behave identical to Ether.
+- [ERC-223](/developers/docs/standards/tokens/erc-223/) - A fungible token standard with "transaction handling" model that makes token behave identical to ether.
 - [ERC-721](/developers/docs/standards/tokens/erc-721/) - A standard interface for non-fungible tokens, like a deed for artwork or a song.
 - [ERC-777](/developers/docs/standards/tokens/erc-777/) - ERC-777 allows people to build extra functionality on top of tokens such as a mixer contract for improved transaction privacy or an emergency recover function to bail you out if you lose your private keys.
 - [ERC-1155](/developers/docs/standards/tokens/erc-1155/) - ERC-1155 allows for more efficient trades and bundling of transactions – thus saving costs. This token standard allows for creating both utility tokens (such as $BNB or $BAT) and Non-Fungible Tokens like CryptoPunks.

--- a/src/data/developer-docs-links.yaml
+++ b/src/data/developer-docs-links.yaml
@@ -195,6 +195,8 @@
           items:
             - id: docs-nav-erc-20
               to: /developers/docs/standards/tokens/erc-20/
+            - id: docs-nav-erc-223
+              to: /developers/docs/standards/tokens/erc-223/
             - id: docs-nav-erc-721
               to: /developers/docs/standards/tokens/erc-721/
             - id: docs-nav-erc-777

--- a/src/intl/en/page-developers-docs.json
+++ b/src/intl/en/page-developers-docs.json
@@ -32,6 +32,7 @@
   "docs-nav-development-networks-description": "Local blockchain environments used to test dapps before deployment",
   "docs-nav-dot-net": ".NET",
   "docs-nav-erc-20": "ERC-20: Fungible Tokens",
+  "docs-nav-erc-223": "ERC-223",
   "docs-nav-erc-721": "ERC-721: NFTs",
   "docs-nav-erc-777": "ERC-777",
   "docs-nav-erc-1155": "ERC-1155",


### PR DESCRIPTION
Recently a pull request that adds ERC-223 to token standards documentation was merged https://github.com/ethereum/ethereum-org-website/pull/9651

This is a follow up update.

## Description

This will display the ERC-223 standard with a short description at the Advanced Standards tab for better visibility since https://ethereum.org/en/developers/docs/standards/tokens/erc-223/ is not accessible from the main navigation menu