### PR TITLE
Update definition of "Oracle" in "Oracles" Page

### DIFF
--- a/public/content/developers/docs/oracles/index.md
+++ b/public/content/developers/docs/oracles/index.md
@@ -4,7 +4,7 @@ description: Oracles provide Ethereum smart contracts with access to real-world 
 lang: en
 ---
 
-Oracles are data feeds that make off-chain data sources available to the blockchain for smart contracts. This is necessary because Ethereum-based smart contracts cannot, by default, access information stored outside the blockchain network.
+Oracles are applications that produce data feeds that make off-chain data sources available to the blockchain for smart contracts. This is necessary because Ethereum-based smart contracts cannot, by default, access information stored outside the blockchain network.
 
 Giving smart contracts the ability to execute using off-chain data extends the utility and value of decentralized applications. For instance, on-chain prediction markets rely on oracles to provide information about outcomes that they use to validate user predictions. Suppose Alice bets 20 ETH on who will become the next U.S. President. In that case, the prediction-market dapp needs an oracle to confirm election results and determine if Alice is eligible for a payout.
 


### PR DESCRIPTION
Oracles are applications that provide data feeds, not data feeds themselves.

## Description
Fix: From "Oracles are data feeds" to "Oracles are *applications that produce* data feeds"

I could be wrong. I didn't find an explicit distinction anywhere online, but I came to this conclusion from what I've gathered below. 
Sources that support this distinction:
["Data feeds are data “produced” by oracles"](https://leancommunity.org/essential-data-feeds-in-blockchain-contracts/)

["decentralized data feeds (dAPIs) delivered by first-party oracle nodes"](https://blockchain.news/news/api3-unveils-enhanced-data-feed-service-to-bolster-tvl-on-polygon-zkevm)

["API3, the first-party blockchain oracle, is releasing beacon data feeds"](https://www.zdnet.com/finance/blockchain/api3-the-first-party-blockchain-oracle-is-releasing-beacon-data-feeds-with-amberdata/)

P.S. I know it is a very small fix, but this is my first contribution ever to open source. 
