### PR TITLE
Remove broken links from /community/grants/

### DIFF
--- a/public/content/community/grants/index.md
+++ b/public/content/community/grants/index.md
@@ -35,7 +35,6 @@ These projects have created their own grants for projects aimed at developing an
 - [Swarm Foundation Grants Program](https://my.ethswarm.org/grants) - _[Swarm Foundation](https://www.ethswarm.org/) ecosystem_
 - [The Graph](https://thegraph.com/ecosystem/grants/) – _[The Graph](https://thegraph.com/) ecosystem_
 - [Uniswap Grants Program](https://www.uniswapfoundation.org/grants) – _[Uniswap](https://uniswap.org/) community_
-- [Web3 Grants](https://web3grants.net) - _An extensive list of web3/crypto related grant programs_
 
 ## Quadratic funding {#quadratic-funding}
 

--- a/public/content/community/grants/index.md
+++ b/public/content/community/grants/index.md
@@ -18,7 +18,6 @@ These programs support the broad Ethereum ecosystem by offering grants to a wide
 - [MetaCartel](https://www.metacartel.org/grants/) - _Dapp development, DAO creation_
 - [Moloch DAO](https://www.molochdao.com/) - _Privacy, layer 2 scaling, client security, and more_
 - [DAO Grants](https://docs.google.com/spreadsheets/d/1XHc-p_MHNRdjacc8uOEjtPoWL86olP4GyxAJOFO0zxY/edit#gid=0) - _Google spreadsheet of organizations offering grants_
-- [Crunchbase for Web3 Grants](https://www.cryptoneur.xyz/web3-grants) - _Filter and search for grants by category, use case, amount, and more. Contribute to help others find the right grant._
 - [Academic Grants](https://esp.ethereum.foundation/academic-grants) - _Grants to support Ethereum-related academic work_
 - [Blockworks Grantfarm](https://blockworks.co/grants/programs) - _Blockworks has compiled a comprehensive directory of all grants, RFPs, and bug bounties._
 

--- a/public/content/translations/de/community/grants/index.md
+++ b/public/content/translations/de/community/grants/index.md
@@ -18,7 +18,6 @@ Diese Programme unterstützen das breit gefächerte Ethereum-Ökosystem, indem s
 - [MetaCartel](https://www.metacartel.org/grants/) - _DApp-Entwicklung, DAO-Erstellung_
 - [Moloch DAO](https://www.molochdao.com/) – _Datenschutz, Layer-2-Skalierung, Client-Sicherheit und mehr_
 - [DAO-Zuschüsse](https://docs.google.com/spreadsheets/d/1XHc-p_MHNRdjacc8uOEjtPoWL86olP4GyxAJOFO0zxY/edit#gid=0) – _Google-Tabelle der Organisationen, die Zuschüsse anbieten_
-- [Crunchbase für Web3-Zuschüsse](https://www.cryptoneur.xyz/web3-grants) – _Filtere und suche nach Zuschüssen nach Kategorie, Anwendungsfall, Betrag und mehr. Hilf anderen dabei, den richtigen Zuschuss zu finden._
 - [Akademische Stipendien](https://esp.ethereum.foundation/academic-grants) – _Stipendien zur Untstützung akademischer Arbeiten in Bezug auf Ethereum_
 - [Blockworks Grantfarm](https://blockworks.co/grants/programs) - _Blockworks hat ein umfassendes Verzeichnis aller Zuschüsse, Ausschreibungen und Bug-Bounties zusammengestellt._
 
@@ -35,7 +34,6 @@ Diese Projekte haben ihre eigenen Zuschüsse für Projektvorhaben zur Entwicklun
 - [SKALE-Network-Förderprogramm](https://skale.space/developers#grants) – _[SKALE-Network](https://skale.space/)-Ökosystem_
 - [The Graph](https://airtable.com/shrdfvnFvVch3IOVm) – _[The-Graph](https://thegraph.com/)-Ökosystem_
 - [Uniswap-Förderprogramm](https://www.uniswapfoundation.org/apply-for-a-grant) – _[Uniswap](https://uniswap.org/)-Community_
-- [Web3-Zuschüsse](https://web3grants.net) – _Eine umfangreiche Liste von Förderprogrammen mit Bezug zu Web3/Krypto_
 
 ## Quadratische Finanzierung {#quadratic-funding}
 

--- a/public/content/translations/el/community/grants/index.md
+++ b/public/content/translations/el/community/grants/index.md
@@ -18,7 +18,6 @@ lang: el
 - [MetaCartel](https://www.metacartel.org/grants/) - _Ανάπτυξη Dapp, δημιουργία DAO_
 - [Moloch DAO](https://www.molochdao.com/) - _Απόρρητο, αναβάθμιση επιπέδου 2, ασφάλεια πελάτη και πολλά άλλα_
 - [Χορηγίες DAO](https://docs.google.com/spreadsheets/d/1XHc-p_MHNRdjacc8uOEjtPoWL86olP4GyxAJOFO0zxY/edit#gid=0) - _Υπολογιστικό φύλλο Google για οργανισμούς που προσφέρουν επιχορηγήσεις_
-- [Crunchbase για επιχορηγήσεις Web3](https://www.cryptoneur.xyz/web3-grants) - _Φιλτράρισμα και αναζήτηση επιχορηγήσεων ανά κατηγορία, περίπτωση χρήσης, ποσό και πολλά άλλα. Συνεισφέρετε για να βοηθήσετε και άλλους να βρουν τη σωστή επιχορήγηση._
 - [Ακαδημαϊκές υποτροφίες](https://esp.ethereum.foundation/academic-grants) - _Χορηγίες για την υποστήριξη ακαδημαϊκής εργασίας που σχετίζεται με το Ethereum_
 - [Blockworks Grantfarm](https://blockworks.co/grants/programs) - _Η Blockworks έχει συντάξει έναν ολοκληρωμένο κατάλογο με όλες τις επιχορηγήσεις, τα RFP και τις αμοιβές εύρεσης σφαλμάτων._
 
@@ -35,7 +34,6 @@ lang: el
 - [Πρόγραμμα επιχορήγησης δικτύου SKALE](https://skale.space/developers#grants) - _[SKALE](https://skale.space/)δίκτυο οικοσυστήματος_
 - [The Graph](https://airtable.com/shrdfvnFvVch3IOVm) – _[The Graph](https://thegraph.com/) οικοσύστημα _
 - [Πρόγραμμα επιχορήγησης Uniswap](https://www.uniswapfoundation.org/apply-for-a-grant) - _[Κοινότητα Uniswap](https://uniswap.org/)_
-- [Χορηγίες Web3](https://web3grants.net) - _Μια εκτενής λίστα προγραμμάτων επιχορήγησης που σχετίζονται με το web3/crypto_
 
 ## Τετραγωνική χρηματοδότηση {#quadratic-funding}
 

--- a/public/content/translations/es/community/grants/index.md
+++ b/public/content/translations/es/community/grants/index.md
@@ -18,7 +18,6 @@ Estos programas apoyan al ecosistema Ethereum ofreciendo subvenciones para una a
 - [MetaCartel](https://www.metacartel.org/grants/): _desarrollo de DApp, creación de DAO_
 - [Moloch DAO](https://www.molochdao.com/): _privacidad, escalabilidad en capa 2, seguridad del cliente y más_.
 - [Subvenciones DAO](https://docs.google.com/spreadsheets/d/1XHc-p_MHNRdjacc8uOEjtPoWL86olP4GyxAJOFO0zxY/edit#gid=0): _hoja de cálculo de Google de organizaciones que ofrecen subvenciones_
-- [Crunchbase para subvenciones Web3](https://www.cryptoneur.xyz/web3-grants): _filtrar y buscar subvenciones por categoría, caso de uso y cantidad, entre otras opciones. Contribuya para que otros puedan encontrar la subvención correcta._
 - [Becas académicas](https://esp.ethereum.foundation/academic-grants): _becas para apoyar el trabajo académico relacionado con Ethereum_
 - [Blockworks Grantfarm](https://blockworks.co/grants/programs) - _Blockworks ha elaborado un directorio exhaustivo de todas las subvenciones, solicitudes de propuestas (o RFP) y recompensas por detección de errores_
 
@@ -35,7 +34,6 @@ Estos proyectos han creado sus propias subvenciones para proyectos con fines de 
 - [Programa de subvenciones para la red SKALE](https://skale.space/developers#grants): _[ecosistema](https://skale.space/) de la red SKALE_
 - [The Graph](https://airtable.com/shrdfvnFvVch3IOVm): _[ecosistema The Graph](https://thegraph.com/)_
 - [Programa de subvenciones Uniswap](https://www.uniswapfoundation.org/apply-for-a-grant): _[Comunidad](https://uniswap.org/)Uniswap_
-- [Subvenciones Web3](https://web3grants.net): _una exhaustiva lista de programas de subvenciones relacionados con la Web3/crypto_
 
 ## Financiamiento cuadrático {#quadratic-funding}
 

--- a/public/content/translations/fa/community/grants/index.md
+++ b/public/content/translations/fa/community/grants/index.md
@@ -18,7 +18,6 @@ lang: fa
 - [MetaCartel‏](https://www.metacartel.org/grants/) - _توسعه‌ی Dapp، ساخت DAO‏_
 - [Moloch DAO](https://www.molochdao.com/) - _حریم خصوصی، مقیاس‌پذیری لایه‌ی 2، امنیت کاربر و غیره_
 - [ کمک‌های مالی DAO‏](https://docs.google.com/spreadsheets/d/1XHc-p_MHNRdjacc8uOEjtPoWL86olP4GyxAJOFO0zxY/edit#gid=0) - _صفحه‌گسترده Google از سازمان‌های ارائه‌دهنده‌ی کمک‌های مالی_
-- [‏Crunchbase برای کمک‌های مالی Web3‏](https://www.cryptoneur.xyz/web3-grants)-_کمک‌های مالی را بر اساس دسته، کاربرد، مبلغ، و غیره فیلتر و جستجو کنید. کمک کنید که دیگران کمک مالی مناسب خود را بهتر بیابند._
 - [کمک‌های مالی تحصیلی](https://esp.ethereum.foundation/academic-grants)-_کمک‌های مالی برای تحقیقات آکادمیک مربوط به اتریوم_
 - [‏Blockworks Grantfarm‏](https://blockworks.co/grants/programs) - _‏Blockworks یک مجموعه جامع از تمامی کمک‌های مالی، RFPها، و پاداش‌های گزارش اشکالات._
 
@@ -35,7 +34,6 @@ lang: fa
 - [برنامه کمک‌های مالی شبکه SKALE‏](https://skale.space/developers#grants) - _[اکوسیستم شبکه](https://skale.space/)‏SKALE‏_
 - [The Graph](https://airtable.com/shrdfvnFvVch3IOVm) – _اکوسیستم [‏The Graph‏](https://thegraph.com/)_
 - [برنامه کمک‌های مالی Uniswap‏](https://www.uniswapfoundation.org/apply-for-a-grant) - _[جامعه](https://uniswap.org/)‏Uniswap‏_
-- [کمک‌های مالی Web3‏](https://web3grants.net) - _یک فهرست گسترده از برنامه‌های کمک‌های مالی مرتبط با web3/رمزارز_
 
 ## کمک مالی درجه‌ی دوم {#quadratic-funding}
 

--- a/public/content/translations/fr/community/grants/index.md
+++ b/public/content/translations/fr/community/grants/index.md
@@ -18,7 +18,6 @@ Ces programmes soutiennent le vaste écosystème Ethereum en offrant des subvent
 - [MetaCartel](https://www.metacartel.org/grants/) - _Développement de DApp, création DAO_
 - [DAO Moloch](https://www.molochdao.com/) - _Confidentialité, mise à l'échelle de la couche 2, sécurité du client, etc._
 - [Subventions DAO](https://docs.google.com/spreadsheets/d/1XHc-p_MHNRdjacc8uOEjtPoWL86olP4GyxAJOFO0zxY/edit#gid=0) - _Feuille de calcul Google regroupant les organisations offrant des subventions_
-- [Crunchbase pour les financements Web3](https://www.cryptoneur.xyz/web3-grants) - _Filtrer et rechercher des subventions par catégorie, cas d'utilisation, montant et bien plus encore. Contribuez à aider les autres à trouver la bonne subvention._
 - [Academic Grants](https://esp.ethereum.foundation/academic-grants) - _Subventions pour soutenir les travaux universitaires liés à Ethereum_
 - [Blockworks Grantfarm](https://blockworks.co/grants/programs) - _Blockworks a compilé un annuaire complet de toutes les subventions, appels d'offres et primes pour la découverte de bugs._
 
@@ -35,7 +34,6 @@ Ces projets ont crée leurs propres subventions pour encourager d'autres projets
 - [Programme de subventions SKALE Network](https://skale.space/developers#grants) - _Écosystème [SKALE Network](https://skale.space/)_
 - [TheGraph](https://airtable.com/shrdfvnFvVch3IOVm) – _Écosystème [TheGraph](https://thegraph.com/)_
 - [Programme de subventions Uniswap](https://www.uniswapfoundation.org/apply-for-a-grant) - _Communauté [Uniswap](https://uniswap.org/)_
-- [Web3 Grants](https://web3grants.net) - _Une liste complète de programmes de subvention liés au web3/crypto_
 
 ## Financement quadratique {#quadratic-funding}
 

--- a/public/content/translations/hu/community/grants/index.md
+++ b/public/content/translations/hu/community/grants/index.md
@@ -18,7 +18,6 @@ Ezek a programok a kiterjed Ethereum-ökoszisztémát támogatják és a projekt
 - [MetaCartel](https://www.metacartel.org/grants/) – _Dapp fejlesztése, DAO létrehozása_
 - [Moloch DAO](https://www.molochdao.com/) – _Adatvédelem, L2 skálázás, kliensbiztonság és más területek_
 - [DAO Grants](https://docs.google.com/spreadsheets/d/1XHc-p_MHNRdjacc8uOEjtPoWL86olP4GyxAJOFO0zxY/edit#gid=0) – _A támogatást ajánló szervezetek listája Google-táblázatban_
-- [Crunchbase for Web3 Grants](https://www.cryptoneur.xyz/web3-grants) – _Támogatások szűrése és keresése kategória, alkalmazási terület, összeg és egyéb alapján. Segítsen, hogy mások is megtalálják a megfelelő támogatást._
 - [Academic Grants](https://esp.ethereum.foundation/academic-grants) – _Az Ethereummal kapcsolatos akadémiai munkák támogatása_
 - [Blockworks Grantfarm](https://blockworks.co/grants/programs) – _A Blockworks egy átfogó jegyzéket hozott létre, lefedve az összes támogatást, változtatási javaslatot (RFP) és hibavadászatot._
 
@@ -35,7 +34,6 @@ Projektek által adott támogatás olyanoknak, akik az adott technológiát fejl
 - [SKALE Network Grants Program](https://skale.space/developers#grants) – _[SKALE Network](https://skale.space/) ökoszisztéma_
 - [The Graph](https://airtable.com/shrdfvnFvVch3IOVm) – _[The Graph](https://thegraph.com/) ökoszisztéma_
 - [Uniswap Grants Program](https://www.uniswapfoundation.org/apply-for-a-grant) – _[Uniswap](https://uniswap.org/) közösség_
-- [Web3-támogatások](https://web3grants.net) – _A web3/kripto területén futó támogatási programok kimerítő listája_
 
 ## Kvadratikus finanszírozás {#quadratic-funding}
 

--- a/public/content/translations/it/community/grants/index.md
+++ b/public/content/translations/it/community/grants/index.md
@@ -18,7 +18,6 @@ Questi programmi supportano il grande ecosistema di Ethereum offrendo sovvenzion
 - [MetaCartel](https://www.metacartel.org/grants/) - _Sviluppo di dApp, creazione di DAO_
 - [Moloch DAO](https://www.molochdao.com/): _Privacy, ridimensionamento del livello 2, sicurezza del client e molto altro_
 - [DAO Grants](https://docs.google.com/spreadsheets/d/1XHc-p_MHNRdjacc8uOEjtPoWL86olP4GyxAJOFO0zxY/edit#gid=0) - _Foglio di calcolo di Google delle organizzazioni che offrono sovvenzioni_
-- [Crunchbase per sovvenzioni Web3](https://www.cryptoneur.xyz/web3-grants) - _Filtra e cerca sovvenzioni per categorie, casi d'uso, importi e altro. Contribuisci ad aiutare gli altri a trovare la giusta sovvenzione._
 - [Sovvenzioni accademiche](https://esp.ethereum.foundation/academic-grants) - _Sovvenzioni per sostenere il lavoro accademico correlato a Ethereum_
 - [Grantfarm di Blockworks](https://blockworks.co/grants/programs) - _Blockworks ha compilato una directory esaustiva di tutte le sovvenzioni, RDP e bug bounty._
 
@@ -35,7 +34,6 @@ Questi progetti hanno creato le proprie sovvenzioni per progetti volti a svilupp
 - [SKALE Network Grants Program](https://skale.space/developers#grants): _ecosistema della [rete SKALE](https://skale.space/)_
 - [The Graph](https://airtable.com/shrdfvnFvVch3IOVm) – _Ecosistema di [The Graph](https://thegraph.com/)_
 - [Uniswap Grants Program](https://www.uniswapfoundation.org/apply-for-a-grant) - _Community di [Uniswap](https://uniswap.org/)_
-- [Sovvenzioni Web3](https://web3grants.net): _Un elenco completo di programmi di sovvenzione relativi a web3/cripto_
 
 ## Finanziamento quadratico {#quadratic-funding}
 

--- a/public/content/translations/ja/community/grants/index.md
+++ b/public/content/translations/ja/community/grants/index.md
@@ -36,7 +36,6 @@ lang: ja
 - [The Graph](https://airtable.com/shrdfvnFvVch3IOVm) – _[The Graph](https://thegraph.com/)エコシステム_
 - [UMA 助成プログラム](https://grants.umaproject.org/) - _[UMA](https://umaproject.org/)デベロッパーサポート_
 - [Uniswap Grants Program](https://www.unigrants.org/) – _[Uniswap](https://uniswap.org/)コミュニティ_
-- [Web3 助成プログラム](https://web3grants.net) - _Web3/暗号資産関連の助成プログラムの広範なリスト_
 
 ## クオドラティック・ファンディング {#quadratic-funding}
 

--- a/public/content/translations/nl/community/grants/index.md
+++ b/public/content/translations/nl/community/grants/index.md
@@ -36,7 +36,6 @@ Deze projecten hebben hun eigen beurzen gecreëerd voor projecten die gericht zi
 - [The Graph](https://airtable.com/shrdfvnFvVch3IOVm) – _[The Graph](https://thegraph.com/)-ecosysteem_
 - [UMA Grants Program](https://grants.umaproject.org/) - _[UMA](https://umaproject.org/)-ontwikkelaarsondersteuning_
 - [Uniswap Grants Program](https://www.unigrants.org/) - _[Uniswap](https://uniswap.org/)-gemeenschap_
-- [Web3 Grants](https://web3grants.net) - _Een uitgebreide lijst van web3-/cryptogerelateerde subsidieprogramma's_
 
 ## Kwadratische financiering {#quadratic-funding}
 

--- a/public/content/translations/pl/community/grants/index.md
+++ b/public/content/translations/pl/community/grants/index.md
@@ -18,7 +18,6 @@ Te programy wspierają rozległy ekosystem Ethereum, oferując granty dla wielu 
 - [MetaCartel](https://www.metacartel.org/grants/) — _rozwój zdecentralizowanych aplikacji, tworzenie DAO_
 - [Moloch DAO](https://www.molochdao.com/) — _prywatność, skalowanie warstwy 2, bezpieczeństwo klienta i nie tylko_
 - [Granty DAO](https://docs.google.com/spreadsheets/d/1XHc-p_MHNRdjacc8uOEjtPoWL86olP4GyxAJOFO0zxY/edit#gid=0) — _arkusz kalkulacyjny Google organizacji oferujących granty_
-- [Crunchbase dla grantów Web3](https://www.cryptoneur.xyz/web3-grants) — _filtruj i wyszukuj granty według kategorii, przypadku użycia, kwoty i nie tylko. Przyczyń się, aby pomóc innym w znalezieniu odpowiedniego grantu._
 - [Granty Akademickie](https://esp.ethereum.foundation/academic-grants) — _granty na wsparcie prac akademickich związanych z Ethereum_
 - [Blockworks Grantfarm](https://blockworks.co/grants/programs) - _Firma Blockworks opracowała kompleksowy katalog wszystkich dotacji, zapytań ofertowych i nagród za błędy._
 
@@ -35,7 +34,6 @@ Projekty te stworzyły własne granty dla projektów mających na celu rozwój i
 - [Program grantów sieci SKALE](https://skale.space/developers#grants) — _ekosystem [sieci SKALE](https://skale.space/)_
 - [The Graph](https://airtable.com/shrdfvnFvVch3IOVm) — _ekosystem [The Graph](https://thegraph.com/)_
 - [Program grantów Uniswap](https://www.uniswapfoundation.org/apply-for-a-grant) — _społeczność [Uniswap](https://uniswap.org/)_
-- [Granty Web3](https://web3grants.net) — _obszerna lista programów grantowych związanych z web3/krypto_
 
 ## Quadratic funding {#quadratic-funding}
 

--- a/public/content/translations/pt-br/community/grants/index.md
+++ b/public/content/translations/pt-br/community/grants/index.md
@@ -18,7 +18,6 @@ Esses programas abrangem um amplo ecossistema Ethereum ao oferecer recompensas a
 - [MetaCartel](https://www.metacartel.org/grants/) – _Desenvolvimento de Dapp, criação de DAO_
 - [Moloch DAO](https://www.molochdao.com/) – _Privacidade, dimensionamento da camada 2, segurança do cliente e mais_
 - [Concessões DAO](https://docs.google.com/spreadsheets/d/1XHc-p_MHNRdjacc8uOEjtPoWL86olP4GyxAJOFO0zxY/edit#gid=0) – _Planilha Google de organizações que oferecem concessões_
-- [Crunchbase para concessões Web3](https://www.cryptoneur.xyz/web3-grants) – _Filtre e pesquise subvenções por categoria, caso de uso, valor e muito mais. Contribua para ajudar outros a encontrar a concessão certa._
 - [Bolsas acadêmicas](https://esp.ethereum.foundation/academic-grants) – _Bolsas para apoiar o trabalho acadêmico relacionado com o Ethereum_
 - [Blockworks Grantfarm](https://blockworks.co/grants/programs) - _A Blockworks compilou um diretório abrangente de todas as recompensas, RFPs e programas de caça a bugs._
 
@@ -35,7 +34,6 @@ Estes projetos criaram seus próprios programas de recompensas destinados a dese
 - [Programa de bolsas da SKALE Network](https://skale.space/developers#grants) - _[Ecossistema da SKALE Network](https://skale.space/)_
 - [The Graph](https://airtable.com/shrdfvnFvVch3IOVm) – _Ecossistema [The Graph](https://thegraph.com/)_
 - [Uniswap Grants Program](https://www.uniswapfoundation.org/apply-for-a-grant) - _[Comunidade da Uniswap](https://uniswap.org/)_
-- [Web3 Grants](https://web3grants.net) – _Uma extensa lista de programas de concessão web3/crypto relacionados_
 
 ## Financiamento quadrático {#quadratic-funding}
 

--- a/public/content/translations/ru/community/grants/index.md
+++ b/public/content/translations/ru/community/grants/index.md
@@ -18,7 +18,6 @@ lang: ru
 - [MetaCartel](https://www.metacartel.org/grants/): _разработка децентрализованных приложений, создание DAO._
 - [DAO Moloch](https://www.molochdao.com/): _конфиденциальность, масштабирование второго уровня, безопасность клиентов и многое другое._
 - [Гранты DAO](https://docs.google.com/spreadsheets/d/1XHc-p_MHNRdjacc8uOEjtPoWL86olP4GyxAJOFO0zxY/edit#gid=0): _Google-таблица организаций, предлагающих гранты._
-- [Crunchbase для грантов по Web3](https://www.cryptoneur.xyz/web3-grants): _отфильтровывайте и ищите гранты по категории, назначению, количеству и другим характеристикам. Помогите другим найти нужный грант._
 - [Академические гранты](https://esp.ethereum.foundation/academic-grants): _гранты на поддержку академической работы, связанной с Ethereum._
 - [Blockworks Grantfarm](https://blockworks.co/grants/programs): _компания Blockworks составила полный каталог всех грантов, запросов предложений (RFP) и наград за найденные ошибки._
 
@@ -35,7 +34,6 @@ lang: ru
 - [Программа грантов SKALE Network](https://skale.space/developers#grants): _экосистема [SKALE Network](https://skale.space/)._
 - [The Graph](https://airtable.com/shrdfvnFvVch3IOVm): _экосистема [The Graph](https://thegraph.com/)._
 - [Программа грантов Uniswap](https://www.uniswapfoundation.org/apply-for-a-grant): _сообщество [Uniswap](https://uniswap.org/)._
-- [Web3 Grants](https://web3grants.net): _обширный список грантов, связанных с web3/криптовалютами._
 
 ## Квадратичное финансирование {#quadratic-funding}
 

--- a/public/content/translations/tr/community/grants/index.md
+++ b/public/content/translations/tr/community/grants/index.md
@@ -18,7 +18,6 @@ Bu programlar geniş bir proje yelpazesine hibeler sağlayarak geniş Ethereum e
 - [MetaCartel](https://www.metacartel.org/grants/) - _Dapp geliştirme, DAO oluşturma_
 - [Moloch DAO](https://www.molochdao.com/) - _Gizlilik, katman 2 ölçeklendirme, istemci güvenliği ve dahası_
 - [DAO Hibeleri](https://docs.google.com/spreadsheets/d/1XHc-p_MHNRdjacc8uOEjtPoWL86olP4GyxAJOFO0zxY/edit#gid=0) - _Hibe sunan organizasyonların Google tablosu_
-- [Web3 Hibeleri için Crunchbase](https://www.cryptoneur.xyz/web3-grants) - _Hibeleri kategori, kullanım alanı, miktar ve dahasına göre filtreleyin ve arayın. Diğerlerinin doğru hibeyi bulabilmesine yardımcı olmak için katkı sağlayın._
 - [Akademik Hibeler](https://esp.ethereum.foundation/academic-grants) - _Ethereum ile ilgili akademik çalışmaları desteklemek için hibeler_
 - [Blockworks Grantfarm](https://blockworks.co/grants/programs) - _Blockworks, tüm hibelerin, RFP'lerin ve hata ödüllerinin kapsamlı bir dizinini derlemiştir._
 
@@ -35,7 +34,6 @@ Bu projeler kendi teknolojilerini geliştirmeye ve deneyimlemeye yönelik olarak
 - [SKALE Ağı Hibe Ekosistemi](https://skale.space/developers#grants) - _[SKALE Ağı](https://skale.space/) ekosistemi_
 - [The Graph](https://airtable.com/shrdfvnFvVch3IOVm) – _[The Graph](https://thegraph.com/) ekosistemi_
 - [Uniswap Grants Program](https://www.uniswapfoundation.org/apply-for-a-grant) - _[Uniswap](https://uniswap.org/) topluluğu_
-- [Web3 Hibeleri](https://web3grants.net) - _Web3/kripto ile ilgili hibe programlarının geniş bir listesi_
 
 ## İkinci dereceden finansman {#quadratic-funding}
 

--- a/public/content/translations/uk/community/grants/index.md
+++ b/public/content/translations/uk/community/grants/index.md
@@ -20,7 +20,6 @@ lang: uk
 - [DAO Moloch](https://www.molochdao.com/) — _конфіденційність, масштабування рівня 2, безпека клієнта й багато іншого_
 - [Відкриті гранти](https://opengrants.com/explore)
 - [DAO Grants](https://docs.google.com/spreadsheets/d/1XHc-p_MHNRdjacc8uOEjtPoWL86olP4GyxAJOFO0zxY/edit#gid=0) - _Електронна таблиця Google з організацій, які пропонують гранти_
-- [Crunchbase for Web3 Grants](https://www.cryptoneur.xyz/web3-grants) - _Фільтр і пошук грантів за категорією, використанням, кількістю тощо. Допоможіть іншим знайти правильний грант._
 - [Academic Grants](https://esp.ethereum.foundation/academic-grants) — _гранти для підтримки академічної роботи, пов’язаної з Ethereum_
 
 ## За типами проєктів {#project-specific}
@@ -38,7 +37,6 @@ lang: uk
 - [The Graph](https://airtable.com/shrdfvnFvVch3IOVm) — _екосистема [The Graph](https://thegraph.com/)_
 - [Програма грантів UMA](https://grants.umaproject.org/) — _підтримка розробників від [UMA](https://umaproject.org/)_
 - [Програма грантів Uniswap](https://www.unigrants.org/) — _спільнота [Uniswap](https://uniswap.org/)_
-- [Web3 Grants](https://web3grants.net) — _великий список пов’язаних грантів для web3/криптовалют_
 
 ## Чотиричне фінансування {#quadratic-funding}
 

--- a/public/content/translations/zh-tw/community/grants/index.md
+++ b/public/content/translations/zh-tw/community/grants/index.md
@@ -18,7 +18,6 @@ lang: zh-tw
 - [MetaCartel](https://www.metacartel.org/grants/) - _開發去中心化應用程式、創建去中心化自治組織_
 - [Moloch DAO](https://www.molochdao.com/) - _隱私性、二層網路擴容、用戶端安全性等_
 - [去中心化自治組織資助計畫](https://docs.google.com/spreadsheets/d/1XHc-p_MHNRdjacc8uOEjtPoWL86olP4GyxAJOFO0zxY/edit#gid=0) - _有關資助機構的 Google 試算表_
-- [Crunchbase Web3 資助計劃](https://www.cryptoneur.xyz/web3-grants) - _按類別、使用案例、總金額等篩選及搜尋資助計劃。 幫助他人尋找適合的資助計劃。_
 - [學術資助](https://esp.ethereum.foundation/academic-grants) - _支援以太坊相關學術工作的資助計劃_
 - [Blockworks Grantfarm](https://blockworks.co/grants/programs) - _Blockworks 彙編了關於所有資助計畫、提案徵集和漏洞懸賞計畫的詳盡清單。_
 
@@ -35,7 +34,6 @@ lang: zh-tw
 - [SKALE 網路資助計劃](https://skale.space/developers#grants) - _[SKALE 網路](https://skale.space/)生態系統_
 - [The Graph](https://airtable.com/shrdfvnFvVch3IOVm) – _[The Graph](https://thegraph.com/) 生態系統_
 - [Uniswap 資助計畫](https://www.uniswapfoundation.org/apply-for-a-grant) - _[Uniswap](https://uniswap.org/) 社群_
-- [Web3 資助計劃](https://web3grants.net) - _與 Web3/加密貨幣相關的資助計劃詳盡列表_
 
 ## 二次融資 {#quadratic-funding}
 

--- a/public/content/translations/zh/community/grants/index.md
+++ b/public/content/translations/zh/community/grants/index.md
@@ -18,7 +18,6 @@ lang: zh
 - [MetaCartel](https://www.metacartel.org/grants/) - _去中心化应用程序开发、去中心化自治组织创建_
 - [Moloch 去中心化自治组织](https://www.molochdao.com/) - _隐私、二层网络扩容、客户端安全性等_
 - [去中心化自治组织资助](https://docs.google.com/spreadsheets/d/1XHc-p_MHNRdjacc8uOEjtPoWL86olP4GyxAJOFO0zxY/edit#gid=0) - _资助组织的 Google 电子表格_
-- [Crunchbase for Web3 资助](https://www.cryptoneur.xyz/web3-grants) - _按类别、用例、金额等筛选和搜索资助。 致力于帮助他人找到合适的资助。_
 - [学术资助](https://esp.ethereum.foundation/academic-grants) - _为以太坊相关学术工作提供资助_
 - [Blockworks Grantfarm](https://blockworks.co/grants/programs) - _Blockworks 编译了一份包含所有资助、提案征求和漏洞悬赏的完整名录。_
 
@@ -35,7 +34,6 @@ lang: zh
 - [SKALE 网络资助方案](https://skale.space/developers#grants) - _[SKALE 网络](https://skale.space/)生态系统_
 - [The Graph](https://airtable.com/shrdfvnFvVch3IOVm) – _[The Graph](https://thegraph.com/) 生态系统_
 - [Uniswap 资助方案](https://www.uniswapfoundation.org/apply-for-a-grant) - _[Uniswap](https://uniswap.org/) 社区_
-- [Web3 Grants](https://web3grants.net) - _Web3/ 加密货币相关资助方案详尽清单_
 
 ## 二次方融资 {#quadratic-funding}
 


### PR DESCRIPTION
Delete link: The site ssl expired more than 6 months.
https://web3grants.net/

## Description

Delete link: The site's SSL expired more than 6 months ago.
Therefore, it looks deletable "https://web3grants.net/".

## Related Issue

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the community grants page to refine the list of grant resources, removing the reference to the "Web3 Grants" website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->