### PR TITLE
fix: adds missing namespace prefix for quizzes title

### DIFF
--- a/src/pages/quizzes.tsx
+++ b/src/pages/quizzes.tsx
@@ -74,12 +74,12 @@ const QuizzesHubPage: NextPage<
   return (
     <Box as={MainArticle}>
       <PageMetadata
-        title={t("quizzes-title")}
+        title={t("common:quizzes-title")}
         description={t("quizzes-subtitle")}
         image="/heroes/quizzes-hub-hero.png"
       />
       <HubHero
-        title={t("quizzes-title")}
+        title={t("common:quizzes-title")}
         description={t("quizzes-subtitle")}
         header={t("test-your-knowledge")}
         heroImg={HeroImage}


### PR DESCRIPTION
This PR adds the missing `common` namespace prefix for quizzes title

<img width="386" alt="Screen Shot 2024-03-06 at 10 22 13" src="https://github.com/ethereum/ethereum-org-website/assets/948922/7dfb8cc6-4512-4e4e-8b9d-005a3f8a80c8">
