### PR TITLE
Remove here strings (<<<) from GH workflows

### DIFF
--- a/.github/workflows/get-crowdin-contributors.yml
+++ b/.github/workflows/get-crowdin-contributors.yml
@@ -59,5 +59,5 @@ jobs:
 
       - name: Create Pull Request
         run: |
-          gh auth login --with-token <<< ${{ secrets.GITHUB_TOKEN }}
+          gh auth login --with-token ${{ secrets.GITHUB_TOKEN }}
           gh pr create --base dev --head "automated-update-${{ env.TIMESTAMP }}" --title "Update translation contributors from Crowdin - ${{ env.READABLE_DATE }}" --body-file pr_body.txt

--- a/.github/workflows/get-translation-progress.yml
+++ b/.github/workflows/get-translation-progress.yml
@@ -60,5 +60,5 @@ jobs:
 
       - name: Create Pull Request
         run: |
-          gh auth login --with-token <<< ${{ secrets.GITHUB_TOKEN }}
+          gh auth login --with-token ${{ secrets.GITHUB_TOKEN }}
           gh pr create --base dev --head "automated-update-${{ env.TIMESTAMP }}" --title "Update translation progress from Crowdin - ${{ env.READABLE_DATE }}" --body-file pr_body.txt


### PR DESCRIPTION
Eliminated the use of '<<<' in the 'gh auth login' command within the 'Create Pull Request' step to ensure authentication integrity.

## Description

This change removes the usage of the '<<<' syntax within the 'gh auth login' command in the 'Create Pull Request' step of the workflow. This modification aims to ensure authentication integrity during the interaction with GitHub through the command-line interface

## Related Issue

https://github.com/ethereum/ethereum-org-website/issues/12363


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Simplified the token input method in GitHub workflows for better efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->