### PR TITLE
'Reset Filters' button on find wallet page is always in English 

### DIFF
--- a/src/components/FindWallet/WalletFilterSidebar/index.tsx
+++ b/src/components/FindWallet/WalletFilterSidebar/index.tsx
@@ -161,7 +161,7 @@ const WalletFilterSidebar: React.FC<WalletFilterSidebarProps> = ({
         }}
       >
         <Icon as={BsArrowCounterclockwise} aria-hidden="true" fontSize="sm" />
-        {"Reset filters".toUpperCase()}
+        {t("page-find-wallet-reset-filters").toUpperCase()}
       </Center>
       <TabPanels
         m={0}

--- a/src/intl/en/page-wallets-find-wallet.json
+++ b/src/intl/en/page-wallets-find-wallet.json
@@ -90,5 +90,6 @@
   "page-find-wallet-browser-desc": "Wallets with browser extensions",
   "page-find-wallet-device": "Device",
   "page-find-choose-to-compare": "Choose to compare",
-  "page-find-wallet-choose-features": "Choose features"
+  "page-find-wallet-choose-features": "Choose features",
+  "page-find-wallet-reset-filters": "Reset filters"
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Setup reset filter label for translation

## Related Issue

Fixes https://github.com/ethereum/ethereum-org-website/issues/11369
