### PR TITLE
Fix list item color in layouts

### DIFF
--- a/src/layouts/Docs.tsx
+++ b/src/layouts/Docs.tsx
@@ -7,8 +7,6 @@ import {
   Flex,
   type FlexProps,
   type HeadingProps,
-  ListItem as ChakraListItem,
-  type ListItemProps,
   type ListProps,
   OrderedList as ChakraOrderedList,
   UnorderedList as ChakraUnorderedList,
@@ -138,10 +136,6 @@ const OrderedList = (props: ListProps) => (
   <ChakraOrderedList ms="1.45rem" {...props} />
 )
 
-const ListItem = (props: ListItemProps) => (
-  <ChakraListItem {...props} />
-)
-
 // Apply styles for classes within markdown here
 const Content = (props: ChildOnlyProp) => {
   const mdBreakpoint = useToken("breakpoints", "md")
@@ -190,7 +184,6 @@ export const docsComponents = {
   p: Paragraph,
   ul: UnorderedList,
   ol: OrderedList,
-  li: ListItem,
   pre: Codeblock,
   ...mdxTableComponents,
   Badge,

--- a/src/layouts/Static.tsx
+++ b/src/layouts/Static.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router"
-import { Box, chakra, Flex, type HeadingProps, Icon } from "@chakra-ui/react"
+import { Box, Flex, type HeadingProps, Icon } from "@chakra-ui/react"
 
 import type { ChildOnlyProp, Lang } from "@/lib/types"
 import type { MdPageContent, StaticFrontmatter } from "@/lib/interfaces"
@@ -51,17 +51,12 @@ const Heading4 = (props: HeadingProps) => (
   <MdHeading4 fontSize={{ base: "md", md: "xl" }} {...props} />
 )
 
-const ListItem = (props: ChildOnlyProp) => (
-  <chakra.li color="text300" {...props} />
-)
-
 // Static layout components
 export const staticComponents = {
   h1: Heading1,
   h2: Heading2,
   h3: Heading3,
   h4: Heading4,
-  li: ListItem,
   Callout,
   Contributors,
   EnergyConsumptionChart,

--- a/src/layouts/Tutorial.tsx
+++ b/src/layouts/Tutorial.tsx
@@ -3,7 +3,6 @@ import {
   Badge,
   Box,
   type BoxProps,
-  chakra,
   Divider,
   Flex,
   type HeadingProps,
@@ -125,10 +124,6 @@ const Paragraph = (props: TextProps) => (
   <Text as="p" mt={8} mb={4} mx={0} color="text300" fontSize="md" {...props} />
 )
 
-const ListItem = (props) => {
-  return <chakra.li color="text300" {...props} />
-}
-
 const KBD = (props) => {
   const borderColor = useToken("colors", "primary.base")
 
@@ -151,7 +146,6 @@ export const tutorialsComponents = {
   h4: Heading4,
   p: Paragraph,
   kbd: KBD,
-  li: ListItem,
   pre: Codeblock,
   ...mdxTableComponents,
   Badge,

--- a/src/layouts/Upgrade.tsx
+++ b/src/layouts/Upgrade.tsx
@@ -9,7 +9,6 @@ import {
   Icon,
   List,
   ListItem,
-  Skeleton,
   Text,
   useToken,
 } from "@chakra-ui/react"
@@ -51,10 +50,6 @@ const Title = (props: ChildOnlyProp) => (
     mt={0}
     {...props}
   />
-)
-
-const SummaryPoint = (props: ChildOnlyProp) => (
-  <ListItem color="text300" mb={0} {...props} />
 )
 
 type ContainerProps = Pick<BoxProps, "children" | "dir">
@@ -190,7 +185,7 @@ export const UpgradeLayout = ({
           <Box>
             <List listStyleType="disc">
               {summaryPoints.map((point, idx) => (
-                <SummaryPoint key={idx}>{point}</SummaryPoint>
+                <ListItem key={idx}>{point}</ListItem>
               ))}
             </List>
           </Box>

--- a/src/layouts/UseCases.tsx
+++ b/src/layouts/UseCases.tsx
@@ -197,7 +197,7 @@ export const UseCasesLayout = ({
           <Box>
             <UnorderedList ms="1.45rem">
               {summaryPoints.map((point, idx) => (
-                <ListItem key={idx} color="text300" mb={0}>
+                <ListItem key={idx} mb={0}>
                   {point}
                 </ListItem>
               ))}


### PR DESCRIPTION
Currently we have this
![image](https://github.com/ethereum/ethereum-org-website/assets/468158/59309f5a-4a7e-4417-95aa-a8441c3a5857)
a different color than `body.base` in our list items.

## Description

This PR fixes the color by removing the custom `ListItem` components used in the layouts to default to the used in the `mdComponents` list.

## Related Issue

#9548 
