### PR TITLE
fix: footer social buttons strange outline [Fixes #12213]

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -311,6 +311,7 @@ const Footer = ({ lastDeployDate }: FooterProps) => {
                 hideArrow
                 color="secondary"
                 aria-label={link.ariaLabel}
+                ms={4}
               >
                 <Icon
                   as={link.icon}
@@ -320,7 +321,6 @@ const Footer = ({ lastDeployDate }: FooterProps) => {
                       "color 0.2s ease-in-out, transform 0.2s ease-in-out",
                   }}
                   fontSize="4xl"
-                  ms={4}
                 />
               </BaseLink>
             )


### PR DESCRIPTION
## Description

To fix the weird social button outline, the margin has been removed from `Icon` component and added to the `BaseLink` component

## Related Issue
[Fixes #12213]
