### PR TITLE
Fix CardList external links not opening in new tabs

### DIFF
--- a/src/components/CardList.tsx
+++ b/src/components/CardList.tsx
@@ -70,6 +70,7 @@ const Card = ({
           <LinkOverlay
             as={BaseLink}
             href={link}
+            isExternal={isExternal}
             hideArrow
             color="text"
             textDecoration="none"


### PR DESCRIPTION
## Description

Fixed this by passing the `isExternal` prop to the `LinkOverlay` component.