### PR TITLE
fix: hidden menu list item

### DIFF
--- a/src/components/LeftNavBar/index.tsx
+++ b/src/components/LeftNavBar/index.tsx
@@ -51,6 +51,7 @@ const LeftNavBar: React.FC<IProps> = ({
       position="sticky"
       top="6.25rem"
       height={calc("100vh").subtract("80px").toString()}
+      zIndex="dropdown"
       {...props}
     >
       {dropdownLinks && <StyledButtonDropdown list={dropdownLinks} />}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
resolved the problem of "menu list" **hidden** under "title card". 
![image](https://github.com/ethereum/ethereum-org-website/assets/24203166/1dbc7710-3c3d-471e-98f0-465733e446cc)
<!--- Describe your changes in detail -->
**changes:** add `zIndex` to `LeftNavBar as "dropdown", which is 100, while `TitileCard` has set as `docker`, which is 10. Now, zindex value 100>10, menu can be set at front. 



<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes: https://github.com/ethereum/ethereum-org-website/issues/11410
Fixes: https://github.com/ethereum/ethereum-org-website/issues/11304
