### PR TITLE
 content: improved comprehensibility in the staking/pools page

### DIFF
--- a/src/content/staking/pools/index.md
+++ b/src/content/staking/pools/index.md
@@ -60,7 +60,7 @@ Have a suggestion for a staking tool we missed? Check out our [product listing p
 ## Frequently asked questions {#faq}
 
 <ExpandableCard title="How do I earn rewards?">
-Typically ERC-20 staking tokens are issued to stakers that represents the value of their staked ETH plus rewards. Keep in mind that different pools will distribute staking rewards to their users via slightly different methods, but this is the common theme.
+Typically ERC-20 staking tokens are issued to stakers and represent the value of their staked ETH plus rewards. Keep in mind that different pools will distribute staking rewards to their users via slightly different methods, but this is the common theme.
 </ExpandableCard>
 
 <ExpandableCard title="When can I withdraw my stake?">


### PR DESCRIPTION
Line 63: changed "that represents" to "and represent"

## Description

Line 63 of the content/staking/pools page contains the sentence "Typically ERC-20 staking tokens are issued to stakers that represents the value of their staked ETH plus rewards". Replacing "that represents" with "and represent" improves comprehensibility.

## Related Issue

None.
