### PR TITLE
Fix zkSync zkPorter Broken Link

### DIFF
--- a/public/content/developers/docs/scaling/validium/index.md
+++ b/public/content/developers/docs/scaling/validium/index.md
@@ -153,7 +153,8 @@ Multiple projects provide implementations of Validium and volitions that you can
 
 **Matter Labs zkPorter**- _zkPorter is a Layer 2 scaling protocol tackling data availability with a hybrid approach that combines the ideas of zkRollup and sharding. It can support arbitrarily many shards, each with its own data availability policy._
 
-- [Documentation](https://docs.zksync.io/zkevm/#what-is-zkporter)
+- [Blog](https://blog.matter-labs.io/zkporter-a-breakthrough-in-l2-scaling-ed5e48842fbf)
+- [Documentation](https://docs.zksync.io/zk-stack/concepts/hyperchains-hyperscaling.html#logical-state-partitions-in-zk-porters)
 - [Website](https://zksync.io/)
 
 ## Further reading {#further-reading}

--- a/public/content/translations/es/developers/docs/scaling/validium/index.md
+++ b/public/content/translations/es/developers/docs/scaling/validium/index.md
@@ -153,7 +153,7 @@ Múltiples proyectos proporcionan implementaciones de Validium y voliciones que 
 
 **Matter Labs zkPorter:**_zkPorter es un protocolo de escalado de capa 2 que aborda la disponibilidad de datos con un enfoque híbrido que combina las ideas de zkRollup y el sharding. Puede soportar arbitrariamente muchos fragmentos (shards), cada uno con su propia política de disponibilidad de datos. _
 
-- [Documentación](https://docs.zksync.io/zkevm/#what-is-zkporter)
+- [Documentación](https://docs.zksync.io/zk-stack/concepts/hyperchains-hyperscaling.html#logical-state-partitions-in-zk-porters)
 - [Sitio web](https://zksync.io/)
 
 ## Más información {#further-reading}

--- a/public/content/translations/fr/developers/docs/scaling/validium/index.md
+++ b/public/content/translations/fr/developers/docs/scaling/validium/index.md
@@ -153,7 +153,7 @@ De multiples projets fournissent des implémentations de Validium et de volition
 
 **Matter Labs zkPorter**- _zkPorter est un protocole de mise à l'échelle de couche 2 s'attaquant à la disponibilité des données avec une approche hybride qui combine les idées de rollup ZK et de fragmentation. Il peut prendre en charge un nombre arbitraire de fragments, chacun ayant sa propre politique de disponibilité des données._
 
-- [Documentation](https://docs.zksync.io/zkevm/#what-is-zkporter)
+- [Documentation](https://docs.zksync.io/zk-stack/concepts/hyperchains-hyperscaling.html#logical-state-partitions-in-zk-porters)
 - [Site Web](https://zksync.io/)
 
 ## Complément d'information {#further-reading}

--- a/public/content/translations/it/developers/docs/scaling/validium/index.md
+++ b/public/content/translations/it/developers/docs/scaling/validium/index.md
@@ -153,7 +153,7 @@ Diversi progetti forniscono implementazioni di validium e volizioni che puoi int
 
 **Matter Labs zkPorter**- _zkPorter è un protocollo di ridimensionamento del Livello 2 che affronta la disponibilità dei dati con un approccio ibrido che combina le idee dei rollup Zk e dello sharding. Può supportare arbitrariamente molti shard, ognuno con la propria politica di disponibilità dei dati._
 
-- [Documentazione](https://docs.zksync.io/zkevm/#what-is-zkporter)
+- [Documentazione](https://docs.zksync.io/zk-stack/concepts/hyperchains-hyperscaling.html#logical-state-partitions-in-zk-porters)
 - [Sito web](https://zksync.io/)
 
 ## Letture consigliate {#further-reading}

--- a/public/content/translations/ja/developers/docs/scaling/validium/index.md
+++ b/public/content/translations/ja/developers/docs/scaling/validium/index.md
@@ -153,7 +153,7 @@ Volitionsは、ゼロ知識ロールアップとバリディアムチェーン�
 
 **Matter Labs zkPorter**- _zkPorterは、ゼロ知識ロールアップとシャーディングを結合したハイブリッド型のアプローチによりデータ化要請を追跡する、レイヤー2のスケーリング・プロトコルです。 任意の数のシャードをサポートしており、シャードごとに異なるデータ可用性ポリシーを定めることができます。_
 
-- [ドキュメント](https://docs.zksync.io/zkevm/#what-is-zkporter)
+- [ドキュメント](https://docs.zksync.io/zk-stack/concepts/hyperchains-hyperscaling.html#logical-state-partitions-in-zk-porters)
 - [ウェブサイト](https://zksync.io/)
 
 ## 参考文献 {#further-reading}

--- a/public/content/translations/pt-br/developers/docs/scaling/validium/index.md
+++ b/public/content/translations/pt-br/developers/docs/scaling/validium/index.md
@@ -153,7 +153,7 @@ Vários projetos fornecem implementações de validium e volitions que você pod
 
 **Matter Labs zkPorter**: _zkPorter é um protocolo de dimensionamento de camada 2 que aborda a disponibilidade de dados com uma abordagem híbrida que combina os conceitos de zkRollup e sharding. Pode suportar arbitrariamente muitos shards, cada um com sua própria política de disponibilidade de dados._
 
-- [Documentação](https://docs.zksync.io/zkevm/#what-is-zkporter)
+- [Documentação](https://docs.zksync.io/zk-stack/concepts/hyperchains-hyperscaling.html#logical-state-partitions-in-zk-porters)
 - [Website](https://zksync.io/)
 
 ## Leitura adicional {#further-reading}

--- a/public/content/translations/tr/developers/docs/scaling/validium/index.md
+++ b/public/content/translations/tr/developers/docs/scaling/validium/index.md
@@ -153,7 +153,7 @@ Merkeziyetsiz uygulamalarınıza entegre edebileceğiniz Validium ve istemlere i
 
 **Matter Labs zkPorter** - _zkPorter, zkRollup ve parçalama fikirlerini birleştirerek veri kullanılabilirliğini hibrit bir yaklaşımla ele alan bir Katman 2 ölçeklendirme protokolüdür. Her biri kendi veri kullanılabilirliği politikasına sahip, keyfi çok sayıda parçayı destekleyebilir._
 
-- [Belgeler](https://docs.zksync.io/zkevm/#what-is-zkporter)
+- [Belgeler](https://docs.zksync.io/zk-stack/concepts/hyperchains-hyperscaling.html#logical-state-partitions-in-zk-porters)
 - [Web sitesi](https://zksync.io/)
 
 ## Daha fazla okuma {#further-reading}

--- a/public/content/translations/zh/developers/docs/scaling/validium/index.md
+++ b/public/content/translations/zh/developers/docs/scaling/validium/index.md
@@ -153,7 +153,7 @@ Validium 实现了可扩展性，它将所有交易数据保存在链下并且�
 
 **Matter Labs zkPorter**- _zkPorter 是一个二层扩容协议，它用一种结合了零知识卷叠和分片观点的混合方法来处理数据可用性。 它支持任意多个分片，每个分片都有自己的数据可用性策略。_
 
-- [相关文档](https://docs.zksync.io/zkevm/#what-is-zkporter)
+- [相关文档](https://docs.zksync.io/zk-stack/concepts/hyperchains-hyperscaling.html#logical-state-partitions-in-zk-porters)
 - [网站](https://zksync.io/)
 
 ## 延伸阅读 {#further-reading}


### PR DESCRIPTION
## Description
1. Fix zkPorter broken documentation link and add a new blog link
2. update the documentation link of non-English versions

zkSync document mentions the blog many times, the detailed explanation is not in the documentation now, it is in the blog.

> zkPorter - it's explained in detail in [this post](https://blog.matter-labs.io/zkporter-a-breakthrough-in-l2-scaling-ed5e48842fbf)

## Related Issue
- Closes #12462

## Summary by CodeRabbit

- **Documentation**
	- Updated the Matter Labs zkPorter documentation link across various language versions to provide users with the latest information on layer 2 scaling solutions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->