### PR TITLE
feat: add year and banner to translathathon page [FIXES #12756]

### DIFF
--- a/public/content/contributing/translation-program/translatathon/index.md
+++ b/public/content/contributing/translation-program/translatathon/index.md
@@ -40,7 +40,7 @@ Office hours, workshops, team formation and FAQ sessions will be hosted on the [
 
 #### Application period {#applications}
 
-The application period will be open from **August 1st** to **August 15th**, 2023
+The application period will be open from **August 1st** to **August 15th**, 2023.
 
 All participants in the Translatathon are required to apply in order to participate and compete for prizes.
 

--- a/public/content/contributing/translation-program/translatathon/index.md
+++ b/public/content/contributing/translation-program/translatathon/index.md
@@ -17,8 +17,7 @@ We invite you to join us in breaking down language barriers and making ethereum.
 ## Overview {#overview}
 
 <InfoBanner emoji=":calendar:">
-  This event has passed. Stay tuned for the next events{" "}
-  <a href="https://twitter.com/ethdotorg">here</a>.
+  This event has passed. <a href="https://twitter.com/ethdotorg">Stay tuned for the next events</a>.
 </InfoBanner>
 
 ### When {#when}


### PR DESCRIPTION
- add InfoBanner with link to twitter page
- add year to the translatathon dates

## Description

Contrary to the expected emoji 🗓️, I added 📆 emoji instead as it looks better and more visible on the info banner background. _See images_

![Screenshot 2024-04-19 at 10 02 09](https://github.com/ethereum/ethereum-org-website/assets/85355882/cd71cb00-2b33-4a86-a5a7-b2a5e708769c)
![Screenshot 2024-04-19 at 10 02 19](https://github.com/ethereum/ethereum-org-website/assets/85355882/521ca6e7-6610-4e47-a027-544391da3bf1)


## Related Issue

[#12756 - Update content (add year + call-out) on Translatathon page](https://github.com/ethereum/ethereum-org-website/issues/12756)
