### PR TITLE
Fix quiz modal bg color

### DIFF
--- a/src/components/Quiz/QuizzesModal.tsx
+++ b/src/components/Quiz/QuizzesModal.tsx
@@ -18,7 +18,7 @@ const QuizzesModal: React.FC<IProps> = ({ children, ...rest }) => {
 
   const statusColor =
     quizStatus === "neutral"
-      ? "white"
+      ? "neutral"
       : quizStatus === "success"
       ? "success.light"
       : "error.light"
@@ -30,10 +30,7 @@ const QuizzesModal: React.FC<IProps> = ({ children, ...rest }) => {
       scrollBehavior="inside"
       {...rest}
     >
-      <ModalOverlay
-        bg="blackAlpha.700"
-        display={{ base: "none", md: "block" }}
-      />
+      <ModalOverlay bg="blackAlpha.700" hideBelow="md" />
 
       <ModalContent justifyContent="center" bg={statusColor}>
         <ModalCloseButton size="lg" p={6} zIndex={1} />


### PR DESCRIPTION
Atm the bg color of the Quiz modal is hardcoded to `white`, which generates the following result in dark mode
![image](https://github.com/ethereum/ethereum-org-website/assets/468158/f9afef66-e86a-4957-a1fc-d75a284101d2)


## Description

This PR uses the semantic token `neutral` to display the correct color between light and dark mode.
