### PR TITLE
fix(contributors): create shape for allTimeData json type

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -19,6 +19,9 @@ import type { CallToActionProps } from "@/components/Hero/CallToAction"
 
 import { layoutMapping } from "@/pages/[...slug]"
 
+// Credit: https://stackoverflow.com/a/52331580
+export type Unpacked<T> = T extends (infer U)[] ? U : T
+
 export type ChildOnlyProp = { children?: ReactNode }
 
 export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
@@ -354,4 +357,52 @@ export type CommunityConference = {
   description: string
   startDate: string
   endDate: string
+}
+
+type TranslatedStats = {
+  tmMatch: number
+  default: number
+  total: number
+}
+
+export type AllTimeData = {
+  name: string
+  url: string
+  unit: string
+  dateRange: {
+    from: string
+    to: string
+  }
+  currency: string
+  mode: string
+  totalCosts: number
+  totalTMSavings: number
+  totalPreTranslated: number
+  data: Array<{
+    user: {
+      id: number
+      username: string
+      fullName: string
+      userRole: string
+      avatarUrl: string
+      preTranslated: number
+      totalCosts: number
+    }
+    languages: Array<{
+      language: {
+        id: string
+        name: string
+        userRole: string
+        tmSavings: number
+        preTranslate: number
+        totalCosts: number
+      }
+      translated: TranslatedStats
+      targetTranslated: TranslatedStats
+      translatedByMt: TranslatedStats
+      approved: TranslatedStats
+      translationCosts: TranslatedStats
+      approvalCosts: TranslatedStats
+    }>
+  }>
 }

--- a/src/pages/contributing/translation-program/contributors.tsx
+++ b/src/pages/contributing/translation-program/contributors.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from "next/router"
 import { GetStaticProps } from "next/types"
-import { SSRConfig, useTranslation } from "next-i18next"
+import { useTranslation } from "next-i18next"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import {
   Box,
@@ -12,7 +12,7 @@ import {
   UnorderedList,
 } from "@chakra-ui/react"
 
-import { BasePageProps } from "@/lib/types"
+import { AllTimeData, BasePageProps, Unpacked } from "@/lib/types"
 
 import Breadcrumbs from "@/components/Breadcrumbs"
 import FeedbackCard from "@/components/FeedbackCard"
@@ -28,8 +28,11 @@ import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 
 import allTimeData from "../../../data/translation-reports/alltime/alltime-data.json"
 
-type Props = SSRConfig & {
-  lastDeployDate: string
+type TranslatorDataType = {
+  user: {
+    username: Unpacked<AllTimeData["data"]>["user"]["username"]
+    fullName: Unpacked<AllTimeData["data"]>["user"]["fullName"]
+  }
 }
 
 export const getStaticProps = (async ({ locale }) => {
@@ -65,39 +68,38 @@ const Contributors = () => {
   const router = useRouter()
 
   // TODO: Remove specific user checks once Acolad has updated their usernames
-  const translatorData =
-    allTimeData.data.flatMap(
-      // use flatMap to get cleaner object types withouts nulls
-      (item) => {
-        const user = item?.user
-        if (!user) return []
+  const translatorData = (
+    allTimeData as AllTimeData
+  ).data.flatMap<TranslatorDataType>(
+    // use flatMap to get cleaner object types withouts nulls
+    (item) => {
+      const user = item.user
 
-        const userName = user.username
-        if (!userName) return []
+      const userName = user.username
 
-        const fullName = user.fullName ?? ""
+      const fullName = user.fullName
 
-        return userName !== "ethdotorg" &&
-          !userName.includes("LQS_") &&
-          !userName.includes("REMOVED_USER") &&
-          !userName.includes("Aco_") &&
-          !fullName.includes("Aco_") &&
-          !userName.includes("Acc_") &&
-          !fullName.includes("Acc_") &&
-          userName !== "Finnish_Sandberg" &&
-          userName !== "Norwegian_Sandberg" &&
-          userName !== "Swedish_Sandberg"
-          ? [
-              {
-                user: {
-                  username: userName,
-                  fullName: fullName,
-                },
+      return userName !== "ethdotorg" &&
+        !userName.includes("LQS_") &&
+        !userName.includes("REMOVED_USER") &&
+        !userName.includes("Aco_") &&
+        !fullName.includes("Aco_") &&
+        !userName.includes("Acc_") &&
+        !fullName.includes("Acc_") &&
+        userName !== "Finnish_Sandberg" &&
+        userName !== "Norwegian_Sandberg" &&
+        userName !== "Swedish_Sandberg"
+        ? [
+            {
+              user: {
+                username: userName,
+                fullName: fullName,
               },
-            ]
-          : []
-      }
-    ) ?? []
+            },
+          ]
+        : []
+    }
+  )
 
   return (
     <Flex direction="column" align="center" w="full">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Currently in the `Contributors` page,  there is a flatmap using the `allTimeData` json to create a simplified array of translator info `translatorData`. 

A type error currently throws: `Property 'data' does not exist on type '{}'`

This is because a type is not being inferred for the json file and is only providing an empty object.

This PR creates the shape for this data structure so there is type safety in the flatmap.

The shape was generated using [Transform Web Converter App](https://transform.tools/json-to-typescript) and double-checked for any undefined fields with the data used.

According to the shape generated, there should be no fields in the JSON structure that would be undefined or null.

<!--- Describe your changes in detail -->

## Related Issue
N/A

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
