### PR TITLE
Fix mobile menu layout

### DIFF
--- a/src/components/Nav/Mobile/MenuFooter.tsx
+++ b/src/components/Nav/Mobile/MenuFooter.tsx
@@ -41,7 +41,7 @@ const MenuFooter = ({
       py={0}
       mt="auto"
     >
-      <Grid templateColumns="repeat(2, 1fr)" w="full">
+      <Grid templateColumns="repeat(3, 1fr)" w="full">
         <FooterButton
           icon={MdSearch}
           onClick={() => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes mobile menu layout to have 3 columns instead of 2.

## Related

Fixes #12856