### PR TITLE
Workdround for brave i18 redirection [Fixes #12027]

### DIFF
--- a/i18n.config.json
+++ b/i18n.config.json
@@ -344,17 +344,17 @@
     "dateFormat": "MM/DD/YYYY"
   },
   {
-    "code": "pt",
-    "crowdinCode": "pt-PT",
-    "name": "Portuguese",
+    "code": "pt-br",
+    "crowdinCode": "pt-BR",
+    "name": "Portuguese (Brazilian)",
     "localName": "Português",
     "langDir": "ltr",
     "dateFormat": "MM/DD/YYYY"
   },
   {
-    "code": "pt-br",
-    "crowdinCode": "pt-BR",
-    "name": "Portuguese (Brazilian)",
+    "code": "pt",
+    "crowdinCode": "pt-PT",
+    "name": "Portuguese",
     "localName": "Português",
     "langDir": "ltr",
     "dateFormat": "MM/DD/YYYY"
@@ -480,18 +480,18 @@
     "dateFormat": "MM/DD/YYYY"
   },
   {
-    "code": "zh",
-    "crowdinCode": "zh-CN",
-    "name": "Chinese Simplified",
-    "localName": "简体中文",
-    "langDir": "ltr",
-    "dateFormat": "YYYY-MM-DD"
-  },
-  {
     "code": "zh-tw",
     "crowdinCode": "zh-TW",
     "name": "Chinese Traditional",
     "localName": "繁體中文",
+    "langDir": "ltr",
+    "dateFormat": "YYYY-MM-DD"
+  },
+  {
+    "code": "zh",
+    "crowdinCode": "zh-CN",
+    "name": "Chinese Simplified",
+    "localName": "简体中文",
     "langDir": "ltr",
     "dateFormat": "YYYY-MM-DD"
   }


### PR DESCRIPTION
[Bug report: Region-specific browser language preferences are being ignored #12027] is caused by only Brave browser specific i18 redirection.

## Description

Only changing of the JSON array order can suppress the bug.

## Related Issue

#12027
