### PR TITLE
Fix paths to translation progress images

### DIFF
--- a/src/components/TranslationChartImage.tsx
+++ b/src/components/TranslationChartImage.tsx
@@ -10,14 +10,14 @@ const TranslationChartImage: React.FC<IProps> = () => {
   const data = useStaticQuery(graphql`
     {
       pageviewsLight: file(
-        relativePath: { eq: "translation-program/pageviews-light.png" }
+        relativePath: { eq: "translation-program/pageviews_light.png" }
       ) {
         childImageSharp {
           gatsbyImageData(height: 500, placeholder: BLURRED, quality: 100)
         }
       }
       pageviewsDark: file(
-        relativePath: { eq: "translation-program/pageviews-dark.png" }
+        relativePath: { eq: "translation-program/pageviews_dark.png" }
       ) {
         childImageSharp {
           gatsbyImageData(height: 500, placeholder: BLURRED, quality: 100)


### PR DESCRIPTION
## Description
- Fixes path names for translation progress images (`-` -> `_`)

<img width="885" alt="image" src="https://github.com/ethereum/ethereum-org-website/assets/54227730/afe7ce59-f58b-4958-9592-f8424e83388a">
