### PR TITLE
Fix documentation typos for GetBlock and Tokenview link 404

### DIFF
--- a/src/content/developers/docs/apis/backend/index.md
+++ b/src/content/developers/docs/apis/backend/index.md
@@ -164,7 +164,7 @@ These libraries abstract away much of the complexity of interacting directly wit
 **Tokenview -** **_The General Multi-Crypto Blockchain APIs Platform._**
 
 - [services.tokenview.io](https://services.tokenview.io/)
-- [Documentation](https://services.tokeniew/docs?type=api)
+- [Documentation](https://services.tokenview/docs?type=api)
 - [GitHub](https://github.com/Tokenview)
 
 ## Further reading {#further-reading}

--- a/src/content/developers/docs/apis/backend/index.md
+++ b/src/content/developers/docs/apis/backend/index.md
@@ -164,7 +164,7 @@ These libraries abstract away much of the complexity of interacting directly wit
 **Tokenview -** **_The General Multi-Crypto Blockchain APIs Platform._**
 
 - [services.tokenview.io](https://services.tokenview.io/)
-- [Documentation](https://services.tokenview/docs?type=api)
+- [Documentation](https://services.tokenview.io/docs?type=api)
 - [GitHub](https://github.com/Tokenview)
 
 ## Further reading {#further-reading}

--- a/src/content/developers/docs/apis/backend/index.md
+++ b/src/content/developers/docs/apis/backend/index.md
@@ -149,7 +149,7 @@ These libraries abstract away much of the complexity of interacting directly wit
 - [Documentation](https://docs.chainbase.com/)
 - [Discord](https://discord.gg/Wx6qpqz4AF)
 
-**GetBlock-** **_Blockchain-as-a-service for Web3 developement_**
+**GetBlock-** **_Blockchain-as-a-service for Web3 development_**
 
 - [GetBlock.io](https://getblock.io/)
 - [Documentation](https://getblock.io/docs/)


### PR DESCRIPTION
This pull request addresses typographical errors in the Backend API libraries documentation that affect the accessibility of external resources.

Changes included:

1. Fixed the Tokenview documentation link text from "tokeniew" to "tokenview" and updated the hyperlink to the correct URL. Previously, navigating to https://ethereum.org/sl/developers/docs/apis/backend/#available-libraries and clicking on the Tokenview [Documentation](https://services.tokeniew/docs?type=api) link would result in a 404 error. 

2. Corrected the service description title for GetBlock from "developement" to "development".

These corrections will enhance the user experience by providing accurate information and functioning links, facilitating a seamless navigation experience in the API documentation.
