### PR TITLE
Update ETH Hong Kong dates

### DIFF
--- a/src/data/community-events.json
+++ b/src/data/community-events.json
@@ -229,9 +229,9 @@
     "to": "https://www.ethhongkong.co/",
     "sponsor": null,
     "location": "Hong Kong",
-    "description": "ETH Hong Kong will be held in Q4 2023. It is the frist-ever large-scale ETH Hong Kong event, which will be developer driven and full of hacking, panel discussions, boot camps and other fun activites.",
-    "startDate": "2023-10-14",
-    "endDate": "2023-10-15"
+    "description": "ETH Hong Kong will be held in Q4 2023. It is the first-ever large-scale ETH Hong Kong event, which will be developer driven and full of hacking, panel discussions, boot camps and other fun activities.",
+    "startDate": "2023-10-22",
+    "endDate": "2023-10-24"
   },
   {
     "title": "ETH Miami 2023",


### PR DESCRIPTION
Updated the dates of ETH HK event to 22-24 Oct 2023.

## Description

Updated the dates of ETH HK event to 22-24 Oct 2023.
More details at https://twitter.com/EthereumHK.
