### PR TITLE
fixed two broken links issue  [Fixes #10972]

### DIFF
--- a/src/content/developers/docs/consensus-mechanisms/pos/block-proposal/index.md
+++ b/src/content/developers/docs/consensus-mechanisms/pos/block-proposal/index.md
@@ -8,7 +8,7 @@ Blocks are the fundamental units of the blockchain. Blocks are discrete units of
 
 ## Prerequisites {#prerequisites}
 
-Block proposal is part of the proof-of-stake protocol. To help understand this page, we recommend you read about [proof-of-stake](src/content/developers/docs/consensus-mechanisms/pos/) and [block architecture](src/content/developers/docs/blocks/).
+Block proposal is part of the proof-of-stake protocol. To help understand this page, we recommend you read about [proof-of-stake](/developers/docs/consensus-mechanisms/pos/) and [block architecture](/developers/docs/blocks/).
 
 ## Who produces blocks? {#who-produces-blocks}
 


### PR DESCRIPTION
Two links on the [block proposal](https://ethereum.org/en/developers/docs/consensus-mechanisms/pos/block-proposal/) are broken. (PREREQUISITES section)

## Description
before
```
[proof-of-stake](src/content/developers/docs/consensus-mechanisms/pos/) and [block architecture](src/content/developers/docs/blocks/).
```
After
```
[proof-of-stake](/developers/docs/consensus-mechanisms/pos/) and [block architecture](/developers/docs/blocks/).
```
Updated both links 
## Related Issue
https://github.com/ethereum/ethereum-org-website/issues/10972
fixed #10972

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
