### PR TITLE
Fix/dev docs prev and next link 

### DIFF
--- a/src/components/DocsNav.tsx
+++ b/src/components/DocsNav.tsx
@@ -137,7 +137,7 @@ const DocsNav = ({ contentNotTranslated }: DocsNavProps) => {
   }
 
   // Extract previous and next doc based on current index +/- 1
-  const previousDoc = currentIndex - 1 > 0 ? docsArray[currentIndex - 1] : null
+  const previousDoc = currentIndex - 1 >= 0 ? docsArray[currentIndex - 1] : null
   const nextDoc =
     currentIndex + 1 < docsArray.length ? docsArray[currentIndex + 1] : null
 

--- a/src/components/DocsNav.tsx
+++ b/src/components/DocsNav.tsx
@@ -128,7 +128,10 @@ const DocsNav = ({ contentNotTranslated }: DocsNavProps) => {
   // Find index that matches current page
   let currentIndex = 0
   for (let i = 0; i < docsArray.length; i++) {
-    if (asPath.indexOf(docsArray[i].to) > -1) {
+    if (
+      asPath.indexOf(docsArray[i].to) > -1 &&
+      asPath.length === docsArray[i].to.length
+    ) {
       currentIndex = i
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I rechecked the 2 values captured with the `indexOf` method according to their lengths and the error was solved.

I changed the `> 0` query that causes skipping the first page when showing the previous page.

<!--- Describe your changes in detail -->

## Related Issue

- #12080 

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
