### PR TITLE
Performance: fix compression issues by adjusting middleware matcher

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -41,12 +41,14 @@
 [functions]
 
   [functions.___netlify-odb-handler]
+    external_node_modules = ["sharp"]
     included_files = [
       "./src/intl/**/*",
       "!./public/**/*",
       "node_modules/next/dist/server/future/route-modules/pages/vendored/contexts/router-context*",
       "node_modules/next/dist/server/future/route-modules/pages/vendored/contexts/amp-context*",
       "node_modules/next/dist/server/future/route-modules/pages/vendored/contexts/head-manager-context*",
+      "node_modules/sharp/**/*",
     ]
 
   [functions.___netlify-handler]

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,8 +2,6 @@ import { NextRequest, NextResponse } from "next/server"
 
 import { DEFAULT_LOCALE, FAKE_LOCALE, LOCALES_CODES } from "./lib/constants"
 
-const PUBLIC_FILE = /\.(.*)$/
-
 function detectLocale(acceptLanguage: string | null) {
   if (!acceptLanguage) {
     return DEFAULT_LOCALE
@@ -21,17 +19,23 @@ function detectLocale(acceptLanguage: string | null) {
   return locale
 }
 
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - api (API routes)
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     * - .well-known (security files)
+     */
+    "/((?!api|_next/static|_next/image|favicon.ico|.well-known).*)",
+  ],
+}
+
 // Middleware required to always display the locale prefix in the URL. It
 // redirects to the default locale if the locale is not present in the URL
 export async function middleware(req: NextRequest) {
-  if (
-    req.nextUrl.pathname.startsWith("/_next") ||
-    req.nextUrl.pathname.includes("/api/") ||
-    PUBLIC_FILE.test(req.nextUrl.pathname)
-  ) {
-    return
-  }
-
   if (req.nextUrl.locale === FAKE_LOCALE) {
     // Apparently, the built-in `localeDetection`from Next does not work when
     // using the faked locale hack. So, we need to detect the locale manually

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -40,7 +40,7 @@ export const config = {
 export async function middleware(req: NextRequest) {
   const { pathname, locale } = req.nextUrl
 
-  if (PUBLIC_FILE.test(pathname)) {
+  if (pathname.startsWith("/_next") || PUBLIC_FILE.test(pathname)) {
     return NextResponse.next()
   }
 


### PR DESCRIPTION
Our current implementation has odd behavior when serving static files that are compressed. Depending on the browser, it will serve files using `gzip` or `br`, since the same browsers support both algorithms (same req header in all these browsers: `Accept-Encoding: gzip, deflate, br, zstd`).

We would like to always serve the `br` version as it is much lighter than the `gzip` version. For example, the `_app.js` bundle size drops from ~330kb to ~215kb when using Brotli.

The issue is related to the custom middleware we use to redirect requests to different locales. Currently, we process all incoming requests (which is not necessary) and for some reason this seems to cause a conflict with the netlify server which ends up serving `gzip` files instead.

## Description

This PR adds a custom `matcher` to the exported middleware config to only process the matched paths and ignore the rest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced middleware to handle locales and redirects more effectively.
  - Introduced configuration to exclude specific paths from middleware processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->