### PR TITLE
Fix Incorrect URL for Bio.xyz Link in 'Get Involved' Section

### DIFF
--- a/src/content/desci/index.md
+++ b/src/content/desci/index.md
@@ -104,7 +104,7 @@ Explore projects and join the DeSci community.
 - [OceanDAO: DAO governed funding for data-related science](https://oceanprotocol.com/dao)
 - [Opscientia: open decentralized science workflows](https://opsci.io/research/)
 - [LabDAO: fold a protein in-silico](https://alphafodl.vercel.app/)
-- [Bio.xyz: get funded for your biotech DAO or desci project](https://www.molecule.to/)
+- [Bio.xyz: get funded for your biotech DAO or desci project](https://www.bio.xyz/)
 - [ResearchHub: post a scientific result and engage in a conversation with peers](https://www.researchhub.com/)
 - [VitaDAO: receive funding through sponsored research agreements for longevity research](https://www.vitadao.com/)
 - [Fleming Protocol: open-source data economy that fuels collaborative biomedical discovery](https://medium.com/@FlemingProtocol/a-data-economy-for-patient-driven-biomedical-innovation-9d56bf63d3dd)


### PR DESCRIPTION
**Description:**

This pull request addresses an issue where the "Bio.xyz: get funded for your biotech DAO or desci project" link in the ['Get involved'](https://ethereum.org/en/desci/#get-involved) section incorrectly directed users to the Molecule website. The link has been updated to point to the intended destination, https://www.bio.xyz, ensuring users are correctly guided to Bio.xyz resources.

closes #11579