### PR TITLE
Added Ethereum San Pedro Sula to Meetup details [Fixes #11257]

### DIFF
--- a/src/data/community-meetups.json
+++ b/src/data/community-meetups.json
@@ -1,5 +1,11 @@
 [
   {
+    "title": "Ethereum San Pedro Sula",
+    "emoji": ":honduras:",
+    "location": "San Pedro Sula, Honduras",
+    "link": "https://ethereumsanpedrosula.org/"
+  },
+  {
     "title": "ETHTbilisi",
     "emoji": ":ge:",
     "location": "Georgia",


### PR DESCRIPTION
## Description

The src/data/community-meetups.json file have been updated with the details of the Ethereum San Pedro Sula Community.

## Related Issue

The current PR fixes #11257
