### PR TITLE
Fix url for Optimism Rollup's

### DIFF
--- a/src/content/developers/docs/scaling/optimistic-rollups/index.md
+++ b/src/content/developers/docs/scaling/optimistic-rollups/index.md
@@ -260,6 +260,6 @@ Multiple implementations of Optimistic rollups exist that you can integrate into
 - [How do optimistic rollups work (The Complete guide)](https://www.alchemy.com/overviews/optimistic-rollups)
 - [Everything you need to know about Optimistic Rollup](https://research.paradigm.xyz/rollups)
 - [The Essential Guide to Arbitrum](https://newsletter.banklesshq.com/p/the-essential-guide-to-arbitrum)
-- [How does Optimism's Rollup really work?](https://research.paradigm.xyz/optimism)
+- [How does Optimism's Rollup really work?](https://www.paradigm.xyz/2021/01/how-does-optimisms-rollup-really-work)
 - [OVM Deep Dive](https://medium.com/ethereum-optimism/ovm-deep-dive-a300d1085f52)
 - [What is the Optimistic Virtual Machine?](https://www.alchemy.com/overviews/optimistic-virtual-machine)

--- a/src/content/translations/de/developers/docs/scaling/optimistic-rollups/index.md
+++ b/src/content/translations/de/developers/docs/scaling/optimistic-rollups/index.md
@@ -53,5 +53,5 @@ Es gibt mehrere Implementierungen von optimistischen Rollups, die Sie in Ihre dA
 
 - [Alles, was Sie über Optimistic Rollup wissen müssen](https://research.paradigm.xyz/rollups)
 - [Der Leitfaden zu Arbitrum](https://newsletter.banklesshq.com/p/the-essential-guide-to-arbitrum)
-- [Wie funktioniert das Rollup von Optimismus wirklich?](https://research.paradigm.xyz/optimism)
+- [Wie funktioniert das Rollup von Optimismus wirklich?](https://www.paradigm.xyz/2021/01/how-does-optimisms-rollup-really-work)
 - [OVM Deep Dive](https://medium.com/ethereum-optimism/ovm-deep-dive-a300d1085f52)

--- a/src/content/translations/es/developers/docs/scaling/optimistic-rollups/index.md
+++ b/src/content/translations/es/developers/docs/scaling/optimistic-rollups/index.md
@@ -53,5 +53,5 @@ Existen múltiples implementaciones de rollups optimistas que puede integrar en 
 
 - [Todo lo que debes saber sobre Optimistic rollup](https://research.paradigm.xyz/rollups)
 - [Guía esencial sobre Arbitrum](https://newsletter.banklesshq.com/p/the-essential-guide-to-arbitrum)
-- [¿Cómo funciona realmente el rollup de Optimism?](https://research.paradigm.xyz/optimism)
+- [¿Cómo funciona realmente el rollup de Optimism?](https://www.paradigm.xyz/2021/01/how-does-optimisms-rollup-really-work)
 - [Análisis detallado de OVM](https://medium.com/ethereum-optimism/ovm-deep-dive-a300d1085f52)

--- a/src/content/translations/fr/developers/docs/scaling/optimistic-rollups/index.md
+++ b/src/content/translations/fr/developers/docs/scaling/optimistic-rollups/index.md
@@ -260,6 +260,6 @@ Plusieurs implémentations de rollups optimistes existent, que vous pouvez inté
 - [Comment fonctionnent les rollups optimistes (Le guide complet)](https://www.alchemy.com/overviews/optimistic-rollups)
 - [Tout ce que vous devez savoir sur les rollups optimisés](https://research.paradigm.xyz/rollups)
 - [Le guide essentiel pour Arbitrum](https://newsletter.banklesshq.com/p/the-essential-guide-to-arbitrum)
-- [Comment fonctionne réellement le rollup d'Optimism ?](https://research.paradigm.xyz/optimism)
+- [Comment fonctionne réellement le rollup d'Optimism ?](https://www.paradigm.xyz/2021/01/how-does-optimisms-rollup-really-work)
 - [OVM Deep Dive](https://medium.com/ethereum-optimism/ovm-deep-dive-a300d1085f52)
 - [Qu’est-ce que la machine virtuelle optimiste ?](https://www.alchemy.com/overviews/optimistic-virtual-machine)

--- a/src/content/translations/id/developers/docs/scaling/layer-2-rollups/index.md
+++ b/src/content/translations/id/developers/docs/scaling/layer-2-rollups/index.md
@@ -143,7 +143,7 @@ Solusi hibrida ada dengan menggabungkan bagian terbaik dari berbagai teknologi l
 
 - [Semua yang perlu Anda ketahui tentang Rollup Optimistic](https://research.paradigm.xyz/rollups)
 - [Panduan Penting untuk Arbitrum](https://newsletter.banklesshq.com/p/the-essential-guide-to-arbitrum)
-- [Bagaimana Rollup Optimism benar-benar berfungsi?](https://research.paradigm.xyz/optimism)
+- [Bagaimana Rollup Optimism benar-benar berfungsi?](https://www.paradigm.xyz/2021/01/how-does-optimisms-rollup-really-work)
 - [OVM Deep Dive](https://medium.com/ethereum-optimism/ovm-deep-dive-a300d1085f52)
 
 **Solusi Hibrida**

--- a/src/content/translations/it/developers/docs/scaling/optimistic-rollups/index.md
+++ b/src/content/translations/it/developers/docs/scaling/optimistic-rollups/index.md
@@ -260,6 +260,6 @@ Esistono molteplici implementazioni dei rollup ottimistici, che puoi integrare n
 - [Come funzionano gli Optimistic Rollup (La guida completa)](https://www.alchemy.com/overviews/optimistic-rollups)
 - [Everything you need to know about Optimistic Rollup](https://research.paradigm.xyz/rollups)
 - [Guida essenziale ad Arbitrum](https://newsletter.banklesshq.com/p/the-essential-guide-to-arbitrum)
-- [Come funziona davvero il rollup di Optimism?](https://research.paradigm.xyz/optimism)
+- [Come funziona davvero il rollup di Optimism?](https://www.paradigm.xyz/2021/01/how-does-optimisms-rollup-really-work)
 - [Approfondimento su OVM](https://medium.com/ethereum-optimism/ovm-deep-dive-a300d1085f52)
 - [What is the Optimistic Virtual Machine?](https://www.alchemy.com/overviews/optimistic-virtual-machine)

--- a/src/content/translations/ja/developers/docs/scaling/optimistic-rollups/index.md
+++ b/src/content/translations/ja/developers/docs/scaling/optimistic-rollups/index.md
@@ -260,6 +260,6 @@ Dapp に統合可能な、既存のオプティミスティック・ロールア
 - [オプティミスティック・ロールアップの仕組み（完全ガイド）](https://www.alchemy.com/overviews/optimistic-rollups)
 - [オプティミスティック・ロールアップについて必要なすべての知識](https://research.paradigm.xyz/rollups)
 - [Arbitrum の基本ガイド](https://newsletter.banklesshq.com/p/the-essential-guide-to-arbitrum)
-- [Optimism のロールアップはどのように機能するのか？](https://research.paradigm.xyz/optimism)
+- [Optimism のロールアップはどのように機能するのか？](https://www.paradigm.xyz/2021/01/how-does-optimisms-rollup-really-work)
 - [OVM の詳細を学ぶ](https://medium.com/ethereum-optimism/ovm-deep-dive-a300d1085f52)
 - [オプティミスティック仮想マシンとは何か？](https://www.alchemy.com/overviews/optimistic-virtual-machine)

--- a/src/content/translations/pl/developers/docs/scaling/layer-2-rollups/index.md
+++ b/src/content/translations/pl/developers/docs/scaling/layer-2-rollups/index.md
@@ -126,7 +126,7 @@ Istnieją rozwiązania hybrydowe, które łączą w sobie najlepsze elementy wie
 
 - [Wszystko, co musisz wiedzieć o optymistycznym pakiecie zbiorczym](https://research.paradigm.xyz/rollups)
 - [OVM Deep Dive](https://medium.com/ethereum-optimism/ovm-deep-dive-a300d1085f52)
-- [Jak faktycznie działa pakiet zbiorczy Optimism?](https://research.paradigm.xyz/optimism)
+- [Jak faktycznie działa pakiet zbiorczy Optimism?](https://www.paradigm.xyz/2021/01/how-does-optimisms-rollup-really-work)
 
 **Rozwiązania hybrydowe**
 

--- a/src/content/translations/pt-br/developers/docs/scaling/optimistic-rollups/index.md
+++ b/src/content/translations/pt-br/developers/docs/scaling/optimistic-rollups/index.md
@@ -260,6 +260,6 @@ Há múltiplas implementações de optimistic rollups que você pode integrar ao
 - [Como funcionam os optimistic rollups (o guia completo)](https://www.alchemy.com/overviews/optimistic-rollups)
 - [Tudo o que você precisa saber sobre otimistic rollup](https://research.paradigm.xyz/rollups)
 - [O guia essencial do Arbitrum](https://newsletter.banklesshq.com/p/the-essential-guide-to-arbitrum)
-- [Como o optimistic rollup realmente funciona?](https://research.paradigm.xyz/optimism)
+- [Como o optimistic rollup realmente funciona?](https://www.paradigm.xyz/2021/01/how-does-optimisms-rollup-really-work)
 - [OVM: aprofundamento](https://medium.com/ethereum-optimism/ovm-deep-dive-a300d1085f52)
 - [O que é a máquina virtual otimista?](https://www.alchemy.com/overviews/optimistic-virtual-machine)

--- a/src/content/translations/ro/developers/docs/scaling/optimistic-rollups/index.md
+++ b/src/content/translations/ro/developers/docs/scaling/optimistic-rollups/index.md
@@ -51,5 +51,5 @@ Există mai multe implementări ale rollup-urilor Optimistic pe care le puteți 
 
 - [Tot ce trebuie să știți despre Rollup-ul Optimistic](https://research.paradigm.xyz/rollups)
 - [Ghidul esențial pentru Arbitrum](https://newsletter.banklesshq.com/p/the-essential-guide-to-arbitrum)
-- [Cum funcționează cu adevărat Rollup-ul Optimistic?](https://research.paradigm.xyz/optimism)
+- [Cum funcționează cu adevărat Rollup-ul Optimistic?](https://www.paradigm.xyz/2021/01/how-does-optimisms-rollup-really-work)
 - [OVM Deep Dive](https://medium.com/ethereum-optimism/ovm-deep-dive-a300d1085f52)

--- a/src/content/translations/sl/developers/docs/scaling/optimistic-rollups/index.md
+++ b/src/content/translations/sl/developers/docs/scaling/optimistic-rollups/index.md
@@ -53,5 +53,5 @@ Obstaja več implementacij optimističnih zvitkov, ki jih lahko integrirate v sv
 
 - [Vse kar morate vedeti o Optimističnih zvitkih](https://research.paradigm.xyz/rollups)
 - [Ključni vodnik za Arbitrum](https://newsletter.banklesshq.com/p/the-essential-guide-to-arbitrum)
-- [Kako zares deluje zvitek Optimizma?](https://research.paradigm.xyz/optimism)
+- [Kako zares deluje zvitek Optimizma?](https://www.paradigm.xyz/2021/01/how-does-optimisms-rollup-really-work)
 - [Globoki vpogled v OVM](https://medium.com/ethereum-optimism/ovm-deep-dive-a300d1085f52)

--- a/src/content/translations/tr/developers/docs/scaling/optimistic-rollups/index.md
+++ b/src/content/translations/tr/developers/docs/scaling/optimistic-rollups/index.md
@@ -53,5 +53,5 @@ Dapp'lerinize entegre edebileceğiniz birden çok İyimser toplama uygulaması m
 
 - [Optimistik Toplama hakkında bilmeniz gereken her şey](https://research.paradigm.xyz/rollups)
 - [Temel Arbitrum Rehberi](https://newsletter.banklesshq.com/p/the-essential-guide-to-arbitrum)
-- [Optimism'in Toplaması aslında nasıl çalışıyor?](https://research.paradigm.xyz/optimism)
+- [Optimism'in Toplaması aslında nasıl çalışıyor?](https://www.paradigm.xyz/2021/01/how-does-optimisms-rollup-really-work)
 - [OVM Deep Dive](https://medium.com/ethereum-optimism/ovm-deep-dive-a300d1085f52)

--- a/src/content/translations/zh/developers/docs/scaling/optimistic-rollups/index.md
+++ b/src/content/translations/zh/developers/docs/scaling/optimistic-rollups/index.md
@@ -260,6 +260,6 @@ ii. 使用乐观卷叠的开发者和项目团队可以利用以太坊的基础�
 - [乐观卷叠如何工作（完整指南）](https://www.alchemy.com/overviews/optimistic-rollups)
 - [乐观卷叠知识大全](https://research.paradigm.xyz/rollups)
 - [Arbitrum 基本指南](https://newsletter.banklesshq.com/p/the-essential-guide-to-arbitrum)
-- [乐观卷叠究竟如何工作？](https://research.paradigm.xyz/optimism)
+- [乐观卷叠究竟如何工作？](https://www.paradigm.xyz/2021/01/how-does-optimisms-rollup-really-work)
 - [深入研究乐观虚拟机](https://medium.com/ethereum-optimism/ovm-deep-dive-a300d1085f52)
 - [什么是乐观虚拟机？](https://www.alchemy.com/overviews/optimistic-virtual-machine)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Replaced link for [https://research.paradigm.xyz/optimism](https://research.paradigm.xyz/optimism) with [https://www.paradigm.xyz/2021/01/how-does-optimisms-rollup-really-work](https://www.paradigm.xyz/2021/01/how-does-optimisms-rollup-really-work)

## Related Issue

#11444 
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
