### PR TITLE
Discord GFI webhook

### DIFF
--- a/src/lib/utils/gh.ts
+++ b/src/lib/utils/gh.ts
@@ -45,13 +45,21 @@ export const getLastModifiedDateByPath = (path: string): string => {
   return extractDateFromGitLogInfo(logInfo)
 }
 
-const LABELS_TO_SEARCH = ["content", "design", "dev", "doc", "translation"]
+const LABELS_TO_SEARCH = [
+  "content",
+  "design",
+  "dev",
+  "doc",
+  "translation",
+  "event",
+]
 const LABELS_TO_TEXT = {
   content: "content",
   design: "design",
   dev: "dev",
   doc: "docs",
   translation: "translation",
+  event: "event",
 }
 
 // Given a list of labels, it returns a new array with the labels that match the

--- a/src/lib/utils/gh.ts
+++ b/src/lib/utils/gh.ts
@@ -52,8 +52,9 @@ const LABELS_TO_SEARCH = [
   "doc",
   "translation",
   "event",
-]
-const LABELS_TO_TEXT = {
+] as const
+
+const LABELS_TO_TEXT: Record<(typeof LABELS_TO_SEARCH)[number], string> = {
   content: "content",
   design: "design",
   dev: "dev",

--- a/src/lib/utils/gh.ts
+++ b/src/lib/utils/gh.ts
@@ -44,3 +44,35 @@ export const getLastModifiedDateByPath = (path: string): string => {
   const logInfo = getGitLogFromPath(path)
   return extractDateFromGitLogInfo(logInfo)
 }
+
+const LABELS_TO_SEARCH = ["content", "design", "dev", "doc", "translation"]
+const LABELS_TO_TEXT = {
+  content: "content",
+  design: "design",
+  dev: "dev",
+  doc: "docs",
+  translation: "translation",
+}
+
+// Given a list of labels, it returns a string with the labels that match the
+// LABELS_TO_SEARCH list, using the LABELS_TO_TEXT values
+// Example:
+// - ["content :pencil:", "ux design"] => "content, design"
+// - ["documentation :emoji:", "dev required", "good first issue"] => "docs, dev"
+export const rawLabelsToText = (labels: string[]) => {
+  return labels
+    .map((label) => {
+      const labelIndex = LABELS_TO_SEARCH.findIndex((l) =>
+        label.toLocaleLowerCase().includes(l)
+      )
+
+      if (labelIndex === -1) {
+        return
+      }
+
+      const labelMatched = LABELS_TO_SEARCH[labelIndex]
+      return LABELS_TO_TEXT[labelMatched]
+    })
+    .filter(Boolean)
+    .join(", ")
+}

--- a/src/lib/utils/gh.ts
+++ b/src/lib/utils/gh.ts
@@ -54,13 +54,13 @@ const LABELS_TO_TEXT = {
   translation: "translation",
 }
 
-// Given a list of labels, it returns a string with the labels that match the
+// Given a list of labels, it returns a new array with the labels that match the
 // LABELS_TO_SEARCH list, using the LABELS_TO_TEXT values
 // Example:
-// - ["content :pencil:", "ux design"] => "content, design"
-// - ["documentation :emoji:", "dev required", "good first issue"] => "docs, dev"
-export const rawLabelsToText = (labels: string[]) => {
-  return labels
+// - ["content :pencil:", "ux design"] => ["content", "design"]
+// - ["documentation :emoji:", "dev required", "good first issue"] => ["docs", "dev"]
+export const normalizeLabels = (labels: string[]) => {
+  const labelsFound = labels
     .map((label) => {
       const labelIndex = LABELS_TO_SEARCH.findIndex((l) =>
         label.toLocaleLowerCase().includes(l)
@@ -74,5 +74,7 @@ export const rawLabelsToText = (labels: string[]) => {
       return LABELS_TO_TEXT[labelMatched]
     })
     .filter(Boolean)
-    .join(", ")
+
+  // remove duplicates
+  return Array.from(new Set(labelsFound))
 }

--- a/src/pages/api/gfi-issues-webhook.ts
+++ b/src/pages/api/gfi-issues-webhook.ts
@@ -1,0 +1,75 @@
+import type { NextApiRequest, NextApiResponse } from "next"
+
+import { rawLabelsToText } from "@/lib/utils/gh"
+
+type ResponseData = {
+  message: string
+}
+
+const GFI_LABEL = "good first issue"
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ResponseData>
+) {
+  const { method } = req
+
+  if (method !== "POST") {
+    return res.status(405).json({ message: "Method not allowed" })
+  }
+
+  const { action, label, issue } = req.body
+
+  if (action !== "labeled") {
+    return res.status(200).json({ message: "Not a label action" })
+  }
+
+  if (label.name !== GFI_LABEL) {
+    return res.status(200).json({ message: "Not a good first issue" })
+  }
+
+  if (issue.assignee) {
+    return res.status(200).json({ message: "Issue already assigned" })
+  }
+
+  // send a notification to discord webhook
+  const webhookUrl = `https://discord.com/api/webhooks/${process.env.DISCORD_ID}/${process.env.DISCORD_TOKEN}`
+
+  const embeds = [
+    {
+      title: issue.title,
+      url: issue.html_url,
+      timestamp: issue.created_at,
+      description: issue.labels.map((label) => label.name).join(" • "),
+      color: 10181046, // purple
+      author: {
+        name: issue.user.login,
+        url: issue.user.html_url,
+        icon_url: issue.user.avatar_url,
+      },
+    },
+  ]
+
+  const allLabels = issue.labels.map((label) => label.name)
+  const labels = rawLabelsToText(allLabels)
+  const labelsText = labels ? ` - ${labels}` : ""
+
+  const message = {
+    content: `## New good first issue${labelsText}`,
+    embeds,
+  }
+
+  const discordRes = await fetch(webhookUrl, {
+    method: "post",
+    body: JSON.stringify(message),
+    headers: { "Content-Type": "application/json" },
+  })
+
+  if (!discordRes.ok) {
+    const error = await discordRes.json()
+    console.log(error)
+    return res.status(500).json({ message: "Error sending GFI to Discord" })
+  }
+
+  res.status(200).json({ message: "New GFI sent to Discord!" })
+}

--- a/src/pages/api/gfi-issues-webhook.ts
+++ b/src/pages/api/gfi-issues-webhook.ts
@@ -1,6 +1,14 @@
 import type { NextApiRequest, NextApiResponse } from "next"
 
-import { rawLabelsToText } from "@/lib/utils/gh"
+import { normalizeLabels } from "@/lib/utils/gh"
+
+const LABELS_TO_EMOJI = {
+  content: "📝",
+  design: "🎨",
+  dev: "🛠️",
+  docs: "📚",
+  translation: "🌐",
+}
 
 type ResponseData = {
   message: string
@@ -51,11 +59,13 @@ export default async function handler(
   ]
 
   const allLabels = issue.labels.map((label) => label.name)
-  const labels = rawLabelsToText(allLabels)
-  const labelsText = labels ? ` - ${labels}` : ""
+  const [firstLabel] = normalizeLabels(allLabels)
+  const labelsText = firstLabel ? ` - ${firstLabel}` : ""
+  const emoji = LABELS_TO_EMOJI[firstLabel]
+  const emojiText = emoji ? `${emoji} ` : ""
 
   const message = {
-    content: `## New good first issue${labelsText}`,
+    content: `### ${emojiText}New good first issue${labelsText}`,
     embeds,
   }
 

--- a/src/pages/api/gfi-issues-webhook.ts
+++ b/src/pages/api/gfi-issues-webhook.ts
@@ -8,6 +8,7 @@ const LABELS_TO_EMOJI = {
   dev: "🛠️",
   docs: "📚",
   translation: "🌐",
+  event: "🗓️",
 }
 
 type ResponseData = {

--- a/src/pages/api/gfi-issues-webhook.ts
+++ b/src/pages/api/gfi-issues-webhook.ts
@@ -61,12 +61,19 @@ export default async function handler(
 
   const allLabels = issue.labels.map((label) => label.name)
   const [firstLabel] = normalizeLabels(allLabels)
-  const labelsText = firstLabel ? ` - ${firstLabel}` : ""
-  const emoji = LABELS_TO_EMOJI[firstLabel]
-  const emojiText = emoji ? `${emoji} ` : ""
+
+  let content: string
+  if (firstLabel) {
+    const labelsText = ` - ${firstLabel}`
+    const emoji = LABELS_TO_EMOJI[firstLabel]
+    const emojiText = emoji ? `${emoji} ` : ""
+    content = `### ${emojiText}New good first issue${labelsText}`
+  } else {
+    content = `### New good first issue`
+  }
 
   const message = {
-    content: `### ${emojiText}New good first issue${labelsText}`,
+    content,
     embeds,
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Simpler alternative to #12436 using the GH webhooks service. Whenever an issue changed, the new api route `/api/gfi-issues-webhook` is going to be called.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a feature to convert GitHub issue labels to human-readable text.
	- Introduced a webhook handler for notifying a Discord channel when a new "good first issue" is labeled on GitHub.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->