### PR TITLE
Fix ts warning on CardList

### DIFF
--- a/src/components/CardList.tsx
+++ b/src/components/CardList.tsx
@@ -25,7 +25,7 @@ export type CardListItem = {
   alt?: string
 }
 
-export interface IProps extends BoxProps {
+export interface IProps extends Omit<BoxProps, "content"> {
   content: Array<CardListItem>
   clickHandler?: (idx: string | number) => void
 }


### PR DESCRIPTION
## Description

Omit `content` from extended `BoxProps` within `CardList` component to fix ts warning

## Related Issue

<img width="679" alt="image" src="https://github.com/ethereum/ethereum-org-website/assets/54227730/e81d34d6-00b6-4589-9a20-a75aa489aceb">
