### PR TITLE
fix(Search): render button components with the `hide*` props

### DIFF
--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -6,9 +6,9 @@ import {
   forwardRef,
   Portal,
   IconButtonProps,
-  useToken,
-  useMediaQuery,
   useMergeRefs,
+  Box,
+  ThemeTypings,
 } from "@chakra-ui/react"
 import { useDocSearchKeyboardEvents } from "@docsearch/react"
 import { DocSearchHit } from "@docsearch/react/dist/esm/types"
@@ -57,13 +57,11 @@ const Search = forwardRef<IProps, "button">(
     const indexName =
       process.env.GATSBY_ALGOLIA_BASE_SEARCH_INDEX_NAME || "ethereumorg"
 
-    // Check for the breakpoint with theme token
-    const xlBp = useToken("breakpoints", "xl")
-    const [isLargerThanXl] = useMediaQuery(`(min-width: ${xlBp})`)
+    const breakpointToken: ThemeTypings["breakpoints"] = "xl"
 
     return (
       <>
-        {isLargerThanXl ? (
+        <Box hideBelow={breakpointToken}>
           <SearchButton
             ref={mergedButtonRefs}
             onClick={() => {
@@ -79,7 +77,8 @@ const Search = forwardRef<IProps, "button">(
               buttonAriaLabel: t("search"),
             }}
           />
-        ) : (
+        </Box>
+        <Box hideFrom={breakpointToken}>
           <SearchIconButton
             onClick={() => {
               onOpen()
@@ -92,7 +91,7 @@ const Search = forwardRef<IProps, "button">(
             ref={mergedButtonRefs}
             aria-label={t("aria-toggle-search-button")}
           />
-        )}
+        </Box>
         <Portal>
           {isOpen && (
             <SearchModal


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

In prod when loading a page on a desktop screen size, the `SearchIconButton` icon would render first, then `SearchButton`. This is due to the `useMediaQuery` check not running immediately upon painting of the content.

This Pr switches to the style prop strategy by using Chakra's `hide*` props to change the display of the components rather than their DOM rendering.

## Related Issue
N/A
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
