### PR TITLE
docs: Add docs for covalent's Golang SDK

### DIFF
--- a/public/content/developers/docs/programming-languages/golang/index.md
+++ b/public/content/developers/docs/programming-languages/golang/index.md
@@ -65,6 +65,7 @@ Need a more basic primer first? Check out [ethereum.org/learn](/learn/) or [ethe
 - [Multi Geth](https://github.com/multi-geth/multi-geth) - _Support for many species of Ethereum networks_
 - [Geth Light Client](https://github.com/zsfelfoldi/go-ethereum/wiki/Geth-Light-Client) - _Light Ethereum Subprotocol's Geth implementation_
 - [Ethereum Golang SDK](https://github.com/everFinance/goether) - _A simple Ethereum wallet implementation and utilities in Golang_
+- [Covalent Golang SDK](https://github.com/covalenthq/covalent-api-sdk-go) - _Efficient blockchain data access via Go SDK for 200+ blockchains_
 
 Looking for more resources? Check out [ethereum.org/developers](/developers/)
 


### PR DESCRIPTION
This PR adds Covalent's Golang SDK apart of `GO PROJECTS AND TOOLS` under programming languages, Golang
Covalent's Golang SDK -> https://github.com/covalenthq/covalent-api-sdk-go