### PR TITLE
Fixed links as per issue #11715

### DIFF
--- a/src/content/developers/docs/consensus-mechanisms/pow/mining-algorithms/ethash/index.md
+++ b/src/content/developers/docs/consensus-mechanisms/pow/mining-algorithms/ethash/index.md
@@ -47,7 +47,7 @@ ACCESSES = 64                     # number of accesses in hashimoto loop
 Ethereum's development coincided with the development of the SHA3 standard, and the
 standards process made a late change in the padding of the finalized hash algorithm, so that Ethereum's
 "sha3_256" and "sha3_512" hashes are not standard sha3 hashes, but a variant often referred
-to as "Keccak-256" and "Keccak-512" in other contexts. See discussion, e.g. [here](https://eips.ethereum.org/EIPS-1803), [here](http://ethereum.stackexchange.com/questions/550/which-cryptographic-hash-function-does-ethereum-use), or [here](http://bitcoin.stackexchange.com/questions/42055/what-is-the-approach-to-calculate-an-ethereum-address-from-a-256-bit-private-key/42057#42057).
+to as "Keccak-256" and "Keccak-512" in other contexts. See discussion, e.g. [here](https://eips.ethereum.org/EIPS/eip-1803), [here](http://ethereum.stackexchange.com/questions/550/which-cryptographic-hash-function-does-ethereum-use), or [here](http://bitcoin.stackexchange.com/questions/42055/what-is-the-approach-to-calculate-an-ethereum-address-from-a-256-bit-private-key/42057#42057).
 
 Please keep that in mind as "sha3" hashes are referred to in the description of the algorithm below.
 


### PR DESCRIPTION
The link to the discussion of "ETHASH: The use of 'SHA3'"was broken as per issue [#11715](https://github.com/ethereum/ethereum-org-website/issues/11715) therefore I added the updated link.

## Description

Fixes [#11715](https://github.com/ethereum/ethereum-org-website/issues/11715)

Just updating the link since the current link to https://eips.ethereum.org/EIPS-1803 is broken, so I updated it to https://eips.ethereum.org/EIPS/eip-1803
