### PR TITLE
Performance: lazy load the `Emoji` & `SearchModal` components

### DIFF
--- a/src/components/Emoji.tsx
+++ b/src/components/Emoji.tsx
@@ -4,8 +4,9 @@ import { Box, type BoxProps } from "@chakra-ui/react"
 
 import { IS_DEV } from "@/lib/utils/env"
 
-const Twemoji = dynamic(() =>
-  import("react-emoji-render").then((mod) => mod.Twemoji)
+const Twemoji = dynamic(
+  () => import("react-emoji-render").then((mod) => mod.Twemoji),
+  { ssr: false }
 )
 
 export type EmojiProps = Omit<BoxProps, "children"> & BaseProps

--- a/src/components/Emoji.tsx
+++ b/src/components/Emoji.tsx
@@ -1,7 +1,12 @@
-import { type BaseProps, Twemoji } from "react-emoji-render"
+import dynamic from "next/dynamic"
+import type { BaseProps } from "react-emoji-render"
 import { Box, type BoxProps } from "@chakra-ui/react"
 
 import { IS_DEV } from "@/lib/utils/env"
+
+const Twemoji = dynamic(() =>
+  import("react-emoji-render").then((mod) => mod.Twemoji)
+)
 
 export type EmojiProps = Omit<BoxProps, "children"> & BaseProps
 

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -1,4 +1,5 @@
 import { useRef } from "react"
+import dynamic from "next/dynamic"
 import { useRouter } from "next/router"
 import { useTranslation } from "next-i18next"
 import { MdSearch } from "react-icons/md"
@@ -21,9 +22,10 @@ import { sanitizeHitTitle } from "@/lib/utils/sanitizeHitTitle"
 import { sanitizeHitUrl } from "@/lib/utils/url"
 
 import SearchButton from "./SearchButton"
-import SearchModal from "./SearchModal"
 
 import "@docsearch/css"
+
+const SearchModal = dynamic(() => import("./SearchModal"))
 
 export const SearchIconButton = forwardRef<IconButtonProps, "button">(
   (props, ref) => (


### PR DESCRIPTION
## Description

Lazy load these components to separate these libs into their own chunks of js bundles.

Currently, they are part of the `app` (main) bundle that is loaded by all the pages and blocking the main thread. We can load these libs async and minimize the work done in it.

`app.js` bundle before (~1.01Mb parsed):
![image](https://github.com/ethereum/ethereum-org-website/assets/468158/44f5ba0a-f7bd-4afd-8d93-7d48647bf70b)

`app.js` bundle after (~788Kb parsed):
![image](https://github.com/ethereum/ethereum-org-website/assets/468158/92eb3423-df33-47c4-9b00-d9bee5bf6a6e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Performance Improvements**
	- Improved loading times by implementing dynamic imports for the Emoji and Search Modal components, enhancing code splitting and lazy loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->