### PR TITLE
refactor:  Delete React.FC in sample code because of code-conventions change

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -83,9 +83,9 @@ Markdown will be translated as whole pages of content, so no specific action is 
 
 ```tsx
 // Example
-import React, { useState, useEffect } from "react"
+import React, { useState, useEffect} from "react"
 
-const ComponentName: React.FC = (props) => {
+const ComponentName = () => {
   // useState hook for managing state variables
   const [greeting, setGreeting] = useState("")
 


### PR DESCRIPTION
Delete React.FC in sample code because of code-conventions change

## Description

Delete React.FC in sample code because of code-conventions change 
https://github.com/ethereum/ethereum-org-website/blob/dev/docs/code-conventions.md#directly-annotate-the-props-object

## Related Issue
Related PR
https://github.com/ethereum/ethereum-org-website/pull/12014