### PR TITLE
Fix broken link to working link

### DIFF
--- a/public/content/developers/docs/nodes-and-clients/run-a-node/index.md
+++ b/public/content/developers/docs/nodes-and-clients/run-a-node/index.md
@@ -127,7 +127,7 @@ Multiple user-friendly projects aim to improve the experience of setting up a cl
 
 Below are a few projects which can help you install and control clients just with a few clicks:
 
-- [DappNode](https://docs.dappnode.io/user/quick-start/first-steps/) - DappNode doesn't come only with a machine from a vendor. The software, the actual node launcher and control center with many features can be used on arbitrary hardware.
+- [DappNode](https://docs.dappnode.io/docs/user/getting-started/setup/) - DappNode doesn't come only with a machine from a vendor. The software, the actual node launcher and control center with many features can be used on arbitrary hardware.
 - [eth-docker](https://eth-docker.net/) - Automated setup using Docker focused on easy and secure staking, requires basic terminal and Docker knowledge, recommended for a bit more advanced users.
 - [Stereum](https://stereum.net/ethereum-node-setup/) - Launcher for installing clients on a remote server via SSH connection with a GUI setup guide, control center, and many other features.
 - [NiceNode](https://www.nicenode.xyz/) - Launcher with a straightforward user experience to run a node on your computer. Just choose clients and start them with a few clicks. Still in development.


### PR DESCRIPTION
Trying to open the DappNode link and it leads to a "page not found", they must've changed their path

Steps to reproduce the behavior
Page -> https://ethereum.org/developers/docs/nodes-and-clients/run-a-node Then-> Search (Cmd+f or control+f) for "DappNode doesn't come only with a machine from a vendor." Then click on the DappNode link

## Description

Changed the broken link to a working link

## Related Issue

Bug Error Issue Link - https://github.com/ethereum/ethereum-org-website/issues/12314
