### PR TITLE
fix(Stat): wrap `Tooltip` child in button

### DIFF
--- a/src/components/Stat/index.tsx
+++ b/src/components/Stat/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react"
 import type { IconType } from "react-icons/lib"
 import { MdInfoOutline, MdWarning } from "react-icons/md"
-import { Flex, HStack, Icon, Text } from "@chakra-ui/react"
+import { Box, chakra,Flex, HStack, Icon, Text } from "@chakra-ui/react"
 
 import { NULL_VALUE } from "@/lib/constants"
 
@@ -44,7 +44,9 @@ const Stat = ({ tooltipProps, value, label, isError }: StatProps) => {
         <Text as="span">{label}</Text>
         {!!tooltipProps && (
           <Tooltip {...tooltipProps}>
-            <Icon as={content.tooltipIcon} />
+            <chakra.a  color='inherit'>
+              <Icon as={content.tooltipIcon} />
+            </chakra.a>
           </Tooltip>
         )}
       </HStack>

--- a/src/components/Stat/index.tsx
+++ b/src/components/Stat/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react"
 import type { IconType } from "react-icons/lib"
 import { MdInfoOutline, MdWarning } from "react-icons/md"
-import { Box, chakra,Flex, HStack, Icon, Text } from "@chakra-ui/react"
+import { Box, chakra, Flex, HStack, Icon, Text } from "@chakra-ui/react"
 
 import { NULL_VALUE } from "@/lib/constants"
 
@@ -44,9 +44,9 @@ const Stat = ({ tooltipProps, value, label, isError }: StatProps) => {
         <Text as="span">{label}</Text>
         {!!tooltipProps && (
           <Tooltip {...tooltipProps}>
-            <chakra.a  color='inherit'>
+            <chakra.button display='flex' color="inherit">
               <Icon as={content.tooltipIcon} />
-            </chakra.a>
+            </chakra.button>
           </Tooltip>
         )}
       </HStack>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This is a follow-up to an issue noticed in the [Stat component creation PR](https://github.com/ethereum/ethereum-org-website/pull/11574#pullrequestreview-2015599608)

Fixes placement of the tooltip popover for the `Stat` component, by wrapping the child content in a button.

Per [Chakra docs for the Popover](https://v2.chakra-ui.com/docs/components/popover/usage#basic-usage) the child element should be able to take have a forwarded ref and be focusable (the later currently not considered). This means that at the very least the element should be a `button` or an `a`.

Wrapping in a button also allows for keyboard focus which triggers the popover.

<!--- Describe your changes in detail -->

## Related Issue

N/A

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
