### PR TITLE
fix: latest contributor for dev docs

### DIFF
--- a/src/hooks/useClientSideGitHubContributors.ts
+++ b/src/hooks/useClientSideGitHubContributors.ts
@@ -53,7 +53,7 @@ export const useClientSideGitHubContributors = (
 
         const authorSet = new Set<string>()
 
-        ;[...oldCommits, ...newCommits]
+        ;[...newCommits, ...oldCommits]
           .filter(({ author }) => author)
           .forEach(({ author, commit }) => {
             const entry: Author = {


### PR DESCRIPTION
## Description

- The array on commits/contributions is ordered most recent to oldest. The order of `...oldCommits` and `...newCommits` was reversed causing the last commit from the old repo to be highlighted. 
- Flips the order of this concatenation to have the most recent commit in [0] position.

## Related Issue
<img width="904" alt="image" src="https://github.com/ethereum/ethereum-org-website/assets/54227730/70fce7c3-e34b-4b54-9871-7d95d1fd88c5">

https://ethereum.org/en/developers/docs/scaling/zk-rollups/

<img width="879" alt="image" src="https://github.com/ethereum/ethereum-org-website/assets/54227730/835b3559-df2c-4685-b3cb-87585e7278bf">

https://github.com/ethereum/ethereum-org-website/commits/dev/public/content/developers/docs/scaling/zk-rollups/index.md