### PR TITLE
Delete site link: Quorum is no longer lineuped in the Consensys site

### DIFF
--- a/public/content/enterprise/private-ethereum/index.md
+++ b/public/content/enterprise/private-ethereum/index.md
@@ -26,5 +26,4 @@ Some collaborative efforts to make Ethereum enterprise friendly have been put to
 - [Hyperledger Besu](https://www.hyperledger.org/use/besu) _Open-source Ethereum client developed under the Apache 2.0 license and written in Java, which includes several consensus algorithms including PoW, and PoA (IBFT, IBFT 2.0, Ethash, and Clique). Its comprehensive permissioning schemes are designed specifically for use in a consortium environment._
 - [Hyperledger Burrow](https://www.hyperledger.org/projects/hyperledger-burrow) _modular blockchain client with a permissioned smart contract interpreter partially developed to the specification of the Ethereum Virtual Machine (EVM)_
 - [Kaleido](https://kaleido.io/) _full-stack platform for building and running cross-cloud, hybrid enterprise ecosystems_
-- [Quorum](https://consensys.net/quorum/) _an Ethereum-based open source enterprise blockchain platform with advanced enterprise grade features enabling privacy, permissioning and performance_
 - [Zeeve](https://www.zeeve.io/) _provides a range of products and tools for building on Ethereum, also infrastructure and APIs for Enterprise Web3 applications_


### PR DESCRIPTION
Delete site link: Quorum is no longer lineuped in the Consensys site.

## Description

Delete site link: Quorum is no longer lineuped in the Consensys site.
In addition, it is no longer linked to the product.

## Related Issue

None.