### PR TITLE
feat: add matomo event to lang picker input

### DIFF
--- a/src/components/LanguagePicker/index.tsx
+++ b/src/components/LanguagePicker/index.tsx
@@ -37,8 +37,15 @@ const LanguagePicker = ({
   menuState,
   ...props
 }: LanguagePickerProps) => {
-  const { t, refs, disclosure, filterValue, setFilterValue, filteredNames } =
-    useLanguagePicker(handleClose, menuState)
+  const {
+    t,
+    refs,
+    disclosure,
+    filterValue,
+    setFilterValue,
+    filteredNames,
+    handleInputFocus,
+  } = useLanguagePicker(handleClose, menuState)
   const { inputRef, firstItemRef, noResultsRef, footerRef } = refs
   const { onClose } = disclosure
 
@@ -137,6 +144,7 @@ const LanguagePicker = ({
                     e.stopPropagation()
                   }
                 }}
+                onFocus={handleInputFocus}
               />
               <InputRightElement
                 hideBelow="lg" // TODO: Confirm breakpoint after nav-menu PR merged

--- a/src/components/LanguagePicker/useLanguagePicker.tsx
+++ b/src/components/LanguagePicker/useLanguagePicker.tsx
@@ -35,6 +35,14 @@ export const useLanguagePicker = (
 
   const [filteredNames, setFilteredNames] = useState<LocaleDisplayInfo[]>([])
 
+  // Used to only send one matomo event for users who focus the filter input
+  const [hasFocusedInput, setHasFocusedInput] = useState(false)
+
+  // Reset if user switches languages
+  useEffect(() => {
+    setHasFocusedInput(false)
+  }, [locale])
+
   // perform all the filtering and mapping when the filter value change
   useEffect(() => {
     const locales = filterRealLocales(rawLocales)
@@ -188,6 +196,21 @@ export const useLanguagePicker = (
     )
   }
 
+  /**
+   * Send Matomo event when user focuses in the filter input.
+   * Only send once per user per session per language
+   * @returns void
+   */
+  const handleInputFocus = (): void => {
+    if (hasFocusedInput) return
+    trackCustomEvent({
+      ...eventBase,
+      eventAction: "Filter input",
+      eventName: "Focused inside filter input",
+    })
+    setHasFocusedInput(true)
+  }
+
   return {
     t,
     refs,
@@ -195,5 +218,6 @@ export const useLanguagePicker = (
     filterValue,
     setFilterValue,
     filteredNames,
+    handleInputFocus,
   }
 }

--- a/src/components/PageMetadata.tsx
+++ b/src/components/PageMetadata.tsx
@@ -2,9 +2,10 @@ import Head from "next/head"
 import { useRouter } from "next/router"
 import { useTranslation } from "next-i18next"
 
+import { getOgImage } from "@/lib/utils/metadata"
 import { filterRealLocales } from "@/lib/utils/translations"
 import { getFullUrl } from "@/lib/utils/url"
-import { getOgImage } from "@/lib/utils/metadata"
+
 import { SITE_URL } from "@/lib/constants"
 
 type NameMeta = {


### PR DESCRIPTION
## Description
- Add matomo event when user focuses in language picker filter input
- De-duped to only send one event per session, per language (resets if user follows a language result and switches languages)

cc: @konopkja 