### PR TITLE
Fix layer 2 button on gas page

### DIFF
--- a/src/pages/gas.tsx
+++ b/src/pages/gas.tsx
@@ -444,7 +444,7 @@ const GasPage = ({ data }: PageProps<Queries.GasPageQuery>) => {
             descriptionKey="Layer 2 extends Ethereum, reducing costs and increasing accessibility for decentralized applications."
           >
             <Box>
-              <ButtonLink to="/get-eth/">Use layer 2</ButtonLink>
+              <ButtonLink to="/layer-2/">Use layer 2</ButtonLink>
             </Box>
           </Box>
           <Box


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Make "Use Layer 2" button go to layer 2 page instead of the get eth page on the gas learning page

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
