### PR TITLE
Revert glossary tooltip link in DeFi page

### DIFF
--- a/src/content/defi/index.md
+++ b/src/content/defi/index.md
@@ -317,7 +317,7 @@ You can think of DeFi in layers:
 
 1. The blockchain – Ethereum contains the transaction history and state of accounts.
 2. The assets – [ETH](/eth/) and the other tokens (currencies).
-3. The protocols – <GlossaryTooltip termKey="smart-contract">smart contracts</GlossaryTooltip> that provide the functionality, for example, a service that allows for decentralized lending of assets.
+3. The protocols – [smart contracts](/glossary/#smart-contract) that provide the functionality, for example, a service that allows for decentralized lending of assets.
 4. [The applications](/dapps/) – the products we use to manage and access the protocols.
 
 ## Build DeFi {#build-defi}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In #10928 we used [the GlossaryTooltip React component on the DeFi markdown page](https://github.com/ethereum/ethereum-org-website/pull/10928/files#r1308431628) to showcase the new feature.

In #11021 we introduce a simpler implementation, that doesn't require us to add unnecessary React components to our markdown files. 

This PR reverts the addition of the GlossaryTooltip to the Defi page in #10928 and uses the original markdown syntax.

## Related Issue

#10928
#11021