### PR TITLE
refactor: useLanguagePicker warning and fallback

### DIFF
--- a/src/components/LanguagePicker/useLanguagePicker.tsx
+++ b/src/components/LanguagePicker/useLanguagePicker.tsx
@@ -108,8 +108,23 @@ export const useLanguagePicker = (
               (dataItem!.words.approved / dataItem!.words.total) * 100
             ) || 0
 
-      if (progressData.length === 0) {
-        console.warn("Missing translation progress data; check GitHub action")
+      const isBrowserDefault = browserLocales.includes(localeOption)
+
+      const returnData: Partial<LocaleDisplayInfo> = {
+        localeOption,
+        sourceName: sourceName ?? localeOption,
+        targetName: targetName ?? localeOption,
+        englishName,
+        isBrowserDefault,
+      }
+
+      if (progressData.length < 1) {
+        console.warn(`Missing translation progress data; check GitHub action`)
+        return {
+          ...returnData,
+          approvalProgress: 0,
+          wordsApproved: 0,
+        } as LocaleDisplayInfo
       }
 
       const totalWords = progressData[0].words.total
@@ -119,17 +134,11 @@ export const useLanguagePicker = (
           ? totalWords || 0
           : dataItem?.words.approved || 0
 
-      const isBrowserDefault = browserLocales.includes(localeOption)
-
       return {
-        localeOption,
+        ...returnData,
         approvalProgress,
-        sourceName: sourceName ?? "",
-        targetName: targetName ?? "",
-        englishName,
         wordsApproved,
-        isBrowserDefault,
-      }
+      } as LocaleDisplayInfo
     }
 
     const displayNames: LocaleDisplayInfo[] =

--- a/src/components/LanguagePicker/useLanguagePicker.tsx
+++ b/src/components/LanguagePicker/useLanguagePicker.tsx
@@ -88,9 +88,11 @@ export const useLanguagePicker = (
       const targetName = i18nConfigTarget || fallbackTarget
 
       if (!sourceName || !targetName) {
-        throw new Error(
-          "Missing language display name, locale: " + localeOption
-        )
+        console.warn("Missing language display name:", {
+          localeOption,
+          sourceName,
+          targetName,
+        })
       }
 
       // English will not have a dataItem
@@ -106,10 +108,9 @@ export const useLanguagePicker = (
               (dataItem!.words.approved / dataItem!.words.total) * 100
             ) || 0
 
-      if (progressData.length === 0)
-        throw new Error(
-          "Missing translation progress data; check GitHub action"
-        )
+      if (progressData.length === 0) {
+        console.warn("Missing translation progress data; check GitHub action")
+      }
 
       const totalWords = progressData[0].words.total
 
@@ -123,8 +124,8 @@ export const useLanguagePicker = (
       return {
         localeOption,
         approvalProgress,
-        sourceName,
-        targetName,
+        sourceName: sourceName ?? "",
+        targetName: targetName ?? "",
         englishName,
         wordsApproved,
         isBrowserDefault,


### PR DESCRIPTION
## Description
- Update `useLanguagePicker.tsx` to remove error throwing when a source or target locale display name is not found
- Adds `console.warn` instead, and adds an empty string fallback to ensure values are never `undefined`

## Related Issue
- https://github.com/ethereum/ethereum-org-website/pull/12204#pullrequestreview-1885619513
