### PR TITLE
Add 'Ethereum Ecosystem' Link to Footer on ethereum.org

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -217,6 +217,10 @@ const Footer = ({ lastDeployDate }: FooterProps) => {
           text: t("esp"),
         },
         {
+          to: "https://www.ethereum-ecosystem.com",
+          text: t("ethereum-ecosystem"),
+        },
+        {
           to: "/bug-bounty/",
           text: t("ethereum-bug-bounty"),
         },

--- a/src/intl/en/common.json
+++ b/src/intl/en/common.json
@@ -78,6 +78,7 @@
   "eth-current-price": "Current ETH price (USD)",
   "ethereum-basics": "Ethereum basics",
   "ethereum-bug-bounty": "Ethereum bug bounty program",
+  "ethereum-ecosystem": "Ethereum Ecosystem page",
   "consensus-when-shipping": "When's it shipping?",
   "ethereum-upgrades": "Ethereum upgrades",
   "ethereum-brand-assets": "Ethereum brand assets",


### PR DESCRIPTION
This PR introduces a link to [Ethereum Ecosystem](https://www.ethereum-ecosystem.com/), an unofficial ecosystem page for Ethereum and its most popular L2s like Base, Optimism and Starknet, that features 1000+ dApps.

## Description

- The new footer link is titled 'Ethereum Ecosystem page'.
- It points to https://www.ethereum-ecosystem.com.
- The link is added in the appropriate place in the footer to maintain the design consistency.


## Related Issue
https://github.com/ethereum/ethereum-org-website/issues/12375
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
