### PR TITLE
Dencun upgrade happened, text should say that

### DIFF
--- a/public/content/roadmap/danksharding/index.md
+++ b/public/content/roadmap/danksharding/index.md
@@ -81,7 +81,7 @@ Data availability sampling is required for validators to quickly and efficiently
 
 ### Current progress {#current-progress}
 
-Full Danksharding remains several years away. Meanwhile, the KZG ceremony has concluded with over 140,000 contributions, and the [EIP](https://eips.ethereum.org/EIPS/eip-4844) for Proto-Danksharding has been fully productionized. This release went live on Ethereum Mainnet on March 13, 2024 ([slot 8626176](https://beaconscan.com/slot/8626176)), as part of the [Dencun](https://blog.ethereum.org/2024/02/27/dencun-mainnet-announcement) upgrade. 
+Full Danksharding is several years away. Meanwhile, the KZG ceremony has concluded with over 140,000 contributions, and the [EIP](https://eips.ethereum.org/EIPS/eip-4844) for Proto-Danksharding has been fully productionized. This release went live on Ethereum Mainnet on March 13, 2024 ([slot 8626176](https://beaconscan.com/slot/8626176)), as part of the [Dencun](https://blog.ethereum.org/2024/02/27/dencun-mainnet-announcement) upgrade. 
 
 ### Further reading {#further-reading}
 

--- a/public/content/roadmap/danksharding/index.md
+++ b/public/content/roadmap/danksharding/index.md
@@ -81,7 +81,7 @@ Data availability sampling is required for validators to quickly and efficiently
 
 ### Current progress {#current-progress}
 
-Full Danksharding is several years away. In the meantime, the KZG ceremony has concluded with over 140,000 contributions, and the [EIP](https://eips.ethereum.org/EIPS/eip-4844) for Proto-Danksharding has matured, with an agreed upon production-ready specification already being tested on testnets. This upgrade is set to go live on Ethereum Mainnet in March 2024 as part of the Deneb + Cancun upgrade. You can keep up to date using the [EIP 4844 readiness checklist](https://github.com/ethereum/pm/blob/master/Dencun/4844-readiness-checklist.md).
+Full Danksharding remains several years away. Meanwhile, the KZG ceremony has concluded with over 140,000 contributions, and the [EIP](https://eips.ethereum.org/EIPS/eip-4844) for Proto-Danksharding has been fully productionized. This release went live on Ethereum Mainnet on March 13, 2024 ([slot 8626176](https://beaconscan.com/slot/8626176)), as part of the [Dencun](https://blog.ethereum.org/2024/02/27/dencun-mainnet-announcement) upgrade. 
 
 ### Further reading {#further-reading}
 


### PR DESCRIPTION
Updating text to account for the fact that the Dencun upgrade has taken place.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Old outdated text updated with more up to date information regarding the Dencun upgrade.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Updated the Danksharding roadmap to reflect the successful launch of Proto-Danksharding with the Dencun upgrade on March 13, 2024, and provided an update on the progress towards Full Danksharding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->