### PR TITLE
fix: overlapping elements in LanguagePicker for RTL langs

### DIFF
--- a/src/components/LanguagePicker/index.tsx
+++ b/src/components/LanguagePicker/index.tsx
@@ -6,8 +6,8 @@ import {
   FormLabel,
   Input,
   InputGroup,
-  InputRightElement,
   InputLeftElement,
+  InputRightElement,
   Kbd,
   Menu,
   MenuList,
@@ -18,7 +18,7 @@ import {
   useEventListener,
 } from "@chakra-ui/react"
 
-import { LocaleDisplayInfo, Lang } from "@/lib/types"
+import { Lang,LocaleDisplayInfo } from "@/lib/types"
 
 import { BaseLink } from "@/components/Link"
 

--- a/src/components/LanguagePicker/index.tsx
+++ b/src/components/LanguagePicker/index.tsx
@@ -18,7 +18,7 @@ import {
   useEventListener,
 } from "@chakra-ui/react"
 
-import { Lang,LocaleDisplayInfo } from "@/lib/types"
+import { Lang, LocaleDisplayInfo } from "@/lib/types"
 
 import { BaseLink } from "@/components/Link"
 
@@ -138,6 +138,7 @@ const LanguagePicker = ({
                 mb="2"
                 bg="background.base"
                 color="body.base"
+                sx={isRtl ? { pl: 10, pr: 2 } : {}}
                 onKeyDown={(e) => {
                   // Navigate to first result on enter
                   if (e.key === "Enter") {
@@ -161,7 +162,7 @@ const LanguagePicker = ({
                   <Kbd
                     fontSize="sm"
                     lineHeight="none"
-                    ms="-2"
+                    ms="4"
                     p="1"
                     py="0.5"
                     me="auto"
@@ -170,7 +171,7 @@ const LanguagePicker = ({
                     color="disabled"
                     rounded="base"
                   >
-                    \
+                    /
                   </Kbd>
                 </InputLeftElement>
               ) : (

--- a/src/components/LanguagePicker/index.tsx
+++ b/src/components/LanguagePicker/index.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from "next/router"
 import {
   Box,
   Flex,
@@ -6,6 +7,7 @@ import {
   Input,
   InputGroup,
   InputRightElement,
+  InputLeftElement,
   Kbd,
   Menu,
   MenuList,
@@ -16,11 +18,12 @@ import {
   useEventListener,
 } from "@chakra-ui/react"
 
-import { LocaleDisplayInfo } from "@/lib/types"
+import { LocaleDisplayInfo, Lang } from "@/lib/types"
 
 import { BaseLink } from "@/components/Link"
 
 import { isMobile } from "@/lib/utils/isMobile"
+import { isLangRightToLeft } from "@/lib/utils/translations"
 
 import MenuItem from "./MenuItem"
 import { MobileCloseBar } from "./MobileCloseBar"
@@ -75,6 +78,9 @@ const LanguagePicker = ({
       eventAction: "Translation program link (menu footer)",
       eventName: "/contributing/translation-program",
     })
+
+  const { locale } = useRouter()
+  const isRtl = isLangRightToLeft(locale! as Lang)
 
   return (
     <Menu isLazy placement={placement} autoSelect={false} {...disclosure}>
@@ -150,22 +156,41 @@ const LanguagePicker = ({
                 }}
                 onFocus={handleInputFocus}
               />
-              <InputRightElement hideBelow="md" cursor="text">
-                <Kbd
-                  fontSize="sm"
-                  lineHeight="none"
-                  me="2"
-                  p="1"
-                  py="0.5"
-                  ms="auto"
-                  border="1px"
-                  borderColor="disabled"
-                  color="disabled"
-                  rounded="base"
-                >
-                  \
-                </Kbd>
-              </InputRightElement>
+              {isRtl ? (
+                <InputLeftElement hideBelow="md" cursor="text">
+                  <Kbd
+                    fontSize="sm"
+                    lineHeight="none"
+                    ms="-2"
+                    p="1"
+                    py="0.5"
+                    me="auto"
+                    border="1px"
+                    borderColor="disabled"
+                    color="disabled"
+                    rounded="base"
+                  >
+                    \
+                  </Kbd>
+                </InputLeftElement>
+              ) : (
+                <InputRightElement hideBelow="md" cursor="text">
+                  <Kbd
+                    fontSize="sm"
+                    lineHeight="none"
+                    me="2"
+                    p="1"
+                    py="0.5"
+                    ms="auto"
+                    border="1px"
+                    borderColor="disabled"
+                    color="disabled"
+                    rounded="base"
+                  >
+                    \
+                  </Kbd>
+                </InputRightElement>
+              )}
             </InputGroup>
 
             {filteredNames.map((displayInfo, index) => (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Fixed the overlapping keyboard shortcut `[\]` in the `LanguagePicker` component for right-to-left (RTL) languages.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #12965 

## Screenshot:

![image](https://github.com/ethereum/ethereum-org-website/assets/78664749/dd63d7d3-ced8-452c-9e25-89a889b3428b)


