### PR TITLE
Fix token standard 4626 developer document

### DIFF
--- a/src/content/developers/docs/standards/tokens/erc-4626/index.md
+++ b/src/content/developers/docs/standards/tokens/erc-4626/index.md
@@ -102,7 +102,7 @@ This function allows users to simulate the effects of their mint at the current 
 function mint(uint256 shares, address receiver) public returns (uint256 assets)
 ```
 
-This function mints exactly `shares` vault shares to `receiver` by depositing `assets` of underlying tokens.
+This function mints vault shares to `receiver` by depositing `assets` of underlying tokens.
 
 #### maxWithdraw {#maxwithdraw}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix Developer docs for token standard ERC-4626. currently, `mint` method description is ambiguous due to repeated `shares` word. 
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
