### PR TITLE
Hotfix: revert hidden search modal

### DIFF
--- a/src/components/Nav/Mobile/MenuFooter.tsx
+++ b/src/components/Nav/Mobile/MenuFooter.tsx
@@ -42,8 +42,7 @@ const MenuFooter = ({
       mt="auto"
     >
       <Grid templateColumns="repeat(2, 1fr)" w="full">
-        {/* Temporarily hide search for now until we resolve issues with the API key */}
-        {/* <FooterButton
+        <FooterButton
           icon={MdSearch}
           onClick={() => {
             // Workaround to ensure the input for the search modal can have focus
@@ -52,7 +51,7 @@ const MenuFooter = ({
           }}
         >
           <FooterItemText>{t("search")}</FooterItemText>
-        </FooterButton> */}
+        </FooterButton>
 
         <FooterButton icon={ThemeIcon} onClick={toggleColorMode}>
           <FooterItemText>{t(themeLabelKey)}</FooterItemText>

--- a/src/components/Nav/index.tsx
+++ b/src/components/Nav/index.tsx
@@ -97,9 +97,8 @@ const Nav = () => {
           >
             <Menu hideBelow="md" sections={linkSections} />
             <Flex alignItems="center" /*  justifyContent="space-between" */>
-              {/* Temporarily hide search for now until we resolve issues with the API key */}
-              {/* <Search {...searchModalDisclosure} /> */}
-        
+              <Search {...searchModalDisclosure} />
+
               {/* Desktop */}
               <HStack hideBelow="md" gap="0">
                 <IconButton


### PR DESCRIPTION
Since our Search API Key for Algolia has been fixed, we can display the search modal again.

## Description

Reverts the hidden search modal in desktop & mobile.

## Related Issue

Prev hotfix #12692
