### PR TITLE
fix: typo in history of ethereum page [Fixes #12400]

### DIFF
--- a/public/content/history/index.md
+++ b/public/content/history/index.md
@@ -63,7 +63,7 @@ Notably this includes EIP-4844, known as **Proto-Danksharding**, which significa
 
 #### Summary {#deneb-summary}
 
-The Deneb upgrade contains a set of improvements to Ethereum's _consensus_ aimed towards improving scalability. This upgrade comes in tandem with the Deneb execution upgrades to enable Proto-Danksharding (EIP-4844), along with other improvements to the Beacon Chain.
+The Deneb upgrade contains a set of improvements to Ethereum's _consensus_ aimed towards improving scalability. This upgrade comes in tandem with the Cancun execution upgrades to enable Proto-Danksharding (EIP-4844), along with other improvements to the Beacon Chain.
 
 Pre-generated signed "voluntary exit messages" no longer expire, thus giving more control to users staking their funds with a third-party node operator. With this signed exit message, stakers can delegate node operation while maintaining the ability to safely exit and withdrawal their funds at any time, without needing to ask permission from anyone.
 


### PR DESCRIPTION
## Description

Fixes a small typo in the Deneb section in the "The history of Ethereum" page.

## Related Issue

Fixes: #12400


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the terminology of execution upgrades in the Ethereum consensus improvements documentation, changing "Deneb" to "Cancun" to reflect the latest naming conventions. This update is part of the ongoing efforts to enhance scalability and improve the Beacon Chain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->