### PR TITLE
[fix] rename footer hyperlink

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -284,7 +284,7 @@ const Footer = ({ lastDeployDate }: FooterProps) => {
         },
         {
           to: "mailto:press@ethereum.org",
-          text: t("contact"),
+          text: t("press-contact"),
         },
       ],
     },

--- a/src/intl/en/common.json
+++ b/src/intl/en/common.json
@@ -157,6 +157,7 @@
   "page-last-updated": "Page last updated",
   "pbs": "Proposer-builder separation",
   "pools": "Pooled staking",
+  "press-contact": "Press Contact",
   "privacy-policy": "Privacy policy",
   "private-ethereum": "Private Ethereum",
   "product-disclaimer": "Products and services are listed as a convenience for the Ethereum community. Inclusion of a product or service <strong>does not represent an endorsement</strong> from the ethereum.org website team, or the Ethereum Foundation.",


### PR DESCRIPTION
## Description
fixes #12138 
In the footer, renamed `Contact` into `Press Contact`, keeping the current mailto [[press@ethereum.org](mailto:press@ethereum.org)].
