### PR TITLE
fix: strip query params/hashes form matomo events

### DIFF
--- a/src/lib/utils/matomo.ts
+++ b/src/lib/utils/matomo.ts
@@ -20,6 +20,8 @@ export const trackCustomEvent = ({
   const isOptedOut = JSON.parse(optedOutValue)
   if (isOptedOut) return
 
+  // Set custom URL removing any query params or hash fragments
+  window && push([`setCustomUrl`, window.location.href.replace(/[?#].*$/, "")])
   push([`trackEvent`, eventCategory, eventAction, eventName, eventValue])
 
   console.debug(


### PR DESCRIPTION
## Description
- Customizes the page URL logged for Matomo events using the `setCustomUrl` function
- Query params and hash links are removed from the current URL before being logged

See:
- https://developer.matomo.org/guides/tracking-javascript-guide#manually-trigger-a-page-view
- https://matomo.org/faq/how-to/how-do-i-set-a-custom-url-using-the-matomo-javascript-tracker/

## Related Issue
cc: @konopkja 