### PR TITLE
Unify GH tokens

### DIFF
--- a/docs/api-keys.md
+++ b/docs/api-keys.md
@@ -11,7 +11,7 @@ We recommend setting this up when running the project locally, as we use the Git
 
 ```sh
 # .env Example:
-GITHUB_TOKEN_READ_ONLY=48f84de812090000demo00000000697cf6e6a059
+NEXT_PUBLIC_GITHUB_TOKEN_READ_ONLY=48f84de812090000demo00000000697cf6e6a059
 ```
 
 2. Add Etherscan API token (free)

--- a/src/lib/api/ghRepoData.ts
+++ b/src/lib/api/ghRepoData.ts
@@ -93,7 +93,8 @@ const frameworksList: Array<Framework> = [
     githubUrl: "https://github.com/scaffold-eth/scaffold-eth-2",
     background: "#ffffff",
     name: "Scaffold-ETH-2",
-    description: "page-developers-local-environment:page-local-environment-scaffold-eth-desc",
+    description:
+      "page-developers-local-environment:page-local-environment-scaffold-eth-desc",
     alt: "page-local-environment-scaffold-eth-logo-alt",
     image: ScaffoldEthImage,
   },
@@ -129,7 +130,7 @@ export const ghRepoData = async (githubUrl: string) => {
     `https://api.github.com/repos/${repoOwner}/${repoName}`,
     {
       headers: {
-        Authorization: `Bearer ${process.env.GITHUB_TOKEN_READ_ONLY}`,
+        Authorization: `Bearer ${process.env.NEXT_PUBLIC_GITHUB_TOKEN_READ_ONLY}`,
       },
     }
   )
@@ -144,7 +145,7 @@ export const ghRepoData = async (githubUrl: string) => {
     `https://api.github.com/repos/${repoOwner}/${repoName}/languages`,
     {
       headers: {
-        Authorization: `Bearer ${process.env.GITHUB_TOKEN_READ_ONLY}`,
+        Authorization: `Bearer ${process.env.NEXT_PUBLIC_GITHUB_TOKEN_READ_ONLY}`,
       },
     }
   )


### PR DESCRIPTION
## Description

This PR simplifies the GH tokens we currently use for the site. Instead of having 2 tokens, it uses just one for all the GH calls we need to make.

- Removes the `GITHUB_TOKEN_READ_ONLY` env var
- Refactor the code to use `NEXT_PUBLIC_GITHUB_TOKEN_READ_ONLY` instead.

Both tokens were of the same type, Github read-only tokens. These were used to fetch commits for a given file and to fetch metadata from repos (star count, programming langs, etc).
