### PR TITLE
fix: fix hyperlink in glossary on consensus client (fixes #12318)

### DIFF
--- a/src/intl/en/glossary.json
+++ b/src/intl/en/glossary.json
@@ -60,7 +60,7 @@
   "consensus-term": "Consensus",
   "consensus-definition": "When a supermajority of nodes on the network all have the same blocks in their locally validated best blockchain. Not to be confused with <a href=\"/glossary/#consensus-rules\">consensus rules</a>.",
   "consensus-client-term": "Consensus client",
-  "consensus-client-definition": "Consensus clients (such as Prysm, Teku, Nimbus, Lighthouse, Lodestar) run Ethereum's <a href=\"/glossary/#pos\">proof-of-stake</a> consensus algorithm allowing the network to reach agreement about the head of the Beacon Chain. Consensus clients do not participate in validating/broadcasting transactions or executing state transitions. This is done by <a href=\"/glossary/#execution-client\">execution clients](#execution-client</a>.",
+  "consensus-client-definition": "Consensus clients (such as Prysm, Teku, Nimbus, Lighthouse, Lodestar) run Ethereum's <a href=\"/glossary/#pos\">proof-of-stake</a> consensus algorithm allowing the network to reach agreement about the head of the Beacon Chain. Consensus clients do not participate in validating/broadcasting transactions or executing state transitions. This is done by <a href=\"/glossary/#execution-client\">execution clients</a>.",
   "consensus-layer-term": "Consensus layer",
   "consensus-layer-definition": "Ethereum's consensus layer is the network of <a href=\"/glossary/#consensus-client\">consensus clients</a>.",
   "consensus-rules-term": "Consensus rules",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed the hyperlink in the glossary on the definition of "consensus client" -- it should work well now

## Related Issue

Fixes issue #12318
