### PR TITLE
Fix heading and spacing in roadmap cards

### DIFF
--- a/src/components/Roadmap/RoadmapActionCard.tsx
+++ b/src/components/Roadmap/RoadmapActionCard.tsx
@@ -2,9 +2,10 @@ import React from "react"
 import { useStaticQuery, graphql } from "gatsby"
 import { GatsbyImage } from "gatsby-plugin-image"
 import {
-  Box,
+  Text,
   Center,
   Flex,
+  Heading,
   Image,
   LinkBox,
   LinkOverlay,
@@ -13,7 +14,6 @@ import {
 import { getImage } from "../../utils/image"
 
 import ButtonLink from "../ButtonLink"
-import Text from "../OldText"
 
 interface IProps {
   to: string
@@ -84,7 +84,6 @@ const RoadmapActionCard: React.FC<IProps> = ({
     <LinkBox
       as={Flex}
       direction="column"
-      justifyContent="space-between"
       border="1px solid"
       borderColor="lightBorder"
     >
@@ -96,13 +95,15 @@ const RoadmapActionCard: React.FC<IProps> = ({
           fit="contain"
         />
       </Center>
-      <Box p={6}>
-        <Text as="h3">{title}</Text>
-        <Text>{description}</Text>
+      <Flex p={6} flex="1" flexDir="column" justify="space-between" gap={4}>
+        <Heading as="h3" size="md">
+          {title}
+        </Heading>
+        <Text flex="1">{description}</Text>
         <LinkOverlay as={ButtonLink} href={to}>
           {buttonText}
         </LinkOverlay>
-      </Box>
+      </Flex>
     </LinkBox>
   )
 }

--- a/src/templates/roadmap.tsx
+++ b/src/templates/roadmap.tsx
@@ -70,12 +70,7 @@ import type { ChildOnlyProp, Context } from "../types"
 import type { List as ButtonDropdownList } from "../components/ButtonDropdown"
 
 const CardGrid = (props: ChildOnlyProp) => (
-  <SimpleGrid
-    columns={{ base: 1, md: 2 }}
-    spacing={8}
-    sx={{ h3: { mt: 0 } }}
-    {...props}
-  />
+  <SimpleGrid columns={{ base: 1, md: 2 }} spacing={8} {...props} />
 )
 
 const HeroContainer = (props: ChildOnlyProp) => (


### PR DESCRIPTION
Current styles:
![image](https://github.com/ethereum/ethereum-org-website/assets/468158/6636d18c-e0e2-4066-9011-82e7578ef82c)

## Description

This PR fixes the styles in the roadmap cards.
- Uses the `Heading` component with the desired size
- Fixes the spacing within the cards
