### PR TITLE
Energy consumption chart missing labels

### DIFF
--- a/src/components/EnergyConsumptionChart.tsx
+++ b/src/components/EnergyConsumptionChart.tsx
@@ -8,11 +8,11 @@ import {
   LabelList,
   ResponsiveContainer,
   Legend,
+  Text,
 } from "recharts"
 import { useTranslation } from "gatsby-plugin-react-i18next"
 
 import Translation from "./Translation"
-import Text from "./OldText"
 
 interface ITickProps {
   x: number


### PR DESCRIPTION
## Description

- Change from OldText to chakra import Text

## Related Issue

Fixes: https://github.com/ethereum/ethereum-org-website/issues/11372
