### PR TITLE
Minor updates to websockets tutorial page

### DIFF
--- a/src/content/developers/tutorials/using-websockets/index.md
+++ b/src/content/developers/tutorials/using-websockets/index.md
@@ -88,7 +88,7 @@ While the subscription is active, you will receive events which are objects with
 - `jsonrpc`: Always "2.0"
 - `method`: Always "eth_subscription"
 - `params`: An object with the following fields:
-  - `subscription`: The subscription ID returned by the `eth_subscription` call which created this subscription.
+  - `subscription`: The subscription ID returned by the `eth_subscribe` call which created this subscription.
   - `result`: An object whose contents vary depending on the type of subscription.
 
 #### Subscription types {#subscription-types}


### PR DESCRIPTION
## Description

typo fix

## Related Issue

There is no issue. I found the `eth_subscription` typo because someone using *web3.py* was looking at the documentation here for examples on `eth_subscribe` types.

Also the Alchemy documentation linked seems to be behind a permissions wall and was inaccessible when I tried to navigate there.