### PR TITLE
Add wordBreak style to avoid overflow bug in HubHero

### DIFF
--- a/src/components/Hero/HubHero/index.tsx
+++ b/src/components/Hero/HubHero/index.tsx
@@ -55,6 +55,7 @@ const HubHero = (props: HubHeroProps) => {
         transform={{ xl: "translateY(-50%)" }}
         backdropFilter={{ xl: "auto" }}
         backdropBlur={{ xl: "base" }}
+        wordBreak="break-word"
       >
         <Heading
           as="h1"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Adds `wordBreak="break-word"` to HubHero to avoid overflow of header and paragraph