### PR TITLE
Remove dead Sepolia faucet

### DIFF
--- a/src/content/developers/docs/networks/index.md
+++ b/src/content/developers/docs/networks/index.md
@@ -57,7 +57,6 @@ The Sepolia network uses a permissioned validator set. It's fairly new, meaning 
 - [QuickNode Sepolia Faucet](https://faucet.quicknode.com/drip)
 - [Grabteeth](https://grabteeth.xyz/)
 - [PoW faucet](https://sepolia-faucet.pk910.de/)
-- [FaucETH](https://fauceth.komputing.org)
 - [Coinbase Wallet Faucet | Sepolia](https://coinbase.com/faucets/ethereum-sepolia-faucet)
 - [Alchemy Sepolia faucet](https://sepoliafaucet.com/)
 - [Infura Sepolia faucet](https://www.infura.io/faucet)

--- a/src/content/translations/es/developers/docs/networks/index.md
+++ b/src/content/translations/es/developers/docs/networks/index.md
@@ -56,8 +56,6 @@ Las dos redes públicas de prueba que los desarrolladores de clientes están man
 - [QuickNode Sepolia Faucet](https://faucet.quicknode.com/drip)
 - [Grabteeth](https://grabteeth.xyz/)
 - [PoW faucet](https://sepolia-faucet.pk910.de/)
-- [Faucet Sepolia](https://faucet.sepolia.dev/)
-- [FaucETH](https://fauceth.komputing.org)
 - [Coinbase Wallet Faucet | Sepolia](https://coinbase.com/faucets/ethereum-sepolia-faucet)
 - [Alchemy Sepolia faucet](https://sepoliafaucet.com/)
 - [Infura Sepolia faucet](https://www.infura.io/faucet)

--- a/src/content/translations/fr/developers/docs/networks/index.md
+++ b/src/content/translations/fr/developers/docs/networks/index.md
@@ -56,8 +56,6 @@ Les deux réseaux de test publics que les développeurs de clients conservent ac
 - [QuickNode Sepolia Faucet](https://faucet.quicknode.com/drip)
 - [Grabteeth](https://grabteeth.xyz/)
 - [Robinet PoW](https://sepolia-faucet.pk910.de/)
-- [Sepolia faucet](https://faucet.sepolia.dev/)
-- [FaucETH](https://fauceth.komputing.org)
 - [Coinbase Wallet Faucet | Sepolia](https://coinbase.com/faucets/ethereum-sepolia-faucet)
 - [Alchemy Sepolia faucet](https://sepoliafaucet.com/)
 - [Infura Sepolia faucet](https://www.infura.io/faucet)

--- a/src/content/translations/it/developers/docs/networks/index.md
+++ b/src/content/translations/it/developers/docs/networks/index.md
@@ -56,8 +56,6 @@ Le due reti di prova pubbliche che gli sviluppatori di client stanno mantenendo 
 - [Faucet Sepolia QuickNode](https://faucet.quicknode.com/drip)
 - [Grabteeth](https://grabteeth.xyz/)
 - [Faucet PoW](https://sepolia-faucet.pk910.de/)
-- [Faucet Sepolia](https://faucet.sepolia.dev/)
-- [FaucETH](https://fauceth.komputing.org)
 - [Faucet Coinbase Wallet | Sepolia](https://coinbase.com/faucets/ethereum-sepolia-faucet)
 - [Faucet Alchemy Sepolia](https://sepoliafaucet.com/)
 - [Faucet Infura Sepolia](https://www.infura.io/faucet)

--- a/src/content/translations/ja/developers/docs/networks/index.md
+++ b/src/content/translations/ja/developers/docs/networks/index.md
@@ -57,7 +57,11 @@ Sepolia (セポリア)は、プルーフ・オブ・ステークのテストネ�
 
 ##### Sepolia フォーセット
 
-
+- [QuickNode Sepolia フォーセット](https://faucet.quicknode.com/drip)
+- [Grabteeth](https://grabteeth.xyz/)
+- [PoW フォーセット](https://sepolia-faucet.pk910.de/)
+- [Coinbase Wallet フォーセット | Sepolia](https://coinbase.com/faucets/ethereum-sepolia-faucet)
+- [Alchemy Sepolia フォーセット](https://sepoliafaucet.com/)
 
 #### Ropsten (ロプステン) _(非推奨)_ {#ropsten}
 

--- a/src/content/translations/ja/developers/docs/networks/index.md
+++ b/src/content/translations/ja/developers/docs/networks/index.md
@@ -57,8 +57,7 @@ Sepolia (セポリア)は、プルーフ・オブ・ステークのテストネ�
 
 ##### Sepolia フォーセット
 
-- [Sepolia faucet](https://faucet.sepolia.dev/)
-- [FaucETH](https://fauceth.komputing.org)
+
 
 #### Ropsten (ロプステン) _(非推奨)_ {#ropsten}
 

--- a/src/content/translations/pt-br/developers/docs/networks/index.md
+++ b/src/content/translations/pt-br/developers/docs/networks/index.md
@@ -56,8 +56,6 @@ As duas redes de testes públicas que os desenvolvedores dos clientes estão atu
 - [Faucet do QuickNode Sepolia](https://faucet.quicknode.com/drip)
 - [Grabteeth](https://grabteeth.xyz/)
 - [Faucet de PoW](https://sepolia-faucet.pk910.de/)
-- [Faucet Sepolia](https://faucet.sepolia.dev/)
-- [FaucETH](https://fauceth.komputing.org)
 - [Faucet da Carteira da Coinbase | Sepolia](https://coinbase.com/faucets/ethereum-sepolia-faucet)
 - [Faucet do Alchemy Sepolia](https://sepoliafaucet.com/)
 - [Faucet do Infura Sepolia](https://www.infura.io/faucet)

--- a/src/content/translations/ru/developers/docs/networks/index.md
+++ b/src/content/translations/ru/developers/docs/networks/index.md
@@ -56,8 +56,6 @@ lang: ru
 - [Кран QuickNode Sepolia](https://faucet.quicknode.com/drip)
 - [Grabteeth](https://grabteeth.xyz/)
 - [Кран PoW](https://sepolia-faucet.pk910.de/)
-- [Кран Sepolia](https://faucet.sepolia.dev/)
-- [FaucETH](https://fauceth.komputing.org)
 - [Кран кошелька Coinbase Wallet | Sepolia](https://coinbase.com/faucets/ethereum-sepolia-faucet)
 - [Кран Alchemy Sepolia](https://sepoliafaucet.com/)
 - [Кран Infura Sepolia](https://www.infura.io/faucet)

--- a/src/content/translations/tr/developers/docs/networks/index.md
+++ b/src/content/translations/tr/developers/docs/networks/index.md
@@ -56,8 +56,6 @@ Mevcut olarak istemci geliştiricilerin sürdürdüğü iki genel test ağı Sep
 - [QuickNode Sepolia Musluğu](https://faucet.quicknode.com/drip)
 - [Grabteeth](https://grabteeth.xyz/)
 - [İş İspatı Musluğu](https://sepolia-faucet.pk910.de/)
-- [Sepolia Musluğu](https://faucet.sepolia.dev/)
-- [FaucETH](https://fauceth.komputing.org)
 - [Coinbase Cüzdanı Musluğu | Sepolia](https://coinbase.com/faucets/ethereum-sepolia-faucet)
 - [Alchemy Sepolia musluğu](https://sepoliafaucet.com/)
 - [Infura Sepolia Musluğu](https://www.infura.io/faucet)

--- a/src/content/translations/zh-tw/developers/docs/networks/index.md
+++ b/src/content/translations/zh-tw/developers/docs/networks/index.md
@@ -56,8 +56,6 @@ lang: zh-tw
 - [QuickNode 的 Sepolia 水龍頭](https://faucet.quicknode.com/drip)
 - [Grabteeth](https://grabteeth.xyz/)
 - [工作量證明水龍頭](https://sepolia-faucet.pk910.de/)
-- [Sepolia 水龍頭](https://faucet.sepolia.dev/)
-- [FaucETH](https://fauceth.komputing.org)
 - [Coinbase 錢包水龍頭 | Sepolia](https://coinbase.com/faucets/ethereum-sepolia-faucet)
 - [Alchemy Sepolia 水龍頭](https://sepoliafaucet.com/)
 - [Infura Sepolia 水龍頭](https://www.infura.io/faucet)

--- a/src/content/translations/zh/developers/docs/networks/index.md
+++ b/src/content/translations/zh/developers/docs/networks/index.md
@@ -56,8 +56,6 @@ lang: zh
 - [QuickNode Sepolia 水龙头](https://faucet.quicknode.com/drip)
 - [Grabteeth](https://grabteeth.xyz/)
 - [PoW 水龙头](https://sepolia-faucet.pk910.de/)
-- [Sepolia 水龙头](https://faucet.sepolia.dev/)
-- [FaucETH](https://fauceth.komputing.org)
 - [Coinbase Wallet 水龙头 | Sepolia](https://coinbase.com/faucets/ethereum-sepolia-faucet)
 - [Alchemy Sepolia 水龙头](https://sepoliafaucet.com/)
 - [Infura Sepolia 水龙头](https://www.infura.io/faucet)


### PR DESCRIPTION
1. https://faucet.sepolia.dev/ was down for long time as in issue #11012 

2. Also https://fauceth.komputing.org was down.

3. Remove and add some faucets in Japanese section.


<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
