### PR TITLE
Adding General Forum on Localism (PDX Dao) community-events.json

### DIFF
--- a/src/data/community-events.json
+++ b/src/data/community-events.json
@@ -349,5 +349,14 @@
     "description": "ETH Riyadh unites developers and builders from Saudi Arabia and the other Middle East regions, nurturing their roles and connections in the Ethereum ecosystem.",
     "startDate": "2023-09-20",
     "endDate": "2023-10-15"
+  },
+  {
+    "title": "A General Forum on Ethereum Localism",
+    "to": "https://blocklive.io/event/a-general-forum-on-ethereum-localism",
+    "sponsor": null,
+    "location": "Portland, OR, USA",
+    "description": "Three days and thoughtful side events will create a container where the Ethereum community can elaborate for itself, in a plurality of directions, what an experimentalism of the city can mean and look like for web3.",
+    "startDate": "2023-10-13",
+    "endDate": "2023-10-15"
   }
 ]


### PR DESCRIPTION
Adding an event put on by a local city DAO in Portland, Oregon.

Blocklive to mint tickets: https://blocklive.io/event/a-general-forum-on-ethereum-localism
The call for Ethereum Localism is here: https://mirror.xyz/ethpdx.eth/kjpsLAAC2Si0XDmr_aFp0F5esPNH4DoPB4lOTlFbR5M