### PR TITLE
fix: dev docs /languages rules [Fixes #12685]

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -174,4 +174,6 @@
 
 /*/deprecated-software /:splat/dapps/ 301!
 
-/*/languages /:splat/contributing/translation-program/ 301!
+/*/developers/docs/smart-contracts/languages/ /:splat/developers/docs/smart-contracts/languages/
+
+/*/languages /:splat/developers/docs/programming-languages/ 301!


### PR DESCRIPTION
## Description
pre-empt developers/docs/smart-contracts/languages/ from matching /*/languages and redirecting inappropriately

## Related Issue
- Fixes #12685 