### PR TITLE
fix: update page edit path logic [Fixes #11994]

### DIFF
--- a/src/lib/utils/editPath.ts
+++ b/src/lib/utils/editPath.ts
@@ -2,4 +2,7 @@ import { join } from 'path'
 
 import { CONTENT_DIR, EDIT_CONTENT_URL } from '@/lib/constants'
 
-export const getEditPath = (relativePath: string): string => join(EDIT_CONTENT_URL, CONTENT_DIR, relativePath, "index.md")
+export const getEditPath = (relativePath: string): string => {
+  const { href } = new URL(join(CONTENT_DIR, relativePath, "index.md"), EDIT_CONTENT_URL)
+  return href
+}


### PR DESCRIPTION
## Description
Updates construction of the "edit path" url to use `new URL()` when adding the base path. Current production uses `join` which collapses the repeated slashes in `https://` and causes broken paths. 

## Related Issue
- Fixes #11994