### PR TITLE
Replaced dead Sepolia faucet.

### DIFF
--- a/src/content/developers/docs/networks/index.md
+++ b/src/content/developers/docs/networks/index.md
@@ -57,7 +57,7 @@ The Sepolia network uses a permissioned validator set. It's fairly new, meaning 
 - [QuickNode Sepolia Faucet](https://faucet.quicknode.com/drip)
 - [Grabteeth](https://grabteeth.xyz/)
 - [PoW faucet](https://sepolia-faucet.pk910.de/)
-- [Sepolia faucet](https://faucet.sepolia.dev/)
+- [Alternative PoW faucet](https://faucet.sepolia.dev/)
 - [FaucETH](https://fauceth.komputing.org)
 - [Coinbase Wallet Faucet | Sepolia](https://coinbase.com/faucets/ethereum-sepolia-faucet)
 - [Alchemy Sepolia faucet](https://sepoliafaucet.com/)

--- a/src/content/developers/docs/networks/index.md
+++ b/src/content/developers/docs/networks/index.md
@@ -57,7 +57,6 @@ The Sepolia network uses a permissioned validator set. It's fairly new, meaning 
 - [QuickNode Sepolia Faucet](https://faucet.quicknode.com/drip)
 - [Grabteeth](https://grabteeth.xyz/)
 - [PoW faucet](https://sepolia-faucet.pk910.de/)
-- [Alternative PoW faucet](https://faucet.sepolia.dev/)
 - [FaucETH](https://fauceth.komputing.org)
 - [Coinbase Wallet Faucet | Sepolia](https://coinbase.com/faucets/ethereum-sepolia-faucet)
 - [Alchemy Sepolia faucet](https://sepoliafaucet.com/)


### PR DESCRIPTION
Updates out of date content [Resolves #10921]

Replaced dead Sepolia faucet from Faucet list because it's down:
https://faucet.sepolia.dev/

with

Alternative PoW faucet:
https://sepolia-faucet.com/

