### PR TITLE
performance: avoid desktop/mobile menus unnecesary renderings

### DIFF
--- a/src/components/LanguagePicker/MobileCloseBar.tsx
+++ b/src/components/LanguagePicker/MobileCloseBar.tsx
@@ -1,0 +1,28 @@
+import { MouseEventHandler } from "react"
+import { useTranslation } from "next-i18next"
+import { Flex } from "@chakra-ui/react"
+
+import { Button } from "@/components/Buttons"
+
+type MobileCloseBarProps = {
+  handleClick: MouseEventHandler<HTMLButtonElement>
+}
+
+export const MobileCloseBar = ({ handleClick }: MobileCloseBarProps) => {
+  const { t } = useTranslation()
+
+  return (
+    <Flex
+      justifyContent="end"
+      hideFrom="md"
+      position="sticky"
+      zIndex="sticky"
+      top="0"
+      bg="background.base"
+    >
+      <Button p="4" variant="ghost" alignSelf="end" onClick={handleClick}>
+        {t("close")}
+      </Button>
+    </Flex>
+  )
+}

--- a/src/components/LanguagePicker/index.tsx
+++ b/src/components/LanguagePicker/index.tsx
@@ -16,6 +16,8 @@ import {
   useEventListener,
 } from "@chakra-ui/react"
 
+import { LocaleDisplayInfo } from "@/lib/types"
+
 import { Button } from "@/components/Buttons"
 import { BaseLink } from "@/components/Link"
 
@@ -61,22 +63,38 @@ const LanguagePicker = ({
     inputRef.current?.focus()
   })
 
-  const MobileCloseBar = () => {
-    return (
-      <Flex
-        justifyContent="end"
-        hideFrom="md"
-        position="sticky"
-        zIndex="sticky"
-        top="0"
-        bg="background.base"
+  // onClick handlers
+  const handleMobileCloseBarClick = () => onClose()
+  const handleMenuItemClose = (displayInfo: LocaleDisplayInfo) =>
+    onClose({
+      eventAction: "Locale chosen",
+      eventName: displayInfo.localeOption,
+    })
+  const handleBaseLinkClose = () =>
+    onClose({
+      eventAction: "Translation program link (menu footer)",
+      eventName: "/contributing/translation-program",
+    })
+
+  const MobileCloseBar = () => (
+    <Flex
+      justifyContent="end"
+      hideFrom="md"
+      position="sticky"
+      zIndex="sticky"
+      top="0"
+      bg="background.base"
+    >
+      <Button
+        p="4"
+        variant="ghost"
+        alignSelf="end"
+        onClick={handleMobileCloseBarClick}
       >
-        <Button p="4" variant="ghost" alignSelf="end" onClick={() => onClose()}>
-          {t("common:close")}
-        </Button>
-      </Flex>
-    )
-  }
+        {t("common:close")}
+      </Button>
+    </Flex>
+  )
 
   return (
     <Menu isLazy placement={placement} autoSelect={false} {...disclosure}>
@@ -178,12 +196,7 @@ const LanguagePicker = ({
                   e.preventDefault()
                   inputRef.current?.focus()
                 }}
-                onClick={() =>
-                  onClose({
-                    eventAction: "Locale chosen",
-                    eventName: displayInfo.localeOption,
-                  })
-                }
+                onClick={() => handleMenuItemClose(displayInfo)}
               />
             ))}
 
