### PR TITLE
adding Ethereum Rio 2024 info into community-events.json (events page)

### DIFF
--- a/src/data/community-events.json
+++ b/src/data/community-events.json
@@ -1,5 +1,14 @@
 [
   {
+    "title": "Etherum Rio",
+    "to": "https://www.ethereumbrasil.com/",
+    "sponsor": null,
+    "location": "Rio de Janeiro, Brasil",
+    "description": "3rd Edition of LATAM's most loved ETH event. Bootcamp, Buildathon & Conference",
+    "startDate": "2024-04-09",
+    "endDate": "2024-04-14"
+  },
+  {
     "title": "ETHKL 2023",
     "to": "https://hack.ethkl.org/",
     "sponsor": null,


### PR DESCRIPTION
adding Ethereum Rio 2024 info into community-events.json (events page)

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
