### PR TITLE
specified that part of the bounty gets burned and the remainder awarded to the validator

### DIFF
--- a/public/content/developers/docs/intro-to-ethereum/index.md
+++ b/public/content/developers/docs/intro-to-ethereum/index.md
@@ -36,7 +36,7 @@ Cryptographic mechanisms ensure that once transactions are verified as valid and
 
 **Ether (ETH)** is the native cryptocurrency of Ethereum. The purpose of ETH is to allow for a market for computation. Such a market provides an economic incentive for participants to verify and execute transaction requests and provide computational resources to the network.
 
-Any participant who broadcasts a transaction request must also offer some amount of ETH to the network as a bounty. The network will award this bounty to whoever eventually does the work of verifying the transaction, executing it, committing it to the blockchain, and broadcasting it to the network.
+Any participant who broadcasts a transaction request must also offer some amount of ETH to the network as a bounty. The network will burn part of the bounty and award the rest to whoever eventually does the work of verifying the transaction, executing it, committing it to the blockchain, and broadcasting it to the network.
 
 The amount of ETH paid corresponds to the resources required to do the computation. These bounties also prevent malicious participants from intentionally clogging the network by requesting the execution of infinite computation or other resource-intensive scripts, as these participants must pay for computation resources.
 


### PR DESCRIPTION
…ded to the verifier

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the "Intro to Ethereum" documentation to reflect changes in the bounty handling mechanism in Ethereum transactions. Now, a portion of the bounty is burned, and the rest is awarded to the participant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->