### PR TITLE
Fix: add explicit matcher for the root path to work on dev mode

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -23,13 +23,11 @@ function detectLocale(acceptLanguage: string | null) {
 
 export const config = {
   matcher: [
+    "/", // explicit matcher for root route
     /*
      * Match all request paths except for the ones starting with:
      * - api (API routes)
      * - _next/static (static files)
-     * - _next/image (image optimization files)
-     * - favicon.ico (favicon file)
-     * - .well-known (security files)
      */
     "/((?!api|_next/static).*)",
   ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds missing root route to the middleware matcher.