### PR TITLE
fix: replaced `add a community event` url on /community/events/

### DIFF
--- a/public/content/community/events/index.md
+++ b/public/content/community/events/index.md
@@ -11,7 +11,7 @@ hideEditButton: true
 
 <UpcomingEventsList/>
 
-This is a non-exhaustive list maintained by our community. Know of an upcoming Ethereum event to add to this list? [Please add it](https://github.com/ethereum/ethereum-org-website/blob/dev/src/data/community-events.ts)!
+This is a non-exhaustive list maintained by our community. Know of an upcoming Ethereum event to add to this list? [Please add it](https://github.com/ethereum/ethereum-org-website/blob/dev/src/data/community-events.json)!
 
 ## Ethereum meetups {#meetups}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes #12961 
## Description

Replaced "add a community event" URL .ts on /community/events/ page.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
