### PR TITLE
Clean up block explorers list (fixes #12306)

### DIFF
--- a/public/content/developers/docs/data-and-analytics/block-explorers/index.md
+++ b/public/content/developers/docs/data-and-analytics/block-explorers/index.md
@@ -17,15 +17,15 @@ You should understand the basic concepts of Ethereum so you can make sense of th
 - [Beaconcha.in](https://beaconcha.in/)
 - [Blockchair](https://blockchair.com/ethereum) -_Also available in Spanish, French, Italian, Dutch, Portuguese, Russian, Chinese, and Farsi_
 - [Blockscout](https://blockscout.com/)
+- [Chainlens](https://www.chainlens.com/)
+- [DexGuru Block Explorer](https://ethereum.dex.guru/)
 - [Etherchain](https://www.etherchain.org/)
+- [Ethernow](https://www.ethernow.xyz/)
 - [Ethplorer](https://ethplorer.io/) -_Also available in Chinese, Spanish, French, Turkish, Russian, Korean and Vietnamese_
+- [EthVM](https://www.ethvm.com/)
 - [OKLink](https://www.oklink.com/eth)
 - [Otterscan](https://otterscan.io/)
 - [Rantom](https://rantom.app/)
-- [Sirato](https://www.web3labs.com/sirato)
-- [EthVM](https://www.ethvm.com/)
-- [DexGuru Block Explorer](https://ethereum.dex.guru/)
-- [Ethernow](https://www.ethernow.xyz/)
 
 ## Data {#data}
 

--- a/public/content/enterprise/index.md
+++ b/public/content/enterprise/index.md
@@ -72,7 +72,7 @@ Some collaborative efforts to make Ethereum enterprise friendly have been made b
 ### Tooling and libraries {#tooling-and-libraries}
 
 - [Alethio](https://explorer.aleth.io/) _Ethereum Data Analytics Platform_
-- [Sirato](https://www.web3labs.com/sirato) _a data and analytics platform for public and private Ethereum compatible networks by Web3 Labs_
+- [Chainlens](https://www.chainlens.com/) _a data and analytics platform for public and private Ethereum compatible networks by Web3 Labs_
 - [Ernst & Young's ‘Nightfall'](https://github.com/EYBlockchain/nightfall) _a toolkit for private transactions_
 - [EthSigner](https://github.com/ConsenSys/ethsigner) _a transaction signing application to be used with a web3 provider_
 - [Tenderly](https://tenderly.co/) _a Data Platform providing real-time analytics, alerting and monitoring with support for private networks_

--- a/public/content/translations/de/developers/docs/data-and-analytics/block-explorers/index.md
+++ b/public/content/translations/de/developers/docs/data-and-analytics/block-explorers/index.md
@@ -17,14 +17,14 @@ Sie sollten das Basiskonzept von Ethereum verstehen, damit Sie die Daten, die Si
 - [Beaconcha.in](https://beaconcha.in/)
 - [Blockchair](https://blockchair.com/ethereum) -_Auch in Spanisch, Französisch, Italienisch, Niederländisch, Portugiesisch, Russisch, Chinesisch und Farsi verfügbar_
 - [Blockscout](https://blockscout.com/)
+- [Chainlens](https://www.chainlens.com/)
+- [DexGuru Block Explorer](https://ethereum.dex.guru/)
 - [Etherchain](https://www.etherchain.org/)
 - [Ethplorer](https://ethplorer.io/) -_Auch in Chinesisch, Spanisch, Französisch, Türkisch, Russisch, Koreanisch und Vietnamesisch verfügbar_
+- [EthVM](https://www.ethvm.com/)
 - [OKLink](https://www.oklink.com/eth)
 - [Otterscan](https://otterscan.io/)
 - [Rantom](https://rantom.app/)
-- [Sirato](https://www.web3labs.com/sirato)
-- [EthVM](https://www.ethvm.com/)
-- [DexGuru Block Explorer](https://ethereum.dex.guru/)
 
 ## Daten {#data}
 

--- a/public/content/translations/de/enterprise/index.md
+++ b/public/content/translations/de/enterprise/index.md
@@ -64,7 +64,7 @@ Verschiedene Organisationen unternahmen gemeinsame Anstrengungen, um Ethereum un
 ### Tools und Bibliotheken {#tooling-and-libraries}
 
 - [Alethio](https://explorer.aleth.io/) _Ethereum-Data-Analytics-Plattform_
-- [Epirus](https://www.web3labs.com/epirus) _eine Plattform zur Entwicklung, Bereitstellung und Überwachung von Blockchain-Anwendungen durch Web3 Labs_
+- [Chainlens](https://www.chainlens.com/) _eine Plattform zur Entwicklung, Bereitstellung und Überwachung von Blockchain-Anwendungen durch Web3 Labs_
 - [Ernst & Youngs 'Nightfall'](https://github.com/EYBlockchain/nightfall) _ein Toolkit für private Transaktionen_
 - [EthSigner](https://github.com/ConsenSys/ethsigner) _eine Transaktionssignierungsanwendung zur Verwendung mit einem Web3-Anbieter_
 - [Tenderly](https://tenderly.co/) _, eine Datenplattform, die Echtzeit-Analysen, Alarmierung und Überwachung mit Unterstützung für private Netzwerke bereitstellt_

--- a/public/content/translations/es/developers/docs/data-and-analytics/block-explorers/index.md
+++ b/public/content/translations/es/developers/docs/data-and-analytics/block-explorers/index.md
@@ -17,14 +17,14 @@ Es necesario que comprendas los conceptos básicos de Ethereum para poder entend
 - [Beaconcha.in](https://beaconcha.in/)
 - [Blockchair:](https://blockchair.com/ethereum) _También disponible en inglés, francés, italiano, neerlandés, portugués, ruso, chino y farsi_
 - [Blockscout](https://blockscout.com/)
+- [Chainlens](https://www.chainlens.com/)
 - [Etherchain](https://www.etherchain.org/)
 - [Ethplorer:](https://ethplorer.io/) _También disponible en chino, español, francés, turco, ruso, coreano y vietnamita_
+- [EthVM](https://www.ethvm.com/)
+- [Explorador de bloques DexGuru](https://ethereum.dex.guru/)
 - [OKLink](https://www.oklink.com/eth)
 - [Otterscan](https://otterscan.io/)
 - [Rantom](https://rantom.app/)
-- [Sirato](https://www.web3labs.com/sirato)
-- [EthVM](https://www.ethvm.com/)
-- [Explorador de bloques DexGuru](https://ethereum.dex.guru/)
 
 ## Datos {#data}
 

--- a/public/content/translations/es/enterprise/index.md
+++ b/public/content/translations/es/enterprise/index.md
@@ -68,7 +68,7 @@ Diferentes organizaciones han emprendido iniciativas de colaboración para que E
 ### Herramientas y bibliotecas {#tooling-and-libraries}
 
 - [Alethio:](https://explorer.aleth.io/) _plataforma de análisis de datos de Ethereum_
-- [Sirato](https://www.web3labs.com/sirato)_es una plataforma de datos y análisis para redes públicas y privadas de Web3 Labs compatibles con Ethereum._
+- [Chainlens](https://www.chainlens.com/)_es una plataforma de datos y análisis para redes públicas y privadas de Web3 Labs compatibles con Ethereum._
 - [Ernst & Nightfall's "Nightfall"](https://github.com/EYBlockchain/nightfall) _: un conjunto de herramientas para realizar transacciones privadas_
 - [EthSigner](https://github.com/ConsenSys/ethsigner) _: una aplicación de firmado de transacción para utilizarse con un proveedor de web3_
 - [Anteriormente](https://tenderly.co/) _era una plataforma de datos que proporciona análisis en tiempo real, alertas y monitoreo con soporte para redes privadas._

--- a/public/content/translations/fr/developers/docs/data-and-analytics/block-explorers/index.md
+++ b/public/content/translations/fr/developers/docs/data-and-analytics/block-explorers/index.md
@@ -17,14 +17,14 @@ Pour que les données fournies par un explorateur de blocs aient du sens, vous d
 - [Beaconcha.in](https://beaconcha.in/)
 - [Blockchair](https://blockchair.com/ethereum) - _Également disponible en espagnol, français, italien, néerlandais, portugais, russe, chinois et Farsi_
 - [Blockscout](https://blockscout.com/)
+- [Chainlens](https://www.chainlens.com/)
 - [Etherchain](https://www.etherchain.org/)
 - [Ethplorer](https://ethplorer.io/) - _Aussi disponible en chinois, espagnol, français, turc, russe, coréen et vietnamien_
+- [EthVM](https://www.ethvm.com/)
+- [Explorateurs de bloc DexGuru](https://ethereum.dex.guru/)
 - [OKLink](https://www.oklink.com/eth)
 - [Otterscan](https://otterscan.io/)
 - [Rantom](https://rantom.app/)
-- [Sirato](https://www.web3labs.com/sirato)
-- [EthVM](https://www.ethvm.com/)
-- [Explorateurs de bloc DexGuru](https://ethereum.dex.guru/)
 
 ## Données {#data}
 

--- a/public/content/translations/fr/enterprise/index.md
+++ b/public/content/translations/fr/enterprise/index.md
@@ -68,7 +68,7 @@ Différentes organisations sont à l'origine d'initiatives collaboratives afin d
 ### Outils et bibliothèques {#tooling-and-libraries}
 
 - [Alethio](https://explorer.aleth.io/) _- Plateforme d'analyse des données Ethereum_
-- [Sirato](https://www.web3labs.com/sirato) _- Plateforme de données et d'analyse, pour les réseaux publics et privés compatibles avec Ethereum (EVM) par Web3 Labs_
+- [Chainlens](https://www.chainlens.com/) _- Plateforme de données et d'analyse, pour les réseaux publics et privés compatibles avec Ethereum (EVM) par Web3 Labs_
 - [Ernst & Young Nightfall](https://github.com/EYBlockchain/nightfall) _- Boîte à outils pour les transactions privées_
 - [EthSigner](https://github.com/ConsenSys/ethsigner) _- Application de signature de transactions à utiliser avec un prestataire Web3_
 - [Tenderly](https://tenderly.co/) _ - Plateforme de données fournissant des analyses en temps réel, des alertes et une surveillance avec support pour les réseaux privés_

--- a/public/content/translations/hu/developers/docs/data-and-analytics/block-explorers/index.md
+++ b/public/content/translations/hu/developers/docs/data-and-analytics/block-explorers/index.md
@@ -17,14 +17,14 @@ Először meg kellene értened az Ethereum alapvető fogalmait ahhoz, hogy érte
 - [Beaconcha.in](https://beaconcha.in/)
 - [Blockchair](https://blockchair.com/ethereum) –_ Spanyol, francia, olasz, holland, portugál, orosz, kínai és fárszi nyelven is elérhető_
 - [Blockscout](https://blockscout.com/)
+- [Chainlens](https://www.chainlens.com/)
+- [DexGuru Block Explorer](https://ethereum.dex.guru/)
 - [Etherchain](https://www.etherchain.org/)
 - [Ethplorer](https://ethplorer.io/) –_Kínai, spanyol, francia, török, orosz, koreai és vietnámi nyelven is elérhető_
+- [EthVM](https://www.ethvm.com/)
 - [OKLink](https://www.oklink.com/eth)
 - [Otterscan](https://otterscan.io/)
 - [Rantom](https://rantom.app/)
-- [Sirato](https://www.web3labs.com/sirato)
-- [EthVM](https://www.ethvm.com/)
-- [DexGuru Block Explorer](https://ethereum.dex.guru/)
 
 ## Adat {#data}
 

--- a/public/content/translations/hu/enterprise/index.md
+++ b/public/content/translations/hu/enterprise/index.md
@@ -68,7 +68,7 @@ Különféle szervezetek számtalan együttműködésen alapuló erőfeszítést
 ### Eszközök és könyvtárak {#tooling-and-libraries}
 
 - Az [Alethio](https://explorer.aleth.io/) _egy Ethereum adatelemzési platform_
-- A [Sirato](https://www.web3labs.com/sirato) _egy adat és elemzési platform publikus és privát, Ethereum kompatibilis hálózatokhoz, melyet a Web3 Labs fejlesztett_
+- A [Chainlens](https://www.chainlens.com/) _egy adat és elemzési platform publikus és privát, Ethereum kompatibilis hálózatokhoz, melyet a Web3 Labs fejlesztett_
 - Az [Ernst & Young Nightfall](https://github.com/EYBlockchain/nightfall) _ egy eszköztár privát tranzakciókhoz_
 - Az [EthSigner](https://github.com/ConsenSys/ethsigner) _egy tranzakció aláírási alkalmazás, amelyet egy web3 szolgáltatóval kell használni_
 - A [Tenderly](https://tenderly.co/) _egy adatplatform, mely valós idejű elemzéseket, figyelmeztetéseket és monitorozást kínál támogatással együtt privát láncoknak._

--- a/public/content/translations/it/developers/docs/data-and-analytics/block-explorers/index.md
+++ b/public/content/translations/it/developers/docs/data-and-analytics/block-explorers/index.md
@@ -17,14 +17,14 @@ I block explorer sono il tuo portale sui dati di Ethereum. Puoi usarli per visua
 - [Beaconcha.in](https://beaconcha.in/)
 - [Blockchair](https://blockchair.com/ethereum): _disponibile anche in spagnolo, francese, italiano, olandese, portoghese, russo, cinese e farsi_
 - [Blockscout](https://blockscout.com/)
+- [Chainlens](https://www.chainlens.com/)
+- [DexGuru Block Explorer](https://ethereum.dex.guru/)
 - [Etherchain](https://www.etherchain.org/)
 - [Ethplorer](https://ethplorer.io/): _disponibile anche in cinese, spagnolo, francese, turco, russo, coreano e vietnamita_
+- [EthVM](https://www.ethvm.com/)
 - [OKLink](https://www.oklink.com/eth)
 - [Otterscan](https://otterscan.io/)
 - [Rantom](https://rantom.app/)
-- [Sirato](https://www.web3labs.com/sirato)
-- [EthVM](https://www.ethvm.com/)
-- [DexGuru Block Explorer](https://ethereum.dex.guru/)
 
 ## Dati {#data}
 

--- a/public/content/translations/it/enterprise/index.md
+++ b/public/content/translations/it/enterprise/index.md
@@ -68,7 +68,7 @@ Alcuni sforzi collaborativi per rendere la rete Ethereum aziendale più intuitiv
 ### Strumenti e librerie {#tooling-and-libraries}
 
 - [Alethio](https://explorer.aleth.io/) _Piattaforma di analisi dei dati di Ethereum_
-- [Sirato](https://www.web3labs.com/sirato) _una piattaforma specializzata nell'analisi dei dati per reti pubbliche e private abilitate a Ethereum realizzata da Labs nel Web3_
+- [Chainlens](https://www.chainlens.com/) _una piattaforma specializzata nell'analisi dei dati per reti pubbliche e private abilitate a Ethereum realizzata da Labs nel Web3_
 - [Ernst & Young's ‘Nightfall'](https://github.com/EYBlockchain/nightfall) _kit di strumenti per transazioni private_
 - [EthSigner](https://github.com/ConsenSys/ethsigner) _applicazione per la firma delle transazioni da usare con un provider web3_
 - [Tenderly](https://tenderly.co/) _una Piattaforma di dati che fornisce analitiche in tempo reale, avvisando e monitorando con supporto alle reti private_

--- a/public/content/translations/ja/developers/docs/data-and-analytics/block-explorers/index.md
+++ b/public/content/translations/ja/developers/docs/data-and-analytics/block-explorers/index.md
@@ -17,14 +17,14 @@ sidebarDepth: 3
 - [Beaconcha.in](https://beaconcha.in/)
 - [blockchair](https://blockchair.com/ethereum) –_スペイン語、フランス語、イタリア語、オランダ語、ポルトガル語、ロシア語、中国語、ペルシア語でも利用できます_
 - [Blockscout](https://blockscout.com/)
+- [Chainlens](https://www.chainlens.com/)
+- [DexGuru ブロックエクスプローラー](https://ethereum.dex.guru/)
 - [Etherchain](https://www.etherchain.org/)
 - [Ethplorer](https://ethplorer.io/) –_中国語、スペイン語、フランス語、トルコ語、ロシア語、韓国語、ベトナム語でも利用できます_
+- [EthVM](https://www.ethvm.com/)
 - [OKLink](https://www.oklink.com/eth)
 - [Otterscan](https://otterscan.io/)
 - [Rantom](https://rantom.app/)
-- [Sirato](https://www.web3labs.com/sirato)
-- [EthVM](https://www.ethvm.com/)
-- [DexGuru ブロックエクスプローラー](https://ethereum.dex.guru/)
 
 ## データ {#data}
 

--- a/public/content/translations/ja/enterprise/index.md
+++ b/public/content/translations/ja/enterprise/index.md
@@ -66,7 +66,7 @@ Hyperledger、Quorum、Corda プロジェクトが開始された 2016 年頃か
 ### ツールとライブラリ {#tooling-and-libraries}
 
 - [Alethio](https://explorer.aleth.io/) _イーサリアムデータ分析プラットフォーム_
-- [Sirato](https://www.web3labs.com/sirato) _Web3 Labs によるパブリックとプライベートイーサリアム互換ネットワークのためのデータおよび分析プラットフォーム_
+- [Chainlens](https://www.chainlens.com/) _Web3 Labs によるパブリックとプライベートイーサリアム互換ネットワークのためのデータおよび分析プラットフォーム_
 - [Ernst & Young's ‘Nightfall’](https://github.com/EYBlockchain/nightfall) _プライベートトランザクション用のツールキット_
 - [EthSigner](https://github.com/ConsenSys/ethsigner) _Web3 プロバイダーで使用するトランザクション署名のアプリケーション_
 - [Tenderly](https://tenderly.co/) _プライベートネットワークをサポートするリアルタイムの分析、アラート、モニタリングを提供するデータプラットフォーム。_

--- a/public/content/translations/pt-br/developers/docs/data-and-analytics/block-explorers/index.md
+++ b/public/content/translations/pt-br/developers/docs/data-and-analytics/block-explorers/index.md
@@ -17,12 +17,12 @@ Você deve entender os conceitos básicos do Ethereum; para que você possa ente
 - [Beaconcha.in](https://beaconcha.in/)
 - [Blockchair](https://blockchair.com/ethereum) -_ Também disponível em espanhol, francês, italiano, holandês, português, russo, chinês e persa_
 - [Blockscout](https://blockscout.com/)
+- [Chainlens](https://www.chainlens.com/)
 - [Etherchain](https://www.etherchain.org/)
 - [Ethplorer](https://ethplorer.io/) -_ Também disponível em chinês, espanhol, francês, turco, russo, coreano e vietnamita_
+- [EthVM](https://www.ethvm.com/)
 - [OKLink](https://www.oklink.com/eth)
 - [Otterscan](https://otterscan.io/)
-- [Sirato](https://www.web3labs.com/sirato)
-- [EthVM](https://www.ethvm.com/)
 
 ## Dados {#data}
 

--- a/public/content/translations/pt-br/enterprise/index.md
+++ b/public/content/translations/pt-br/enterprise/index.md
@@ -68,7 +68,7 @@ Diversas organizações trabalharam juntas para tornar o Ethereum amigável para
 ### Ferramentas e bibliotecas {#tooling-and-libraries}
 
 - [Alethio](https://explorer.aleth.io/) _Plataforma de Análise de Dados do Ethereum_
-- [Sirato](https://www.web3labs.com/sirato) _uma plataforma de dados e análises para redes públicas e privadas Ethereum compatíveis da Web3 Labs_
+- [Chainlens](https://www.chainlens.com/) _uma plataforma de dados e análises para redes públicas e privadas Ethereum compatíveis da Web3 Labs_
 - [Ernst & Young ‘Nightfall’](https://github.com/EYBlockchain/nightfall) _é um conjunto de ferramentas para transações privadas_
 - [EthSigner](https://github.com/ConsenSys/ethsigner) _é um aplicativo de assinatura de transações para ser usado com um provedor web3_
 - [Tenderly](https://tenderly.co/) _é uma plataforma de dados que fornece análise em tempo real, alertando e monitorando com suporte a redes privadas_

--- a/public/content/translations/tr/developers/docs/data-and-analytics/block-explorers/index.md
+++ b/public/content/translations/tr/developers/docs/data-and-analytics/block-explorers/index.md
@@ -17,14 +17,14 @@ Bir blok arayıcısının size verdiği verileri anlamlandırabilmeniz için Eth
 - [Beaconcha.in](https://beaconcha.in/)
 - [Blockchair](https://blockchair.com/ethereum) -_Ayrıca İspanyolca, Fransızca, İtalyanca, Danca, Portekizce, Rusça, Çince ve Farsça olarak da mevcut_
 - [Blockscout](https://blockscout.com/)
+- [Chainlens](https://www.chainlens.com/)
+- [DexGuru Blok Arayıcısı](https://ethereum.dex.guru/)
 - [Etherchain](https://www.etherchain.org/)
 - [Ethplorer](https://ethplorer.io/) -_Ayrıca Çince, İspanyolca, Fransızca, Türkçe, Rusça, Korece ve Vietnamca dillerinde de mevcut_
+- [EthVM](https://www.ethvm.com/)
 - [Oklink](https://www.oklink.com/eth)
 - [Otterscan](https://otterscan.io/)
 - [Rantom](https://rantom.app/)
-- [Sirato](https://www.web3labs.com/sirato)
-- [EthVM](https://www.ethvm.com/)
-- [DexGuru Blok Arayıcısı](https://ethereum.dex.guru/)
 
 ## Veri {#data}
 

--- a/public/content/translations/tr/enterprise/index.md
+++ b/public/content/translations/tr/enterprise/index.md
@@ -68,7 +68,7 @@ Ethereum'u işletme dostu hâle getirmek için farklı kuruluşlar tarafından b
 ### Araçlar ve kütüphaneler {#tooling-and-libraries}
 
 - [Alethio](https://explorer.aleth.io/) _Ethereum Veri Analizi Platformu_
-- [Sirato](https://www.web3labs.com/sirato), _Web3 Labs'den Ethereum ile uyumlu herkese açık ve özel ağlara yönelik bir veri ve analiz platformu_
+- [Chainlens](https://www.chainlens.com/), _Web3 Labs'den Ethereum ile uyumlu herkese açık ve özel ağlara yönelik bir veri ve analiz platformu_
 - [Ernst & Young'ın "Nightfall"u](https://github.com/EYBlockchain/nightfall) _özel işlemler için bir araç takımı_
 - [EthSigner](https://github.com/ConsenSys/ethsigner) _bir web3 sağlayıcısıyla kullanılacak bir işlem imzalama uygulaması_
 - [Tenderly](https://tenderly.co/)_gerçek zamanlı analizler sağlayan, özel ağlar için destek sunarak uyarılarda bulunan ve izleme gerçekleştiren bir Veri Platformudur_

--- a/public/content/translations/zh/developers/docs/data-and-analytics/block-explorers/index.md
+++ b/public/content/translations/zh/developers/docs/data-and-analytics/block-explorers/index.md
@@ -17,14 +17,14 @@ sidebarDepth: 3
 - [Beaconcha.in](https://beaconcha.in/)
 - [Blockchair](https://blockchair.com/ethereum) -_ 还支持西班牙语、法语、意大利语、荷兰语、葡萄牙语、俄语、中文和波斯语_
 - [Blockscout](https://blockscout.com/)
+- [Chainlens](https://www.chainlens.com/)
+- [DexGuru 区块浏览器](https://ethereum.dex.guru/)
 - [Etherchain](https://www.etherchain.org/)
 - [Ethplorer](https://ethplorer.io/) -_ 还支持中文、西班牙语、法语、土耳其语、俄语、韩语和越南语_
+- [EthVM](https://www.ethvm.com/)
 - [OKLink](https://www.oklink.com/eth)
 - [Otterscan](https://otterscan.io/)
 - [Rantom](https://rantom.app/)
-- [Sirato](https://www.web3labs.com/sirato)
-- [EthVM](https://www.ethvm.com/)
-- [DexGuru 区块浏览器](https://ethereum.dex.guru/)
 
 ## 数据 {#data}
 

--- a/public/content/translations/zh/enterprise/index.md
+++ b/public/content/translations/zh/enterprise/index.md
@@ -66,7 +66,7 @@ lang: zh
 ### 工具和库 {#tooling-and-libraries}
 
 - [Alathio](https://explorer.aleth.io/) _以太坊数据分析平台_
-- [Sirato](https://www.web3labs.com/sirato) _面向公共和私有以太坊兼容网络的数据和分析平台，由 Web3 Labs 提供_
+- [Chainlens](https://www.chainlens.com/) _面向公共和私有以太坊兼容网络的数据和分析平台，由 Web3 Labs 提供_
 - [Ernst & Young 的“Nightfall”](https://github.com/EYBlockchain/nightfall) _私有的交易工具包_
 - [EthSigner](https://github.com/ConsenSys/ethsigner) _与 Web3 应用提供商一起使用的交易签名应用程序_
 - [Tenderly](https://tenderly.co/)_，一个提供实时分析、告警和监控，并为专用网络提供支持的数据平台_


### PR DESCRIPTION
## Description

The block explorers list is not in alphabetical order, this PR updates it so it is with the exception of Etherscan remaining at the top.

I've also updated references to Sirato block explorer to be Chainlens as its been rebranded.

## Related Issue

This pull request fixes issue #12306 