### PR TITLE
Remove note about Erigon binaries

### DIFF
--- a/src/content/developers/docs/nodes-and-clients/run-a-node/index.md
+++ b/src/content/developers/docs/nodes-and-clients/run-a-node/index.md
@@ -152,7 +152,7 @@ Here are the release pages of clients where you can find their pre-built binarie
 ##### Execution clients
 
 - [Besu](https://github.com/hyperledger/besu/releases)
-- [Erigon](https://github.com/ledgerwatch/erigon#usage) (Doesn't provide a pre-built binary, has to be compiled)
+- [Erigon](https://github.com/ledgerwatch/erigon/releases)
 - [Geth](https://geth.ethereum.org/downloads/)
 - [Nethermind](https://downloads.nethermind.io/)
 


### PR DESCRIPTION
Erigon has provided pre-built binaries on their [GitHub releases page](https://github.com/ledgerwatch/erigon/releases) since release [v2.39.0](https://github.com/ledgerwatch/erigon/releases/tag/v2.39.0) (released February 19, 2023), so the note is no longer accurate.