### PR TITLE
feat: add LocaleDateTime for markdown time

### DIFF
--- a/src/components/LocaleDateTime.tsx
+++ b/src/components/LocaleDateTime.tsx
@@ -1,0 +1,53 @@
+import { useRouter } from "next/router"
+
+type LocaleDateTimeProps = {
+  utcDateTime: string
+  hideDate?: boolean
+  hideTime?: boolean
+  options?: Intl.DateTimeFormatOptions
+}
+
+/**
+ * Renders a localized date and time component
+ * @param utcDateTime - The UTC date and time string, ie "2022-04-20T16:20:00Z"
+ * @param hideDate - Whether to hide the date portion
+ * @param hideTime - Whether to hide the time portion
+ * @param options - Options override for formatting the date and time
+ * @returns The rendered LocaleDateTime component
+ */
+const LocaleDateTime = ({
+  utcDateTime,
+  hideDate,
+  hideTime,
+  options,
+}: LocaleDateTimeProps) => {
+  if (hideDate && hideTime)
+    throw new Error(
+      "LocaleDateTime hideDate and hideTime props cannot both be true"
+    )
+
+  const { locale } = useRouter()
+  const date = new Date(utcDateTime)
+  const defaultDateOptions: Intl.DateTimeFormatOptions = {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  }
+  const defaultTimeOptions: Intl.DateTimeFormatOptions = {
+    hour: "numeric",
+    minute: "numeric",
+    second: "numeric",
+  }
+  const dateTimeOptions: Intl.DateTimeFormatOptions = {
+    ...(hideDate ? {} : defaultDateOptions),
+    ...(hideTime ? {} : defaultTimeOptions),
+    ...options,
+  }
+  return (
+    <time dateTime={utcDateTime}>
+      {new Intl.DateTimeFormat(locale, dateTimeOptions).format(date)}
+    </time>
+  )
+}
+
+export default LocaleDateTime

--- a/src/components/MdComponents.tsx
+++ b/src/components/MdComponents.tsx
@@ -40,6 +40,7 @@ import Emoji from "./Emoji"
 import ExpandableCard from "./ExpandableCard"
 import FeaturedText from "./FeaturedText"
 import InfoBanner from "./InfoBanner"
+import LocaleDateTime from "./LocaleDateTime"
 import MainArticle from "./MainArticle"
 
 /**
@@ -160,6 +161,7 @@ export const htmlElements = {
   ol: OrderedList,
   p: Paragraph,
   pre: Pre,
+  time: LocaleDateTime,
   ul: UnorderedList,
   ...mdxTableComponents,
 }


### PR DESCRIPTION
## Description
- Adds a component that parses a date/time string for use within static Markdown pages
- Component mapped to `time` html element in `MdComponents` for use within markdown pages
- Accepts `utcDateTime` prop which will be parsed as a `Date` object
- Accepts a `hideDate` OR `hideTime` prop to optionally hide one half of the resulting string
- Accepts optional `options` override to customize styling if needed

## Example usage
This PR only adds the component but does not implement it anywhere.

Example of how to use would be `<time utcDateTime="2024-04-20T01:00:00Z" />` inside a markdown file, which would render as `April 19, 2024 at 9:00:00 PM` for Eastern US timezone. Adding `hideTime` would result in `April 19, 2024`, and adding `hideDate` would render as `6:00:00 PM`. A different `locale` would adjust accordingly.

## Related Issue
- Fixes #12425

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
	- Introduced a `LocaleDateTime` component for displaying date and time in a localized format with customization options.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->