### PR TITLE
Update MeetupList.tsx to open links in new tabs [Fixes #11902]

### DIFF
--- a/src/components/MeetupList.tsx
+++ b/src/components/MeetupList.tsx
@@ -115,6 +115,8 @@ const MeetupList: React.FC<IProps> = () => {
                   textDecor="none"
                   color="text"
                   hideArrow
+                  target="_blank"
+                  rel="noopener noreferrer"
                 >
                   {meetup.title}
                 </LinkOverlay>

--- a/src/components/MeetupList.tsx
+++ b/src/components/MeetupList.tsx
@@ -115,8 +115,7 @@ const MeetupList: React.FC<IProps> = () => {
                   textDecor="none"
                   color="text"
                   hideArrow
-                  target="_blank"
-                  rel="noopener noreferrer"
+                  isExternal
                 >
                   {meetup.title}
                 </LinkOverlay>


### PR DESCRIPTION
Fixes #11902

## Description

Added the `isExternal` prop to the `LinkOverlay` component.

## Related Issue

This pull request addresses the issue described in Issue #11902 

Related issue link: https://github.com/ethereum/ethereum-org-website/issues/11902