### PR TITLE
Performance: import lodash submodules

### DIFF
--- a/src/@chakra-ui/components/Avatar.ts
+++ b/src/@chakra-ui/components/Avatar.ts
@@ -1,4 +1,4 @@
-import { pick } from "lodash"
+import pick from "lodash/pick"
 import { avatarAnatomy } from "@chakra-ui/anatomy"
 import {
   createMultiStyleConfigHelpers,

--- a/src/@chakra-ui/components/components.utils.ts
+++ b/src/@chakra-ui/components/components.utils.ts
@@ -1,4 +1,4 @@
-import { merge } from "lodash"
+import merge from "lodash/merge"
 import { cssVar, SystemStyleObject, theme } from "@chakra-ui/react"
 
 const {

--- a/src/components/Contributors.tsx
+++ b/src/components/Contributors.tsx
@@ -1,4 +1,4 @@
-import { shuffle } from "lodash"
+import shuffle from "lodash/shuffle"
 import { Box, Flex, Image, LinkBox, LinkOverlay } from "@chakra-ui/react"
 
 import InlineLink from "@/components/Link"

--- a/src/components/FindWallet/WalletFilterSidebar/WalletFilterFeature/index.tsx
+++ b/src/components/FindWallet/WalletFilterSidebar/WalletFilterFeature/index.tsx
@@ -1,5 +1,5 @@
 import React, { MutableRefObject } from "react"
-import { uniqueId } from "lodash"
+import uniqueId from "lodash/uniqueId"
 import { BsToggleOff, BsToggleOn } from "react-icons/bs"
 import {
   Accordion,

--- a/src/components/MeetupList.tsx
+++ b/src/components/MeetupList.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react"
-import { sortBy } from "lodash"
+import sortBy from "lodash/sortBy"
 import {
   Box,
   Flex,

--- a/src/components/Quiz/QuizWidget/QuizSummary.tsx
+++ b/src/components/Quiz/QuizWidget/QuizSummary.tsx
@@ -1,5 +1,3 @@
-import { useEffect } from "react"
-import { merge } from "lodash"
 import { useRouter } from "next/router"
 import { useTranslation } from "next-i18next"
 import {

--- a/src/components/Quiz/QuizWidget/useQuizWidget.tsx
+++ b/src/components/Quiz/QuizWidget/useQuizWidget.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react"
-import { shuffle } from "lodash"
+import shuffle from "lodash/shuffle"
 import { useTranslation } from "next-i18next"
 
 import type {

--- a/src/components/RandomAppList.tsx
+++ b/src/components/RandomAppList.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { shuffle } from "lodash"
+import shuffle from "lodash/shuffle"
 
 import type { TranslationKey } from "@/lib/types"
 

--- a/src/components/Staking/StakingProductsCardGrid.tsx
+++ b/src/components/Staking/StakingProductsCardGrid.tsx
@@ -1,5 +1,5 @@
 import { ComponentType, SVGProps, useEffect, useState } from "react"
-import { shuffle } from "lodash"
+import shuffle from "lodash/shuffle"
 import { useTranslation } from "next-i18next"
 import {
   Badge,

--- a/src/components/StatsBoxGrid/GridItem.tsx
+++ b/src/components/StatsBoxGrid/GridItem.tsx
@@ -1,7 +1,7 @@
-import { kebabCase } from "lodash"
+import kebabCase from "lodash/kebabCase"
 import { MdInfoOutline } from "react-icons/md"
 import { Area, AreaChart, ResponsiveContainer, XAxis, YAxis } from "recharts"
-import { Box, Flex, HStack, Icon, Text, VStack } from "@chakra-ui/react"
+import { Box, Flex, Icon, Text } from "@chakra-ui/react"
 
 import type { StatsBoxMetric } from "@/lib/types"
 

--- a/src/components/TranslationLeaderboard.tsx
+++ b/src/components/TranslationLeaderboard.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react"
-import { reverse, sortBy } from "lodash"
+import reverse from "lodash/reverse"
+import sortBy from "lodash/sortBy"
 import { useTranslation } from "next-i18next"
 import {
   Box,

--- a/src/hooks/useCentralizedExchanges.ts
+++ b/src/hooks/useCentralizedExchanges.ts
@@ -1,5 +1,5 @@
 import { useState } from "react"
-import { shuffle } from "lodash"
+import shuffle from "lodash/shuffle"
 import { useRouter } from "next/router"
 import { useTranslation } from "next-i18next"
 

--- a/src/pages/developers/learning-tools.tsx
+++ b/src/pages/developers/learning-tools.tsx
@@ -1,4 +1,4 @@
-import { shuffle } from "lodash"
+import shuffle from "lodash/shuffle"
 import { GetStaticProps } from "next"
 import { useTranslation } from "next-i18next"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"

--- a/src/pages/layer-2.tsx
+++ b/src/pages/layer-2.tsx
@@ -1,4 +1,4 @@
-import { merge } from "lodash"
+import merge from "lodash/merge"
 import { GetStaticProps } from "next"
 import { useTranslation } from "next-i18next"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"

--- a/src/pages/wallets/find-wallet.tsx
+++ b/src/pages/wallets/find-wallet.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from "react"
-import { shuffle } from "lodash"
+import shuffle from "lodash/shuffle"
 import { GetStaticProps } from "next"
 import { useRouter } from "next/router"
 import { SSRConfig, useTranslation } from "next-i18next"


### PR DESCRIPTION
Imports `lodash` submodules to reduce bundle size.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Optimized lodash imports across various components for improved efficiency and bundle size.
- **Chores**
	- Removed unused imports to clean up the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->