### PR TITLE
Add ChainIDE to Ethereum support-tooling

### DIFF
--- a/src/content/community/support/index.md
+++ b/src/content/community/support/index.md
@@ -60,6 +60,7 @@ Here are some popular examples:
 - [Truffle](https://discord.gg/8uKcsccEYE)
 - [Alchemy](http://alchemy.com/discord)
 - [Tenderly](https://discord.gg/fBvDJYR)
+- [ChainIDE](https://discord.gg/6VCEWn6tUY)
 
 ## Running a node {#node-support}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

[ChainIDE](https://www.chainide.com) is a multi-chain cloud-powered development platform that provides one-stop development services for blockchain developers. 
We want to add ChainIDE to Ethereum support-tooling.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
