### PR TITLE
Fix GitHub contributors history

### DIFF
--- a/src/hooks/useClientSideGitHubContributors.ts
+++ b/src/hooks/useClientSideGitHubContributors.ts
@@ -4,7 +4,11 @@ import { useEffect, useState } from "react"
 
 import type { Author, FileContributorsState } from "@/lib/types"
 
-import { CONTENT_DIR,GITHUB_COMMITS_URL } from "@/lib/constants"
+import {
+  CONTENT_DIR,
+  GITHUB_COMMITS_URL,
+  OLD_CONTENT_DIR,
+} from "@/lib/constants"
 
 export const gitHubAuthHeaders = {
   headers: new Headers({
@@ -13,42 +17,19 @@ export const gitHubAuthHeaders = {
   }),
 }
 
-const fetchGitHubContributors = async (
-  relativePath: string
-): Promise<FileContributorsState> => {
+const fetchGitHubCommits = async (filePath: string): Promise<any[]> => {
   const url = new URL(GITHUB_COMMITS_URL)
-  const filePath = join(CONTENT_DIR, relativePath, "index.md")
   url.searchParams.set("path", filePath)
 
   try {
     const response = await fetch(url, gitHubAuthHeaders)
     if (!response.ok) throw new Error(response.statusText)
-    const commits = await response.json()
-    const authorSet = new Set<string>()
-    commits
-      .filter(({ author }) => author)
-      .forEach(({ author, commit }) => {
-        const entry: Author = {
-          name: commit.author.name,
-          email: commit.author.email,
-          avatarUrl: author.avatar_url,
-          user: {
-            login: author.login,
-            url: author.html_url,
-          },
-        }
-        // Unique authors only
-        authorSet.add(JSON.stringify(entry))
-      })
-    const authors = Array.from(authorSet).map(
-      JSON.parse as (entry: string) => Author
-    )
-    return { loading: false, data: authors }
+    return await response.json()
   } catch (error: unknown) {
     if (error instanceof Error) {
       console.error(filePath, error.message)
     }
-    return { loading: false, error }
+    throw error
   }
 }
 /**
@@ -63,7 +44,41 @@ export const useClientSideGitHubContributors = (
   const [state, setState] = useState<FileContributorsState>({ loading: true })
   useEffect(() => {
     ;(async () => {
-      setState(await fetchGitHubContributors(relativePath))
+      const oldFilePath = join(OLD_CONTENT_DIR, relativePath, "index.md")
+      const filePath = join(CONTENT_DIR, relativePath, "index.md")
+
+      try {
+        const oldCommits = await fetchGitHubCommits(oldFilePath)
+        const newCommits = await fetchGitHubCommits(filePath)
+
+        const authorSet = new Set<string>()
+
+        ;[...oldCommits, ...newCommits]
+          .filter(({ author }) => author)
+          .forEach(({ author, commit }) => {
+            const entry: Author = {
+              name: commit.author.name,
+              email: commit.author.email,
+              avatarUrl: author.avatar_url,
+              user: {
+                login: author.login,
+                url: author.html_url,
+              },
+            }
+            // Unique authors only
+            authorSet.add(JSON.stringify(entry))
+          })
+        const authors = Array.from(authorSet).map(
+          JSON.parse as (entry: string) => Author
+        )
+
+        setState({
+          loading: false,
+          data: authors,
+        })
+      } catch (error: unknown) {
+        setState({ loading: false, error })
+      }
     })()
   }, [relativePath])
   return state

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -2,6 +2,7 @@ import { ReportsModel } from "@crowdin/crowdin-api-client"
 
 import i18nConfig from "../../i18n.config.json"
 
+export const OLD_CONTENT_DIR = "src/content"
 export const CONTENT_DIR = "public/content"
 export const TRANSLATIONS_DIR = "public/content/translations"
 export const TRANSLATED_IMAGES_DIR = "/content/translations"


### PR DESCRIPTION
## Description

Fetches the file history from the old content directory (`src/content`) + the new content directory (`public/content`) and combine both to display the full history.