### PR TITLE
fix typo on testing smart contract page [fixes #12508]

### DIFF
--- a/public/content/developers/docs/smart-contracts/testing/index.md
+++ b/public/content/developers/docs/smart-contracts/testing/index.md
@@ -238,7 +238,7 @@ Still, you can further increase the possibility of catching contract vulnerabili
 
 Audits are performed by auditors experienced at finding cases of security flaws and poor development practices in smart contracts. An audit will usually include testing (and possibly formal verification) as well as a manual review of the entire codebase.
 
-Conversely, a bug bounty program usually involves involves offering a financial reward to an individual (commonly described as [whitehat hackers](<https://en.wikipedia.org/wiki/White_hat_(computer_security)>)) that discovers a vulnerability in a smart contract and discloses it to developers. Bug bounties are similar to audits since it involves asking others to help find defects in smart contracts.
+Conversely, a bug bounty program usually involves offering a financial reward to an individual (commonly described as [whitehat hackers](<https://en.wikipedia.org/wiki/White_hat_(computer_security)>)) that discovers a vulnerability in a smart contract and discloses it to developers. Bug bounties are similar to audits since it involves asking others to help find defects in smart contracts.
 
 The major difference is that bug bounty programs are open to the wider developer/hacker community and attract a broad class of ethical hackers and independent security professionals with unique skills and experience. This may be an advantage over smart contract audits that mainly rely on teams who may possess limited or narrow expertise.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Removes the double instance of 'involves' on the testing smart contracts page.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#12508 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected a text duplication error in the smart contracts testing documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->