### PR TITLE
fix: add 301 redirect for /deprecated-software

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -171,3 +171,5 @@
 /*/staking/withdraws /:splat/staking/withdrawals/ 301!
 
 /*/guides/how-to-register-an-ethereum-account /:splat/guides/how-to-create-an-ethereum-account/ 301!
+
+/*/deprecated-software /:splat/dapps/ 301!


### PR DESCRIPTION
## Description
- Adds redirect from `/*/deprecated-software` to `/:splat/dapps`

## Related Issue
- Related to #12193

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Implemented a redirect from `/deprecated-software` to `/dapps/` to streamline user navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->