### PR TITLE
feat: add tracking for cta buttons in /find-wallet

### DIFF
--- a/src/components/FindWallet/WalletTable/index.tsx
+++ b/src/components/FindWallet/WalletTable/index.tsx
@@ -230,6 +230,16 @@ const WalletTable = ({
   // Context API
   const { supportedLanguage } = useContext(WalletSupportedLanguageContext)
 
+  const handleStickyFiltersClick = () => {
+    onOpen()
+
+    trackCustomEvent({
+      eventCategory: "MobileFilterToggle",
+      eventAction: "Tap MobileFilterToggle - sticky",
+      eventName: "show mobile filters true",
+    })
+  }
+
   return (
     <Container>
       <WalletContentHeader>
@@ -243,7 +253,7 @@ const WalletTable = ({
               color="primary.base"
               textTransform="uppercase"
               cursor="pointer"
-              onClick={onOpen}
+              onClick={handleStickyFiltersClick}
               as="button"
             >
               {`${t("page-find-wallet-filters")} (${

--- a/src/components/FindWallet/WalletTable/index.tsx
+++ b/src/components/FindWallet/WalletTable/index.tsx
@@ -320,6 +320,14 @@ const WalletTable = ({
               })
           }
 
+          const handleClick = (walletName: string) => {
+            trackCustomEvent({
+              eventCategory: "WalletExternalLinkList",
+              eventAction: "Tap main button",
+              eventName: `${walletName}`,
+            })
+          }
+
           return (
             <WalletContainer
               key={wallet.key}
@@ -420,6 +428,7 @@ const WalletTable = ({
                               w="auto"
                               isExternal
                               size="sm"
+                              onClick={() => handleClick(wallet.name)}
                             >
                               {t("page-find-wallet-visit-website")}
                             </ButtonLink>
@@ -446,6 +455,7 @@ const WalletTable = ({
                       w="100%"
                       isExternal
                       size="sm"
+                      onClick={() => handleClick(wallet.name)}
                     >
                       {t("page-find-wallet-visit-website")}
                     </ButtonLink>

--- a/src/components/FindWallet/WalletTable/index.tsx
+++ b/src/components/FindWallet/WalletTable/index.tsx
@@ -330,7 +330,7 @@ const WalletTable = ({
               })
           }
 
-          const handleClick = (walletName: string) => {
+          const handleWalletWebsiteClick = (walletName: string) => {
             trackCustomEvent({
               eventCategory: "WalletExternalLinkList",
               eventAction: "Tap main button",
@@ -438,7 +438,9 @@ const WalletTable = ({
                               w="auto"
                               isExternal
                               size="sm"
-                              onClick={() => handleClick(wallet.name)}
+                              onClick={() =>
+                                handleWalletWebsiteClick(wallet.name)
+                              }
                             >
                               {t("page-find-wallet-visit-website")}
                             </ButtonLink>
@@ -465,7 +467,7 @@ const WalletTable = ({
                       w="100%"
                       isExternal
                       size="sm"
-                      onClick={() => handleClick(wallet.name)}
+                      onClick={() => handleWalletWebsiteClick(wallet.name)}
                     >
                       {t("page-find-wallet-visit-website")}
                     </ButtonLink>


### PR DESCRIPTION
This PR adds some requested Matomo tracking for `/find-wallet` page

Fixes https://github.com/ethereum/ethereum-org-website/issues/12642