### PR TITLE
Add H1 to bug bounty page

### DIFF
--- a/src/pages/bug-bounty.tsx
+++ b/src/pages/bug-bounty.tsx
@@ -5,6 +5,7 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import {
   Box,
   Center,
+  Heading,
   ListItem,
   UnorderedList,
   useColorModeValue,
@@ -103,18 +104,21 @@ const Subtitle = (props: ChildOnlyProp) => (
 
 const SloganGradient = (props: ChildOnlyProp) => (
   <Box
-    fontWeight="extrabold"
-    fontSize={{ base: "2.5rem", lg: "5xl" }}
-    lineHeight="xs"
     maxW="720px"
     mt="4"
-    mb="0"
     bgClip="text"
     overflow="auto"
     sx={{ WebkitBackgroundClip: "text", WebkitTextFillColor: "transparent" }}
     bg="upgradesGradient"
   >
-    <Text>{props.children}</Text>
+    <Heading
+      as="h1"
+      fontSize={{ base: "2.5rem", lg: "5xl" }}
+      fontWeight="800"
+      mb="1.45rem"
+    >
+      {props.children}
+    </Heading>
   </Box>
 )
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds H1 in place of the current paragraph tag to the bug bounty page

_Note: The styling is close but not perfect because of the different line heights on paragraphs/H1s, but given that this is non-standard styling, it didn't seem worth the time to make it perfect :)_

## Related Issue

Fixes #12255
Related #12252
