### PR TITLE
fix the typo where a wrong address is used

### DIFF
--- a/src/content/developers/docs/data-structures-and-encoding/patricia-merkle-trie/index.md
+++ b/src/content/developers/docs/data-structures-and-encoding/patricia-merkle-trie/index.md
@@ -228,7 +228,7 @@ undefined
 The `path` is therefore `keccak256(<6661e9d6d8b923d5bbaab1b96e1dd51ff6ea2a93520fdc9eb75d059238b8c5e9>)`. This can now be used to retrieve the data from the storage trie as before:
 
 ```
-curl -X POST --data '{"jsonrpc":"2.0", "method": "eth_getStorageAt", "params": ["0x295a70b2de5e3953354a6a8344e616ed314d7251", "0x6661e9d6d8b923d5bbaab1b96e1dd51ff6ea2a93520fdc9eb75d059238b8c5e9", "latest"], "id": 1}' localhost:8545
+curl -X POST --data '{"jsonrpc":"2.0", "method": "eth_getStorageAt", "params": ["0x391694e7e0b0cce554cb130d723a9d27458f9298", "0x6661e9d6d8b923d5bbaab1b96e1dd51ff6ea2a93520fdc9eb75d059238b8c5e9", "latest"], "id": 1}' localhost:8545
 
 {"jsonrpc":"2.0","id":1,"result":"0x000000000000000000000000000000000000000000000000000000000000162e"}
 ```


### PR DESCRIPTION
## Description

Based on the context, it is supposed to be reading the storage slot of the address `0x391694e7e0b0cce554cb130d723a9d27458f9298`, but the other address `0x295a70b2de5e3953354a6a8344e616ed314d7251` is used here. This PR fixes it.

## Related Issue

NA
