### PR TITLE
fix(HubHero): create semantic token for content background color

### DIFF
--- a/src/@chakra-ui/gatsby-plugin/semanticTokens.ts
+++ b/src/@chakra-ui/gatsby-plugin/semanticTokens.ts
@@ -92,6 +92,10 @@ const semanticTokens = {
       _dark: "whiteAlpha.400",
     },
     switchBackground: { _light: "gray.300", _dark: "whiteAlpha.400" },
+    hubHeroContentBg: {
+      _light: "rgba(255, 255, 255, 0.80)",
+      _dark: "rgba(34, 34, 34, 0.80)",
+    },
   },
   gradients: {
     bgMainGradient: {

--- a/src/components/Hero/HubHero/index.tsx
+++ b/src/components/Hero/HubHero/index.tsx
@@ -1,12 +1,5 @@
 import * as React from "react"
-import {
-  Box,
-  Heading,
-  HStack,
-  Stack,
-  Text,
-  useColorModeValue,
-} from "@chakra-ui/react"
+import { Box, Heading, HStack, Stack, Text } from "@chakra-ui/react"
 import GatsbyImage from "../../GatsbyImage"
 import { CallToAction } from "../CallToAction"
 import { CommonHeroProps } from "../utils"
@@ -21,11 +14,6 @@ const HubHero = (props: HubHeroProps) => {
       "Can not have more than two call-to-action buttons in this hero component."
     )
   }
-
-  const largeContentBg = useColorModeValue(
-    "rgba(255, 255, 255, 0.80)",
-    "rgba(34, 34, 34, 0.80)"
-  )
 
   return (
     <Box position="relative">
@@ -47,7 +35,7 @@ const HubHero = (props: HubHeroProps) => {
         p={{ base: "4", lg: "8" }}
         textAlign={{ base: "center", xl: "start" }}
         borderRadius={{ xl: "base" }}
-        bg={{ xl: largeContentBg }}
+        bg={{ xl: "hubHeroContentBg" }}
         position={{ xl: "absolute" }}
         insetStart={{ xl: "8" }}
         maxW={{ xl: "sm" }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

In prod, the content background of the `HubHero` component suffers from color flash in dark mode. This PR creates a semantic token in place of `useColorModeValue` to render the color.

## Related Issue
N/A
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
