### PR TITLE
chore: update Japanese translation for developers docs navigation

### DIFF
--- a/src/intl/ja/page-developers-docs.json
+++ b/src/intl/ja/page-developers-docs.json
@@ -28,7 +28,7 @@
   "docs-nav-design-fundamentals": "デザインの基礎",
   "docs-nav-development-frameworks": "開発フレームワーク",
   "docs-nav-development-frameworks-description": "イーサリアムでの開発を容易にするツール",
-  "docs-nav-development-networks": "開発フレームワーク",
+  "docs-nav-development-networks": "開発用ネットワーク",
   "docs-nav-development-networks-description": "デプロイ前の分散型アプリ(Dapp)テストに使用されるローカルブロックチェーン環境",
   "docs-nav-dot-net": ".NET",
   "docs-nav-erc-20": "ERC-20: 代替可能トークン",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

In the side menu, where it should have been Development Network(開発用ネットワーク), it was Development Framework(開発フレームワーク), which has been corrected.

<img width="387" alt="スクリーンショット 2024-06-09 19 30 57" src="https://github.com/ethereum/ethereum-org-website/assets/701242/1cbb8346-c7af-406b-8c72-109ab39fb0b9">

https://ethereum.org/en/developers/docs/development-networks/

<img width="421" alt="スクリーンショット 2024-06-09 19 30 52" src="https://github.com/ethereum/ethereum-org-website/assets/701242/d8a41667-4a28-4703-8193-b1f76b585d12">

https://ethereum.org/ja/developers/docs/development-networks/

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
