### PR TITLE
add updated tutorials from speedrunethereum.com

### DIFF
--- a/src/data/externalTutorials.json
+++ b/src/data/externalTutorials.json
@@ -557,5 +557,89 @@
     "lang": "en",
     "timeToRead": "10",
     "publishDate": "07/01/2023"
+  },
+  {
+    "url": "https://speedrunethereum.com/challenge/simple-nft-example",
+    "title": "Simple NFT Example",
+    "description": "Build, mint, and transfer your own ERC721",
+    "author": "Austin Griffith",
+    "authorGithub": "https://github.com/austintgriffith",
+    "tags": ["solidity", "smart contracts", "react", "nextjs", "wagmi", "nft", "javascript", "typescript", "openzeppelin"],
+    "skillLevel": "beginner",
+    "lang": "en",
+    "timeToRead": "10",
+    "publishDate": "04/24/2024"
+  },
+  {
+    "url": "https://speedrunethereum.com/challenge/decentralized-staking",
+    "title": "Decentralized Staking App",
+    "description": "Build, test, and deploy your own decentralized staking app",
+    "author": "Austin Griffith",
+    "authorGithub": "https://github.com/austintgriffith",
+    "tags": ["solidity", "smart contracts", "react", "nextjs", "wagmi", "javascript", "typescript", "frontend"],
+    "skillLevel": "beginner",
+    "timeToRead": "30",
+    "lang": "en",
+    "publishDate": "04/24/2024"
+  },
+  {
+    "url": "https://speedrunethereum.com/challenge/token-vendor",
+    "title": "Token Vendor",
+    "description": "Build a vending machine to buy and sell your own ERC20",
+    "author": "Austin Griffith",
+    "authorGithub": "https://github.com/austintgriffith",
+    "tags": ["solidity", "smart contracts", "react", "nextjs", "wagmi", "javascript", "typescript", "frontend","ERC-20", "openzeppelin"],
+    "skillLevel": "beginner",
+    "timeToRead": "30",
+    "lang": "en",
+    "publishDate": "04/24/2024"
+  },
+  {
+    "url": "https://speedrunethereum.com/challenge/dice-game",
+    "title": "Dice Game",
+    "description": "Deploy a contract to attack a DiceGame contract and predict the randomness so you only roll winners",
+    "author": "Austin Griffith",
+    "authorGithub": "https://github.com/austintgriffith",
+    "tags": ["solidity", "smart contracts", "react", "nextjs", "wagmi", "javascript", "typescript", "frontend", "openzeppelin"],
+    "skillLevel": "beginner",
+    "timeToRead": "25",
+    "lang": "en",
+    "publishDate": "04/24/2024"
+  },
+  {
+    "url": "https://speedrunethereum.com/challenge/minimum-viable-exchange",
+    "title": "Build a DEX",
+    "description": "Deploy a decentralized exchange to swap an ERC20 and ETH",
+    "author": "Austin Griffith",
+    "authorGithub": "https://github.com/austintgriffith",
+    "tags": ["solidity", "smart contracts", "react", "nextjs", "wagmi", "javascript", "typescript", "frontend", "ERC-20", "openzeppelin"],
+    "skillLevel": "intermediate",
+    "timeToRead": "60",
+    "lang": "en",
+    "publishDate": "04/24/2024"
+  },
+  {
+    "url": "https://speedrunethereum.com/challenge/state-channels",
+    "title": "State Channel Application",
+    "description": "Create an app to lock collateral onchain, transact offchain, then finalize onchain.",
+    "author": "Austin Griffith",
+    "authorGithub": "https://github.com/austintgriffith",
+    "tags": ["solidity", "smart contracts", "react", "nextjs", "wagmi", "javascript", "typescript", "frontend", "openzeppelin"],
+    "skillLevel": "intermediate",
+    "timeToRead": "60",
+    "lang": "en",
+    "publishDate": "04/24/2024"
+  },
+  {
+    "url": "https://github.com/scaffold-eth/se-2-challenges/tree/challenge-6-multisig",
+    "title": "Multisig wallet",
+    "description": "Deploy a multi-signature wallet where enough signatures are required to execute a transaction",
+    "author": "Austin Griffith",
+    "authorGithub": "https://github.com/austintgriffith",
+    "tags": ["solidity", "smart contracts", "react", "nextjs", "wagmi", "javascript", "typescript", "frontend", "openzeppelin", "signing"],
+    "skillLevel": "intermediate",
+    "timeToRead": "90",
+    "lang": "en",
+    "publishDate": "04/24/2024"
   }
 ]


### PR DESCRIPTION
Updated the externalTutorials.json file to add 7 new tutorials from SpeedRunEthereum.com.  

<img width="978" alt="image" src="https://github.com/ethereum/ethereum-org-website/assets/12072395/fc635f63-2d31-40a7-95f8-1b152d6a1b51">

<img width="974" alt="image" src="https://github.com/ethereum/ethereum-org-website/assets/12072395/d99196c2-cf8c-4fb1-b161-5ec6a95e02d1">

<img width="978" alt="image" src="https://github.com/ethereum/ethereum-org-website/assets/12072395/9b162ba5-baeb-4a47-9153-1c540f8d094a">


Along with [PR#12834](https://github.com/ethereum/ethereum-org-website/pull/12834) which removes the outdated SRE challenge, Closes #12834 
