### PR TITLE
Add .replace(/\\./g, "/") to gatsby.node 

### DIFF
--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -38,7 +38,7 @@ const commonRedirectProps = {
  * @returns boolean for if file is outdated or not
  */
 const checkIsMdxOutdated = (filePath: string): boolean => {
-  const dirname = path.resolve("./")
+  const dirname = path.resolve("./").replace(/\\./g, "/")
   const splitPath = filePath.split(dirname)
   const tempSplitPath = splitPath[1]
   const tempSplit = tempSplitPath.split("/")

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -38,6 +38,7 @@ const commonRedirectProps = {
  * @returns boolean for if file is outdated or not
  */
 const checkIsMdxOutdated = (filePath: string): boolean => {
+  // .replace(/\\./g, "/") to replace \ in windows paths ex: C:\\folder\\myfile.txt becomes C:/folder/myfile.txt
   const dirname = path.resolve("./").replace(/\\./g, "/")
   const splitPath = filePath.split(dirname)
   const tempSplitPath = splitPath[1]

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -38,8 +38,8 @@ const commonRedirectProps = {
  * @returns boolean for if file is outdated or not
  */
 const checkIsMdxOutdated = (filePath: string): boolean => {
-  // .replace(/\\./g, "/") to replace \ in windows paths ex: C:\\folder\\myfile.txt becomes C:/folder/myfile.txt
-  const dirname = path.resolve("./").replace(/\\./g, "/")
+  // .replace(/\\/g, "/") to replace \ in windows paths ex: C:\\folder\\myfile.txt becomes C:/folder/myfile.txt
+  const dirname = path.resolve("./").replace(/\\/g, "/")
   const splitPath = filePath.split(dirname)
   const tempSplitPath = splitPath[1]
   const tempSplit = tempSplitPath.split("/")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- add .replace(/\\./g, "/") to `const dirname = path.resolve('./)` 

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
