### PR TITLE
Performance: avoid mono font preload

### DIFF
--- a/src/lib/fonts.ts
+++ b/src/lib/fonts.ts
@@ -5,6 +5,7 @@ export const inter = localFont({
   src: "../fonts/Inter-VariableFont_slnt,wght.ttf",
   display: "swap",
   fallback: ["sans-serif"],
+  preload: true,
 })
 
 // downloaded from https://fonts.google.com/specimen/IBM+Plex+Mono
@@ -13,4 +14,5 @@ export const mono = localFont({
   display: "swap",
   weight: "400",
   fallback: ["Courier", "monospace"],
+  preload: false,
 })


### PR DESCRIPTION
## Description

As the `mono` font is not critical for the UI, lets load it once the page is ready.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
	- Improved font loading speed by preloading `inter` and `mono` fonts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->