### PR TITLE
feat: Crowdin build automation

### DIFF
--- a/.github/workflows/build-crowdin.yml
+++ b/.github/workflows/build-crowdin.yml
@@ -2,7 +2,7 @@ name: Build Crowdin project
 
 on:
   schedule:
-    - cron: "20 04 1 * *"
+    - cron: "20 04 1 * *" # Runs at 4:20 AM on the first day of every month
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-crowdin.yml
+++ b/.github/workflows/build-crowdin.yml
@@ -2,7 +2,7 @@ name: Build Crowdin project
 
 on:
   schedule:
-    - cron: "20 16 * * Mon"
+    - cron: "20 04 1 * *"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-crowdin.yml
+++ b/.github/workflows/build-crowdin.yml
@@ -1,0 +1,30 @@
+name: Build Crowdin project
+
+on:
+  schedule:
+    - cron: "20 16 * * Mon"
+  workflow_dispatch:
+
+jobs:
+  create_pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Install ts-node
+        run: yarn global add ts-node
+
+      - name: Run script
+        run: npx ts-node -O '{"module":"commonjs"}' ./src/scripts/crowdin/translations/triggerBuild.ts
+        env:
+          CROWDIN_API_KEY: ${{ secrets.CROWDIN_API_KEY }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}

--- a/src/scripts/crowdin/getTranslationProgress.ts
+++ b/src/scripts/crowdin/getTranslationProgress.ts
@@ -24,13 +24,13 @@ async function main() {
 
     const progress = response.data.map(
       ({ data }) =>
-      ({
-        languageId: data.languageId,
-        words: {
-          approved: data.words.approved,
-          total: data.words.total,
-        },
-      } as ProjectProgressData)
+        ({
+          languageId: data.languageId,
+          words: {
+            approved: data.words.approved,
+            total: data.words.total,
+          },
+        } as ProjectProgressData)
     )
 
     fs.writeFileSync(

--- a/src/scripts/crowdin/translations/triggerBuild.ts
+++ b/src/scripts/crowdin/translations/triggerBuild.ts
@@ -1,0 +1,17 @@
+import crowdin from "../api-client/crowdinClient"
+
+import "dotenv/config"
+
+async function triggerBuild() {
+  const projectId = Number(process.env.CROWDIN_PROJECT_ID) || 363359
+
+  try {
+    await crowdin.translationsApi.buildProject(projectId)
+  } catch (error: unknown) {
+    console.error((error as Error).message)
+  }
+}
+
+triggerBuild()
+
+export default triggerBuild

--- a/src/scripts/crowdin/translations/triggerBuild.ts
+++ b/src/scripts/crowdin/translations/triggerBuild.ts
@@ -6,7 +6,9 @@ async function triggerBuild() {
   const projectId = Number(process.env.CROWDIN_PROJECT_ID) || 363359
 
   try {
-    await crowdin.translationsApi.buildProject(projectId)
+    await crowdin.translationsApi.buildProject(projectId, {
+      exportApprovedOnly: true,
+    })
   } catch (error: unknown) {
     console.error((error as Error).message)
   }


### PR DESCRIPTION
## Description
- `build-crowdin.yml` - New GitHub action workflow, which runs a new `triggerBuild.ts` script on the 1st of every month.
- `triggerBuild.ts` - Simple script to call `crowdin.translationsApi.buildProject()`, triggering Crowdin to build our project

## Related Issue
Crowdin CI/CD efforts

cc: @lukassim 