### PR TITLE
Fixed broken link

### DIFF
--- a/src/content/developers/docs/bridges/index.md
+++ b/src/content/developers/docs/bridges/index.md
@@ -30,7 +30,7 @@ For developers, bridges enable the following:
 
 ## How do bridges work? {#how-do-bridges-work}
 
-While there are many [types of bridge designs](https://blog.li.fi/what-are-blockchain-bridges-and-how-can-we-classify-them-560dc6ec05fa), three ways to facilitate the cross-chain transfer of assets stand out:
+While there are many [types of bridge designs](https://li.fi/knowledge-hub/blockchain-bridges-and-classification/), three ways to facilitate the cross-chain transfer of assets stand out:
 
 - **Lock and mint –** Lock assets on the source chain and mint assets on the destination chain.
 - **Burn and mint –** Burn assets on the source chain and mint assets on the destination chain.


### PR DESCRIPTION
## Description
Changed link from `https://blog.li.fi/what-are-blockchain-bridges-and-how-can-we-classify-them-560dc6ec05fa`  to `https://li.fi/knowledge-hub/blockchain-bridges-and-classification/`

## Related Issue
#11162 