### PR TITLE
Update community-meetups.json

### DIFF
--- a/src/data/community-meetups.json
+++ b/src/data/community-meetups.json
@@ -6,6 +6,12 @@
     "link": "https://www.meetup.com/web3-ne/"
   },
   {
+    "title": "ETH Belgrade Community",
+    "emoji": "🇷🇸",
+    "location": "Belgrade",
+    "link": "https://ethbelgrade.rs/community"
+  },
+  {
     "title": "ETHTbilisi",
     "emoji": ":ge:",
     "location": "Georgia",


### PR DESCRIPTION
Add ETH Belgrade Community meetups

## Description

ETH Belgrade Community is a natural extension of ETH Belgrade conference. ETH Belgrade Community consists of monthly meetups, workshops, and a variety of other events that occur throughout the year.
