### PR TITLE
fix: remove trailing slash from canonical url

### DIFF
--- a/src/components/PageMetadata.tsx
+++ b/src/components/PageMetadata.tsx
@@ -44,9 +44,14 @@ const PageMetadata: React.FC<IProps> = ({
   const path = asPath.replace(/[\?\#].*/, "")
   const slug = path.split("/")
 
-  /* Set canonical URL w/ language path to avoid duplicate content */
-  /* e.g. set ethereum.org/about/ to ethereum.org/en/about/ */
-  const url = new URL(join(locale === DEFAULT_LOCALE ? "" : locale!, path), SITE_URL).href
+  /**
+   * Set canonical URL w/ language path to avoid duplicate content
+   * If English, remove language path
+   * Remove trailing slash
+   * @example ethereum.org/about/ -> ethereum.org/about
+   * @example ethereum.org/pt-br/web3/ -> ethereum.org/pt-br/web3
+   */
+  const url = new URL(join(locale === DEFAULT_LOCALE ? "" : locale!, path), SITE_URL).href.replace(/\/$/, "")
   const canonical = canonicalUrl || url
 
   /* Set fallback ogImage based on path */


### PR DESCRIPTION
## Description
- fix: remove trailing slash from canonical url
- fixes Algolia search crawler issues related to canonical URL
