### PR TITLE
remove svg and xlsx files from crowdin import

### DIFF
--- a/src/scripts/crowdin-import.ts
+++ b/src/scripts/crowdin-import.ts
@@ -290,9 +290,7 @@ const scrapeDirectory = (
       // Update .json tracker
       trackers.langs[repoLangCode].jsonCopyCount++
     } else if (
-      item.endsWith(".md") ||
-      item.endsWith(".svg") ||
-      item.endsWith(".xlsx")
+      item.endsWith(".md")
     ) {
       const mdDestDirPath: string = join(
         repoRoot,

--- a/src/scripts/crowdin/import/utils.ts
+++ b/src/scripts/crowdin/import/utils.ts
@@ -46,9 +46,7 @@ export const scrapeDirectory = (
       // Update .json tracker
       trackers.langs[repoLangCode].jsonCopyCount++
     } else if (
-      item.endsWith(".md") ||
-      item.endsWith(".svg") ||
-      item.endsWith(".xlsx")
+      item.endsWith(".md")
     ) {
       const mdDestDirPath: string = join(
         TRANSLATIONS_DIR,


### PR DESCRIPTION
## Description

- removes svg and xlsx files from crowdin import scripts as images are handled through a separate import process
