### PR TITLE
chore(Icons.stories): update storybook directory placement

### DIFF
--- a/src/components/icons/Icons.stories.tsx
+++ b/src/components/icons/Icons.stories.tsx
@@ -90,8 +90,9 @@ import {
 } from "./wallets"
 
 export default {
+  title: "Atoms / Media & Icons / Icons",
   component: VStack,
-} as Meta<typeof VStack>
+} satisfies Meta<typeof VStack>
 
 const iconsDefinitions = [
   CorrectIcon,
@@ -193,7 +194,7 @@ const items = iconsDefinitions.map((IconDef) => (
   </Box>
 ))
 
-export const IconsList: StoryObj<typeof VStack> = {
+export const Icons: StoryObj<typeof VStack> = {
   render: () => {
     return (
       <VStack


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Per the [Storybook directory structure proposal](https://www.figma.com/file/Ne3iAassyfAcJ0AlgqioAP/DS-to-storybook-structure?node-id=47%3A74&mode=dev) the story for the icons should be placed in `Atoms / Media & Icons / Icons`

Also updates naming of the story to match the directory name, as it is only one story and does not need to be in an additional level.

This PR overall is promoting consistency of the story file usage.

## Related Issue
N/A
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
