### PR TITLE
Receipt logs may contain no non-indexed arguments

### DIFF
--- a/src/content/developers/docs/apis/json-rpc/index.md
+++ b/src/content/developers/docs/apis/json-rpc/index.md
@@ -1552,7 +1552,7 @@ params: [
   - `blockHash`: `DATA`, 32 Bytes - hash of the block where this log was in. `null` when its pending. `null` when its pending log.
   - `blockNumber`: `QUANTITY` - the block number where this log was in. `null` when its pending. `null` when its pending log.
   - `address`: `DATA`, 20 Bytes - address from which this log originated.
-  - `data`: `DATA` - contains one or more 32 Bytes non-indexed arguments of the log.
+  - `data`: `DATA` - contains zero or more 32 Bytes non-indexed arguments of the log.
   - `topics`: `Array of DATA` - Array of 0 to 4 32 Bytes `DATA` of indexed log arguments. (In _solidity_: The first topic is the _hash_ of the signature of the event (e.g. `Deposit(address,bytes32,uint256)`), except you declared the event with the `anonymous` specifier.)
 - **Example**
 


### PR DESCRIPTION
`data` may be empty, indicating no non-indexed arguments are in the log.

Example:

- https://etherscan.io/tx/0xa3b805acacb25da412a44bd9612a73464292fc684a400ab54f0a9626f7d9c3f2#eventlog
