### PR TITLE
typo: change "asset" to "assert" in glossary

### DIFF
--- a/src/intl/en/glossary.json
+++ b/src/intl/en/glossary.json
@@ -15,7 +15,7 @@
   "apr-definition": "APR, or Annual Percentage Rate, reflects the yearly cost of borrowing money, including interest and fees, as a percentage.",
   "asic-term": "ASIC",
   "asic-definition": "Application-specific integrated circuit. This usually refers to an integrated circuit, custom-built for cryptocurrency mining.",
-  "assert-term": "asset",
+  "assert-term": "assert",
   "assert-definition": "In <a href=\"/glossary/#solidity\">Solidity</a>, `assert(false)` compiles to `0xfe`, an invalid opcode, which uses up all remaining <a href=\"/glossary/#gas\">gas</a> and reverts all changes. When an `assert()` statement fails, something very wrong and unexpected is happening, and you will need to fix your code. You should use `assert()` to avoid conditions that should never, ever occur. <a href=\"/developers/docs/smart-contracts/security/\">More on smart contract security</a>.",
   "attestation-term": "Attestation",
   "attestation-definition": "A claim made by an entity that something is true. In context of Ethereum, consensus validators must make a claim as to what they believe the state of the chain to be. At designated times, each validator is responsible for publishing different attestations that formally declare this validator's view of the chain, including the last finalized checkpoint and the current head of the chain. <a href=\"/developers/docs/consensus-mechanisms/pos/attestations/\">More on attestations</a>.",

--- a/src/intl/fr/glossary.json
+++ b/src/intl/fr/glossary.json
@@ -11,7 +11,7 @@
   "api-definition": "Une interface de programmation d'application (API) est un ensemble de définitions sur la manière d'utiliser un logiciel. Une API se situe entre une application et un serveur web, et facilite le transfert de données entre eux.",
   "asic-term": "ASIC",
   "asic-definition": "Circuit intégré spécifique à une application. Il s'agit généralement d'un circuit intégré conçu sur mesure pour le minage de crypto-monnaies.",
-  "assert-term": "asset",
+  "assert-term": "assert",
   "assert-definition": "Dans <a href=\"/glossary/#solidity\">Solidity</a>, `assert(false)` compile vers `0xfe`, un opcode invalide, qui utilise tout le <a href=\"/glossary/#gas\">gaz</a> restant et annule tous les changements. Quand une déclaration `assert()` échoue, quelque chose de très mauvais et d'inattendu est en train de se produire, et vous devrez corriger votre code. Vous devriez utiliser `assert()` pour éviter des conditions qui ne devraient jamais se produire. <a href=\"/developers/docs/smart-contracts/security/\">En savoir plus sur la sécurité des contrats intelligents</a>.",
   "attestation-term": "Attestation",
   "attestation-definition": "Une affirmation faite par une entité que quelque chose est vrai. Dans le contexte d'Ethereum, les validateurs de consensus doivent affirmer ce qu'ils pensent être l'état de la chaîne. À certains moments, chaque validateur est responsable de la publication de différentes attestations qui déclarent formellement son point de vue sur la chaîne, y compris le dernier point de contrôle finalisé et la tête actuelle de la chaîne. <a href=\"/developers/docs/consensus-mechanisms/pos/attestations/\">En savoir plus sur les attestations</a>.",

--- a/src/intl/hu/glossary.json
+++ b/src/intl/hu/glossary.json
@@ -11,7 +11,7 @@
   "api-definition": "Az Alkalmazás programozási felület (API) definíciók kötege arról, hogyan lehet használni egy szoftverrészt. Az API az alkalmazás és a webszerver között helyezkedik el, s az ezek közötti adatátadást teszi lehetővé.",
   "asic-term": "ASIC",
   "asic-definition": "Alkalmazásspecifikus intergált körök. Ez általában egy integrált körre vonatkozik, mely személyre szabottan készült a kriptovaluta bányászatához.",
-  "assert-term": "asset",
+  "assert-term": "assert",
   "assert-definition": "A <a href=\"/glossary/#solidity\">Solidity</a> programozási nyelvben az assert(false) a „0xfe” érvénytelen operációs kódra lesz átfordítva, ami felhasználja az összes maradék <a href=\"/glossary/#gas\">gázt</a> és visszafordítja a változtatásokat. Amikor egy assert() parancs hibára fut, akkor valami nagyon rossz és váratlan történik, és a fejlesztőknek meg kell javítaniuk a kódot. Az assert() parancsot arra kell használni a programban, hogy sohe ne történhessenek meg bizonyos események. <a href=\"/developers/docs/smart-contracts/security/\">Bővebben az okosszerződésbiztonságról</a>.",
   "attestation-term": "Tanúsítás",
   "attestation-definition": "Egy entitás állítása arról, hogy valami igaz. Az Ethereum kontextusában a konszenzusvalidátorok egy állítást tesznek arról, hogy mi a lánc státusza. Előre meghatározott időben minden egyes validátor felel azért, hogy tanúsításokat adjon, ami hivatalosan igazolja, hogy ő mit lát a láncon, beleértve a legutóbbi befejezett ellenőrzési pontot és a lánc aktuális elejét. <a href=\"/developers/docs/consensus-mechanisms/pos/attestations/\">Bővebben a tanúsításokról</a>.",

--- a/src/intl/it/glossary.json
+++ b/src/intl/it/glossary.json
@@ -11,7 +11,7 @@
   "api-definition": "Un'Interfaccia di programmazione dell'applicazione (API) è una serie di definizioni per l'utilizzo di un software. Un'API si trova tra un'applicazione e un server web e facilita il trasferimento di dati tra di essi.",
   "asic-term": "ASIC",
   "asic-definition": "Circuito integrato specifico per l'applicazione. Questo solitamente si riferisce a un circuito integrato, costruito appositamente per il mining di criptovalute.",
-  "assert-term": "asset",
+  "assert-term": "assert",
   "assert-definition": "In <a href=\"/glossary/#solidity\">Solidity</a>, `assert(false)` si compila a `0xfe`, un opcode non valido, che utilizza tutto il <a href=\"/glossary/#gas\">gas</a> rimanente e annulla tutte le modifiche. Quando un'istruzione di `assert()` fallisce, si sta verificando qualcosa di molto sbagliato e imprevisto, e dovrai correggere il tuo codice. Dovresti utilizzare `assert()` per evitare condizioni che non dovrebbero mai e poi mai verificarsi. <a href=\"/developers/docs/smart-contracts/security/\">Maggiori informazioni sulla sicurezza dei contratti intelligenti</a>.",
   "attestation-term": "Attestazione",
   "attestation-definition": "Una dichiarazione resa da un'entità che afferma che qualcosa è vero. Nel contesto di Ethereum, i validatori del consenso devono affermare quale credono sia lo stato della catena. In momenti specifici, ogni validatore è responsabile della pubblicazione di attestazioni differenti che dichiarano formalmente il parere di questo validatore sulla catena, incluso l'ultimo punto di controllo finalizzato e la testa attuale della catena. <a href=\"/developers/docs/consensus-mechanisms/pos/attestations/\">Maggiori informazioni sulle attestazioni</a>.",


### PR DESCRIPTION
## Description

Glossary entry for "assert" is incorrectly titled "asset".

Typo was found in 4 translations. Fixed for all.