### PR TITLE
refactor: migrate clipboard to chakra useClipboard [Fixes: #12020]

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@emotion/styled": "^11.11.0",
     "@radix-ui/react-navigation-menu": "^1.1.4",
     "@socialgouv/matomo-next": "^1.8.0",
-    "clipboard": "^2.0.11",
     "embla-carousel-react": "^7.0.0",
     "ethereum-blockies-base64": "^1.0.2",
     "focus-trap-react": "^10.2.3",

--- a/src/components/CopyToClipboard.tsx
+++ b/src/components/CopyToClipboard.tsx
@@ -1,6 +1,4 @@
-import { useEffect, useRef, useState } from "react"
-import ClipboardJS from "clipboard"
-import { Box } from "@chakra-ui/react"
+import { Box, useClipboard } from "@chakra-ui/react"
 
 export type CopyToClipboardProps = {
   text: string
@@ -13,38 +11,15 @@ const CopyToClipboard = ({
   text,
   inline = false,
 }: CopyToClipboardProps) => {
-  const [isCopied, setIsCopied] = useState<boolean>(false)
-  const targetEl = useRef<HTMLDivElement>(null)
-  const timer = useRef(0)
-
-  useEffect(() => {
-    const afterCopy = () => {
-      setIsCopied(true)
-      clearTimeout(timer.current)
-      timer.current = window.setTimeout(() => setIsCopied(false), 1500)
-    }
-
-    const clipboard = new ClipboardJS(targetEl.current!, {
-      text: () => text,
-    })
-
-    clipboard.on("success", (e) => {
-      afterCopy()
-    })
-
-    clipboard.on("error", (e) => {
-      console.log("error: failed to copy text")
-    })
-
-    return () => {
-      clipboard.destroy()
-      clearTimeout(timer.current)
-    }
-  }, [text])
+  const { onCopy, hasCopied } = useClipboard(text, { timeout: 1500 })
 
   return (
-    <Box ref={targetEl} display={inline ? "inline" : "block"} cursor="pointer">
-      {children(isCopied)}
+    <Box
+      cursor="pointer"
+      onClick={onCopy}
+      display={inline ? "inline" : "block"}
+    >
+      {children(hasCopied)}
     </Box>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5990,15 +5990,6 @@ client-only@0.0.1:
   resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
   integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
 
-clipboard@^2.0.11:
-  version "2.0.11"
-  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-2.0.11.tgz#62180360b97dd668b6b3a84ec226975762a70be5"
-  integrity sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==
-  dependencies:
-    good-listener "^1.2.2"
-    select "^1.1.2"
-    tiny-emitter "^2.0.0"
-
 clipboardy@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/clipboardy/-/clipboardy-4.0.0.tgz#e73ced93a76d19dd379ebf1f297565426dffdca1"
@@ -6659,11 +6650,6 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
-
-delegate@^3.1.2:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/delegate/-/delegate-3.2.0.tgz#b66b71c3158522e8ab5744f720d8ca0c2af59166"
-  integrity sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==
 
 denque@^2.1.0:
   version "2.1.0"
@@ -8136,13 +8122,6 @@ globrex@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/globrex/-/globrex-0.1.2.tgz#dd5d9ec826232730cd6793a5e33a9302985e6098"
   integrity sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==
-
-good-listener@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/good-listener/-/good-listener-1.2.2.tgz#d53b30cdf9313dffb7dc9a0d477096aa6d145c50"
-  integrity sha512-goW1b+d9q/HIwbVYZzZ6SsTr4IgE+WA44A0GmPIQstuOrgsFcT7VEJ48nmr9GaRtNu0XTKacFLGnBPAM6Afouw==
-  dependencies:
-    delegate "^3.1.2"
 
 gopd@^1.0.1:
   version "1.0.1"
@@ -11970,11 +11949,6 @@ section-matter@^1.0.0:
     extend-shallow "^2.0.1"
     kind-of "^6.0.0"
 
-select@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
-  integrity sha512-OwpTSOfy6xSs1+pwcNrv0RBMOzI39Lp3qQKUTPVVPRjCdNa5JH/oPRiqsesIskK8TVgmRiHwO4KXlV2Li9dANA==
-
 "semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.6.0:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
@@ -12661,11 +12635,6 @@ timers-browserify@^2.0.12:
   integrity sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==
   dependencies:
     setimmediate "^1.0.4"
-
-tiny-emitter@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
-  integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
 
 tiny-glob@^0.2.9:
   version "0.2.9"


### PR DESCRIPTION
## Description

- Refactored `CopyToClipboard` component to use chakra's `useClipboard` instead of standalone `clipboard` package.
- Uninstalled `clipboard` package from repo.

## Notes

- `CopyToClipboard` API remains unchanged.
- `CopyToClipboard` is currently used in 4 parent components. I've provided the locations below for ease of testing:

|Component|Path|
|---|---|
|`Codeblock`|`/en/developers/docs/smart-contracts/`|
|`TutorialMetadata`|`/en/developers/tutorials/calling-a-smart-contract-from-javascript/`|
|`WithdrawalCredentials`|`/en/staking/withdrawals/`|
|`deposit-contract`|`/en/staking/deposit-contract/`|

## Related Issue

#12020 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the `CopyToClipboard` component by utilizing the `useClipboard` hook for enhanced clipboard interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->