### PR TITLE
Performance - enable NEXT_FORCE_EDGE_IMAGES

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,6 +9,9 @@
   # Default build command.
   command = "yarn build"
 
+[build.environment]
+  NEXT_FORCE_EDGE_IMAGES="true"
+
 [[headers]]
   for = "/*"
   [headers.values]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Enables `NEXT_FORCE_EDGE_IMAGES` env var to serve images from the edge env and avoid the extra redirect we currently have to the `ipx` endpoint.

https://github.com/netlify/next-runtime/tree/main?tab=readme-ov-file#enabling-edge-images

prod
![image](https://github.com/ethereum/ethereum-org-website/assets/468158/aa89ffea-1542-446f-a108-13a9c9f1f18d)

preview deploy
![image](https://github.com/ethereum/ethereum-org-website/assets/468158/6c2a2d9c-bb24-486b-bccc-4d19d4ff011c)
