### PR TITLE
fix: override box-shadow to none to avoid tooltip border #12597

### DIFF
--- a/src/@chakra-ui/components/Popover.ts
+++ b/src/@chakra-ui/components/Popover.ts
@@ -35,6 +35,9 @@ const baseStyle = definePartsStyle(
       maxWidth: "xs", // 20rem
       lineHeight: "base",
       w: "auto",
+      _focusVisible: { 
+        boxShadow: 'none',
+      },
     },
     body: {
       color: "body.base",


### PR DESCRIPTION
fix: override box-shadow to none to avoid tooltip border [#12597](https://github.com/ethereum/ethereum-org-website/issues/12597)

## Description

This pull request addresses the issue where a colored border appears around tooltips on mobile devices due to the focus-visible state. The changes ensure that the box-shadow is set to none when elements are focused, effectively removing the unwanted visual effect and maintaining a consistent appearance across devices.
