### PR TITLE
added the useEffect to allow the reorder for the wallets based on locale

### DIFF
--- a/src/hooks/useWalletTable.tsx
+++ b/src/hooks/useWalletTable.tsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from "react"
+import { useContext, useEffect, useState } from "react"
 
 import { DropdownOption } from "@/lib/types"
 
@@ -125,6 +125,14 @@ export const useWalletTable = ({
       return { ...wallet, moreInfo: false, key: wallet.name }
     })
   )
+
+  useEffect(() => {
+    setWalletData(
+      walletData.map((wallet) => {
+        return { ...wallet, moreInfo: false, key: wallet.name }
+      })
+    )
+  }, [walletData])
 
   // Context API for language filter
   const { supportedLanguage } = useContext(WalletSupportedLanguageContext)

--- a/src/pages/wallets/find-wallet.tsx
+++ b/src/pages/wallets/find-wallet.tsx
@@ -95,11 +95,15 @@ const FindWalletPage = () => {
 
   // If any wallet supports user's locale, show them (shuffled) at the top and then the remaining ones
   useEffect(() => {
+    const supportedLocaleWallets = getSupportedLocaleWallets(locale!)
+
+    const noSupportedLocaleWallets = getNonSupportedLocaleWallets(locale!)
+
     setRandomizedWalletData(
       supportedLocaleWallets.concat(noSupportedLocaleWallets)
     )
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [locale])
 
   const updateFilterOption = (key) => {
     const updatedFilters = { ...filters }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Added the useEffect to reorder the wallet based on the language change.
Set the supported and unSupported language wallet based on the locale change and update the state for the walletData in the useWalletTable hook. [Fixes #12640]

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
