### PR TITLE
Add Tokenview ETH Node Service to nodes-as-a-service

### DIFF
--- a/src/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
+++ b/src/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
@@ -270,7 +270,6 @@ Here is a list of some of the most popular Ethereum node providers, feel free to
 - [**QuickNode**](https://www.quicknode.com)
   - [Docs](https://www.quicknode.com/docs/)
   - Features
-    - Industry-leading performance and reliability
     - 24/7 technical support & dev Discord community
     - Geo-balanced, multi cloud/metal, low-latency network
     - Multichain support (Optimism, Arbitrum, Polygon + 11 others)
@@ -359,21 +358,20 @@ Here is a list of some of the most popular Ethereum node providers, feel free to
   - RPC endpoints offer authenticated access to API’s, hassle free management with intuitive dashboard and analytics.
   - Provides both managed cloud and bring your own cloud options to choose from and supports all major cloud providers like AWS, Azure, Google Cloud, Digital Ocean and on-premise.
   - We use intelligent routing to hit the node closest to your user every time
-    
+
 [**Tokenview**](https://services.tokenview.io/)
 
 - [Docs](https://services.tokeniew/docs?type=nodeService)
 - Features
-  - Industry-leading performance and reliability
   - 24/7 technical support & Dev Telegram community
-  - Multichain support (Bitcoin, Ethereum, Tron, BNB Smart Chain,  Ethereum Classic)
+  - Multichain support (Bitcoin, Ethereum, Tron, BNB Smart Chain, Ethereum Classic)
   - Both rpc and wss endpoints are open to use
   - Unlimited access to archive data API
   - Dashboard with Request Explorer and Mempool Watcher
   - NFT data API and Webhook notify
   - Pay in Crypto
   - External support for extra behavior requirements
-    
+
 ## Further reading {#further-reading}
 
 - [List of Ethereum node services](https://ethereumnodes.com/)

--- a/src/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
+++ b/src/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
@@ -359,7 +359,21 @@ Here is a list of some of the most popular Ethereum node providers, feel free to
   - RPC endpoints offer authenticated access to API’s, hassle free management with intuitive dashboard and analytics.
   - Provides both managed cloud and bring your own cloud options to choose from and supports all major cloud providers like AWS, Azure, Google Cloud, Digital Ocean and on-premise.
   - We use intelligent routing to hit the node closest to your user every time
+    
+[**Tokenview**](https://services.tokenview.io/)
 
+- [Docs](https://services.tokeniew/docs?type=nodeService)
+- Features
+  - Industry-leading performance and reliability
+  - 24/7 technical support & Dev Telegram community
+  - Multichain support (Bitcoin, Ethereum, Tron, BNB Smart Chain,  Ethereum Classic)
+  - Both rpc and wss endpoints are open to use
+  - Unlimited access to archive data API
+  - Dashboard with Request Explorer and Mempool Watcher
+  - NFT data API and Webhook notify
+  - Pay in Crypto
+  - External support for extra behavior requirements
+    
 ## Further reading {#further-reading}
 
 - [List of Ethereum node services](https://ethereumnodes.com/)


### PR DESCRIPTION
Hi There,

Tokenview support Ethereum RPC Node service, and the Tokenview ETH Node Service is built on the strong load-balanced node cluster, which can provide high-performance and high-concurrency processing requests.  I take this opportunity to bring to your attention that Tokenview has been one of the most popular web3 platforms for millions of users.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
