### PR TITLE
Fix fallback for locale display names

### DIFF
--- a/src/components/LanguagePicker/useLanguagePicker.tsx
+++ b/src/components/LanguagePicker/useLanguagePicker.tsx
@@ -71,8 +71,14 @@ export const useLanguagePicker = (
       const fallbackSource =
         intlSource !== localeOption ? intlSource : englishName
       const i18nKey = "language-" + localeOption.toLowerCase()
-      const i18nSource = t(i18nKey)
-      const sourceName = i18nSource === i18nKey ? fallbackSource : i18nSource
+      const i18nSource = t(i18nKey) // Falls back to English namespace if not found
+
+      // If i18nSource (fetched from `language-{locale}` in current namespace)
+      // is not translated (output === englishName), or not available
+      // (output === i18nKey), use the Intl.DisplayNames result as fallback
+      const sourceName = [i18nKey, englishName].includes(i18nSource)
+        ? fallbackSource
+        : i18nSource
 
       // Get "target" display name (Language choice displayed in that language)
       const fallbackTarget = new Intl.DisplayNames([localeOption], {

--- a/src/intl/ar/page-languages.json
+++ b/src/intl/ar/page-languages.json
@@ -23,7 +23,6 @@
   "langauge-be": "البيلاروسية",
   "language-bg": "البلغارية",
   "language-bn": "البنغالية",
-  "language-bs": "",
   "language-ca": "الكتالونية",
   "language-cs": "التشيكية",
   "language-da": "الدانماركية",

--- a/src/intl/fa/page-languages.json
+++ b/src/intl/fa/page-languages.json
@@ -17,7 +17,6 @@
   "page-languages-translated": "ترجمه‌شده",
   "page-languages-words": "کلمات",
   "page-languages-recruit-community": "به ما در ترجمه ethereum.org کمک کنید.",
-  "langauge-am": "",
   "language-ar": "عربی",
   "language-az": "آذربایجانی",
   "langauge-be": "بلاروسی",

--- a/src/intl/fil/page-languages.json
+++ b/src/intl/fil/page-languages.json
@@ -17,7 +17,6 @@
   "page-languages-translated": "naisalin",
   "page-languages-words": "mga salita",
   "page-languages-recruit-community": "Tulungan kaming isalin ang ethereum.org.",
-  "langauge-am": "",
   "language-ar": "Arabic",
   "language-az": "Azerbaijani",
   "langauge-be": "Belarusian",

--- a/src/intl/sl/common.json
+++ b/src/intl/sl/common.json
@@ -164,7 +164,6 @@
   "search-box-blank-state-text": "Začnite iskati!",
   "search-eth-address": "To je videti kot naslov Ethereum. Ne zagotavljamo podatkov za posamezne naslove. Poskusite ga poiskati v pregledovalniku blokov, kot je",
   "search-no-results": "Ni rezultatov iskanja",
-  "single-slot-finality": "",
   "statelessness": "Brezdomovinstvo",
   "see-contributors": "Pokaži sodelavce",
   "set-up-local-env": "Nastavitev lokalnega okolja",

--- a/src/intl/uk/page-languages.json
+++ b/src/intl/uk/page-languages.json
@@ -55,7 +55,6 @@
   "language-mr": "Маратхі",
   "language-ms": "Малайзійська",
   "language-nb": "Норвезька",
-  "language-ne-np": "",
   "language-nl": "Нідерландська",
   "language-pcm": "Нігерійський піджин",
   "language-fil": "Філіппінська",


### PR DESCRIPTION
## Description
- Removes all empty strings from the `intl` folder (will fallback to English string)
- Improve check inside `useLanguagePicker` to check if we have an internal translation available or not
  If the output of `t()` matches the English name _or_ the i18n key, then this string isn't available internally and Intl.DisplayNames used as fallback to display the locale name. 