### PR TITLE
fix: add url to dapp listing template

### DIFF
--- a/.github/ISSUE_TEMPLATE/suggest_dapp.yaml
+++ b/.github/ISSUE_TEMPLATE/suggest_dapp.yaml
@@ -24,6 +24,13 @@ body:
       description: Please provide the official name of the dapp
     validations:
       required: true
+  - type: input
+    id: dapp_url
+    attributes:
+      label: Dapp URL
+      description: Please provide a URL to the dapp
+    validations:
+      required: true
   - type: textarea
     id: dapp_description
     attributes:


### PR DESCRIPTION
## Description
- Add required "url" input for `suggest_dapp.yaml` issue template

## Related Issue
- Discovered during issue reviews; dapp listing requests lacking this information