### PR TITLE
Added 2023 to Translatathon page

### DIFF
--- a/public/content/contributing/translation-program/translatathon/index.md
+++ b/public/content/contributing/translation-program/translatathon/index.md
@@ -18,10 +18,10 @@ We invite you to join us in breaking down language barriers and making ethereum.
 
 ### When {#when}
 
-- Application period: August 1st - August 15th
-- Translation period: August 16th - August 23rd
-- Evaluation & QA period: August 23rd - August 30th
-- Results announcement: August 31st
+- Application period: August 1st - August 15th, 2023
+- Translation period: August 16th - August 23rd, 2023
+- Evaluation & QA period: August 23rd - August 30th, 2023
+- Results announcement: August 31st, 2023
 
 ### Where {#where}
 

--- a/public/content/contributing/translation-program/translatathon/index.md
+++ b/public/content/contributing/translation-program/translatathon/index.md
@@ -35,7 +35,7 @@ Office hours, workshops, team formation and FAQ sessions will be hosted on the [
 
 #### Application period {#applications}
 
-The application period will be open from **August 1st** to **August 15th**
+The application period will be open from **August 1st** to **August 15th** 2023.
 
 All participants in the Translatathon are required to apply in order to participate and compete for prizes.
 


### PR DESCRIPTION
I've added the missing year after the dates under the page https://ethereum.org/en/contributing/translation-program/
