### PR TITLE
style: hover color and rotation for search icon

### DIFF
--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -27,7 +27,19 @@ import "@docsearch/css"
 
 export const SearchIconButton = forwardRef<IconButtonProps, "button">(
   (props, ref) => (
-    <Button ref={ref} variant="ghost" isSecondary px={1.5} {...props}>
+    <Button
+      ref={ref}
+      variant="ghost"
+      isSecondary
+      px={1.5}
+      _hover={{
+        color: "primary.base",
+        transform: "rotate(5deg)",
+        transition: "transform 0.2s ease-in-out",
+      }}
+      transition="transform 0.2s ease-in-out"
+      {...props}
+    >
       <MdSearch />
     </Button>
   )


### PR DESCRIPTION
## Description
- Adds hover color and rotation styling to "tablet" search icon
- Desktop (>xl) screens left unchanged given "outline button" styling with a label
- Mobile menu left unchanged

Note: Other nav icons using a 10deg rotation. Went with 5deg here since the magnifying glass looked a little strange when rotating too much. Open to feedback/changing

## Related Issue
Related to navigation updates