### PR TITLE
Fix #12101: Bug: missing space in history entries

### DIFF
--- a/src/components/History/NetworkUpgradeSummary.tsx
+++ b/src/components/History/NetworkUpgradeSummary.tsx
@@ -52,7 +52,7 @@ const NetworkUpgradeSummary = ({ name }: NetworkUpgradeSummaryProps) => {
         <Emoji fontSize="sm" me={2} text=":bricks:" />
         {t(translationKey)}:{" "}
         <InlineLink to={`${explorerUrl}${number}`}>
-          {new Intl.NumberFormat(localeForStatsBoxNumbers).format(number)}
+          <span style={{ marginLeft: '4px' }}>{new Intl.NumberFormat(localeForStatsBoxNumbers).format(number)}</span>
         </InlineLink>
       </Flex>
     )

--- a/src/components/History/NetworkUpgradeSummary.tsx
+++ b/src/components/History/NetworkUpgradeSummary.tsx
@@ -48,11 +48,11 @@ const NetworkUpgradeSummary = ({ name }: NetworkUpgradeSummaryProps) => {
 
   const blockTypeTranslation = (translationKey, explorerUrl, number) => {
     return (
-      <Flex>
+      <Flex whiteSpace='pre-wrap'>
         <Emoji fontSize="sm" me={2} text=":bricks:" />
         {t(translationKey)}:{" "}
         <InlineLink to={`${explorerUrl}${number}`}>
-          <span style={{ marginLeft: '4px' }}>{new Intl.NumberFormat(localeForStatsBoxNumbers).format(number)}</span>
+         {new Intl.NumberFormat(localeForStatsBoxNumbers).format(number)}
         </InlineLink>
       </Flex>
     )


### PR DESCRIPTION
## Description
Hello,
Since there was no space before the **block/epoch/slot** values for each entry on the _/history_ page, I add a span tag for the corresponding value with **marginLeft** style property, having value of 4px.
With these code changes in place, there has been decent space added before the values on the history page.
I hope these code changes meet the requirements asked.
If at all there are any changes required, then do let me know about the same.

Issue: #12101