### PR TITLE
fix: search modal scroll position and overlay

### DIFF
--- a/src/components/Search/SearchModal.tsx
+++ b/src/components/Search/SearchModal.tsx
@@ -9,9 +9,10 @@ type ModalPropsNoScroll = Omit<DocSearchModalProps, "initialScrollY">
 const DocSearchModalWithChakra = chakra(
   (props: ModalPropsNoScroll & { className?: string }) => {
     const { className, ...docModalProps } = props
+    const windowScrollY = typeof window === "undefined" ? 0 : window.scrollY
     return (
       <div className={className}>
-        <DocSearchModal initialScrollY={0} {...docModalProps} />
+        <DocSearchModal initialScrollY={windowScrollY} {...docModalProps} />
       </div>
     )
   }

--- a/src/components/Search/utils.ts
+++ b/src/components/Search/utils.ts
@@ -74,6 +74,11 @@ export const getSearchModalStyles = (): SystemStyleObject => ({
   "--docsearch-modal-width": "650px",
   "--docsearch-hit-height": "fit-content",
 
+  ".DocSearch.DocSearch-Container": {
+    position: "fixed",
+    inset: 0,
+  },
+
   ".DocSearch-SearchBar": {
     p: { base: 4, md: 8 },
     pb: 4,
@@ -103,10 +108,9 @@ export const getSearchModalStyles = (): SystemStyleObject => ({
     },
   },
 
-  ".DocSearch-Container--Stalled .DocSearch-MagnifierLabel, .DocSearch-Container--Stalled .DocSearch-LoadingIndicator":
-    {
-      color: "primary.highContrast",
-    },
+  ".DocSearch-Container--Stalled .DocSearch-MagnifierLabel, .DocSearch-Container--Stalled .DocSearch-LoadingIndicator": {
+    color: "primary.highContrast",
+  },
 
   ".DocSearch-Dropdown": {
     ps: { base: 4, md: 8 },


### PR DESCRIPTION
## Description
- Maintain scroll position when closing search modal
- Fix modal overlay (`.DocSearch.DocSearch-Container`) to screen

## Related Issue
Bug: Modal overlay stays at top, and scroll position returns to the top after closing search modal:

https://github.com/ethereum/ethereum-org-website/assets/54227730/d96f9c10-8ac9-4500-8ae8-674db4b216d8


