### PR TITLE
Fix Tooltip overwritten prop

### DIFF
--- a/src/components/Glossary/GlossaryTooltip/index.tsx
+++ b/src/components/Glossary/GlossaryTooltip/index.tsx
@@ -26,7 +26,7 @@ const GlossaryTooltip = ({ children, termKey }: GlossaryTooltipProps) => {
             options={{ ns: "glossary-tooltip" }}
           />
         }
-        onOpen={() => {
+        onBeforeOpen={() => {
           trackCustomEvent({
             eventCategory: "Glossary Tooltip",
             eventAction: cleanPath(asPath),

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -14,9 +14,15 @@ import { isMobile } from "@/lib/utils/isMobile"
 export interface IProps extends PopoverProps {
   content: ReactNode
   children?: ReactNode
+  onBeforeOpen?: () => void
 }
 
-const Tooltip: React.FC<IProps> = ({ content, children, ...rest }) => {
+const Tooltip: React.FC<IProps> = ({
+  content,
+  children,
+  onBeforeOpen,
+  ...rest
+}) => {
   const { isOpen, onOpen, onClose } = useDisclosure()
 
   // Close the popover when the user scrolls.
@@ -46,19 +52,19 @@ const Tooltip: React.FC<IProps> = ({ content, children, ...rest }) => {
   }, [isOpen, onClose])
 
   const handleOpen = () => {
+    onBeforeOpen?.()
     onOpen()
-    rest.onOpen?.()
   }
 
   return (
     <Popover
+      isOpen={isOpen}
+      onOpen={handleOpen}
+      onClose={onClose}
       placement="top"
       trigger={isMobile() ? "click" : "hover"}
       gutter={8}
       {...rest}
-      isOpen={isOpen}
-      onOpen={handleOpen}
-      onClose={onClose}
     >
       <PopoverTrigger>{children}</PopoverTrigger>
       <PopoverContent>

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -45,15 +45,20 @@ const Tooltip: React.FC<IProps> = ({ content, children, ...rest }) => {
     }
   }, [isOpen, onClose])
 
+  const handleOpen = () => {
+    onOpen()
+    rest.onOpen?.()
+  }
+
   return (
     <Popover
-      isOpen={isOpen}
-      onOpen={onOpen}
-      onClose={onClose}
       placement="top"
       trigger={isMobile() ? "click" : "hover"}
       gutter={8}
       {...rest}
+      isOpen={isOpen}
+      onOpen={handleOpen}
+      onClose={onClose}
     >
       <PopoverTrigger>{children}</PopoverTrigger>
       <PopoverContent>


### PR DESCRIPTION
## Description

Avoids the overwriting of the prop `onOpen` and calls it after it is handled internally.

## Related Issue

Fixes #12592