### PR TITLE
Chromatic SB build path

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -16,6 +16,7 @@ on:
       - "src/pages/**/*"
       - "src/layouts/**/*"
       - "src/@chakra-ui/**/*"
+      - ".storybook/**/*"
 
 # List of jobs
 jobs:


### PR DESCRIPTION
Currently, any changes on the SB configuration/setup files won't trigger the chromatic job.

## Description

Adds storybook folder to chromatic build paths.

## Related Issue

#12668