### PR TITLE
Fix alignment of staking product name and icon

### DIFF
--- a/src/components/Staking/StakingProductsCardGrid.tsx
+++ b/src/components/Staking/StakingProductsCardGrid.tsx
@@ -6,6 +6,7 @@ import {
   BoxProps,
   Center,
   Flex,
+  Heading,
   HStack,
   Icon,
   List,
@@ -213,9 +214,9 @@ const StakingProductCard: React.FC<ICardProps> = ({
         maxH={24}
       >
         {!!Svg && <Icon as={Svg} fontSize="2rem" color="white" />}
-        <OldHeading fontSize="2xl" color="white" mb={0}>
+        <Heading as="h4" fontSize="2xl" color="white">
           {name}
-        </OldHeading>
+        </Heading>
       </HStack>
       {typeof minEth !== "undefined" && (
         <Center

--- a/src/components/Staking/StakingProductsCardGrid.tsx
+++ b/src/components/Staking/StakingProductsCardGrid.tsx
@@ -20,7 +20,6 @@ import stakingProducts from "../../data/staking-products.json"
 // Component imports
 import ButtonLink from "../ButtonLink"
 import Translation from "../Translation"
-import OldHeading from "../OldHeading"
 // SVG imports
 import {
   CautionProductGlyphIcon,

--- a/src/components/Staking/StakingProductsCardGrid.tsx
+++ b/src/components/Staking/StakingProductsCardGrid.tsx
@@ -213,7 +213,7 @@ const StakingProductCard: React.FC<ICardProps> = ({
         maxH={24}
       >
         {!!Svg && <Icon as={Svg} fontSize="2rem" color="white" />}
-        <OldHeading fontSize="2xl" color="white">
+        <OldHeading fontSize="2xl" color="white" mb={0}>
           {name}
         </OldHeading>
       </HStack>


### PR DESCRIPTION
## Description
- Switches to the `Heading` component for the product names on the staking product cards
- This fixes the alignment issue between the name and the icon (no more bottom margin)

<img width="1043" alt="image" src="https://github.com/ethereum/ethereum-org-website/assets/54227730/71cdecfc-8dfa-496d-bfe2-e2aa9c2e2da5">

Serves as a patch until full design system can be implemented