### PR TITLE
fix: Link [execution-diversity.info] change to supermajority.info

### DIFF
--- a/public/content/developers/docs/data-and-analytics/index.md
+++ b/public/content/developers/docs/data-and-analytics/index.md
@@ -30,7 +30,7 @@ Using [GraphQL](https://graphql.org/), developers can query any of the curated o
 
 ## Client diversity
 
-[Client diversity](/developers/docs/nodes-and-clients/client-diversity/) is important for the overall health of the Ethereum network because it provides resilience to bugs and exploits. There are now several client diversity dashboards including [clientdiversity.org](https://clientdiversity.org/), [rated.network](https://www.rated.network), [execution-diversity.info](https://execution-diversity.info/) and [Ethernodes](https://ethernodes.org/).
+[Client diversity](/developers/docs/nodes-and-clients/client-diversity/) is important for the overall health of the Ethereum network because it provides resilience to bugs and exploits. There are now several client diversity dashboards including [clientdiversity.org](https://clientdiversity.org/), [rated.network](https://www.rated.network), [supermajority.info](https://supermajority.info//) and [Ethernodes](https://ethernodes.org/).
 
 ## Dune Analytics {#dune-analytics}
 

--- a/public/content/developers/docs/nodes-and-clients/client-diversity/index.md
+++ b/public/content/developers/docs/nodes-and-clients/client-diversity/index.md
@@ -92,7 +92,7 @@ Several dashboards give real-time client diversity statistics for the execution 
 - [clientdiversity.org](https://clientdiversity.org/)
   **Execution layer:**
 
-- [execution-diversity.info](https://execution-diversity.info/)
+- [supermajority.info](https://supermajority.info//)
 - [Ethernodes](https://ethernodes.org/)
 
 ## Further reading {#further-reading}

--- a/public/content/translations/de/developers/docs/data-and-analytics/index.md
+++ b/public/content/translations/de/developers/docs/data-and-analytics/index.md
@@ -30,7 +30,7 @@ Mit [GraphQL](https://graphql.org/) können Entwickler jede der kuratierten offe
 
 ## Client-Diversität
 
-Die [Client-Vielfalt](/developers/docs/nodes-and-clients/client-diversity/) ist wichtig für die allgemeine Sicherheit des Ethereum-Netzwerks, da sie die Widerstandsfähigkeit gegen Fehler und Schwachstellen gewährleistet. Es gibt inzwischen mehrere Dashboards zur Client-Vielfalt, darunter [clientdiversity.org](https://clientdiversity.org/), [rated.network](https://rated.network), [execution-diversity.info](https://execution-diversity.info/) und [Ethernodes](https://ethernodes.org/).
+Die [Client-Vielfalt](/developers/docs/nodes-and-clients/client-diversity/) ist wichtig für die allgemeine Sicherheit des Ethereum-Netzwerks, da sie die Widerstandsfähigkeit gegen Fehler und Schwachstellen gewährleistet. Es gibt inzwischen mehrere Dashboards zur Client-Vielfalt, darunter [clientdiversity.org](https://clientdiversity.org/), [rated.network](https://rated.network), [supermajority.info](https://supermajority.info//) und [Ethernodes](https://ethernodes.org/).
 
 ## Dune Analytics {#dune-analytics}
 

--- a/public/content/translations/de/developers/docs/nodes-and-clients/client-diversity/index.md
+++ b/public/content/translations/de/developers/docs/nodes-and-clients/client-diversity/index.md
@@ -90,7 +90,7 @@ Verschiedene Dashboards geben Echtzeit-Statistiken zur Client-Vielfalt für die 
 - [Rated.network](https://www.rated.network/)
 - [clientdiversity.org](https://clientdiversity.org/) **Ausführungsebene:**
 
-- [execution-diversity.info](https://execution-diversity.info/)
+- [supermajority.info](https://supermajority.info//)
 - [Ethernodes](https://ethernodes.org/)
 
 ## Weiterführende Informationen {#further-reading}

--- a/public/content/translations/es/developers/docs/data-and-analytics/index.md
+++ b/public/content/translations/es/developers/docs/data-and-analytics/index.md
@@ -30,7 +30,7 @@ Usando [GraphQL](https://graphql.org/), los desarrolladores pueden consultar cua
 
 ## Diversidad de clientes
 
-La [diversidad de clientes](/developers/docs/nodes-and-clients/client-diversity/) es importante para la salud general de la red de Ethereum porque esta provee resistencia a errores y exploits. Ahora hay varios paneles de diversidad de clientes, incluidos [clientdiversity.org](https://clientdiversity.org/), [ated.network](https://www.rated.network), [execution-diversity.info](https://execution-diversity.info/) y [Ethernodes](https://ethernodes.org/).
+La [diversidad de clientes](/developers/docs/nodes-and-clients/client-diversity/) es importante para la salud general de la red de Ethereum porque esta provee resistencia a errores y exploits. Ahora hay varios paneles de diversidad de clientes, incluidos [clientdiversity.org](https://clientdiversity.org/), [ated.network](https://www.rated.network), [supermajority.info](https://supermajority.info//) y [Ethernodes](https://ethernodes.org/).
 
 ## Dune Analytics {#dune-analytics}
 

--- a/public/content/translations/es/developers/docs/nodes-and-clients/client-diversity/index.md
+++ b/public/content/translations/es/developers/docs/nodes-and-clients/client-diversity/index.md
@@ -90,7 +90,7 @@ Hay varios paneles que ofrecen estadísticas en tiempo real sobre la diversidad 
 - [Rated.network](https://www.rated.network/)
 - [clientdiversity.org](https://clientdiversity.org/) **/Capa de ejecución:**
 
-- [execution-diversity.info](https://execution-diversity.info/)
+- [supermajority.info](https://supermajority.info//)
 - [Ethernodes](https://ethernodes.org/)
 
 ## Más información {#further-reading}

--- a/public/content/translations/fr/developers/docs/data-and-analytics/index.md
+++ b/public/content/translations/fr/developers/docs/data-and-analytics/index.md
@@ -30,7 +30,7 @@ En utilisant [GraphQL](https://graphql.org/), les développeurs peuvent interrog
 
 ## Diversité des clients
 
-[La diversité du client](/developers/docs/nodes-and-clients/client-diversity/) est importante pour la santé globale du réseau Ethereum, car elle fournit de la résilience aux bogues et aux exploitations. Il y a maintenant plusieurs tableaux de bord de la diversité de clients dont [clientdiversity.org](https://clientdiversity.org/), [rated.etwork](https://www.rated.network), [execution-diversity.info](https://execution-diversity.info/), [et Ethernodes](https://ethernodes.org/).
+[La diversité du client](/developers/docs/nodes-and-clients/client-diversity/) est importante pour la santé globale du réseau Ethereum, car elle fournit de la résilience aux bogues et aux exploitations. Il y a maintenant plusieurs tableaux de bord de la diversité de clients dont [clientdiversity.org](https://clientdiversity.org/), [rated.etwork](https://www.rated.network), [supermajority.info](https://supermajority.info//), [et Ethernodes](https://ethernodes.org/).
 
 ## Dune Analytics {#dune-analytics}
 

--- a/public/content/translations/fr/developers/docs/nodes-and-clients/client-diversity/index.md
+++ b/public/content/translations/fr/developers/docs/nodes-and-clients/client-diversity/index.md
@@ -90,7 +90,7 @@ Plusieurs tableaux de bord donnent des statistiques en temps réel de la diversi
 - [Rated.network](https://www.rated.network/)
 - [clientdiversity.org](https://clientdiversity.org/) **Couche d'exécution :**
 
-- [execution-diversity.info](https://execution-diversity.info/)
+- [supermajority.info](https://supermajority.info//)
 - [Ethernodes](https://ethernodes.org/)
 
 ## Complément d'information {#further-reading}

--- a/public/content/translations/hu/developers/docs/data-and-analytics/index.md
+++ b/public/content/translations/hu/developers/docs/data-and-analytics/index.md
@@ -30,7 +30,7 @@ A [GraphQL](https://graphql.org/) lekérdezési nyelv használatával a fejleszt
 
 ## Kliensdiverzitás
 
-A [kliensdiverzitás](/developers/docs/nodes-and-clients/client-diversity/) rendkívül fontos az egész Ethereum-hálózat átfogó egészsége szempontjából, mivel védelmet biztosít a hibák és támadások ellen. Számos kliensdiverzitásról szóló kimutatás elérhető, mint a [clientdiversity.org](https://clientdiversity.org/), [rated.network](https://www.rated.network), [execution-diversity.info](https://execution-diversity.info/) és az [Ethernodes](https://ethernodes.org/).
+A [kliensdiverzitás](/developers/docs/nodes-and-clients/client-diversity/) rendkívül fontos az egész Ethereum-hálózat átfogó egészsége szempontjából, mivel védelmet biztosít a hibák és támadások ellen. Számos kliensdiverzitásról szóló kimutatás elérhető, mint a [clientdiversity.org](https://clientdiversity.org/), [rated.network](https://www.rated.network), [supermajority.info](https://supermajority.info//) és az [Ethernodes](https://ethernodes.org/).
 
 ## Dune Analytics {#dune-analytics}
 

--- a/public/content/translations/it/developers/docs/data-and-analytics/index.md
+++ b/public/content/translations/it/developers/docs/data-and-analytics/index.md
@@ -30,7 +30,7 @@ Usando [GraphQL](https://graphql.org/), gli sviluppatori possono interrogare una
 
 ## Diversità dei client
 
-La [diversità dei client](/developers/docs/nodes-and-clients/client-diversity/) è importante per la salute complessiva della rete di Ethereum, poiché fornisce resilienza a bug ed exploit. Attualmente esistono vari pannelli di controllo della diversità del client, tra cui [clientdiversity.org](https://clientdiversity.org/), [rated.network](https://www.rated.network), [execution-diversity.info](https://execution-diversity.info/) ed [Ethernodes](https://ethernodes.org/).
+La [diversità dei client](/developers/docs/nodes-and-clients/client-diversity/) è importante per la salute complessiva della rete di Ethereum, poiché fornisce resilienza a bug ed exploit. Attualmente esistono vari pannelli di controllo della diversità del client, tra cui [clientdiversity.org](https://clientdiversity.org/), [rated.network](https://www.rated.network), [supermajority.info](https://supermajority.info//) ed [Ethernodes](https://ethernodes.org/).
 
 ## Dune Analytics {#dune-analytics}
 

--- a/public/content/translations/it/developers/docs/nodes-and-clients/client-diversity/index.md
+++ b/public/content/translations/it/developers/docs/nodes-and-clients/client-diversity/index.md
@@ -90,7 +90,7 @@ Diversi pannelli di controllo forniscono statistiche sulla diversità dei client
 - [Rated.network](https://www.rated.network/)
 - [clientdiversity.org](https://clientdiversity.org/) **Livello di esecuzione:**
 
-- [execution-diversity.info](https://execution-diversity.info/)
+- [supermajority.info](https://supermajority.info//)
 - [Ethernodes](https://ethernodes.org/)
 
 ## Letture consigliate {#further-reading}

--- a/public/content/translations/ja/developers/docs/data-and-analytics/index.md
+++ b/public/content/translations/ja/developers/docs/data-and-analytics/index.md
@@ -31,7 +31,7 @@ lang: ja
 ## クライアントの多様性
 
 [クライアントの多様性](/developers/docs/nodes-and-clients/client-diversity/)は、バグや脆弱性に対する回復力を提供します。そのため、イーサリアムネットワーク全体の健全性にとって重要です。 現在、
-clientdiversity.org[rated.network](https://www.rated.network)、[execution-diversity.info](https://execution-diversity.info/)、[Ethernodes](https://ethernodes.org/)など、いくつかのクライアント多様性ダッシュボードが存在します。
+clientdiversity.org[rated.network](https://www.rated.network)、[supermajority.info](https://supermajority.info//)、[Ethernodes](https://ethernodes.org/)など、いくつかのクライアント多様性ダッシュボードが存在します。
 
 
 

--- a/public/content/translations/ja/developers/docs/nodes-and-clients/client-diversity/index.md
+++ b/public/content/translations/ja/developers/docs/nodes-and-clients/client-diversity/index.md
@@ -90,7 +90,7 @@ sidebarDepth: 2
 - [Rated.network](https://www.rated.network/)
 - [clientdiversity.org](https://clientdiversity.org/) **実行レイヤー:**
 
-- [execution-diversity.info](https://execution-diversity.info/)
+- [supermajority.info](https://supermajority.info//)
 - [Ethernodes](https://ethernodes.org/)
 
 ## 参考文献 {#further-reading}

--- a/public/content/translations/pt-br/developers/docs/data-and-analytics/index.md
+++ b/public/content/translations/pt-br/developers/docs/data-and-analytics/index.md
@@ -30,7 +30,7 @@ Usando o [GraphQL](https://graphql.org/), os desenvolvedores podem consultar qua
 
 ## Diversidade dos clientes
 
-A [diversidade do cliente](/developers/docs/nodes-and-clients/client-diversity/) é importante para a saúde geral da rede Ethereum porque fornece resiliência a bugs e explorações. Agora existem vários painéis de diversidade do cliente, incluindo [clientdiversity.org](https://clientdiversity.org/), [rated.network](https://rated.network/), [execution-diversity.info](https://execution-diversity.info/) e [Ethernodes](https://ethernodes.org/).
+A [diversidade do cliente](/developers/docs/nodes-and-clients/client-diversity/) é importante para a saúde geral da rede Ethereum porque fornece resiliência a bugs e explorações. Agora existem vários painéis de diversidade do cliente, incluindo [clientdiversity.org](https://clientdiversity.org/), [rated.network](https://rated.network/), [supermajority.info](https://supermajority.info//) e [Ethernodes](https://ethernodes.org/).
 
 ## Dune Analytics {#dune-analytics}
 

--- a/public/content/translations/pt-br/developers/docs/nodes-and-clients/client-diversity/index.md
+++ b/public/content/translations/pt-br/developers/docs/nodes-and-clients/client-diversity/index.md
@@ -90,7 +90,7 @@ Vários painéis fornecem estatísticas de diversidade de cliente em tempo real 
 - [Rated.network](https://www.rated.network/)
 - [clientdiversity.org](https://clientdiversity.org/) **Camada de execução:**
 
-- [execution-diversity.info](https://execution-diversity.info/)
+- [supermajority.info](https://supermajority.info//)
 - [Ethernodes](https://ethernodes.org/)
 
 ## Leitura adicional {#further-reading}

--- a/public/content/translations/tr/developers/docs/data-and-analytics/index.md
+++ b/public/content/translations/tr/developers/docs/data-and-analytics/index.md
@@ -30,7 +30,7 @@ Geliştiriciler, [GraphQL](https://graphql.org/)'u kullanarak, alt grafikler ola
 
 ## İstemci çeşitliliği
 
-[İstemci çeşitliliği](/developers/docs/nodes-and-clients/client-diversity/), Ethereum ağı için genel sağlık açısından önemlidir çünkü hatalara veya açıklardan kaynaklanabilecek istismar ve sorunlara karşı esneklik veya direnç sağlar. Şu anda [clientdiversity.org](https://clientdiversity.org/), [rated.network](https://rated.network/), [execution-diversity.info](https://execution-diversity.info/) ve [Ethernodes](https://ethernodes.org/) dahil olmak üzere çeşitli istemci çeşitliliği gösterge panelleri bulunmaktadır.
+[İstemci çeşitliliği](/developers/docs/nodes-and-clients/client-diversity/), Ethereum ağı için genel sağlık açısından önemlidir çünkü hatalara veya açıklardan kaynaklanabilecek istismar ve sorunlara karşı esneklik veya direnç sağlar. Şu anda [clientdiversity.org](https://clientdiversity.org/), [rated.network](https://rated.network/), [supermajority.info](https://supermajority.info//) ve [Ethernodes](https://ethernodes.org/) dahil olmak üzere çeşitli istemci çeşitliliği gösterge panelleri bulunmaktadır.
 
 ## Dune Analytics {#dune-analytics}
 

--- a/public/content/translations/tr/developers/docs/nodes-and-clients/client-diversity/index.md
+++ b/public/content/translations/tr/developers/docs/nodes-and-clients/client-diversity/index.md
@@ -90,7 +90,7 @@ Birden fazla gösterge paneli yürütüm ve fikir birliği katmanları için ger
 - [Rated.network](https://www.rated.network/)
 - [clientdiversity.org](https://clientdiversity.org/) **Yürütüm katmanı:**
 
-- [execution-diversity.info](https://execution-diversity.info/)
+- [supermajority.info](https://supermajority.info//)
 - [Ethernodes](https://ethernodes.org/)
 
 ## Daha fazla okuma {#further-reading}

--- a/public/content/translations/zh/developers/docs/data-and-analytics/index.md
+++ b/public/content/translations/zh/developers/docs/data-and-analytics/index.md
@@ -30,7 +30,7 @@ lang: zh
 
 ## 客户端多样性
 
-[客户端多样性](/developers/docs/nodes-and-clients/client-diversity/)对于以太坊网络的整体健康很重要，因为它提供了对错误和漏洞利用的弹性。 目前，出现了一些客户端多样性仪表板，包括 [clientdiversity.org](https://clientdiversity.org/)、[rated.network](https://www.rated.network)、[execution-diversity.info](https://execution-diversity.info/) 和 [Ethernodes](https://ethernodes.org/)。
+[客户端多样性](/developers/docs/nodes-and-clients/client-diversity/)对于以太坊网络的整体健康很重要，因为它提供了对错误和漏洞利用的弹性。 目前，出现了一些客户端多样性仪表板，包括 [clientdiversity.org](https://clientdiversity.org/)、[rated.network](https://www.rated.network)、[supermajority.info](https://supermajority.info//) 和 [Ethernodes](https://ethernodes.org/)。
 
 ## Dune Analytics {#dune-analytics}
 

--- a/public/content/translations/zh/developers/docs/nodes-and-clients/client-diversity/index.md
+++ b/public/content/translations/zh/developers/docs/nodes-and-clients/client-diversity/index.md
@@ -90,7 +90,7 @@ sidebarDepth: 2
 - [Rated.network](https://www.rated.network/)
 - [clientdiversity.org](https://clientdiversity.org/) **执行层：**
 
-- [execution-diversity.info](https://execution-diversity.info/)
+- [supermajority.info](https://supermajority.info//)
 - [Ethernodes](https://ethernodes.org/)
 
 ## 延伸阅读 {#further-reading}


### PR DESCRIPTION
Fix: Link:[execution-diversity.info](https://execution-diversity.info/)  redirects to https://supermajority.info/. 

## Description

 Updated the link name to the redirected website name

## Related Issue

(https://github.com/ethereum/ethereum-org-website/issues/12740)
