### PR TITLE
Fixed links as per issue #11643

### DIFF
--- a/src/content/developers/docs/programming-languages/rust/index.md
+++ b/src/content/developers/docs/programming-languages/rust/index.md
@@ -35,7 +35,7 @@ Need a more basic primer first? Check out [ethereum.org/learn](/learn/) or [ethe
 - [Build A Decentralized Chat Using JavaScript and Rust](https://medium.com/perlin-network/build-a-decentralized-chat-using-javascript-rust-webassembly-c775f8484b52)
 - [Build a Decentralized Todo App Using Vue.js & Rust](https://medium.com/@jjmace01/build-a-decentralized-todo-app-using-vue-js-rust-webassembly-5381a1895beb)
 
-- [An Intro to Secret Contracts](https://blog.enigma.co/getting-started-with-enigma-an-intro-to-secret-contracts-cdba4fe501c2)
+- [An Intro to Secret Contracts](https://docs.scrt.network/secret-network-documentation/development/secret-contract-fundamentals/secret-contracts-introduction)
 - [Build a blockchain in Rust](https://blog.logrocket.com/how-to-build-a-blockchain-in-rust/)
 
 ## Rust projects and tools {#rust-projects-and-tools}

--- a/src/content/developers/docs/programming-languages/rust/index.md
+++ b/src/content/developers/docs/programming-languages/rust/index.md
@@ -35,7 +35,6 @@ Need a more basic primer first? Check out [ethereum.org/learn](/learn/) or [ethe
 - [Build A Decentralized Chat Using JavaScript and Rust](https://medium.com/perlin-network/build-a-decentralized-chat-using-javascript-rust-webassembly-c775f8484b52)
 - [Build a Decentralized Todo App Using Vue.js & Rust](https://medium.com/@jjmace01/build-a-decentralized-todo-app-using-vue-js-rust-webassembly-5381a1895beb)
 
-- [An Intro to Secret Contracts](https://docs.scrt.network/secret-network-documentation/development/secret-contract-fundamentals/secret-contracts-introduction)
 - [Build a blockchain in Rust](https://blog.logrocket.com/how-to-build-a-blockchain-in-rust/)
 
 ## Rust projects and tools {#rust-projects-and-tools}


### PR DESCRIPTION
The link to "An Intro to Secret Contracts" was broken as per issue #11643 therefore I added the updated link.

## Description

Fixes #11643 

Just updating the link since the current link to https://blog.enigma.co/getting-started-with-enigma-an-intro-to-secret-contracts-cdba4fe501c2 is outdated, so I updated it to https://docs.scrt.network/secret-network-documentation/development/secret-contract-fundamentals/secret-contracts-introduction