### PR TITLE
Remove broken link in reading-web-security

### DIFF
--- a/src/content/security/index.md
+++ b/src/content/security/index.md
@@ -271,7 +271,6 @@ Airdrop scams involve a scam project airdropping an asset (NFT, token) into your
 
 ### Web security {#reading-web-security}
 
-- [This is why you shouldn’t use texts for two-factor authentication](https://www.theverge.com/2017/9/18/16328172/sms-two-factor-authentication-hack-password-bitcoin) - _The Verge_
 - [Up to 3 million devices infected by malware-laced Chrome and Edge add-ons](https://arstechnica.com/information-technology/2020/12/up-to-3-million-devices-infected-by-malware-laced-chrome-and-edge-add-ons/) - _Dan Goodin_
 - [How to Create a Strong Password — That You Won’t Forget](https://www.avg.com/en/signal/how-to-create-a-strong-password-that-you-wont-forget) - _AVG_
 - [What is a security key?](https://help.coinbase.com/en/coinbase/getting-started/verify-my-account/security-keys-faq) - _Coinbase_


### PR DESCRIPTION
Remove broken link in reading-web-security

## Description
The video in this link has expired, users cannot see the demo video in the article.

## Related Issue

https://www.theverge.com/2017/9/18/16328172/sms-two-factor-authentication-hack-password-bitcoin
