### PR TITLE
Wallettable empty state

### DIFF
--- a/src/components/FindWallet/WalletTable/WalletEmptyState.tsx
+++ b/src/components/FindWallet/WalletTable/WalletEmptyState.tsx
@@ -23,15 +23,10 @@ export const WalletEmptyState = ({
     >
       <Stack textAlign="center" p={12} lineHeight="1.6">
         <Heading as="h3" fontSize="3xl" fontWeight="normal" mb={6}>
-          {/* TODO: add i18n namespace */}
-          {"No results"}
+          {t("page-find-wallet-empty-results-title")}
         </Heading>
 
-        {/* TODO: add i18n namespace */}
-        <Text>
-          There are no wallets matching your criteria, try removing some
-          filters.
-        </Text>
+        <Text>{t("page-find-wallet-empty-results-desc")}</Text>
 
         <Text
           mb={0}

--- a/src/components/FindWallet/WalletTable/WalletEmptyState.tsx
+++ b/src/components/FindWallet/WalletTable/WalletEmptyState.tsx
@@ -4,8 +4,8 @@ import { Flex, Heading, Stack, Text } from "@chakra-ui/react"
 import { trackCustomEvent } from "@/lib/utils/matomo"
 
 interface WalletEmptyStateProps {
-  resetFilters: any
-  resetWalletFilter: any
+  resetFilters: () => void
+  resetWalletFilter: React.MutableRefObject<() => void>
 }
 
 export const WalletEmptyState = ({

--- a/src/components/FindWallet/WalletTable/WalletEmptyState.tsx
+++ b/src/components/FindWallet/WalletTable/WalletEmptyState.tsx
@@ -1,0 +1,56 @@
+import { useTranslation } from "next-i18next"
+import { Flex, Heading, Stack, Text } from "@chakra-ui/react"
+
+import { trackCustomEvent } from "@/lib/utils/matomo"
+
+interface WalletEmptyStateProps {
+  resetFilters: any
+  resetWalletFilter: any
+}
+
+export const WalletEmptyState = ({
+  resetFilters,
+  resetWalletFilter,
+}: WalletEmptyStateProps) => {
+  const { t } = useTranslation("page-wallets-find-wallet")
+
+  return (
+    <Flex
+      justifyContent="center"
+      m={{ base: 12, md: 24 }}
+      border="2px dashed"
+      borderColor="body.light"
+    >
+      <Stack textAlign="center" p={12} lineHeight="1.6">
+        <Heading as="h3" fontSize="3xl" fontWeight="normal" mb={6}>
+          {/* TODO: add i18n namespace */}
+          {"No results"}
+        </Heading>
+
+        {/* TODO: add i18n namespace */}
+        <Text>
+          There are no wallets matching your criteria, try removing some
+          filters.
+        </Text>
+
+        <Text
+          mb={0}
+          color="primary.base"
+          textDecoration="underline"
+          cursor="pointer"
+          onClick={() => {
+            resetFilters()
+            resetWalletFilter.current()
+            trackCustomEvent({
+              eventCategory: "WalletFilterReset",
+              eventAction: `WalletFilterReset clicked`,
+              eventName: `reset filters`,
+            })
+          }}
+        >
+          {t("page-find-wallet-reset-filters")}
+        </Text>
+      </Stack>
+    </Flex>
+  )
+}

--- a/src/components/FindWallet/WalletTable/index.tsx
+++ b/src/components/FindWallet/WalletTable/index.tsx
@@ -9,7 +9,6 @@ import {
   Flex,
   FlexProps,
   forwardRef,
-  Heading,
   Icon,
   keyframes,
   SimpleGrid,
@@ -42,6 +41,8 @@ import {
 import { WalletData } from "@/data/wallets/wallet-data"
 
 import { NAV_BAR_PX_HEIGHT } from "@/lib/constants"
+
+import { WalletEmptyState } from "./WalletEmptyState"
 
 import { useLanguagesList } from "@/hooks/useLanguagesList"
 
@@ -400,192 +401,159 @@ const WalletTable = ({
           />
         </Th>
       </WalletContentHeader>
-      {/* TODO: move to separate component WalletTableEmptyState */}
       {filteredWallets.length === 0 && (
-        <Flex
-          justifyContent="center"
-          m={{ base: 12, md: 24 }}
-          border="2px dashed"
-          borderColor="body.light"
-        >
-          <Stack textAlign="center" p={12} lineHeight="1.6">
-            <Heading as="h3" fontSize="3xl" fontWeight="normal" mb={6}>
-              {/* TODO: add i18n namespace */}
-              {"No results"}
-            </Heading>
-
-            {/* TODO: add i18n namespace */}
-            <Text>
-              There are no wallets matching your criteria, try removing some
-              filters.
-            </Text>
-
-            <Text
-              mb={0}
-              color="primary.base"
-              textDecoration="underline"
-              cursor="pointer"
-              onClick={() => {
-                resetFilters()
-                resetWalletFilter.current()
-                trackCustomEvent({
-                  eventCategory: "WalletFilterReset",
-                  eventAction: `WalletFilterReset clicked`,
-                  eventName: `reset filters`,
-                })
-              }}
-            >
-              {t("page-find-wallet-reset-filters")}
-            </Text>
-          </Stack>
-        </Flex>
+        <WalletEmptyState
+          resetFilters={resetFilters}
+          resetWalletFilter={resetWalletFilter}
+        />
       )}
 
-      {filteredWallets.map((wallet, idx) => {
-        const deviceLabels: Array<string> = []
+      {filteredWallets.length > 0 &&
+        filteredWallets.map((wallet, idx) => {
+          const deviceLabels: Array<string> = []
 
-        wallet.ios && deviceLabels.push(t("page-find-wallet-iOS"))
-        wallet.android && deviceLabels.push(t("page-find-wallet-android"))
-        wallet.linux && deviceLabels.push(t("page-find-wallet-linux"))
-        wallet.windows && deviceLabels.push(t("page-find-wallet-windows"))
-        wallet.macOS && deviceLabels.push(t("page-find-wallet-macOS"))
-        wallet.chromium && deviceLabels.push(t("page-find-wallet-chromium"))
-        wallet.firefox && deviceLabels.push(t("page-find-wallet-firefox"))
-        wallet.hardware && deviceLabels.push(t("page-find-wallet-hardware"))
+          wallet.ios && deviceLabels.push(t("page-find-wallet-iOS"))
+          wallet.android && deviceLabels.push(t("page-find-wallet-android"))
+          wallet.linux && deviceLabels.push(t("page-find-wallet-linux"))
+          wallet.windows && deviceLabels.push(t("page-find-wallet-windows"))
+          wallet.macOS && deviceLabels.push(t("page-find-wallet-macOS"))
+          wallet.chromium && deviceLabels.push(t("page-find-wallet-chromium"))
+          wallet.firefox && deviceLabels.push(t("page-find-wallet-firefox"))
+          wallet.hardware && deviceLabels.push(t("page-find-wallet-hardware"))
 
-        const walletPersonas = getWalletPersonas(wallet)
-        const supportedLanguages = getSupportedLanguages(
-          wallet.languages_supported,
-          languagesList
-        )
+          const walletPersonas = getWalletPersonas(wallet)
+          const supportedLanguages = getSupportedLanguages(
+            wallet.languages_supported,
+            languagesList
+          )
 
-        return (
-          <WalletContainer key={wallet.key}>
-            <Wallet
-              onClick={() => {
-                updateMoreInfo(wallet.key)
-                // Log "more info" event only on expanding
-                wallet.moreInfo &&
-                  trackCustomEvent({
-                    eventCategory: "WalletMoreInfo",
-                    eventAction: `More info wallet`,
-                    eventName: `More info ${wallet.name}`,
-                  })
-              }}
-            >
-              <Td lineHeight="revert">
-                <Flex justifyContent="space-between" alignItems="center">
-                  <FlexInfo w={{ base: "100%", md: "auto" }}>
-                    {/* Wallet image */}
-                    <Box w="56px">
-                      <Image
-                        src={wallet.image}
-                        alt=""
-                        objectFit="contain"
-                        boxSize="56px"
-                      />
-                    </Box>
+          return (
+            <WalletContainer key={wallet.key}>
+              <Wallet
+                onClick={() => {
+                  updateMoreInfo(wallet.key)
+                  // Log "more info" event only on expanding
+                  wallet.moreInfo &&
+                    trackCustomEvent({
+                      eventCategory: "WalletMoreInfo",
+                      eventAction: `More info wallet`,
+                      eventName: `More info ${wallet.name}`,
+                    })
+                }}
+              >
+                <Td lineHeight="revert">
+                  <Flex justifyContent="space-between" alignItems="center">
+                    <FlexInfo w={{ base: "100%", md: "auto" }}>
+                      {/* Wallet image */}
+                      <Box w="56px">
+                        <Image
+                          src={wallet.image}
+                          alt=""
+                          objectFit="contain"
+                          boxSize="56px"
+                        />
+                      </Box>
 
-                    <Box w={{ base: "100%", md: "auto" }}>
-                      <Stack gap={5}>
-                        <Text>{wallet.name}</Text>
+                      <Box w={{ base: "100%", md: "auto" }}>
+                        <Stack gap={5}>
+                          <Text>{wallet.name}</Text>
 
-                        {/* Wallet Personas supported */}
-                        <Flex gap={1.5}>
-                          {walletPersonas.map((persona) => (
-                            <Tag
-                              key={persona}
-                              label={t(persona).toUpperCase()}
-                            />
-                          ))}
-                        </Flex>
+                          {/* Wallet Personas supported */}
+                          <Flex gap={1.5}>
+                            {walletPersonas.map((persona) => (
+                              <Tag
+                                key={persona}
+                                label={t(persona).toUpperCase()}
+                              />
+                            ))}
+                          </Flex>
 
-                        {/* Device labels */}
-                        <Flex
-                          alignItems="center"
-                          gap={3}
-                          display={deviceLabels.length > 0 ? "flex" : "none"}
-                        >
-                          <Icon as={DevicesIcon} fontSize="2xl" />
-
-                          <Text
-                            hideBelow="sm"
-                            fontSize="1rem !important"
-                            fontWeight="normal !important"
+                          {/* Device labels */}
+                          <Flex
+                            alignItems="center"
+                            gap={3}
+                            display={deviceLabels.length > 0 ? "flex" : "none"}
                           >
-                            {deviceLabels.join(" · ")}
-                          </Text>
-                        </Flex>
+                            <Icon as={DevicesIcon} fontSize="2xl" />
 
-                        {/* Supported languages */}
-                        <Flex alignItems="center" gap={3}>
-                          <Icon as={LanguagesIcon} fontSize="2xl" />
+                            <Text
+                              hideBelow="sm"
+                              fontSize="1rem !important"
+                              fontWeight="normal !important"
+                            >
+                              {deviceLabels.join(" · ")}
+                            </Text>
+                          </Flex>
 
-                          <Text
-                            hideBelow="sm"
-                            fontSize="1rem !important"
-                            fontWeight="normal !important"
-                          >
-                            {formatSupportedLanguages(supportedLanguages)}
-                          </Text>
-                        </Flex>
+                          {/* Supported languages */}
+                          <Flex alignItems="center" gap={3}>
+                            <Icon as={LanguagesIcon} fontSize="2xl" />
 
-                        {/* Wallet Website (desktop) */}
-                        <Box display={{ base: "none", md: "block" }} w="auto">
-                          <ButtonLink
-                            to={wallet.url}
-                            variant="outline"
-                            w="auto"
-                            isExternal
-                          >
-                            {t("page-find-wallet-visit-website")}
-                          </ButtonLink>
-                        </Box>
-                      </Stack>
-                    </Box>
-                  </FlexInfo>
+                            <Text
+                              hideBelow="sm"
+                              fontSize="1rem !important"
+                              fontWeight="normal !important"
+                            >
+                              {formatSupportedLanguages(supportedLanguages)}
+                            </Text>
+                          </Flex>
 
-                  <FlexInfoCenter>
-                    <Box>
-                      <Icon
-                        as={wallet.moreInfo ? MdExpandLess : MdExpandMore}
-                        color="primary.base"
-                        fontSize={{ base: "5xl", md: "4xl" }}
-                      />
-                    </Box>
-                  </FlexInfoCenter>
-                </Flex>
-                {/* Wallet Website (mobile) */}
-                <Box
-                  display={{ base: "block", md: "none" }}
-                  mt={6}
-                  w="100%"
-                  ps={1}
-                  pe={3}
-                >
-                  <ButtonLink
-                    to={wallet.url}
-                    variant="outline"
+                          {/* Wallet Website (desktop) */}
+                          <Box display={{ base: "none", md: "block" }} w="auto">
+                            <ButtonLink
+                              to={wallet.url}
+                              variant="outline"
+                              w="auto"
+                              isExternal
+                            >
+                              {t("page-find-wallet-visit-website")}
+                            </ButtonLink>
+                          </Box>
+                        </Stack>
+                      </Box>
+                    </FlexInfo>
+
+                    <FlexInfoCenter>
+                      <Box>
+                        <Icon
+                          as={wallet.moreInfo ? MdExpandLess : MdExpandMore}
+                          color="primary.base"
+                          fontSize={{ base: "5xl", md: "4xl" }}
+                        />
+                      </Box>
+                    </FlexInfoCenter>
+                  </Flex>
+                  {/* Wallet Website (mobile) */}
+                  <Box
+                    display={{ base: "block", md: "none" }}
+                    mt={6}
                     w="100%"
-                    isExternal
+                    ps={1}
+                    pe={3}
                   >
-                    {t("page-find-wallet-visit-website")}
-                  </ButtonLink>
-                </Box>
-              </Td>
-            </Wallet>
+                    <ButtonLink
+                      to={wallet.url}
+                      variant="outline"
+                      w="100%"
+                      isExternal
+                    >
+                      {t("page-find-wallet-visit-website")}
+                    </ButtonLink>
+                  </Box>
+                </Td>
+              </Wallet>
 
-            {wallet.moreInfo && (
-              <WalletMoreInfo
-                wallet={wallet}
-                filters={filters}
-                idx={idx}
-                featureDropdownItems={featureDropdownItems}
-              />
-            )}
-          </WalletContainer>
-        )
-      })}
+              {wallet.moreInfo && (
+                <WalletMoreInfo
+                  wallet={wallet}
+                  filters={filters}
+                  idx={idx}
+                  featureDropdownItems={featureDropdownItems}
+                />
+              )}
+            </WalletContainer>
+          )
+        })}
     </Container>
   )
 }

--- a/src/components/FindWallet/WalletTable/index.tsx
+++ b/src/components/FindWallet/WalletTable/index.tsx
@@ -391,6 +391,27 @@ const WalletTable = ({ filters, walletData }: WalletTableProps) => {
           />
         </Th>
       </WalletContentHeader>
+      {filteredWallets.length === 0 && (
+        <Flex
+          justifyContent="center"
+          m={{ base: 12, md: 24 }}
+          borderStyle="dashed"
+          borderColor="disabled"
+          border="dashed red"
+        >
+          <Stack textAlign="center" p={12}>
+            <Text>No results</Text>
+
+            <Text>
+              There are no wallets matching your criteria, try removing some
+              filters.
+            </Text>
+
+            <Text mb={0}>Reset filters</Text>
+          </Stack>
+        </Flex>
+      )}
+
       {filteredWallets.map((wallet, idx) => {
         const deviceLabels: Array<string> = []
 

--- a/src/components/FindWallet/WalletTable/index.tsx
+++ b/src/components/FindWallet/WalletTable/index.tsx
@@ -298,9 +298,8 @@ const thirdCol = "thirdCol"
 
 export interface WalletTableProps {
   filters: Record<string, boolean>
-  // TODO: update type
-  resetFilters: any
-  resetWalletFilter: any
+  resetFilters: () => void
+  resetWalletFilter: React.MutableRefObject<() => void>
   walletData: WalletData[]
 }
 

--- a/src/components/FindWallet/WalletTable/index.tsx
+++ b/src/components/FindWallet/WalletTable/index.tsx
@@ -9,6 +9,7 @@ import {
   Flex,
   FlexProps,
   forwardRef,
+  Heading,
   Icon,
   keyframes,
   SimpleGrid,
@@ -391,22 +392,28 @@ const WalletTable = ({ filters, walletData }: WalletTableProps) => {
           />
         </Th>
       </WalletContentHeader>
+      {/* TODO: move to separate component WalletTableEmptyState */}
       {filteredWallets.length === 0 && (
         <Flex
           justifyContent="center"
           m={{ base: 12, md: 24 }}
-          borderStyle="dashed"
-          borderColor="disabled"
+          // borderStyle="dashed"
+          // borderColor="disabled"
           border="dashed red"
         >
-          <Stack textAlign="center" p={12}>
-            <Text>No results</Text>
+          <Stack textAlign="center" p={12} lineHeight="1.6">
+            <Heading as="h3" fontSize="3xl" fontWeight="normal" mb={6}>
+              {/* TODO: add i18n namespace */}
+              {"No results"}
+            </Heading>
 
+            {/* TODO: add i18n namespace */}
             <Text>
               There are no wallets matching your criteria, try removing some
               filters.
             </Text>
 
+            {/* TODO: add i18n namespace */}
             <Text mb={0}>Reset filters</Text>
           </Stack>
         </Flex>

--- a/src/components/FindWallet/WalletTable/index.tsx
+++ b/src/components/FindWallet/WalletTable/index.tsx
@@ -297,10 +297,18 @@ const thirdCol = "thirdCol"
 
 export interface WalletTableProps {
   filters: Record<string, boolean>
+  // TODO: update type
+  resetFilters: any
+  resetWalletFilter: any
   walletData: WalletData[]
 }
 
-const WalletTable = ({ filters, walletData }: WalletTableProps) => {
+const WalletTable = ({
+  filters,
+  resetFilters,
+  resetWalletFilter,
+  walletData,
+}: WalletTableProps) => {
   const { t } = useTranslation("page-wallets-find-wallet")
   const {
     featureDropdownItems,
@@ -397,9 +405,8 @@ const WalletTable = ({ filters, walletData }: WalletTableProps) => {
         <Flex
           justifyContent="center"
           m={{ base: 12, md: 24 }}
-          // borderStyle="dashed"
-          // borderColor="disabled"
-          border="dashed red"
+          border="2px dashed"
+          borderColor="body.light"
         >
           <Stack textAlign="center" p={12} lineHeight="1.6">
             <Heading as="h3" fontSize="3xl" fontWeight="normal" mb={6}>
@@ -413,8 +420,23 @@ const WalletTable = ({ filters, walletData }: WalletTableProps) => {
               filters.
             </Text>
 
-            {/* TODO: add i18n namespace */}
-            <Text mb={0}>Reset filters</Text>
+            <Text
+              mb={0}
+              color="primary.base"
+              textDecoration="underline"
+              cursor="pointer"
+              onClick={() => {
+                resetFilters()
+                resetWalletFilter.current()
+                trackCustomEvent({
+                  eventCategory: "WalletFilterReset",
+                  eventAction: `WalletFilterReset clicked`,
+                  eventName: `reset filters`,
+                })
+              }}
+            >
+              {t("page-find-wallet-reset-filters")}
+            </Text>
           </Stack>
         </Flex>
       )}

--- a/src/intl/en/page-wallets-find-wallet.json
+++ b/src/intl/en/page-wallets-find-wallet.json
@@ -94,5 +94,7 @@
   "page-find-wallet-choose-features": "Choose features",
   "page-find-wallet-reset-filters": "Reset filters",
   "page-find-wallet-visit-website": "Visit website",
-  "page-find-wallet-social-links": "Links"
+  "page-find-wallet-social-links": "Links",
+  "page-find-wallet-empty-results-title": "No results",
+  "page-find-wallet-empty-results-desc": "There are no wallets matching your criteria, try removing some filters."
 }

--- a/src/pages/wallets/find-wallet.tsx
+++ b/src/pages/wallets/find-wallet.tsx
@@ -318,7 +318,12 @@ const FindWalletPage = () => {
             },
           }}
         >
-          <WalletTable filters={filters} walletData={randomizedWalletData} />
+          <WalletTable
+            filters={filters}
+            resetFilters={resetFilters}
+            resetWalletFilter={resetWalletFilter}
+            walletData={randomizedWalletData}
+          />
         </Box>
       </Flex>
     </Flex>


### PR DESCRIPTION
This PR adds the WalletTable empty state as defined in the [design](https://www.figma.com/file/rv850lIICwOwRnyqSdtZED/Redesign-find-wallet?type=design&node-id=1842-22283&mode=design&t=28QQPGqW3a5BGm31-0). This PR branches off https://github.com/ethereum/ethereum-org-website/pull/12191 as it builds on top of the new wallet table layout, so should be merged first.

## Description

- adds `WalletEmptyState` component
- adds `WalletEmptyState` i18n strings
- displays `WalletEmptyState` if filtered results throw no results

## Note

This PR needs to be merged BEFORE https://github.com/ethereum/ethereum-org-website/pull/12191

## Preview

https://deploy-preview-12232--ethereumorg.netlify.app/wallets/find-wallet

## Testing

Update the filters/`wallet-data.ts` to have 0 results or just pass an empty array as `walletData` to `WalletTable` in `find-wallet.tsx` page.