### PR TITLE
Improve copywriting: rename guides hub and change wallet simulator CTA

### DIFF
--- a/src/intl/en/common.json
+++ b/src/intl/en/common.json
@@ -107,7 +107,7 @@
   "grants": "Grants",
   "grant-programs": "Ecosystem Grant Programs",
   "guides": "Guides",
-  "guides-hub": "Guides hub",
+  "guides-hub": "How-to guides",
   "history-of-ethereum": "History of Ethereum",
   "home": "Home",
   "how-ethereum-works": "How Ethereum works",

--- a/src/pages-conditional/wallets.tsx
+++ b/src/pages-conditional/wallets.tsx
@@ -208,7 +208,7 @@ const WalletsPage = ({
             },
             {
               to: `#${SIMULATOR_ID}`,
-              content: "Interactive tutorial",
+              content: "How to use a wallet",
               matomo: {
                 eventCategory: "wallet hero buttons",
                 eventAction: "click",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Change "Guides hub" -> "How-to guides"
- Change "Interactive tutorial" -> "How to use a wallet"

## Related Issue

Fixes https://github.com/ethereum/ethereum-org-website/issues/11362
