### PR TITLE
fix: nav item hover zone, opening delay duration

### DIFF
--- a/src/components/Nav/Menu/index.tsx
+++ b/src/components/Nav/Menu/index.tsx
@@ -4,7 +4,7 @@ import * as NavigationMenu from "@radix-ui/react-navigation-menu"
 
 import { Button } from "@/components/Buttons"
 
-import { SECTION_LABELS } from "@/lib/constants"
+import { NAV_PY, SECTION_LABELS } from "@/lib/constants"
 
 import type { NavSections } from "../types"
 
@@ -32,6 +32,7 @@ const Menu = ({ sections, ...props }: NavMenuProps) => {
         dir={direction}
         orientation="horizontal"
         onValueChange={handleSectionChange}
+        delayDuration={0}
       >
         <NavigationMenu.List asChild>
           <UnorderedList display="flex" listStyleType="none" m="0">
@@ -42,7 +43,8 @@ const Menu = ({ sections, ...props }: NavMenuProps) => {
                 <NavigationMenu.Item key={sectionKey} value={label}>
                   <NavigationMenu.Trigger asChild>
                     <Button
-                      py="2"
+                      pt="2"
+                      pb={2 + NAV_PY}
                       px={{ base: "3", lg: "4" }}
                       variant="ghost"
                       whiteSpace="nowrap"
@@ -55,6 +57,7 @@ const Menu = ({ sections, ...props }: NavMenuProps) => {
                           layoutId="active-section-highlight"
                           position="absolute"
                           inset="0"
+                          bottom={NAV_PY}
                           bg="primary.lowContrast"
                           rounded="base"
                           zIndex={0}

--- a/src/components/Nav/Menu/index.tsx
+++ b/src/components/Nav/Menu/index.tsx
@@ -43,12 +43,18 @@ const Menu = ({ sections, ...props }: NavMenuProps) => {
                 <NavigationMenu.Item key={sectionKey} value={label}>
                   <NavigationMenu.Trigger asChild>
                     <Button
-                      pt="2"
-                      pb={2 + NAV_PY}
+                      py="2"
                       px={{ base: "3", lg: "4" }}
                       variant="ghost"
                       whiteSpace="nowrap"
                       color={isActive ? "primary.base" : "body.base"}
+                      _after={{
+                        content: '""',
+                        position: "absolute",
+                        insetInline: 0,
+                        top: "100%",
+                        height: NAV_PY,
+                      }}
                     >
                       {/* Animated highlight for active section */}
                       {isActive && (
@@ -57,7 +63,6 @@ const Menu = ({ sections, ...props }: NavMenuProps) => {
                           layoutId="active-section-highlight"
                           position="absolute"
                           inset="0"
-                          bottom={NAV_PY}
                           bg="primary.lowContrast"
                           rounded="base"
                           zIndex={0}

--- a/src/components/Nav/index.tsx
+++ b/src/components/Nav/index.tsx
@@ -22,6 +22,8 @@ import LanguagePicker from "@/components/LanguagePicker"
 import { BaseLink } from "@/components/Link"
 import Search from "@/components/Search"
 
+import { NAV_PY } from "@/lib/constants"
+
 import Menu from "./Menu"
 import MobileNavMenu from "./Mobile"
 import { useNav } from "./useNav"
@@ -69,7 +71,7 @@ const Nav = () => {
         borderColor="rgba(0, 0, 0, 0.1)"
         height="4.75rem"
         justifyContent="center"
-        py={4}
+        py={NAV_PY}
         px={{ base: 4, xl: 8 }}
       >
         <Flex
@@ -94,7 +96,7 @@ const Nav = () => {
             ms={{ base: 3, xl: 8 }}
           >
             <Menu hideBelow="md" sections={linkSections} />
-            <Flex alignItems="center"/*  justifyContent="space-between" */>
+            <Flex alignItems="center" /*  justifyContent="space-between" */>
               <Search {...searchModalDisclosure} />
               {/* Desktop */}
               <HStack hideBelow="md" gap="0">

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -87,3 +87,5 @@ export const SECTION_LABELS: NavSectionKey[] = [
   "participate",
   "research",
 ]
+
+export const NAV_PY = 4


### PR DESCRIPTION
## Description
- Removes delay duration when hovering over a nav menu item (menu now opens immediately upon hovering)
- Extends the click/hover zone for each button to the bottom of the nav bar, eliminating dead-space between the buttons and the menu that opens which could close the menu if cursor is paused in this space

## Related Issue
Bug surfaced from #12125 review

cc: @konopkja 