### PR TITLE
added a link for the beacon deposit contract on etherscan

### DIFF
--- a/public/content/developers/docs/consensus-mechanisms/pos/rewards-and-penalties/index.md
+++ b/public/content/developers/docs/consensus-mechanisms/pos/rewards-and-penalties/index.md
@@ -4,7 +4,7 @@ description: Learn about the in-protocol incentives in proof-of-stake Ethereum.
 lang: en
 ---
 
-Ethereum is secured using its native cryptocurrency, ether (ETH). Node operators that wish to participate in validating blocks and identifying the head of the chain deposit ether into a smart contract on Ethereum. They are then paid in ether to run validator software that checks the validity of new blocks received over the peer-to-peer network and apply the fork-choice algorithm to identify the head of the chain.
+Ethereum is secured using its native cryptocurrency, ether (ETH). Node operators that wish to participate in validating blocks and identifying the head of the chain, deposit ether into a [deposit smart contract](https://etherscan.io/address/0x00000000219ab540356cbb839cbe05303d7705fa) on Ethereum. They are then paid in ether to run validator software that checks the validity of new blocks received over the peer-to-peer network and apply the fork-choice algorithm to identify the head of the chain.
 
 There are two primary roles for a validator: 1) checking new blocks and “attesting” to them if they are valid, 2) proposing new blocks when selected at random from the total validator pool. If the validator fails to do either of these tasks when asked they miss out on an ether payout. Validators are also sometimes tasked with signature aggregation and participating in sync committees.
 

--- a/public/content/developers/docs/consensus-mechanisms/pos/rewards-and-penalties/index.md
+++ b/public/content/developers/docs/consensus-mechanisms/pos/rewards-and-penalties/index.md
@@ -4,7 +4,7 @@ description: Learn about the in-protocol incentives in proof-of-stake Ethereum.
 lang: en
 ---
 
-Ethereum is secured using its native cryptocurrency, ether (ETH). Node operators that wish to participate in validating blocks and identifying the head of the chain, deposit ether into a [deposit smart contract](https://etherscan.io/address/0x00000000219ab540356cbb839cbe05303d7705fa) on Ethereum. They are then paid in ether to run validator software that checks the validity of new blocks received over the peer-to-peer network and apply the fork-choice algorithm to identify the head of the chain.
+Ethereum is secured using its native cryptocurrency, ether (ETH). Node operators that wish to participate in validating blocks and identifying the head of the chain, deposit ether into the [deposit contract](/staking/deposit-contract/) on Ethereum. They are then paid in ether to run validator software that checks the validity of new blocks received over the peer-to-peer network and apply the fork-choice algorithm to identify the head of the chain.
 
 There are two primary roles for a validator: 1) checking new blocks and “attesting” to them if they are valid, 2) proposing new blocks when selected at random from the total validator pool. If the validator fails to do either of these tasks when asked they miss out on an ether payout. Validators are also sometimes tasked with signature aggregation and participating in sync committees.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to specify that node operators must deposit ether into a specific smart contract on Ethereum when participating in block validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->