### PR TITLE
fix: infinite redirect loop at developers/docs/scaling [FIXES #12330]

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -148,8 +148,6 @@
 
 /*/eth2 /:splat/upgrades/ 301!
 
-/*/developers/docs/scaling /:splat/developers/docs/scaling 301!
-
 /*/developers/docs/scaling/layer-2-rollups /:splat/developers/docs/scaling 301!
 
 /*/about/web-developer /:splat/about/#open-jobs 301!


### PR DESCRIPTION
- Remove a 301 redirect from `/developers/docs/scaling` to itself

## Description

A previous commit that removed a deprecated redirect introduced an issue where the subpage `/developers/docs/scaling` redirects back to itself, causing an infinite redirect loop.

Issue #12330 describes that this only happens when trying to visit the page, doesn't happen when routing through the navigation. This is probably because during the visit, Netlify triggers the redirect, while navigation uses Next.js to push a new path without triggering a reload/redirect.

To fix this issue, we simply remove the redirect in `_redirects` for Netlify.

## Related Issue
[Issue #12330 - Navigating directly to the scaling docs enters a redirect loop](https://github.com/ethereum/ethereum-org-website/issues/12330)
