### PR TITLE
performance: optimize react-icons

### DIFF
--- a/src/components/ButtonDropdown.tsx
+++ b/src/components/ButtonDropdown.tsx
@@ -1,6 +1,5 @@
 import React, { MouseEvent, useState } from "react"
 import { useTranslation } from "next-i18next"
-import { MdMenu } from "react-icons/md"
 import {
   Button,
   ButtonProps,
@@ -9,6 +8,7 @@ import {
   MenuItem,
   MenuList,
 } from "@chakra-ui/react"
+import { MdMenu } from "@react-icons/all-files/md/MdMenu"
 
 // Utils
 import { trackCustomEvent } from "@/lib/utils/matomo"

--- a/src/components/Buttons/Button.stories.tsx
+++ b/src/components/Buttons/Button.stories.tsx
@@ -1,7 +1,8 @@
 import * as React from "react"
-import { MdChevronRight, MdExpandMore, MdNightlight } from "react-icons/md"
+import { MdChevronRight, MdNightlight } from "react-icons/md"
 import { HStack, Text, ThemingProps, VStack } from "@chakra-ui/react"
 import { getThemingArgTypes } from "@chakra-ui/storybook-addon"
+import { MdExpandMore } from "@react-icons/all-files/md/MdExpandMore"
 import { Meta, StoryObj } from "@storybook/react"
 
 import theme from "../../@chakra-ui/theme"

--- a/src/components/CallToContribute.tsx
+++ b/src/components/CallToContribute.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from "react"
-import { FaGithub } from "react-icons/fa"
 import { Flex, FlexProps, Icon, useToken } from "@chakra-ui/react"
+import { FaGithub } from "@react-icons/all-files/fa/FaGithub"
 
 import { ChildOnlyProp } from "@/lib/types"
 

--- a/src/components/CommunityEvents/index.tsx
+++ b/src/components/CommunityEvents/index.tsx
@@ -1,6 +1,5 @@
 import { useRouter } from "next/router"
 import { useTranslation } from "next-i18next"
-import { FaDiscord } from "react-icons/fa"
 import {
   Box,
   Center,
@@ -10,6 +9,7 @@ import {
   GridItem,
   Icon,
 } from "@chakra-ui/react"
+import { FaDiscord } from "@react-icons/all-files/fa/FaDiscord"
 
 import type { Lang } from "@/lib/types"
 import type { CommunityEvent } from "@/lib/interfaces"

--- a/src/components/EthPriceCard.tsx
+++ b/src/components/EthPriceCard.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react"
 import { useRouter } from "next/router"
 import { useTranslation } from "next-i18next"
-import { MdInfoOutline } from "react-icons/md"
 import {
   Box,
   Flex,
@@ -10,6 +9,7 @@ import {
   Icon,
   Text,
 } from "@chakra-ui/react"
+import { MdInfoOutline } from "@react-icons/all-files/md/MdInfoOutline"
 
 import type { LoadingState } from "@/lib/types"
 

--- a/src/components/ExpandableInfo.tsx
+++ b/src/components/ExpandableInfo.tsx
@@ -1,6 +1,5 @@
 import { motion } from "framer-motion"
 import type { ReactNode } from "react"
-import { MdExpandMore } from "react-icons/md"
 import {
   type BackgroundProps,
   Box,
@@ -14,6 +13,7 @@ import {
   useDisclosure,
   VStack,
 } from "@chakra-ui/react"
+import { MdExpandMore } from "@react-icons/all-files/md/MdExpandMore"
 
 import { Image, type ImageProps } from "@/components/Image"
 import Text from "@/components/OldText"

--- a/src/components/FindWallet/WalletTable/WalletMoreInfoCategory.tsx
+++ b/src/components/FindWallet/WalletTable/WalletMoreInfoCategory.tsx
@@ -1,5 +1,4 @@
 import { useTranslation } from "next-i18next"
-import { MdInfoOutline } from "react-icons/md"
 import {
   Box,
   Heading,
@@ -8,6 +7,7 @@ import {
   ListItem,
   UnorderedList,
 } from "@chakra-ui/react"
+import { MdInfoOutline } from "@react-icons/all-files/md/MdInfoOutline"
 
 import { DropdownOption } from "@/lib/types"
 

--- a/src/components/FindWallet/WalletTable/WalletSocialLinks.tsx
+++ b/src/components/FindWallet/WalletTable/WalletSocialLinks.tsx
@@ -1,7 +1,9 @@
 import { useRouter } from "next/router"
 import { useTranslation } from "next-i18next"
-import { FaDiscord, FaGlobe, FaTwitter } from "react-icons/fa"
+import { FaGlobe } from "react-icons/fa"
 import { Flex, Heading, Icon, Stack, Text } from "@chakra-ui/react"
+import { FaDiscord } from "@react-icons/all-files/fa/FaDiscord"
+import { FaTwitter } from "@react-icons/all-files/fa/FaTwitter"
 
 import { Lang, WalletFilter } from "@/lib/types"
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,6 +1,5 @@
 import { useRouter } from "next/router"
 import { useTranslation } from "next-i18next"
-import { FaDiscord, FaGithub, FaTwitter } from "react-icons/fa"
 import {
   Box,
   Flex,
@@ -10,6 +9,9 @@ import {
   ListItem,
   SimpleGrid,
 } from "@chakra-ui/react"
+import { FaDiscord } from "@react-icons/all-files/fa/FaDiscord"
+import { FaGithub } from "@react-icons/all-files/fa/FaGithub"
+import { FaTwitter } from "@react-icons/all-files/fa/FaTwitter"
 
 import type { FooterLink, FooterLinkSection, Lang } from "@/lib/types"
 

--- a/src/components/GitStars.tsx
+++ b/src/components/GitStars.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from "next/router"
-import { FaGithub } from "react-icons/fa"
 import { Center, Flex, Icon } from "@chakra-ui/react"
+import { FaGithub } from "@react-icons/all-files/fa/FaGithub"
 
 import Emoji from "./Emoji"
 import { BaseLink, LinkProps } from "./Link"

--- a/src/components/Nav/Dropdown.tsx
+++ b/src/components/Nav/Dropdown.tsx
@@ -1,6 +1,6 @@
 import React, { createRef, useContext, useState } from "react"
-import { MdExpandMore } from "react-icons/md"
 import { Box, Fade, Flex, Icon, ListItem } from "@chakra-ui/react"
+import { MdExpandMore } from "@react-icons/all-files/md/MdExpandMore"
 
 import { BaseLink, type LinkProps } from "../Link"
 

--- a/src/components/Quiz/QuizWidget/QuizButtonGroup.tsx
+++ b/src/components/Quiz/QuizWidget/QuizButtonGroup.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from "react"
-import { useRouter } from "next/navigation"
-import { FaTwitter } from "react-icons/fa"
 import { Center, Icon } from "@chakra-ui/react"
+import { FaTwitter } from "@react-icons/all-files/fa/FaTwitter"
 
 import { Button } from "@/components/Buttons"
 import Translation from "@/components/Translation"

--- a/src/components/Quiz/QuizzesStats.tsx
+++ b/src/components/Quiz/QuizzesStats.tsx
@@ -1,6 +1,5 @@
 import { useRouter } from "next/router"
 import { useTranslation } from "next-i18next"
-import { FaTwitter } from "react-icons/fa"
 import {
   Box,
   Circle,
@@ -15,6 +14,7 @@ import {
   Text,
   UnorderedList,
 } from "@chakra-ui/react"
+import { FaTwitter } from "@react-icons/all-files/fa/FaTwitter"
 
 import { CompletedQuizzes, QuizShareStats } from "@/lib/types"
 

--- a/src/components/SideNav.tsx
+++ b/src/components/SideNav.tsx
@@ -1,8 +1,8 @@
-import { ReactNode, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 import { motion } from "framer-motion"
 import { useTranslation } from "next-i18next"
-import { MdExpandMore } from "react-icons/md"
 import { Box, HStack, Icon } from "@chakra-ui/react"
+import { MdExpandMore } from "@react-icons/all-files/md/MdExpandMore"
 
 import { ChildOnlyProp } from "@/lib/types"
 import { DeveloperDocsLink } from "@/lib/interfaces"

--- a/src/components/SideNavMobile.tsx
+++ b/src/components/SideNavMobile.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from "react"
 import { AnimatePresence, motion } from "framer-motion"
 import { useTranslation } from "next-i18next"
-import { MdExpandMore } from "react-icons/md"
 import { Box, Center, HStack, Icon } from "@chakra-ui/react"
+import { MdExpandMore } from "@react-icons/all-files/md/MdExpandMore"
 
 import type { ChildOnlyProp, TranslationKey } from "@/lib/types"
 import { DeveloperDocsLink } from "@/lib/interfaces"

--- a/src/components/Simulator/MoreInfoPopover.tsx
+++ b/src/components/Simulator/MoreInfoPopover.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react"
 import { motion } from "framer-motion"
-import { MdInfoOutline } from "react-icons/md"
 import {
   Button,
   Icon,
@@ -10,9 +9,9 @@ import {
   type PopoverBodyProps,
   PopoverCloseButton,
   PopoverContent,
-  PopoverHeader,
   PopoverTrigger,
 } from "@chakra-ui/react"
+import { MdInfoOutline } from "@react-icons/all-files/md/MdInfoOutline"
 
 import { PulseAnimation } from "./PulseAnimation"
 

--- a/src/components/SocialListItem.tsx
+++ b/src/components/SocialListItem.tsx
@@ -2,11 +2,11 @@ import {
   FaGlobe,
   FaRedditAlien,
   FaStackExchange,
-  FaTwitter,
   FaYoutube,
 } from "react-icons/fa"
 import { Box, Flex, Icon } from "@chakra-ui/react"
 import { FaDiscord } from "@react-icons/all-files/fa/FaDiscord"
+import { FaTwitter } from "@react-icons/all-files/fa/FaTwitter"
 
 const socialColors = {
   reddit: "#ff4301",

--- a/src/components/SocialListItem.tsx
+++ b/src/components/SocialListItem.tsx
@@ -1,5 +1,4 @@
 import {
-  FaDiscord,
   FaGlobe,
   FaRedditAlien,
   FaStackExchange,
@@ -7,6 +6,7 @@ import {
   FaYoutube,
 } from "react-icons/fa"
 import { Box, Flex, Icon } from "@chakra-ui/react"
+import { FaDiscord } from "@react-icons/all-files/fa/FaDiscord"
 
 const socialColors = {
   reddit: "#ff4301",

--- a/src/components/Staking/StakingStatsBox.tsx
+++ b/src/components/Staking/StakingStatsBox.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from "next/router"
 import { useTranslation } from "next-i18next"
-import { MdInfoOutline } from "react-icons/md"
 import { Box, Code, Flex, Icon, VStack } from "@chakra-ui/react"
+import { MdInfoOutline } from "@react-icons/all-files/md/MdInfoOutline"
 
 import type { ChildOnlyProp, Lang, StakingStatsData } from "@/lib/types"
 

--- a/src/components/StatsBoxGrid/GridItem.tsx
+++ b/src/components/StatsBoxGrid/GridItem.tsx
@@ -1,7 +1,7 @@
 import kebabCase from "lodash/kebabCase"
-import { MdInfoOutline } from "react-icons/md"
 import { Area, AreaChart, ResponsiveContainer, XAxis, YAxis } from "recharts"
 import { Box, Flex, Icon, Text } from "@chakra-ui/react"
+import { MdInfoOutline } from "@react-icons/all-files/md/MdInfoOutline"
 
 import type { StatsBoxMetric } from "@/lib/types"
 

--- a/src/components/TableOfContents/TableOfContentsMobile.tsx
+++ b/src/components/TableOfContents/TableOfContentsMobile.tsx
@@ -1,6 +1,5 @@
 import React from "react"
 import { useTranslation } from "next-i18next"
-import { MdExpandMore } from "react-icons/md"
 import {
   Box,
   chakra,
@@ -8,10 +7,10 @@ import {
   Flex,
   Icon,
   List,
-  Show,
   useDisclosure,
   useToken,
 } from "@chakra-ui/react"
+import { MdExpandMore } from "@react-icons/all-files/md/MdExpandMore"
 
 import type { ToCItem } from "@/lib/types"
 

--- a/src/components/TableOfContents/index.tsx
+++ b/src/components/TableOfContents/index.tsx
@@ -1,5 +1,4 @@
 import { useTranslation } from "next-i18next"
-import { FaGithub } from "react-icons/fa"
 import {
   Box,
   BoxProps,
@@ -9,6 +8,7 @@ import {
   ListItem,
   useToken,
 } from "@chakra-ui/react"
+import { FaGithub } from "@react-icons/all-files/fa/FaGithub"
 
 import type { ToCItem } from "@/lib/types"
 

--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -1,7 +1,8 @@
 import * as React from "react"
-import { MdInfoOutline, MdLanguage } from "react-icons/md"
+import { MdLanguage } from "react-icons/md"
 import { TbSquareRoundedNumber8Filled } from "react-icons/tb"
 import { Box, HStack, Link, VStack } from "@chakra-ui/react"
+import { MdInfoOutline } from "@react-icons/all-files/md/MdInfoOutline"
 import { Meta, StoryObj } from "@storybook/react"
 
 import Tag, { EthTagProps } from "."

--- a/src/layouts/Upgrade.tsx
+++ b/src/layouts/Upgrade.tsx
@@ -1,6 +1,5 @@
 import { useRouter } from "next/router"
 import { useTranslation } from "next-i18next"
-import { MdExpandMore } from "react-icons/md"
 import {
   Box,
   type BoxProps,
@@ -9,10 +8,10 @@ import {
   Icon,
   List,
   ListItem,
-  Skeleton,
   Text,
   useToken,
 } from "@chakra-ui/react"
+import { MdExpandMore } from "@react-icons/all-files/md/MdExpandMore"
 
 import type { ChildOnlyProp, Lang } from "@/lib/types"
 import type { MdPageContent, UpgradeFrontmatter } from "@/lib/interfaces"

--- a/src/layouts/UseCases.tsx
+++ b/src/layouts/UseCases.tsx
@@ -1,6 +1,5 @@
 import { useRouter } from "next/router"
 import { useTranslation } from "next-i18next"
-import { MdExpandMore } from "react-icons/md"
 import {
   Box,
   Flex,
@@ -10,6 +9,7 @@ import {
   UnorderedList,
   useToken,
 } from "@chakra-ui/react"
+import { MdExpandMore } from "@react-icons/all-files/md/MdExpandMore"
 
 import type { ChildOnlyProp } from "@/lib/types"
 import type { MdPageContent, UseCasesFrontmatter } from "@/lib/interfaces"

--- a/src/pages/developers/tutorials.tsx
+++ b/src/pages/developers/tutorials.tsx
@@ -3,7 +3,6 @@ import { GetStaticProps, InferGetServerSidePropsType } from "next"
 import { useRouter } from "next/router"
 import { useTranslation } from "next-i18next"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
-import { FaGithub } from "react-icons/fa"
 import {
   Badge,
   Box,
@@ -13,6 +12,7 @@ import {
   Heading,
   useToken,
 } from "@chakra-ui/react"
+import { FaGithub } from "@react-icons/all-files/fa/FaGithub"
 
 import { BasePageProps, Lang } from "@/lib/types"
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,7 +3,6 @@ import type { GetStaticProps, InferGetStaticPropsType } from "next"
 import { useRouter } from "next/router"
 import { useTranslation } from "next-i18next"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
-import { FaGithub } from "react-icons/fa"
 import {
   Box,
   chakra,
@@ -17,6 +16,7 @@ import {
   Stack,
   useToken,
 } from "@chakra-ui/react"
+import { FaGithub } from "@react-icons/all-files/fa/FaGithub"
 
 import { AllMetricData, BasePageProps, ChildOnlyProp, Lang } from "@/lib/types"
 import type { CommunityEventsReturnType } from "@/lib/interfaces"

--- a/src/pages/quizzes.tsx
+++ b/src/pages/quizzes.tsx
@@ -2,8 +2,8 @@ import { useMemo, useState } from "react"
 import { GetStaticProps, InferGetStaticPropsType, NextPage } from "next"
 import { useTranslation } from "next-i18next"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
-import { FaGithub } from "react-icons/fa"
 import { Box, Flex, Icon, Stack, Text, useDisclosure } from "@chakra-ui/react"
+import { FaGithub } from "@react-icons/all-files/fa/FaGithub"
 
 import { BasePageProps, QuizKey, QuizStatus } from "@/lib/types"
 

--- a/src/pages/run-a-node.tsx
+++ b/src/pages/run-a-node.tsx
@@ -2,7 +2,6 @@ import type { GetStaticProps } from "next/types"
 import { useTranslation } from "next-i18next"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import type { ComponentProps, ReactNode } from "react"
-import { FaDiscord } from "react-icons/fa"
 import {
   Box,
   type BoxProps,
@@ -13,6 +12,7 @@ import {
   type HeadingProps,
   type Icon as ChakraIcon,
 } from "@chakra-ui/react"
+import { FaDiscord } from "@react-icons/all-files/fa/FaDiscord"
 
 import type { BasePageProps, ChildOnlyProp } from "@/lib/types"
 

--- a/src/pages/what-is-ethereum.tsx
+++ b/src/pages/what-is-ethereum.tsx
@@ -2,7 +2,6 @@ import { GetStaticProps, InferGetStaticPropsType } from "next"
 import { useRouter } from "next/router"
 import { useTranslation } from "next-i18next"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
-import { MdInfoOutline } from "react-icons/md"
 import {
   Box,
   type BoxProps,
@@ -15,6 +14,7 @@ import {
   ListItem,
   UnorderedList,
 } from "@chakra-ui/react"
+import { MdInfoOutline } from "@react-icons/all-files/md/MdInfoOutline"
 
 import type {
   BasePageProps,


### PR DESCRIPTION
[WIP] This PR optimizes how icons from `react-icons` are being imported, to reduce bundle size. Apparently tree-shaking doesn't work very good with this library, so when we use some icons it ends importing the entire package. To avoid this, [we need to import icons individually from a different path](https://github.com/react-icons/react-icons/issues/154#issuecomment-895976123).