### PR TITLE
Add ethereum-json-rpc.com

### DIFF
--- a/src/content/developers/docs/apis/json-rpc/index.md
+++ b/src/content/developers/docs/apis/json-rpc/index.md
@@ -28,6 +28,8 @@ An internal API is also used for inter-client communication within a node - that
 
 [Read the full JSON-RPC API spec on GitHub](https://github.com/ethereum/execution-apis).
 
+You can also use the [interactive JSON-RPC API playground](https://ethereum-json-rpc.com).
+
 ## Conventions {#conventions}
 
 ### Hex value encoding {#hex-encoding}


### PR DESCRIPTION
Adds a link and a short description for [ethereum-json-rpc.com](https://ethereum-json-rpc.com).

## Description

Adds a paragraph to the "Execution client spec" section on the "JSON-RPC" page, highlighting "Ethereum JSON RPC" tool — the interactive API playground for Ethereum JSON-RPC spec. One distinctive feature of the tool is that it allows the user to execute methods right from the browser.

The playground is [open-source](https://github.com/Destiner/ethereum-json-rpc).

> Disclaimer: I am the creator of the tool.