### PR TITLE
Remove View in English button from Translation Banner

### DIFF
--- a/src/components/TranslationBanner.tsx
+++ b/src/components/TranslationBanner.tsx
@@ -96,7 +96,9 @@ const TranslationBanner = ({
                 {t("translation-banner-button-translate-page")}
               </ButtonLink>
             </Box>
-            {!isPageContentEnglish && (
+            {/* Todo: Reimplement once fixed */}
+            {/* Issue: https://github.com/ethereum/ethereum-org-website/issues/12292 */}
+            {/* {!isPageContentEnglish && (
               <Box>
                 <ButtonLink
                   to={originalPagePath}
@@ -110,7 +112,7 @@ const TranslationBanner = ({
                   {t("translation-banner-button-see-english")}
                 </ButtonLink>
               </Box>
-            )}
+            )} */}
           </Flex>
         </Flex>
         <CloseButton


### PR DESCRIPTION
## Description

Temporarily removes 'View in English' button from the translation banner, as it is currently causing thousands of 404s due to a logic bug.

<img width="1510" alt="Screenshot 2024-02-26 at 09 17 16" src="https://github.com/ethereum/ethereum-org-website/assets/62268199/1b98eb27-6204-415b-a17b-52ee1c044934">

## Related Issue

#12292
