### PR TITLE
Update Portal Network discord invite link

### DIFF
--- a/src/content/developers/docs/networking-layer/portal-network/index.md
+++ b/src/content/developers/docs/networking-layer/portal-network/index.md
@@ -78,5 +78,5 @@ If one client experiences issues or vulnerabilities, other clients can continue 
 ## Further reading {#futher-reading}
 
 - [The Portal Network (Piper Merriam at Devcon Bogota)](https://www.youtube.com/watch?v=0stc9jnQLXA).
-- [The Portal Network discord](https://discord.gg/6XFs56cX)
+- [The Portal Network discord](https://discord.gg/CFFnmE7Hbs)
 - [The Portal Network website](ethportal.net)


### PR DESCRIPTION
Discord made it so servers not in "community mode" couldn't have non-expiring invite links. So the Portal Network invite link on the Portal Network page expired. We just changed the server to "community mode" and this PR is adding a new non-expiring invite link

## Description

Replaced expired discord invite link with new non-expiry invite link for the Portal Network server