### PR TITLE
Prevent redirect for `/developers/docs/smart-contracts/languages`

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -174,4 +174,6 @@
 
 /*/deprecated-software /:splat/dapps/ 301!
 
+/developers/docs/smart-contracts/languages /developers/docs/smart-contracts/languages 200
+
 /*/languages /:splat/contributing/translation-program/ 301!


### PR DESCRIPTION
## Description

Excludes the path from being redirected as part of the global locale prefix redirect rule.

## Related Issue

#12685
