### PR TITLE
Move divider to end of numerical h2 (/glossary)

### DIFF
--- a/src/content/glossary/index.md
+++ b/src/content/glossary/index.md
@@ -6,11 +6,11 @@ lang: en
 
 # Glossary {#ethereum-glossary}
 
-<Divider />
-
 ## \# {#section-numbers}
 
 <GlossaryDefinition term="51%-attack" />
+
+<Divider />
 
 ## A {#section-a}
 


### PR DESCRIPTION
## Description
The "numerical" (`#`) section of the glossary is missing the Divider at the end. PR places one there, and removes the one currently underneeth the "Glossary" h1.

## Related Issue
https://ethereum.org/en/glossary

See Divider usage at top of page:
<img width="996" alt="image" src="https://github.com/ethereum/ethereum-org-website/assets/54227730/c791ed48-f02d-46b4-8944-b33c06650e10">

vs Divider usage everywhere else on that page:
<img width="774" alt="image" src="https://github.com/ethereum/ethereum-org-website/assets/54227730/4ff3ab27-2914-45e9-93bc-97d69691357b">

With this PR:
<img width="991" alt="image" src="https://github.com/ethereum/ethereum-org-website/assets/54227730/a81c2225-1e05-4cf2-a86b-40b21a8a2637">

cc: @nloureiro
