### PR TITLE
Fix bad grammar/improve understandability on Uniswap V2 tutorial

### DIFF
--- a/src/content/developers/tutorials/uniswap-v2-annotated-code/index.md
+++ b/src/content/developers/tutorials/uniswap-v2-annotated-code/index.md
@@ -366,7 +366,7 @@ If the time elapsed is not zero, it means we are the first exchange transaction 
         }
 ```
 
-Each cost accumulator is updated with the latest cost (reserve of the other token/reserve of this token) times the elapsed time in seconds. To get an average price you read the cumulative price is two points in time, and divide by the time difference between them. For example, assume this sequence of events:
+Each cost accumulator is updated with the latest cost (reserve of the other token/reserve of this token) times the elapsed time in seconds. To get an average price you read the cumulative price in two points in time, and divide by the time difference between them. For example, assume this sequence of events:
 
 | Event                                                    |  reserve0 |  reserve1 | timestamp | Marginal exchange rate (reserve1 / reserve0) |       price0CumulativeLast |
 | -------------------------------------------------------- | --------: | --------: | --------- | -------------------------------------------: | -------------------------: |

--- a/src/content/developers/tutorials/uniswap-v2-annotated-code/index.md
+++ b/src/content/developers/tutorials/uniswap-v2-annotated-code/index.md
@@ -366,7 +366,7 @@ If the time elapsed is not zero, it means we are the first exchange transaction 
         }
 ```
 
-Each cost accumulator is updated with the latest cost (reserve of the other token/reserve of this token) times the elapsed time in seconds. To get an average price you read the cumulative price in two points in time, and divide by the time difference between them. For example, assume this sequence of events:
+Each cost accumulator is updated with the latest cost (reserve of the other token/reserve of this token) times the elapsed time in seconds. To get an average price, you read the cumulative price in two points in time and divide by the time difference between them. For example, assume this sequence of events:
 
 | Event                                                    |  reserve0 |  reserve1 | timestamp | Marginal exchange rate (reserve1 / reserve0) |       price0CumulativeLast |
 | -------------------------------------------------------- | --------: | --------: | --------- | -------------------------------------------: | -------------------------: |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description


Changed "is" to "in" in the sentence "To get an average price you read the cumulative price **is** two points in time".

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
