### PR TITLE
typo: Typo a residual parenthesis in EVM page

### DIFF
--- a/public/content/developers/docs/evm/index.md
+++ b/public/content/developers/docs/evm/index.md
@@ -76,7 +76,7 @@ Over Ethereum's nine year history, the EVM has undergone several revisions, and 
 - [Ethereum Virtual Machine Opcodes](https://www.ethervm.io/)
 - [Ethereum Virtual Machine Opcodes Interactive Reference](https://www.evm.codes/)
 - [A short introduction in Solidity's documentation](https://docs.soliditylang.org/en/latest/introduction-to-smart-contracts.html#index-6)
-- [Mastering Ethereum - The Ethereum Virtual Machine](https://github.com/ethereumbook/ethereumbook/blob/develop/13evm.asciidoc))
+- [Mastering Ethereum - The Ethereum Virtual Machine](https://github.com/ethereumbook/ethereumbook/blob/develop/13evm.asciidoc)
 
 ## Related Topics {#related-topics}
 


### PR DESCRIPTION
typo: Typo a residual parenthesis in EVM page

## Description

typo: Typo a residual parenthesis in EVM page

## Related Issue

none
