### PR TITLE
fix: remove unused property causing build breaks

### DIFF
--- a/src/lib/api/calendarEvents.ts
+++ b/src/lib/api/calendarEvents.ts
@@ -30,7 +30,6 @@ export async function fetchCommunityEvents(): Promise<CommunityEventsReturnType>
           date: event.start.dateTime,
           title: event.summary,
           calendarLink: event.htmlLink,
-          pastEventLink: event.location,
         }
       })
     const upcomingEventData = futureEventsReqData
@@ -41,7 +40,6 @@ export async function fetchCommunityEvents(): Promise<CommunityEventsReturnType>
           date: event.start.dateTime,
           title: event.summary,
           calendarLink: event.htmlLink,
-          pastEventLink: event.location,
         }
       })
 

--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -184,7 +184,6 @@ export interface CommunityEvent {
   date: string
   title: string
   calendarLink: string
-  pastEventLink?: string
 }
 
 export interface ReqCommunityEvent {


### PR DESCRIPTION
## Description
The `pastEventLink` property was resulting `undefined` in some cases causing the build to fail when attempting to serialize. This value is not being consumed by the frontend and is not needed. PR removes this variable which resolved build errors. 

## Related Issue
Current `dev` branch build failures:

```
Error serializing `.communityEvents.pastEventData[2].pastEventLink` returned from `getStaticProps` in "/".
Reason: `undefined` cannot be serialized as JSON. Please use `null` or omit this value.
```