### PR TITLE
fix: battle tested logic

### DIFF
--- a/src/components/Staking/StakingProductsCardGrid/utils.ts
+++ b/src/components/Staking/StakingProductsCardGrid/utils.ts
@@ -74,14 +74,8 @@ const getBattleTestedFlag = (
   halfYearAgo.setDate(now.getDate() - 183)
   oneYearAgo.setDate(now.getDate() - 365)
 
-  if (halfYearAgo > launchDate) {
-    return FlagType.CAUTION
-  }
-
-  if (oneYearAgo > launchDate) {
-    return FlagType.VALID
-  }
-
+  if (oneYearAgo > launchDate) return FlagType.VALID
+  if (halfYearAgo > launchDate) return FlagType.CAUTION
   return FlagType.WARNING
 }
 


### PR DESCRIPTION
## Description
- Fixes a bug introduced in #11477 with the logic for the "battle tested" indicator on staking products.
- That PR switches this logic to use guard statements, but returning after the first check was causing the "Caution" flag (6-12 months live) to take precedent even if the product had been around over 1 year ("Valid" flag). This flips the ordering so it will return the best possible flag, falling back to the "warning" flag.

## Related Issue
Surfaced with PR #11477
Can see bug here (before merging): https://dev--ethereumorg.netlify.app/en/staking/saas/#saas-providers (Notice all products are listed with a yellow caution icon for "battle tested")