### PR TITLE
Fix a typo "权益正明" in Chinese doc

### DIFF
--- a/src/intl/zh/page-developers-docs.json
+++ b/src/intl/zh/page-developers-docs.json
@@ -129,7 +129,7 @@
   "docs-nav-archive-nodes": "归档节点",
   "docs-nav-attack-and-defense": "权益证明攻击与防御",
   "docs-nav-pos-vs-pow": "权益证明与工作量证明",
-  "docs-nav-pos-faqs": "权益正明常见问题",
+  "docs-nav-pos-faqs": "权益证明常见问题",
   "page-calltocontribute-desc-1": "如果你是这方面的专家，并想发表意见，那么编辑此页分享你的智慧。",
   "page-calltocontribute-desc-2": "你将获得嘉奖并会为以太坊社区提供帮助！",
   "page-calltocontribute-desc-3": "自由发挥",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`权益正明` should be `权益证明` in navbar

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
