### PR TITLE
fix: popup layer close button z-index issueShow error

### DIFF
--- a/src/components/Quiz/QuizzesModal.tsx
+++ b/src/components/Quiz/QuizzesModal.tsx
@@ -40,7 +40,7 @@ const QuizzesModal = ({
       <ModalOverlay bg="blackAlpha.700" />
 
       <Center as={ModalContent} m={0} bg={getStatusColor()} py="16">
-        <ModalCloseButton size="lg" p="6" sx={{ zIndex: '999'}}/>
+        <ModalCloseButton size="lg" p="6" zIndex="1"/>
         {children}
       </Center>
     </ChakraModal>

--- a/src/components/Quiz/QuizzesModal.tsx
+++ b/src/components/Quiz/QuizzesModal.tsx
@@ -40,7 +40,7 @@ const QuizzesModal = ({
       <ModalOverlay bg="blackAlpha.700" />
 
       <Center as={ModalContent} m={0} bg={getStatusColor()} py="16">
-        <ModalCloseButton size="lg" p="6" />
+        <ModalCloseButton size="lg" p="6" sx={{ zIndex: '999'}}/>
         {children}
       </Center>
     </ChakraModal>

--- a/src/pages/run-a-node.tsx
+++ b/src/pages/run-a-node.tsx
@@ -862,7 +862,7 @@ const RunANodePage = () => {
         </Column>
       </StakingCalloutContainer>
       <Content>
-        <H3 id="plan-on-staking">
+        <H3 id="plan-on-staking" sx={{ display: 'flex', alignItems: 'center' }}>
           <Emoji text=":cut_of_meat:" fontSize="2em" me="4" />
           {t("page-run-a-node-staking-plans-title")}
         </H3>
@@ -875,7 +875,7 @@ const RunANodePage = () => {
             {t("page-run-a-node-staking-plans-ethstaker-link-label")}
           </InlineLink>
         </Text>
-        <H3 id="rasp-pi">
+        <H3 id="rasp-pi" sx={{ display: 'flex', alignItems: 'center' }}>
           <Emoji text=":pie:" fontSize="2em" me="4" />
           {t("page-run-a-node-rasp-pi-title")}
         </H3>

--- a/src/pages/run-a-node.tsx
+++ b/src/pages/run-a-node.tsx
@@ -862,7 +862,7 @@ const RunANodePage = () => {
         </Column>
       </StakingCalloutContainer>
       <Content>
-        <H3 id="plan-on-staking" sx={{ display: 'flex', alignItems: 'center' }}>
+        <H3 id="plan-on-staking">
           <Emoji text=":cut_of_meat:" fontSize="2em" me="4" />
           {t("page-run-a-node-staking-plans-title")}
         </H3>
@@ -875,7 +875,7 @@ const RunANodePage = () => {
             {t("page-run-a-node-staking-plans-ethstaker-link-label")}
           </InlineLink>
         </Text>
-        <H3 id="rasp-pi" sx={{ display: 'flex', alignItems: 'center' }}>
+        <H3 id="rasp-pi">
           <Emoji text=":pie:" fontSize="2em" me="4" />
           {t("page-run-a-node-rasp-pi-title")}
         </H3>


### PR DESCRIPTION
## Description
![image](https://github.com/ethereum/ethereum-org-website/assets/57232813/e5a9d82d-f81f-4c4e-a247-5b02cc11fdf7)

This issue arises due to the user's resolution height being too small, causing the button to be covered by the background of the content area.

https://github.com/ethereum/ethereum-org-website/blob/88de114f13b66ae24c89e1c510e64e7b662f4fa7/src/components/Quiz/QuizzesModal.tsx#L42-L45

```diff
-         <ModalCloseButton size="lg" p="6" />
+         <ModalCloseButton size="lg" p="6" sx={{ zIndex: '999'}}/>
```

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://discord.com/channels/714888181740339261/938069231570923550/1219383919305162865

This issue was raised by [@UNOFFICIALbgd](https://github.com/UNOFFICIALbgd) on the official ethereum.org channel. **If you're concerned about security, you can use a privacy-focused browser to open it.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Style**
	- Improved visibility of the `ModalCloseButton` in the `QuizzesModal` component by adjusting its layering order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->