### PR TITLE
Use `header` as H1 if `title` is missing in HubHero

### DIFF
--- a/src/components/Hero/HubHero/index.tsx
+++ b/src/components/Hero/HubHero/index.tsx
@@ -14,7 +14,7 @@ const HubHero = ({
 }: CommonHeroProps) => {
   if (buttons && buttons.length > 2) {
     throw new Error(
-      "Cannot have more than two call-to-action buttons in this hero component."
+      "Can not have more than two call-to-action buttons in this hero component."
     )
   }
 
@@ -81,4 +81,4 @@ const HubHero = ({
   )
 }
 
-export default HubHero;
+export default HubHero

--- a/src/components/Hero/HubHero/index.tsx
+++ b/src/components/Hero/HubHero/index.tsx
@@ -13,8 +13,8 @@ const HubHero = ({
   buttons,
 }: CommonHeroProps) => {
   if (buttons && buttons.length > 2) {
-    throw Error(
-      "Can not have more than two call-to-action buttons in this hero component."
+    throw new Error(
+      "Cannot have more than two call-to-action buttons in this hero component."
     )
   }
 
@@ -49,21 +49,25 @@ const HubHero = ({
         backdropBlur={{ xl: "base" }}
         wordBreak="break-word"
       >
-        <Heading
-          as="h1"
-          size="sm"
-          color="body.medium"
-          fontWeight="normal"
-          textTransform="uppercase"
-        >
-          {title}
-        </Heading>
+        {title ? (
+          <Heading
+            as="h1"
+            size="sm"
+            color="body.medium"
+            fontWeight="normal"
+            textTransform="uppercase"
+          >
+            {title}
+          </Heading>
+        ) : null}
         <Stack
           alignSelf="center"
           spacing={{ base: "2", md: "1" }}
           maxW="container.md"
         >
-          <Heading size="2xl">{header}</Heading>
+          <Heading as={title ? "h2" : "h1"} size="2xl">
+            {header}
+          </Heading>
           <Text size="lg">{description}</Text>
         </Stack>
         <HStack justify={{ md: "center", xl: "start" }} spacing="4">
@@ -77,4 +81,4 @@ const HubHero = ({
   )
 }
 
-export default HubHero
+export default HubHero;


### PR DESCRIPTION
### Description

If a `title` is not passed in props, use the `header` as H1 instead.

![image](https://github.com/ethereum/ethereum-org-website/assets/62268199/a7965321-98ae-4a04-b101-be1eda90266e)

cc: @nloureiro this probably has design system considerations

### Other

Small fix to error syntax

### Related Issue

Fixes #12253
Related #12252 
