### PR TITLE
fix: README logo image src path

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![gitpoap badge](https://public-api.gitpoap.io/v1/repo/ethereum/ethereum-org-website/badge)](https://www.gitpoap.io/gh/ethereum/ethereum-org-website)
 
 <div align="center" style="margin-top: 1em; margin-bottom: 3em;">
-  <a href="https://ethereum.org"><img alt="ethereum logo" src="./eth-transparent.png" alt="ethereum.org" width="125"></a>
+  <a href="https://ethereum.org"><img alt="ethereum logo" src="./public/assets/eth-transparent.png" alt="ethereum.org" width="125"></a>
   <h1>👋 Welcome to ethereum.org!</h1>
 </div>
 


### PR DESCRIPTION
## Description
- Adds `public/assets/` to the src path for the logo in repo README

<img width="1361" alt="image" src="https://github.com/ethereum/ethereum-org-website/assets/54227730/99da9a92-470b-46f9-990f-9d46cd331b10">


## Related Issue
<img width="935" alt="image" src="https://github.com/ethereum/ethereum-org-website/assets/54227730/5933928c-e763-4e0b-86b5-4171e3924426">
