### PR TITLE
feat: Remove Gitcoin bounties from get involved page

### DIFF
--- a/public/content/community/get-involved/index.md
+++ b/public/content/community/get-involved/index.md
@@ -13,7 +13,6 @@ Start by reading about the ethereum.org mission and values in our [code of condu
 ## Developers <Emoji text=":computer:" size={1} />‍ {#developers}
 
 - Learn about and try Ethereum at [ethereum.org/developers/](/developers/)
-- [Find a bounty on Gitcoin](https://gitcoin.co/), work on a small or large technical issue, earn crypto!
 - Attend an [ETHGlobal](http://ethglobal.co/) hackathon near you!
 - Check out [projects related to your area of expertise or programming language of choice](/developers/docs/programming-languages/)
 - Watch or participate in the [Core Dev calls](https://www.youtube.com/@EthereumProtocol)

--- a/public/content/translations/ca/community/get-involved/index.md
+++ b/public/content/translations/ca/community/get-involved/index.md
@@ -11,7 +11,6 @@ La comunitat Ethereum inclou gent de diferents àmbits i amb diferents habilitat
 ## Desenvolupadors <Emoji text=":computer:" size={1} /> {#developers}
 
 - Descobriu i proveu Ethereum en [ethereum.org/developers/](/developers/)
-- [Trobeu una recompensa en Gitcoin](https://gitcoin.co/), treballeu en un problema tècnic gran o petit, guanyeu criptoactius!
 - Assistiu a una convenció de programadors [ETHGlobal](http://ethglobal.co/) al vostre voltant!
 - Doneu una ullada a [projectes relacionats amb la vostra àrea de coneixements o de llenguatge de programació de la vostra elecció](/developers/docs/programming-languages/)
 - Mireu o participeu en les [trucades de desenvolupament bàsic](https://www.youtube.com/@EthereumProtocol)

--- a/public/content/translations/de/community/get-involved/index.md
+++ b/public/content/translations/de/community/get-involved/index.md
@@ -13,7 +13,6 @@ Machen Sie sich zunächst mit der Mission und den Grundsätze von ethereum.org i
 ## Entwickler <Emoji text=":computer." size={1} /> {#developers}
 
 - Erfahren Sie mehr über Ethereum auf [ethereum.org/developers/](/developers/)
-- [Finden Sie ein Bounty auf Gitcoin](https://gitcoin.co/), arbeiten Sie an kleinen und großen technischen Problemen und verdienen Sie Kryptowährung.
 - Besuchen Sie ein [ETHGlobal](http://ethglobal.co/)-Hakathon in Ihrer Nähe.
 - Schauen Sie sich an, welche [Projekte im Zusammenhang mit Ihrem Fachgebiet oder der Programmiersprache Ihrer Wahl](/developers/docs/programming-languages/) es gibt
 - Nehmen Sie teil an den [Core DEV-Calls](https://www.youtube.com/@EthereumProtocol) oder sehen Sie sie sich an

--- a/public/content/translations/el/community/get-involved/index.md
+++ b/public/content/translations/el/community/get-involved/index.md
@@ -13,7 +13,6 @@ lang: el
 ## Προγραμματιστές <Emoji text=":computer:" size={1} /> {#developers}
 
 - Μάθετε σχετικά και δοκιμάστε το Ethereum στο [ethereum.org/developers/](/developers/).
-- [Εντοπίστε ένα σφάλμα στο Gitcoin](https://gitcoin.co/), εργαστείτε σε ένα μικρό ή μεγάλο τεχνικό ζήτημα και κερδίστε κρυπτονομίσματα!
 - Παρακολουθήστε ένα [ETHGlobal](http://ethglobal.co/) hackathon κοντά σας!
 - Δείτε τα [έργα που σχετίζονται με τον τομέα που γνωρίζετε καλύτερα ή τη γλώσσα προγραμματισμού της επιλογής σας](/developers/docs/programming-languages/).
 - Παρακολουθήστε ή συμμετέχετε στις [Συγκεντρώσεις των βασικών προγραμματιστών](https://www.youtube.com/@EthereumProtocol).

--- a/public/content/translations/es/community/get-involved/index.md
+++ b/public/content/translations/es/community/get-involved/index.md
@@ -13,7 +13,6 @@ Le sugerimos que comience enterándose de la misión y los valores de ethereum.o
 ## Desarrolladores <Emoji text=":computer:" size={1} /> {#developers}
 
 - Aprenda y pruebe Ethereum en [ethereum.org/developers/](/developers/)
-- [Encuentre una recompensa en Gitcoin](https://gitcoin.co/), ¡solucione problemas técnicos sencillos o complejos y gane criptomonedas!
 - ¡Participe en un hackaton (o encuentro de programadores) [ETHGlobal](http://ethglobal.co/) cerca de donde viveo
 - Consulte [los proyectos relacionados con su área especialidad o el lenguaje de programación de su elección](/developers/docs/programming-languages/).
 - Mire o participe en las [reuniones Core Dev](https://www.youtube.com/@EthereumProtocol)

--- a/public/content/translations/fa/community/get-involved/index.md
+++ b/public/content/translations/fa/community/get-involved/index.md
@@ -13,7 +13,6 @@ lang: fa
 ## توسعه‌دهندگان <Emoji text=":computer:" size={1} /> {#developers}
 
 - در [ethereum.org/developers/](/developers/) درباره اتریوم یاد بگیرید و آن را امتحان کنید
-- [یک جایزه در Gitcoin پیدا کنید](https://gitcoin.co/)، روی یک مشکل فنی کوچک یا بزرگ کار کنید، ارز دیجیتال کسب کنید!
 - در یک هکاتون [ETHGlobal](http://ethglobal.co/) در نزدیکی خود شرکت کنید!
 - [پروژه‌های مرتبط با حوزه‌ی تخصصی یا زبان برنامه‌نویسی انتخابی خود را بررسی کنید](/developers/docs/programming-languages/)
 - [تماس‌های Core Dev](https://www.youtube.com/@EthereumProtocol) را تماشا کنید و یا در آن شرکت کنید

--- a/public/content/translations/fr/community/get-involved/index.md
+++ b/public/content/translations/fr/community/get-involved/index.md
@@ -13,7 +13,6 @@ Commencez à lire la mission et les valeurs d'ethereum.org dans notre [code de c
 ## Développeurs <Emoji text=":computer:" size={1} /> {#developers}
 
 - Découvrez et essayez Ethereum sur [ethereum.org/developers/](/developers/)
-- [Trouvez une prime sur Gitcoin](https://gitcoin.co/), travaillez sur un petit ou gros problème technique, gagnez de la crypto !
 - Participez à un hackathon [ETHGlobal](http://ethglobal.co/) près de chez vous !
 - Consultez les [projets liés à votre domaine d'expertise ou au langage de programmation de votre choix](/developers/docs/programming-languages/)
 - Regardez ou participez aux [appels Core Dev](https://www.youtube.com/@EthereumProtocol)

--- a/public/content/translations/hu/community/get-involved/index.md
+++ b/public/content/translations/hu/community/get-involved/index.md
@@ -13,7 +13,6 @@ Kezdje azzal, hogy elolvassa az ethereum.org misszióját és értékeit a [maga
 ## Fejlesztők <Emoji text=":computer:" size={1} /> {#developers}
 
 - Tanuljon az Ethereumról és próbálja ki az [ethereum.org/developers/](/developers/) oldalon
-- [Nyerjen jutalmat a Gitcoin-on](https://gitcoin.co/) azáltal, hogy kisebb-nagyobb technikai problémákon dolgozik, és kapjon érte kriptót!
 - Vegyen részt egy Önhöz közel eső [ETHGlobal](http://ethglobal.co/) hackathonon!
 - Nézze meg azokat a [projekteket, melyek a szakterületéhez vagy a választott programnyelvéhez kapcsolódnak](/developers/docs/programming-languages/)
 - Vegyen részt a [protokollfejlesztők megbeszélésein (Core Dev calls)](https://www.youtube.com/@EthereumProtocol)

--- a/public/content/translations/id/community/get-involved/index.md
+++ b/public/content/translations/id/community/get-involved/index.md
@@ -11,7 +11,7 @@ Komunitas Ethereum meliputi orang-orang dari beragam latar belakang dan kemampua
 ## Pengembang <Emoji text=":computer:" size={1} />‍ {#developers}
 
 - Pelajari tentang dan cobalah Ethereum di [ethereum.org/developers/](/developers/)
-- [Temukan hadiah bounty di Gitcoin](https://gitcoin.co/), selesaikan masalah teknis kecil atau besar, dapatkan kripto!
+<!-- - [Temukan hadiah bounty di Gitcoin](https://gitcoin.co/), selesaikan masalah teknis kecil atau besar, dapatkan kripto! -->
 - Datanglah ke hackathon [ETHGlobal](http://ethglobal.co/) di dekat Anda!
 - Lihat [proyek yang terkait dengan bidang keahlian atau bahasa pemrograman pilihan Anda](/developers/docs/programming-languages/)
 - Tonton atau berpartisipasilah dalam [Panggilan Dev Core](https://www.youtube.com/@EthereumProtocol)

--- a/public/content/translations/id/community/get-involved/index.md
+++ b/public/content/translations/id/community/get-involved/index.md
@@ -11,7 +11,6 @@ Komunitas Ethereum meliputi orang-orang dari beragam latar belakang dan kemampua
 ## Pengembang <Emoji text=":computer:" size={1} />‍ {#developers}
 
 - Pelajari tentang dan cobalah Ethereum di [ethereum.org/developers/](/developers/)
-<!-- - [Temukan hadiah bounty di Gitcoin](https://gitcoin.co/), selesaikan masalah teknis kecil atau besar, dapatkan kripto! -->
 - Datanglah ke hackathon [ETHGlobal](http://ethglobal.co/) di dekat Anda!
 - Lihat [proyek yang terkait dengan bidang keahlian atau bahasa pemrograman pilihan Anda](/developers/docs/programming-languages/)
 - Tonton atau berpartisipasilah dalam [Panggilan Dev Core](https://www.youtube.com/@EthereumProtocol)

--- a/public/content/translations/it/community/get-involved/index.md
+++ b/public/content/translations/it/community/get-involved/index.md
@@ -13,8 +13,7 @@ Inizia leggendo la missione e i valori di ethereum.org nel nostro [codice di con
 ## Sviluppatori <Emoji text=":computer:" size={1} />‍ {#developers}
 
 - Scopri e prova Ethereum su [ethereum.org/developers/](/developers/)
-- [Trova una ricompensa su Gitcoin](https://gitcoin.co/), lavora su una segnalazione tecnica di piccola o grande entità, guadagna in crypto!
-- Partecipa ad un Hackathon vicino a te!
+- Partecipa ad un [ETHGlobal](http://ethglobal.co/) Hackathon vicino a te!
 - Dai un'occhiata a [progetti relativi alla tua area di competenza o a linguaggi di programmazione di tua scelta](/developers/docs/programming-languages/)
 - Segui o partecipa alle [riunioni dei Core Dev](https://www.youtube.com/@EthereumProtocol)
 - [Lista del programma di supporto degli ecosistemi](https://esp.ethereum.foundation/wishlist/) - strumenti, documentazione, e infrastrutture dove il programma di supporto per l'ecosistema Ethereum è attivamente alla ricerca di domande di sovvenzione

--- a/public/content/translations/ja/community/get-involved/index.md
+++ b/public/content/translations/ja/community/get-involved/index.md
@@ -11,7 +11,6 @@ lang: ja
 ## デベロッパー<Emoji text=":computer:" size={1} /> {#developers}
 
 - [ethereum.org/developers/](/developers/) - イーサリアムについての学習
-- [Gitcoin](https://gitcoin.co/) - 大小規模の技術問題に取り組み、暗号通貨の報酬を獲得
 - [ETHGlobal](http://ethglobal.co/) - お近くの ETHGlobal ハッカソンへの参加
 - [自分の専門分野や好きなプログラミング言語に関連するプロジェクト](/developers/docs/programming-languages/)の確認
 - [Core Dev calls](https://www.youtube.com/@EthereumProtocol) - 動画の視聴および参加

--- a/public/content/translations/nl/community/get-involved/index.md
+++ b/public/content/translations/nl/community/get-involved/index.md
@@ -11,7 +11,6 @@ De Ethereum-gemeenschap omvat mensen met verschillende achtergronden en vaardigh
 ## Ontwikkelaars <Emoji text=":computer:" size={1} />→ {#developers}
 
 - Leer meer over en probeer Ethereum op [ethereum.org/developers/](/developers/)
-- [Vind een premie op Gitcoin](https://gitcoin.co/), werk aan een klein of groot technisch probleem, verdien crypto!
 - Doe mee aan een [ETHGlobal](http://ethglobal.co/) hackathon bij u in de buurt!
 - Bekijk [projecten gerelateerd aan uw gebied van expertise of programmeertaal van keuze](/developers/docs/programming-languages/)
 - Bekijk of neem deel aan [Core Dev calls](https://www.youtube.com/@EthereumProtocol)

--- a/public/content/translations/pl/community/get-involved/index.md
+++ b/public/content/translations/pl/community/get-involved/index.md
@@ -13,7 +13,6 @@ Zacznij od zapoznania się z misją i wartościami ethereum.org w naszym [kodeks
 ## Deweloperzy <Emoji text=":computer:" size={1} /> {#developers}
 
 - Ucz się i wypróbuj Ethereum na stronie [ethereum.org/developers/](/developers/)
-- [Szukaj ofert nagród za wyszukiwanie błędów (bounties) na platformie Gitcoin](https://gitcoin.co/), pracuj nad małym lub poważniejszym błędem technicznym i zarabiaj kryptowaluty!
 - Weź udział w hakatonie [ETHGlobal](http://ethglobal.co/) w pobliżu Twojego miejsca zamieszkania!
 - Sprawdź [projekty związane z Twoją dziedziną lub wybranym językiem programowania](/developers/docs/programming-languages/)
 - Oglądaj lub bierz udział w spotkaniach [Core Dev calls](https://www.youtube.com/@EthereumProtocol)

--- a/public/content/translations/pt-br/community/get-involved/index.md
+++ b/public/content/translations/pt-br/community/get-involved/index.md
@@ -13,7 +13,6 @@ Comece lendo sobre a missão e os valores da ethereum.org no nosso [código de c
 ## Desenvolvedores <Emoji text=":computer:" size={1} /> {#developers}
 
 - Conheça e experimente o Ethereum em [ethereum.org/developers/](/developers/)
-- [ Seja recompensado no Gitcoin](https://gitcoin.co/), resolva problemas técnicos pequenos ou grandes, ganhe criptomoedas!
 - Participe de uma hackathon [ETHGlobal](http://ethglobal.co/) perto de você!
 - Dê uma olhada nos [projetos relacionados à sua área de conhecimento ou linguagem de programação favorito](/developers/docs/programming-languages/)
 - Assista ou participe das [reuniões do núcleo de desenvolvedores](https://www.youtube.com/@EthereumProtocol)

--- a/public/content/translations/ro/community/get-involved/index.md
+++ b/public/content/translations/ro/community/get-involved/index.md
@@ -11,7 +11,6 @@ Comunitatea Ethereum include persoane din medii și cu competențe diferite. Fie
 ## Dezvoltatori <Emoji text=":computer:" size={1} /> {#developers}
 
 - Aflați despre Ethereum și testați-l la adresa [ethereum.org/developers/](/developers/)
-- [Găsiți o recompensă pe Gitcoin](https://gitcoin.co/), lucrați la o problemă tehnică mică sau mare, câștigați cripto!
 - Participați la „hackathon-ul” [ETHGlobal](http://ethglobal.co/) din apropiere!
 - Consultați [proiectele legate de domeniul dvs. de experiență sau de limbajul de programare preferat](/developers/docs/programming-languages/)
 - Vizionați sau participați la [apeluri Core Dev](https://www.youtube.com/@EthereumProtocol) pe YouTube

--- a/public/content/translations/ru/community/get-involved/index.md
+++ b/public/content/translations/ru/community/get-involved/index.md
@@ -13,7 +13,6 @@ lang: ru
 ## Разработчики <Emoji text=":computer:" size={1} /> {#developers}
 
 - Узнайте подробнее об Ethereum на [ethereum.org/developers/](/developers/) и попробуйте использовать
-- [Получите награду на Gitcoin](https://gitcoin.co/), поработайте над незначительной или серьезной технической проблемой, заработайте криптовалюту!
 - Посетите ближайший к вам хакатон [ETHGlobal](http://ethglobal.co/)!
 - Ознакомьтесь с [проектами в вашей компетенции или на языке программирования по вашему выбору](/developers/docs/programming-languages/)
 - [Онлайн-встречи Core Dev](https://www.youtube.com/@EthereumProtocol): смотрите или поучаствуйте сами

--- a/public/content/translations/sw/community/get-involved/index.md
+++ b/public/content/translations/sw/community/get-involved/index.md
@@ -11,7 +11,6 @@ Jumuiya ya Ethereum inahusisha watu wa asili tofauti na wenye ujuzi wa kila aina
 ## Wasimbuaji <Emoji text=":computer:" size={1} /> {#developers}
 
 - Jifunze kuhusu Ethereum na ijaribishe kwenye [etehereum.org/developers/](/developers/)
-- [Tafuta fadhila kwenye Gitcoin](https://gitcoin.co/), fanyia kazi itilafu ndogo ama kubwa na ujipatie kripto!
 - Shiriki kwenye[ETHGlobal](http://ethglobal.co/)hackathon iliyokaribu nawe!
 - Vinjari juu ya [miradi inayohusiana na taaluma yako au lugha ya usimbuajiutakayochagua.](/developers/docs/programming-languages/)
 - Tazama au shiriki kwenye [mikutano ya wasimbuaji wa ndani](https://www.youtube.com/@EthereumProtocol)

--- a/public/content/translations/tr/community/get-involved/index.md
+++ b/public/content/translations/tr/community/get-involved/index.md
@@ -13,7 +13,6 @@ Ethereum topluluğu, birçok farklı geçmişe ve beceriye sahip insanları içe
 ## Geliştiriciler <Emoji text=":computer:" size={1} />‍ {#developers}
 
 - [ethereum.org/developers/](/developers/) adresinden Ethereum hakkında bilgi edinin ve Ethereum'u deneyin
-- [Gitcoin'de bir ödül bulun](https://gitcoin.co/), küçük veya büyük bir teknik sorun üzerinde çalışın ve kripto kazanın!
 - Yakınınızdaki bir [ETHGlobal](http://ethglobal.co/) hackathon'una katılın!
 - Uzmanlık alanınızla veya seçtiğiniz programlama diliyle ilgili [projeleri inceleyin](/developers/docs/programming-languages/)
 - [Core Dev çağrılarını](https://www.youtube.com/@EthereumProtocol) izleyin veya bunlara katılın

--- a/public/content/translations/uk/community/get-involved/index.md
+++ b/public/content/translations/uk/community/get-involved/index.md
@@ -11,7 +11,6 @@ lang: uk
 ## Розробники <Emoji text=":computer:" size={1} /> {#developers}
 
 - Дізнайтеся докладніше про Ethereum на [ethereum.org/developers/](/developers/) і спробуйте використовувати
-- [Знайдіть винагороду на Gitcoin](https://gitcoin.co/), попрацюйте з незначною або серйозною технічною проблемою, заробіть криптовалюту!
 - Відвідайте хакатон [ETHGlobal](http://ethglobal.co/) поруч із вами!
 - Ознайомтеся з [проєктами, що стосуються вашої галузі знань або вибраної мови програмування](/developers/docs/programming-languages/)
 - Дивіться [онлайн-зустрічі розробників](https://www.youtube.com/@EthereumProtocol) або беріть у них участь

--- a/public/content/translations/zh-tw/community/get-involved/index.md
+++ b/public/content/translations/zh-tw/community/get-involved/index.md
@@ -13,7 +13,6 @@ lang: zh-tw
 ## 程式開發人員<Emoji text=":computer:" size={1} /> {#developers}
 
 - 造訪 [ethereum.org/developers/](/developers/)，瞭解和嘗試使用以太坊
-- [從 Gitcoin 獲得賞金](https://gitcoin.co/)，透過解決大小技術問題來賺取加密貨幣！
 - 參加你附近的 [ETHGlobal](http://ethglobal.co/) 駭客松活動。
 - 留意[與你的專業領域或偏好的編程語言有關的專案](/developers/docs/programming-languages/)
 - 觀看或參與[核心開發者會議](https://www.youtube.com/@EthereumProtocol)

--- a/public/content/translations/zh/community/get-involved/index.md
+++ b/public/content/translations/zh/community/get-involved/index.md
@@ -13,7 +13,6 @@ lang: zh
 ## 开发人员 <Emoji text=":computer:" size={1} /> {#developers}
 
 - 访问 [ethereum.org/developers/](/developers/)，了解和尝试使用以太坊
-- [在 Gitcoin 上查找悬赏](https://gitcoin.co/)，解决一个或大或小的技术问题，赚取加密货币！
 - 参加你附近的一个 [ETHGlobal](http://ethglobal.co/) 黑客马拉松活动！
 - 查看[与你的专业领域或所选编程语言相关的项目](/developers/docs/programming-languages/)
 - 观看或参与[核心开发人员电话会议](https://www.youtube.com/@EthereumProtocol)


### PR DESCRIPTION
## Description

I removed all the links to Gitcoin on the get-involved page, I also added a link to ETHGlobal on the italian translation  of "Attend an [ETHGlobal(opens in a new tab)](http://ethglobal.co/) hackathon near you!".

## Related Issue
https://github.com/ethereum/ethereum-org-website/issues/12725