### PR TITLE
Remove unnecessary backslash

### DIFF
--- a/public/content/developers/docs/apis/json-rpc/index.md
+++ b/public/content/developers/docs/apis/json-rpc/index.md
@@ -53,7 +53,7 @@ When encoding unformatted data (byte arrays, account addresses, hashes, bytecode
 Here are some examples:
 
 - 0x41 (size 1, "A")
-- 0x004200 (size 3, "\0B\0")
+- 0x004200 (size 3, "0B0")
 - 0x (size 0, "")
 - WRONG: 0xf0f0f (must be even number of digits)
 - WRONG: 004200 (must be prefixed 0x)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Removed unnecessary backslash in `0x004200 (size 3, "\0B\0")`

## Description

`0x004200` has `0x` prefix and remaining 6 characters for 3 bytes where 2 characters represent 1 byte.

| HEX | Decimal | Ascii |
|--------|------------|--------|
|00|0|0|
|42|66|B|
|00|0|0|

[Learn More](https://www.ascii-code.com/66)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
fix #12838