### PR TITLE
fix: Internal transaction term visibility in glossary list

### DIFF
--- a/public/content/glossary/index.md
+++ b/public/content/glossary/index.md
@@ -226,7 +226,7 @@ lang: en
 
 <GlossaryDefinition term="immutable-deployed-code-problem" />
 
-<GlossaryDefinition term="internal-transactions" />
+<GlossaryDefinition term="internal-transaction" />
 
 <GlossaryDefinition term="issuance" />
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

I've fixed the issue that was making the definition and term for internal transactions not show up in the glossary list. Look at the screenshots for a clearer understanding.

## Screenshots
### Before
![Screenshot (115)](https://github.com/ethereum/ethereum-org-website/assets/112751524/498c1bab-3a27-4eff-b810-e4ac2e2173fe)


### After
![Screenshot (114)](https://github.com/ethereum/ethereum-org-website/assets/112751524/37aff43b-3582-403a-81f0-704b3b2d6d40)

