### PR TITLE
fix: labeler yml syntax, add labeler refining step

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -29,12 +29,10 @@
 "translation 🌍":
   - public/content/translations/**/*
   - src/intl/**/*
-  - !src/intl/en/**
 
 "content 🖋️":
   - src/intl/en/**
   - public/content/**/*
-  - !public/content/translations/**/*
 
 "event 📅":
   - src/data/community-events.json

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -11,3 +11,26 @@ jobs:
       - uses: actions/labeler@v2
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Refine labels
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            try {
+              const { owner, repo, number: pull_number } = context.issue;
+              const { data: files } = await github.pulls.listFiles({ owner, repo, pull_number });
+
+              const allInEn = files.every(file => file.filename.startsWith('src/intl/en/'));
+              const allInTranslations = files.every(file => file.filename.startsWith('public/content/translations/'));
+              
+              if (allInEn) {
+                await github.issues.removeLabel({ owner, repo, issue_number: pull_number, name: 'translation 🌍' });
+              }
+              
+              if (allInTranslations) {
+                await github.issues.removeLabel({ owner, repo, issue_number: pull_number, name: 'content 🖋️' });
+              }
+            } catch (error) {
+              console.warn("Problem occurred refining labels")
+            }


### PR DESCRIPTION
## Description
- `- !src/intl/en/**` syntax invalid for `actions/labeler@v2` config `yml`
- Removes these conditions, and added a follow-up task that updates the labels that match those conditions
- This helps keep English content updates/additions labeled separately from non-English translation updates
- Fixes labeler action failures