### PR TITLE
fix: rtl support for embla carousel (Slider component)

### DIFF
--- a/src/components/Slider/index.tsx
+++ b/src/components/Slider/index.tsx
@@ -3,13 +3,16 @@ import useEmblaCarousel from "embla-carousel-react"
 import { MdChevronLeft, MdChevronRight } from "react-icons/md"
 import { Box, Center, Flex, IconButton, Stack } from "@chakra-ui/react"
 
+import { useRtlFlip } from "@/hooks/useRtlFlip"
+
 export interface IProps {
   children?: React.ReactNode
   onSlideChange?: (slideIndex: number) => void
 }
 
 const Slider: React.FC<IProps> = ({ children, onSlideChange }) => {
-  const [emblaRef, embla] = useEmblaCarousel()
+  const { flipForRtl, direction } = useRtlFlip()
+  const [emblaRef, embla] = useEmblaCarousel({ direction })
   const [prevBtnEnabled, setPrevBtnEnabled] = useState(false)
   const [nextBtnEnabled, setNextBtnEnabled] = useState(false)
   const [selectedIndex, setSelectedIndex] = useState(0)
@@ -78,6 +81,7 @@ const Slider: React.FC<IProps> = ({ children, onSlideChange }) => {
           bg={prevBtnEnabled ? "sliderBtnBg" : "sliderBtnBgDisabled"}
           size="sm"
           color={prevBtnEnabled ? "sliderBtnColor" : "sliderBtnColorDisabled"}
+          transform={flipForRtl}
         />
         <IconButton
           aria-label="MdChevronRight"
@@ -89,6 +93,7 @@ const Slider: React.FC<IProps> = ({ children, onSlideChange }) => {
           bg={nextBtnEnabled ? "sliderBtnBg" : "sliderBtnBgDisabled"}
           size="sm"
           color={nextBtnEnabled ? "sliderBtnColor" : "sliderBtnColorDisabled"}
+          transform={flipForRtl}
         />
       </Flex>
       <Center

--- a/src/hooks/useRtlFlip.ts
+++ b/src/hooks/useRtlFlip.ts
@@ -4,14 +4,19 @@ import type { Lang } from "@/lib/types"
 
 import { isLangRightToLeft } from "@/lib/utils/translations"
 
+type UseDirection = {
+  flipForRtl: "scaleX(-1)" | undefined
+  isRtl: boolean
+  direction: "ltr" | "rtl"
+}
+
 /**
- * Checks locale text direction and conditionally applies a scaleX(-1) for RTL locales
- * Applied to elements that should be visually flipped for RTL languages, ie: directional arrows
- * Usage: const { flipForRtl } = useRtlFlip(); transform={flipForRtl}
- * @returns { flipForRtl: "scaleX(-1)" | undefined }
+ * Custom hook that determines the direction and transformation for right-to-left (RTL) languages.
+ * @example const { flipForRtl } = useRtlFlip(); transform={flipForRtl}
+ * @returns An object containing the CSS transformation, RTL flag, and direction.
  */
-export const useRtlFlip = (): { flipForRtl: string | undefined } => {
+export const useRtlFlip = (): UseDirection => {
   const { locale } = useRouter()
   const isRtl = isLangRightToLeft(locale as Lang)
-  return { flipForRtl: isRtl ? "scaleX(-1)" : undefined }
+  return { flipForRtl: isRtl ? "scaleX(-1)" : undefined, isRtl, direction: isRtl ? "rtl" : "ltr" }
 }


### PR DESCRIPTION
**Builds on #11905 -- DO NOT MERGE before that PR**

## Description
- Updates `useRtlFlip` hook to also return `isRtl` and `direction` for convenience in niche cases where these may be needed to further adjust a component for RTL details.
- Pass `direction` (`"rtl" | "ltr"`) to `useEmblaCarousel` ([see embla docs](https://www.embla-carousel.com/api/options/#direction))

https://github.com/ethereum/ethereum-org-website/assets/54227730/bccf3bf0-d0b9-4a1c-b570-e12fdfdbef5d

## Related Issue
- https://github.com/ethereum/ethereum-org-website/pull/11905#pullrequestreview-1833317222