### PR TITLE
adding punctuation (similar to tutorials, learning-tools and local-environment)

### DIFF
--- a/src/intl/en/page-developers-index.json
+++ b/src/intl/en/page-developers-index.json
@@ -44,7 +44,7 @@
   "page-developers-language-desc": "Using Ethereum with familiar languages",
   "page-developers-languages": "Programming languages",
   "page-developers-learn": "Learn Ethereum development",
-  "page-developers-learn-desc": "Read up on core concepts and the Ethereum stack with our docs",
+  "page-developers-learn-desc": "Read up on core concepts and the Ethereum stack with our docs.",
   "page-developers-learn-tutorials": "Learn through tutorials",
   "page-developers-learn-tutorials-cta": "View tutorials",
   "page-developers-learn-tutorials-desc": "Learn Ethereum development step-by-step from builders who have already done it.",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In the link https://ethereum.org/en/developers/

"How would you like to get started?" Section

There are 4 sub sections.

- Learn Ethereum development
- Learn through tutorials
- Start experimenting
- Set up local environment

All the descriptions of these subsections have similar punctuation except the "Learn Ethereum development" description.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
