### PR TITLE
add ValleyDAO to desci page

### DIFF
--- a/public/content/desci/index.md
+++ b/public/content/desci/index.md
@@ -112,6 +112,7 @@ Explore projects and join the DeSci community.
 - [CureDAO: Community-Owned Precision Health Platform](https://docs.curedao.org/)
 - [IdeaMarkets: enabling decentralized scientific credibility](https://ideamarket.io/)
 - [DeSci Labs](https://www.desci.com/)
+- [ValleyDAO: an open, global community offering funding and translational support for synthetic biology research](https://www.valleydao.bio)
 
 We welcome suggestions for new projects to list - please look at our [listing policy](/contributing/adding-desci-projects/) to get started!
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add ValleyDAO to desci page

## Description

<!--- Describe your changes in detail -->

User @SeaBlue22 requested for their page [ValleyDAO](https://www.valleydao.bio) to be added to the [Ethereum.org Desci page](https://ethereum.org/en/desci). As per there request I have added the link to the page in case their request is to be approved. Disregard this PR if not, just wanted to provide a quick fix in case it was needed.

## Related Issue

This PR closes #12105 

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
