### PR TITLE
Update broken Crowdin link on translated Translation program page

### DIFF
--- a/public/content/translations/es/contributing/translation-program/how-to-translate/index.md
+++ b/public/content/translations/es/contributing/translation-program/how-to-translate/index.md
@@ -18,7 +18,7 @@ Para quienes aprenden mejor observando, vean la guía paso a paso de Luka para c
 
 Deberá iniciar sesión en su cuenta de Crowdin o registrarse si aún no tiene una. Para registrarse solo necesita una cuenta de correo electrónico y una contraseña.
 
-<ButtonLink to="https://crowdin.com/project/ethereum-org/invite">
+<ButtonLink to="https://crowdin.com/project/ethereum-org/">
   Únase al proyecto
 </ButtonLink>
 

--- a/public/content/translations/es/contributing/translation-program/index.md
+++ b/public/content/translations/es/contributing/translation-program/index.md
@@ -22,7 +22,7 @@ El programa de traducción es un esfuerzo colaborativo para traducir ethereum.or
 
 _Únase a [ethereum.org Discord](/discord/) para colaborar en traducciones, hacer preguntas, compartir comentarios e ideas o unirse a un grupo de traducción._
 
-<ButtonLink to="https://crowdin.com/project/ethereum-org/invite">
+<ButtonLink to="https://crowdin.com/project/ethereum-org/">
   Empezar a traducir
 </ButtonLink>
 

--- a/public/content/translations/fr/contributing/translation-program/how-to-translate/index.md
+++ b/public/content/translations/fr/contributing/translation-program/how-to-translate/index.md
@@ -18,7 +18,7 @@ Pour les apprenants plus visuels, regardez la vidéo de Luka qui présente le pa
 
 Vous devrez vous connecter à votre compte Crowdin ou vous inscrire si vous n'avez pas encore de compte. Tout ce qui est nécessaire pour vous inscrire est un compte de messagerie et un mot de passe.
 
-<ButtonLink to="https://crowdin.com/project/ethereum-org/invite">
+<ButtonLink to="https://crowdin.com/project/ethereum-org/">
   Rejoindre le projet
 </ButtonLink>
 

--- a/public/content/translations/fr/contributing/translation-program/index.md
+++ b/public/content/translations/fr/contributing/translation-program/index.md
@@ -22,7 +22,7 @@ Le programme de traduction d'ethereum.org est ouvert et n'importe qui peut y con
 
 _Rejoignez [ethereum.org Discord](/discord/) pour collaborer aux traductions, poser des questions, partager des commentaires et des idées, ou rejoindre un groupe de traduction._
 
-<ButtonLink to="https://crowdin.com/project/ethereum-org/invite">
+<ButtonLink to="https://crowdin.com/project/ethereum-org/">
   Commencez à traduire
 </ButtonLink>
 

--- a/public/content/translations/it/contributing/translation-program/how-to-translate/index.md
+++ b/public/content/translations/it/contributing/translation-program/how-to-translate/index.md
@@ -18,7 +18,7 @@ Se preferisci un approccio più visivo, consulta la guida di Luka per l'impostaz
 
 Dovrai accedere al tuo profilo di Crowdin o registrarti se non ne hai già uno. Per iscriversi bastano un account di posta elettronica e una password.
 
-<ButtonLink to="https://crowdin.com/project/ethereum-org/invite">
+<ButtonLink to="https://crowdin.com/project/ethereum-org/">
   Unisciti al progetto
 </ButtonLink>
 

--- a/public/content/translations/it/contributing/translation-program/index.md
+++ b/public/content/translations/it/contributing/translation-program/index.md
@@ -22,7 +22,7 @@ Il Programma di Traduzione di ethereum.org è aperto e tutti possono contribuire
 
 _Unisciti a [Discord di ethereum.org](/discord/) per collaborare alle traduzioni, fare domande, condividere feedback e idee, o unirsi a un gruppo di traduzione._
 
-<ButtonLink to="https://crowdin.com/project/ethereum-org/invite">
+<ButtonLink to="https://crowdin.com/project/ethereum-org/">
   Inizia a tradurre
 </ButtonLink>
 

--- a/public/content/translations/pt-br/contributing/translation-program/how-to-translate/index.md
+++ b/public/content/translations/pt-br/contributing/translation-program/how-to-translate/index.md
@@ -18,7 +18,7 @@ Para as pessoas que aprendem melhor de forma visual, assistam ao vídeo do Luka 
 
 Você precisará fazer login na sua conta do Crowdin ou criar uma conta, caso ainda não tenha. Você só precisa de uma conta de e-mail e senha para se cadastrar.
 
-<ButtonLink to="https://crowdin.com/project/ethereum-org/invite">
+<ButtonLink to="https://crowdin.com/project/ethereum-org/">
   Junte-se ao projeto
 </ButtonLink>
 

--- a/public/content/translations/pt-br/contributing/translation-program/index.md
+++ b/public/content/translations/pt-br/contributing/translation-program/index.md
@@ -22,7 +22,7 @@ O Programa de Tradução do ethereum.org está aberto e qualquer um pode contrib
 
 _Junte-se ao [ethereum.org Discord](/discord/) para colaborar com traduções, fazer perguntas, compartilhar comentários e ideias ou juntar-se a um grupo de tradução._
 
-<ButtonLink to="https://crowdin.com/project/ethereum-org/invite">
+<ButtonLink to="https://crowdin.com/project/ethereum-org/">
   Comece a traduzir
 </ButtonLink>
 


### PR DESCRIPTION
## Description

Update link to the ethereum.org Crowdin project on translated versions of the Translation program page, as the old link (https://crowdin.com/project/ethereum-org/invite) does not work

## Related Issue

No related issue
