### PR TITLE
Fix various grammatical errors and typos in Ethereum tutorials

### DIFF
--- a/src/content/developers/tutorials/run-node-raspberry-pi/index.md
+++ b/src/content/developers/tutorials/run-node-raspberry-pi/index.md
@@ -25,7 +25,7 @@ To use Ethereum on Arm to turn a Raspberry Pi into an Ethereum node, the followi
 
 ## Why run Ethereum on ARM? {#why-run-ethereum-on-arm}
 
-ARM boards are very affordable, flexible, small computers. They are good choices for running Ethereum nodes because they can be bought cheaply, configured so that all their resources focus just on the node, making them efficient, they consume low amounts of power and have are physically small so they can fit unobtrusively in any home. It is also very easy to spin up nodes because the Raspberry Pi's MicroSD can simply be flashed with a prebuilt image, with no downloading or building software required.
+ARM boards are very affordable, flexible, small computers. They are good choices for running Ethereum nodes because they can be bought cheaply, configured so that all their resources focus just on the node, making them efficient, they consume low amounts of power and are physically small so they can fit unobtrusively in any home. It is also very easy to spin up nodes because the Raspberry Pi's MicroSD can simply be flashed with a prebuilt image, with no downloading or building software required.
 
 ## How does it work? {#how-does-it-work}
 

--- a/src/content/developers/tutorials/set-up-web3js-to-use-ethereum-in-javascript/index.md
+++ b/src/content/developers/tutorials/set-up-web3js-to-use-ethereum-in-javascript/index.md
@@ -89,4 +89,4 @@ if (window.ethereum != null) {
 }
 ```
 
-Alternatives to web3.js like [Ethers.js](https://docs.ethers.io/) do exist and are also commonly used. In the next tutorial we’ll see [how to easily listen to new incoming blocks on the blockchain and see what they contains](https://ethereumdev.io/listening-to-new-transactions-happening-on-the-blockchain/).
+Alternatives to web3.js like [Ethers.js](https://docs.ethers.io/) do exist and are also commonly used. In the next tutorial we’ll see [how to easily listen to new incoming blocks on the blockchain and see what they contain](https://ethereumdev.io/listening-to-new-transactions-happening-on-the-blockchain/).

--- a/src/content/developers/tutorials/smart-contract-security-guidelines/index.md
+++ b/src/content/developers/tutorials/smart-contract-security-guidelines/index.md
@@ -30,9 +30,9 @@ Documentation can be written at different levels, and should be updated while im
 
 ### Upgradeability {#upgradeability}
 
-We discussed the different upgradeability solutions in [our blogpost](https://blog.trailofbits.com/2018/09/05/contract-upgrade-anti-patterns/). Make a deliberate choice to support upgradeability or not prior to writing any code. The decision will influence how you structure our code. In general, we recommend:
+We discussed the different upgradeability solutions in [our blogpost](https://blog.trailofbits.com/2018/09/05/contract-upgrade-anti-patterns/). Make a deliberate choice to support upgradeability or not prior to writing any code. The decision will influence how you structure your code. In general, we recommend:
 
-- **Favoring [contract migration](https://blog.trailofbits.com/2018/10/29/how-contract-migration-works/) over upgradeability.** Migration system have many of the same advantages than upgradeable, without their drawbacks.
+- **Favoring [contract migration](https://blog.trailofbits.com/2018/10/29/how-contract-migration-works/) over upgradeability.** Migration systems have many of the same advantages as upgradeable ones, without their drawbacks.
 - **Using the data separation pattern over the delegatecallproxy one.** If your project has a clear abstraction separation, upgradeability using data separation will necessitate only a few adjustments. The delegatecallproxy requires EVM expertise and is highly error-prone.
 - **Document the migration/upgrade procedure before the deployment.** If you have to react under stress without any guidelines, you will make mistakes. Write the procedure to follow ahead of time. It should include:
   - The calls that initiate the new contracts

--- a/src/content/developers/tutorials/testing-erc-20-tokens-with-waffle/index.md
+++ b/src/content/developers/tutorials/testing-erc-20-tokens-with-waffle/index.md
@@ -661,7 +661,7 @@ pragma solidity ^0.6.0;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
-// Example class - a mock class using delivering from ERC20
+// Example class - a mock class derived from ERC20
 contract BasicToken is ERC20 {
     constructor(uint256 initialBalance) ERC20("Basic", "BSC") public {
         _mint(msg.sender, initialBalance);

--- a/src/content/developers/tutorials/waffle-dynamic-mocking-and-testing-calls/index.md
+++ b/src/content/developers/tutorials/waffle-dynamic-mocking-and-testing-calls/index.md
@@ -193,7 +193,7 @@ describe("Am I Rich Already", () => {
 })
 ```
 
