### PR TITLE
Contextualize the "More on EIPs" link in the Governance page

### DIFF
--- a/src/content/governance/index.md
+++ b/src/content/governance/index.md
@@ -57,7 +57,7 @@ _Note: any individual can be part of multiple of these groups (e.g. a protocol d
 
 ## What is an EIP? {#what-is-an-eip}
 
-One important process used in Ethereum governance is the proposal of **Ethereum Improvement Proposals (EIPs)**. EIPs are standards specifying potential new features or processes for Ethereum. Anyone within the Ethereum community can create an EIP. For example, none of the authors of EIP-721, the EIP that standardized NFTs, have worked directly on Ethereum's protocol development.
+One important process used in Ethereum governance is the proposal of **Ethereum Improvement Proposals (EIPs)**. EIPs are standards specifying potential new features or processes for Ethereum. Anyone within the Ethereum community can create an EIP. If you're interested in writing an EIP or participating in peer-review and/or governance, see:
 
 <ButtonLink to="/eips/">
   More on EIPs


### PR DESCRIPTION
## Description

Removes a fact that isn't particularly relevant to the topic, and adds context for the "More on EIPs" link that follows it.

CC @dtedesco1 

## Related Issue

*N.A.*