### PR TITLE
twitter icon to X - [Fixes #11221]

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "react-emoji-render": "^2.0.1",
     "react-helmet": "^6.1.0",
     "react-i18next": "^12.1.4",
-    "react-icons": "^4.3.1",
+    "react-icons": "^4.11.0",
     "react-instantsearch-dom": "^6.32.0",
     "react-select": "^4.3.0",
     "recharts": "^2.1.9",

--- a/src/components/FindWallet/WalletTable/index.tsx
+++ b/src/components/FindWallet/WalletTable/index.tsx
@@ -3,7 +3,8 @@ import React, { ReactNode } from "react"
 import { useTranslation } from "gatsby-plugin-react-i18next"
 import Select from "react-select"
 import { MdExpandLess, MdExpandMore } from "react-icons/md"
-import { FaDiscord, FaGlobe, FaTwitter } from "react-icons/fa"
+import { FaDiscord, FaGlobe } from "react-icons/fa"
+import { FaXTwitter } from "react-icons/fa6"
 import {
   Box,
   chakra,
@@ -486,8 +487,8 @@ const WalletTable = ({ data, filters, walletData }: WalletTableProps) => {
                             }}
                           >
                             <Icon
-                              as={FaTwitter}
-                              color="#1da1f2"
+                              as={FaXTwitter}
+                              color="#000000"
                               fontSize="2xl"
                             />
                           </SocialLink>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -11,7 +11,8 @@ import {
 import { graphql, useStaticQuery } from "gatsby"
 import { useI18next, useTranslation } from "gatsby-plugin-react-i18next"
 import React from "react"
-import { FaDiscord, FaGithub, FaTwitter } from "react-icons/fa"
+import { FaDiscord, FaGithub } from "react-icons/fa"
+import { FaXTwitter } from "react-icons/fa6"
 
 import { Lang } from "../utils/languages"
 import { getLocaleTimestamp } from "../utils/time"
@@ -27,10 +28,10 @@ const socialLinks = [
     color: "#333",
   },
   {
-    icon: FaTwitter,
+    icon: FaXTwitter,
     to: "https://twitter.com/ethdotorg",
     ariaLabel: "Twitter",
-    color: "#1DA1F2",
+    color: "#000000",
   },
   {
     icon: FaDiscord,

--- a/src/components/Quiz/QuizWidget.tsx
+++ b/src/components/Quiz/QuizWidget.tsx
@@ -17,7 +17,7 @@ import {
   Container,
 } from "@chakra-ui/react"
 import { shuffle } from "lodash"
-import { FaTwitter } from "react-icons/fa"
+import { FaXTwitter } from "react-icons/fa6"
 import { useTranslation } from "gatsby-plugin-react-i18next"
 
 import Button from "../Button"
@@ -495,7 +495,7 @@ const QuizWidget: React.FC<IProps> = ({
                   >
                     <Button
                       variant="outline-color"
-                      leftIcon={<Icon as={FaTwitter} />}
+                      leftIcon={<Icon as={FaXTwitter} />}
                       onClick={handleShare}
                     >
                       <Translation id="share-results" />

--- a/src/components/Quiz/QuizzesStats.tsx
+++ b/src/components/Quiz/QuizzesStats.tsx
@@ -9,7 +9,7 @@ import {
   Stack,
   Text,
 } from "@chakra-ui/react"
-import { FaTwitter } from "react-icons/fa"
+import { FaXTwitter } from "react-icons/fa6"
 import { useI18next } from "gatsby-plugin-react-i18next"
 
 import Button from "../Button"
@@ -97,7 +97,7 @@ const QuizzesStats: React.FC = () => {
           >
             <Button
               variant="outline-color"
-              leftIcon={<FaTwitter />}
+              leftIcon={<FaXTwitter />}
               onClick={() =>
                 handleShare({ score: userScore, total: totalQuizzesPoints })
               }

--- a/src/components/SocialListItem.tsx
+++ b/src/components/SocialListItem.tsx
@@ -2,7 +2,6 @@
 import React from "react"
 import { Flex, Box, Icon } from "@chakra-ui/react"
 import {
-  FaTwitter,
   FaYoutube,
   FaDiscord,
   FaRedditAlien,
@@ -10,9 +9,11 @@ import {
   FaGlobe,
 } from "react-icons/fa"
 
+import { FaXTwitter } from "react-icons/fa6"
+
 const socialColors = {
   reddit: "#ff4301",
-  twitter: "#1da1f2",
+  twitter: "#000000",
   youtube: "#ff0000",
   discord: "#7289da",
   stackExchange: "#48a2da",
@@ -20,7 +21,7 @@ const socialColors = {
 
 const icons = {
   reddit: FaRedditAlien,
-  twitter: FaTwitter,
+  twitter: FaXTwitter,
   youtube: FaYoutube,
   discord: FaDiscord,
   stackExchange: FaStackExchange,

--- a/yarn.lock
+++ b/yarn.lock
@@ -15925,10 +15925,10 @@ react-i18next@^12.1.4:
     "@babel/runtime" "^7.20.6"
     html-parse-stringify "^3.0.1"
 
-react-icons@^4.3.1:
-  version "4.10.1"
-  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.10.1.tgz#3f3b5eec1f63c1796f6a26174a1091ca6437a500"
-  integrity sha512-/ngzDP/77tlCfqthiiGNZeYFACw85fUjZtLbedmJ5DTlNDIwETxhwBzdOJ21zj4iJdvc0J3y7yOsX3PpxAJzrw==
+react-icons@^4.11.0:
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.11.0.tgz#4b0e31c9bfc919608095cc429c4f1846f4d66c65"
+  integrity sha512-V+4khzYcE5EBk/BvcuYRq6V/osf11ODUM2J8hg2FDSswRrGvqiYUYPRy4OdrWaQOBj4NcpJfmHZLNaD+VH0TyA==
 
 react-input-autosize@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
twitter icon to X - [Fixes #10797]

## Description
The Twitter logo has been updated recently and hasn't been updated on ethereum site.
We will find the new twitter icon in the updated version of react-icon 
Have updated the icon at all 4 places

<img width="303" alt="Screenshot 2023-09-20 at 11 13 17 PM" src="https://github.com/ethereum/ethereum-org-website/assets/69191344/ab3d858f-5e76-438d-8daf-c578513ce8b0">

<img width="290" alt="Screenshot 2023-09-20 at 11 14 38 PM" src="https://github.com/ethereum/ethereum-org-website/assets/69191344/8c36fd4d-944e-448d-a30f-2f95c4217afc">

<img width="614" alt="Screenshot 2023-09-20 at 11 14 53 PM" src="https://github.com/ethereum/ethereum-org-website/assets/69191344/d2057db8-4dcb-4207-a6cd-68c3f19d7445">


<img width="379" alt="Screenshot 2023-09-20 at 11 15 12 PM" src="https://github.com/ethereum/ethereum-org-website/assets/69191344/dfb8f400-016f-4974-90e9-3449bd793936">



## Related Issue

<!--- This project accepts pull requests related to open issues -->
https://github.com/ethereum/ethereum-org-website/issues/11221