### PR TITLE
Move Blockscout away from faucets section

### DIFF
--- a/public/content/developers/docs/networks/index.md
+++ b/public/content/developers/docs/networks/index.md
@@ -51,6 +51,7 @@ The Sepolia network uses a permissioned validator set. It's fairly new, meaning 
 - [GitHub](https://github.com/eth-clients/sepolia)
 - [Otterscan](https://sepolia.otterscan.io/)
 - [Etherscan](https://sepolia.etherscan.io)
+- [Blockscout](https://eth-sepolia.blockscout.com/)
 
 ##### Faucets
 
@@ -61,7 +62,6 @@ The Sepolia network uses a permissioned validator set. It's fairly new, meaning 
 - [Alchemy Sepolia faucet](https://sepoliafaucet.com/)
 - [Infura Sepolia faucet](https://www.infura.io/faucet)
 - [Chainstack Sepolia faucet](https://faucet.chainstack.com/sepolia-faucet)
-- [Blockscout](https://eth-sepolia.blockscout.com/)
 
 #### Goerli _(long-term support)_ {#goerli}
 
@@ -78,6 +78,7 @@ Goerli is a testnet for testing validating and staking. The Goerli network is op
 - [Website](https://goerli.net/)
 - [GitHub](https://github.com/eth-clients/goerli)
 - [Etherscan](https://goerli.etherscan.io)
+- [Blockscout](https://eth-goerli.blockscout.com/)
 
 ##### Faucets
 
@@ -89,7 +90,6 @@ Goerli is a testnet for testing validating and staking. The Goerli network is op
 - [All That Node Goerli Faucet](https://www.allthatnode.com/faucet/ethereum.dsrv)
 - [Coinbase Wallet Faucet | Goerli](https://coinbase.com/faucets/ethereum-goerli-faucet)
 - [Chainstack Goerli faucet](https://faucet.chainstack.com/goerli-faucet)
-- [Blockscout](https://eth-goerli.blockscout.com/)
 
 To launch a Validator on Goerli testnet, use ethstaker's ["cheap goerli validator" launchpad](https://goerli.launchpad.ethstaker.cc/en/).
 


### PR DESCRIPTION
## Description

Move links to Blockscout explorer from "Faucets" section to "Resources" section.

