### PR TITLE
Typo Ethhash -> Ethash

### DIFF
--- a/public/content/developers/docs/consensus-mechanisms/pow/mining/index.md
+++ b/public/content/developers/docs/consensus-mechanisms/pow/mining/index.md
@@ -70,7 +70,7 @@ Watch Austin walk you through mining and the proof-of-work blockchain.
 
 ## The mining algorithm {#mining-algorithm}
 
-Ethereum Mainnet only ever used one mining algorithm - ['Ethash'](/developers/docs/consensus-mechanisms/pow/mining/mining-algorithms/ethash/). Ethhash was the successor to an original R&D algorithm known as ['Dagger-Hashimoto'](/developers/docs/consensus-mechanisms/pow/mining/mining-algorithms/dagger-hashimoto/).
+Ethereum Mainnet only ever used one mining algorithm - ['Ethash'](/developers/docs/consensus-mechanisms/pow/mining/mining-algorithms/ethash/). Ethash was the successor to an original R&D algorithm known as ['Dagger-Hashimoto'](/developers/docs/consensus-mechanisms/pow/mining/mining-algorithms/dagger-hashimoto/).
 
 [More on mining algorithms](/developers/docs/consensus-mechanisms/pow/mining/mining-algorithms/).
 


### PR DESCRIPTION
Typo in the mining page

## Description

Corrected following typo 

Ethhash -> Ethash

## Related Issue

none 
