### PR TITLE
fix: CryptoDevs broken discord link

### DIFF
--- a/src/content/community/support/index.md
+++ b/src/content/community/support/index.md
@@ -39,7 +39,7 @@ Looking for an Ethereum wallet? [Explore our full list of Ethereum wallets](/wal
 Building can be hard. Here are some development focused spaces with experienced Ethereum developers that are happy to help.
 
 - [Alchemy University](https://university.alchemy.com/#starter_code)
-- [CryptoDevs discord](https://discord.gg/Z9TA39m8Yu)
+- [CryptoDevs discord](https://discord.com/invite/5W5tVb3)
 - [Ethereum StackExchange](https://ethereum.stackexchange.com/)
 - [StackOverflow](https://stackoverflow.com/questions/tagged/web3)
 - [Web3 University](https://www.web3.university/)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
I have fixed the broken Discord link for CryptoDevs by replacing it with a new one.

Previous link : https://discord.com/invite/Z9TA39m8Yu

New link : https://discord.com/invite/5W5tVb3

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
