### PR TITLE
Performance - contributors component refactor

### DIFF
--- a/src/components/FileContributors.tsx
+++ b/src/components/FileContributors.tsx
@@ -8,8 +8,7 @@ import {
   ListItem,
   ModalBody,
   ModalHeader,
-  Skeleton as ChakraSkeleton,
-  SkeletonCircle as ChakraSkeletonCircle,
+  SkeletonText,
   UnorderedList,
   useBreakpointValue,
   VStack,
@@ -34,13 +33,7 @@ const skeletonColorProps = {
   endColor: "searchBackgroundEmpty",
 }
 
-const Skeleton = (props) => (
-  <ChakraSkeleton {...skeletonColorProps} borderRadius="md" {...props} />
-)
-
-const SkeletonCircle = (props) => (
-  <ChakraSkeletonCircle {...skeletonColorProps} {...props} />
-)
+const Skeleton = (props) => <SkeletonText {...skeletonColorProps} {...props} />
 
 const ContributorList = ({ children }: { children: React.ReactNode }) => {
   return (
@@ -114,16 +107,18 @@ const FileContributors = ({
 
         <ModalBody>
           <Translation id="contributors-thanks" />
-          {contributors ? (
-            <ContributorList>
-              {contributors.map((contributor) => (
-                <Contributor
-                  contributor={contributor}
-                  key={contributor.email}
-                />
-              ))}
-            </ContributorList>
-          ) : null}
+          <Skeleton noOfLines="4" mt="4" isLoaded={!loading}>
+            {contributors ? (
+              <ContributorList>
+                {contributors.map((contributor) => (
+                  <Contributor
+                    contributor={contributor}
+                    key={contributor.email}
+                  />
+                ))}
+              </ContributorList>
+            ) : null}
+          </Skeleton>
         </ModalBody>
       </Modal>
 
@@ -138,28 +133,24 @@ const FileContributors = ({
         <Flex me={4} alignItems="center" flex="1">
           {isDesktop && (
             <>
-              <SkeletonCircle size="10" me={4} isLoaded={!loading}>
-                <Avatar
-                  height="40px"
-                  width="40px"
-                  src={lastContributor.avatarUrl}
-                  name={lastContributor.name}
-                  me={2}
-                />
-              </SkeletonCircle>
+              <Avatar
+                height="40px"
+                width="40px"
+                src={lastContributor.avatarUrl}
+                name={lastContributor.name}
+                me={2}
+              />
 
-              <Skeleton isLoaded={!loading}>
-                <Text m={0} color="text200">
-                  <Translation id="last-edit" />:{" "}
-                  {lastContributor.user?.url && (
-                    <InlineLink href={lastContributor.user.url}>
-                      @{lastContributor.user.login}
-                    </InlineLink>
-                  )}
-                  {!lastContributor.user && <span>{lastContributor.name}</span>}
-                  , {getLocaleTimestamp(locale as Lang, lastEdit)}
-                </Text>
-              </Skeleton>
+              <Text m={0} color="text200">
+                <Translation id="last-edit" />:{" "}
+                {lastContributor.user?.url && (
+                  <InlineLink href={lastContributor.user.url}>
+                    @{lastContributor.user.login}
+                  </InlineLink>
+                )}
+                {!lastContributor.user && <span>{lastContributor.name}</span>},{" "}
+                {getLocaleTimestamp(locale as Lang, lastEdit)}
+              </Text>
             </>
           )}
         </Flex>

--- a/src/components/FileContributors.tsx
+++ b/src/components/FileContributors.tsx
@@ -11,6 +11,7 @@ import {
   Skeleton as ChakraSkeleton,
   SkeletonCircle as ChakraSkeletonCircle,
   UnorderedList,
+  useBreakpointValue,
   VStack,
 } from "@chakra-ui/react"
 
@@ -87,6 +88,8 @@ const FileContributors = ({
   const [isModalOpen, setModalOpen] = useState(false)
   const { locale } = useRouter()
 
+  const isDesktop = useBreakpointValue({ base: false, md: true })
+
   if (error) return null
   const lastContributor: Author = contributors.length
     ? contributors[0]
@@ -133,49 +136,52 @@ const FileContributors = ({
         {...props}
       >
         <Flex me={4} alignItems="center" flex="1">
-          <SkeletonCircle size="10" me={4} isLoaded={!loading}>
-            <Avatar
-              height="40px"
-              width="40px"
-              src={lastContributor.avatarUrl}
-              name={lastContributor.name}
-              me={2}
-            />
-          </SkeletonCircle>
+          {isDesktop && (
+            <>
+              <SkeletonCircle size="10" me={4} isLoaded={!loading}>
+                <Avatar
+                  height="40px"
+                  width="40px"
+                  src={lastContributor.avatarUrl}
+                  name={lastContributor.name}
+                  me={2}
+                />
+              </SkeletonCircle>
 
-          <Skeleton isLoaded={!loading}>
-            <Text m={0} color="text200">
-              <Translation id="last-edit" />:{" "}
-              {lastContributor.user?.url && (
-                <InlineLink href={lastContributor.user.url}>
-                  @{lastContributor.user.login}
-                </InlineLink>
-              )}
-              {!lastContributor.user && <span>{lastContributor.name}</span>},{" "}
-              {getLocaleTimestamp(locale as Lang, lastEdit)}
-            </Text>
-          </Skeleton>
+              <Skeleton isLoaded={!loading}>
+                <Text m={0} color="text200">
+                  <Translation id="last-edit" />:{" "}
+                  {lastContributor.user?.url && (
+                    <InlineLink href={lastContributor.user.url}>
+                      @{lastContributor.user.login}
+                    </InlineLink>
+                  )}
+                  {!lastContributor.user && <span>{lastContributor.name}</span>}
+                  , {getLocaleTimestamp(locale as Lang, lastEdit)}
+                </Text>
+              </Skeleton>
+            </>
+          )}
         </Flex>
 
         <VStack align="stretch" justifyContent="space-between" spacing={2}>
-          <Skeleton isLoaded={!loading} mt={{ base: 4, md: 0 }}>
-            <Button
-              variant="outline"
-              bg="background.base"
-              border={0}
-              onClick={() => {
-                setModalOpen(true)
-                trackCustomEvent({
-                  eventCategory: "see contributors",
-                  eventAction: "click",
-                  eventName: "click",
-                })
-              }}
-              w={{ base: "full", md: "inherit" }}
-            >
-              <Translation id="see-contributors" />
-            </Button>
-          </Skeleton>
+          <Button
+            variant="outline"
+            bg="background.base"
+            border={0}
+            mb={{ base: 4, md: 0 }}
+            onClick={() => {
+              setModalOpen(true)
+              trackCustomEvent({
+                eventCategory: "see contributors",
+                eventAction: "click",
+                eventName: "click",
+              })
+            }}
+            w={{ base: "full", md: "inherit" }}
+          >
+            <Translation id="see-contributors" />
+          </Button>
         </VStack>
       </Flex>
     </>

--- a/src/components/SideNav.tsx
+++ b/src/components/SideNav.tsx
@@ -13,13 +13,13 @@ import docLinks from "../data/developer-docs-links.yaml"
 
 export const dropdownIconContainerVariant = {
   open: {
-    rotate: 0,
+    rotate: 90,
     y: 3,
     transition: {
       duration: 0.4,
     },
   },
-  closed: { rotate: -90, y: 0 },
+  closed: { rotate: 0, y: 0 },
 }
 
 const innerLinksVariants = {
@@ -105,8 +105,14 @@ const NavLink = ({ item, path, isTopLevel }: NavLinkProps) => {
             variants={dropdownIconContainerVariant}
             animate={isOpen ? "open" : "closed"}
             cursor="pointer"
+            display="flex"
           >
-            <Icon as={MdExpandMore} boxSize={6} color="secondary" />
+            <Icon
+              as={MdExpandMore}
+              transform="rotate(-90deg)"
+              boxSize={6}
+              color="secondary"
+            />
           </Box>
         </LinkContainer>
         <Box

--- a/src/components/SideNav.tsx
+++ b/src/components/SideNav.tsx
@@ -1,7 +1,7 @@
-import { ReactNode, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 import { motion } from "framer-motion"
 import { useTranslation } from "next-i18next"
-import { MdExpandMore } from "react-icons/md"
+import { MdChevronRight } from "react-icons/md"
 import { Box, HStack, Icon } from "@chakra-ui/react"
 
 import { ChildOnlyProp } from "@/lib/types"
@@ -14,12 +14,11 @@ import docLinks from "../data/developer-docs-links.yaml"
 export const dropdownIconContainerVariant = {
   open: {
     rotate: 90,
-    y: 3,
     transition: {
       duration: 0.4,
     },
   },
-  closed: { rotate: 0, y: 0 },
+  closed: { rotate: 0 },
 }
 
 const innerLinksVariants = {
@@ -107,12 +106,7 @@ const NavLink = ({ item, path, isTopLevel }: NavLinkProps) => {
             cursor="pointer"
             display="flex"
           >
-            <Icon
-              as={MdExpandMore}
-              transform="rotate(-90deg)"
-              boxSize={6}
-              color="secondary"
-            />
+            <Icon as={MdChevronRight} boxSize={6} color="secondary" />
           </Box>
         </LinkContainer>
         <Box

--- a/src/components/SideNavMobile.tsx
+++ b/src/components/SideNavMobile.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react"
 import { AnimatePresence, motion } from "framer-motion"
 import { useTranslation } from "next-i18next"
-import { MdExpandMore } from "react-icons/md"
+import { MdChevronRight } from "react-icons/md"
 import { Box, Center, HStack, Icon } from "@chakra-ui/react"
 
 import type { ChildOnlyProp, TranslationKey } from "@/lib/types"
@@ -113,14 +113,7 @@ const NavLink = ({ item, path, toggle }: NavLinkProps) => {
             variants={dropdownIconContainerVariant}
             animate={isOpen ? "open" : "closed"}
           >
-            <Icon
-              as={MdExpandMore}
-              // display by default the icon in this position `>` (close state)
-              // this will prevent the icon from rotating when the page loads
-              transform="rotate(-90deg)"
-              boxSize={6}
-              color="secondary"
-            />
+            <Icon as={MdChevronRight} boxSize={6} color="secondary" />
           </Box>
         </LinkContainer>
         <Box
@@ -197,12 +190,7 @@ const SideNavMobile = ({ path }: SideNavMobileProps) => {
           variants={dropdownIconContainerVariant}
           animate={isOpen ? "open" : "closed"}
         >
-          <Icon
-            as={MdExpandMore}
-            transform="rotate(-90deg)"
-            boxSize={6}
-            color="secondary"
-          />
+          <Icon as={MdChevronRight} boxSize={6} color="secondary" />
         </Box>
       </Center>
       <AnimatePresence>

--- a/src/components/SideNavMobile.tsx
+++ b/src/components/SideNavMobile.tsx
@@ -108,11 +108,19 @@ const NavLink = ({ item, path, toggle }: NavLinkProps) => {
           <Box
             as={motion.div}
             cursor="pointer"
+            display="flex"
             onClick={() => setIsOpen(!isOpen)}
             variants={dropdownIconContainerVariant}
             animate={isOpen ? "open" : "closed"}
           >
-            <Icon as={MdExpandMore} boxSize={6} color="secondary" />
+            <Icon
+              as={MdExpandMore}
+              // display by default the icon in this position `>` (close state)
+              // this will prevent the icon from rotating when the page loads
+              transform="rotate(-90deg)"
+              boxSize={6}
+              color="secondary"
+            />
           </Box>
         </LinkContainer>
         <Box
@@ -185,10 +193,16 @@ const SideNavMobile = ({ path }: SideNavMobileProps) => {
         <Box
           as={motion.div}
           cursor="pointer"
+          display="flex"
           variants={dropdownIconContainerVariant}
           animate={isOpen ? "open" : "closed"}
         >
-          <Icon as={MdExpandMore} boxSize={6} color="secondary" />
+          <Icon
+            as={MdExpandMore}
+            transform="rotate(-90deg)"
+            boxSize={6}
+            color="secondary"
+          />
         </Box>
       </Center>
       <AnimatePresence>

--- a/src/layouts/Docs.tsx
+++ b/src/layouts/Docs.tsx
@@ -98,7 +98,7 @@ const H1 = (props: HeadingProps) => (
     {...baseHeadingStyle}
     fontSize={{ base: "2rem", md: "2.5rem" }}
     mt={{ base: 0, md: 8 }}
-    mb={{ base: 4, md: 8 }}
+    mb="8"
     {...props}
   />
 )

--- a/src/layouts/Docs.tsx
+++ b/src/layouts/Docs.tsx
@@ -145,7 +145,7 @@ const Content = (props: ChildOnlyProp) => {
       as={MainArticle}
       flex={`1 1 ${mdBreakpoint}`}
       w={{ base: "full", lg: "0" }}
-      pt={{ base: 32, md: 12 }}
+      pt={{ base: 8, md: 12 }}
       pb={{ base: 8, md: 16 }}
       px={{ base: 8, md: 16 }}
       m="0 auto"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Immediately display the contributors modal button to reduce LCP.

Other changes:
- Used the MdChevronRight icon to match the initial close state and avoid the initial animation causing the LCP to be higher sometimes
- Removed the Skeletons and add one inside the modal

====
### Tests after changes
Webpagetest https://www.webpagetest.org/result/240430_BiDc8E_92E/

All the LCPs are the same now, ~2/3s.