@@ -216,12 +229,7 @@ const LanguagePicker = ({
             <BaseLink
               ref={footerRef}
               href="/contributing/translation-program"
-              onClick={() =>
-                onClose({
-                  eventAction: "Translation program link (menu footer)",
-                  eventName: "/contributing/translation-program",
-                })
-              }
+              onClick={handleBaseLinkClose}
             >
               {t("common:learn-more")}
             </BaseLink>

--- a/src/components/LanguagePicker/index.tsx
+++ b/src/components/LanguagePicker/index.tsx
@@ -18,12 +18,12 @@ import {
 
 import { LocaleDisplayInfo } from "@/lib/types"
 
-import { Button } from "@/components/Buttons"
 import { BaseLink } from "@/components/Link"
 
 import { isMobile } from "@/lib/utils/isMobile"
 
 import MenuItem from "./MenuItem"
+import { MobileCloseBar } from "./MobileCloseBar"
 import NoResultsCallout from "./NoResultsCallout"
 import { useLanguagePicker } from "./useLanguagePicker"
 
@@ -76,26 +76,6 @@ const LanguagePicker = ({
       eventName: "/contributing/translation-program",
     })
 
-  const MobileCloseBar = () => (
-    <Flex
-      justifyContent="end"
-      hideFrom="md"
-      position="sticky"
-      zIndex="sticky"
-      top="0"
-      bg="background.base"
-    >
-      <Button
-        p="4"
-        variant="ghost"
-        alignSelf="end"
-        onClick={handleMobileCloseBarClick}
-      >
-        {t("common:close")}
-      </Button>
-    </Flex>
-  )
-
   return (
     <Menu isLazy placement={placement} autoSelect={false} {...disclosure}>
       {children}
@@ -114,7 +94,9 @@ const LanguagePicker = ({
       >
         {/* Mobile Close bar */}
         {/* avoid rendering mobile only feature on desktop */}
-        {isMobile() && <MobileCloseBar />}
+        {isMobile() && (
+          <MobileCloseBar handleClick={handleMobileCloseBarClick} />
+        )}
 
         {/* Main Language selection menu */}
         <Box

--- a/src/components/LanguagePicker/index.tsx
+++ b/src/components/LanguagePicker/index.tsx
@@ -19,6 +19,8 @@ import {
 import { Button } from "@/components/Buttons"
 import { BaseLink } from "@/components/Link"
 
+import { isMobile } from "@/lib/utils/isMobile"
+
 import MenuItem from "./MenuItem"
 import NoResultsCallout from "./NoResultsCallout"
 import { useLanguagePicker } from "./useLanguagePicker"
@@ -59,6 +61,23 @@ const LanguagePicker = ({
     inputRef.current?.focus()
   })
 
+  const MobileCloseBar = () => {
+    return (
+      <Flex
+        justifyContent="end"
+        hideFrom="md"
+        position="sticky"
+        zIndex="sticky"
+        top="0"
+        bg="background.base"
+      >
+        <Button p="4" variant="ghost" alignSelf="end" onClick={() => onClose()}>
+          {t("common:close")}
+        </Button>
+      </Flex>
+    )
+  }
+
   return (
     <Menu isLazy placement={placement} autoSelect={false} {...disclosure}>
       {children}
@@ -76,23 +95,8 @@ const LanguagePicker = ({
         {...props}
       >
         {/* Mobile Close bar */}
-        <Flex
-          justifyContent="end"
-          hideFrom="md"
-          position="sticky"
-          zIndex="sticky"
-          top="0"
-          bg="background.base"
-        >
-          <Button
-            p="4"
-            variant="ghost"
-            alignSelf="end"
-            onClick={() => onClose()}
-          >
-            {t("common:close")}
-          </Button>
-        </Flex>
+        {/* avoid rendering mobile only feature on desktop */}
+        {isMobile() && <MobileCloseBar />}
 
         {/* Main Language selection menu */}
         <Box
@@ -146,10 +150,7 @@ const LanguagePicker = ({
                 }}
                 onFocus={handleInputFocus}
               />
-              <InputRightElement
-                hideBelow="md"
-                cursor="text"
-              >
+              <InputRightElement hideBelow="md" cursor="text">
                 <Kbd
                   fontSize="sm"
                   lineHeight="none"

--- a/src/components/Nav/Menu/index.tsx
+++ b/src/components/Nav/Menu/index.tsx
@@ -4,6 +4,8 @@ import * as NavigationMenu from "@radix-ui/react-navigation-menu"
 
 import { Button } from "@/components/Buttons"
 
+import { isMobile } from "@/lib/utils/isMobile"
+
 import { MAIN_NAV_ID, NAV_PY, SECTION_LABELS } from "@/lib/constants"
 
 import type { NavSections } from "../types"
@@ -25,6 +27,8 @@ const Menu = ({ sections, ...props }: NavMenuProps) => {
     menuColors,
     onClose,
   } = useNavMenu(sections)
+
+  const isDesktop = !isMobile()
 
   return (
     <Box {...props}>
@@ -78,32 +82,37 @@ const Menu = ({ sections, ...props }: NavMenuProps) => {
                       </Text>
                     </Button>
                   </NavigationMenu.Trigger>
-                  <NavigationMenu.Content asChild>
-                    {/**
-                     * This is the CONTAINER for all three menu levels
-                     * This renders inside the NavigationMenu.Viewport component
-                     */}
-                    <Box
-                      as={motion.div}
-                      variants={containerVariants}
-                      initial={false}
-                      animate={isOpen ? "open" : "closed"}
-                      position="absolute"
-                      top="19"
-                      insetInline="0"
-                      shadow="md"
-                      border="1px"
-                      borderColor={menuColors.stroke}
-                      bg={menuColors.lvl[1].background}
-                    >
-                      <SubMenu
-                        lvl={1}
-                        items={items}
-                        activeSection={activeSection}
-                        onClose={onClose}
-                      />
-                    </Box>
-                  </NavigationMenu.Content>
+
+                  {/* avoid rendering desktop menu on mobile */}
+                  {/* Desktop Menu content */}
+                  {isDesktop && (
+                    <NavigationMenu.Content asChild>
+                      {/**
+                       * This is the CONTAINER for all three menu levels
+                       * This renders inside the NavigationMenu.Viewport component
+                       */}
+                      <Box
+                        as={motion.div}
+                        variants={containerVariants}
+                        initial={false}
+                        animate={isOpen ? "open" : "closed"}
+                        position="absolute"
+                        top="19"
+                        insetInline="0"
+                        shadow="md"
+                        border="1px"
+                        borderColor={menuColors.stroke}
+                        bg={menuColors.lvl[1].background}
+                      >
+                        <SubMenu
+                          lvl={1}
+                          items={items}
+                          activeSection={activeSection}
+                          onClose={onClose}
+                        />
+                      </Box>
+                    </NavigationMenu.Content>
+                  )}
                 </NavigationMenu.Item>
               )
             })}

--- a/src/components/Nav/Menu/index.tsx
+++ b/src/components/Nav/Menu/index.tsx
@@ -78,9 +78,6 @@ const Menu = ({ sections, ...props }: NavMenuProps) => {
                       </Text>
                     </Button>
                   </NavigationMenu.Trigger>
-
-                  {/* avoid rendering desktop menu on mobile */}
-                  {/* Desktop Menu content */}
                   <NavigationMenu.Content asChild>
                     {/**
                      * This is the CONTAINER for all three menu levels

--- a/src/components/Nav/Menu/index.tsx
+++ b/src/components/Nav/Menu/index.tsx
@@ -4,8 +4,6 @@ import * as NavigationMenu from "@radix-ui/react-navigation-menu"
 
 import { Button } from "@/components/Buttons"
 
-import { isMobile } from "@/lib/utils/isMobile"
-
 import { MAIN_NAV_ID, NAV_PY, SECTION_LABELS } from "@/lib/constants"
 
 import type { NavSections } from "../types"
@@ -27,8 +25,6 @@ const Menu = ({ sections, ...props }: NavMenuProps) => {
     menuColors,
     onClose,
   } = useNavMenu(sections)
-
-  const isDesktop = !isMobile()
 
   return (
     <Box {...props}>
@@ -85,34 +81,32 @@ const Menu = ({ sections, ...props }: NavMenuProps) => {
 
                   {/* avoid rendering desktop menu on mobile */}
                   {/* Desktop Menu content */}
-                  {isDesktop && (
-                    <NavigationMenu.Content asChild>
-                      {/**
-                       * This is the CONTAINER for all three menu levels
-                       * This renders inside the NavigationMenu.Viewport component
-                       */}
-                      <Box
-                        as={motion.div}
-                        variants={containerVariants}
-                        initial={false}
-                        animate={isOpen ? "open" : "closed"}
-                        position="absolute"
-                        top="19"
-                        insetInline="0"
-                        shadow="md"
-                        border="1px"
-                        borderColor={menuColors.stroke}
-                        bg={menuColors.lvl[1].background}
-                      >
-                        <SubMenu
-                          lvl={1}
-                          items={items}
-                          activeSection={activeSection}
-                          onClose={onClose}
-                        />
-                      </Box>
-                    </NavigationMenu.Content>
-                  )}
+                  <NavigationMenu.Content asChild>
+                    {/**
+                     * This is the CONTAINER for all three menu levels
+                     * This renders inside the NavigationMenu.Viewport component
+                     */}
+                    <Box
+                      as={motion.div}
+                      variants={containerVariants}
+                      initial={false}
+                      animate={isOpen ? "open" : "closed"}
+                      position="absolute"
+                      top="19"
+                      insetInline="0"
+                      shadow="md"
+                      border="1px"
+                      borderColor={menuColors.stroke}
+                      bg={menuColors.lvl[1].background}
+                    >
+                      <SubMenu
+                        lvl={1}
+                        items={items}
+                        activeSection={activeSection}
+                        onClose={onClose}
+                      />
+                    </Box>
+                  </NavigationMenu.Content>
                 </NavigationMenu.Item>
               )
             })}

--- a/src/components/Nav/index.tsx
+++ b/src/components/Nav/index.tsx
@@ -22,6 +22,8 @@ import LanguagePicker from "@/components/LanguagePicker"
 import { BaseLink } from "@/components/Link"
 import Search from "@/components/Search"
 
+import { isMobile } from "@/lib/utils/isMobile"
+
 import { DESKTOP_LANGUAGE_BUTTON_NAME, NAV_PY } from "@/lib/constants"
 
 import Menu from "./Menu"
@@ -33,6 +35,7 @@ const Nav = () => {
   const { toggleColorMode, linkSections, mobileNavProps } = useNav()
   const { locale } = useRouter()
   const { t } = useTranslation("common")
+  const isDesktop = !isMobile()
   const searchModalDisclosure = useDisclosure()
   const navWrapperRef = useRef(null)
   const languagePickerState = useDisclosure()
@@ -95,76 +98,80 @@ const Nav = () => {
             justifyContent={{ base: "flex-end", md: "space-between" }}
             ms={{ base: 3, xl: 8 }}
           >
-            <Menu hideBelow="md" sections={linkSections} />
+            {/* avoid rendering desktop Menu version on mobile */}
+            {isDesktop && <Menu hideBelow="md" sections={linkSections} />}
+
             <Flex alignItems="center" /*  justifyContent="space-between" */>
               <Search {...searchModalDisclosure} />
-
               {/* Desktop */}
-              <HStack hideBelow="md" gap="0">
-                <IconButton
-                  transition="transform 0.5s, color 0.2s"
-                  icon={ThemeIcon}
-                  aria-label={themeIconAriaLabel}
-                  variant="ghost"
-                  isSecondary
-                  px={{ base: "2", xl: "3" }}
-                  _hover={{
-                    transform: "rotate(10deg)",
-                    color: "primary.hover",
-                  }}
-                  onClick={toggleColorMode}
-                />
-
-                {/* Locale-picker menu */}
-                <LanguagePicker
-                  placement="bottom-end"
-                  minH="unset"
-                  maxH="75vh"
-                  w="xs"
-                  inset="unset"
-                  top="unset"
-                  menuState={languagePickerState}
-                >
-                  <MenuButton
-                    as={Button}
-                    name={DESKTOP_LANGUAGE_BUTTON_NAME}
-                    ref={languagePickerRef}
+              {/* avoid rendering desktop LanguagePicker version on mobile */}
+              {isDesktop && (
+                <HStack hideBelow="md" gap="0">
+                  <IconButton
+                    transition="transform 0.5s, color 0.2s"
+                    icon={ThemeIcon}
+                    aria-label={themeIconAriaLabel}
                     variant="ghost"
-                    color="body.base"
-                    transition="color 0.2s"
+                    isSecondary
                     px={{ base: "2", xl: "3" }}
                     _hover={{
+                      transform: "rotate(10deg)",
                       color: "primary.hover",
-                      "& svg": {
-                        transform: "rotate(10deg)",
-                        transition: "transform 0.5s",
-                      },
                     }}
-                    _active={{
-                      color: "primary.hover",
-                      bg: "primary.lowContrast",
-                    }}
-                    sx={{
-                      "& svg": {
-                        transform: "rotate(0deg)",
-                        transition: "transform 0.5s",
-                      },
-                    }}
+                    onClick={toggleColorMode}
+                  />
+
+                  {/* Locale-picker menu */}
+                  <LanguagePicker
+                    placement="bottom-end"
+                    minH="unset"
+                    maxH="75vh"
+                    w="xs"
+                    inset="unset"
+                    top="unset"
+                    menuState={languagePickerState}
                   >
-                    <Icon
-                      as={BsTranslate}
-                      fontSize="2xl"
-                      verticalAlign="middle"
-                      me={2}
-                    />
-                    <Text hideBelow="lg" as="span">
-                      {t("common:languages")}&nbsp;
-                    </Text>
-                    {locale!.toUpperCase()}
-                  </MenuButton>
-                </LanguagePicker>
-              </HStack>
-              {/* Mobile */}
+                    <MenuButton
+                      as={Button}
+                      name={DESKTOP_LANGUAGE_BUTTON_NAME}
+                      ref={languagePickerRef}
+                      variant="ghost"
+                      color="body.base"
+                      transition="color 0.2s"
+                      px={{ base: "2", xl: "3" }}
+                      _hover={{
+                        color: "primary.hover",
+                        "& svg": {
+                          transform: "rotate(10deg)",
+                          transition: "transform 0.5s",
+                        },
+                      }}
+                      _active={{
+                        color: "primary.hover",
+                        bg: "primary.lowContrast",
+                      }}
+                      sx={{
+                        "& svg": {
+                          transform: "rotate(0deg)",
+                          transition: "transform 0.5s",
+                        },
+                      }}
+                    >
+                      <Icon
+                        as={BsTranslate}
+                        fontSize="2xl"
+                        verticalAlign="middle"
+                        me={2}
+                      />
+                      <Text hideBelow="lg" as="span">
+                        {t("common:languages")}&nbsp;
+                      </Text>
+                      {locale!.toUpperCase()}
+                    </MenuButton>
+                  </LanguagePicker>
+                </HStack>
+              )}
+
               <MobileNavMenu
                 {...mobileNavProps}
                 linkSections={linkSections}


### PR DESCRIPTION
This PR avoids unnecesary nav menus renderings on desktop/mobile

## Description

- avoids rendering desktop Menu version on mobile
- avoids rendering desktop LanguagePicker version on mobile
- extracts `MobileCloseBar` component and renders on mobile only
- moves `LanguagePicker` handlers to external functions to avoid re-creating them on each render