### PR TITLE
Add community education resources to EIPs page

### DIFF
--- a/public/content/eips/index.md
+++ b/public/content/eips/index.md
@@ -56,7 +56,7 @@ If you’re interested to read more about EIPs, check out the [EIPs website](htt
 
 ### Official EIP resources
 
-- [A list of every EIP](https://eips.ethereum.org/all)
+- [A list of every Ethereum Improvement Proposal](https://eips.ethereum.org)
 - [A description of all EIP types](https://eips.ethereum.org/EIPS/eip-1#eip-types)
 - [A description of all EIP statuses](https://eips.ethereum.org/EIPS/eip-1#eip-process)
 

--- a/public/content/eips/index.md
+++ b/public/content/eips/index.md
@@ -54,16 +54,14 @@ Full standardization process alongside with chart is described in [EIP-1](https:
 
 If you’re interested to read more about EIPs, check out the [EIPs website](https://eips.ethereum.org/) and [EIP-1](https://eips.ethereum.org/EIPS/eip-1). Here are some useful links:
 
-### Official EIP resources
-
-- [A list of every Ethereum Improvement Proposal](https://eips.ethereum.org)
+- [A list of every Ethereum Improvement Proposal](https://eips.ethereum.org/all)
 - [A description of all EIP types](https://eips.ethereum.org/EIPS/eip-1#eip-types)
 - [A description of all EIP statuses](https://eips.ethereum.org/EIPS/eip-1#eip-process)
 
 ### Community education projects {#community-projects}
 
-- [EIPs For Nerds](https://ethereum2077.substack.com/t/eip-research) — *EIPs For Nerds provides comprhensive, ELI5-style overviews of various Ethereum Improvement Proposals (EIPs), including core EIPs and application/infrastructure-layer EIPs (ERCs), to educate readers and shape consensus around proposed changes to the Ethereum protocol.* 
 - [PEEPanEIP](https://www.youtube.com/playlist?list=PL4cwHXAawZxqu0PKKyMzG_3BJV_xZTi1F) — *PEEPanEIP is an educational video series that discusses Ethereum Improvement Proposal (EIPs) and key features of upcoming upgrades.*
+- [EIPs For Nerds](https://ethereum2077.substack.com/t/eip-research) — *EIPs For Nerds provides comprehensive, ELI5-style overviews of various Ethereum Improvement Proposals (EIPs), including core EIPs and application/infrastructure-layer EIPs (ERCs), to educate readers and shape consensus around proposed changes to the Ethereum protocol.* 
 - [EIPs.wtf](https://www.eips.wtf/) — *EIPs.wtf provides extra information for Ethereum Improvement Proposals (EIPs), including their status, implementation details, related pull requests, and community feedback.* 
 - [EIP.Fun](https://eipfun.substack.com/) — *EIP.Fun provides the latest news on Ethereum Improvement Proposals (EIPs), updates on EIP meetings, and more.*
 - [EIPs Insight](https://eipsinsight.com/) — *EIPs Insight is a representation of state of Ethereum Improvement Proposals (EIPs) process & statistics as per information collected from different resoucrces.*

--- a/public/content/eips/index.md
+++ b/public/content/eips/index.md
@@ -60,7 +60,8 @@ If you’re interested to read more about EIPs, check out the [EIPs website](htt
 - [A description of all EIP types](https://eips.ethereum.org/EIPS/eip-1#eip-types)
 - [A description of all EIP statuses](https://eips.ethereum.org/EIPS/eip-1#eip-process)
 
-### Community education projects
+### Community education projects {#community-projects}
+
 - [EIPs For Nerds](https://ethereum2077.substack.com/t/eip-research) — *EIPs For Nerds provides comprhensive, ELI5-style overviews of various Ethereum Improvement Proposals (EIPs), including core EIPs and application/infrastructure-layer EIPs (ERCs), to educate readers and shape consensus around proposed changes to the Ethereum protocol.* 
 - [PEEPanEIP](https://www.youtube.com/playlist?list=PL4cwHXAawZxqu0PKKyMzG_3BJV_xZTi1F) — *PEEPanEIP is an educational video series that discusses Ethereum Improvement Proposal (EIPs) and key features of upcoming upgrades.*
 - [EIPs.wtf](https://www.eips.wtf/) — *EIPs.wtf provides extra information for Ethereum Improvement Proposals (EIPs), including their status, implementation details, related pull requests, and community feedback.* 

--- a/public/content/eips/index.md
+++ b/public/content/eips/index.md
@@ -54,9 +54,18 @@ Full standardization process alongside with chart is described in [EIP-1](https:
 
 If you’re interested to read more about EIPs, check out the [EIPs website](https://eips.ethereum.org/) and [EIP-1](https://eips.ethereum.org/EIPS/eip-1). Here are some useful links:
 
+### Official EIP resources
+
 - [A list of every EIP](https://eips.ethereum.org/all)
 - [A description of all EIP types](https://eips.ethereum.org/EIPS/eip-1#eip-types)
 - [A description of all EIP statuses](https://eips.ethereum.org/EIPS/eip-1#eip-process)
+
+### Community education projects
+- [EIPs For Nerds](https://ethereum2077.substack.com/t/eip-research) — *EIPs For Nerds provides comprhensive, ELI5-style overviews of various Ethereum Improvement Proposals (EIPs), including core EIPs and application/infrastructure-layer EIPs (ERCs), to educate readers and shape consensus around proposed changes to the Ethereum protocol.* 
+- [PEEPanEIP](https://www.youtube.com/playlist?list=PL4cwHXAawZxqu0PKKyMzG_3BJV_xZTi1F) — *PEEPanEIP is an educational video series that discusses Ethereum Improvement Proposal (EIPs) and key features of upcoming upgrades.*
+- [EIPs.wtf](https://www.eips.wtf/) — *EIPs.wtf provides extra information for Ethereum Improvement Proposals (EIPs), including their status, implementation details, related pull requests, and community feedback.* 
+- [EIP.Fun](https://eipfun.substack.com/) — *EIP.Fun provides the latest news on Ethereum Improvement Proposals (EIPs), updates on EIP meetings, and more.*
+- [EIPs Insight](https://eipsinsight.com/) — *EIPs Insight is a representation of state of Ethereum Improvement Proposals (EIPs) process & statistics as per information collected from different resoucrces.*
 
 ## Participate {#participate}
 


### PR DESCRIPTION
- Added community education projects working to increase awareness of Ethereum Improvement Proposals (EIPs) since the page only lists official resources from eips.ethereum.org
- Split resources into two sections to keep the page's original structure (where resources from eips.ethereum.org are listed first) and to distinguish from authoritative sources from other places readers can visit to learn more about the EIP ecosystem


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added a section on official EIP resources to the index page.
	- Introduced a new section on community education projects related to EIPs, including links and descriptions.
	- Updated the structure and content organization of the EIPs index page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->