### PR TITLE
fix: add forward ref to `BaseLink`

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,6 +1,5 @@
 import React from "react"
 import {
-  Box,
   forwardRef,
   Icon,
   Link as ChakraLink,
@@ -89,7 +88,9 @@ export const BaseLink = forwardRef<IProps, "a">(
       eventName: to,
     }
 
-    const commonProps = {
+    const commonProps: LinkProps & { ref: React.ForwardedRef<any> } = {
+      ref,
+      href: to,
       dir,
       ...restProps,
     }
@@ -100,8 +101,6 @@ export const BaseLink = forwardRef<IProps, "a">(
     if (isHash) {
       return (
         <ChakraLink
-          ref={ref}
-          href={to}
           onClick={(e) => {
             // only track events on external links and hash links
             if (!isHash) {
@@ -125,8 +124,6 @@ export const BaseLink = forwardRef<IProps, "a">(
     if (isExternal || isPdf || isStatic) {
       return (
         <ChakraLink
-          ref={ref}
-          href={to}
           isExternal
           onClick={(e) => {
             // only track events on external links and hash links
@@ -161,8 +158,6 @@ export const BaseLink = forwardRef<IProps, "a">(
     // Use `gatsby-theme-i18n` Link (which prepends lang path)
     return (
       <ChakraLink
-        ref={ref}
-        to={to}
         as={IntlLink}
         language={language}
         partiallyActive={isPartiallyActive}

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -90,7 +90,6 @@ export const BaseLink = forwardRef<IProps, "a">(
 
     const commonProps: LinkProps & { ref: React.ForwardedRef<any> } = {
       ref,
-      href: to,
       dir,
       ...restProps,
     }
@@ -101,6 +100,7 @@ export const BaseLink = forwardRef<IProps, "a">(
     if (isHash) {
       return (
         <ChakraLink
+          href={to}
           onClick={(e) => {
             // only track events on external links and hash links
             if (!isHash) {
@@ -124,6 +124,7 @@ export const BaseLink = forwardRef<IProps, "a">(
     if (isExternal || isPdf || isStatic) {
       return (
         <ChakraLink
+          href={to}
           isExternal
           onClick={(e) => {
             // only track events on external links and hash links
@@ -159,6 +160,7 @@ export const BaseLink = forwardRef<IProps, "a">(
     return (
       <ChakraLink
         as={IntlLink}
+        to={to}
         language={language}
         partiallyActive={isPartiallyActive}
         activeStyle={


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Currently the following React warning throws in development:

```
Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?
```

This points to the `BaseLink` component in the warning stack.

This PR wraps the component in Chakra's `forwardRef`.

In addition, a minor refactor with the `commonProps` object as the `ref` prop is used in all render conditions.

## Related Issue
N/A
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
