### PR TITLE
Removing /discord/ from redirects

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -4,10 +4,6 @@
     "toPath": "https://discord.gg/rZz26QWfCg"
   },
   {
-    "fromPath": "/*/discord",
-    "toPath": "https://discord.gg/rZz26QWfCg"
-  },
-  {
     "fromPath": "/pdfs/*",
     "toPath": "/en/"
   },


### PR DESCRIPTION
## Description

/discord/ redirects to https://discord.com/invite/rZz26QWfCg which is invalid.

