### PR TITLE
chore: use `href` instead of deprecated `to` prop in InlineLink usage

### DIFF
--- a/src/components/CommunityEvents/index.tsx
+++ b/src/components/CommunityEvents/index.tsx
@@ -1,7 +1,3 @@
-import { DateTime, DateTimeFormatOptions } from "luxon"
-import { useRouter } from "next/router"
-import { useTranslation } from "next-i18next"
-import { FaDiscord } from "react-icons/fa"
 import {
   Box,
   Center,
@@ -11,6 +7,10 @@ import {
   GridItem,
   Icon,
 } from "@chakra-ui/react"
+import { DateTime, DateTimeFormatOptions } from "luxon"
+import { useTranslation } from "next-i18next"
+import { useRouter } from "next/router"
+import { FaDiscord } from "react-icons/fa"
 
 import type { CommunityEvent } from "@/lib/interfaces"
 
@@ -67,7 +67,7 @@ const Event = ({ event, language, type }: EventProps) => {
         </Text>
       </GridItem>
       <GridItem>
-        <InlineLink to={calendarLink} onClick={() => matomoEvent(type)}>
+        <InlineLink href={calendarLink} onClick={() => matomoEvent(type)}>
           {title}
         </InlineLink>
       </GridItem>

--- a/src/components/CommunityEvents/index.tsx
+++ b/src/components/CommunityEvents/index.tsx
@@ -1,3 +1,7 @@
+import { DateTime, DateTimeFormatOptions } from "luxon"
+import { useRouter } from "next/router"
+import { useTranslation } from "next-i18next"
+import { FaDiscord } from "react-icons/fa"
 import {
   Box,
   Center,
@@ -7,10 +11,6 @@ import {
   GridItem,
   Icon,
 } from "@chakra-ui/react"
-import { DateTime, DateTimeFormatOptions } from "luxon"
-import { useTranslation } from "next-i18next"
-import { useRouter } from "next/router"
-import { FaDiscord } from "react-icons/fa"
 
 import type { CommunityEvent } from "@/lib/interfaces"
 

--- a/src/components/FileContributors.tsx
+++ b/src/components/FileContributors.tsx
@@ -1,18 +1,18 @@
-import { useState } from "react"
-import { useRouter } from "next/router"
 import {
   Avatar,
+  Skeleton as ChakraSkeleton,
+  SkeletonCircle as ChakraSkeletonCircle,
   Flex,
   FlexProps,
   Heading,
   ListItem,
   ModalBody,
   ModalHeader,
-  Skeleton as ChakraSkeleton,
-  SkeletonCircle as ChakraSkeletonCircle,
   UnorderedList,
   VStack,
 } from "@chakra-ui/react"
+import { useRouter } from "next/router"
+import { useState } from "react"
 
 import type { Author, Lang } from "@/lib/types"
 
@@ -60,7 +60,7 @@ const Contributor = ({ contributor }: { contributor: Author }) => {
         me={2}
       />
       {contributor.user && (
-        <InlineLink to={contributor.user.url}>
+        <InlineLink href={contributor.user.url}>
           @{contributor.user.login}
         </InlineLink>
       )}
@@ -147,7 +147,7 @@ const FileContributors = ({
             <Text m={0} color="text200">
               <Translation id="last-edit" />:{" "}
               {lastContributor.user && (
-                <InlineLink to={lastContributor.user.url}>
+                <InlineLink href={lastContributor.user.url}>
                   @{lastContributor.user.login}
                 </InlineLink>
               )}

--- a/src/components/FileContributors.tsx
+++ b/src/components/FileContributors.tsx
@@ -1,18 +1,18 @@
+import { useState } from "react"
+import { useRouter } from "next/router"
 import {
   Avatar,
-  Skeleton as ChakraSkeleton,
-  SkeletonCircle as ChakraSkeletonCircle,
   Flex,
   FlexProps,
   Heading,
   ListItem,
   ModalBody,
   ModalHeader,
+  Skeleton as ChakraSkeleton,
+  SkeletonCircle as ChakraSkeletonCircle,
   UnorderedList,
   VStack,
 } from "@chakra-ui/react"
-import { useRouter } from "next/router"
-import { useState } from "react"
 
 import type { Author, Lang } from "@/lib/types"
 

--- a/src/components/History/NetworkUpgradeSummary.tsx
+++ b/src/components/History/NetworkUpgradeSummary.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from "react"
-import { useRouter } from "next/router"
-import { useTranslation } from "next-i18next"
 import { Flex, Stack, Text } from "@chakra-ui/react"
+import { useTranslation } from "next-i18next"
+import { useRouter } from "next/router"
+import { useEffect, useState } from "react"
 
 import type { Lang } from "@/lib/types"
 
@@ -48,11 +48,11 @@ const NetworkUpgradeSummary = ({ name }: NetworkUpgradeSummaryProps) => {
 
   const blockTypeTranslation = (translationKey, explorerUrl, number) => {
     return (
-      <Flex whiteSpace='pre-wrap'>
+      <Flex whiteSpace="pre-wrap">
         <Emoji fontSize="sm" me={2} text=":bricks:" />
         {t(translationKey)}:{" "}
-        <InlineLink to={`${explorerUrl}${number}`}>
-         {new Intl.NumberFormat(localeForStatsBoxNumbers).format(number)}
+        <InlineLink href={`${explorerUrl}${number}`}>
+          {new Intl.NumberFormat(localeForStatsBoxNumbers).format(number)}
         </InlineLink>
       </Flex>
     )
@@ -97,7 +97,7 @@ const NetworkUpgradeSummary = ({ name }: NetworkUpgradeSummaryProps) => {
       {waybackLink && (
         <Flex>
           <Emoji fontSize="sm" me={2} text=":desktop_computer:" />
-          <InlineLink to={waybackLink}>
+          <InlineLink href={waybackLink}>
             {t("page-history:page-history-ethereum-org-wayback")}
           </InlineLink>
         </Flex>

--- a/src/components/History/NetworkUpgradeSummary.tsx
+++ b/src/components/History/NetworkUpgradeSummary.tsx
@@ -1,7 +1,7 @@
-import { Flex, Stack, Text } from "@chakra-ui/react"
-import { useTranslation } from "next-i18next"
-import { useRouter } from "next/router"
 import { useEffect, useState } from "react"
+import { useRouter } from "next/router"
+import { useTranslation } from "next-i18next"
+import { Flex, Stack, Text } from "@chakra-ui/react"
 
 import type { Lang } from "@/lib/types"
 

--- a/src/components/Layer2/Layer2Onboard.tsx
+++ b/src/components/Layer2/Layer2Onboard.tsx
@@ -1,6 +1,3 @@
-import { useState } from "react"
-import { StaticImageData } from "next/image"
-import { useTranslation } from "next-i18next"
 import {
   Box,
   chakra,
@@ -10,6 +7,9 @@ import {
   Stack,
   UnorderedList,
 } from "@chakra-ui/react"
+import { useTranslation } from "next-i18next"
+import { StaticImageData } from "next/image"
+import { useState } from "react"
 
 import type { ChildOnlyProp } from "@/lib/types"
 
@@ -240,7 +240,7 @@ const Layer2Onboard = ({
             <H4>{t("layer-2-onboard-wallet-title")}</H4>
             <Text>{t("layer-2-onboard-wallet-1")}</Text>
             <Text>
-              <InlineLink to="/bridges/">
+              <InlineLink href="/bridges/">
                 {t("layer-2-more-on-bridges")}
               </InlineLink>
             </Text>
@@ -269,7 +269,7 @@ const Layer2Onboard = ({
             <Text>{t("layer-2-onboard-exchange-1")}</Text>
             <Text>
               {t("layer-2-onboard-exchange-2")}{" "}
-              <InlineLink to="/wallets/find-wallet/">
+              <InlineLink href="/wallets/find-wallet/">
                 {t("layer-2-onboard-find-a-wallet")}
               </InlineLink>
             </Text>

--- a/src/components/Layer2/Layer2Onboard.tsx
+++ b/src/components/Layer2/Layer2Onboard.tsx
@@ -1,3 +1,6 @@
+import { useState } from "react"
+import { StaticImageData } from "next/image"
+import { useTranslation } from "next-i18next"
 import {
   Box,
   chakra,
@@ -7,9 +10,6 @@ import {
   Stack,
   UnorderedList,
 } from "@chakra-ui/react"
-import { useTranslation } from "next-i18next"
-import { StaticImageData } from "next/image"
-import { useState } from "react"
 
 import type { ChildOnlyProp } from "@/lib/types"
 

--- a/src/components/Layer2ProductCard.tsx
+++ b/src/components/Layer2ProductCard.tsx
@@ -1,7 +1,7 @@
 // Libraries
-import { Box, Center, Flex, Heading } from "@chakra-ui/react"
-import { useTranslation } from "next-i18next"
 import { StaticImageData } from "next/image"
+import { useTranslation } from "next-i18next"
+import { Box, Center, Flex, Heading } from "@chakra-ui/react"
 
 import { ButtonLink } from "@/components/Buttons"
 import { Image } from "@/components/Image"

--- a/src/components/Layer2ProductCard.tsx
+++ b/src/components/Layer2ProductCard.tsx
@@ -1,7 +1,7 @@
 // Libraries
-import { StaticImageData } from "next/image"
-import { useTranslation } from "next-i18next"
 import { Box, Center, Flex, Heading } from "@chakra-ui/react"
+import { useTranslation } from "next-i18next"
+import { StaticImageData } from "next/image"
 
 import { ButtonLink } from "@/components/Buttons"
 import { Image } from "@/components/Image"
@@ -83,17 +83,17 @@ const Layer2ProductCard = ({
           )}
         </Box>
         {bridge && (
-          <InlineLink to={bridge}>
+          <InlineLink href={bridge}>
             {name} {t("layer-2-bridge")}
           </InlineLink>
         )}
         {ecosystemPortal && (
-          <InlineLink to={ecosystemPortal}>
+          <InlineLink href={ecosystemPortal}>
             {name} {t("layer-2-ecosystem-portal")}
           </InlineLink>
         )}
         {tokenLists && (
-          <InlineLink to={tokenLists}>
+          <InlineLink href={tokenLists}>
             {name} {t("layer-2-token-lists")}
           </InlineLink>
         )}

--- a/src/components/MeetupList.tsx
+++ b/src/components/MeetupList.tsx
@@ -1,5 +1,3 @@
-import { useState } from "react"
-import { sortBy } from "lodash"
 import {
   Box,
   Flex,
@@ -11,6 +9,8 @@ import {
   useToken,
   VisuallyHidden,
 } from "@chakra-ui/react"
+import { sortBy } from "lodash"
+import { useState } from "react"
 
 import Emoji from "@/components/Emoji"
 import InfoBanner from "@/components/InfoBanner"
@@ -153,7 +153,7 @@ const MeetupList = () => {
         {!filteredMeetups.length && (
           <InfoBanner emoji=":information_source:">
             <Translation id="page-community-meetuplist-no-meetups" />{" "}
-            <InlineLink to="https://github.com/ethereum/ethereum-org-website/blob/dev/src/data/community-meetups.json">
+            <InlineLink href="https://github.com/ethereum/ethereum-org-website/blob/dev/src/data/community-meetups.json">
               <Translation id="page-community-please-add-to-page" />
             </InlineLink>
           </InfoBanner>

--- a/src/components/MeetupList.tsx
+++ b/src/components/MeetupList.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react"
+import { sortBy } from "lodash"
 import {
   Box,
   Flex,
@@ -9,8 +11,6 @@ import {
   useToken,
   VisuallyHidden,
 } from "@chakra-ui/react"
-import { sortBy } from "lodash"
-import { useState } from "react"
 
 import Emoji from "@/components/Emoji"
 import InfoBanner from "@/components/InfoBanner"

--- a/src/components/RandomAppList.tsx
+++ b/src/components/RandomAppList.tsx
@@ -1,5 +1,5 @@
-import { shuffle } from "lodash"
 import { useEffect, useState } from "react"
+import { shuffle } from "lodash"
 
 import type { TranslationKey } from "@/lib/types"
 

--- a/src/components/RandomAppList.tsx
+++ b/src/components/RandomAppList.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from "react"
 import { shuffle } from "lodash"
+import { useEffect, useState } from "react"
 
 import type { TranslationKey } from "@/lib/types"
 
@@ -62,7 +62,7 @@ const RandomAppList = () => {
     <ul>
       {randomAppList.map((item, idx) => (
         <li key={idx}>
-          <InlineLink to={item.url}>{item.name}</InlineLink>
+          <InlineLink href={item.url}>{item.name}</InlineLink>
           , <Translation id={item.description} />
         </li>
       ))}

--- a/src/components/RollupProductDevDoc.tsx
+++ b/src/components/RollupProductDevDoc.tsx
@@ -1,4 +1,3 @@
-import React from "react"
 import { Box, Flex, Heading, ListItem, UnorderedList } from "@chakra-ui/react"
 
 import { layer2Data, Rollups, RollupType } from "@/data/layer-2/layer-2"
@@ -38,17 +37,17 @@ const RollupProductDevDoc = ({ rollupType }: RollupProductDevDocProps) => {
                   )}
                   <UnorderedList>
                     <ListItem>
-                      <InlineLink to={website}>
+                      <InlineLink href={website}>
                         <Translation id="rollup-component-website" />
                       </InlineLink>
                     </ListItem>
                     <ListItem>
-                      <InlineLink to={developerDocs}>
+                      <InlineLink href={developerDocs}>
                         <Translation id="rollup-component-developer-docs" />
                       </InlineLink>
                     </ListItem>
                     <ListItem>
-                      <InlineLink to={l2beat}>
+                      <InlineLink href={l2beat}>
                         <Translation id="rollup-component-technology-and-risk-summary" />
                       </InlineLink>
                     </ListItem>

--- a/src/components/StablecoinAccordion/index.tsx
+++ b/src/components/StablecoinAccordion/index.tsx
@@ -1,6 +1,3 @@
-import { ReactNode } from "react"
-import { useTranslation } from "next-i18next"
-import { MdArrowForward } from "react-icons/md"
 import {
   Accordion,
   Box,
@@ -10,6 +7,8 @@ import {
   LinkBox,
   LinkOverlay,
 } from "@chakra-ui/react"
+import { useTranslation } from "next-i18next"
+import { MdArrowForward } from "react-icons/md"
 
 import { ChildOnlyProp, TranslationKey } from "@/lib/types"
 
@@ -136,7 +135,7 @@ const StablecoinAccordion = () => {
           </SectionTitle>
           <p>
             {t("page-stablecoins-accordion-swap-dapp-intro")}{" "}
-            <InlineLink to="/get-eth/#dex">
+            <InlineLink href="/get-eth/#dex">
               {t("page-stablecoins-accordion-swap-dapp-link")}
             </InlineLink>
           </p>
@@ -225,7 +224,7 @@ const StablecoinAccordion = () => {
           </SectionTitle>
           <p>
             {t("page-stablecoins-accordion-borrow-crypto-collateral-copy")}{" "}
-            <InlineLink to="#how">
+            <InlineLink href="#how">
               {t("page-stablecoins-accordion-borrow-crypto-collateral-link")}
             </InlineLink>
           </p>
@@ -249,7 +248,7 @@ const StablecoinAccordion = () => {
           </SectionTitle>
           <p>
             {t("page-stablecoins-accordion-borrow-risks-copy")}{" "}
-            <InlineLink to="/eth/">
+            <InlineLink href="/eth/">
               {t("page-stablecoins-accordion-borrow-risks-link")}
             </InlineLink>
           </p>

--- a/src/components/StablecoinAccordion/index.tsx
+++ b/src/components/StablecoinAccordion/index.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from "next-i18next"
+import { MdArrowForward } from "react-icons/md"
 import {
   Accordion,
   Box,
@@ -7,8 +9,6 @@ import {
   LinkBox,
   LinkOverlay,
 } from "@chakra-ui/react"
-import { useTranslation } from "next-i18next"
-import { MdArrowForward } from "react-icons/md"
 
 import { ChildOnlyProp, TranslationKey } from "@/lib/types"
 

--- a/src/components/Staking/StakingStatsBox.tsx
+++ b/src/components/Staking/StakingStatsBox.tsx
@@ -1,7 +1,7 @@
-import { Code, Flex, Icon, VStack } from "@chakra-ui/react"
-import { useTranslation } from "next-i18next"
 import { useRouter } from "next/router"
+import { useTranslation } from "next-i18next"
 import { MdInfoOutline } from "react-icons/md"
+import { Code, Flex, Icon, VStack } from "@chakra-ui/react"
 
 import type { ChildOnlyProp, Lang, StakingStatsData } from "@/lib/types"
 

--- a/src/components/Staking/StakingStatsBox.tsx
+++ b/src/components/Staking/StakingStatsBox.tsx
@@ -1,7 +1,7 @@
-import { useRouter } from "next/router"
-import { useTranslation } from "next-i18next"
-import { MdInfoOutline } from "react-icons/md"
 import { Code, Flex, Icon, VStack } from "@chakra-ui/react"
+import { useTranslation } from "next-i18next"
+import { useRouter } from "next/router"
+import { MdInfoOutline } from "react-icons/md"
 
 import type { ChildOnlyProp, Lang, StakingStatsData } from "@/lib/types"
 
@@ -96,7 +96,7 @@ const StakingStatsBox = ({ data }: StakingStatsBoxProps) => {
           <BeaconchainTooltip>
             <Text>{t("page-staking-stats-box-metric-1-tooltip")}</Text>
             {t("common:data-provided-by")}{" "}
-            <InlineLink to="https://beaconcha.in/">Beaconcha.in</InlineLink>
+            <InlineLink href="https://beaconcha.in/">Beaconcha.in</InlineLink>
           </BeaconchainTooltip>
         </Label>
       </Cell>
@@ -107,7 +107,7 @@ const StakingStatsBox = ({ data }: StakingStatsBoxProps) => {
           <BeaconchainTooltip>
             <Text>{t("page-staking-stats-box-metric-2-tooltip")}</Text>
             {t("common:data-provided-by")}{" "}
-            <InlineLink to="https://beaconcha.in/">Beaconcha.in</InlineLink>
+            <InlineLink href="https://beaconcha.in/">Beaconcha.in</InlineLink>
           </BeaconchainTooltip>
         </Label>
       </Cell>
@@ -118,7 +118,7 @@ const StakingStatsBox = ({ data }: StakingStatsBoxProps) => {
           <BeaconchainTooltip>
             <Text>{t("page-staking-stats-box-metric-3-tooltip")}</Text>
             {t("common:data-provided-by")}{" "}
-            <InlineLink to="https://beaconcha.in/ethstore">
+            <InlineLink href="https://beaconcha.in/ethstore">
               Beaconcha.in
             </InlineLink>
           </BeaconchainTooltip>

--- a/src/components/StatsBoxGrid/GridItem.tsx
+++ b/src/components/StatsBoxGrid/GridItem.tsx
@@ -1,7 +1,7 @@
+import { Box, Flex, Icon, Text, VStack } from "@chakra-ui/react"
 import { kebabCase } from "lodash"
 import { MdInfoOutline } from "react-icons/md"
 import { Area, AreaChart, ResponsiveContainer, XAxis, YAxis } from "recharts"
-import { Box, Flex, Icon, Text, VStack } from "@chakra-ui/react"
 
 import type { StatsBoxMetric } from "@/lib/types"
 
@@ -16,7 +16,7 @@ import Translation from "../Translation"
 const tooltipContent = (metric: StatsBoxMetric) => (
   <div>
     <Translation id="data-provided-by" />{" "}
-    <InlineLink to={metric.apiUrl}>{metric.apiProvider}</InlineLink>
+    <InlineLink href={metric.apiUrl}>{metric.apiProvider}</InlineLink>
   </div>
 )
 

--- a/src/components/StatsBoxGrid/GridItem.tsx
+++ b/src/components/StatsBoxGrid/GridItem.tsx
@@ -1,7 +1,7 @@
-import { Box, Flex, Icon, Text, VStack } from "@chakra-ui/react"
 import { kebabCase } from "lodash"
 import { MdInfoOutline } from "react-icons/md"
 import { Area, AreaChart, ResponsiveContainer, XAxis, YAxis } from "recharts"
+import { Box, Flex, Icon, Text, VStack } from "@chakra-ui/react"
 
 import type { StatsBoxMetric } from "@/lib/types"
 

--- a/src/components/TutorialMetadata.tsx
+++ b/src/components/TutorialMetadata.tsx
@@ -1,9 +1,9 @@
-import { useRouter } from "next/router"
-import { useTranslation } from "next-i18next"
 import { Badge, Box, Flex, HStack, Text } from "@chakra-ui/react"
+import { useTranslation } from "next-i18next"
+import { useRouter } from "next/router"
 
-import type { Lang, TranslationKey } from "@/lib/types"
 import { TutorialFrontmatter } from "@/lib/interfaces"
+import type { Lang, TranslationKey } from "@/lib/types"
 
 import CopyToClipboard from "@/components/CopyToClipboard"
 import Emoji from "@/components/Emoji"
@@ -81,7 +81,7 @@ const TutorialMetadata = ({
         {hasSource && (
           <Box>
             <Emoji fontSize="sm" me={2} text=":books:" />
-            <InlineLink to={frontmatter.sourceUrl}>
+            <InlineLink href={frontmatter.sourceUrl}>
               {frontmatter.source}
             </InlineLink>
           </Box>

--- a/src/components/TutorialMetadata.tsx
+++ b/src/components/TutorialMetadata.tsx
@@ -1,9 +1,9 @@
-import { Badge, Box, Flex, HStack, Text } from "@chakra-ui/react"
-import { useTranslation } from "next-i18next"
 import { useRouter } from "next/router"
+import { useTranslation } from "next-i18next"
+import { Badge, Box, Flex, HStack, Text } from "@chakra-ui/react"
 
-import { TutorialFrontmatter } from "@/lib/interfaces"
 import type { Lang, TranslationKey } from "@/lib/types"
+import { TutorialFrontmatter } from "@/lib/interfaces"
 
 import CopyToClipboard from "@/components/CopyToClipboard"
 import Emoji from "@/components/Emoji"

--- a/src/components/UpcomingEventsList.tsx
+++ b/src/components/UpcomingEventsList.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from "react"
-import { useTranslation } from "next-i18next"
 import { Box } from "@chakra-ui/react"
+import { useTranslation } from "next-i18next"
+import { useEffect, useState } from "react"
 
 import type { CommunityConference } from "@/lib/types"
 
@@ -86,7 +86,7 @@ const UpcomingEventsList = () => {
     return (
       <InfoBanner emoji=":information_source:">
         {t("page-community-upcoming-events-no-events")}{" "}
-        <InlineLink to="https://github.com/ethereum/ethereum-org-website/blob/dev/src/data/community-events.json">
+        <InlineLink href="https://github.com/ethereum/ethereum-org-website/blob/dev/src/data/community-events.json">
           {t("page-community-please-add-to-page")}
         </InlineLink>
       </InfoBanner>

--- a/src/components/UpcomingEventsList.tsx
+++ b/src/components/UpcomingEventsList.tsx
@@ -1,6 +1,6 @@
-import { Box } from "@chakra-ui/react"
-import { useTranslation } from "next-i18next"
 import { useEffect, useState } from "react"
+import { useTranslation } from "next-i18next"
+import { Box } from "@chakra-ui/react"
 
 import type { CommunityConference } from "@/lib/types"
 

--- a/src/components/UpgradeBannerNotification.tsx
+++ b/src/components/UpgradeBannerNotification.tsx
@@ -1,4 +1,3 @@
-import React from "react"
 import { Box } from "@chakra-ui/react"
 
 import BannerNotification from "./BannerNotification"
@@ -13,7 +12,7 @@ const UpgradeBannerNotification = () => (
         We&apos;ve deprecated our use of &apos;Eth1&apos; and &apos;Eth2&apos;
         terms.
       </b>{" "}
-      <InlineLink to="https://blog.ethereum.org/2022/01/24/the-great-eth2-renaming/">
+      <InlineLink href="https://blog.ethereum.org/2022/01/24/the-great-eth2-renaming/">
         Read the full announcement
       </InlineLink>
     </Box>

--- a/src/pages/assets.tsx
+++ b/src/pages/assets.tsx
@@ -1,16 +1,16 @@
+import type { GetStaticProps } from "next/types"
+import { useTranslation } from "next-i18next"
+import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import {
   Box,
   Center,
   Flex,
   Heading,
-  SimpleGrid,
-  useColorModeValue,
   type HeadingProps,
+  SimpleGrid,
   type SimpleGridProps,
+  useColorModeValue,
 } from "@chakra-ui/react"
-import { useTranslation } from "next-i18next"
-import { serverSideTranslations } from "next-i18next/serverSideTranslations"
-import type { GetStaticProps } from "next/types"
 
 import type { BasePageProps, ChildOnlyProp } from "@/lib/types"
 
@@ -36,29 +36,29 @@ import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
 // import leslieTheRhino from "@/public/upgrades/upgrade_rhino.png"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 
+import ethDiamondBlack from "@/public/assets/eth-diamond-black.png"
 import ethDiamondBlackGray from "@/public/assets/eth-diamond-black-gray.png"
 import ethDiamondBlackWhite from "@/public/assets/eth-diamond-black-white.jpg"
-import ethDiamondBlack from "@/public/assets/eth-diamond-black.png"
 import ethDiamondGlyph from "@/public/assets/eth-diamond-glyph.png"
+import ethDiamondPurple from "@/public/assets/eth-diamond-purple.png"
 import ethDiamondPurplePurple from "@/public/assets/eth-diamond-purple-purple.png"
 import ethDiamondPurpleWhite from "@/public/assets/eth-diamond-purple-white.jpg"
-import ethDiamondPurple from "@/public/assets/eth-diamond-purple.png"
 import ethDiamondColor from "@/public/assets/eth-diamond-rainbow.png"
 import ethGlyphColored from "@/public/assets/eth-glyph-colored.png"
-import ethLandscapeBlackGray from "@/public/assets/ethereum-logo-landscape-black-gray.png"
 import ethLandscapeBlack from "@/public/assets/ethereum-logo-landscape-black.png"
+import ethLandscapeBlackGray from "@/public/assets/ethereum-logo-landscape-black-gray.png"
+import ethLandscapePurple from "@/public/assets/ethereum-logo-landscape-purple.png"
 import ethLandscapePurplePurple from "@/public/assets/ethereum-logo-landscape-purple-purple.png"
 import ethLandscapePurpleWhite from "@/public/assets/ethereum-logo-landscape-purple-white.png"
-import ethLandscapePurple from "@/public/assets/ethereum-logo-landscape-purple.png"
-import ethPortraitBlackGray from "@/public/assets/ethereum-logo-portrait-black-gray.png"
 import ethPortraitBlack from "@/public/assets/ethereum-logo-portrait-black.png"
-import ethPortraitPurplePurple from "@/public/assets/ethereum-logo-portrait-purple-purple.png"
+import ethPortraitBlackGray from "@/public/assets/ethereum-logo-portrait-black-gray.png"
 import ethPortraitPurple from "@/public/assets/ethereum-logo-portrait-purple.png"
-import ethWordmarkBlackGray from "@/public/assets/ethereum-wordmark-black-gray.png"
+import ethPortraitPurplePurple from "@/public/assets/ethereum-logo-portrait-purple-purple.png"
 import ethWordmarkBlack from "@/public/assets/ethereum-wordmark-black.png"
+import ethWordmarkBlackGray from "@/public/assets/ethereum-wordmark-black-gray.png"
+import ethWordmarkPurple from "@/public/assets/ethereum-wordmark-purple.png"
 import ethWordmarkPurplePurple from "@/public/assets/ethereum-wordmark-purple-purple.png"
 import ethWordmarkPurpleWhite from "@/public/assets/ethereum-wordmark-purple-white.png"
-import ethWordmarkPurple from "@/public/assets/ethereum-wordmark-purple.png"
 import developers from "@/public/developers-eth-blocks.png"
 import doge from "@/public/doge-computer.png"
 import enterprise from "@/public/enterprise-eth.png"
@@ -74,8 +74,8 @@ import layer2Hero from "@/public/heroes/layer-2-hub-hero.jpg"
 import learnHero from "@/public/heroes/learn-hub-hero.png"
 import quizzesHub from "@/public/heroes/quizzes-hub-hero.png"
 import roadmapHero from "@/public/heroes/roadmap-hub-hero.jpg"
-import heroPanda from "@/public/home/hero-panda.png"
 import hero from "@/public/home/hero.png"
+import heroPanda from "@/public/home/hero-panda.png"
 import mergePanda from "@/public/home/merge-panda.png"
 import impact from "@/public/impact_transparent.png"
 import infrastructure from "@/public/infrastructure_transparent.png"

--- a/src/pages/assets.tsx
+++ b/src/pages/assets.tsx
@@ -1,16 +1,16 @@
-import type { GetStaticProps } from "next/types"
-import { useTranslation } from "next-i18next"
-import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import {
   Box,
   Center,
   Flex,
   Heading,
-  type HeadingProps,
   SimpleGrid,
-  type SimpleGridProps,
   useColorModeValue,
+  type HeadingProps,
+  type SimpleGridProps,
 } from "@chakra-ui/react"
+import { useTranslation } from "next-i18next"
+import { serverSideTranslations } from "next-i18next/serverSideTranslations"
+import type { GetStaticProps } from "next/types"
 
 import type { BasePageProps, ChildOnlyProp } from "@/lib/types"
 
@@ -36,29 +36,29 @@ import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
 // import leslieTheRhino from "@/public/upgrades/upgrade_rhino.png"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 
-import ethDiamondBlack from "@/public/assets/eth-diamond-black.png"
 import ethDiamondBlackGray from "@/public/assets/eth-diamond-black-gray.png"
 import ethDiamondBlackWhite from "@/public/assets/eth-diamond-black-white.jpg"
+import ethDiamondBlack from "@/public/assets/eth-diamond-black.png"
 import ethDiamondGlyph from "@/public/assets/eth-diamond-glyph.png"
-import ethDiamondPurple from "@/public/assets/eth-diamond-purple.png"
 import ethDiamondPurplePurple from "@/public/assets/eth-diamond-purple-purple.png"
 import ethDiamondPurpleWhite from "@/public/assets/eth-diamond-purple-white.jpg"
+import ethDiamondPurple from "@/public/assets/eth-diamond-purple.png"
 import ethDiamondColor from "@/public/assets/eth-diamond-rainbow.png"
 import ethGlyphColored from "@/public/assets/eth-glyph-colored.png"
-import ethLandscapeBlack from "@/public/assets/ethereum-logo-landscape-black.png"
 import ethLandscapeBlackGray from "@/public/assets/ethereum-logo-landscape-black-gray.png"
-import ethLandscapePurple from "@/public/assets/ethereum-logo-landscape-purple.png"
+import ethLandscapeBlack from "@/public/assets/ethereum-logo-landscape-black.png"
 import ethLandscapePurplePurple from "@/public/assets/ethereum-logo-landscape-purple-purple.png"
 import ethLandscapePurpleWhite from "@/public/assets/ethereum-logo-landscape-purple-white.png"
-import ethPortraitBlack from "@/public/assets/ethereum-logo-portrait-black.png"
+import ethLandscapePurple from "@/public/assets/ethereum-logo-landscape-purple.png"
 import ethPortraitBlackGray from "@/public/assets/ethereum-logo-portrait-black-gray.png"
-import ethPortraitPurple from "@/public/assets/ethereum-logo-portrait-purple.png"
+import ethPortraitBlack from "@/public/assets/ethereum-logo-portrait-black.png"
 import ethPortraitPurplePurple from "@/public/assets/ethereum-logo-portrait-purple-purple.png"
-import ethWordmarkBlack from "@/public/assets/ethereum-wordmark-black.png"
+import ethPortraitPurple from "@/public/assets/ethereum-logo-portrait-purple.png"
 import ethWordmarkBlackGray from "@/public/assets/ethereum-wordmark-black-gray.png"
-import ethWordmarkPurple from "@/public/assets/ethereum-wordmark-purple.png"
+import ethWordmarkBlack from "@/public/assets/ethereum-wordmark-black.png"
 import ethWordmarkPurplePurple from "@/public/assets/ethereum-wordmark-purple-purple.png"
 import ethWordmarkPurpleWhite from "@/public/assets/ethereum-wordmark-purple-white.png"
+import ethWordmarkPurple from "@/public/assets/ethereum-wordmark-purple.png"
 import developers from "@/public/developers-eth-blocks.png"
 import doge from "@/public/doge-computer.png"
 import enterprise from "@/public/enterprise-eth.png"
@@ -74,8 +74,8 @@ import layer2Hero from "@/public/heroes/layer-2-hub-hero.jpg"
 import learnHero from "@/public/heroes/learn-hub-hero.png"
 import quizzesHub from "@/public/heroes/quizzes-hub-hero.png"
 import roadmapHero from "@/public/heroes/roadmap-hub-hero.jpg"
-import hero from "@/public/home/hero.png"
 import heroPanda from "@/public/home/hero-panda.png"
+import hero from "@/public/home/hero.png"
 import mergePanda from "@/public/home/merge-panda.png"
 import impact from "@/public/impact_transparent.png"
 import infrastructure from "@/public/infrastructure_transparent.png"
@@ -160,17 +160,17 @@ const AssetsPage = () => {
             </Heading>
           </Center>
           <Center>
-            <InlineLink to="/assets/#illustrations">
+            <InlineLink href="/assets/#illustrations">
               {t("page-assets-illustrations")}
             </InlineLink>
           </Center>
           <Center>
-            <InlineLink to="/assets/#historical">
+            <InlineLink href="/assets/#historical">
               {t("page-assets-historical-artwork")}
             </InlineLink>
           </Center>
           <Center>
-            <InlineLink to="/assets/#brand">
+            <InlineLink href="/assets/#brand">
               {t("page-assets-ethereum-brand-assets")}
             </InlineLink>
           </Center>

--- a/src/pages/contributing/translation-program/acknowledgements.tsx
+++ b/src/pages/contributing/translation-program/acknowledgements.tsx
@@ -1,3 +1,7 @@
+import { useRouter } from "next/router"
+import { GetStaticProps } from "next/types"
+import { useTranslation } from "next-i18next"
+import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import {
   Box,
   BoxProps,
@@ -7,10 +11,6 @@ import {
   ListItem,
   useColorModeValue,
 } from "@chakra-ui/react"
-import { useTranslation } from "next-i18next"
-import { serverSideTranslations } from "next-i18next/serverSideTranslations"
-import { useRouter } from "next/router"
-import { GetStaticProps } from "next/types"
 
 import { BasePageProps } from "@/lib/types"
 

--- a/src/pages/contributing/translation-program/acknowledgements.tsx
+++ b/src/pages/contributing/translation-program/acknowledgements.tsx
@@ -1,7 +1,3 @@
-import { useRouter } from "next/router"
-import { GetStaticProps } from "next/types"
-import { useTranslation } from "next-i18next"
-import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import {
   Box,
   BoxProps,
@@ -11,6 +7,10 @@ import {
   ListItem,
   useColorModeValue,
 } from "@chakra-ui/react"
+import { useTranslation } from "next-i18next"
+import { serverSideTranslations } from "next-i18next/serverSideTranslations"
+import { useRouter } from "next/router"
+import { GetStaticProps } from "next/types"
 
 import { BasePageProps } from "@/lib/types"
 
@@ -122,7 +122,7 @@ const TranslatorAcknowledgements = () => {
               {t(
                 "page-contributing-translation-program-acknowledgements-acknowledgement-page-3"
               )}{" "}
-              <InlineLink to="/contributing/translation-program/contributors/">
+              <InlineLink href="/contributing/translation-program/contributors/">
                 {t(
                   "page-contributing-translation-program-acknowledgements-acknowledgement-page-link"
                 )}
@@ -283,7 +283,7 @@ const TranslatorAcknowledgements = () => {
             {t(
               "page-contributing-translation-program-acknowledgements-how-to-claim-1"
             )}{" "}
-            <InlineLink to="https://discord.gg/CetY6Y4">
+            <InlineLink href="https://discord.gg/CetY6Y4">
               {t(
                 "page-contributing-translation-program-acknowledgements-how-to-claim-1-discord"
               )}

--- a/src/pages/contributing/translation-program/contributors.tsx
+++ b/src/pages/contributing/translation-program/contributors.tsx
@@ -1,7 +1,3 @@
-import { useRouter } from "next/router"
-import { GetStaticProps } from "next/types"
-import { useTranslation } from "next-i18next"
-import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import {
   Box,
   BoxProps,
@@ -11,6 +7,10 @@ import {
   SimpleGrid,
   UnorderedList,
 } from "@chakra-ui/react"
+import { useTranslation } from "next-i18next"
+import { serverSideTranslations } from "next-i18next/serverSideTranslations"
+import { useRouter } from "next/router"
+import { GetStaticProps } from "next/types"
 
 import { AllTimeData, BasePageProps, Unpacked } from "@/lib/types"
 
@@ -150,7 +150,7 @@ const Contributors = () => {
         </Text>
         <Text>
           {t("page-languages:page-languages-interested")}{" "}
-          <InlineLink to="/contributing/translation-program/">
+          <InlineLink href="/contributing/translation-program/">
             {t("page-languages:page-languages-learn-more")}
           </InlineLink>
           .
@@ -178,7 +178,7 @@ const Contributors = () => {
         </SimpleGrid>
         <Text>
           {t("page-languages:page-languages-interested")}{" "}
-          <InlineLink to="/contributing/translation-program/">
+          <InlineLink href="/contributing/translation-program/">
             {t("page-languages:page-languages-learn-more")}
           </InlineLink>
           .

--- a/src/pages/contributing/translation-program/contributors.tsx
+++ b/src/pages/contributing/translation-program/contributors.tsx
@@ -1,3 +1,7 @@
+import { useRouter } from "next/router"
+import { GetStaticProps } from "next/types"
+import { useTranslation } from "next-i18next"
+import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import {
   Box,
   BoxProps,
@@ -7,10 +11,6 @@ import {
   SimpleGrid,
   UnorderedList,
 } from "@chakra-ui/react"
-import { useTranslation } from "next-i18next"
-import { serverSideTranslations } from "next-i18next/serverSideTranslations"
-import { useRouter } from "next/router"
-import { GetStaticProps } from "next/types"
 
 import { AllTimeData, BasePageProps, Unpacked } from "@/lib/types"
 

--- a/src/pages/dapps.tsx
+++ b/src/pages/dapps.tsx
@@ -1,22 +1,22 @@
-import { type ComponentPropsWithRef, useEffect, useRef, useState } from "react"
-import { type GetStaticProps } from "next"
-import { useRouter } from "next/router"
-import { useTranslation } from "next-i18next"
-import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import {
   Badge,
   Box,
   Button,
-  type ButtonProps,
   Divider as ChakraDivider,
-  type DividerProps,
   Flex,
-  type FlexProps,
   Heading,
-  type HeadingProps,
   SimpleGrid,
   useToken,
+  type ButtonProps,
+  type DividerProps,
+  type FlexProps,
+  type HeadingProps,
 } from "@chakra-ui/react"
+import { type GetStaticProps } from "next"
+import { useTranslation } from "next-i18next"
+import { serverSideTranslations } from "next-i18next/serverSideTranslations"
+import { useRouter } from "next/router"
+import { useEffect, useRef, useState, type ComponentPropsWithRef } from "react"
 
 import type { BasePageProps, ChildOnlyProp } from "@/lib/types"
 
@@ -107,15 +107,16 @@ import dai from "@/public/dapps/stabledai.png"
 import status from "@/public/dapps/status.png"
 import superrare from "@/public/dapps/superrare.png"
 import synthetix from "@/public/dapps/synthetix.png"
-import uniswapec from "@/public/dapps/uni.png"
-import uniswap from "@/public/dapps/uni.png"
+import {
+  default as uniswap,
+  default as uniswapec,
+} from "@/public/dapps/uni.png"
 import xmtp from "@/public/dapps/xmtp.png"
 import yearn from "@/public/dapps/yearn.png"
 import zapper from "@/public/dapps/zapper.png"
 import zerion from "@/public/dapps/zerion.png"
 import developers from "@/public/developers-eth-blocks.png" // Handled inside Callout => height=200
-import doge from "@/public/doge-computer.png" // HERO, full? 624px
-import ogImage from "@/public/doge-computer.png" // PageMetadata, src only
+import { default as doge, default as ogImage } from "@/public/doge-computer.png" // HERO, full? 624px
 import oneinch from "@/public/exchanges/1inch.png"
 import magicians from "@/public/magicians.png"
 import wallet from "@/public/wallet.png" // width=300
@@ -1859,7 +1860,7 @@ const DappsPage = () => {
           <Text textAlign={{ base: "left", sm: "center" }} maxW="800px" mb={4}>
             {t("page-dapps-magic-behind-dapps-description")}
           </Text>
-          <InlineLink to="/what-is-ethereum/">
+          <InlineLink href="/what-is-ethereum/">
             {t("page-dapps-magic-behind-dapps-link")}
           </InlineLink>
         </Flex>

--- a/src/pages/dapps.tsx
+++ b/src/pages/dapps.tsx
@@ -1,22 +1,22 @@
+import { type ComponentPropsWithRef,useEffect, useRef, useState } from "react"
+import { type GetStaticProps } from "next"
+import { useRouter } from "next/router"
+import { useTranslation } from "next-i18next"
+import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import {
   Badge,
   Box,
   Button,
+  type ButtonProps,
   Divider as ChakraDivider,
+  type DividerProps,
   Flex,
+  type FlexProps,
   Heading,
+  type HeadingProps,
   SimpleGrid,
   useToken,
-  type ButtonProps,
-  type DividerProps,
-  type FlexProps,
-  type HeadingProps,
 } from "@chakra-ui/react"
-import { type GetStaticProps } from "next"
-import { useTranslation } from "next-i18next"
-import { serverSideTranslations } from "next-i18next/serverSideTranslations"
-import { useRouter } from "next/router"
-import { useEffect, useRef, useState, type ComponentPropsWithRef } from "react"
 
 import type { BasePageProps, ChildOnlyProp } from "@/lib/types"
 

--- a/src/pages/developers/index.tsx
+++ b/src/pages/developers/index.tsx
@@ -1,3 +1,7 @@
+import { ReactNode } from "react"
+import { GetStaticProps } from "next"
+import { useTranslation } from "next-i18next"
+import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import {
   Box,
   chakra,
@@ -6,10 +10,6 @@ import {
   TextProps,
   useColorModeValue,
 } from "@chakra-ui/react"
-import { GetStaticProps } from "next"
-import { useTranslation } from "next-i18next"
-import { serverSideTranslations } from "next-i18next/serverSideTranslations"
-import { ReactNode } from "react"
 
 import { BasePageProps, ChildOnlyProp } from "@/lib/types"
 

--- a/src/pages/developers/index.tsx
+++ b/src/pages/developers/index.tsx
@@ -1,7 +1,3 @@
-import { ReactNode } from "react"
-import { GetStaticProps } from "next"
-import { useTranslation } from "next-i18next"
-import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import {
   Box,
   chakra,
@@ -10,6 +6,10 @@ import {
   TextProps,
   useColorModeValue,
 } from "@chakra-ui/react"
+import { GetStaticProps } from "next"
+import { useTranslation } from "next-i18next"
+import { serverSideTranslations } from "next-i18next/serverSideTranslations"
+import { ReactNode } from "react"
 
 import { BasePageProps, ChildOnlyProp } from "@/lib/types"
 
@@ -255,7 +255,7 @@ const DevelopersPage = () => {
             </Text>
             <Text>
               <Translation id="page-developers-index:page-developers-feedback" />{" "}
-              <InlineLink to="https://discord.gg/ethereum-org">
+              <InlineLink href="https://discord.gg/ethereum-org">
                 <Translation id="page-developers-index:page-developers-discord" />
               </InlineLink>
             </Text>
@@ -286,42 +286,42 @@ const DevelopersPage = () => {
             <OldHeading as="h3" fontSize={{ base: "xl", md: "2xl" }}>
               <Translation id="page-developers-index:page-developers-docs-introductions" />
             </OldHeading>
-            <InlineLink to="/developers/docs/intro-to-ethereum/">
+            <InlineLink href="/developers/docs/intro-to-ethereum/">
               <Translation id="page-developers-index:page-developers-intro-eth-link" />
             </InlineLink>
             <Text>
               <Translation id="page-developers-index:page-developers-into-eth-desc" />
             </Text>
 
-            <InlineLink to="/developers/docs/intro-to-ether/">
+            <InlineLink href="/developers/docs/intro-to-ether/">
               <Translation id="page-developers-index:page-developers-intro-ether-link" />
             </InlineLink>
             <Text>
               <Translation id="page-developers-index:page-developers-intro-ether-desc" />
             </Text>
 
-            <InlineLink to="/developers/docs/dapps/">
+            <InlineLink href="/developers/docs/dapps/">
               <Translation id="page-developers-index:page-developers-intro-dapps-link" />
             </InlineLink>
             <Text>
               <Translation id="page-developers-index:page-developers-intro-dapps-desc" />
             </Text>
 
-            <InlineLink to="/developers/docs/ethereum-stack/">
+            <InlineLink href="/developers/docs/ethereum-stack/">
               <Translation id="page-developers-index:page-developers-intro-stack" />
             </InlineLink>
             <Text>
               <Translation id="page-developers-index:page-developers-intro-stack-desc" />
             </Text>
 
-            <InlineLink to="/developers/docs/web2-vs-web3/">
+            <InlineLink href="/developers/docs/web2-vs-web3/">
               <Translation id="page-developers-index:page-developers-web3-link" />
             </InlineLink>
             <Text>
               <Translation id="page-developers-index:page-developers-web3-desc" />
             </Text>
 
-            <InlineLink to="/developers/docs/programming-languages/">
+            <InlineLink href="/developers/docs/programming-languages/">
               <Translation id="page-developers-index:page-developers-languages" />
             </InlineLink>
             <Text>
@@ -339,63 +339,63 @@ const DevelopersPage = () => {
             <OldHeading as="h3" fontSize={{ base: "xl", md: "2xl" }}>
               <Translation id="page-developers-index:page-developers-fundamentals" />
             </OldHeading>
-            <InlineLink to="/developers/docs/accounts/">
+            <InlineLink href="/developers/docs/accounts/">
               <Translation id="page-developers-index:page-developers-accounts-link" />
             </InlineLink>
             <Text>
               <Translation id="page-developers-index:page-developers-account-desc" />
             </Text>
 
-            <InlineLink to="/developers/docs/transactions/">
+            <InlineLink href="/developers/docs/transactions/">
               <Translation id="page-developers-index:page-developers-transactions-link" />
             </InlineLink>
             <Text>
               <Translation id="page-developers-index:page-developers-transactions-desc" />
             </Text>
 
-            <InlineLink to="/developers/docs/blocks/">
+            <InlineLink href="/developers/docs/blocks/">
               <Translation id="page-developers-index:page-developers-blocks-link" />
             </InlineLink>
             <Text>
               <Translation id="page-developers-index:page-developers-block-desc" />
             </Text>
 
-            <InlineLink to="/developers/docs/evm/">
+            <InlineLink href="/developers/docs/evm/">
               <Translation id="page-developers-index:page-developers-evm-link" />
             </InlineLink>
             <Text>
               <Translation id="page-developers-index:page-developers-evm-desc" />
             </Text>
 
-            <InlineLink to="/developers/docs/gas/">
+            <InlineLink href="/developers/docs/gas/">
               <Translation id="page-developers-index:page-developers-gas-link" />
             </InlineLink>
             <Text>
               <Translation id="page-developers-index:page-developers-gas-desc" />
             </Text>
 
-            <InlineLink to="/developers/docs/nodes-and-clients/">
+            <InlineLink href="/developers/docs/nodes-and-clients/">
               <Translation id="page-developers-index:page-developers-node-clients-link" />
             </InlineLink>
             <Text>
               <Translation id="page-developers-index:page-developers-node-clients-desc" />
             </Text>
 
-            <InlineLink to="/developers/docs/networks/">
+            <InlineLink href="/developers/docs/networks/">
               <Translation id="page-developers-index:page-developers-networks-link" />
             </InlineLink>
             <Text>
               <Translation id="page-developers-index:page-developers-networks-desc" />
             </Text>
 
-            <InlineLink to="/developers/docs/consensus-mechanisms/pow/mining/">
+            <InlineLink href="/developers/docs/consensus-mechanisms/pow/mining/">
               <Translation id="page-developers-index:page-developers-mining-link" />
             </InlineLink>
             <Text>
               <Translation id="page-developers-index:page-developers-mining-desc" />
             </Text>
 
-            <InlineLink to="/developers/docs/consensus-mechanisms/pow/mining-algorithms/">
+            <InlineLink href="/developers/docs/consensus-mechanisms/pow/mining-algorithms/">
               <Translation id="page-developers-index:page-developers-mining-algorithms-link" />
             </InlineLink>
             <Text>
@@ -406,49 +406,49 @@ const DevelopersPage = () => {
             <OldHeading as="h3" fontSize={{ base: "xl", md: "2xl" }}>
               <Translation id="page-developers-index:page-developers-stack" />
             </OldHeading>
-            <InlineLink to="/developers/docs/smart-contracts/">
+            <InlineLink href="/developers/docs/smart-contracts/">
               <Translation id="page-developers-index:page-developers-smart-contracts-link" />
             </InlineLink>
             <Text>
               <Translation id="page-developers-index:page-developers-smart-contracts-desc" />
             </Text>
-            <InlineLink to="/developers/docs/frameworks/">
+            <InlineLink href="/developers/docs/frameworks/">
               <Translation id="page-developers-index:page-developers-frameworks-link" />
             </InlineLink>
             <Text>
               <Translation id="page-developers-index:page-developers-frameworks-desc" />
             </Text>
-            <InlineLink to="/developers/docs/apis/javascript/">
+            <InlineLink href="/developers/docs/apis/javascript/">
               <Translation id="page-developers-index:page-developers-js-libraries-link" />
             </InlineLink>
             <Text>
               <Translation id="page-developers-index:page-developers-js-libraries-desc" />
             </Text>
-            <InlineLink to="/developers/docs/apis/backend/">
+            <InlineLink href="/developers/docs/apis/backend/">
               <Translation id="page-developers-index:page-developers-api-link" />
             </InlineLink>
             <Text>
               <Translation id="page-developers-index:page-developers-api-desc" />
             </Text>
-            <InlineLink to="/developers/docs/data-and-analytics/block-explorers/">
+            <InlineLink href="/developers/docs/data-and-analytics/block-explorers/">
               <Translation id="page-developers-index:page-developers-block-explorers-link" />
             </InlineLink>
             <Text>
               <Translation id="page-developers-index:page-developers-block-explorers-desc" />
             </Text>
-            <InlineLink to="/developers/docs/smart-contracts/security/">
+            <InlineLink href="/developers/docs/smart-contracts/security/">
               <Translation id="page-developers-index:page-developers-smart-contract-security-link" />
             </InlineLink>
             <Text>
               <Translation id="page-developers-index:page-developers-smart-contract-security-desc" />
             </Text>
-            <InlineLink to="/developers/docs/storage/">
+            <InlineLink href="/developers/docs/storage/">
               <Translation id="page-developers-index:page-developers-storage-link" />
             </InlineLink>
             <Text>
               <Translation id="page-developers-index:page-developers-storage-desc" />
             </Text>
-            <InlineLink to="/developers/docs/ides/">
+            <InlineLink href="/developers/docs/ides/">
               <Translation id="page-developers-index:page-developers-dev-env-link" />
             </InlineLink>
             <Text>
@@ -457,37 +457,37 @@ const DevelopersPage = () => {
             <OldHeading as="h3" fontSize={{ base: "xl", md: "2xl" }}>
               <Translation id="page-developers-index:page-developers-advanced" />
             </OldHeading>
-            <InlineLink to="/developers/docs/standards/tokens/">
+            <InlineLink href="/developers/docs/standards/tokens/">
               <Translation id="page-developers-index:page-developers-token-standards-link" />
             </InlineLink>
             <Text>
               <Translation id="page-developers-index:page-developers-token-standards-desc" />
             </Text>
-            <InlineLink to="/developers/docs/mev/">
+            <InlineLink href="/developers/docs/mev/">
               <Translation id="page-developers-index:page-developers-mev-link" />
             </InlineLink>
             <Text>
               <Translation id="page-developers-index:page-developers-mev-desc" />
             </Text>
-            <InlineLink to="/developers/docs/oracles/">
+            <InlineLink href="/developers/docs/oracles/">
               <Translation id="page-developers-index:page-developers-oracles-link" />
             </InlineLink>
             <Text>
               <Translation id="page-developers-index:page-developers-oracle-desc" />
             </Text>
-            <InlineLink to="/developers/docs/scaling/">
+            <InlineLink href="/developers/docs/scaling/">
               <Translation id="page-developers-index:page-developers-scaling-link" />
             </InlineLink>
             <Text>
               <Translation id="page-developers-index:page-developers-scaling-desc" />
             </Text>
-            <InlineLink to="/developers/docs/networking-layer/">
+            <InlineLink href="/developers/docs/networking-layer/">
               <Translation id="page-developers-index:page-developers-networking-layer-link" />
             </InlineLink>
             <Text>
               <Translation id="page-developers-index:page-developers-networking-layer-desc" />
             </Text>
-            <InlineLink to="/developers/docs/data-structures-and-encoding/">
+            <InlineLink href="/developers/docs/data-structures-and-encoding/">
               <Translation id="page-developers-index:page-developers-data-structures-and-encoding-link" />
             </InlineLink>
             <Text>

--- a/src/pages/developers/tutorials.tsx
+++ b/src/pages/developers/tutorials.tsx
@@ -1,3 +1,9 @@
+import { useEffect, useMemo, useState } from "react"
+import { GetStaticProps, InferGetServerSidePropsType } from "next"
+import { useRouter } from "next/router"
+import { useTranslation } from "next-i18next"
+import { serverSideTranslations } from "next-i18next/serverSideTranslations"
+import { FaGithub } from "react-icons/fa"
 import {
   Badge,
   Box,
@@ -7,12 +13,6 @@ import {
   Heading,
   useToken,
 } from "@chakra-ui/react"
-import { GetStaticProps, InferGetServerSidePropsType } from "next"
-import { useTranslation } from "next-i18next"
-import { serverSideTranslations } from "next-i18next/serverSideTranslations"
-import { useRouter } from "next/router"
-import { useEffect, useMemo, useState } from "react"
-import { FaGithub } from "react-icons/fa"
 
 import { BasePageProps, Lang } from "@/lib/types"
 

--- a/src/pages/developers/tutorials.tsx
+++ b/src/pages/developers/tutorials.tsx
@@ -1,9 +1,3 @@
-import { useEffect, useMemo, useState } from "react"
-import { GetStaticProps, InferGetServerSidePropsType } from "next"
-import { useRouter } from "next/router"
-import { useTranslation } from "next-i18next"
-import { serverSideTranslations } from "next-i18next/serverSideTranslations"
-import { FaGithub } from "react-icons/fa"
 import {
   Badge,
   Box,
@@ -13,6 +7,12 @@ import {
   Heading,
   useToken,
 } from "@chakra-ui/react"
+import { GetStaticProps, InferGetServerSidePropsType } from "next"
+import { useTranslation } from "next-i18next"
+import { serverSideTranslations } from "next-i18next/serverSideTranslations"
+import { useRouter } from "next/router"
+import { useEffect, useMemo, useState } from "react"
+import { FaGithub } from "react-icons/fa"
 
 import { BasePageProps, Lang } from "@/lib/types"
 
@@ -246,7 +246,7 @@ const TutorialPage = ({
         </Heading>
         <Text>
           <Translation id="page-developers-tutorials:page-tutorial-listing-policy-intro" />{" "}
-          <InlineLink to="/contributing/content-resources/">
+          <InlineLink href="/contributing/content-resources/">
             <Translation id="page-developers-tutorials:page-tutorial-listing-policy" />
           </InlineLink>
         </Text>

--- a/src/pages/eth.tsx
+++ b/src/pages/eth.tsx
@@ -1,16 +1,16 @@
+import {
+  Box,
+  Flex,
+  Heading,
+  ListItem,
+  UnorderedList,
+  type FlexProps,
+  type HeadingProps,
+} from "@chakra-ui/react"
 import { GetStaticProps } from "next"
 import { useTranslation } from "next-i18next"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import type { ComponentProps } from "react"
-import {
-  Box,
-  Flex,
-  type FlexProps,
-  Heading,
-  type HeadingProps,
-  ListItem,
-  UnorderedList,
-} from "@chakra-ui/react"
 
 import type { BasePageProps, ChildOnlyProp } from "@/lib/types"
 
@@ -36,9 +36,8 @@ import { existsNamespace } from "@/lib/utils/existsNamespace"
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 
-import eth from "@/public/eth.png"
-import ogImage from "@/public/eth.png"
 import ethCat from "@/public/eth-gif-cat.png"
+import { default as eth, default as ogImage } from "@/public/eth.png"
 import defi from "@/public/finance_transparent.png"
 import ethereum from "@/public/what-is-ethereum.png"
 
@@ -427,7 +426,7 @@ const EthPage = () => {
           <InfoBanner emoji=":wave:" shouldCenter>
             <Text as="b">{t("page-eth-buy-some")}</Text>{" "}
             {t("page-eth-buy-some-desc")}{" "}
-            <InlineLink to="/what-is-ethereum/">
+            <InlineLink href="/what-is-ethereum/">
               {t("page-eth-more-on-ethereum-link")}
             </InlineLink>
             {t("page-eth-period")}
@@ -450,7 +449,7 @@ const EthPage = () => {
             </Text>
             <Text>
               {t("page-eth-fuels-staking")}{" "}
-              <InlineLink to="/staking/">
+              <InlineLink href="/staking/">
                 {t("page-eth-fuels-more-staking")}
               </InlineLink>
             </Text>
@@ -480,25 +479,25 @@ const EthPage = () => {
             <Text>{t("page-eth-uses-desc-2")} </Text>
             <UnorderedList>
               <ListItem>
-                <InlineLink to="https://sablier.com">
+                <InlineLink href="https://sablier.com">
                   {t("page-eth-stream-link")}
                 </InlineLink>{" "}
                 – {t("page-eth-uses-desc-3")}
               </ListItem>
               <ListItem>
-                <InlineLink to="/get-eth/#dex">
+                <InlineLink href="/get-eth/#dex">
                   {t("page-eth-trade-link-2")}
                 </InlineLink>{" "}
                 – {t("page-eth-uses-desc-4")}
               </ListItem>
               <ListItem>
-                <InlineLink to="https://app.compound.finance/">
+                <InlineLink href="https://app.compound.finance/">
                   {t("page-eth-earn-interest-link")}
                 </InlineLink>{" "}
                 – {t("page-eth-uses-desc-5")}
               </ListItem>
               <ListItem>
-                <InlineLink to="/stablecoins/">
+                <InlineLink href="/stablecoins/">
                   {t("page-eth-stablecoins-link")}
                 </InlineLink>{" "}
                 – {t("page-eth-uses-desc-6")}

--- a/src/pages/eth.tsx
+++ b/src/pages/eth.tsx
@@ -1,16 +1,16 @@
-import {
-  Box,
-  Flex,
-  Heading,
-  ListItem,
-  UnorderedList,
-  type FlexProps,
-  type HeadingProps,
-} from "@chakra-ui/react"
 import { GetStaticProps } from "next"
 import { useTranslation } from "next-i18next"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import type { ComponentProps } from "react"
+import {
+  Box,
+  Flex,
+  type FlexProps,
+  Heading,
+  type HeadingProps,
+  ListItem,
+  UnorderedList,
+} from "@chakra-ui/react"
 
 import type { BasePageProps, ChildOnlyProp } from "@/lib/types"
 
@@ -36,8 +36,8 @@ import { existsNamespace } from "@/lib/utils/existsNamespace"
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 
-import ethCat from "@/public/eth-gif-cat.png"
 import { default as eth, default as ogImage } from "@/public/eth.png"
+import ethCat from "@/public/eth-gif-cat.png"
 import defi from "@/public/finance_transparent.png"
 import ethereum from "@/public/what-is-ethereum.png"
 

--- a/src/pages/gas.tsx
+++ b/src/pages/gas.tsx
@@ -1,3 +1,7 @@
+import { ComponentPropsWithRef } from "react"
+import { GetStaticProps } from "next/types"
+import { useTranslation } from "next-i18next"
+import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import {
   Box,
   BoxProps,
@@ -15,10 +19,6 @@ import {
   Tr,
   UnorderedList,
 } from "@chakra-ui/react"
-import { useTranslation } from "next-i18next"
-import { serverSideTranslations } from "next-i18next/serverSideTranslations"
-import { GetStaticProps } from "next/types"
-import { ComponentPropsWithRef } from "react"
 
 import { BasePageProps } from "@/lib/types"
 

--- a/src/pages/gas.tsx
+++ b/src/pages/gas.tsx
@@ -1,7 +1,3 @@
-import { ComponentPropsWithRef } from "react"
-import { GetStaticProps } from "next/types"
-import { useTranslation } from "next-i18next"
-import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import {
   Box,
   BoxProps,
@@ -19,6 +15,10 @@ import {
   Tr,
   UnorderedList,
 } from "@chakra-ui/react"
+import { useTranslation } from "next-i18next"
+import { serverSideTranslations } from "next-i18next/serverSideTranslations"
+import { GetStaticProps } from "next/types"
+import { ComponentPropsWithRef } from "react"
 
 import { BasePageProps } from "@/lib/types"
 
@@ -260,7 +260,7 @@ const GasPage = () => {
             <Text>{t("page-gas-what-causes-high-gas-fees-text-3")}</Text>
             <Text>
               {t("page-gas-want-to-dive-deeper")}{" "}
-              <InlineLink to="/developers/docs/gas/">
+              <InlineLink href="/developers/docs/gas/">
                 {t("page-gas-check-out-the-developer-docs")}
               </InlineLink>
             </Text>

--- a/src/pages/languages.tsx
+++ b/src/pages/languages.tsx
@@ -1,10 +1,10 @@
-import { Box, Flex, IconButton, LinkBox, LinkOverlay } from "@chakra-ui/react"
+import React, { useState } from "react"
 import { GetStaticProps } from "next"
+import { useRouter } from "next/router"
 import { useTranslation } from "next-i18next"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
-import { useRouter } from "next/router"
-import React, { useState } from "react"
 import { MdClose } from "react-icons/md"
+import { Box, Flex, IconButton, LinkBox, LinkOverlay } from "@chakra-ui/react"
 
 import { BasePageProps, I18nLocale, TranslationKey } from "@/lib/types"
 

--- a/src/pages/languages.tsx
+++ b/src/pages/languages.tsx
@@ -1,12 +1,10 @@
-import { join } from "path"
-
-import React, { useState } from "react"
+import { Box, Flex, IconButton, LinkBox, LinkOverlay } from "@chakra-ui/react"
 import { GetStaticProps } from "next"
-import { useRouter } from "next/router"
 import { useTranslation } from "next-i18next"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
+import { useRouter } from "next/router"
+import React, { useState } from "react"
 import { MdClose } from "react-icons/md"
-import { Box, Flex, IconButton, LinkBox, LinkOverlay } from "@chakra-ui/react"
 
 import { BasePageProps, I18nLocale, TranslationKey } from "@/lib/types"
 
@@ -103,14 +101,14 @@ const LanguagesPage = () => {
           <Text>{t("page-languages-p1")}</Text>
           <Text>
             {t("page-languages-interested")}{" "}
-            <InlineLink to="/contributing/translation-program/">
+            <InlineLink href="/contributing/translation-program/">
               {t("page-languages-learn-more")}
             </InlineLink>
             .
           </Text>
           <Text>
             {t("page-languages-resources-paragraph")}{" "}
-            <InlineLink to="/community/language-resources">
+            <InlineLink href="/community/language-resources">
               {t("page-languages-resources-link")}
             </InlineLink>
             .
@@ -205,7 +203,7 @@ const LanguagesPage = () => {
           </OldHeading>
           <Text>
             {t("page-languages-want-more-paragraph")}{" "}
-            <InlineLink to="/contributing/translation-program/">
+            <InlineLink href="/contributing/translation-program/">
               {t("page-languages-want-more-link")}
             </InlineLink>
             .

--- a/src/pages/layer-2.tsx
+++ b/src/pages/layer-2.tsx
@@ -1,7 +1,3 @@
-import { merge } from "lodash"
-import { GetStaticProps } from "next"
-import { useTranslation } from "next-i18next"
-import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import {
   Badge,
   Box,
@@ -14,6 +10,10 @@ import {
   SimpleGrid,
   UnorderedList,
 } from "@chakra-ui/react"
+import { merge } from "lodash"
+import { GetStaticProps } from "next"
+import { useTranslation } from "next-i18next"
+import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 
 import type {
   BasePageProps,
@@ -319,7 +319,7 @@ const Layer2Page = () => {
             />
             <Text>
               {t("layer-2-what-is-layer-1-list-link-1")}{" "}
-              <InlineLink to="/what-is-ethereum/">
+              <InlineLink href="/what-is-ethereum/">
                 {t("layer-2-what-is-layer-1-list-link-2")}
               </InlineLink>
             </Text>
@@ -355,7 +355,7 @@ const Layer2Page = () => {
             <Text>
               <Translation id="page-layer-2:layer-2-why-do-we-need-layer-2-scalability-2" />
             </Text>
-            <InlineLink to="/roadmap/vision/">
+            <InlineLink href="/roadmap/vision/">
               {t("layer-2-why-do-we-need-layer-2-scalability-3")}
             </InlineLink>
           </Box>
@@ -436,7 +436,7 @@ const Layer2Page = () => {
                 <SectionHeading as="h3">{title}</SectionHeading>
                 <Text>{description}</Text>
                 <Text>
-                  <InlineLink to={childLink}>{childSentence}</InlineLink>
+                  <InlineLink href={childLink}>{childSentence}</InlineLink>
                 </Text>
               </Flex>
             )
@@ -568,12 +568,12 @@ const Layer2Page = () => {
             <Text>{t("layer-2-sidechains-2")}</Text>
             <UnorderedList>
               <ListItem>
-                <InlineLink to="/developers/docs/scaling/sidechains/">
+                <InlineLink href="/developers/docs/scaling/sidechains/">
                   {t("layer-2-more-on-sidechains")}
                 </InlineLink>
               </ListItem>
               <ListItem>
-                <InlineLink to="/developers/docs/scaling/validium/">
+                <InlineLink href="/developers/docs/scaling/validium/">
                   {t("layer-2-more-on-validiums")}
                 </InlineLink>
               </ListItem>
@@ -623,12 +623,12 @@ const Layer2Page = () => {
           <Text>{t("layer-2-faq-question-2-description-2")}</Text>
           <Text>{t("layer-2-faq-question-2-description-3")}</Text>
           <Text>
-            <InlineLink to="/developers/docs/scaling/optimistic-rollups/">
+            <InlineLink href="/developers/docs/scaling/optimistic-rollups/">
               {t("layer-2-more-info-on-optimistic-rollups")}
             </InlineLink>
           </Text>
           <Text>
-            <InlineLink to="/developers/docs/scaling/zk-rollups/">
+            <InlineLink href="/developers/docs/scaling/zk-rollups/">
               {t("layer-2-more-info-on-zk-rollups")}
             </InlineLink>
           </Text>
@@ -642,7 +642,7 @@ const Layer2Page = () => {
             <Translation id="page-layer-2:layer-2-faq-question-4-description-3" />
           </Text>
           <Text>
-            <InlineLink to="/bridges/">
+            <InlineLink href="/bridges/">
               {t("layer-2-more-on-bridges")}
             </InlineLink>
           </Text>
@@ -650,7 +650,7 @@ const Layer2Page = () => {
         <ExpandableCard title={`${t("layer-2-faq-question-5-title")}`}>
           <Text>
             {t("layer-2-faq-question-5-description-1")}{" "}
-            <InlineLink to="/contributing/adding-layer-2s/">
+            <InlineLink href="/contributing/adding-layer-2s/">
               {t("layer-2-faq-question-5-view-listing-policy")}
             </InlineLink>
           </Text>
@@ -664,31 +664,31 @@ const Layer2Page = () => {
         <SectionHeading>{t("layer-2-further-reading-title")}</SectionHeading>
         <UnorderedList ms="1.45rem" mb="1.45rem">
           <ListItem>
-            <InlineLink to="https://ethereum-magicians.org/t/a-rollup-centric-ethereum-roadmap/4698">
+            <InlineLink href="https://ethereum-magicians.org/t/a-rollup-centric-ethereum-roadmap/4698">
               {t("a-rollup-centric-ethereum-roadmap")}
             </InlineLink>{" "}
             <i>- Vitalik Buterin </i>
           </ListItem>
           <ListItem>
-            <InlineLink to="https://vitalik.eth.limo/general/2021/01/05/rollup.html">
+            <InlineLink href="https://vitalik.eth.limo/general/2021/01/05/rollup.html">
               {t("an-incomplete-guide-to-rollups")}
             </InlineLink>{" "}
             <i>- Vitalik Buterin</i>
           </ListItem>
           <ListItem>
-            <InlineLink to="https://www.youtube.com/watch?v=DyNbmgkyxJI">
+            <InlineLink href="https://www.youtube.com/watch?v=DyNbmgkyxJI">
               {t("polygon-sidechain-vs-ethereum-rollups")}
             </InlineLink>{" "}
             <i>- Lex Clips</i>
           </ListItem>
           <ListItem>
-            <InlineLink to="https://www.youtube.com/watch?v=7pWxCklcNsU">
+            <InlineLink href="https://www.youtube.com/watch?v=7pWxCklcNsU">
               {t("rollups-the-ultimate-ethereum-scaling-strategy")}
             </InlineLink>{" "}
             <i>- Finematics</i>
           </ListItem>
           <ListItem>
-            <InlineLink to="https://barnabe.substack.com/p/understanding-rollup-economics-from?s=r">
+            <InlineLink href="https://barnabe.substack.com/p/understanding-rollup-economics-from?s=r">
               {t("understanding-rollup-economics-from-first-principals")}
             </InlineLink>{" "}
             <i>- Barnabé Monnot</i>

--- a/src/pages/layer-2.tsx
+++ b/src/pages/layer-2.tsx
@@ -1,3 +1,7 @@
+import { merge } from "lodash"
+import { GetStaticProps } from "next"
+import { useTranslation } from "next-i18next"
+import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import {
   Badge,
   Box,
@@ -10,10 +14,6 @@ import {
   SimpleGrid,
   UnorderedList,
 } from "@chakra-ui/react"
-import { merge } from "lodash"
-import { GetStaticProps } from "next"
-import { useTranslation } from "next-i18next"
-import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 
 import type {
   BasePageProps,

--- a/src/pages/run-a-node.tsx
+++ b/src/pages/run-a-node.tsx
@@ -1,18 +1,18 @@
-import {
-  Box,
-  Center,
-  Flex,
-  type BoxProps,
-  type CenterProps,
-  type Icon as ChakraIcon,
-  type FlexProps,
-  type HeadingProps,
-} from "@chakra-ui/react"
+import type { GetStaticProps } from "next/types"
 import { useTranslation } from "next-i18next"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
-import type { GetStaticProps } from "next/types"
 import type { ComponentProps, ReactNode } from "react"
 import { FaDiscord } from "react-icons/fa"
+import {
+  Box,
+  type BoxProps,
+  Center,
+  type CenterProps,
+  Flex,
+  type FlexProps,
+  type HeadingProps,
+  type Icon as ChakraIcon,
+} from "@chakra-ui/react"
 
 import type { BasePageProps, ChildOnlyProp } from "@/lib/types"
 

--- a/src/pages/run-a-node.tsx
+++ b/src/pages/run-a-node.tsx
@@ -1,18 +1,18 @@
-import type { GetStaticProps } from "next/types"
-import { useTranslation } from "next-i18next"
-import { serverSideTranslations } from "next-i18next/serverSideTranslations"
-import type { ComponentProps, ReactNode } from "react"
-import { FaDiscord } from "react-icons/fa"
 import {
   Box,
-  type BoxProps,
   Center,
-  type CenterProps,
   Flex,
+  type BoxProps,
+  type CenterProps,
+  type Icon as ChakraIcon,
   type FlexProps,
   type HeadingProps,
-  type Icon as ChakraIcon,
 } from "@chakra-ui/react"
+import { useTranslation } from "next-i18next"
+import { serverSideTranslations } from "next-i18next/serverSideTranslations"
+import type { GetStaticProps } from "next/types"
+import type { ComponentProps, ReactNode } from "react"
+import { FaDiscord } from "react-icons/fa"
 
 import type { BasePageProps, ChildOnlyProp } from "@/lib/types"
 
@@ -543,7 +543,7 @@ const RunANodePage = () => {
                   )}
                 </Text>
               </Text>
-              <InlineLink to="/developers/docs/nodes-and-clients/run-a-node/">
+              <InlineLink href="/developers/docs/nodes-and-clients/run-a-node/">
                 {t("page-run-a-node-getting-started-software-section-1-link")}
               </InlineLink>
             </ColumnFill>
@@ -822,19 +822,19 @@ const RunANodePage = () => {
         <H2>{t("page-run-a-node-further-reading-title")}</H2>
         <ul>
           <li>
-            <InlineLink to="https://github.com/ethereumbook/ethereumbook/blob/develop/03clients.asciidoc#should-i-run-a-full-node">
+            <InlineLink href="https://github.com/ethereumbook/ethereumbook/blob/develop/03clients.asciidoc#should-i-run-a-full-node">
               {t("page-run-a-node-further-reading-1-link")}
             </InlineLink>{" "}
             -{" "}
             <Text as="i">{t("page-run-a-node-further-reading-1-author")}</Text>
           </li>
           <li>
-            <InlineLink to="https://ethereum-on-arm-documentation.readthedocs.io/en/latest/">
+            <InlineLink href="https://ethereum-on-arm-documentation.readthedocs.io/en/latest/">
               {t("page-run-a-node-further-reading-2-link")}
             </InlineLink>
           </li>
           <li>
-            <InlineLink to="https://vitalik.eth.limo/general/2021/05/23/scaling.html">
+            <InlineLink href="https://vitalik.eth.limo/general/2021/05/23/scaling.html">
               {t("page-run-a-node-further-reading-3-link")}
             </InlineLink>{" "}
             -{" "}
@@ -878,7 +878,7 @@ const RunANodePage = () => {
         </Text>
         <Text>
           {t("page-run-a-node-staking-plans-ethstaker-link-description")} -{" "}
-          <InlineLink to="https://youtu.be/C2wwu1IlhDc">
+          <InlineLink href="https://youtu.be/C2wwu1IlhDc">
             {t("page-run-a-node-staking-plans-ethstaker-link-label")}
           </InlineLink>
         </Text>
@@ -889,7 +889,7 @@ const RunANodePage = () => {
         <Text>{t("page-run-a-node-rasp-pi-description")}</Text>
         <ul>
           <li>
-            <InlineLink to="https://docs.dappnode.io/user/quick-start/Core/installation#arm">
+            <InlineLink href="https://docs.dappnode.io/user/quick-start/Core/installation#arm">
               {t("page-run-a-node-rasp-pi-note-1-link")}
             </InlineLink>{" "}
             -{" "}
@@ -898,7 +898,7 @@ const RunANodePage = () => {
             </Text>
           </li>
           <li>
-            <InlineLink to="https://ethereum-on-arm-documentation.readthedocs.io/en/latest">
+            <InlineLink href="https://ethereum-on-arm-documentation.readthedocs.io/en/latest">
               {t("page-run-a-node-rasp-pi-note-2-link")}
             </InlineLink>{" "}
             -{" "}
@@ -907,7 +907,7 @@ const RunANodePage = () => {
             </Text>
           </li>
           <li>
-            <InlineLink to="/developers/tutorials/run-node-raspberry-pi">
+            <InlineLink href="/developers/tutorials/run-node-raspberry-pi">
               {t("page-run-a-node-rasp-pi-note-3-link")}
             </InlineLink>{" "}
             -{" "}

--- a/src/pages/stablecoins.tsx
+++ b/src/pages/stablecoins.tsx
@@ -1,3 +1,6 @@
+import { GetStaticProps } from "next/types"
+import { useTranslation } from "next-i18next"
+import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import {
   Box,
   BoxProps,
@@ -8,9 +11,6 @@ import {
   Icon,
   SimpleGrid,
 } from "@chakra-ui/react"
-import { useTranslation } from "next-i18next"
-import { serverSideTranslations } from "next-i18next/serverSideTranslations"
-import { GetStaticProps } from "next/types"
 
 import { BasePageProps } from "@/lib/types"
 

--- a/src/pages/stablecoins.tsx
+++ b/src/pages/stablecoins.tsx
@@ -1,6 +1,3 @@
-import { GetStaticProps } from "next/types"
-import { useTranslation } from "next-i18next"
-import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import {
   Box,
   BoxProps,
@@ -11,6 +8,9 @@ import {
   Icon,
   SimpleGrid,
 } from "@chakra-ui/react"
+import { useTranslation } from "next-i18next"
+import { serverSideTranslations } from "next-i18next/serverSideTranslations"
+import { GetStaticProps } from "next/types"
 
 import { BasePageProps } from "@/lib/types"
 
@@ -238,7 +238,7 @@ const StablecoinsPage = ({ markets, marketsHasError }) => {
   const tooltipContent = (
     <div>
       {t("data-provided-by")}{" "}
-      <InlineLink to="https://www.coingecko.com/en/api">
+      <InlineLink href="https://www.coingecko.com/en/api">
         coingecko.com
       </InlineLink>
     </div>
@@ -422,7 +422,7 @@ const StablecoinsPage = ({ markets, marketsHasError }) => {
             <H2 mt={0}>{t("page-stablecoins-why-stablecoins")}</H2>
             <Text>
               {t("page-stablecoins-prices-definition")}{" "}
-              <InlineLink to="#how">
+              <InlineLink href="#how">
                 {t("page-stablecoins-prices-definition-how")}
               </InlineLink>
             </Text>
@@ -479,12 +479,12 @@ const StablecoinsPage = ({ markets, marketsHasError }) => {
             <Text>{t("page-stablecoins-find-stablecoin-intro")}</Text>
             <ul>
               <li>
-                <InlineLink to="#how">
+                <InlineLink href="#how">
                   {t("page-stablecoins-find-stablecoin-types-link")}
                 </InlineLink>
               </li>
               <li>
-                <InlineLink to="#explore">
+                <InlineLink href="#explore">
                   {t("page-stablecoins-find-stablecoin-how-to-get-them")}
                 </InlineLink>
               </li>
@@ -688,7 +688,7 @@ const StablecoinsPage = ({ markets, marketsHasError }) => {
             </Text>
             <Text as="em">
               {t("page-stablecoins-bank-apy-source")}{" "}
-              <InlineLink to="https://www.nytimes.com/2020/09/18/your-money/savings-interest-rates.html">
+              <InlineLink href="https://www.nytimes.com/2020/09/18/your-money/savings-interest-rates.html">
                 {t("page-stablecoins-bank-apy-source-link")}
               </InlineLink>
             </Text>
@@ -726,7 +726,7 @@ const StablecoinsPage = ({ markets, marketsHasError }) => {
       </Content>
       <Box id="tools" py={12} px={8} w="full">
         <H2>{t("page-stablecoins-tools-title")}</H2>
-        
+
         <Flex
           alignItems="flex-start"
           width="full"

--- a/src/pages/staking/deposit-contract.tsx
+++ b/src/pages/staking/deposit-contract.tsx
@@ -1,20 +1,20 @@
+import { ReactNode, useEffect, useState } from "react"
+import makeBlockie from "ethereum-blockies-base64"
+import { type GetStaticProps } from "next"
+import { useRouter } from "next/router"
+import { useTranslation } from "next-i18next"
+import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import {
   Box,
   Button,
+  type ButtonProps,
   Checkbox,
   Flex,
   Heading,
   Img,
   Text,
   useToken,
-  type ButtonProps,
 } from "@chakra-ui/react"
-import makeBlockie from "ethereum-blockies-base64"
-import { type GetStaticProps } from "next"
-import { useTranslation } from "next-i18next"
-import { serverSideTranslations } from "next-i18next/serverSideTranslations"
-import { useRouter } from "next/router"
-import { ReactNode, useEffect, useState } from "react"
 
 import type { BasePageProps, ChildOnlyProp, TranslationKey } from "@/lib/types"
 

--- a/src/pages/staking/deposit-contract.tsx
+++ b/src/pages/staking/deposit-contract.tsx
@@ -1,20 +1,20 @@
-import { ReactNode, useEffect, useState } from "react"
-import makeBlockie from "ethereum-blockies-base64"
-import { type GetStaticProps } from "next"
-import { useRouter } from "next/router"
-import { useTranslation } from "next-i18next"
-import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import {
   Box,
   Button,
-  type ButtonProps,
   Checkbox,
   Flex,
   Heading,
   Img,
   Text,
   useToken,
+  type ButtonProps,
 } from "@chakra-ui/react"
+import makeBlockie from "ethereum-blockies-base64"
+import { type GetStaticProps } from "next"
+import { useTranslation } from "next-i18next"
+import { serverSideTranslations } from "next-i18next/serverSideTranslations"
+import { useRouter } from "next/router"
+import { ReactNode, useEffect, useState } from "react"
 
 import type { BasePageProps, ChildOnlyProp, TranslationKey } from "@/lib/types"
 
@@ -351,7 +351,7 @@ const DepositContractPage = () => {
           <OldHeading>{t("page-staking-deposit-contract-h2")}</OldHeading>
           <Text>
             {t("page-staking-deposit-contract-staking")}{" "}
-            <InlineLink to="/staking/">
+            <InlineLink href="/staking/">
               {t("page-staking-deposit-contract-staking-more-link")}
             </InlineLink>
           </Text>
@@ -478,7 +478,7 @@ const DepositContractPage = () => {
               <InfoBanner isWarning emoji=":warning:">
                 <div>
                   {t("page-staking-deposit-contract-warning-2")}{" "}
-                  <InlineLink to="https://launchpad.ethereum.org">
+                  <InlineLink href="https://launchpad.ethereum.org">
                     {t("page-staking-deposit-contract-launchpad-2")}
                   </InlineLink>
                 </div>

--- a/src/pages/what-is-ethereum.tsx
+++ b/src/pages/what-is-ethereum.tsx
@@ -1,20 +1,20 @@
-import { GetStaticProps, InferGetStaticPropsType } from "next"
-import { useRouter } from "next/router"
-import { useTranslation } from "next-i18next"
-import { serverSideTranslations } from "next-i18next/serverSideTranslations"
-import { MdInfoOutline } from "react-icons/md"
 import {
   Box,
-  type BoxProps,
   Center,
   Flex,
-  type FlexProps,
   Heading,
-  type HeadingProps,
   Icon,
   ListItem,
   UnorderedList,
+  type BoxProps,
+  type FlexProps,
+  type HeadingProps,
 } from "@chakra-ui/react"
+import { GetStaticProps, InferGetStaticPropsType } from "next"
+import { useTranslation } from "next-i18next"
+import { serverSideTranslations } from "next-i18next/serverSideTranslations"
+import { useRouter } from "next/router"
+import { MdInfoOutline } from "react-icons/md"
 
 import type {
   BasePageProps,
@@ -295,7 +295,7 @@ const WhatIsEthereumPage = ({
   const tooltipContent = ({ apiUrl, apiProvider, ariaLabel }) => (
     <div>
       {t("common:data-provided-by")}{" "}
-      <InlineLink to={apiUrl} aria-label={ariaLabel}>
+      <InlineLink href={apiUrl} aria-label={ariaLabel}>
         {apiProvider}
       </InlineLink>
     </div>
@@ -692,14 +692,14 @@ const WhatIsEthereumPage = ({
               </Text>
               <UnorderedList>
                 <ListItem>
-                  <InlineLink to="https://www.europol.europa.eu/publications-events/publications/cryptocurrencies-tracing-evolution-of-criminal-finances#downloads">
+                  <InlineLink href="https://www.europol.europa.eu/publications-events/publications/cryptocurrencies-tracing-evolution-of-criminal-finances#downloads">
                     Europol Spotlight - Cryptocurrencies - Tracing the evolution
                     of criminal finances.pdf
                   </InlineLink>{" "}
                   EN (1.4 MB)
                 </ListItem>
                 <ListItem>
-                  <InlineLink to="https://go.chainalysis.com/2021-CryptoCrime-Report.html">
+                  <InlineLink href="https://go.chainalysis.com/2021-CryptoCrime-Report.html">
                     Chainalysis (2021), The 2021 Crypto Crime report
                   </InlineLink>{" "}
                   EN
@@ -730,20 +730,20 @@ const WhatIsEthereumPage = ({
       <Content>
         <H2>{t("page-what-is-ethereum-additional-reading")}</H2>
         <Text>
-          <InlineLink to="https://weekinethereumnews.com/">
+          <InlineLink href="https://weekinethereumnews.com/">
             {t("page-what-is-ethereum-week-in-ethereum")}
           </InlineLink>{" "}
           {t("page-what-is-ethereum-week-in-ethereum-desc")}
         </Text>
         <Text>
-          <InlineLink to="https://stark.mirror.xyz/n2UpRqwdf7yjuiPKVICPpGoUNeDhlWxGqjulrlpyYi0">
+          <InlineLink href="https://stark.mirror.xyz/n2UpRqwdf7yjuiPKVICPpGoUNeDhlWxGqjulrlpyYi0">
             {t("page-what-is-ethereum-atoms-institutions-blockchains")}
           </InlineLink>{" "}
           {t("page-what-is-ethereum-atoms-institutions-blockchains-desc")}
         </Text>
 
         <Text>
-          <InlineLink to="https://www.kernel.community/en/learn/module-1/dreamers">
+          <InlineLink href="https://www.kernel.community/en/learn/module-1/dreamers">
             {t("page-what-is-ethereum-kernel-dreamers")}
           </InlineLink>{" "}
           {t("page-what-is-ethereum-kernel-dreamers-desc")}

--- a/src/pages/what-is-ethereum.tsx
+++ b/src/pages/what-is-ethereum.tsx
@@ -1,20 +1,20 @@
+import { GetStaticProps, InferGetStaticPropsType } from "next"
+import { useRouter } from "next/router"
+import { useTranslation } from "next-i18next"
+import { serverSideTranslations } from "next-i18next/serverSideTranslations"
+import { MdInfoOutline } from "react-icons/md"
 import {
   Box,
+  type BoxProps,
   Center,
   Flex,
+  type FlexProps,
   Heading,
+  type HeadingProps,
   Icon,
   ListItem,
   UnorderedList,
-  type BoxProps,
-  type FlexProps,
-  type HeadingProps,
 } from "@chakra-ui/react"
-import { GetStaticProps, InferGetStaticPropsType } from "next"
-import { useTranslation } from "next-i18next"
-import { serverSideTranslations } from "next-i18next/serverSideTranslations"
-import { useRouter } from "next/router"
-import { MdInfoOutline } from "react-icons/md"
 
 import type {
   BasePageProps,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Noticed that the `to` prop in `InlineLink` component is deprecated, so updating all usages to reflect that.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
