### PR TITLE
refactor: update sablier domain name

### DIFF
--- a/src/content/developers/tutorials/kickstart-your-dapp-frontend-development-wth-create-eth-app/index.md
+++ b/src/content/developers/tutorials/kickstart-your-dapp-frontend-development-wth-create-eth-app/index.md
@@ -11,7 +11,7 @@ source: soliditydeveloper.com
 sourceUrl: https://soliditydeveloper.com/create-eth-app
 ---
 
-Last time we looked at [the big picture of Solidity](https://soliditydeveloper.com/solidity-overview-2020) and already mentioned the [create-eth-app](https://github.com/PaulRBerg/create-eth-app). Now you will find out how to use it, what features are integrated and additional ideas on how to expand on it. Started by Paul Razvan Berg, the founder of [Sablier](http://sablier.finance/), this app will kickstart your frontend development and comes with several optional integrations to choose from.
+Last time we looked at [the big picture of Solidity](https://soliditydeveloper.com/solidity-overview-2020) and already mentioned the [create-eth-app](https://github.com/PaulRBerg/create-eth-app). Now you will find out how to use it, what features are integrated and additional ideas on how to expand on it. Started by Paul Razvan Berg, the founder of [Sablier](http://sablier.com/), this app will kickstart your frontend development and comes with several optional integrations to choose from.
 
 ## Installation {#installation}
 
@@ -98,7 +98,7 @@ Unfortunately, at the time of this writing the integration is only for Uniswap v
 
 ### Sablier {#sablier}
 
-[Sablier](https://sablier.finance/) allows users streaming money payments. Instead of a single payday, you actually get your money constantly without further administration after the initial setup. The integration includes its [own subgraph](https://thegraph.com/explorer/subgraph/sablierhq/sablier).
+[Sablier](https://sablier.com/) allows users streaming money payments. Instead of a single payday, you actually get your money constantly without further administration after the initial setup. The integration includes its [own subgraph](https://thegraph.com/explorer/subgraph/sablierhq/sablier).
 
 ## What's next? {#whats-next}
 

--- a/src/content/translations/fr/developers/tutorials/kickstart-your-dapp-frontend-development-wth-create-eth-app/index.md
+++ b/src/content/translations/fr/developers/tutorials/kickstart-your-dapp-frontend-development-wth-create-eth-app/index.md
@@ -16,7 +16,7 @@ source: soliditydeveloper.com
 sourceUrl: https://soliditydeveloper.com/create-eth-app
 ---
 
-La dernière fois nous nous sommes intéressés à [Solidity](https://soliditydeveloper.com/solidity-overview-2020) et avons mentionné [create-eth-app](https://github.com/PaulRBerg/create-eth-app). Vous allez maintenant découvrir comment l'utiliser, quelles fonctionnalités y sont intégrées et comment l'étendre encore. Initiée par Paul Razvan Berg, fondateur de [Sablier](http://sablier.finance/), cette application livrée avec plusieurs intégrations facultatives au choix va vous permettre de débuter le développement de votre interface.
+La dernière fois nous nous sommes intéressés à [Solidity](https://soliditydeveloper.com/solidity-overview-2020) et avons mentionné [create-eth-app](https://github.com/PaulRBerg/create-eth-app). Vous allez maintenant découvrir comment l'utiliser, quelles fonctionnalités y sont intégrées et comment l'étendre encore. Initiée par Paul Razvan Berg, fondateur de [Sablier](http://sablier.com/), cette application livrée avec plusieurs intégrations facultatives au choix va vous permettre de débuter le développement de votre interface.
 
 ## Installation {#installation}
 
@@ -103,7 +103,7 @@ Malheureusement, à l'heure où ces lignes sont écrites, l'intégration est uni
 
 ### Sablier {#sablier}
 
-[Sablier](https://sablier.finance/) permet aux utilisateurs d'effectuer des paiements en continu. Au lieu d'un seul versement, vous recevez en fait votre argent en continu sans avoir rien d'autre à faire après la mise en place initiale. L'intégration inclut son [propre sous-graphe](https://thegraph.com/explorer/subgraph/sablierhq/sablier).
+[Sablier](https://sablier.com/) permet aux utilisateurs d'effectuer des paiements en continu. Au lieu d'un seul versement, vous recevez en fait votre argent en continu sans avoir rien d'autre à faire après la mise en place initiale. L'intégration inclut son [propre sous-graphe](https://thegraph.com/explorer/subgraph/sablierhq/sablier).
 
 ## Et après ? {#whats-next}
 

--- a/src/content/translations/id/developers/tutorials/kickstart-your-dapp-frontend-development-wth-create-eth-app/index.md
+++ b/src/content/translations/id/developers/tutorials/kickstart-your-dapp-frontend-development-wth-create-eth-app/index.md
@@ -16,7 +16,7 @@ source: soliditydeveloper.com
 sourceUrl: https://soliditydeveloper.com/create-eth-app
 ---
 
-Sebelumnya, kita membahas tentang [gambaran besar Solidity](https://soliditydeveloper.com/solidity-overview-2020) dan telah menyebutkan [create-eth-app](https://github.com/PaulRBerg/create-eth-app). Sekarang Anda akan melihat cara menggunakannya, fitur apa saja yang terintegrasi di dalamnya, dan ide tambahan untuk memperluas penggunaanya. Dimulai oleh Paul Razvan Berg, pendiri [Sablier](http://sablier.finance/), aplikasi ini akan memulai pengembangan frontend Anda dan memiliki beberapa integrasi opsional yang dapat dipilih.
+Sebelumnya, kita membahas tentang [gambaran besar Solidity](https://soliditydeveloper.com/solidity-overview-2020) dan telah menyebutkan [create-eth-app](https://github.com/PaulRBerg/create-eth-app). Sekarang Anda akan melihat cara menggunakannya, fitur apa saja yang terintegrasi di dalamnya, dan ide tambahan untuk memperluas penggunaanya. Dimulai oleh Paul Razvan Berg, pendiri [Sablier](http://sablier.com/), aplikasi ini akan memulai pengembangan frontend Anda dan memiliki beberapa integrasi opsional yang dapat dipilih.
 
 ## Instalasi {#installation}
 
@@ -103,7 +103,7 @@ Sayangnya, pada saat penulisan ini, integrasi hanya dapat dilakukan untuk Uniswa
 
 ### Sablier {#sablier}
 
-[Sablier](https://sablier.finance/) memungkinkan para pengguna menyiarkan pembayaran uang. Alih alih sekali pembayaran, Anda mendapatkan uang secara konstan tanpa administrasi tambahan setelah pengaturan awalnya selesai. Integrasinya mencakup [subgraphnya](https://thegraph.com/explorer/subgraph/sablierhq/sablier) sendiri.
+[Sablier](https://sablier.com/) memungkinkan para pengguna menyiarkan pembayaran uang. Alih alih sekali pembayaran, Anda mendapatkan uang secara konstan tanpa administrasi tambahan setelah pengaturan awalnya selesai. Integrasinya mencakup [subgraphnya](https://thegraph.com/explorer/subgraph/sablierhq/sablier) sendiri.
 
 ## Selajutnya? {#whats-next}
 

--- a/src/content/translations/it/developers/tutorials/kickstart-your-dapp-frontend-development-wth-create-eth-app/index.md
+++ b/src/content/translations/it/developers/tutorials/kickstart-your-dapp-frontend-development-wth-create-eth-app/index.md
@@ -16,7 +16,7 @@ source: soliditydeveloper.com
 sourceUrl: https://soliditydeveloper.com/create-eth-app
 ---
 
-L'ultima volta abbiamo dato un'occhiata al [quadro generale di Solidity](https://soliditydeveloper.com/solidity-overview-2020) e abbiamo già accennato a [create-eth-app](https://github.com/PaulRBerg/create-eth-app). Ora scoprirai come usarlo, quali funzionalità sono integrate e alcune idee aggiuntive su come approfondilo. Creata da Paul Razvan Berg, fondatore di [Sablier](http://sablier.finance/), quest'app avvierà lo sviluppo del tuo frontend, offrendo diverse integrazioni opzionali tra cui scegliere.
+L'ultima volta abbiamo dato un'occhiata al [quadro generale di Solidity](https://soliditydeveloper.com/solidity-overview-2020) e abbiamo già accennato a [create-eth-app](https://github.com/PaulRBerg/create-eth-app). Ora scoprirai come usarlo, quali funzionalità sono integrate e alcune idee aggiuntive su come approfondilo. Creata da Paul Razvan Berg, fondatore di [Sablier](http://sablier.com/), quest'app avvierà lo sviluppo del tuo frontend, offrendo diverse integrazioni opzionali tra cui scegliere.
 
 ## Installazione {#installation}
 
@@ -103,7 +103,7 @@ Sfortunatamente, al momento della redazione del del presente articolo, l'integra
 
 ### Sablier {#sablier}
 
-[Sablier](https://sablier.finance/) consente agli utenti di trasmettere pagamenti in denaro. Invece di un singolo giorno di pagamento, in realtà puoi ricevere denaro costantemente senza ulteriore amministrazione dopo la configurazione iniziale. L'integrazione include i [propri subgraph](https://thegraph.com/explorer/subgraph/sablierhq/sablier).
+[Sablier](https://sablier.com/) consente agli utenti di trasmettere pagamenti in denaro. Invece di un singolo giorno di pagamento, in realtà puoi ricevere denaro costantemente senza ulteriore amministrazione dopo la configurazione iniziale. L'integrazione include i [propri subgraph](https://thegraph.com/explorer/subgraph/sablierhq/sablier).
 
 ## E poi? {#whats-next}
 

--- a/src/content/translations/ja/developers/tutorials/kickstart-your-dapp-frontend-development-wth-create-eth-app/index.md
+++ b/src/content/translations/ja/developers/tutorials/kickstart-your-dapp-frontend-development-wth-create-eth-app/index.md
@@ -19,7 +19,7 @@ source: soliditydeveloper.com
 sourceUrl: https://soliditydeveloper.com/create-eth-app
 ---
 
-[create-eth-app](https://github.com/PaulRBerg/create-eth-app)については、前回の記事（[Solidity の全体像](https://soliditydeveloper.com/solidity-overview-2020)）で紹介しました。 今回は、create-eth-app をどのように使うか、どのような機能が統合されているか、およびさらに拡張する方法について学びます。 create-eth-app は、[ Sablier ](http://sablier.finance/)の創業者である Paul Razvan Berg が立ち上げたプロジェクトで、フロントエンド開発をすばやく開始できるだけでなく、さまざまなオプションの統合機能も活用できます。
+[create-eth-app](https://github.com/PaulRBerg/create-eth-app)については、前回の記事（[Solidity の全体像](https://soliditydeveloper.com/solidity-overview-2020)）で紹介しました。 今回は、create-eth-app をどのように使うか、どのような機能が統合されているか、およびさらに拡張する方法について学びます。 create-eth-app は、[ Sablier ](http://sablier.com/)の創業者である Paul Razvan Berg が立ち上げたプロジェクトで、フロントエンド開発をすばやく開始できるだけでなく、さまざまなオプションの統合機能も活用できます。
 
 ## インストール {#installation}
 
@@ -106,7 +106,7 @@ Aave と*create-eth-app*を統合すると、[Aave 用の subgraph](https://docs
 
 ### Sablier {#sablier}
 
-[ Sablier](https://sablier.finance/)は、ストリーミング決済を可能にする分散型アプリです。 Sablier をセットアップすれば、その後の管理を必要とせずに、1 回の支払日の代わりに常にお金を受け取ることができるようになります。 create-eth-app では、[独自の subgraph](https://thegraph.com/explorer/subgraph/sablierhq/sablier)が利用できます。
+[ Sablier](https://sablier.com/)は、ストリーミング決済を可能にする分散型アプリです。 Sablier をセットアップすれば、その後の管理を必要とせずに、1 回の支払日の代わりに常にお金を受け取ることができるようになります。 create-eth-app では、[独自の subgraph](https://thegraph.com/explorer/subgraph/sablierhq/sablier)が利用できます。
 
 ## 次のステップ {#whats-next}
 

--- a/src/content/translations/ro/developers/tutorials/kickstart-your-dapp-frontend-development-wth-create-eth-app/index.md
+++ b/src/content/translations/ro/developers/tutorials/kickstart-your-dapp-frontend-development-wth-create-eth-app/index.md
@@ -16,7 +16,7 @@ source: soliditydeveloper.com
 sourceUrl: https://soliditydeveloper.com/create-eth-app
 ---
 
-Ultima dată am examinat [imaginea Solidity în ansamblu](https://soliditydeveloper.com/solidity-overview-2020) şi am menționat deja [create-eth-app](https://github.com/PaulRBerg/create-eth-app). Acum veţi afla cum să o folosiţi, ce funcţionalităţi sunt integrate şi câteva idei suplimentare despre cum să-i dezvoltaţi utilitatea. Lansat de Paul Răzvan Berg, fondatorul [Sablier](http://sablier.finance/), această aplicație vă va da startul pentru dezvoltarea frontend și pune la dispoziţie mai multe integrări opționale din care să alegeți.
+Ultima dată am examinat [imaginea Solidity în ansamblu](https://soliditydeveloper.com/solidity-overview-2020) şi am menționat deja [create-eth-app](https://github.com/PaulRBerg/create-eth-app). Acum veţi afla cum să o folosiţi, ce funcţionalităţi sunt integrate şi câteva idei suplimentare despre cum să-i dezvoltaţi utilitatea. Lansat de Paul Răzvan Berg, fondatorul [Sablier](http://sablier.com/), această aplicație vă va da startul pentru dezvoltarea frontend și pune la dispoziţie mai multe integrări opționale din care să alegeți.
 
 ## Instalare {#installation}
 
@@ -103,7 +103,7 @@ Din nefericire, în momentul la care scriem acestea integrarea este doar pentru 
 
 ### Sablier {#sablier}
 
-[Sablier](https://sablier.finance/) permite utilizatorilor să acceseze bani în streaming. În loc de o singură plată, primiți banii în mod constant, fără alte necesităţi de administrare după configurarea inițială. Integrarea include [propriul subgraf](https://thegraph.com/explorer/subgraph/sablierhq/sablier).
+[Sablier](https://sablier.com/) permite utilizatorilor să acceseze bani în streaming. În loc de o singură plată, primiți banii în mod constant, fără alte necesităţi de administrare după configurarea inițială. Integrarea include [propriul subgraf](https://thegraph.com/explorer/subgraph/sablierhq/sablier).
 
 ## Ce urmează? {#whats-next}
 

--- a/src/content/translations/tr/developers/tutorials/kickstart-your-dapp-frontend-development-wth-create-eth-app/index.md
+++ b/src/content/translations/tr/developers/tutorials/kickstart-your-dapp-frontend-development-wth-create-eth-app/index.md
@@ -16,7 +16,7 @@ source: soliditydeveloper.com
 sourceUrl: https://soliditydeveloper.com/create-eth-app
 ---
 
-Geçen sefer [Solidity'nin büyük resmine baktık ve](https://soliditydeveloper.com/solidity-overview-2020) hâlihazırda [create-eth-app](https://github.com/PaulRBerg/create-eth-app)'den bahsettik. Şimdi onu nasıl kullanacağınızı, hangi özelliklerin entegre olduğunu ve nasıl genişleteceğinize dair ek fikirleri öğreneceksiniz. [Sablier](http://sablier.finance/)'in kurucusu Paul Razvan Berg tarafından başlatılan bu uygulama, ön uç geliştirmenizi başlatacak ve beraberinde aralarından seçim yapabileceğiniz çeşitli isteğe bağlı entegrasyonlar getiriyor.
+Geçen sefer [Solidity'nin büyük resmine baktık ve](https://soliditydeveloper.com/solidity-overview-2020) hâlihazırda [create-eth-app](https://github.com/PaulRBerg/create-eth-app)'den bahsettik. Şimdi onu nasıl kullanacağınızı, hangi özelliklerin entegre olduğunu ve nasıl genişleteceğinize dair ek fikirleri öğreneceksiniz. [Sablier](http://sablier.com/)'in kurucusu Paul Razvan Berg tarafından başlatılan bu uygulama, ön uç geliştirmenizi başlatacak ve beraberinde aralarından seçim yapabileceğiniz çeşitli isteğe bağlı entegrasyonlar getiriyor.
 
 ## Kurulum {#installation}
 
@@ -103,7 +103,7 @@ Ne yazık ki, bu yazının yazıldığı sırada entegrasyon yalnızca Uniswap v
 
 ### Sablier {#sablier}
 
-[Sablier](https://sablier.finance/), kullanıcıların para ödemeleri akışına izin verir. Tek bir ödeme günü yerine, ilk kurulumdan sonra başka bir yönetim olmaksızın paranızı sürekli olarak alırsınız. Bu entegrasyon [kendi alt grafiğini](https://thegraph.com/explorer/subgraph/sablierhq/sablier) içerir.
+[Sablier](https://sablier.com/), kullanıcıların para ödemeleri akışına izin verir. Tek bir ödeme günü yerine, ilk kurulumdan sonra başka bir yönetim olmaksızın paranızı sürekli olarak alırsınız. Bu entegrasyon [kendi alt grafiğini](https://thegraph.com/explorer/subgraph/sablierhq/sablier) içerir.
 
 ## Sırada ne var? {#whats-next}
 

--- a/src/content/translations/zh/developers/tutorials/kickstart-your-dapp-frontend-development-wth-create-eth-app/index.md
+++ b/src/content/translations/zh/developers/tutorials/kickstart-your-dapp-frontend-development-wth-create-eth-app/index.md
@@ -16,7 +16,7 @@ source: soliditydeveloper.com
 sourceUrl: https://soliditydeveloper.com/create-eth-app
 ---
 
-上一次，我们了解 [Solidity](https://soliditydeveloper.com/solidity-overview-2020) 大的框架时，已经提到了 [create-eth-app](https://github.com/PaulRBerg/create-eth-app)。 现在，您将了解如何使用它，它集成了哪些功能以及如何对其进行扩展等内容。 这个应用程序由 [Sablier](http://sablier.finance/)创始人 Paul Razvan Berg 启动，它将启动您的前端开发，并且具有多个可选集成供您选择。
+上一次，我们了解 [Solidity](https://soliditydeveloper.com/solidity-overview-2020) 大的框架时，已经提到了 [create-eth-app](https://github.com/PaulRBerg/create-eth-app)。 现在，您将了解如何使用它，它集成了哪些功能以及如何对其进行扩展等内容。 这个应用程序由 [Sablier](http://sablier.com/)创始人 Paul Razvan Berg 启动，它将启动您的前端开发，并且具有多个可选集成供您选择。
 
 ## 安装 {#installation}
 
@@ -103,7 +103,7 @@ React.useEffect(() => {
 
 ### Sablier {#sablier}
 
-[Sablier](https://sablier.finance/) 允许用户进行流支付。 完成最初的设置后，您实际上是不断地得到您的货币，而不是在某个支付日，并且不需要进行进一步的管理。 该集成包含了它[自己的子图](https://thegraph.com/explorer/subgraph/sablierhq/sablier)。
+[Sablier](https://sablier.com/) 允许用户进行流支付。 完成最初的设置后，您实际上是不断地得到您的货币，而不是在某个支付日，并且不需要进行进一步的管理。 该集成包含了它[自己的子图](https://thegraph.com/explorer/subgraph/sablierhq/sablier)。
 
 ## 接下来是什么？ {#whats-next}
 

--- a/src/pages-conditional/dapps.tsx
+++ b/src/pages-conditional/dapps.tsx
@@ -726,7 +726,7 @@ const DappsPage = ({
     {
       title: "Sablier",
       description: t("page-dapps-dapp-description-sablier"),
-      link: "https://pay.sablier.finance/",
+      link: "https://app.sablier.com",
       image: getImage(data.sablier),
       alt: t("page-dapps-sablier-logo-alt"),
     },

--- a/src/pages-conditional/eth.tsx
+++ b/src/pages-conditional/eth.tsx
@@ -489,7 +489,7 @@ const EthPage = (props: PageProps<Queries.EthPageQuery, Context>) => {
             </Text>
             <UnorderedList>
               <ListItem>
-                <Link to="https://sablier.finance">
+                <Link to="https://sablier.com">
                   <Translation id="page-eth-stream-link" />
                 </Link>{" "}
                 – <Translation id="page-eth-uses-desc-3" />


### PR DESCRIPTION
Sablier can now be found at [sablier.com](https://sablier.com).

[Twitter reference](https://twitter.com/Sablier/status/1679567131569184768).