### PR TITLE
fixed POAP logo render

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Learn more about how we review pull requests [here](docs/review-process.md).
 
 <hr style="margin-top: 3em; margin-bottom: 3em;">
 
-![POAP Logo](src/assets/poap-logo.svg)
+![POAP Logo](public/poap-logo.svg)
 
 ## Claim your POAP!
 


### PR DESCRIPTION
The POAP logo path was wrong, upon going through the files, I figured out the right path and changed it.

## Description:
Changed the poap-logo.svg path from "src/assets/poap-logo.svg" to "public/poap-logo.svg"
<img width="439" alt="Screenshot 2024-01-31 at 3 11 51 PM" src="https://github.com/ethereum/ethereum-org-website/assets/132053521/a8b185c6-9ad9-46af-a3ca-ba4c407ec784">

## Issue:
Issue - "Missing Images in README.md File #12068"
Link - https://github.com/ethereum/ethereum-org-website/issues/12068