### PR TITLE
Remove dead sepolia faucet - https://testnet-faucet.com/sepolia/

### DIFF
--- a/public/content/developers/docs/networks/index.md
+++ b/public/content/developers/docs/networks/index.md
@@ -61,7 +61,6 @@ The Sepolia network uses a permissioned validator set. It's fairly new, meaning 
 - [Alchemy Sepolia faucet](https://sepoliafaucet.com/)
 - [Infura Sepolia faucet](https://www.infura.io/faucet)
 - [Chainstack Sepolia faucet](https://faucet.chainstack.com/sepolia-faucet)
-- [Testnet Faucet | Sepolia](https://testnet-faucet.com/sepolia/)
 - [Blockscout](https://eth-sepolia.blockscout.com/)
 
 #### Goerli _(long-term support)_ {#goerli}

--- a/public/content/translations/de/developers/docs/networks/index.md
+++ b/public/content/translations/de/developers/docs/networks/index.md
@@ -60,7 +60,6 @@ Die beiden öffentlichen Testnets, die die Client-Entwickler derzeit betreiben, 
 - [Faucet für Alchemy Sepolia](https://sepoliafaucet.com/)
 - [Faucet für Infura Sepolia](https://www.infura.io/faucet)
 - [Faucet für Chainstack Sepolia](https://faucet.chainstack.com/sepolia-faucet)
-- [Testnetz-Faucet | Sepolia](https://testnet-faucet.com/sepolia/)
 
 #### Goerli _(Langzeit-Support)_ {#goerli}
 

--- a/public/content/translations/es/developers/docs/networks/index.md
+++ b/public/content/translations/es/developers/docs/networks/index.md
@@ -60,7 +60,6 @@ Las dos redes públicas de prueba que los desarrolladores de clientes están man
 - [Alchemy Sepolia faucet](https://sepoliafaucet.com/)
 - [Faucet Infura Sepolia](https://www.infura.io/faucet)
 - [Faucet Chainstack Sepolia](https://faucet.chainstack.com/sepolia-faucet)
-- [Faucet de red de prueba | Sepolia](https://testnet-faucet.com/sepolia/)
 
 #### Goerli _(soporte a largo plazo)_ {#goerli}
 

--- a/public/content/translations/fa/developers/docs/networks/index.md
+++ b/public/content/translations/fa/developers/docs/networks/index.md
@@ -60,7 +60,6 @@ lang: fa
 - [فاست Alchemy Sepolia](https://sepoliafaucet.com/)
 - [فاست Infura Sepolia](https://www.infura.io/faucet)
 - [فاست Chainstack Sepolia](https://faucet.chainstack.com/sepolia-faucet)
-- [فاست Testnet |‏ Sepolia](https://testnet-faucet.com/sepolia/)
 
 #### Goerli_(پشتیبانی طولانی مدت)_ {#goerli}
 

--- a/public/content/translations/fr/developers/docs/networks/index.md
+++ b/public/content/translations/fr/developers/docs/networks/index.md
@@ -60,7 +60,6 @@ Les deux réseaux de test publics que les développeurs de clients conservent ac
 - [Alchemy Sepolia faucet](https://sepoliafaucet.com/)
 - [Infura Sepolia faucet](https://www.infura.io/faucet)
 - [Robinet Sepolia Chainstack](https://faucet.chainstack.com/sepolia-faucet)
-- [Robinet pour le réseau de test Sepolia](https://testnet-faucet.com/sepolia/)
 
 #### Goerli _(support à long terme)_ {#goerli}
 

--- a/public/content/translations/hu/developers/docs/networks/index.md
+++ b/public/content/translations/hu/developers/docs/networks/index.md
@@ -60,7 +60,6 @@ A két nyilvános teszthálózat, amelyet a kliens fejlesztők jelenleg fenntart
 - [Alchemy Sepolia csap](https://sepoliafaucet.com/)
 - [Infura Sepolia csap](https://www.infura.io/faucet)
 - [Chainstack Sepolia csap](https://faucet.chainstack.com/sepolia-faucet)
-- [Testnet csap | Sepolia](https://testnet-faucet.com/sepolia/)
 
 #### Goerli _(hosszútávú támogatás)_ {#goerli}
 

--- a/public/content/translations/it/developers/docs/networks/index.md
+++ b/public/content/translations/it/developers/docs/networks/index.md
@@ -60,7 +60,6 @@ Le due reti di prova pubbliche che gli sviluppatori di client stanno mantenendo 
 - [Faucet Alchemy Sepolia](https://sepoliafaucet.com/)
 - [Faucet Infura Sepolia](https://www.infura.io/faucet)
 - [Faucet Chainstack Sepolia](https://faucet.chainstack.com/sepolia-faucet)
-- [Testnet Faucet | Sepolia](https://testnet-faucet.com/sepolia/)
 
 #### Goerli _(supporto a lungo termine)_ {#goerli}
 

--- a/public/content/translations/pt-br/developers/docs/networks/index.md
+++ b/public/content/translations/pt-br/developers/docs/networks/index.md
@@ -60,7 +60,6 @@ As duas redes de testes públicas que os desenvolvedores dos clientes estão atu
 - [Faucet do Alchemy Sepolia](https://sepoliafaucet.com/)
 - [Faucet do Infura Sepolia](https://www.infura.io/faucet)
 - [Faucet da Chainstack Sepolia](https://faucet.chainstack.com/sepolia-faucet)
-- [Faucet da rede de teste | Sepolia](https://testnet-faucet.com/sepolia/)
 
 #### Goerli _(suporte a longo prazo)_ {#goerli}
 

--- a/public/content/translations/ru/developers/docs/networks/index.md
+++ b/public/content/translations/ru/developers/docs/networks/index.md
@@ -60,7 +60,6 @@ lang: ru
 - [Кран Alchemy Sepolia](https://sepoliafaucet.com/)
 - [Кран Infura Sepolia](https://www.infura.io/faucet)
 - [Кран Chainstack Sepolia](https://faucet.chainstack.com/sepolia-faucet)
-- [Кран тестовой сети | Sepolia](https://testnet-faucet.com/sepolia/)
 
 #### Goerli _(долгосрочная поддержка)_ {#goerli}
 

--- a/public/content/translations/zh-tw/developers/docs/networks/index.md
+++ b/public/content/translations/zh-tw/developers/docs/networks/index.md
@@ -60,7 +60,6 @@ lang: zh-tw
 - [Alchemy Sepolia 水龍頭](https://sepoliafaucet.com/)
 - [Infura Sepolia 水龍頭](https://www.infura.io/faucet)
 - [Chainstack Sepolia 水龍頭](https://faucet.chainstack.com/sepolia-faucet)
-- [測試網水龍頭 | Sepolia](https://testnet-faucet.com/sepolia/)
 
 #### Goerli_（長期支援）_ {#goerli}
 

--- a/public/content/translations/zh/developers/docs/networks/index.md
+++ b/public/content/translations/zh/developers/docs/networks/index.md
@@ -60,7 +60,6 @@ lang: zh
 - [Alchemy Sepolia 水龙头](https://sepoliafaucet.com/)
 - [Infura Sepolia 水龙头](https://www.infura.io/faucet)
 - [Chainstack Sepolia 水龙头](https://faucet.chainstack.com/sepolia-faucet)
-- [Testnet Faucet | Sepolia](https://testnet-faucet.com/sepolia/)
 
 #### Goerli _（长期支持）_ {#goerli}
 


### PR DESCRIPTION
The Sepolia faucet doesn't work and the link leads nowhere
- https://testnet-faucet.com/sepolia/ has been down since 2023 and the link leads nowhere.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Documentation**
	- Removed the Testnet Faucet | Sepolia link from the Sepolia network documentation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->