### PR TITLE
Fix canonical English URLs to fix Algolia search crawling

### DIFF
--- a/src/components/PageMetadata.tsx
+++ b/src/components/PageMetadata.tsx
@@ -4,7 +4,7 @@ import Head from "next/head"
 import { useRouter } from "next/router"
 import { useTranslation } from "next-i18next"
 
-import { SITE_URL } from "@/lib/constants"
+import { DEFAULT_LOCALE, SITE_URL } from "@/lib/constants"
 
 type NameMeta = {
   name: string
@@ -47,7 +47,7 @@ const PageMetadata: React.FC<IProps> = ({
 
   /* Set canonical URL w/ language path to avoid duplicate content */
   /* e.g. set ethereum.org/about/ to ethereum.org/en/about/ */
-  const url = new URL(join(locale!, path), origin).href
+  const url = new URL(join(locale === DEFAULT_LOCALE ? "" : locale!, path), origin).href
   const canonical = canonicalUrl || url
 
   /* Set fallback ogImage based on path */


### PR DESCRIPTION
## Description
- Removes the "en" path prefix from the canonical URL being generated inside `PageMetadata` component

## Related Issue
With the Next.js migration, English pages no longer use the `/en/` path prefix, and going to these routes will redirect to `/**`. As such this, this is causing cyclical logic within our Algolia search crawler:

- Crawling https://ethereum.org/ is skipped, in favor of "canonical" https://ethereum.org/en/
  <img width="501" alt="image" src="https://github.com/ethereum/ethereum-org-website/assets/54227730/7c170b10-3f50-4f64-8031-d00e576536e1">
- And https://ethereum.org/en/ is skipped by redirecting back to https://ethereum.org/
  <img width="400" alt="image" src="https://github.com/ethereum/ethereum-org-website/assets/54227730/51d50c7e-a7a9-4571-ac39-15533528acdc">
