### PR TITLE
feat: run-a-node page content alignItems

### DIFF
--- a/src/pages/run-a-node.tsx
+++ b/src/pages/run-a-node.tsx
@@ -862,7 +862,7 @@ const RunANodePage = () => {
         </Column>
       </StakingCalloutContainer>
       <Content>
-        <H3 id="plan-on-staking">
+        <H3 id="plan-on-staking" sx={{ display: 'flex', alignItems: 'center' }}>
           <Emoji text=":cut_of_meat:" fontSize="2em" me="4" />
           {t("page-run-a-node-staking-plans-title")}
         </H3>
@@ -875,7 +875,7 @@ const RunANodePage = () => {
             {t("page-run-a-node-staking-plans-ethstaker-link-label")}
           </InlineLink>
         </Text>
-        <H3 id="rasp-pi">
+        <H3 id="rasp-pi" sx={{ display: 'flex', alignItems: 'center' }}>
           <Emoji text=":pie:" fontSize="2em" me="4" />
           {t("page-run-a-node-rasp-pi-title")}
         </H3>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

![image](https://github.com/ethereum/ethereum-org-website/assets/57232813/3b52b2e9-2208-44cb-a18e-41dd4c15c34e)

#### Let them be horizontally centered!

https://github.com/ethereum/ethereum-org-website/blob/90e43100bccc5a85dff3e923081fc846a5c9bfd0/src/pages/run-a-node.tsx#L865-L881

```diff
-         <H3 id="plan-on-staking">
+         <H3 id="plan-on-staking" sx={{ display: 'flex', alignItems: 'center' }}>

-         <H3 id="rasp-pi">
+         <H3 id="plan-on-staking" sx={{ display: 'flex', alignItems: 'center' }}
```
