### PR TITLE
Only save .md files to file-ids JSON

### DIFF
--- a/src/scripts/crowdin/source-files/fetchAndSaveFileIds.ts
+++ b/src/scripts/crowdin/source-files/fetchAndSaveFileIds.ts
@@ -31,14 +31,12 @@ async function fetchFileIdsForDirectory(
       return []
     }
 
-    return response.data.map(
-      (item: ResponseObject<SourceFilesModel.File>): FileItem => {
-        return {
-          id: item.data.id,
-          path: item.data.path,
-        }
-      }
-    )
+    return response.data
+    .map((item: ResponseObject<SourceFilesModel.File>): FileItem => ({
+      id: item.data.id,
+      path: item.data.path,
+    }))
+    .filter((file: FileItem) => file.path.endsWith('.md')); // filter out non-md files
   } catch (error: unknown) {
     if (error instanceof Error) {
       console.error(


### PR DESCRIPTION
## Description
I noticed we were incorrectly displaying `GitHubContributors` instead of `CrowdinContributors` on some pages that are translated. For example, the [blocks page in Spanish](https://ethereum.org/es/developers/docs/blocks/).

This is happening because during the process of matching file paths from JSON to a URL path, our current implementation continues to iterate through all available entries even after a match is found, leading to potential mismatches in identifying the correct file for `CrowdinContributors`.

The scenario I tested:

URL Path: `/content/developers/docs/blocks`
Normalized Path Used for Matching: `developers/docs/blocks`

Output:

File ID 2894 matched with the path `/developers/docs/blocks/index.md`
File ID 7773 matched with the path `/developers/docs/blocks/tx-block.svg`
File ID 8173 matched with the path `/developers/docs/blocks/tx-block.svg.xlsx`

The last file in the list (ID 8173) is an Excel file (which has no contributors) causing the process to fallback to using GitHub contributors.

Only saving ids for paths that end in `.md` should solve this problem.
