### PR TITLE
fix(theme/Heading): flip `lineHeight`s rendered to match DS

### DIFF
--- a/src/@chakra-ui/gatsby-plugin/components/Heading.ts
+++ b/src/@chakra-ui/gatsby-plugin/components/Heading.ts
@@ -5,10 +5,10 @@ const { sizes: defaultSizes } = headingDefaultTheme
 
 const lineHeightScale = {
   "4xl": "6xs",
-  "3xl": ["5xs", null, "6xs"],
-  "2xl": ["5xs", null, "4xs"],
-  xl: ["3xs", null, "2xs"],
-  lg: ["3xs", null, "2xs"],
+  "3xl": ["6xs", null, "5xs"],
+  "2xl": ["4xs", null, "5xs"],
+  xl: ["2xs", null, "4xs"],
+  lg: ["2xs", null, "3xs"],
   md: "xs",
   sm: "base",
   xs: "base",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR addresses the `lineHeight`s not being applied correctly for the `Heading` component. Based on breakpoint, the sizes either needed to be flipped or replaced to match the DS

## Related Issue
N/A
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
