### PR TITLE
fix  Ethereum&nbsp spelling in french learn page

### DIFF
--- a/public/content/translations/fr/security/index.md
+++ b/public/content/translations/fr/security/index.md
@@ -104,7 +104,7 @@ Les extensions de navigateur comme les extensions Chrome ou les modules complém
 L'une des principales raisons pour lesquelles les gens se font arnaquer dans l'univers des cryptomonnaies est souvent le manque de compréhension. Par exemple, si vous ne comprenez pas que le réseau Ethereum est décentralisé et n'appartient à personne, il est facile de devenir la cible de quelqu'un qui prétend faire partie de l'équipe de support et qui vous promet de vous rendre vos ETH perdus en échange de vos clés privées. S'informer sur le fonctionnement d'Ethereum est un investissement qui en vaut la peine.
 
 <DocLink to="/what-is-ethereum/">
-  Qu'est-ce qu'Ethereum&nbsp;?
+  Qu'est-ce qu'Ethereum ?
 </DocLink>
 
 <DocLink to="/eth/">

--- a/src/intl/fr/page-learn.json
+++ b/src/intl/fr/page-learn.json
@@ -12,7 +12,7 @@
   "hero-button-lets-get-started": "C'est parti !",
   "what-is-crypto-1": "Vous avez peut-être entendu parler de cryptomonnaies, de blockchains et de Bitcoin. Les liens ci-dessous vous aideront à apprendre ce qu'ils sont et comment ils s'articulent avec Ethereum.",
   "what-is-crypto-2": "Les cryptomonnaies, comme le Bitcoin, permettent à n'importe qui de transférer de l'argent à l'échelle mondiale. Ethereum le permet également, mais il peut également exécuter du code qui permet aux gens de créer des applications et des organisations. Il est à la fois résilient et flexible : n'importe quel programme informatique peut être exécuté sur Ethereum. Apprenez-en davantage et découvrez comment commencer :",
-  "what-is-ethereum-card-title": "Qu'est-ce qu'Ethereum&nbsp;?",
+  "what-is-ethereum-card-title": "Qu'est-ce qu'Ethereum ?",
   "what-is-ethereum-card-description": "Si vous êtes nouveau, commencez ici pour savoir pourquoi Ethereum est important.",
   "what-is-ethereum-card-image-alt": "Illustration d'une personne jetant un coup d'œil à un bazar, destiné à représenter Ethereum.",
   "what-is-eth-card-title": "Qu'est-ce que l'ETH ?",


### PR DESCRIPTION
## Description

In this pull request, I have corrected the French spelling errors on the web page.
"Qu'est-ce qu'Ethereum&nbsp;?" by "Qu'est-ce qu'Ethereum ?"

 I have reviewed the text and made necessary adjustments to ensure proper spelling and grammar in French.

## Related Issue

No specific issue was opened for this task.
