### PR TITLE
fix(.storybook): import inter font css to preview

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -3,6 +3,7 @@ import { action } from "@storybook/addon-actions"
 
 import i18n, { baseLocales } from "./i18next"
 import theme from "../src/@chakra-ui/gatsby-plugin/theme"
+import "../static/fonts/inter-font-face.css"
 
 const chakraBreakpointArray = Object.entries(theme.breakpoints)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The `Inter` font-face set in the local was not exposed in the Storybook server.

Here, importing the css file `inter-font-face.css` from the `static` folder to `preview.ts` should provide the necessary exposure.


(Not quite sure how that was missed 🤔 )

## Related Issue
N/A
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
