### PR TITLE
Fix CalloutBanner imge sizing/layout bugs

### DIFF
--- a/src/components/CalloutBanner.tsx
+++ b/src/components/CalloutBanner.tsx
@@ -11,7 +11,6 @@ export type CalloutBannerProps = FlexProps & {
   children?: React.ReactNode
   image: ImageProps["src"]
   imageWidth?: number
-  maxImageWidth?: ImageProps["width"]
   titleKey: TranslationKey
   descriptionKey: TranslationKey
   alt: string
@@ -20,7 +19,6 @@ export type CalloutBannerProps = FlexProps & {
 const CalloutBanner = ({
   image,
   imageWidth,
-  maxImageWidth,
   titleKey,
   descriptionKey,
   alt,
@@ -44,11 +42,10 @@ const CalloutBanner = ({
             src={image}
             alt={alt}
             width={imageWidth}
-            maxW={{ base: "auto", md: maxImageWidth }}
             style={{
               objectFit: "contain",
             }}
-            alignSelf="center"
+            mx="auto"
             mt={-24}
             mb={{ base: 0, lg: -24 }}
           />

--- a/src/pages/get-eth.tsx
+++ b/src/pages/get-eth.tsx
@@ -478,7 +478,7 @@ const GetEthPage = ({
         descriptionKey="page-get-eth:page-get-eth-use-your-eth-dapps"
         image={dapps}
         alt={t("page-index:page-index-sections-individuals-image-alt")}
-        maxImageWidth={600}
+        imageWidth={600}
       >
         <Box>
           <ButtonLink href="/dapps/">

--- a/src/pages/stablecoins.tsx
+++ b/src/pages/stablecoins.tsx
@@ -633,7 +633,7 @@ const StablecoinsPage = ({ markets, marketsHasError }) => {
             "page-stablecoins-stablecoins-dapp-callout-description"
           )}
           image={dogeComputerImg}
-          maxImageWidth={600}
+          imageWidth={600}
           alt={t("page-stablecoins-stablecoins-dapp-callout-image-alt")}
         >
           <Flex flexFlow="wrap" gap="1em">


### PR DESCRIPTION
## Description
- Switches to using `imageWidth` prop instead of `maxImageWidth` prop in both `get-eth` and `stablecoins` page components, fixing sizing and overflow issues (especially seen on tablet sizes)
- `maxImageWidth` prop no longer being used by any components; removed from usage within `CalloutBanner` to prevent confusion in the future over which to use
- Replaced `alignSelf="center"` with `mx="auto"` which fixes mobile alignment issue

## Related Issue
https://www.notion.so/efdn/BUG-small-visual-issue-in-Callout-banner-c6e1b5a94ec14a90bf3f8934d5a7b171?pvs=4

## Preview links
- **https://deploy-preview-11958--ethereumorg.netlify.app/get-eth**
- **https://deploy-preview-11958--ethereumorg.netlify.app/staking**
- **https://deploy-preview-11958--ethereumorg.netlify.app/stablecoins**

Gatsby archive link for comparisons (goal):
- https://web.archive.org/web/20231127082345/https://ethereum.org/en/get-eth
- https://web.archive.org/web/20231127082345/https://ethereum.org/en/staking/
- https://web.archive.org/web/20231127082345/https://ethereum.org/en/stablecoins/

Current production for comparison (buggy):
- https://ethereum.org/get-eth
- https://ethereum.org/staking
- https://ethereum.org/stablecoins