### PR TITLE
[Performance] Preload fonts

### DIFF
--- a/gatsby-ssr.tsx
+++ b/gatsby-ssr.tsx
@@ -18,21 +18,5 @@ export const onRenderBody = ({ setHeadComponents }: RenderBodyArgs) => {
       crossOrigin="anonymous"
       key="interFont"
     />,
-    <link
-      rel="preload"
-      href="/fonts/Inter-Regular.woff"
-      as="font"
-      type="font/woff"
-      crossOrigin="anonymous"
-      key="interFont"
-    />,
-    <link
-      rel="preload"
-      href="/fonts/IBMPlexMono-Regular.woff2"
-      as="font"
-      type="font/woff2"
-      crossOrigin="anonymous"
-      key="interFont"
-    />,
   ])
 }


### PR DESCRIPTION
Currently, we are preloading [3 fonts](https://github.com/ethereum/ethereum-org-website/blob/dev/gatsby-ssr.tsx). The problem is that the browser is always going to fetch them, even if it doesn't need all of them. Also, the font `Inter-Regular`, is preloaded in 2 different types, woff and woff2 (only one is going to be used).

Another problem it arises is the 

## Description

To optimize this, this PR only preloads the `Inter-Regular.woff2` font since
1. It is the most used font in the website
2. The woff2 format has a [pretty good adoption (~96% global)](https://caniuse.com/woff2) and its lighter than the others.
3. It doesn't mean that we are not going to load the rest of the fonts, they are going to be loaded but normally, not preloaded.
