### PR TITLE
ERC4526 withdraw event documentation wrong field name for shares

### DIFF
--- a/public/content/developers/docs/standards/tokens/erc-4626/index.md
+++ b/public/content/developers/docs/standards/tokens/erc-4626/index.md
@@ -195,7 +195,7 @@ event Withdraw(
     address indexed receiver,
     address indexed owner,
     uint256 assets,
-    uint256 share
+    uint256 shares
 )
 ```
 


### PR DESCRIPTION
In the ERC4526 the Withdraw event parameter is described as `shares` not `share`

<!--- Provide a general summary of your changes in the Title above -->

## Description

Changing documentation to align with the [EIP for ERC4626 ](https://eips.ethereum.org/EIPS/eip-4626#events).

This also aligns with how it is implemented in e.g. sDAI.


