### PR TITLE
Patch i18n string key

### DIFF
--- a/src/pages/get-eth.tsx
+++ b/src/pages/get-eth.tsx
@@ -212,7 +212,7 @@ const GetETHPage = ({ data }: PageProps<Queries.GetEthPageQuery>) => {
           description={t("page-get-eth-peers-desc")}
         >
           <InlineLink to="/wallets/">
-            <Translation id="page-get-eth-wallets-link-desc" />
+            <Translation id="page-get-eth-wallets-link" />
           </InlineLink>
         </StyledCard>
         <StyledCard


### PR DESCRIPTION
## Description
Patches a broken i18n string on the `/get-eth` page.

There are two cards in this section that link to the wallets page... we should probably try and avoid this redundancy, but would like to address that separately to just patch the i18n key being displayed at the moment

<img width="1361" alt="image" src="https://github.com/ethereum/ethereum-org-website/assets/54227730/bd16fdb8-d2df-4e5f-a706-5fea4a295ca5">

## Related Issue
<img width="1459" alt="image" src="https://github.com/ethereum/ethereum-org-website/assets/54227730/6d34cdd5-3d99-45a2-83f6-b85ef5114fec">

https://ethereum.org/en/get-eth/