### PR TITLE
Documentation Cleanup: Typos and Grammar Fixes

### DIFF
--- a/src/content/bridges/index.md
+++ b/src/content/bridges/index.md
@@ -6,7 +6,7 @@ lang: en
 
 # Blockchain bridges {#prerequisites}
 
-_Web3 has evolved into an ecosystem of L1 blockchains and L2 scaling solutions, each designed with unique capabilities and trade-offs. As the number of blockchains protocols increases, so does [the demand to move assets across chains](<https://dune.xyz/eliasimos/Bridge-Away-(from-Ethereum)>). To fulfill this demand, we need bridges._
+_Web3 has evolved into an ecosystem of L1 blockchains and L2 scaling solutions, each designed with unique capabilities and trade-offs. As the number of blockchain protocols increases, so does [the demand to move assets across chains](<https://dune.xyz/eliasimos/Bridge-Away-(from-Ethereum)>). To fulfill this demand, we need bridges._
 
 <Divider />
 

--- a/src/content/community/get-involved/index.md
+++ b/src/content/community/get-involved/index.md
@@ -29,7 +29,7 @@ Do you have a background in mathematics, cryptography, or economics? You might b
   - Write an EIP
     1. Submit your idea on [Ethereum Magicians](https://ethereum-magicians.org)
     2. Read [EIP-1](https://eips.ethereum.org/EIPS/eip-1) - **Yes, that's the _entire_ document.**
-    3. Follow the directons in EIP-1. Reference it as you write your draft.
+    3. Follow the directions in EIP-1. Reference it as you write your draft.
   - Learn how to become an [EIP Editor](https://eips.ethereum.org/EIPS/eip-5069)
     - You can peer-review EIPs right now! See [open PRs with the `e-review` tag](https://github.com/ethereum/EIPs/pulls?q=is%3Apr+is%3Aopen+label%3Ae-review). Provide technical feedback on the `discussion-to` link.
   - Participate in [EIP Governance](https://github.com/ethereum-cat-herders/EIPIP)

--- a/src/content/community/grants/index.md
+++ b/src/content/community/grants/index.md
@@ -20,7 +20,7 @@ These programs support the broad Ethereum ecosystem by offering grants to a wide
 - [DAO Grants](https://docs.google.com/spreadsheets/d/1XHc-p_MHNRdjacc8uOEjtPoWL86olP4GyxAJOFO0zxY/edit#gid=0) - _Google spreadsheet of organizations offering grants_
 - [Crunchbase for Web3 Grants](https://www.cryptoneur.xyz/web3-grants) - _Filter and search for grants by category, use case, amount, and more. Contribute to help others find the right grant._
 - [Academic Grants](https://esp.ethereum.foundation/academic-grants) - _Grants to support Ethereum-related academic work_
-- [Blockworks Grantfarm](https://blockworks.co/grants/programs) - \_Blockworks has compiled a comprehensive directory of all grants, RFPs, and bug bounties.
+- [Blockworks Grantfarm](https://blockworks.co/grants/programs) - _Blockworks has compiled a comprehensive directory of all grants, RFPs, and bug bounties._
 
 ## Project specific {#project-specific}
 

--- a/src/content/community/research/index.md
+++ b/src/content/community/research/index.md
@@ -156,7 +156,7 @@ Sharding Ethereum's blockchain has long been part of the development roadmap. Ho
 
 #### Recent research {#recent-research-5}
 
-- [ecdsa on FGPAs](https://ethresear.ch/t/does-ecdsa-on-fpga-solve-the-scaling-problem/6738)
+- [ecdsa on FPGAs](https://ethresear.ch/t/does-ecdsa-on-fpga-solve-the-scaling-problem/6738)
 
 ## Security {#security}
 

--- a/src/content/contributing/translation-program/content-buckets/index.md
+++ b/src/content/contributing/translation-program/content-buckets/index.md
@@ -45,8 +45,8 @@ Below is a breakdown of the website pages each content bucket contains.
 
 - [Decentralized finance (DeFi)](/defi/)
 - [Introduction to smart contracts](/smart-contracts/)
-- [Decentralized identity)](/decentralized-identity/)
-- [Decentralized social networks)](/social-networks/)
+- [Decentralized identity](/decentralized-identity/)
+- [Decentralized social networks](/social-networks/)
 - [Decentralized science (DeSci))](/desci/)
 
 ## 6) Staking pages {#staking-pages}

--- a/src/content/contributing/translation-program/faq/index.md
+++ b/src/content/contributing/translation-program/faq/index.md
@@ -18,7 +18,7 @@ The goal of the Translation Program is to make Ethereum content accessible to ev
 
 For this reason, the Translation Program is open and voluntary, and participation is not subject to compensation. If we were to compensate translators for the number of words they translate, we could only invite those with sufficient translation experience (professional translators) to join the Translation Program. This would make the Translation Program exclusionary and prevent us from reaching the outlined goals, specifically: allowing everyone to participate and get involved with the ecosystem.
 
-We make every effort to enable our contributors to succeed in the Ethereum ecosystem; many non-monteary incentives are in place such as: [offering POAPs](/contributing/translation-program/acknowledgements/#poap) and a [translator certificate](/contributing/translation-program/acknowledgements/#certificate), as well as organizing the [Translation Leaderboards](/contributing/translation-program/acknowledgements/) and [listing all of our translators on the site](/contributing/translation-program/contributors/).
+We make every effort to enable our contributors to succeed in the Ethereum ecosystem; many non-monetary incentives are in place such as: [offering POAPs](/contributing/translation-program/acknowledgements/#poap) and a [translator certificate](/contributing/translation-program/acknowledgements/#certificate), as well as organizing the [Translation Leaderboards](/contributing/translation-program/acknowledgements/) and [listing all of our translators on the site](/contributing/translation-program/contributors/).
 
 ## How do I translate strings with `<HTML tags>`? {#tags}
 

--- a/src/content/contributing/translation-program/playbook/index.md
+++ b/src/content/contributing/translation-program/playbook/index.md
@@ -192,7 +192,7 @@ An example workflow in this case would be:
 
 Read more about translation workflows:
 
-[Content rules on the five phrases of the translation workflow](https://contentrules.com/creating-translation-workflow/)
+[Content rules on the five phases of the translation workflow](https://contentrules.com/creating-translation-workflow/)
 
 [Smartling on what is translation workflow management](https://www.smartling.com/resources/101/what-is-translation-workflow-management/)
 


### PR DESCRIPTION
## Description

This Pull Request addresses multiple typographical and grammatical errors across different sections of the documentation. The changes aim to improve readability and clarity for users.

**Detailed Changes:**
1. Corrected the word "phrases" to "phases" in the translation workflow hyperlink text.
2. Corrected "non-monteary" to "non-monetary" in the translation compensation section.
3. Removed extra closing brackets in the "5) Use case pages" section.
4. Fixed a typo from "FGPAs" to "FPGAs" (Field-Programmable Gate Arrays) in the context of "ecdsa on FPGAs".
5. Added a missing underscore to correctly format text in italic using markdown.
6. Corrected "directons" to "directions".
7. Corrected "blockchains protocols" to "blockchain protocols".

## Related Issue

- No specific related issue, this PR focuses on general typographical and grammatical improvements.
