### PR TITLE
fix: removed skiff (defunct and shutting down in 6 months)

### DIFF
--- a/src/pages/dapps.tsx
+++ b/src/pages/dapps.tsx
@@ -101,7 +101,6 @@ import rotki from "@/public/dapps/rotki.png"
 import rubic from "@/public/dapps/rubic.png"
 import sablier from "@/public/dapps/sablier.png"
 import set from "@/public/dapps/set.png"
-import skiff from "@/public/dapps/skiff.png"
 import spatial from "@/public/dapps/spatial.png"
 import spruce from "@/public/dapps/spruce.png"
 import dai from "@/public/dapps/stabledai.png"
@@ -1138,13 +1137,6 @@ const DappsPage = () => {
       link: "https://xmtp.org/",
       image: xmtp,
       alt: t("page-dapps-xmtp-logo-alt"),
-    },
-    {
-      title: "Skiff",
-      description: t("page-dapps-dapp-description-skiff"),
-      link: "https://skiff.com/",
-      image: skiff,
-      alt: t("page-dapps-skiff-logo-alt"),
     },
   ]
 


### PR DESCRIPTION
Skiff is defunct and shutting down in 6 months, this PR removes it.

https://skiff.com/data-migration