### PR TITLE
build: add .vscode folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ robots.txt
 
 # .crowdin folder used as temp forlder for crowdin-import script
 .crowdin
+
+# vscode workplace configuration
+.vscode


### PR DESCRIPTION
## Description
Since we don't utilize a committed/shared set of vscode settings, this adds the `.vscode` folder back to the `.gitignore` file so users can save their own settings without potentially committing them. 

This was previously present in the Gatsby repo and we accidentally regressed during the Next.js migration.