### PR TITLE
Add Ethereum Ecosystem Sepolia faucet to dev docs /networks

### DIFF
--- a/public/content/developers/docs/networks/index.md
+++ b/public/content/developers/docs/networks/index.md
@@ -62,6 +62,7 @@ The Sepolia network uses a permissioned validator set. It's fairly new, meaning 
 - [Alchemy Sepolia faucet](https://sepoliafaucet.com/)
 - [Infura Sepolia faucet](https://www.infura.io/faucet)
 - [Chainstack Sepolia faucet](https://faucet.chainstack.com/sepolia-faucet)
+- [Ethereum Ecosystem faucet](https://www.ethereum-ecosystem.com/faucets/ethereum-sepolia)
 
 #### Goerli _(long-term support)_ {#goerli}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR introduces a link to Ethereum Ecosystem' sepolia faucet: https://www.ethereum-ecosystem.com/faucets/ethereum-sepolia

People struggle to find faucets that have plenty of ETH to distribute AND do not get depleted by malicous actors with bots. This faucet is bot/spam-resistant and provides generous drips to users.