### PR TITLE
Fix typo on the Gas and fees page

### DIFF
--- a/public/content/developers/docs/gas/index.md
+++ b/public/content/developers/docs/gas/index.md
@@ -138,4 +138,4 @@ If you want to monitor gas prices, so you can send your ETH for less, you can us
 - [Proof of Stake versus Proof of Work](https://blockgeeks.com/guides/proof-of-work-vs-proof-of-stake/)
 - [Gas Optimization Strategies for Developers](https://www.alchemy.com/overviews/solidity-gas-optimization)
 - [EIP-1559 docs](https://eips.ethereum.org/EIPS/eip-1559).
-- [Time Beiko's EIP-1559 Resources](https://hackmd.io/@timbeiko/1559-resources).
+- [Tim Beiko's EIP-1559 Resources](https://hackmd.io/@timbeiko/1559-resources).

--- a/public/content/translations/de/developers/docs/gas/index.md
+++ b/public/content/translations/de/developers/docs/gas/index.md
@@ -152,4 +152,4 @@ Wenn Sie die Gaspreise überwachen möchten, damit Sie Ihre ETH günstiger versc
 - [Proof-of-Stake und Proof-of-Work im Vergleich](https://blockgeeks.com/guides/proof-of-work-vs-proof-of-stake/)
 - [Strategien für Programmierer zur Optimierung des Gasverbrauchs](https://www.alchemy.com/overviews/solidity-gas-optimization)
 - [Spezifikationen zu EIP-1559](https://eips.ethereum.org/EIPS/eip-1559).
-- [Ressourcen von Time Beiko zu EIP-1559](https://hackmd.io/@timbeiko/1559-resources).
+- [Ressourcen von Tim Beiko zu EIP-1559](https://hackmd.io/@timbeiko/1559-resources).

--- a/public/content/translations/es/developers/docs/gas/index.md
+++ b/public/content/translations/es/developers/docs/gas/index.md
@@ -152,4 +152,4 @@ Si desea supervisar las tarifas de gas, para poder enviar sus ETH por menos, pue
 - [Prueba de participación frente a prueba de trabajo](https://blockgeeks.com/guides/proof-of-work-vs-proof-of-stake/)
 - [Estrategias de optimización de gas para desarrolladores](https://www.alchemy.com/overviews/solidity-gas-optimization)
 - [Documentacion sobre EIP-1559](https://eips.ethereum.org/EIPS/eip-1559).
-- [ Recursos de Time Beiko sobre EIP-1559](https://hackmd.io/@timbeiko/1559-resources).
+- [ Recursos de Tim Beiko sobre EIP-1559](https://hackmd.io/@timbeiko/1559-resources).

--- a/public/content/translations/fr/developers/docs/gas/index.md
+++ b/public/content/translations/fr/developers/docs/gas/index.md
@@ -152,4 +152,4 @@ Si vous voulez surveiller les prix du gaz et pouvoir envoyer votre ETH à moindr
 - [Preuve d'enjeu contre preuve de travail](https://blockgeeks.com/guides/proof-of-work-vs-proof-of-stake/)
 - [Des Stratégies pour Optimiser la Consommation de Gas, pour les Développeurs](https://www.alchemy.com/overviews/solidity-gas-optimization)
 - [documentation EIP-1559](https://eips.ethereum.org/EIPS/eip-1559).
-- [Ressources EIP-1559 de Time Beiko](https://hackmd.io/@timbeiko/1559-resources).
+- [Ressources EIP-1559 de Tim Beiko](https://hackmd.io/@timbeiko/1559-resources).


### PR DESCRIPTION
## Description

Changed "Time Beiko" to "Tim Beiko"

## Related Issue

- Fixes #12506


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected typos in hyperlinks related to EIP-1559 resources across the English, German, Spanish, and French documentation, ensuring accurate reference to Tim Beiko.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->