### PR TITLE
Fix the unintended behaviour of clicking visit website on find wallet #12644

### DIFF
--- a/src/components/FindWallet/WalletTable/index.tsx
+++ b/src/components/FindWallet/WalletTable/index.tsx
@@ -310,8 +310,6 @@ const WalletTable = ({
           )
 
           const showMoreInfo = (wallet) => {
-            // Prevent expanding the wallet more info section when clicking on the "Visit website" button
-
             updateMoreInfo(wallet.key)
             // Log "more info" event only on expanding
             wallet.moreInfo &&
@@ -333,6 +331,7 @@ const WalletTable = ({
                   if (e.key === "Enter") showMoreInfo(wallet)
                 }}
                 onClick={(e) => {
+                  // Prevent expanding the wallet more info section when clicking on the "Visit website" button
                   if (
                     (e.target as HTMLElement).matches("a, a svg")
                   )

--- a/src/components/FindWallet/WalletTable/index.tsx
+++ b/src/components/FindWallet/WalletTable/index.tsx
@@ -309,7 +309,15 @@ const WalletTable = ({
             sliceSize
           )
 
-          const showMoreInfo = (wallet) => {
+          const showMoreInfo = (wallet, event) => {
+            // Prevent expanding the wallet more info section when clicking on the "Visit website" button
+            let classList = event?.target?.classList
+            if (
+              Object.values(classList)?.includes("chakra-button") ||
+              Object.values(classList)?.includes("css-1bbj57d")
+            ) {
+              return
+            }
             updateMoreInfo(wallet.key)
             // Log "more info" event only on expanding
             wallet.moreInfo &&
@@ -328,9 +336,11 @@ const WalletTable = ({
               <Wallet
                 // Make wallets more info section open on 'Enter'
                 onKeyUp={(e) => {
-                  if (e.key === "Enter") showMoreInfo(wallet)
+                  if (e.key === "Enter") showMoreInfo(wallet, e)
                 }}
-                onClick={() => showMoreInfo(wallet)}
+                onClick={(e) => {
+                  showMoreInfo(wallet, e)
+                }}
               >
                 <Td lineHeight="revert">
                   <Flex

--- a/src/components/FindWallet/WalletTable/index.tsx
+++ b/src/components/FindWallet/WalletTable/index.tsx
@@ -334,8 +334,7 @@ const WalletTable = ({
                 }}
                 onClick={(e) => {
                   if (
-                    (e.target as HTMLTableRowElement).tagName === "A" ||
-                    (e.target as HTMLTableRowElement).tagName === "svg"
+                    (e.target as HTMLElement).matches("a, a svg")
                   )
                     return
                   showMoreInfo(wallet)

--- a/src/components/FindWallet/WalletTable/index.tsx
+++ b/src/components/FindWallet/WalletTable/index.tsx
@@ -309,15 +309,9 @@ const WalletTable = ({
             sliceSize
           )
 
-          const showMoreInfo = (wallet, event) => {
+          const showMoreInfo = (wallet) => {
             // Prevent expanding the wallet more info section when clicking on the "Visit website" button
-            let classList = event?.target?.classList
-            if (
-              Object.values(classList)?.includes("chakra-button") ||
-              Object.values(classList)?.includes("css-1bbj57d")
-            ) {
-              return
-            }
+
             updateMoreInfo(wallet.key)
             // Log "more info" event only on expanding
             wallet.moreInfo &&
@@ -336,10 +330,15 @@ const WalletTable = ({
               <Wallet
                 // Make wallets more info section open on 'Enter'
                 onKeyUp={(e) => {
-                  if (e.key === "Enter") showMoreInfo(wallet, e)
+                  if (e.key === "Enter") showMoreInfo(wallet)
                 }}
                 onClick={(e) => {
-                  showMoreInfo(wallet, e)
+                  if (
+                    (e.target as HTMLTableRowElement).tagName === "A" ||
+                    (e.target as HTMLTableRowElement).tagName === "svg"
+                  )
+                    return
+                  showMoreInfo(wallet)
                 }}
               >
                 <Td lineHeight="revert">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When the Visit website is clicked on the wallet, the event is compared with the associated class and allows to show the detailed view accordingly. [Fixes #12644 ]

<!--- Describe your changes in detail -->


