### PR TITLE
Fix: Edit path for markdown files

### DIFF
--- a/src/layouts/Docs.tsx
+++ b/src/layouts/Docs.tsx
@@ -47,8 +47,10 @@ import TableOfContents from "@/components/TableOfContents"
 import Translation from "@/components/Translation"
 import YouTube from "@/components/YouTube"
 
+import { getEditPath } from "@/lib/utils/editPath"
+
 // Utils
-import { DEFAULT_LOCALE, EDIT_CONTENT_URL } from "@/lib/constants"
+import { DEFAULT_LOCALE } from "@/lib/constants"
 
 import { useClientSideGitHubLastEdit } from "@/hooks/useClientSideGitHubLastEdit"
 
@@ -220,7 +222,7 @@ export const DocsLayout = ({
 }: DocsLayoutProps) => {
   const isPageIncomplete = !!frontmatter.incomplete
   const { asPath: relativePath } = useRouter()
-  const absoluteEditPath = `${EDIT_CONTENT_URL}${relativePath}`
+  const absoluteEditPath = getEditPath(relativePath)
 
   const gitHubLastEdit = useClientSideGitHubLastEdit(relativePath)
   const intlLastEdit = "data" in gitHubLastEdit ? gitHubLastEdit.data! : ""

--- a/src/layouts/Static.tsx
+++ b/src/layouts/Static.tsx
@@ -30,10 +30,9 @@ import Translation from "@/components/Translation"
 import TranslationChartImage from "@/components/TranslationChartImage"
 import UpcomingEventsList from "@/components/UpcomingEventsList"
 
+import { getEditPath } from "@/lib/utils/editPath"
 import { getLocaleTimestamp } from "@/lib/utils/time"
 import { isLangRightToLeft } from "@/lib/utils/translations"
-
-import { CONTENT_DIR } from "@/lib/constants"
 
 import GuideHeroImage from "@/public/heroes/guides-hub-hero.jpg"
 
@@ -91,10 +90,7 @@ export const StaticLayout: React.FC<IProps> = ({
 }) => {
   const { locale } = useRouter()
 
-  const repo =
-    process.env.NEXT_PUBLIC_GITHUB_REPO || "ethereum/ethereum-org-website"
-  const baseEditPath = `https://github.com/${repo}/tree/dev/${CONTENT_DIR}/`
-  const absoluteEditPath = baseEditPath + slug + "index.md"
+  const absoluteEditPath = getEditPath(slug)
 
   return (
     <Box w="full">

--- a/src/layouts/Tutorial.tsx
+++ b/src/layouts/Tutorial.tsx
@@ -35,13 +35,14 @@ import {
   Heading4 as MdHeading4,
 } from "@/components/MdComponents"
 import MdLink from "@/components/MdLink"
-import PageMetadata from "@/components/PageMetadata"
 import { mdxTableComponents } from "@/components/Table"
 import TableOfContents from "@/components/TableOfContents"
 import TutorialMetadata from "@/components/TutorialMetadata"
 import YouTube from "@/components/YouTube"
 
-import { DEFAULT_LOCALE, EDIT_CONTENT_URL } from "@/lib/constants"
+import { getEditPath } from "@/lib/utils/editPath"
+
+import { DEFAULT_LOCALE } from "@/lib/constants"
 
 import { useClientSideGitHubLastEdit } from "@/hooks/useClientSideGitHubLastEdit"
 
@@ -180,7 +181,8 @@ export const TutorialLayout = ({
   crowdinContributors,
 }: TutorialLayoutProps) => {
   const { asPath: relativePath } = useRouter()
-  const absoluteEditPath = `${EDIT_CONTENT_URL}${relativePath}`
+  const absoluteEditPath = getEditPath(relativePath)
+
   const borderColor = useToken("colors", "border")
   const postMergeBannerTranslationString =
     frontmatter.postMergeBannerTranslation as TranslationKey | null

--- a/src/layouts/UseCases.tsx
+++ b/src/layouts/UseCases.tsx
@@ -30,9 +30,10 @@ import {
 } from "@/components/MdComponents"
 import TableOfContents from "@/components/TableOfContents"
 
+import { getEditPath } from "@/lib/utils/editPath"
 import { getSummaryPoints } from "@/lib/utils/getSummaryPoints"
 
-import { EDIT_CONTENT_URL, MAIN_CONTENT_ID } from "@/lib/constants"
+import { MAIN_CONTENT_ID } from "@/lib/constants"
 
 const HeroContainer = (props: ChildOnlyProp) => (
   <Flex
@@ -94,7 +95,7 @@ export const UseCasesLayout: React.FC<IProps> = ({
 
   const summaryPoints = getSummaryPoints(frontmatter)
 
-  const absoluteEditPath = `${EDIT_CONTENT_URL}${relativePath}`
+  const absoluteEditPath = getEditPath(relativePath)
 
   // Assign hero styling, default to "defi"
   let useCase = "defi"

--- a/src/lib/utils/editPath.ts
+++ b/src/lib/utils/editPath.ts
@@ -1,0 +1,5 @@
+import { join } from 'path'
+
+import { CONTENT_DIR, EDIT_CONTENT_URL } from '@/lib/constants'
+
+export const getEditPath = (relativePath: string): string => join(EDIT_CONTENT_URL, CONTENT_DIR, relativePath, "index.md")


### PR DESCRIPTION
## Description
- Adds a util helper function to get the edit path for markdown files
- Implement in layouts: Static, UseCases, Docs, Tutorial
