### PR TITLE
fix: ButtonLink onClick handler

### DIFF
--- a/src/components/Buttons/ButtonLink.tsx
+++ b/src/components/Buttons/ButtonLink.tsx
@@ -4,12 +4,18 @@ import { BaseLink, type LinkProps } from "@/components/Link"
 import { type MatomoEventOptions, trackCustomEvent } from "@/lib/utils/matomo"
 
 export type ButtonLinkProps = LinkProps &
-  Omit<ButtonProps, "toId"> & {
+  Omit<ButtonProps, "toId" | "onClick"> & {
     customEventOptions?: MatomoEventOptions
   }
 
-const ButtonLink = ({ ...props }: ButtonLinkProps) => {
-  return <Button as={BaseLink} activeStyle={{}} {...props} />
+const ButtonLink = ({ customEventOptions, ...props }: ButtonLinkProps) => {
+  const handleClick = () => {
+    customEventOptions && trackCustomEvent(customEventOptions)
+  }
+
+  return (
+    <Button as={BaseLink} activeStyle={{}} {...props} onClick={handleClick} />
+  )
 }
 
 export default ButtonLink

--- a/src/components/Buttons/ButtonLink.tsx
+++ b/src/components/Buttons/ButtonLink.tsx
@@ -4,16 +4,26 @@ import { BaseLink, type LinkProps } from "@/components/Link"
 import { type MatomoEventOptions, trackCustomEvent } from "@/lib/utils/matomo"
 
 export type ButtonLinkProps = LinkProps &
-  Omit<ButtonProps, "toId" | "onClick"> & {
+  Omit<ButtonProps, "toId"> & {
     customEventOptions?: MatomoEventOptions
   }
 
-const ButtonLink = ({ customEventOptions, ...props }: ButtonLinkProps) => {
+const ButtonLink = ({
+  customEventOptions,
+  onClick,
+  ...props
+}: ButtonLinkProps) => {
   const handleClick = () => {
     customEventOptions && trackCustomEvent(customEventOptions)
   }
+
   return (
-    <Button as={BaseLink} activeStyle={{}} {...props} onClick={handleClick} />
+    <Button
+      as={BaseLink}
+      activeStyle={{}}
+      {...props}
+      onClick={onClick ? onClick : handleClick}
+    />
   )
 }
 

--- a/src/components/Buttons/ButtonLink.tsx
+++ b/src/components/Buttons/ButtonLink.tsx
@@ -8,23 +8,8 @@ export type ButtonLinkProps = LinkProps &
     customEventOptions?: MatomoEventOptions
   }
 
-const ButtonLink = ({
-  customEventOptions,
-  onClick,
-  ...props
-}: ButtonLinkProps) => {
-  const handleClick = () => {
-    customEventOptions && trackCustomEvent(customEventOptions)
-  }
-
-  return (
-    <Button
-      as={BaseLink}
-      activeStyle={{}}
-      {...props}
-      onClick={onClick ? onClick : handleClick}
-    />
-  )
+const ButtonLink = ({ ...props }: ButtonLinkProps) => {
+  return <Button as={BaseLink} activeStyle={{}} {...props} />
 }
 
 export default ButtonLink

--- a/src/components/FindWallet/WalletTable/index.tsx
+++ b/src/components/FindWallet/WalletTable/index.tsx
@@ -330,14 +330,6 @@ const WalletTable = ({
               })
           }
 
-          const handleWalletWebsiteClick = (walletName: string) => {
-            trackCustomEvent({
-              eventCategory: "WalletExternalLinkList",
-              eventAction: "Tap main button",
-              eventName: `${walletName}`,
-            })
-          }
-
           return (
             <WalletContainer
               key={wallet.key}
@@ -350,10 +342,7 @@ const WalletTable = ({
                 }}
                 onClick={(e) => {
                   // Prevent expanding the wallet more info section when clicking on the "Visit website" button
-                  if (
-                    (e.target as HTMLElement).matches("a, a svg")
-                  )
-                    return
+                  if ((e.target as HTMLElement).matches("a, a svg")) return
                   showMoreInfo(wallet)
                 }}
               >
@@ -393,7 +382,11 @@ const WalletTable = ({
                           {hasPersonasLabels && (
                             <Flex gap={1.5} wrap="wrap">
                               {walletPersonas.map((persona) => (
-                                <Tag key={persona} label={t(persona)} variant="highContrast" />
+                                <Tag
+                                  key={persona}
+                                  label={t(persona)}
+                                  variant="highContrast"
+                                />
                               ))}
                             </Flex>
                           )}
@@ -445,9 +438,11 @@ const WalletTable = ({
                               w="auto"
                               isExternal
                               size="sm"
-                              onClick={() =>
-                                handleWalletWebsiteClick(wallet.name)
-                              }
+                              customEventOptions={{
+                                eventCategory: "WalletExternalLinkList",
+                                eventAction: "Tap main button",
+                                eventName: `${wallet.name}`,
+                              }}
                             >
                               {t("page-find-wallet-visit-website")}
                             </ButtonLink>
@@ -474,7 +469,11 @@ const WalletTable = ({
                       w="100%"
                       isExternal
                       size="sm"
-                      onClick={() => handleWalletWebsiteClick(wallet.name)}
+                      customEventOptions={{
+                        eventCategory: "WalletExternalLinkList",
+                        eventAction: "Tap main button",
+                        eventName: `${wallet.name}`,
+                      }}
                     >
                       {t("page-find-wallet-visit-website")}
                     </ButtonLink>


### PR DESCRIPTION
This PR updates the `ButtonLink` component to handle custom `onClick` events and override its behavior when needed. Fixes the issue of `/wallets/find-wallet/` `Visit website` CTA not being tracking the event when clicked.

## Testing

- Go to `/wallets/find-wallet/` now the `Visit website` button should be triggering the custom `handleWalletWebsiteClick` event handler
- Go to any other page like `/community/` to check that the `ButtonLink` component is still working as expected for other cases

<img width="607" alt="Screen Shot 2024-05-08 at 17 06 47" src="https://github.com/ethereum/ethereum-org-website/assets/948922/9fbdf8cf-26c2-45aa-b73d-94e1f81505e7">

## Preview

https://deploy-preview-12935--ethereumorg.netlify.app/wallets/find-wallet