### PR TITLE
Update eth2book link

### DIFF
--- a/public/content/developers/docs/consensus-mechanisms/pos/attestations/index.md
+++ b/public/content/developers/docs/consensus-mechanisms/pos/attestations/index.md
@@ -87,6 +87,6 @@ Note that in some cases a lucky aggregator may also become the block proposer. I
 ## Further reading {#further-reading}
 
 - [Attestations in Vitalik's annotated consensus spec](https://github.com/ethereum/annotated-spec/blob/master/phase0/beacon-chain.md#attestationdata)
-- [Attestations in eth2book.info](https://eth2book.info/altair/part3/containers/dependencies#attestationdata)
+- [Attestations in eth2book.info](https://eth2book.info/capella/part3/containers/dependencies/#attestationdata)
 
 _Know of a community resource that helped you? Edit this page and add it!_


### PR DESCRIPTION
When you go to the book's current link, it says this version is old and provides a newer version link so it is updated to the newer version.

<!--- Provide a general summary of your changes in the Title above -->

## Description

When you go to the current link, it has a warning at the top of the page:
<!--- Describe your changes in detail -->
<img width="600" alt="Screenshot 2024-02-10 at 16 23 11" src="https://github.com/ethereum/ethereum-org-website/assets/9151261/598aeeeb-fef3-4835-b90a-16a1b812a034">



## Related Issue 
Fixes #12144

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
