### PR TITLE
style(ButtonTwoLines): alter `size` and `color` prop usage for text

### DIFF
--- a/src/components/Buttons/ButtonTwoLines/index.tsx
+++ b/src/components/Buttons/ButtonTwoLines/index.tsx
@@ -87,13 +87,20 @@ const ButtonTwoLines = (props: ButtonTwoLinesProps) => {
       >
         <Text
           as="span"
-          fontSize="md"
+          size="md"
           fontWeight={size === "md" ? "bold" : "normal"}
         >
           {mainText}
         </Text>
-        {/* TODO: use `size='xs'` instead when the Text theme is added  */}
-        <Text as="span" fontSize="xs">
+        <Text
+          as="span"
+          size="xs"
+          color={
+            rest.variant === "outline" || rest.isSecondary
+              ? "body.medium"
+              : undefined
+          }
+        >
           {helperText}
         </Text>
       </Stack>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- Primary: use `body.medium` color for helper text with `outline` variant or `isSecondary` (per DS)
- Secondary: use `size` theme prop instead of `fontSize` to include `lineHeight` for both `Text` components

## Related Issue
N/A
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
