### PR TITLE
feat: add desktop nav menu animations

### DIFF
--- a/src/components/Nav/Menu/SubMenu.tsx
+++ b/src/components/Nav/Menu/SubMenu.tsx
@@ -38,33 +38,15 @@ type LvlContentProps = {
  * @param onClose - Function to close the menu
  * @returns The JSX element representing the menu content.
  */
-const SubMenu = ({
-  lvl,
-  items,
-  activeSection,
-  onClose,
-}: LvlContentProps) => {
-  const {
-    activeSub,
-    asPath,
-    locale,
-    menuColors,
-    menuVariants,
-    PADDING,
-    setActiveSub,
-    handleSubMenuChange,
-  } = useSubMenu()
+const SubMenu = ({ lvl, items, activeSection, onClose }: LvlContentProps) => {
+  const { asPath, locale, menuColors, menuVariants, PADDING } = useSubMenu()
 
   if (lvl > 3) return null
 
   const templateColumns = `repeat(${4 - lvl}, 1fr)`
 
   return (
-    <NavigationMenu.Sub
-      orientation="vertical"
-      asChild
-      onValueChange={handleSubMenuChange}
-    >
+    <NavigationMenu.Sub orientation="vertical" asChild>
       <AnimatePresence>
         <Grid
           as={motion.div}
@@ -109,7 +91,7 @@ const SubMenu = ({
                   variant: "ghost",
                 }
                 return (
-                  <NavigationMenu.Item key={label} asChild value={label}>
+                  <NavigationMenu.Item key={label} asChild>
                     <ListItem
                       mb={PADDING / 2}
                       _last={{ mb: 0 }}

--- a/src/components/Nav/Menu/index.tsx
+++ b/src/components/Nav/Menu/index.tsx
@@ -1,5 +1,4 @@
-import { useState } from "react"
-import { AnimatePresence, motion, MotionProps } from "framer-motion"
+import { AnimatePresence, motion } from "framer-motion"
 import { Box, type BoxProps, Flex, Text } from "@chakra-ui/react"
 import * as NavigationMenu from "@radix-ui/react-navigation-menu"
 
@@ -9,7 +8,7 @@ import { SECTION_LABELS } from "@/lib/constants"
 
 import type { NavSections } from "../types"
 
-import SubMenu from "./LvlContent"
+import SubMenu from "./SubMenu"
 import { useNavMenu } from "./useNavMenu"
 
 type NavMenuProps = BoxProps & {
@@ -17,21 +16,15 @@ type NavMenuProps = BoxProps & {
 }
 
 const Menu = ({ sections, ...props }: NavMenuProps) => {
-  const { direction, menuColors, activeSection, handleSectionChange } =
-    useNavMenu(sections)
-
-  const isOpen = activeSection !== null
-
-  const containerVariants: MotionProps["variants"] = {
-    open: {
-      opacity: 1,
-      maxHeight: "100vh",
-      transition: { duration: 0.2 },
-    },
-    closed: {
-      opacity: 0,
-    },
-  }
+  const {
+    activeSection,
+    containerVariants,
+    direction,
+    handleSectionChange,
+    isOpen,
+    menuColors,
+    onClose,
+  } = useNavMenu(sections)
 
   return (
     <Box {...props}>
@@ -97,6 +90,7 @@ const Menu = ({ sections, ...props }: NavMenuProps) => {
                           lvl={1}
                           items={items}
                           activeSection={activeSection}
+                          onClose={onClose}
                         />
                       </Box>
                     </NavigationMenu.Content>

--- a/src/components/Nav/Menu/index.tsx
+++ b/src/components/Nav/Menu/index.tsx
@@ -9,7 +9,7 @@ import { SECTION_LABELS } from "@/lib/constants"
 
 import type { NavSections } from "../types"
 
-import LvlContent from "./LvlContent"
+import SubMenu from "./LvlContent"
 import { useNavMenu } from "./useNavMenu"
 
 type NavMenuProps = BoxProps & {
@@ -93,7 +93,7 @@ const Menu = ({ sections, ...props }: NavMenuProps) => {
                         borderColor={menuColors.stroke}
                         bg={menuColors.lvl[1].background}
                       >
-                        <LvlContent
+                        <SubMenu
                           lvl={1}
                           items={items}
                           activeSection={activeSection}

--- a/src/components/Nav/Menu/index.tsx
+++ b/src/components/Nav/Menu/index.tsx
@@ -66,35 +66,32 @@ const Menu = ({ sections, ...props }: NavMenuProps) => {
                       </Text>
                     </Button>
                   </NavigationMenu.Trigger>
-                  <AnimatePresence>
-                    <NavigationMenu.Content asChild>
-                      {/**
-                       * This is the CONTAINER for all three menu levels
-                       * This renders inside the NavigationMenu.Viewport component
-                       */}
-                      <Box
-                        as={motion.div}
-                        key={sectionKey + "-content"}
-                        variants={containerVariants}
-                        initial={false}
-                        animate={isOpen ? "open" : "closed"}
-                        position="absolute"
-                        top="19"
-                        insetInline="0"
-                        shadow="md"
-                        border="1px"
-                        borderColor={menuColors.stroke}
-                        bg={menuColors.lvl[1].background}
-                      >
-                        <SubMenu
-                          lvl={1}
-                          items={items}
-                          activeSection={activeSection}
-                          onClose={onClose}
-                        />
-                      </Box>
-                    </NavigationMenu.Content>
-                  </AnimatePresence>
+                  <NavigationMenu.Content asChild>
+                    {/**
+                     * This is the CONTAINER for all three menu levels
+                     * This renders inside the NavigationMenu.Viewport component
+                     */}
+                    <Box
+                      as={motion.div}
+                      variants={containerVariants}
+                      initial={false}
+                      animate={isOpen ? "open" : "closed"}
+                      position="absolute"
+                      top="19"
+                      insetInline="0"
+                      shadow="md"
+                      border="1px"
+                      borderColor={menuColors.stroke}
+                      bg={menuColors.lvl[1].background}
+                    >
+                      <SubMenu
+                        lvl={1}
+                        items={items}
+                        activeSection={activeSection}
+                        onClose={onClose}
+                      />
+                    </Box>
+                  </NavigationMenu.Content>
                 </NavigationMenu.Item>
               )
             })}

--- a/src/components/Nav/Menu/useNavMenu.ts
+++ b/src/components/Nav/Menu/useNavMenu.ts
@@ -1,4 +1,5 @@
 import { useState } from "react"
+import type { MotionProps } from "framer-motion"
 
 import type { NavSectionKey, NavSections } from "../types"
 
@@ -24,10 +25,30 @@ export const useNavMenu = (sections: NavSections) => {
     setActiveSection(getEnglishSectionName(activeSection))
   }
 
+  const isOpen = activeSection !== null
+
+  const onClose = () => {
+    setActiveSection(null)
+  }
+
+  const containerVariants: MotionProps["variants"] = {
+    open: {
+      opacity: 1,
+      maxHeight: "100vh",
+      transition: { duration: 0.2 },
+    },
+    closed: {
+      opacity: 0,
+    },
+  }
+
   return {
-    direction,
-    menuColors,
     activeSection,
+    containerVariants,
+    direction,
     handleSectionChange,
+    isOpen,
+    menuColors,
+    onClose,
   }
 }

--- a/src/components/Nav/Menu/useSubMenu.ts
+++ b/src/components/Nav/Menu/useSubMenu.ts
@@ -12,7 +12,7 @@ export const useSubMenu = () => {
   const { isRtl } = useRtlFlip()
 
   const menuVariants: MotionProps["variants"] = {
-    closed: { opacity: 0, scaleX: 0.8, originX: isRtl ? 1 : 0 },
+    closed: { opacity: 0, scaleX: 0.9, originX: isRtl ? 1 : 0 },
     open: { opacity: 1, scaleX: 1, originX: isRtl ? 1 : 0 },
   }
 

--- a/src/components/Nav/Menu/useSubMenu.ts
+++ b/src/components/Nav/Menu/useSubMenu.ts
@@ -1,4 +1,3 @@
-import { useState } from "react"
 import type { MotionProps } from "framer-motion"
 import { useRouter } from "next/router"
 
@@ -11,25 +10,17 @@ export const useSubMenu = () => {
   const { asPath, locale } = useRouter()
   const menuColors = useNavMenuColors()
   const { isRtl } = useRtlFlip()
-  const [activeSub, setActiveSub] = useState<string | null>(null)
 
   const menuVariants: MotionProps["variants"] = {
     closed: { opacity: 0, scaleX: 0.8, originX: isRtl ? 1 : 0 },
     open: { opacity: 1, scaleX: 1, originX: isRtl ? 1 : 0 },
   }
 
-  const handleSubMenuChange = (value: string) => {
-    setActiveSub(value)
-  }
-
   return {
-    activeSub,
     asPath,
     locale,
     menuColors,
     menuVariants,
     PADDING,
-    setActiveSub,
-    handleSubMenuChange,
   }
 }

--- a/src/components/Nav/Menu/useSubMenu.ts
+++ b/src/components/Nav/Menu/useSubMenu.ts
@@ -1,0 +1,35 @@
+import { useState } from "react"
+import type { MotionProps } from "framer-motion"
+import { useRouter } from "next/router"
+
+import { useNavMenuColors } from "@/hooks/useNavMenuColors"
+import { useRtlFlip } from "@/hooks/useRtlFlip"
+
+const PADDING = 4 // Chakra-UI space token
+
+export const useSubMenu = () => {
+  const { asPath, locale } = useRouter()
+  const menuColors = useNavMenuColors()
+  const { isRtl } = useRtlFlip()
+  const [activeSub, setActiveSub] = useState<string | null>(null)
+
+  const menuVariants: MotionProps["variants"] = {
+    closed: { opacity: 0, scaleX: 0.8, originX: isRtl ? 1 : 0 },
+    open: { opacity: 1, scaleX: 1, originX: isRtl ? 1 : 0 },
+  }
+
+  const handleSubMenuChange = (value: string) => {
+    setActiveSub(value)
+  }
+
+  return {
+    activeSub,
+    asPath,
+    locale,
+    menuColors,
+    menuVariants,
+    PADDING,
+    setActiveSub,
+    handleSubMenuChange,
+  }
+}


### PR DESCRIPTION
## Target branch `nav-menu-radix-ui` (#12125)

## Description
- Adds animations for navigation menu using framer-motion
- Opacity fade-in and unfolding for entire menu on opening
- Opacity fade-in and slight horizontal scaling effect for sub-menus on opening

## Related Issue
- #12125