### PR TITLE
EIP-1 URL link change because of a typo that breaks the connection

### DIFF
--- a/src/content/community/get-involved/index.md
+++ b/src/content/community/get-involved/index.md
@@ -28,7 +28,7 @@ Do you have a background in mathematics, cryptography, or economics? You might b
 - Write or review an Ethereum Improvement Proposal
   - Write an EIP
     1. Submit your idea on [Ethereum Magicians](https://ethereum-magicians.org)
-    2. Read [EIP-1](https://eip.ethereum.org/EIPS/eip-1) - **Yes, that's the _entire_ document.**
+    2. Read [EIP-1](https://eips.ethereum.org/EIPS/eip-1) - **Yes, that's the _entire_ document.**
     3. Follow the directons in EIP-1. Reference it as you write your draft.
   - Learn how to become an [EIP Editor](https://eips.ethereum.org/EIPS/eip-5069)
     - You can peer-review EIPs right now! See [open PRs with the `e-review` tag](https://github.com/ethereum/EIPs/pulls?q=is%3Apr+is%3Aopen+label%3Ae-review). Provide technical feedback on the `discussion-to` link.


### PR DESCRIPTION

The URL link to EIP-1 had a typo. 

Changed https://eip.ethereum.org/EIPS/eip-1 to https://eips.ethereum.org/EIPS/eip-1