-Let's write the first test to the the `AmIRichAlready` contract. What do you think our test should be about? Yeah, you're right! We should check if we are already rich :)
+Let's write the first test for the `AmIRichAlready` contract. What do you think our test should be about? Yeah, you're right! We should check if we are already rich :)
 
 But wait a second. How will our mocked contract know what values to return? We haven't implemented any logic for the `balanceOf()` function. Again, Waffle can help here. Our mocked contract has some new fancy stuff to it now:
 
@@ -211,7 +211,7 @@ it("returns false if the wallet has less than 1000000 tokens", async () => {
 })
 ```
 
-Let's brake down this test into parts:
+Let's break down this test into parts:
 
 1. We set our mock ERC20 contract to always return balance of 999999 tokens.
 2. Check if the `contract.check()` method returns `false`.

--- a/src/content/developers/tutorials/waffle-say-hello-world-with-hardhat-and-ethers/index.md
+++ b/src/content/developers/tutorials/waffle-say-hello-world-with-hardhat-and-ethers/index.md
@@ -68,7 +68,7 @@ MyWaffleProject
 │   └── sample-script.js
 ├── test
 │   └── sample-test.js
-├── .gitattributs
+├── .gitattributes
 ├── .gitignore
 ├── hardhat.config.js
 └── package.json

--- a/src/content/developers/tutorials/waffle-say-hello-world-with-hardhat-and-ethers/index.md
+++ b/src/content/developers/tutorials/waffle-say-hello-world-with-hardhat-and-ethers/index.md
@@ -11,7 +11,7 @@ published: 2020-10-16
 
 In this [Waffle](https://ethereum-waffle.readthedocs.io) tutorial, we will learn how to set up a simple "Hello world" smart contract project, using [hardhat](https://hardhat.org/) and [ethers.js](https://docs.ethers.io/v5/). Then we will learn how to add a new functionality to our smart contract and how to test it with Waffle.
 
-Let's start with creating new project:
+Let's start by creating a new project:
 
 ```bash
 yarn init


### PR DESCRIPTION
#### Description:
This pull request introduces a series of grammar and typo corrections across different tutorials related to Ethereum development. The changes focus on enhancing the clarity, accuracy, and readability of the documentation. No functional code changes are included.

#### List of Changes:
1. **Update Grammar in Project Setup Instructions**: Corrected a grammatical error in the Waffle tutorial to improve clarity in the project setup instructions.
   
2. **Fix Typo in .gitattributes Filename**: Corrected the filename from `.gitattributs` to `.gitattributes` in the same tutorial, ensuring accurate file naming conventions.

3. **Fix Typos in Test Description of 'AmIRichAlready' Tutorial**: Addressed two typographical errors in the testing section of the 'AmIRichAlready' contract tutorial. Changes include clarifying a sentence and correcting a grammatical error.

4. **Refactor: Update Grammar in BasicToken.sol Comments**: Improved the grammatical accuracy in the comments of the BasicToken.sol contract, specifically changing 'delivering from ERC20' to 'derived from ERC20'.

5. **Fix Grammatical Errors in Upgradeability Section**: Corrected plural forms and comparative structures in a sentence describing the advantages of migration systems in smart contract security guidelines.

6. **Correct Grammar: Change 'contains' to 'contain' in Documentation**: Addressed a grammatical error in a tutorial on setting up web3.js, improving the sentence structure for better readability.

7. **Fix Grammatical Error in 'Why Run Ethereum on ARM?' Section**: Corrected a grammatical error in the section discussing the benefits of running Ethereum on ARM platforms, enhancing clarity and accuracy.

These corrections aim to provide a more polished and professional appearance to the Ethereum tutorial documentation, making it more accessible and easier to understand for developers.
