### PR TITLE
Matomo updates

### DIFF
--- a/src/components/Buttons/Button.tsx
+++ b/src/components/Buttons/Button.tsx
@@ -6,6 +6,7 @@ import {
 } from "@chakra-ui/react"
 
 import { scrollIntoView } from "../../utils/scrollIntoView"
+import { type MatomoEventOptions, trackCustomEvent } from "../../utils/matomo"
 
 export const checkIsSecondary = (props: {
   variant?: string
@@ -33,15 +34,15 @@ export interface IProps extends ButtonProps {
    * `NOTE`: Does not apply to the `Solid` or `Link` variants
    */
   isSecondary?: boolean
+  customEventOptions?: MatomoEventOptions
 }
 
 const Button = forwardRef<IProps, "button">((props, ref) => {
-  const { toId, onClick, isSecondary, ...rest } = props
+  const { toId, onClick, isSecondary, customEventOptions, ...rest } = props
 
   const handleOnClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-    if (toId) {
-      scrollIntoView(toId)
-    }
+    toId && scrollIntoView(toId)
+    customEventOptions && trackCustomEvent(customEventOptions)
 
     onClick?.(e)
   }

--- a/src/components/FindWallet/WalletTable/index.tsx
+++ b/src/components/FindWallet/WalletTable/index.tsx
@@ -427,11 +427,13 @@ const WalletTable = ({ data, filters, walletData }: WalletTableProps) => {
             <Wallet
               onClick={() => {
                 updateMoreInfo(wallet.key)
-                trackCustomEvent({
-                  eventCategory: "WalletMoreInfo",
-                  eventAction: `More info wallet`,
-                  eventName: `More info ${wallet.name} ${wallet.moreInfo}`,
-                })
+                // Log "more info" event only on expanding
+                wallet.moreInfo &&
+                  trackCustomEvent({
+                    eventCategory: "WalletMoreInfo",
+                    eventAction: `More info wallet`,
+                    eventName: `More info ${wallet.name}`,
+                  })
               }}
             >
               <Td lineHeight="revert">
@@ -473,7 +475,7 @@ const WalletTable = ({ data, filters, walletData }: WalletTableProps) => {
                           customEventOptions={{
                             eventCategory: "WalletExternalLinkList",
                             eventAction: `Go to wallet`,
-                            eventName: `${wallet.name} ${idx}`,
+                            eventName: `Website: ${wallet.name} ${idx}`,
                             eventValue: JSON.stringify(filters),
                           }}
                         >
@@ -486,7 +488,7 @@ const WalletTable = ({ data, filters, walletData }: WalletTableProps) => {
                             customEventOptions={{
                               eventCategory: "WalletExternalLinkList",
                               eventAction: `Go to wallet`,
-                              eventName: `${wallet.name} ${idx}`,
+                              eventName: `Twitter: ${wallet.name} ${idx}`,
                               eventValue: JSON.stringify(filters),
                             }}
                           >
@@ -504,7 +506,7 @@ const WalletTable = ({ data, filters, walletData }: WalletTableProps) => {
                             customEventOptions={{
                               eventCategory: "WalletExternalLinkList",
                               eventAction: `Go to wallet`,
-                              eventName: `${wallet.name} ${idx}`,
+                              eventName: `Discord: ${wallet.name} ${idx}`,
                               eventValue: JSON.stringify(filters),
                             }}
                           >

--- a/src/utils/matomo.ts
+++ b/src/utils/matomo.ts
@@ -13,19 +13,17 @@ export const trackCustomEvent = ({
   eventName,
   eventValue,
 }: MatomoEventOptions): void => {
-  if (process.env.NODE_ENV === "production" || window.dev === true) {
-    const optedOutValue = localStorage.getItem(MATOMO_LS_KEY) || "false"
-    const isOptedOut = JSON.parse(optedOutValue)
-    if (!window._paq || isOptedOut) return
+  if (process.env.NODE_ENV !== "production" && !window.dev) return
+  const optedOutValue = localStorage.getItem(MATOMO_LS_KEY) || "false"
+  const isOptedOut = JSON.parse(optedOutValue)
+  if (!window._paq || isOptedOut) return
 
-    const { _paq, dev } = window
+  const { _paq, dev } = window
 
-    _paq.push([`trackEvent`, eventCategory, eventAction, eventName, eventValue])
+  _paq.push([`trackEvent`, eventCategory, eventAction, eventName, eventValue])
+  if (!dev) return
 
-    if (dev) {
-      console.debug(
-        `[Matomo] event tracked, category: ${eventCategory}, action: ${eventAction}, name: ${eventName}, value: ${eventValue}`
-      )
-    }
-  }
+  console.debug(
+    `[Matomo] event tracked, category: ${eventCategory}, action: ${eventAction}, name: ${eventName}, value: ${eventValue}`
+  )
 }


### PR DESCRIPTION
## Description
Implement updates to Matomo tracking for wallet pages
- Removes event when collapsing wallet details; only logs when item is expanded
- Differentiate external links to website vs Twitter vs Discord for wallets
- "Check out ___" button logging patched -- This required updating the `Button` component which was not utilizing the MatomoEventOptions being passed.
- Small refactor to use guard clauses instead of nesting primary logic inside `if` statements inside `matomo.ts`

## Related Issue
- Partially resolves #11521 [(Notion Card)](https://www.notion.so/efdn/Event-tracking-issues-fix-14550da4fa0b4a5a895e7910848d8f36?pvs=4)

cc: @konopkja Left a note for you about remaining item in that Notion card