### PR TITLE
Typo: Corrected Ethereum.org -> ethereum.org on Design contribution page

### DIFF
--- a/public/content/contributing/adding-wallets/index.md
+++ b/public/content/contributing/adding-wallets/index.md
@@ -68,7 +68,8 @@ As is the fluid nature of Ethereum, teams and products come and go and innovatio
 - ensure that all wallets and dapps listed still fulfil our criteria
 - verify there aren't products that have been suggested that meet more of our criteria than the ones currently listed
 
-Ethereum.org is maintained by the open source community & we rely on the community to help keep this up to date. If you notice any information about listed wallets that needs to be updated, please [open an issue](https://github.com/ethereum/ethereum-org-website/issues/new?assignees=&labels=wallet+%3Apurse%3A&template=suggest_wallet.yaml) or [pull request](https://github.com/ethereum/ethereum-org-website/pulls)!
+ethereum.org is maintained by the open source community & we rely on the community to help keep this up to date. If you notice any information about listed wallets that needs to be updated, please [open an issue](https://github.com/ethereum/ethereum-org-website/issues/new?assignees=&labels=wallet+%3Apurse%3A&template=suggest_wallet.yaml) or [pull request](https://github.com/ethereum/ethereum-org-website/pulls)!
+
 
 ## Terms of use {#terms-of-use}
 

--- a/public/content/contributing/design/index.md
+++ b/public/content/contributing/design/index.md
@@ -6,7 +6,7 @@ lang: en
 
 # Design contribution to ethereum.org {#design-contributions}
 
-Design is a critical component of any project, and by devoting your time and design skills to Ethereum.org, you can help to improve the user experience for our visitors. Contributing to an open-source project provides an opportunity to gain relevant experience and develop your skills in a collaborative environment. You will have the chance to work with other designers, developers, and community members, all of whom will have their own unique perspectives and insights.
+Design is a critical component of any project, and by devoting your time and design skills to ethereum.org, you can help to improve the user experience for our visitors. Contributing to an open-source project provides an opportunity to gain relevant experience and develop your skills in a collaborative environment. You will have the chance to work with other designers, developers, and community members, all of whom will have their own unique perspectives and insights.
 
 Ultimately, this is a great way to build a diverse and impressive portfolio that showcases your design skills.
 
@@ -30,7 +30,7 @@ Provide feedback on our website by:
 
 ### <Emoji text=":three:" size={1} /> &nbsp;Find design related issues on the website and report them {#report-design-issues}
 
-Ethereum.org is a fast growing website with many features and content. Some of the UI can easily become obsolete or could be improved. If you encounter any such instance, please report it so that it gets our attention.
+ethereum.org is a fast growing website with many features and content. Some of the UI can easily become obsolete or could be improved. If you encounter any such instance, please report it so that it gets our attention.
 
 1. Go through the website and pay attention to its design.
 2. Take screenshots and notes if you see any visual or UX issues.


### PR DESCRIPTION
Corrected Ethereum.org -> ethereum.org on Design contribution page

## Description

Corrected Ethereum.org -> ethereum.org on Design contribution page

## Related Issue

None
