### PR TITLE
Hide contributor's profile link if the url doesn't exist

### DIFF
--- a/src/components/FileContributors.tsx
+++ b/src/components/FileContributors.tsx
@@ -146,7 +146,7 @@ const FileContributors = ({
           <Skeleton isLoaded={!loading}>
             <Text m={0} color="text200">
               <Translation id="last-edit" />:{" "}
-              {lastContributor.user && (
+              {lastContributor.user?.url && (
                 <InlineLink to={lastContributor.user.url}>
                   @{lastContributor.user.login}
                 </InlineLink>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Hides the contributor's profile link if the url doesn't exist.

## Related Issue

Fixes #12269