### PR TITLE
fix: return home link on 404 page and netlify redirect [FIXES #12471]

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -173,3 +173,5 @@
 /*/guides/how-to-register-an-ethereum-account /:splat/guides/how-to-create-an-ethereum-account/ 301!
 
 /*/deprecated-software /:splat/dapps/ 301!
+
+/enindex/ /en/ 301!

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,10 +1,9 @@
 import type { GetStaticProps } from "next"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
-import { Box, Flex, Heading, Text } from "@chakra-ui/react"
+import { Box, Flex, Heading, Link, Text } from "@chakra-ui/react"
 
 import { BasePageProps } from "@/lib/types"
 
-import InlineLink from "@/components/Link"
 import MainArticle from "@/components/MainArticle"
 import Translation from "@/components/Translation"
 
@@ -37,9 +36,9 @@ const NotFoundPage = () => (
       </Heading>
       <Text mb={8}>
         <Translation id="try-using-search" />{" "}
-        <InlineLink href="/">
+        <Link href="/" isExternal={false}>
           <Translation id="return-home" />
-        </InlineLink>
+        </Link>
         .
       </Text>
     </Box>


### PR DESCRIPTION
- add redirect from faulty `/enindex` page to home page
- change link component in `404.tsx` to redirect browser directly to `/en`

## Description

The issue describing a redirect to home page turning into a 404 instead is working fine within local environment.
Therefore it seems that it triggers somewhere within prod/Netlify setup.
These changes modify the link to hopefully redirect to homepage without triggering the error.
_(there should be no stylistic differences introduced with this change)_

Also added a Netlify redirect, which should push all false 404s to the home page:
```
/enindex/ /en/ 301!
```

[This article](https://answers.netlify.com/t/how-to-get-netlify-to-point-to-an-index-html-file-that-is-in-a-folder-that-is-not-the-main-folder/14146) may also be worth taking a look at. The support guide gives great insights into how this issue can happen with integrations between Netlify and JS-based navigation such as Next.js.

## Related Issue
-Fixes #12471

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Implemented a new redirect rule to enhance user navigation.
- **Bug Fixes**
	- Improved the "return home" link on the 404 page for better usability and consistency with the app's design system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->