### PR TITLE
Connect to Web3 sim updates

### DIFF
--- a/src/components/Simulator/PulseAnimation.tsx
+++ b/src/components/Simulator/PulseAnimation.tsx
@@ -1,7 +1,12 @@
 import React from "react"
 import { Box } from "@chakra-ui/react"
 import { motion } from "framer-motion"
-import { CIRCLE, FULL_BUTTON, NARROW_BUTTON } from "./constants"
+import {
+  BASE_ANIMATION_DELAY_SEC,
+  CIRCLE,
+  FULL_BUTTON,
+  NARROW_BUTTON,
+} from "./constants"
 import type { PulseOption } from "./types"
 
 const MotionBox = motion(Box)
@@ -14,8 +19,7 @@ export const PulseAnimation: React.FC<IProps> = ({ type = CIRCLE }) => {
   const scaleY = type === FULL_BUTTON ? 1.7 : type === NARROW_BUTTON ? 1.5 : 1.5
   const inset = type === NARROW_BUTTON ? -1 : 0
   const borderRadius = type === FULL_BUTTON ? "base" : "full"
-  const BASE_DURATION = 2.5
-  const delay = type === NARROW_BUTTON ? 0 : BASE_DURATION
+  const delay = type === NARROW_BUTTON ? 0 : BASE_ANIMATION_DELAY_SEC
   return (
     <MotionBox
       position="absolute"
@@ -26,7 +30,7 @@ export const PulseAnimation: React.FC<IProps> = ({ type = CIRCLE }) => {
       initial={{ scale: 1 }}
       animate={{ scaleX, scaleY, opacity: [0, 1, 0] }}
       transition={{
-        duration: 2.5,
+        duration: BASE_ANIMATION_DELAY_SEC,
         repeat: Infinity,
         ease: "easeOut",
         delay,

--- a/src/components/Simulator/constants.ts
+++ b/src/components/Simulator/constants.ts
@@ -43,3 +43,5 @@ export const defaultTokenBalances: Array<TokenBalance> = [
 export const FALLBACK_ETH_PRICE = 1000
 export const USD_RECEIVE_AMOUNT = 50
 export const ETH_TRANSFER_FEE = 0.00042 // 21_000gas * 20gwei
+
+export const BASE_ANIMATION_DELAY_SEC = 2.5

--- a/src/components/Simulator/screens/ConnectWeb3/Browser.tsx
+++ b/src/components/Simulator/screens/ConnectWeb3/Browser.tsx
@@ -7,6 +7,7 @@ import { IoEllipsisHorizontalSharp } from "react-icons/io5"
 import { motion } from "framer-motion"
 import { NotificationPopover } from "../../NotificationPopover"
 import { EXAMPLE_APP_URL } from "./constants"
+import { BASE_ANIMATION_DELAY_SEC } from "../../constants"
 
 interface IProps extends FlexProps {
   progressStepper: () => void
@@ -16,7 +17,7 @@ export const Browser: React.FC<IProps> = ({ progressStepper, ...props }) => {
   useEffect(() => {
     const timeout = setTimeout(() => {
       setTyping(true)
-    }, 3000)
+    }, BASE_ANIMATION_DELAY_SEC * 1000)
     return () => clearTimeout(timeout)
   }, [])
 

--- a/src/components/Simulator/screens/ConnectWeb3/Browser.tsx
+++ b/src/components/Simulator/screens/ConnectWeb3/Browser.tsx
@@ -12,6 +12,7 @@ import { BsTriangle } from "react-icons/bs"
 import { PiMagnifyingGlass } from "react-icons/pi"
 import { IoEllipsisHorizontalSharp } from "react-icons/io5"
 import { NFTSupportIcon } from "../../../icons/wallets/NFTSupportIcon"
+import { NotificationPopover } from "../../NotificationPopover"
 
 interface IProps extends FlexProps {
   progressStepper: () => void
@@ -20,9 +21,16 @@ export const Browser: React.FC<IProps> = ({ progressStepper, ...props }) => {
   return (
     <Flex direction="column" h="full" bg="body.light" {...props}>
       <Box bg="background.highlight" w="full" px={3} pt={9} pb={3}>
-        <Box bg="background.base" w="full" borderRadius="base" px={3} py={2}>
-          <Text color="disabled">Search or enter address</Text>
-        </Box>
+        <NotificationPopover
+          title="Example walkthrough"
+          content="Try logging into a real app with your wallet when finished here"
+        >
+          <Box bg="background.base" w="full" borderRadius="base" px={3} py={2}>
+            <Text color="disabled" cursor="default">
+              Search or enter address
+            </Text>
+          </Box>
+        </NotificationPopover>
       </Box>
       <Box p={8} flex={1}>
         <Button

--- a/src/components/Simulator/screens/ConnectWeb3/Browser.tsx
+++ b/src/components/Simulator/screens/ConnectWeb3/Browser.tsx
@@ -1,11 +1,22 @@
 import React from "react"
-import { Box, type FlexProps, Text, Icon, Flex, Grid } from "@chakra-ui/react"
+import {
+  Box,
+  type FlexProps,
+  Text,
+  Icon,
+  Flex,
+  Grid,
+  Button,
+} from "@chakra-ui/react"
 import { BsTriangle } from "react-icons/bs"
 import { PiMagnifyingGlass } from "react-icons/pi"
 import { IoEllipsisHorizontalSharp } from "react-icons/io5"
 import { NFTSupportIcon } from "../../../icons/wallets/NFTSupportIcon"
 
-export const Browser: React.FC<FlexProps> = (props) => {
+interface IProps extends FlexProps {
+  progressStepper: () => void
+}
+export const Browser: React.FC<IProps> = ({ progressStepper, ...props }) => {
   return (
     <Flex direction="column" h="full" bg="body.light" {...props}>
       <Box bg="background.highlight" w="full" px={3} pt={9} pb={3}>
@@ -14,18 +25,38 @@ export const Browser: React.FC<FlexProps> = (props) => {
         </Box>
       </Box>
       <Box p={8} flex={1}>
-        <Flex direction="column" alignItems="center" gap={2} w="fit-content">
+        <Button
+          variant="ghost"
+          display="flex"
+          flexDirection="column"
+          alignItems="center"
+          data-group
+          onClick={progressStepper}
+          gap={4}
+          p={0}
+        >
           <Grid
+            bg="background.highlight"
+            borderRadius="lg"
             placeItems="center"
             w={16}
             h={16}
-            bg="background.highlight"
-            borderRadius="lg"
+            _groupHover={{ bg: "primary.hover" }}
           >
-            <Icon as={NFTSupportIcon} fontSize="4xl" />
+            <Icon as={NFTSupportIcon} color="white" w={10} h={10} />
           </Grid>
-          <Text>NFT Market</Text>
-        </Flex>
+          <Box position="relative">
+            <Text
+              fontWeight="bold"
+              color="primary.base"
+              textAlign="center"
+              m={0}
+              _groupHover={{ color: "primary.hover" }}
+            >
+              NFT Market
+            </Text>
+          </Box>
+        </Button>
       </Box>
       <Flex
         bg="background.highlight"

--- a/src/components/Simulator/screens/ConnectWeb3/Browser.tsx
+++ b/src/components/Simulator/screens/ConnectWeb3/Browser.tsx
@@ -1,0 +1,47 @@
+import React from "react"
+import { Box, type FlexProps, Text, Icon, Flex, Grid } from "@chakra-ui/react"
+import { BsTriangle } from "react-icons/bs"
+import { PiMagnifyingGlass } from "react-icons/pi"
+import { IoEllipsisHorizontalSharp } from "react-icons/io5"
+import { NFTSupportIcon } from "../../../icons/wallets/NFTSupportIcon"
+
+export const Browser: React.FC<FlexProps> = (props) => {
+  return (
+    <Flex direction="column" h="full" bg="body.light" {...props}>
+      <Box bg="background.highlight" w="full" px={3} pt={9} pb={3}>
+        <Box bg="background.base" w="full" borderRadius="base" px={3} py={2}>
+          <Text color="disabled">Search or enter address</Text>
+        </Box>
+      </Box>
+      <Box p={8} flex={1}>
+        <Flex direction="column" alignItems="center" gap={2} w="fit-content">
+          <Grid
+            placeItems="center"
+            w={16}
+            h={16}
+            bg="background.highlight"
+            borderRadius="lg"
+          >
+            <Icon as={NFTSupportIcon} fontSize="4xl" />
+          </Grid>
+          <Text>NFT Market</Text>
+        </Flex>
+      </Box>
+      <Flex
+        bg="background.highlight"
+        w="full"
+        px={3}
+        pb={9}
+        pt={4}
+        justify="space-around"
+        fontSize="xl"
+        color="disabled"
+      >
+        <Icon as={BsTriangle} transform="rotate(-90deg)" />
+        <Icon as={BsTriangle} transform="rotate(90deg)" />
+        <Icon as={PiMagnifyingGlass} />
+        <Icon as={IoEllipsisHorizontalSharp} />
+      </Flex>
+    </Flex>
+  )
+}

--- a/src/components/Simulator/screens/ConnectWeb3/Browser.tsx
+++ b/src/components/Simulator/screens/ConnectWeb3/Browser.tsx
@@ -1,23 +1,37 @@
-import React from "react"
-import {
-  Box,
-  type FlexProps,
-  Text,
-  Icon,
-  Flex,
-  Grid,
-  Button,
-} from "@chakra-ui/react"
+import React, { useEffect, useState } from "react"
+import { Box, type FlexProps, Text, Icon, Flex } from "@chakra-ui/react"
 import { BsTriangle } from "react-icons/bs"
 import { PiMagnifyingGlass } from "react-icons/pi"
+import { TbWorldWww } from "react-icons/tb"
 import { IoEllipsisHorizontalSharp } from "react-icons/io5"
-import { NFTSupportIcon } from "../../../icons/wallets/NFTSupportIcon"
+import { motion } from "framer-motion"
 import { NotificationPopover } from "../../NotificationPopover"
+import { EXAMPLE_APP_URL } from "./constants"
 
 interface IProps extends FlexProps {
   progressStepper: () => void
 }
 export const Browser: React.FC<IProps> = ({ progressStepper, ...props }) => {
+  const [typing, setTyping] = useState(false)
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setTyping(true)
+    }, 3000)
+    return () => clearTimeout(timeout)
+  }, [])
+
+  const sentence = {
+    hidden: { opacity: 1 },
+    visible: {
+      opacity: 1,
+      transition: { staggerChildren: 0.12 },
+    },
+  }
+  const letter = {
+    hidden: { opacity: 0 },
+    visible: { opacity: 1, transition: { duration: 0 } },
+  }
+
   return (
     <Flex direction="column" h="full" bg="body.light" {...props}>
       <Box bg="background.highlight" w="full" px={3} pt={9} pb={3}>
@@ -25,53 +39,47 @@ export const Browser: React.FC<IProps> = ({ progressStepper, ...props }) => {
           title="Example walkthrough"
           content="Try logging into a real app with your wallet when finished here"
         >
-          <Box bg="background.base" w="full" borderRadius="base" px={3} py={2}>
-            <Text color="disabled" cursor="default">
-              Search or enter address
-            </Text>
-          </Box>
+          <Flex
+            bg="background.base"
+            borderRadius="base"
+            px={3}
+            py={2}
+            align="center"
+            color="disabled"
+            cursor="default"
+          >
+            <Box
+              borderInlineEnd="1px"
+              borderColor="background.highlight"
+              flex={1}
+            >
+              {typing ? (
+                <Text
+                  as={motion.p}
+                  variants={sentence}
+                  initial="hidden"
+                  animate="visible"
+                  color="body.medium"
+                >
+                  {EXAMPLE_APP_URL.split("").map((char, index) => (
+                    <motion.span key={char + "-" + index} variants={letter}>
+                      {char}
+                    </motion.span>
+                  ))}
+                </Text>
+              ) : (
+                <Text>Search or enter website</Text>
+              )}
+            </Box>
+            <Icon as={TbWorldWww} ms={3} />
+          </Flex>
         </NotificationPopover>
       </Box>
-      <Box p={8} flex={1}>
-        <Button
-          variant="ghost"
-          display="flex"
-          flexDirection="column"
-          alignItems="center"
-          data-group
-          onClick={progressStepper}
-          gap={4}
-          p={0}
-        >
-          <Grid
-            bg="background.highlight"
-            borderRadius="lg"
-            placeItems="center"
-            w={16}
-            h={16}
-            _groupHover={{ bg: "primary.hover" }}
-          >
-            <Icon
-              as={NFTSupportIcon}
-              color="body.base"
-              w={10}
-              h={10}
-              _groupHover={{ color: "background.base" }}
-            />
-          </Grid>
-          <Box position="relative">
-            <Text
-              fontWeight="bold"
-              color="body.base"
-              textAlign="center"
-              m={0}
-              _groupHover={{ color: "primary.hover" }}
-            >
-              NFT Market
-            </Text>
-          </Box>
-        </Button>
-      </Box>
+
+      <Flex flex={1} justify="center" pt={{ base: 20, md: 24 }}>
+        <Icon as={TbWorldWww} fontSize="8xl" strokeWidth="1" color="disabled" />
+      </Flex>
+
       <Flex
         bg="background.highlight"
         w="full"

--- a/src/components/Simulator/screens/ConnectWeb3/Browser.tsx
+++ b/src/components/Simulator/screens/ConnectWeb3/Browser.tsx
@@ -43,12 +43,18 @@ export const Browser: React.FC<IProps> = ({ progressStepper, ...props }) => {
             h={16}
             _groupHover={{ bg: "primary.hover" }}
           >
-            <Icon as={NFTSupportIcon} color="white" w={10} h={10} />
+            <Icon
+              as={NFTSupportIcon}
+              color="body.base"
+              w={10}
+              h={10}
+              _groupHover={{ color: "background.base" }}
+            />
           </Grid>
           <Box position="relative">
             <Text
               fontWeight="bold"
-              color="primary.base"
+              color="body.base"
               textAlign="center"
               m={0}
               _groupHover={{ color: "primary.hover" }}

--- a/src/components/Simulator/screens/ConnectWeb3/Slider.tsx
+++ b/src/components/Simulator/screens/ConnectWeb3/Slider.tsx
@@ -1,13 +1,18 @@
-import { Box, Flex, Grid, Icon, Text } from "@chakra-ui/react"
+import { Box, Flex, Grid, Icon, Text, TextProps } from "@chakra-ui/react"
 import React from "react"
 import { motion } from "framer-motion"
 import { EthGlyphIcon } from "../../icons"
 import { PiCheckThin } from "react-icons/pi"
 
-interface IProps {
+interface IProps extends Pick<TextProps, "children"> {
   isConnected: boolean
+  displayUrl: string
 }
-export const Slider: React.FC<IProps> = ({ isConnected }) => {
+export const Slider: React.FC<IProps> = ({
+  isConnected,
+  displayUrl,
+  children,
+}) => {
   const ICON_SIZE = "4.5rem" as const
   return (
     <>
@@ -96,14 +101,11 @@ export const Slider: React.FC<IProps> = ({ isConnected }) => {
                   />
                 </Grid>
                 <Text mb={0} me={0.5}>
-                  app.example.com
+                  {displayUrl}
                 </Text>
               </Flex>
               {/* Information */}
-              <Text>
-                Connecting to the website will not share any personal
-                information with the site owners.
-              </Text>
+              <Text>{children}</Text>
             </>
           )}
         </Flex>

--- a/src/components/Simulator/screens/ConnectWeb3/Slider.tsx
+++ b/src/components/Simulator/screens/ConnectWeb3/Slider.tsx
@@ -73,7 +73,7 @@ export const Slider: React.FC<IProps> = ({
             </Flex>
           ) : (
             <>
-              <Text textAlign="center" fontWeight="bold" fontSize="lg">
+              <Text textAlign="center" fontWeight="bold" fontSize="lg" mb={4}>
                 Connect account?
               </Text>
               {/* URL Pill */}

--- a/src/components/Simulator/screens/ConnectWeb3/Web3App.tsx
+++ b/src/components/Simulator/screens/ConnectWeb3/Web3App.tsx
@@ -8,30 +8,40 @@ import {
 } from "@chakra-ui/react"
 import React from "react"
 import { GrMenu } from "react-icons/gr"
+import { FAKE_DEMO_ADDRESS } from "../../constants"
 import { EthGlyphIcon } from "../../icons"
 import { NotificationPopover } from "../../NotificationPopover"
 
-interface IProps extends BoxProps {}
-export const Web3App: React.FC<IProps> = ({ children, ...boxProps }) => {
+interface IProps extends BoxProps {
+  displayUrl: string
+  connected?: boolean
+}
+export const Web3App: React.FC<IProps> = ({
+  displayUrl,
+  connected,
+  children,
+  ...boxProps
+}) => {
   const bg = useColorModeValue("#e8e8e8", "#171717")
 
   return (
     <Box h="full" w="full" bg="background.highlight" {...boxProps}>
       <Box p={1} bg={bg}>
         <Text textAlign="center" fontSize="xs" m={0}>
-          app.example.com
+          {displayUrl}
         </Text>
       </Box>
       <NotificationPopover
         title="Example walkthrough"
         content="Try out a real Ethereum application when finished here"
       >
-        <Flex p={6} fontSize="4xl" justify="space-between">
+        <Flex p={6} fontSize="4xl" justify="space-between" alignItems="center">
           <Icon as={EthGlyphIcon} />
+          {connected && <Text fontSize="sm">{FAKE_DEMO_ADDRESS}</Text>}
           <Icon as={GrMenu} sx={{ path: { stroke: "body.base" } }} />
         </Flex>
       </NotificationPopover>
-      <>{children}</>
+      {children}
     </Box>
   )
 }

--- a/src/components/Simulator/screens/ConnectWeb3/Web3App.tsx
+++ b/src/components/Simulator/screens/ConnectWeb3/Web3App.tsx
@@ -14,11 +14,11 @@ import { NotificationPopover } from "../../NotificationPopover"
 
 interface IProps extends BoxProps {
   displayUrl: string
-  connected?: boolean
+  appName?: string
 }
 export const Web3App: React.FC<IProps> = ({
   displayUrl,
-  connected,
+  appName,
   children,
   ...boxProps
 }) => {
@@ -35,9 +35,18 @@ export const Web3App: React.FC<IProps> = ({
         title="Example walkthrough"
         content="Try out a real Ethereum application when finished here"
       >
-        <Flex p={6} fontSize="4xl" justify="space-between" alignItems="center">
+        <Flex p={6} fontSize="4xl" gap={3} alignItems="center">
           <Icon as={EthGlyphIcon} />
-          {connected && <Text fontSize="sm">{FAKE_DEMO_ADDRESS}</Text>}
+          <Box flex={1} cursor="default">
+            {appName && (
+              <>
+                <Text fontSize="md" fontWeight="bold">
+                  {appName}
+                </Text>
+                <Text fontSize="sm">{FAKE_DEMO_ADDRESS}</Text>
+              </>
+            )}
+          </Box>
           <Icon as={GrMenu} sx={{ path: { stroke: "body.base" } }} />
         </Flex>
       </NotificationPopover>

--- a/src/components/Simulator/screens/ConnectWeb3/constants.ts
+++ b/src/components/Simulator/screens/ConnectWeb3/constants.ts
@@ -1,0 +1,1 @@
+export const EXAMPLE_APP_URL = "app.example.com"

--- a/src/components/Simulator/screens/ConnectWeb3/index.tsx
+++ b/src/components/Simulator/screens/ConnectWeb3/index.tsx
@@ -1,25 +1,29 @@
 import { Box, Button, Flex, Icon, Text } from "@chakra-ui/react"
-import React, { useMemo, useState } from "react"
+import React, { useEffect, useMemo, useState } from "react"
 import {
   RiPriceTag2Line,
   RiAuctionLine,
   RiFileTransferLine,
 } from "react-icons/ri"
 import { AnimatePresence, motion } from "framer-motion"
-import { Slider } from "./Slider"
-import { Web3App } from "./Web3App"
+import GatsbyImage from "../../../GatsbyImage"
+import { NotificationPopover } from "../../NotificationPopover"
 import { ProgressCta } from "../../ProgressCta"
 import { WalletHome } from "../../WalletHome"
-import type { PhoneScreenProps } from "../../interfaces"
 import type { TokenBalance } from "../../WalletHome/interfaces"
-import { defaultTokenBalances } from "../../constants"
-import { useEthPrice } from "../../../../hooks/useEthPrice"
 import { useNFT } from "../../WalletHome/hooks/useNFT"
-import GatsbyImage from "../../../GatsbyImage"
-import { FALLBACK_ETH_PRICE, USD_RECEIVE_AMOUNT } from "../../constants"
-import { EXAMPLE_APP_URL } from "./constants"
 import { Browser } from "./Browser"
-import { NotificationPopover } from "../../NotificationPopover"
+import { Slider } from "./Slider"
+import { Web3App } from "./Web3App"
+import {
+  defaultTokenBalances,
+  FALLBACK_ETH_PRICE,
+  USD_RECEIVE_AMOUNT,
+  BASE_ANIMATION_DELAY_SEC,
+} from "../../constants"
+import { EXAMPLE_APP_URL } from "./constants"
+import type { PhoneScreenProps } from "../../interfaces"
+import { useEthPrice } from "../../../../hooks/useEthPrice"
 
 export const ConnectWeb3: React.FC<PhoneScreenProps> = ({ nav, ctaLabel }) => {
   const { progressStepper, step } = nav
@@ -45,6 +49,17 @@ export const ConnectWeb3: React.FC<PhoneScreenProps> = ({ nav, ctaLabel }) => {
     initial: { opacity: 0 },
     animate: { opacity: 1 },
   }
+
+  // Enable ProgressCta button after short delay for first step
+  const [ctaDisabled, setCtaDisabled] = useState(step === 0)
+  useEffect(() => {
+    if (step !== 0) return
+    const timeout = setTimeout(() => {
+      setCtaDisabled(false)
+    }, BASE_ANIMATION_DELAY_SEC * 1000)
+    return () => clearTimeout(timeout)
+  }, [])
+
   return (
     <>
       {[0].includes(step) && <Browser progressStepper={progressStepper} />}
@@ -173,6 +188,7 @@ export const ConnectWeb3: React.FC<PhoneScreenProps> = ({ nav, ctaLabel }) => {
       {[0, 1, 2, 3, 4].includes(step) && (
         <ProgressCta
           isAnimated={step === 0}
+          isDisabled={ctaDisabled}
           progressStepper={progressStepper}
           mb={step === 0 ? 16 : 0}
         >

--- a/src/components/Simulator/screens/ConnectWeb3/index.tsx
+++ b/src/components/Simulator/screens/ConnectWeb3/index.tsx
@@ -19,6 +19,7 @@ import GatsbyImage from "../../../GatsbyImage"
 import { FALLBACK_ETH_PRICE, USD_RECEIVE_AMOUNT } from "../../constants"
 import { EXAMPLE_APP_URL } from "./constants"
 import { Browser } from "./Browser"
+import { NotificationPopover } from "../../NotificationPopover"
 
 export const ConnectWeb3: React.FC<PhoneScreenProps> = ({ nav, ctaLabel }) => {
   const { progressStepper, step } = nav
@@ -108,45 +109,59 @@ export const ConnectWeb3: React.FC<PhoneScreenProps> = ({ nav, ctaLabel }) => {
               </Text>
               <Flex gap={2} mb={6}>
                 <GatsbyImage image={NFTs[0].image} alt="NFT Image" />
-                <Flex
-                  direction="column"
-                  fontSize={{ base: "xs", sm: "sm" }}
-                  textAlign="start"
-                  alignItems="start"
-                  gap={1}
+                <NotificationPopover
+                  title="Example walkthrough"
+                  content="These are some things you could do as the owner of your NFTs"
+                  placement="top"
                 >
-                  <Text fontWeight="bold" fontSize="md" mb="auto" ms={2}>
-                    Cool art
-                  </Text>
-                  <Button
-                    variant="link"
-                    isDisabled
-                    leftIcon={<Icon as={RiAuctionLine} fontSize="xs" />}
+                  <Flex
+                    direction="column"
+                    fontSize={{ base: "xs", sm: "sm" }}
+                    textAlign="start"
+                    alignItems="start"
+                    gap={1}
                   >
-                    Set a price
-                  </Button>
-                  <Button
-                    variant="link"
-                    isDisabled
-                    leftIcon={<Icon as={RiPriceTag2Line} fontSize="xs" />}
-                  >
-                    Auction item
-                  </Button>
-                  <Button
-                    variant="link"
-                    isDisabled
-                    leftIcon={<Icon as={RiFileTransferLine} fontSize="xs" />}
-                  >
-                    Transfer item
-                  </Button>
-                </Flex>
+                    <Text fontWeight="bold" fontSize="md" mb="auto" ms={2}>
+                      Cool art
+                    </Text>
+                    <Button
+                      variant="link"
+                      isDisabled
+                      leftIcon={<Icon as={RiAuctionLine} fontSize="xs" />}
+                    >
+                      Set a price
+                    </Button>
+                    <Button
+                      variant="link"
+                      isDisabled
+                      leftIcon={<Icon as={RiPriceTag2Line} fontSize="xs" />}
+                    >
+                      Auction item
+                    </Button>
+                    <Button
+                      variant="link"
+                      isDisabled
+                      leftIcon={<Icon as={RiFileTransferLine} fontSize="xs" />}
+                    >
+                      Transfer item
+                    </Button>
+                  </Flex>
+                </NotificationPopover>
               </Flex>
-              <Button variant="link" isDisabled>
-                Browse other artwork
-              </Button>
-              <Button variant="link" isDisabled>
-                Mint new NFT
-              </Button>
+              <NotificationPopover
+                title="Example walkthrough"
+                content="Try out a real Ethereum application when finished here"
+                placement="top"
+              >
+                <Box fontSize={{ base: "sm", md: "md" }}>
+                  <Button variant="link" isDisabled display="block">
+                    Browse other artwork
+                  </Button>
+                  <Button variant="link" isDisabled>
+                    Mint new NFT
+                  </Button>
+                </Box>
+              </NotificationPopover>
             </Box>
           </Web3App>
         </motion.div>

--- a/src/components/Simulator/screens/ConnectWeb3/index.tsx
+++ b/src/components/Simulator/screens/ConnectWeb3/index.tsx
@@ -17,6 +17,8 @@ import { useEthPrice } from "../../../../hooks/useEthPrice"
 import { useNFT } from "../../WalletHome/hooks/useNFT"
 import GatsbyImage from "../../../GatsbyImage"
 import { FALLBACK_ETH_PRICE, USD_RECEIVE_AMOUNT } from "../../constants"
+import { EXAMPLE_APP_URL } from "./constants"
+import { Browser } from "./Browser"
 
 export const ConnectWeb3: React.FC<PhoneScreenProps> = ({ nav, ctaLabel }) => {
   const { progressStepper, step } = nav
@@ -44,8 +46,9 @@ export const ConnectWeb3: React.FC<PhoneScreenProps> = ({ nav, ctaLabel }) => {
   }
   return (
     <>
-      {[0, 1, 2].includes(step) && (
-        <Web3App>
+      {[0].includes(step) && <Browser />}
+      {[1, 2, 3].includes(step) && (
+        <Web3App displayUrl={EXAMPLE_APP_URL}>
           <Flex
             px={6}
             py={{ base: 8, md: 16 }}
@@ -80,18 +83,28 @@ export const ConnectWeb3: React.FC<PhoneScreenProps> = ({ nav, ctaLabel }) => {
         </Web3App>
       )}
       <AnimatePresence>
-        {[1, 2].includes(step) && <Slider isConnected={step === 2} />}
+        {[2, 3].includes(step) && (
+          <Slider isConnected={step === 3} displayUrl={EXAMPLE_APP_URL}>
+            Connecting to the website will not share any personal or secure
+            information with the site owners.
+          </Slider>
+        )}
       </AnimatePresence>
-      {[3].includes(step) && (
+      {[4].includes(step) && (
         <motion.div
           {...fadeInProps}
           exit={{ opacity: 0 }}
           style={{ height: "100%" }}
         >
-          <Web3App bg="background.base">
-            <Box px={6} py={{ base: 2, md: 6 }} fontSize="lg">
+          <Web3App bg="background.base" connected displayUrl="app.example.com">
+            <Box
+              px={6}
+              py={{ base: 2, md: 6 }}
+              fontSize="lg"
+              sx={{ button: { textDecoration: "none" } }}
+            >
               <Text fontWeight="bold" mb={4}>
-                Your collection
+                Your collection (1)
               </Text>
               <Flex gap={2} mb={6}>
                 <GatsbyImage image={NFTs[0].image} alt="NFT Image" />
@@ -101,7 +114,6 @@ export const ConnectWeb3: React.FC<PhoneScreenProps> = ({ nav, ctaLabel }) => {
                   textAlign="start"
                   alignItems="start"
                   gap={1}
-                  sx={{ button: { textDecoration: "none" } }}
                 >
                   <Text fontWeight="bold" fontSize="md" mb="auto" ms={2}>
                     Cool art
@@ -129,19 +141,26 @@ export const ConnectWeb3: React.FC<PhoneScreenProps> = ({ nav, ctaLabel }) => {
                   </Button>
                 </Flex>
               </Flex>
-              <Button variant="outline" w="full" isDisabled>
-                Browser other artwork
+              <Button variant="link" isDisabled>
+                Browse other artwork
+              </Button>
+              <Button variant="link" isDisabled>
+                Mint new NFT
               </Button>
             </Box>
           </Web3App>
         </motion.div>
       )}
-      {[0, 1, 2, 3].includes(step) && (
-        <ProgressCta isAnimated={step === 0} progressStepper={progressStepper}>
+      {[0, 1, 2, 3, 4].includes(step) && (
+        <ProgressCta
+          isAnimated={step === 0}
+          progressStepper={progressStepper}
+          mb={step === 0 ? 16 : 0}
+        >
           {ctaLabel}
         </ProgressCta>
       )}
-      {[4].includes(step) && (
+      {[5].includes(step) && (
         <motion.div
           key="final-wallet-display"
           {...fadeInProps}

--- a/src/components/Simulator/screens/ConnectWeb3/index.tsx
+++ b/src/components/Simulator/screens/ConnectWeb3/index.tsx
@@ -46,7 +46,7 @@ export const ConnectWeb3: React.FC<PhoneScreenProps> = ({ nav, ctaLabel }) => {
   }
   return (
     <>
-      {[0].includes(step) && <Browser />}
+      {[0].includes(step) && <Browser progressStepper={progressStepper} />}
       {[1, 2, 3].includes(step) && (
         <Web3App displayUrl={EXAMPLE_APP_URL}>
           <Flex

--- a/src/components/Simulator/screens/ConnectWeb3/index.tsx
+++ b/src/components/Simulator/screens/ConnectWeb3/index.tsx
@@ -97,7 +97,11 @@ export const ConnectWeb3: React.FC<PhoneScreenProps> = ({ nav, ctaLabel }) => {
           exit={{ opacity: 0 }}
           style={{ height: "100%" }}
         >
-          <Web3App bg="background.base" connected displayUrl="app.example.com">
+          <Web3App
+            bg="background.base"
+            appName="NFT Marketplace"
+            displayUrl="app.example.com"
+          >
             <Box
               px={6}
               py={{ base: 2, md: 6 }}

--- a/src/components/Simulator/screens/SendReceive/SendFromContacts.tsx
+++ b/src/components/Simulator/screens/SendReceive/SendFromContacts.tsx
@@ -1,14 +1,4 @@
-import {
-  Box,
-  Button,
-  Flex,
-  Icon,
-  Popover,
-  PopoverBody,
-  PopoverContent,
-  PopoverTrigger,
-  Text,
-} from "@chakra-ui/react"
+import { Box, Button, Flex, Icon, Text } from "@chakra-ui/react"
 import React from "react"
 import { PiMagnifyingGlass } from "react-icons/pi"
 import { CategoryTabs } from "../../WalletHome/CategoryTabs"

--- a/src/data/WalletSimulatorData.tsx
+++ b/src/data/WalletSimulatorData.tsx
@@ -432,7 +432,7 @@ export const walletOnboardingSimData: SimulatorData = {
       },
     ],
     ctaLabels: [
-      "Go to web app",
+      "Visit NFT market",
       "Connect wallet",
       "Connect to app",
       "Go to account",

--- a/src/data/WalletSimulatorData.tsx
+++ b/src/data/WalletSimulatorData.tsx
@@ -333,11 +333,26 @@ export const walletOnboardingSimData: SimulatorData = {
         description: (
           <>
             <Text>
+              Your wallet can be used to connect to all sorts of applications,
+              allowing you to interact with your on-chain assets.
+            </Text>
+            <Text>
+              Your friend just sent an NFT art piece to your address! Let's
+              login to a new NFT marketplace to view it.
+            </Text>
+          </>
+        ),
+      },
+      {
+        header: "No need to create a new account for each service",
+        description: (
+          <>
+            <Text>
               Your account is universal across all Ethereum and
               Ethereum-compatible applications.
             </Text>
             <Text>
-              There is no need to create a new account for each service.
+              Assets stored on-chain can be accessed from any application.
             </Text>
           </>
         ),
@@ -352,7 +367,8 @@ export const walletOnboardingSimData: SimulatorData = {
               Polygon or Optimism.
             </Text>
             <Text>
-              Assets stored on-chain can be accessed from any application.
+              Logins are handled by your wallet—no more creating insecure
+              passwords.
             </Text>
           </>
         ),
@@ -366,16 +382,19 @@ export const walletOnboardingSimData: SimulatorData = {
               Your personal information, such as email or phone number, is not
               needed to use Web3 apps—you only need a wallet.
             </Text>
+            <Text>
+              Also note there are no associated transaction fees here—signing in
+              using Ethereum is free, fast and easy!
+            </Text>
           </>
         ),
       },
-
       {
         header:
           "No geographical or political discrimination against who can use Ethereum services",
         description: (
           <>
-            <Text>You can use the same address on multiple devices.</Text>
+            <Text>There's the NFT you received!</Text>
             <Text>
               Wallets are technically only an interface to show you your balance
               and to make transactions—
@@ -413,6 +432,7 @@ export const walletOnboardingSimData: SimulatorData = {
       },
     ],
     ctaLabels: [
+      "Go to website",
       "Connect wallet",
       "Connect to app",
       "Go to account",

--- a/src/data/WalletSimulatorData.tsx
+++ b/src/data/WalletSimulatorData.tsx
@@ -337,8 +337,8 @@ export const walletOnboardingSimData: SimulatorData = {
               allowing you to interact with your on-chain assets.
             </Text>
             <Text>
-              Your friend just sent an NFT art piece to your address! Let's
-              login to a new NFT marketplace to view it.
+              Your friend just sent an NFT art piece to your address! Let's go
+              to a new NFT marketplace website to view it.
             </Text>
           </>
         ),
@@ -432,7 +432,7 @@ export const walletOnboardingSimData: SimulatorData = {
       },
     ],
     ctaLabels: [
-      "Go to website",
+      "Go to web app",
       "Connect wallet",
       "Connect to app",
       "Go to account",


### PR DESCRIPTION
## Description
- Adds a new starting screen/step to the Connect to Web3 sim
- Introduced a new `Browser` component for that step that starts with the user needing to go to the website for the dapp, after receiving an NFT as part of the story line
- Adjusts some copy to fit the new screen flow
- Typo correction, and added "Mint new NFT" to dapp account screen

## Preview link
https://ethereumorgwebsitedev01-simupdates.gatsbyjs.io/en/wallets/?sim=connect-web3#sim

## Related Issue
None filed