### PR TITLE
fix: gh auth step in workflows

### DIFF
--- a/.github/workflows/get-crowdin-contributors.yml
+++ b/.github/workflows/get-crowdin-contributors.yml
@@ -59,5 +59,5 @@ jobs:
 
       - name: Create Pull Request
         run: |
-          gh auth login --with-token ${{ secrets.GITHUB_TOKEN }}
+          echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
           gh pr create --base dev --head "automated-update-${{ env.TIMESTAMP }}" --title "Update translation contributors from Crowdin - ${{ env.READABLE_DATE }}" --body-file pr_body.txt

--- a/.github/workflows/get-translation-progress.yml
+++ b/.github/workflows/get-translation-progress.yml
@@ -60,5 +60,5 @@ jobs:
 
       - name: Create Pull Request
         run: |
-          gh auth login --with-token ${{ secrets.GITHUB_TOKEN }}
+          echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
           gh pr create --base dev --head "automated-update-${{ env.TIMESTAMP }}" --title "Update translation progress from Crowdin - ${{ env.READABLE_DATE }}" --body-file pr_body.txt

--- a/.github/workflows/import-community-events.yml
+++ b/.github/workflows/import-community-events.yml
@@ -55,5 +55,5 @@ jobs:
 
       - name: Create Pull Request
         run: |
-          gh auth login --with-token ${{ secrets.GITHUB_TOKEN }}
+          echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
           gh pr create --base dev --head "automated-update-${{ env.TIMESTAMP }}" --title "Update community events from external spreadsheet - ${{ env.READABLE_DATE }}" --body-file pr_body.txt


### PR DESCRIPTION
## Description
Due to a change in the GitHub CLI gh version 2.0.0 the --with-token flag no longer accepts an argument and instead it reads from standard input

- Updates workflows to pipe standard input into `gh auth` command

## Related Issue
Related workflows have been failing for the past few weeks as a result of this.