### PR TITLE
Disable SVG URLs in AssetDownload

### DIFF
--- a/src/components/AssetDownload/index.tsx
+++ b/src/components/AssetDownload/index.tsx
@@ -62,11 +62,12 @@ const AssetDownload = ({
           {t("page-assets-download-download")} (
           {extname(imgSrc).slice(1).toUpperCase()})
         </ButtonLink>
-        {svgUrl && (
+        {/* Disables SVG due to bug: https://github.com/ethereum/ethereum-org-website/issues/12267 */}
+        {/* {svgUrl && (
           <ButtonLink href={svgUrl} onClick={matomoHandler} target="_blank">
             {t("page-assets-download-download")} (SVG)
           </ButtonLink>
-        )}
+        )} */}
       </Flex>
     </Flex>
   )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Disables the SVG download functionality, whilst we sort the bug in #12267

## Related Issue

#12267
