### PR TITLE
add ETH Canal Meetup for community-meetups [Fixes #10820]

### DIFF
--- a/src/data/community-meetups.json
+++ b/src/data/community-meetups.json
@@ -406,4 +406,11 @@
     "location": "Brussels",
     "link": "https://dao.brussels/"
   }
+  ,
+  {
+    "title": "ETH Canal Meetup",
+    "emoji": ":panama:",
+    "location": "Panama",
+    "link": "https://www.meetup.com/eth-canal/"
+  }
 ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

    "title": "ETH Canal Meetup",
    "emoji": ":panama:",
    "location": "Panama",
    "link": "https://www.meetup.com/eth-canal/"

## Related Issue

https://github.com/ethereum/ethereum-org-website/issues/10818 ETH Canal Conference

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
