### PR TITLE
Fix icon of the edit button

### DIFF
--- a/src/components/ButtonLink.tsx
+++ b/src/components/ButtonLink.tsx
@@ -21,7 +21,6 @@ const ButtonLink: React.FC<IProps> = ({ children, isSecondary, ...props }) => {
     <Button
       as={Link}
       activeStyle={{}}
-      hideArrow
       // `styles` object sent to `sx` prop per convention
       sx={{
         ...styles,

--- a/src/components/ButtonLink.tsx
+++ b/src/components/ButtonLink.tsx
@@ -21,6 +21,7 @@ const ButtonLink: React.FC<IProps> = ({ children, isSecondary, ...props }) => {
     <Button
       as={Link}
       activeStyle={{}}
+      hideArrow
       // `styles` object sent to `sx` prop per convention
       sx={{
         ...styles,

--- a/src/components/TableOfContents/index.tsx
+++ b/src/components/TableOfContents/index.tsx
@@ -94,11 +94,12 @@ const TableOfContents: React.FC<IProps> = ({
         <List {...outerListProps}>
           {!hideEditButton && (
             <ListItem mb={2}>
-              <ButtonLink to={editPath} variant="outline" hideArrow mt={0}>
-                <Flex alignItems="center">
-                  <Icon as={FaGithub} color="text" boxSize={6} me={2} />
-                  <Translation id="edit-page" />
-                </Flex>
+              <ButtonLink
+                leftIcon={<Icon as={FaGithub} />}
+                to={editPath}
+                variant="outline"
+              >
+                <Translation id="edit-page" />
               </ButtonLink>
             </ListItem>
           )}


### PR DESCRIPTION
Simplify and use the new DS styles on the buttons with icons.
![image](https://github.com/ethereum/ethereum-org-website/assets/468158/ccf793d4-3086-41b0-b1cd-8681492ab28a)

## Description

Changes the color of the Edit button's icon to the primary color.

~~This PR also sets `hideArrow` as always true in the `ButtonLink` as we never want to display the arrow for any link wrapped by this component.~~
