### PR TITLE
fix(theme): reposition `extendBaseTheme` call for Chakra CLI

### DIFF
--- a/src/@chakra-ui/theme.ts
+++ b/src/@chakra-ui/theme.ts
@@ -1,4 +1,4 @@
-import type { ThemeConfig } from "@chakra-ui/react"
+import { extendBaseTheme, type ThemeConfig } from "@chakra-ui/react"
 
 import components from "./components"
 import foundations from "./foundations"
@@ -25,4 +25,4 @@ const theme = {
   components,
 }
 
-export default theme
+export default extendBaseTheme(theme)

--- a/src/components/Buttons/Button.stories.tsx
+++ b/src/components/Buttons/Button.stories.tsx
@@ -41,6 +41,7 @@ const variants: ThemingProps<"Button">["variant"][] = [
 export const StyleVariants: Story = {
   argTypes: {
     size: {
+      // @ts-expect-error looking for a more specific type, but this is still valid
       ...getThemingArgTypes(theme, "Button")?.size,
       defaultValue: "md",
     },

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,9 +1,9 @@
 import { useEffect } from "react"
+import { merge } from "lodash"
 import { appWithTranslation } from "next-i18next"
 // ChakraProvider import updated as recommended on https://github.com/chakra-ui/chakra-ui/issues/4975#issuecomment-1174234230
 // to reduce bundle size. Should be reverted to "@chakra-ui/react" in case on theme issues
 import { ChakraProvider } from "@chakra-ui/provider"
-import { extendBaseTheme } from "@chakra-ui/react"
 import { init } from "@socialgouv/matomo-next"
 
 import customTheme from "@/@chakra-ui/theme"
@@ -32,7 +32,7 @@ const App = ({ Component, pageProps }: AppPropsWithLayout) => {
 
   const direction = useLocaleDirection()
 
-  const theme = extendBaseTheme({ direction, ...customTheme })
+  const theme = merge(customTheme, { direction })
 
   return (
     <>


### PR DESCRIPTION
With the Chakra CLI, it looks for a default exported object of the theme to extract and define the custom theming types. However, the object extracted is the raw theme object of only the custom themes, so the CLI is not including the types for the default foundation tokens.

This PR repositions the `extendBaseTheme` function back to the theme file so it is called during type generation, and exposes the default foundation tokens.

A simple object merge can be done to bring in the updated language direction from NextJS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the theme extension approach to enhance app customization and consistency.

- **Refactor**
	- Improved type specificity in button component stories for clearer codebase understanding.

- **Style**
	- Integrated a more robust theming configuration to improve UI consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->