### PR TITLE
Update EIP-1559 transaction type information for wallets

### DIFF
--- a/.github/ISSUE_TEMPLATE/suggest_wallet.yaml
+++ b/.github/ISSUE_TEMPLATE/suggest_wallet.yaml
@@ -293,7 +293,7 @@ body:
     id: wallet_eip_1559_support
     attributes:
       label: Does the wallet support EIP-1559 (type 2) transactions?
-      description: Please provide information on the type of transactions this wallet supports.
+      description: Does your wallet support EIP-1559 (type 2) transactions for Ethereum Mainnet. Please provide information on the type of transactions this wallet supports. If this is not applicable, please explain. 
     validations:
       required: true
   - type: textarea

--- a/public/content/contributing/adding-wallets/index.md
+++ b/public/content/contributing/adding-wallets/index.md
@@ -25,7 +25,7 @@ Wallets are rapidly changing in Ethereum. We've tried to create a fair framework
 - **Worked on by an active team** - this helps to ensure quality and that a user will get support for their queries.
 - **Honest and accurate listing information** - it is expected that any suggested listings from projects come with honest and accurate information. Products that falsify listing information, such as declaring your product is “open source” when it is not, will be removed.
 - **Point of contact** - A point of contact for the wallet will greatly help us get accurate information when changes are made. This will keep updating ethereum.org manageable when gathering future information.
-- **EIP-1559 (type 2) transactions** - your wallet must support EIP-1559 (type 2) transactions.
+- **EIP-1559 (type 2) transactions** - your wallet must support EIP-1559 (type 2) transactions for transactions on Mainnet Ethereum.
 - **Good user experience** - While UX is subjective, if several core team members test the product and find it difficult to use, we reserve the right to reject the wallet and will instead provide useful suggestions to improve. This is done to protect our user base that is mostly comprised of beginners. 
 
 ### Product removals {#product-removals}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Update description for EIP-1559 (type 2) transactions for wallet listing. This is required for Ethereum Mainnet, but for wallets that don't support mainnet and are layer 2 first wallets, they may not have this. 
