### PR TITLE
Add ETH Riyadh 2023 to ETH events

### DIFF
--- a/src/data/community-events.json
+++ b/src/data/community-events.json
@@ -313,5 +313,14 @@
     "description": "Full day of learning about Ethereum, onboarding new users and builders.",
     "startDate": "2023-11-25",
     "endDate": "2023-11-25"
+  },
+  {
+    "title": "ETH Riyadh",
+    "to": "https://ethriyadh.com/",
+    "sponsor": null,
+    "location": "Riyadh, Saudi Arabia",
+    "description": "ETH Riyadh unites developers and builders from Saudi Arabia and the other Middle East regions, nurturing their roles and connections in the Ethereum ecosystem."
+    "startDate": "2023-09-20",
+    "endDate": "2023-10-15"
   }
 ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

[ETH Riyadh](https://ethriyadh.com/) unites developers and builders from Saudi Arabia and the other Middle East regions, nurturing their roles and connections in the Ethereum ecosystem.
We will hold Events from September 20 to October 15, 2023, and hope to join ETH Events.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
