### PR TITLE
fix(storybook): expose `Inter` local fonts to storybook

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,7 @@
+<style type="text/css">
+
+    :root {
+        --font-inter: 'Inter', sans-serif;
+    }
+
+</style>

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -5,3 +5,5 @@
     }
 
 </style>
+
+<link rel="preload" href="/fonts/inter/latin.woff2" as="font" type="font/woff2" crossorigin="anonymous" />

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -5,6 +5,8 @@ import theme from "../src/@chakra-ui/theme"
 
 import i18n, { baseLocales } from "./i18next"
 
+import "../src/styles/global.css"
+
 const extendedTheme = extendBaseTheme(theme)
 
 const chakraBreakpointArray = Object.entries(extendedTheme.breakpoints)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Somehow in a past build (probably during the project migration to NextJS), the `Inter` font lost exposure in Storybook; It is no longer available in the existing configuration to being available to the Chakra theme in the SB environment.

And with the Inter font now being served locally via PR #12501, there needed to be  different approach to applying it back into the environment

- Creates `preview-head.html` to redefine the CSS variable `--font-inter` to it is available to the Chakra theme in the SB environment
  - This variable in prod is currently declared in `_app.tsx` so it is unavailable to the SB environment from that location
- Exposes the `global.css` to make the inter font faces available

## Additional Information
This PR does not consider the mono font, which is also not exposed to Storybook. Because of the current approach to making the font available for Chakra in NextJS, it makes it difficult to apply in SB. Recommend also adding this font locally.

<!--- Describe your changes in detail -->

## Related Issue
N/A
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
