### PR TITLE
Disable Bug Bounty Banner

### DIFF
--- a/src/pages/bug-bounty.tsx
+++ b/src/pages/bug-bounty.tsx
@@ -456,8 +456,7 @@ const BugBountiesPage = () => {
         title={t("page-upgrades-bug-bounty-meta-title")}
         description={t("page-upgrades-bug-bounty-meta-description")}
       />
-      {/* TODO: Remove two weeks prior to scheduled mainnet Dencun hardfork */}
-      <BugBountyBanner />
+      {/* INFO: Uncommon this to enable Bug Bounty Banner: <BugBountyBanner /> */}
       <Content>
         <HeroCard>
           <HeroContainer>

--- a/src/pages/bug-bounty.tsx
+++ b/src/pages/bug-bounty.tsx
@@ -456,7 +456,7 @@ const BugBountiesPage = () => {
         title={t("page-upgrades-bug-bounty-meta-title")}
         description={t("page-upgrades-bug-bounty-meta-description")}
       />
-      {/* INFO: Uncommon this to enable Bug Bounty Banner: <BugBountyBanner /> */}
+      {/* INFO: Uncomment this to enable Bug Bounty Banner: <BugBountyBanner /> */}
       <Content>
         <HeroCard>
           <HeroContainer>


### PR DESCRIPTION
## Description

Disabled the Bug Bounty Banner. I would prefer to not remove this but instead keep it commented out as we want to repeat this a few times per year.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Temporarily disabled the Bug Bounty Banner on the Bug Bounties page for maintenance.
	- Added informational comment for enabling the Bug Bounty Banner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->