### PR TITLE
Remove Truffle from deployment tools

### DIFF
--- a/src/content/developers/docs/smart-contracts/deploying/index.md
+++ b/src/content/developers/docs/smart-contracts/deploying/index.md
@@ -20,16 +20,14 @@ Finally, you'll need to compile your contract before deploying it, so make sure 
 
 ### What you'll need {#what-youll-need}
 
-- your contract's bytecode – this is generated through [compilation](/developers/docs/smart-contracts/compiling/)
+- Your contract's bytecode – this is generated through [compilation](/developers/docs/smart-contracts/compiling/)
 - ETH for gas – you'll set your gas limit like other transactions so be aware that contract deployment needs a lot more gas than a simple ETH transfer
 - a deployment script or plugin
 - access to an [Ethereum node](/developers/docs/nodes-and-clients/), either by running your own, connecting to a public node, or via an API key using a [node service](/developers/docs/nodes-and-clients/nodes-as-a-service/)
 
 ### Steps to deploy a smart contract {#steps-to-deploy}
 
-The specific steps involved will depend on the tooling you use. For an example, check out the [Hardhat documentation on deploying your contracts](https://hardhat.org/guides/deploying.html) or [Truffle documentation on networks and app deployment](https://www.trufflesuite.com/docs/truffle/advanced/networks-and-app-deployment). These are two of the most popular tools for smart contract deployment, which involve writing a script to handle the deployment steps.
-
-Once deployed, your contract will have an Ethereum address like other [accounts](/developers/docs/accounts/).
+The specific steps involved will depend on the development framework in question. For example, you can check out [Hardhat's documentation on deploying your contracts](https://hardhat.org/guides/deploying.html) or [Foundry's documentation on deploying and verifying a smart contract](https://book.getfoundry.sh/forge/deploying). Once deployed, your contract will have an Ethereum address like other [accounts](/developers/docs/accounts/) and can be verified using [source code verification tools](/developers/docs/smart-contracts/verifying/#source-code-verification-tools).
 
 ## Related tools {#related-tools}
 
@@ -50,12 +48,6 @@ Once deployed, your contract will have an Ethereum address like other [accounts]
 - [Docs on deploying your contracts](https://hardhat.org/guides/deploying.html)
 - [GitHub](https://github.com/nomiclabs/hardhat)
 - [Discord](https://discord.com/invite/TETZs2KK4k)
-
-**Truffle -** **_A development environment, testing framework, build pipeline, and other tools._**
-
-- [trufflesuite.com](https://www.trufflesuite.com/)
-- [Docs on networks and app deployment](https://www.trufflesuite.com/docs/truffle/advanced/networks-and-app-deployment)
-- [GitHub](https://github.com/trufflesuite/truffle)
 
 **thirdweb - _Easily deploy any contract to any EVM compatible chain, using a single command_**
 


### PR DESCRIPTION
Truffle is [being sunset](https://consensys.io/blog/consensys-announces-the-sunset-of-truffle-and-ganache-and-new-hardhat?utm_source=github&utm_medium=referral&utm_campaign=2023_Sep_truffle-sunset-2023_announcement_) and developers are encouraged to transition to other tools to avoid disruptions to development workflows. To avoid confusion, we'll have to remove the tool from the listing of contract deployment tools (which I've done in this PR). 

## Description

- Removed links to documentation for deploying smart contracts with Truffle
- Replaced external link to Truffle deployment workflow with link to Forge's contract deployment guide 
- Added an internal link to source code verification (ie. to show developers they'll need to verify contracts after deploying)

