### PR TITLE
Revalidate find-wallet page daily

### DIFF
--- a/src/pages/wallets/find-wallet.tsx
+++ b/src/pages/wallets/find-wallet.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/lib/utils/wallets"
 
 import {
+  BASE_TIME_UNIT,
   DEFAULT_LOCALE,
   NAV_BAR_PX_HEIGHT,
   WALLETS_FILTERS_DEFAULT,
@@ -81,6 +82,8 @@ export const getStaticProps = (async ({ locale }) => {
       lastDeployDate,
       wallets,
     },
+    // Updated once a day
+    revalidate: BASE_TIME_UNIT * 24,
   }
 }) satisfies GetStaticProps<Props>
 


### PR DESCRIPTION
Created from [this comment](https://github.com/ethereum/ethereum-org-website/pull/13066#pullrequestreview-2108854241) because we forgot to add `revalidate` to this page.