### PR TITLE
performance: get last edit/deploy locale timestamp for layouts on build time

### DIFF
--- a/src/components/FileContributors.tsx
+++ b/src/components/FileContributors.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react"
-import { useRouter } from "next/router"
 import {
   Avatar,
   Flex,
@@ -9,7 +8,7 @@ import {
   VStack,
 } from "@chakra-ui/react"
 
-import type { ChildOnlyProp, FileContributor, Lang } from "@/lib/types"
+import type { ChildOnlyProp, FileContributor } from "@/lib/types"
 
 import { Button } from "@/components/Buttons"
 import InlineLink from "@/components/Link"
@@ -18,7 +17,6 @@ import Text from "@/components/OldText"
 import Translation from "@/components/Translation"
 
 import { trackCustomEvent } from "@/lib/utils/matomo"
-import { getLocaleTimestamp } from "@/lib/utils/time"
 
 const ContributorList = ({ children }: Required<ChildOnlyProp>) => (
   <UnorderedList maxH="2xs" m={0} mt={6} overflowY="scroll">
@@ -44,16 +42,15 @@ const Contributor = ({ contributor }: ContributorProps) => (
 
 export type FileContributorsProps = FlexProps & {
   contributors: FileContributor[]
-  lastEdit: string
+  lastEditLocaleTimestamp: string
 }
 
 const FileContributors = ({
   contributors,
-  lastEdit,
+  lastEditLocaleTimestamp,
   ...props
 }: FileContributorsProps) => {
   const [isModalOpen, setModalOpen] = useState(false)
-  const { locale } = useRouter()
 
   const lastContributor: FileContributor = contributors.length
     ? contributors[0]
@@ -102,7 +99,7 @@ const FileContributors = ({
             <InlineLink href={"https://github.com/" + lastContributor.login}>
               @{lastContributor.login}
             </InlineLink>
-            , {getLocaleTimestamp(locale as Lang, lastEdit)}
+            , {lastEditLocaleTimestamp}
           </Text>
         </Flex>
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,4 +1,3 @@
-import { useRouter } from "next/router"
 import { useTranslation } from "next-i18next"
 import { FaDiscord, FaGithub, FaTwitter } from "react-icons/fa"
 import { IoChevronUpSharp } from "react-icons/io5"
@@ -13,13 +12,12 @@ import {
   Text,
 } from "@chakra-ui/react"
 
-import type { FooterLink, FooterLinkSection, Lang } from "@/lib/types"
+import type { FooterLink, FooterLinkSection } from "@/lib/types"
 
 import { BaseLink } from "@/components/Link"
 import Translation from "@/components/Translation"
 
 import { scrollIntoView } from "@/lib/utils/scrollIntoView"
-import { getLocaleTimestamp } from "@/lib/utils/time"
 
 import { Button } from "./Buttons"
 
@@ -42,11 +40,10 @@ const socialLinks = [
 ]
 
 type FooterProps = {
-  lastDeployDate: string
+  lastDeployLocaleTimestamp: string
 }
 
-const Footer = ({ lastDeployDate }: FooterProps) => {
-  const { locale } = useRouter()
+const Footer = ({ lastDeployLocaleTimestamp }: FooterProps) => {
   const { t } = useTranslation("common")
 
   const linkSections: FooterLinkSection[] = [
@@ -319,6 +316,7 @@ const Footer = ({ lastDeployDate }: FooterProps) => {
       fill: "primary.base",
     },
   }
+
   const linkProps = {
     isPartiallyActive: false,
     textDecor: "none",
@@ -335,7 +333,7 @@ const Footer = ({ lastDeployDate }: FooterProps) => {
   return (
     <Box as="footer" py="4" px="8">
       <Flex
-        justify={{ base: "center", md: 'space-between'}}
+        justify={{ base: "center", md: "space-between" }}
         alignItems="center"
         flexWrap="wrap"
         gap={8}
@@ -344,10 +342,10 @@ const Footer = ({ lastDeployDate }: FooterProps) => {
         borderTop={"1px solid"}
         borderColor={"body.light"}
       >
-        {lastDeployDate && (
+        {lastDeployLocaleTimestamp && (
           <Text fontSize={"sm"} fontStyle={"italic"} color={"body.medium"}>
             <Translation id="website-last-updated" />:{" "}
-            {getLocaleTimestamp(locale as Lang, lastDeployDate)}
+            {lastDeployLocaleTimestamp}
           </Text>
         )}
 
@@ -428,11 +426,7 @@ const Footer = ({ lastDeployDate }: FooterProps) => {
           m={0}
         >
           {dipperLinks.map(({ to, text }) => (
-            <ListItem
-              key={text}
-              textAlign="center"
-              px="2"
-            >
+            <ListItem key={text} textAlign="center" px="2">
               <BaseLink href={to} w={["100%", null]} {...linkProps}>
                 {text}
               </BaseLink>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -342,12 +342,9 @@ const Footer = ({ lastDeployLocaleTimestamp }: FooterProps) => {
         borderTop={"1px solid"}
         borderColor={"body.light"}
       >
-        {lastDeployLocaleTimestamp && (
-          <Text fontSize={"sm"} fontStyle={"italic"} color={"body.medium"}>
-            <Translation id="website-last-updated" />:{" "}
-            {lastDeployLocaleTimestamp}
-          </Text>
-        )}
+        <Text fontSize={"sm"} fontStyle={"italic"} color={"body.medium"}>
+          <Translation id="website-last-updated" />: {lastDeployLocaleTimestamp}
+        </Text>
 
         <Button
           leftIcon={<IoChevronUpSharp />}

--- a/src/layouts/Docs.tsx
+++ b/src/layouts/Docs.tsx
@@ -233,7 +233,7 @@ export const DocsLayout = ({
           <H1 id="top">{frontmatter.title}</H1>
           <FileContributors
             contributors={contributors}
-            lastEditLocaleTimestamp={lastEditLocaleTimestamp}
+            lastEditLocaleTimestamp={lastEditLocaleTimestamp!}
           />
           <TableOfContents
             slug={slug}

--- a/src/layouts/Docs.tsx
+++ b/src/layouts/Docs.tsx
@@ -201,7 +201,7 @@ type DocsLayoutProps = Pick<
   | "contributors"
   | "contentNotTranslated"
 > &
-  MdPageContent &
+  Required<Pick<MdPageContent, "lastEditLocaleTimestamp">> &
   ChildOnlyProp & {
     frontmatter: DocsFrontmatter
   }

--- a/src/layouts/Docs.tsx
+++ b/src/layouts/Docs.tsx
@@ -233,7 +233,7 @@ export const DocsLayout = ({
           <H1 id="top">{frontmatter.title}</H1>
           <FileContributors
             contributors={contributors}
-            lastEditLocaleTimestamp={lastEditLocaleTimestamp!}
+            lastEditLocaleTimestamp={lastEditLocaleTimestamp}
           />
           <TableOfContents
             slug={slug}

--- a/src/layouts/Docs.tsx
+++ b/src/layouts/Docs.tsx
@@ -197,11 +197,11 @@ type DocsLayoutProps = Pick<
   MdPageContent,
   | "slug"
   | "tocItems"
-  | "lastUpdatedDate"
+  | "lastEditLocaleTimestamp"
   | "contributors"
   | "contentNotTranslated"
 > &
-  Required<Pick<MdPageContent, "lastUpdatedDate">> &
+  MdPageContent &
   ChildOnlyProp & {
     frontmatter: DocsFrontmatter
   }
@@ -211,7 +211,7 @@ export const DocsLayout = ({
   frontmatter,
   slug,
   tocItems,
-  lastUpdatedDate,
+  lastEditLocaleTimestamp,
   contributors,
   contentNotTranslated,
 }: DocsLayoutProps) => {
@@ -233,7 +233,7 @@ export const DocsLayout = ({
           <H1 id="top">{frontmatter.title}</H1>
           <FileContributors
             contributors={contributors}
-            lastEdit={lastUpdatedDate}
+            lastEditLocaleTimestamp={lastEditLocaleTimestamp}
           />
           <TableOfContents
             slug={slug}

--- a/src/layouts/Roadmap.tsx
+++ b/src/layouts/Roadmap.tsx
@@ -9,7 +9,7 @@ import {
   WrapItem,
 } from "@chakra-ui/react"
 
-import type { ChildOnlyProp, TranslationKey } from "@/lib/types"
+import type { ChildOnlyProp } from "@/lib/types"
 import type { MdPageContent, RoadmapFrontmatter } from "@/lib/interfaces"
 
 import Breadcrumbs from "@/components/Breadcrumbs"

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -68,7 +68,7 @@ export const RootLayout = ({
 
       {children}
 
-      <Footer lastDeployLocaleTimestamp={lastDeployLocaleTimestamp} />
+      <Footer lastDeployLocaleTimestamp={lastDeployLocaleTimestamp!} />
       <FeedbackWidget />
     </Container>
   )

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -68,7 +68,7 @@ export const RootLayout = ({
 
       {children}
 
-      <Footer lastDeployLocaleTimestamp={lastDeployLocaleTimestamp!} />
+      <Footer lastDeployLocaleTimestamp={lastDeployLocaleTimestamp} />
       <FeedbackWidget />
     </Container>
   )

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -24,7 +24,7 @@ export const RootLayout = ({
   children,
   // contentIsOutdated,
   // contentNotTranslated,
-  lastDeployDate,
+  lastDeployLocaleTimestamp,
 }: Root) => {
   // const { locale, asPath } = useRouter()
 
@@ -68,7 +68,7 @@ export const RootLayout = ({
 
       {children}
 
-      <Footer lastDeployDate={lastDeployDate} />
+      <Footer lastDeployLocaleTimestamp={lastDeployLocaleTimestamp} />
       <FeedbackWidget />
     </Container>
   )

--- a/src/layouts/Static.tsx
+++ b/src/layouts/Static.tsx
@@ -33,7 +33,6 @@ import TranslationChartImage from "@/components/TranslationChartImage"
 import UpcomingEventsList from "@/components/UpcomingEventsList"
 
 import { getEditPath } from "@/lib/utils/editPath"
-import { getLocaleTimestamp } from "@/lib/utils/time"
 import { isLangRightToLeft } from "@/lib/utils/translations"
 
 import GuideHeroImage from "@/public/heroes/guides-hub-hero.jpg"
@@ -76,7 +75,7 @@ export const staticComponents = {
 type StaticLayoutProps = ChildOnlyProp &
   Pick<
     MdPageContent,
-    "slug" | "tocItems" | "lastUpdatedDate" | "contentNotTranslated"
+    "slug" | "tocItems" | "lastEditLocaleTimestamp" | "contentNotTranslated"
   > & {
     frontmatter: StaticFrontmatter
   }
@@ -85,7 +84,7 @@ export const StaticLayout = ({
   frontmatter,
   slug,
   tocItems,
-  lastUpdatedDate,
+  lastEditLocaleTimestamp,
   contentNotTranslated,
 }: StaticLayoutProps) => {
   const { locale, asPath } = useRouter()
@@ -115,13 +114,13 @@ export const StaticLayout = ({
           ) : (
             <>
               <Breadcrumbs slug={slug} mb="8" />
-              {lastUpdatedDate && (
+              {lastEditLocaleTimestamp && (
                 <Text
                   color="text200"
                   dir={isLangRightToLeft(locale as Lang) ? "rtl" : "ltr"}
                 >
                   <Translation id="page-last-updated" />:{" "}
-                  {getLocaleTimestamp(locale as Lang, lastUpdatedDate)}
+                  {lastEditLocaleTimestamp}
                 </Text>
               )}
             </>

--- a/src/layouts/Static.tsx
+++ b/src/layouts/Static.tsx
@@ -114,15 +114,14 @@ export const StaticLayout = ({
           ) : (
             <>
               <Breadcrumbs slug={slug} mb="8" />
-              {lastEditLocaleTimestamp && (
-                <Text
-                  color="text200"
-                  dir={isLangRightToLeft(locale as Lang) ? "rtl" : "ltr"}
-                >
-                  <Translation id="page-last-updated" />:{" "}
-                  {lastEditLocaleTimestamp}
-                </Text>
-              )}
+
+              <Text
+                color="text200"
+                dir={isLangRightToLeft(locale as Lang) ? "rtl" : "ltr"}
+              >
+                <Translation id="page-last-updated" />:{" "}
+                {lastEditLocaleTimestamp}
+              </Text>
             </>
           )}
 

--- a/src/layouts/Tutorial.tsx
+++ b/src/layouts/Tutorial.tsx
@@ -155,7 +155,7 @@ export const tutorialsComponents = {
 }
 type TutorialLayoutProps = ChildOnlyProp &
   Pick<MdPageContent, "tocItems" | "contributors" | "contentNotTranslated"> &
-  Required<Pick<MdPageContent, "lastUpdatedDate">> & {
+  Required<Pick<MdPageContent, "lastEditLocaleTimestamp">> & {
     frontmatter: TutorialFrontmatter
     timeToRead: number
   }
@@ -165,7 +165,7 @@ export const TutorialLayout = ({
   frontmatter,
   tocItems,
   timeToRead,
-  lastUpdatedDate,
+  lastEditLocaleTimestamp,
   contributors,
   contentNotTranslated,
 }: TutorialLayoutProps) => {
@@ -196,7 +196,7 @@ export const TutorialLayout = ({
           {children}
           <FileContributors
             contributors={contributors}
-            lastEdit={lastUpdatedDate}
+            lastEditLocaleTimestamp={lastEditLocaleTimestamp}
           />
           <FeedbackCard />
         </ContentContainer>

--- a/src/layouts/Upgrade.tsx
+++ b/src/layouts/Upgrade.tsx
@@ -117,11 +117,10 @@ export const UpgradeLayout = ({
                 ))}
               </List>
             </Box>
-            {lastEditLocaleTimestamp && (
-              <LastUpdated>
-                {t("common:page-last-updated")}: {lastEditLocaleTimestamp}
-              </LastUpdated>
-            )}
+
+            <LastUpdated>
+              {t("common:page-last-updated")}: {lastEditLocaleTimestamp}
+            </LastUpdated>
           </>
         }
         heroImg={frontmatter.image}

--- a/src/layouts/Upgrade.tsx
+++ b/src/layouts/Upgrade.tsx
@@ -1,4 +1,3 @@
-import { useRouter } from "next/router"
 import { useTranslation } from "next-i18next"
 import {
   Box,
@@ -10,7 +9,7 @@ import {
   useToken,
 } from "@chakra-ui/react"
 
-import type { ChildOnlyProp, Lang } from "@/lib/types"
+import type { ChildOnlyProp } from "@/lib/types"
 import type { MdPageContent, UpgradeFrontmatter } from "@/lib/interfaces"
 
 import BeaconChainActions from "@/components/BeaconChainActions"
@@ -29,7 +28,6 @@ import MergeInfographic from "@/components/MergeInfographic"
 import UpgradeStatus from "@/components/UpgradeStatus"
 
 import { getSummaryPoints } from "@/lib/utils/getSummaryPoints"
-import { getLocaleTimestamp } from "@/lib/utils/time"
 
 const Page = (props: FlexProps) => <MdPage sx={{}} {...props} />
 
@@ -62,7 +60,7 @@ export const upgradeComponents = {
 type UpgradeLayoutProps = ChildOnlyProp &
   Pick<
     MdPageContent,
-    "slug" | "tocItems" | "lastUpdatedDate" | "contentNotTranslated"
+    "slug" | "tocItems" | "lastEditLocaleTimestamp" | "contentNotTranslated"
   > & {
     frontmatter: UpgradeFrontmatter
   }
@@ -71,11 +69,10 @@ export const UpgradeLayout = ({
   frontmatter,
   slug,
   tocItems,
-  lastUpdatedDate,
+  lastEditLocaleTimestamp,
   contentNotTranslated,
 }: UpgradeLayoutProps) => {
   const { t } = useTranslation("page-upgrades")
-  const { locale } = useRouter()
 
   const summaryPoints = getSummaryPoints(frontmatter)
 
@@ -120,10 +117,9 @@ export const UpgradeLayout = ({
                 ))}
               </List>
             </Box>
-            {lastUpdatedDate && (
+            {lastEditLocaleTimestamp && (
               <LastUpdated>
-                {t("common:page-last-updated")}:{" "}
-                {getLocaleTimestamp(locale as Lang, lastUpdatedDate)}
+                {t("common:page-last-updated")}: {lastEditLocaleTimestamp}
               </LastUpdated>
             )}
           </>

--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -105,7 +105,7 @@ export interface MdPageContent {
   content: string
   frontmatter: Frontmatter
   tocItems: ToCItem[]
-  lastEditLocaleTimestamp?: string
+  lastEditLocaleTimestamp: string
   lastDeployLocaleTimestamp: string
   contentNotTranslated: boolean
   contributors: FileContributor[]

--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -105,7 +105,8 @@ export interface MdPageContent {
   content: string
   frontmatter: Frontmatter
   tocItems: ToCItem[]
-  lastUpdatedDate?: string
+  lastEditLocaleTimestamp?: string
+  lastDeployLocaleTimestamp?: string
   contentNotTranslated: boolean
   contributors: FileContributor[]
 }

--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -106,7 +106,7 @@ export interface MdPageContent {
   frontmatter: Frontmatter
   tocItems: ToCItem[]
   lastEditLocaleTimestamp?: string
-  lastDeployLocaleTimestamp?: string
+  lastDeployLocaleTimestamp: string
   contentNotTranslated: boolean
   contributors: FileContributor[]
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -44,7 +44,7 @@ export type Root = {
   children: ReactNode
   contentIsOutdated: boolean
   contentNotTranslated: boolean
-  lastDeployLocaleTimestamp?: string
+  lastDeployLocaleTimestamp: string
 }
 
 export type BasePageProps = SSRConfig &

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -44,7 +44,7 @@ export type Root = {
   children: ReactNode
   contentIsOutdated: boolean
   contentNotTranslated: boolean
-  lastDeployLocaleTimestamp: string
+  lastDeployLocaleTimestamp?: string
 }
 
 export type BasePageProps = SSRConfig &

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -44,11 +44,11 @@ export type Root = {
   children: ReactNode
   contentIsOutdated: boolean
   contentNotTranslated: boolean
-  lastDeployDate: string
+  lastDeployLocaleTimestamp: string
 }
 
 export type BasePageProps = SSRConfig &
-  Pick<Root, "contentNotTranslated" | "lastDeployDate">
+  Pick<Root, "contentNotTranslated" | "lastDeployLocaleTimestamp">
 
 export type Frontmatter = RoadmapFrontmatter &
   UpgradeFrontmatter &

--- a/src/lib/utils/md.ts
+++ b/src/lib/utils/md.ts
@@ -336,7 +336,13 @@ export const getContentBySlug = (slug: string) => {
   const fileContents = fs.readFileSync(fullPath, "utf8")
   const { data, content } = matter(fileContents)
   const frontmatter = data as Frontmatter
-  const items: Omit<MdPageContent, "tocItems" | "contributors"> = {
+  const items: Omit<
+    MdPageContent,
+    | "tocItems"
+    | "contributors"
+    | "lastEditLocaleTimestamp"
+    | "lastDeployLocaleTimestamp"
+  > = {
     slug,
     content,
     frontmatter,

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -2,7 +2,7 @@ import type { GetStaticProps } from "next"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { Box, Flex, Heading, Text } from "@chakra-ui/react"
 
-import { BasePageProps } from "@/lib/types"
+import { BasePageProps, Lang } from "@/lib/types"
 
 import InlineLink from "@/components/Link"
 import MainArticle from "@/components/MainArticle"
@@ -10,6 +10,7 @@ import Translation from "@/components/Translation"
 
 import { existsNamespace } from "@/lib/utils/existsNamespace"
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
+import { getLocaleTimestamp } from "@/lib/utils/time"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 
 export const getStaticProps = (async ({ locale }) => {
@@ -19,12 +20,16 @@ export const getStaticProps = (async ({ locale }) => {
   const contentNotTranslated = !existsNamespace(locale!, requiredNamespaces[0])
 
   const lastDeployDate = getLastDeployDate()
+  const lastDeployLocaleTimestamp = getLocaleTimestamp(
+    locale as Lang,
+    lastDeployDate
+  )
 
   return {
     props: {
       ...(await serverSideTranslations(locale!, requiredNamespaces)),
       contentNotTranslated,
-      lastDeployDate,
+      lastDeployLocaleTimestamp,
     },
   }
 }) satisfies GetStaticProps<BasePageProps>

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -29,6 +29,7 @@ import PageMetadata from "@/components/PageMetadata"
 
 import { getFileContributorInfo } from "@/lib/utils/contributors"
 import { dateToString } from "@/lib/utils/date"
+import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
 import { getContent, getContentBySlug } from "@/lib/utils/md"
 import { runOnlyOnce } from "@/lib/utils/runOnlyOnce"
 import { getLocaleTimestamp } from "@/lib/utils/time"
@@ -155,6 +156,7 @@ export const getStaticProps = (async (context) => {
   const timeToRead = readingTime(markdown.content)
   const tocItems = remapTableOfContents(tocNodeItems, mdxSource.compiledSource)
   const slug = `/${params.slug.join("/")}/`
+  const lastDeployDate = getLastDeployDate()
 
   // Get corresponding layout
   let layout = (frontmatter.template as Layout) ?? "static"
@@ -196,6 +198,10 @@ export const getStaticProps = (async (context) => {
         locale as Lang,
         lastUpdatedDate
       ),
+      lastDeployLocaleTimestamp: getLocaleTimestamp(
+        locale as Lang,
+        lastDeployDate
+      ),
       contentNotTranslated,
       layout,
       timeToRead: Math.round(timeToRead.minutes),
@@ -232,6 +238,7 @@ ContentPage.getLayout = (page) => {
     slug,
     frontmatter,
     lastEditLocaleTimestamp,
+    lastDeployLocaleTimestamp,
     layout,
     timeToRead,
     tocItems,
@@ -243,6 +250,7 @@ ContentPage.getLayout = (page) => {
     slug,
     frontmatter,
     lastEditLocaleTimestamp,
+    lastDeployLocaleTimestamp,
     timeToRead,
     tocItems,
     contributors,

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -156,7 +156,6 @@ export const getStaticProps = (async (context) => {
   const timeToRead = readingTime(markdown.content)
   const tocItems = remapTableOfContents(tocNodeItems, mdxSource.compiledSource)
   const slug = `/${params.slug.join("/")}/`
-  const lastDeployDate = getLastDeployDate()
 
   // Get corresponding layout
   let layout = (frontmatter.template as Layout) ?? "static"
@@ -186,6 +185,16 @@ export const getStaticProps = (async (context) => {
     commitHistoryCache
   )
 
+  const lastDeployDate = getLastDeployDate()
+  const lastEditLocaleTimestamp = getLocaleTimestamp(
+    locale as Lang,
+    lastUpdatedDate
+  )
+  const lastDeployLocaleTimestamp = getLocaleTimestamp(
+    locale as Lang,
+    lastDeployDate
+  )
+
   const gfissues = await gfIssuesDataFetch()
 
   return {
@@ -194,14 +203,8 @@ export const getStaticProps = (async (context) => {
       mdxSource,
       slug,
       frontmatter,
-      lastEditLocaleTimestamp: getLocaleTimestamp(
-        locale as Lang,
-        lastUpdatedDate
-      ),
-      lastDeployLocaleTimestamp: getLocaleTimestamp(
-        locale as Lang,
-        lastDeployDate
-      ),
+      lastEditLocaleTimestamp,
+      lastDeployLocaleTimestamp,
       contentNotTranslated,
       layout,
       timeToRead: Math.round(timeToRead.minutes),

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -194,8 +194,6 @@ export const getStaticProps = (async (context) => {
       mdxSource,
       slug,
       frontmatter,
-      // lastUpdatedDate,
-      // lastDeployDate,
       lastEditLocaleTimestamp: getLocaleTimestamp(
         locale as Lang,
         lastUpdatedDate
@@ -239,7 +237,6 @@ ContentPage.getLayout = (page) => {
   const {
     slug,
     frontmatter,
-    // lastUpdatedDate,
     lastEditLocaleTimestamp,
     lastDeployLocaleTimestamp,
     layout,
@@ -252,7 +249,6 @@ ContentPage.getLayout = (page) => {
   const layoutProps = {
     slug,
     frontmatter,
-    // lastUpdatedDate,
     lastEditLocaleTimestamp,
     lastDeployLocaleTimestamp,
     timeToRead,

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -17,6 +17,7 @@ import remarkGfm from "remark-gfm"
 
 import type {
   CommitHistory,
+  Lang,
   Layout,
   LayoutMappingType,
   NextPageWithLayout,
@@ -31,6 +32,7 @@ import { dateToString } from "@/lib/utils/date"
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
 import { getContent, getContentBySlug } from "@/lib/utils/md"
 import { runOnlyOnce } from "@/lib/utils/runOnlyOnce"
+import { getLocaleTimestamp } from "@/lib/utils/time"
 import { remapTableOfContents } from "@/lib/utils/toc"
 import {
   filterRealLocales,
@@ -194,6 +196,14 @@ export const getStaticProps = (async (context) => {
       frontmatter,
       lastUpdatedDate,
       lastDeployDate,
+      lastEditLocaleTimestamp: getLocaleTimestamp(
+        locale as Lang,
+        lastUpdatedDate
+      ),
+      lastDeployLocaleTimestamp: getLocaleTimestamp(
+        locale as Lang,
+        lastDeployDate
+      ),
       contentNotTranslated,
       layout,
       timeToRead: Math.round(timeToRead.minutes),
@@ -230,6 +240,8 @@ ContentPage.getLayout = (page) => {
     slug,
     frontmatter,
     lastUpdatedDate,
+    lastEditLocaleTimestamp,
+    lastDeployLocaleTimestamp,
     layout,
     timeToRead,
     tocItems,
@@ -241,6 +253,8 @@ ContentPage.getLayout = (page) => {
     slug,
     frontmatter,
     lastUpdatedDate,
+    lastEditLocaleTimestamp,
+    lastDeployLocaleTimestamp,
     timeToRead,
     tocItems,
     contributors,

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -29,7 +29,6 @@ import PageMetadata from "@/components/PageMetadata"
 
 import { getFileContributorInfo } from "@/lib/utils/contributors"
 import { dateToString } from "@/lib/utils/date"
-import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
 import { getContent, getContentBySlug } from "@/lib/utils/md"
 import { runOnlyOnce } from "@/lib/utils/runOnlyOnce"
 import { getLocaleTimestamp } from "@/lib/utils/time"
@@ -156,7 +155,6 @@ export const getStaticProps = (async (context) => {
   const timeToRead = readingTime(markdown.content)
   const tocItems = remapTableOfContents(tocNodeItems, mdxSource.compiledSource)
   const slug = `/${params.slug.join("/")}/`
-  const lastDeployDate = getLastDeployDate()
 
   // Get corresponding layout
   let layout = (frontmatter.template as Layout) ?? "static"
@@ -198,10 +196,6 @@ export const getStaticProps = (async (context) => {
         locale as Lang,
         lastUpdatedDate
       ),
-      lastDeployLocaleTimestamp: getLocaleTimestamp(
-        locale as Lang,
-        lastDeployDate
-      ),
       contentNotTranslated,
       layout,
       timeToRead: Math.round(timeToRead.minutes),
@@ -238,7 +232,6 @@ ContentPage.getLayout = (page) => {
     slug,
     frontmatter,
     lastEditLocaleTimestamp,
-    lastDeployLocaleTimestamp,
     layout,
     timeToRead,
     tocItems,
@@ -250,7 +243,6 @@ ContentPage.getLayout = (page) => {
     slug,
     frontmatter,
     lastEditLocaleTimestamp,
-    lastDeployLocaleTimestamp,
     timeToRead,
     tocItems,
     contributors,

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -194,8 +194,8 @@ export const getStaticProps = (async (context) => {
       mdxSource,
       slug,
       frontmatter,
-      lastUpdatedDate,
-      lastDeployDate,
+      // lastUpdatedDate,
+      // lastDeployDate,
       lastEditLocaleTimestamp: getLocaleTimestamp(
         locale as Lang,
         lastUpdatedDate
@@ -239,7 +239,7 @@ ContentPage.getLayout = (page) => {
   const {
     slug,
     frontmatter,
-    lastUpdatedDate,
+    // lastUpdatedDate,
     lastEditLocaleTimestamp,
     lastDeployLocaleTimestamp,
     layout,
@@ -252,7 +252,7 @@ ContentPage.getLayout = (page) => {
   const layoutProps = {
     slug,
     frontmatter,
-    lastUpdatedDate,
+    // lastUpdatedDate,
     lastEditLocaleTimestamp,
     lastDeployLocaleTimestamp,
     timeToRead,

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -48,7 +48,7 @@ const App = ({ Component, pageProps }: AppPropsWithLayout) => {
         <RootLayout
           contentIsOutdated={!!pageProps.frontmatter?.isOutdated}
           contentNotTranslated={pageProps.contentNotTranslated}
-          lastDeployDate={pageProps.lastDeployDate}
+          lastDeployLocaleTimestamp={pageProps.lastDeployLocaleTimestamp}
         >
           {getLayout(<Component {...pageProps} />)}
         </RootLayout>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -34,6 +34,8 @@ const App = ({ Component, pageProps }: AppPropsWithLayout) => {
 
   const theme = merge(customTheme, { direction })
 
+  console.log({ pageProps })
+
   return (
     <>
       <style jsx global>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -34,8 +34,6 @@ const App = ({ Component, pageProps }: AppPropsWithLayout) => {
 
   const theme = merge(customTheme, { direction })
 
-  console.log({ pageProps })
-
   return (
     <>
       <style jsx global>

--- a/src/pages/assets.tsx
+++ b/src/pages/assets.tsx
@@ -12,7 +12,7 @@ import {
   useColorModeValue,
 } from "@chakra-ui/react"
 
-import type { BasePageProps, ChildOnlyProp } from "@/lib/types"
+import type { BasePageProps, ChildOnlyProp, Lang } from "@/lib/types"
 
 import AssetDownload from "@/components/AssetDownload"
 import FeedbackCard from "@/components/FeedbackCard"
@@ -24,6 +24,7 @@ import PageMetadata from "@/components/PageMetadata"
 
 import { existsNamespace } from "@/lib/utils/existsNamespace"
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
+import { getLocaleTimestamp } from "@/lib/utils/time"
 // import efLogo from "@/public/ef-logo.png"
 // import efLogoWhite from "@/public/ef-logo-white.png"
 // import ethDiamondBlackHero from "@/public/assets/eth-diamond-black.png"
@@ -123,12 +124,16 @@ export const getStaticProps = (async ({ locale }) => {
   const contentNotTranslated = !existsNamespace(locale!, requiredNamespaces[2])
 
   const lastDeployDate = getLastDeployDate()
+  const lastDeployLocaleTimestamp = getLocaleTimestamp(
+    locale as Lang,
+    lastDeployDate
+  )
 
   return {
     props: {
       ...(await serverSideTranslations(locale!, requiredNamespaces)),
       contentNotTranslated,
-      lastDeployDate,
+      lastDeployLocaleTimestamp,
     },
   }
 }) satisfies GetStaticProps<BasePageProps>

--- a/src/pages/bug-bounty.tsx
+++ b/src/pages/bug-bounty.tsx
@@ -11,9 +11,8 @@ import {
   useColorModeValue,
 } from "@chakra-ui/react"
 
-import type { BasePageProps, ChildOnlyProp } from "@/lib/types"
+import type { BasePageProps, ChildOnlyProp, Lang } from "@/lib/types"
 
-import BugBountyBanner from "@/components/Banners/BugBountyBanner"
 import Breadcrumbs from "@/components/Breadcrumbs"
 import BugBountyCards from "@/components/BugBountyCards"
 import ButtonLink from "@/components/Buttons/ButtonLink"
@@ -33,6 +32,7 @@ import Translation from "@/components/Translation"
 
 import { existsNamespace } from "@/lib/utils/existsNamespace"
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
+import { getLocaleTimestamp } from "@/lib/utils/time"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 
 import consensusData from "@/data/consensus-bounty-hunters.json"
@@ -335,12 +335,16 @@ export const getStaticProps = (async ({ locale }) => {
   const contentNotTranslated = !existsNamespace(locale!, requiredNamespaces[2])
 
   const lastDeployDate = getLastDeployDate()
+  const lastDeployLocaleTimestamp = getLocaleTimestamp(
+    locale as Lang,
+    lastDeployDate
+  )
 
   return {
     props: {
       ...(await serverSideTranslations(locale!, requiredNamespaces)),
       contentNotTranslated,
-      lastDeployDate,
+      lastDeployLocaleTimestamp,
     },
   }
 }) satisfies GetStaticProps<BasePageProps>

--- a/src/pages/community.tsx
+++ b/src/pages/community.tsx
@@ -10,7 +10,7 @@ import {
   useTheme,
 } from "@chakra-ui/react"
 
-import { BasePageProps, ChildOnlyProp } from "@/lib/types"
+import { BasePageProps, ChildOnlyProp, Lang } from "@/lib/types"
 import { ICard, IGetInvolvedCard } from "@/lib/interfaces"
 
 import ActionCard from "@/components/ActionCard"
@@ -27,6 +27,7 @@ import PageMetadata from "@/components/PageMetadata"
 
 import { existsNamespace } from "@/lib/utils/existsNamespace"
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
+import { getLocaleTimestamp } from "@/lib/utils/time"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 
 // Static assets
@@ -48,12 +49,16 @@ export const getStaticProps = (async ({ locale }) => {
   const contentNotTranslated = !existsNamespace(locale!, requiredNamespaces[2])
 
   const lastDeployDate = getLastDeployDate()
+  const lastDeployLocaleTimestamp = getLocaleTimestamp(
+    locale as Lang,
+    lastDeployDate
+  )
 
   return {
     props: {
       ...(await serverSideTranslations(locale!, requiredNamespaces)),
       contentNotTranslated,
-      lastDeployDate,
+      lastDeployLocaleTimestamp,
     },
   }
 }) satisfies GetStaticProps<BasePageProps>

--- a/src/pages/contributing/translation-program/acknowledgements.tsx
+++ b/src/pages/contributing/translation-program/acknowledgements.tsx
@@ -12,7 +12,7 @@ import {
   useColorModeValue,
 } from "@chakra-ui/react"
 
-import { BasePageProps } from "@/lib/types"
+import { BasePageProps, Lang } from "@/lib/types"
 
 import ActionCard from "@/components/ActionCard"
 import Breadcrumbs from "@/components/Breadcrumbs"
@@ -27,6 +27,7 @@ import TranslationLeaderboard from "@/components/TranslationLeaderboard"
 
 import { existsNamespace } from "@/lib/utils/existsNamespace"
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
+import { getLocaleTimestamp } from "@/lib/utils/time"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 
 import allTimeData from "../../../data/translation-reports/alltime/alltime-data.json"
@@ -48,6 +49,10 @@ const ContentHeading = (props: HeadingProps) => (
 
 export const getStaticProps = (async ({ locale }) => {
   const lastDeployDate = getLastDeployDate()
+  const lastDeployLocaleTimestamp = getLocaleTimestamp(
+    locale as Lang,
+    lastDeployDate
+  )
 
   const requiredNamespaces = getRequiredNamespacesForPage(
     "/contributing/translation-program/acknowledgements"
@@ -59,7 +64,7 @@ export const getStaticProps = (async ({ locale }) => {
     props: {
       ...(await serverSideTranslations(locale!, requiredNamespaces)),
       contentNotTranslated,
-      lastDeployDate,
+      lastDeployLocaleTimestamp,
     },
   }
 }) satisfies GetStaticProps<BasePageProps>

--- a/src/pages/contributing/translation-program/contributors.tsx
+++ b/src/pages/contributing/translation-program/contributors.tsx
@@ -12,10 +12,7 @@ import {
   UnorderedList,
 } from "@chakra-ui/react"
 
-import {
-  BasePageProps,
-  CostLeaderboardData,
-} from "@/lib/types"
+import { BasePageProps, CostLeaderboardData, Lang } from "@/lib/types"
 
 import Breadcrumbs from "@/components/Breadcrumbs"
 import FeedbackCard from "@/components/FeedbackCard"
@@ -27,12 +24,17 @@ import PageMetadata from "@/components/PageMetadata"
 
 import { existsNamespace } from "@/lib/utils/existsNamespace"
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
+import { getLocaleTimestamp } from "@/lib/utils/time"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 
 import allTimeData from "../../../data/translation-reports/alltime/alltime-data.json"
 
 export const getStaticProps = (async ({ locale }) => {
   const lastDeployDate = getLastDeployDate()
+  const lastDeployLocaleTimestamp = getLocaleTimestamp(
+    locale as Lang,
+    lastDeployDate
+  )
 
   const requiredNamespaces = getRequiredNamespacesForPage(
     "/contributing/translation-program/contributors"
@@ -44,7 +46,7 @@ export const getStaticProps = (async ({ locale }) => {
     props: {
       ...(await serverSideTranslations(locale!, requiredNamespaces)),
       contentNotTranslated,
-      lastDeployDate,
+      lastDeployLocaleTimestamp,
     },
   }
 }) satisfies GetStaticProps<BasePageProps>

--- a/src/pages/dapps.tsx
+++ b/src/pages/dapps.tsx
@@ -24,7 +24,7 @@ import {
   useToken,
 } from "@chakra-ui/react"
 
-import type { BasePageProps, ChildOnlyProp } from "@/lib/types"
+import type { BasePageProps, ChildOnlyProp, Lang } from "@/lib/types"
 
 import BoxGrid from "@/components/BoxGrid"
 import ButtonLink from "@/components/Buttons/ButtonLink"
@@ -35,7 +35,6 @@ import DocLink from "@/components/DocLink"
 import Emoji from "@/components/Emoji"
 import FeedbackCard from "@/components/FeedbackCard"
 import GhostCard from "@/components/GhostCard"
-import GlossaryTooltip from "@/components/Glossary/GlossaryTooltip"
 import { Image } from "@/components/Image"
 import InfoBanner from "@/components/InfoBanner"
 import InlineLink, { BaseLink } from "@/components/Link"
@@ -53,6 +52,7 @@ import Translation from "@/components/Translation"
 import { existsNamespace } from "@/lib/utils/existsNamespace"
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
 import { trackCustomEvent } from "@/lib/utils/matomo"
+import { getLocaleTimestamp } from "@/lib/utils/time"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 
 import aave from "@/public/dapps/aave.png"
@@ -440,12 +440,16 @@ export const getStaticProps = (async ({ locale }) => {
   const contentNotTranslated = !existsNamespace(locale!, requiredNamespaces[2])
 
   const lastDeployDate = getLastDeployDate()
+  const lastDeployLocaleTimestamp = getLocaleTimestamp(
+    locale as Lang,
+    lastDeployDate
+  )
 
   return {
     props: {
       ...(await serverSideTranslations(locale!, requiredNamespaces)),
       contentNotTranslated,
-      lastDeployDate,
+      lastDeployLocaleTimestamp,
     },
   }
 }) satisfies GetStaticProps<BasePageProps>

--- a/src/pages/developers/index.tsx
+++ b/src/pages/developers/index.tsx
@@ -13,7 +13,7 @@ import {
   useColorModeValue,
 } from "@chakra-ui/react"
 
-import { BasePageProps, ChildOnlyProp } from "@/lib/types"
+import { BasePageProps, ChildOnlyProp, Lang } from "@/lib/types"
 
 import ButtonLink from "@/components/Buttons/ButtonLink"
 import Callout from "@/components/Callout"
@@ -30,6 +30,7 @@ import Translation from "@/components/Translation"
 
 import { existsNamespace } from "@/lib/utils/existsNamespace"
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
+import { getLocaleTimestamp } from "@/lib/utils/time"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 
 import SpeedRunEthereumImage from "@/public/dev-tools/speed-run-ethereum-banner.png"
@@ -167,9 +168,7 @@ const SpeedRunEthereumBanner = ({
       wordBreak="break-word"
       alignItems="flex-start"
     >
-      <Heading>
-        {title}
-      </Heading>
+      <Heading>{title}</Heading>
       <ButtonLink href="https://speedrunethereum.com/">{linkLabel}</ButtonLink>
     </Stack>
   </Box>
@@ -181,12 +180,16 @@ export const getStaticProps = (async ({ locale }) => {
   const contentNotTranslated = !existsNamespace(locale!, requiredNamespaces[2])
 
   const lastDeployDate = getLastDeployDate()
+  const lastDeployLocaleTimestamp = getLocaleTimestamp(
+    locale as Lang,
+    lastDeployDate
+  )
 
   return {
     props: {
       ...(await serverSideTranslations(locale!, requiredNamespaces)),
       contentNotTranslated,
-      lastDeployDate,
+      lastDeployLocaleTimestamp,
     },
   }
 }) satisfies GetStaticProps<BasePageProps>

--- a/src/pages/developers/learning-tools.tsx
+++ b/src/pages/developers/learning-tools.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "next-i18next"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { Box, Flex, HeadingProps } from "@chakra-ui/react"
 
-import { BasePageProps, ChildOnlyProp, LearningTool } from "@/lib/types"
+import { BasePageProps, ChildOnlyProp, Lang, LearningTool } from "@/lib/types"
 
 import ButtonLink from "@/components/Buttons/ButtonLink"
 import CalloutBanner from "@/components/CalloutBanner"
@@ -19,6 +19,7 @@ import Translation from "@/components/Translation"
 
 import { existsNamespace } from "@/lib/utils/existsNamespace"
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
+import { getLocaleTimestamp } from "@/lib/utils/time"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 
 import AlchemyUniversityImage from "@/public/dev-tools/alchemyuniversity.png"
@@ -125,12 +126,16 @@ export const getStaticProps = (async ({ locale }) => {
   const contentNotTranslated = !existsNamespace(locale!, requiredNamespaces[2])
 
   const lastDeployDate = getLastDeployDate()
+  const lastDeployLocaleTimestamp = getLocaleTimestamp(
+    locale as Lang,
+    lastDeployDate
+  )
 
   return {
     props: {
       ...(await serverSideTranslations(locale!, requiredNamespaces)),
       contentNotTranslated,
-      lastDeployDate,
+      lastDeployLocaleTimestamp,
     },
   }
 }) satisfies GetStaticProps<BasePageProps>

--- a/src/pages/developers/local-environment.tsx
+++ b/src/pages/developers/local-environment.tsx
@@ -9,7 +9,7 @@ import {
   UnorderedList,
 } from "@chakra-ui/react"
 
-import { BasePageProps, ChildOnlyProp } from "@/lib/types"
+import { BasePageProps, ChildOnlyProp, Lang } from "@/lib/types"
 import { Framework } from "@/lib/interfaces"
 
 import FeedbackCard from "@/components/FeedbackCard"
@@ -24,6 +24,7 @@ import Translation from "@/components/Translation"
 import { existsNamespace } from "@/lib/utils/existsNamespace"
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
 import { runOnlyOnce } from "@/lib/utils/runOnlyOnce"
+import { getLocaleTimestamp } from "@/lib/utils/time"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 
 import { getLocalEnvironmentFrameworkData } from "@/lib/api/ghRepoData"
@@ -70,13 +71,17 @@ export const getStaticProps = (async ({ locale }) => {
   const frameworksListData = await cachedFetchLocalEnvironmentFrameworkData()
 
   const lastDeployDate = getLastDeployDate()
+  const lastDeployLocaleTimestamp = getLocaleTimestamp(
+    locale as Lang,
+    lastDeployDate
+  )
 
   return {
     props: {
       ...(await serverSideTranslations(locale!, requiredNamespaces)),
       contentNotTranslated,
       frameworksList: frameworksListData,
-      lastDeployDate,
+      lastDeployLocaleTimestamp,
     },
   }
 }) satisfies GetStaticProps<Props>

--- a/src/pages/developers/tutorials.tsx
+++ b/src/pages/developers/tutorials.tsx
@@ -87,13 +87,17 @@ export const getStaticProps = (async ({ locale }) => {
   const contentNotTranslated = !existsNamespace(locale!, requiredNamespaces[2])
 
   const lastDeployDate = getLastDeployDate()
+  const lastDeployLocaleTimestamp = getLocaleTimestamp(
+    locale as Lang,
+    lastDeployDate
+  )
 
   return {
     props: {
       ...(await serverSideTranslations(locale!, requiredNamespaces)),
       contentNotTranslated,
       internalTutorials: getTutorialsData(locale!),
-      lastDeployDate,
+      lastDeployLocaleTimestamp,
     },
   }
 }) satisfies GetStaticProps<Props>
@@ -126,6 +130,7 @@ export interface ITutorial {
 
 const published = (locale: string, published: string) => {
   const localeTimestamp = getLocaleTimestamp(locale as Lang, published)
+
   return localeTimestamp !== "Invalid Date" ? (
     <span>
       <Emoji text=":calendar:" fontSize="sm" ms={2} me={2} />

--- a/src/pages/eth.tsx
+++ b/src/pages/eth.tsx
@@ -12,7 +12,7 @@ import {
   UnorderedList,
 } from "@chakra-ui/react"
 
-import type { BasePageProps, ChildOnlyProp } from "@/lib/types"
+import type { BasePageProps, ChildOnlyProp, Lang } from "@/lib/types"
 
 import ActionCard from "@/components/ActionCard"
 import ButtonLink from "@/components/Buttons/ButtonLink"
@@ -35,6 +35,7 @@ import Translation from "@/components/Translation"
 
 import { existsNamespace } from "@/lib/utils/existsNamespace"
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
+import { getLocaleTimestamp } from "@/lib/utils/time"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 
 import eth from "@/public/eth.png"
@@ -269,12 +270,16 @@ export const getStaticProps = (async ({ locale }) => {
   const contentNotTranslated = !existsNamespace(locale!, requiredNamespaces[2])
 
   const lastDeployDate = getLastDeployDate()
+  const lastDeployLocaleTimestamp = getLocaleTimestamp(
+    locale as Lang,
+    lastDeployDate
+  )
 
   return {
     props: {
       ...(await serverSideTranslations(locale!, requiredNamespaces)),
       contentNotTranslated,
-      lastDeployDate,
+      lastDeployLocaleTimestamp,
     },
   }
 }) satisfies GetStaticProps<BasePageProps>

--- a/src/pages/gas.tsx
+++ b/src/pages/gas.tsx
@@ -20,7 +20,7 @@ import {
   UnorderedList,
 } from "@chakra-ui/react"
 
-import { BasePageProps } from "@/lib/types"
+import { BasePageProps, Lang } from "@/lib/types"
 
 import { ButtonLink } from "@/components/Buttons"
 import Callout from "@/components/Callout"
@@ -43,6 +43,7 @@ import Translation from "@/components/Translation"
 
 import { existsNamespace } from "@/lib/utils/existsNamespace"
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
+import { getLocaleTimestamp } from "@/lib/utils/time"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 
 // Static assets
@@ -103,12 +104,16 @@ export const getStaticProps = (async ({ locale }) => {
   const contentNotTranslated = !existsNamespace(locale!, requiredNamespaces[2])
 
   const lastDeployDate = getLastDeployDate()
+  const lastDeployLocaleTimestamp = getLocaleTimestamp(
+    locale as Lang,
+    lastDeployDate
+  )
 
   return {
     props: {
       ...(await serverSideTranslations(locale!, requiredNamespaces)),
       contentNotTranslated,
-      lastDeployDate,
+      lastDeployLocaleTimestamp,
     },
   }
 }) satisfies GetStaticProps<BasePageProps>

--- a/src/pages/get-eth.tsx
+++ b/src/pages/get-eth.tsx
@@ -10,7 +10,7 @@ import {
   useBreakpointValue,
 } from "@chakra-ui/react"
 
-import type { BasePageProps, ChildOnlyProp } from "@/lib/types"
+import type { BasePageProps, ChildOnlyProp, Lang } from "@/lib/types"
 
 import ButtonLink from "@/components/Buttons/ButtonLink"
 import CalloutBanner from "@/components/CalloutBanner"
@@ -34,6 +34,7 @@ import { existsNamespace } from "@/lib/utils/existsNamespace"
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
 import { getLastModifiedDateByPath } from "@/lib/utils/gh"
 import { trackCustomEvent } from "@/lib/utils/matomo"
+import { getLocaleTimestamp } from "@/lib/utils/time"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 
 import uniswap from "@/public/dapps/uni.png"
@@ -114,12 +115,16 @@ export const getStaticProps = (async ({ locale }) => {
   )
 
   const lastDeployDate = getLastDeployDate()
+  const lastDeployLocaleTimestamp = getLocaleTimestamp(
+    locale as Lang,
+    lastDeployDate
+  )
 
   return {
     props: {
       ...(await serverSideTranslations(locale!, requiredNamespaces)),
       contentNotTranslated,
-      lastDeployDate,
+      lastDeployLocaleTimestamp,
       lastDataUpdateDate,
     },
   }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -30,7 +30,6 @@ import CommunityEvents from "@/components/CommunityEvents"
 import HomeHero from "@/components/Hero/HomeHero"
 import { Image } from "@/components/Image"
 import MainArticle from "@/components/MainArticle"
-import Modal from "@/components/Modal"
 import PageMetadata from "@/components/PageMetadata"
 import StatsBoxGrid from "@/components/StatsBoxGrid"
 import TitleCardList, { ITitleCardItem } from "@/components/TitleCardList"
@@ -39,6 +38,7 @@ import Translation from "@/components/Translation"
 import { existsNamespace } from "@/lib/utils/existsNamespace"
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
 import { runOnlyOnce } from "@/lib/utils/runOnlyOnce"
+import { getLocaleTimestamp } from "@/lib/utils/time"
 import {
   getRequiredNamespacesForPage,
   isLangRightToLeft,
@@ -208,13 +208,17 @@ export const getStaticProps = (async ({ locale }) => {
 
   // load last deploy date to pass to Footer in RootLayout
   const lastDeployDate = getLastDeployDate()
+  const lastDeployLocaleTimestamp = getLocaleTimestamp(
+    locale as Lang,
+    lastDeployDate
+  )
 
   return {
     props: {
       ...(await serverSideTranslations(locale!, requiredNamespaces)),
       communityEvents,
       contentNotTranslated,
-      lastDeployDate,
+      lastDeployLocaleTimestamp,
       metricResults,
     },
     revalidate: BASE_TIME_UNIT * 24,

--- a/src/pages/layer-2.tsx
+++ b/src/pages/layer-2.tsx
@@ -15,7 +15,7 @@ import {
   UnorderedList,
 } from "@chakra-ui/react"
 
-import type { BasePageProps, TranslationKey } from "@/lib/types"
+import type { BasePageProps, Lang, TranslationKey } from "@/lib/types"
 
 import { ButtonLink } from "@/components/Buttons"
 import Card from "@/components/Card"
@@ -37,6 +37,7 @@ import Translation from "@/components/Translation"
 
 import { existsNamespace } from "@/lib/utils/existsNamespace"
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
+import { getLocaleTimestamp } from "@/lib/utils/time"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 
 import { layer2Data } from "@/data/layer-2/layer-2"
@@ -108,6 +109,10 @@ const Layer2CardGrid = (props) => (
 
 export const getStaticProps = (async ({ locale }) => {
   const lastDeployDate = getLastDeployDate()
+  const lastDeployLocaleTimestamp = getLocaleTimestamp(
+    locale as Lang,
+    lastDeployDate
+  )
 
   const requiredNamespaces = getRequiredNamespacesForPage("/layer-2")
 
@@ -117,7 +122,7 @@ export const getStaticProps = (async ({ locale }) => {
     props: {
       ...(await serverSideTranslations(locale!, requiredNamespaces)),
       contentNotTranslated,
-      lastDeployDate,
+      lastDeployLocaleTimestamp,
     },
   }
 }) satisfies GetStaticProps<BasePageProps>

--- a/src/pages/learn.tsx
+++ b/src/pages/learn.tsx
@@ -12,7 +12,7 @@ import {
   useToken,
 } from "@chakra-ui/react"
 
-import type { BasePageProps, ChildOnlyProp, ToCItem } from "@/lib/types"
+import type { BasePageProps, ChildOnlyProp, Lang, ToCItem } from "@/lib/types"
 
 import ButtonLink from "@/components/Buttons/ButtonLink"
 import OriginalCard, {
@@ -33,6 +33,7 @@ import PageMetadata from "@/components/PageMetadata"
 
 import { existsNamespace } from "@/lib/utils/existsNamespace"
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
+import { getLocaleTimestamp } from "@/lib/utils/time"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 
 import developersEthBlocks from "@/public/developers-eth-blocks.png"
@@ -130,12 +131,16 @@ export const getStaticProps = (async ({ locale }) => {
   const contentNotTranslated = !existsNamespace(locale!, requiredNamespaces[2])
 
   const lastDeployDate = getLastDeployDate()
+  const lastDeployLocaleTimestamp = getLocaleTimestamp(
+    locale as Lang,
+    lastDeployDate
+  )
 
   return {
     props: {
       ...(await serverSideTranslations(locale!, requiredNamespaces)),
       contentNotTranslated,
-      lastDeployDate,
+      lastDeployLocaleTimestamp,
     },
   }
 }) satisfies GetStaticProps<BasePageProps>

--- a/src/pages/quizzes.tsx
+++ b/src/pages/quizzes.tsx
@@ -5,7 +5,7 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { FaGithub } from "react-icons/fa"
 import { Box, Flex, Icon, Stack, Text, useDisclosure } from "@chakra-ui/react"
 
-import { BasePageProps, QuizKey, QuizStatus } from "@/lib/types"
+import { BasePageProps, Lang, QuizKey, QuizStatus } from "@/lib/types"
 
 import { ButtonLink } from "@/components/Buttons"
 import FeedbackCard from "@/components/FeedbackCard"
@@ -21,6 +21,7 @@ import { useLocalQuizData } from "@/components/Quiz/useLocalQuizData"
 import { existsNamespace } from "@/lib/utils/existsNamespace"
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
 import { trackCustomEvent } from "@/lib/utils/matomo"
+import { getLocaleTimestamp } from "@/lib/utils/time"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 
 import { ethereumBasicsQuizzes, usingEthereumQuizzes } from "@/data/quizzes"
@@ -42,12 +43,16 @@ export const getStaticProps = (async ({ locale }) => {
   const contentNotTranslated = !existsNamespace(locale!, requiredNamespaces[2])
 
   const lastDeployDate = getLastDeployDate()
+  const lastDeployLocaleTimestamp = getLocaleTimestamp(
+    locale as Lang,
+    lastDeployDate
+  )
 
   return {
     props: {
       ...(await serverSideTranslations(locale!, requiredNamespaces)),
       contentNotTranslated,
-      lastDeployDate,
+      lastDeployLocaleTimestamp,
     },
   }
 }) satisfies GetStaticProps<BasePageProps>

--- a/src/pages/roadmap/vision.tsx
+++ b/src/pages/roadmap/vision.tsx
@@ -15,7 +15,7 @@ import {
   useToken,
 } from "@chakra-ui/react"
 
-import type { BasePageProps, ChildOnlyProp } from "@/lib/types"
+import type { BasePageProps, ChildOnlyProp, Lang } from "@/lib/types"
 
 import Breadcrumbs from "@/components/Breadcrumbs"
 import ButtonLink from "@/components/Buttons/ButtonLink"
@@ -35,6 +35,7 @@ import Trilemma from "@/components/Trilemma"
 
 import { existsNamespace } from "@/lib/utils/existsNamespace"
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
+import { getLocaleTimestamp } from "@/lib/utils/time"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 
 import oldship from "@/public/upgrades/oldship.png"
@@ -122,12 +123,16 @@ export const getStaticProps = (async ({ locale }) => {
   const contentNotTranslated = !existsNamespace(locale!, requiredNamespaces[2])
 
   const lastDeployDate = getLastDeployDate()
+  const lastDeployLocaleTimestamp = getLocaleTimestamp(
+    locale as Lang,
+    lastDeployDate
+  )
 
   return {
     props: {
       ...(await serverSideTranslations(locale!, requiredNamespaces)),
       contentNotTranslated,
-      lastDeployDate,
+      lastDeployLocaleTimestamp,
     },
   }
 }) satisfies GetStaticProps<BasePageProps>

--- a/src/pages/run-a-node.tsx
+++ b/src/pages/run-a-node.tsx
@@ -14,7 +14,7 @@ import {
   type Icon as ChakraIcon,
 } from "@chakra-ui/react"
 
-import type { BasePageProps, ChildOnlyProp } from "@/lib/types"
+import type { BasePageProps, ChildOnlyProp, Lang } from "@/lib/types"
 
 import { Button, ButtonLink } from "@/components/Buttons"
 import Emoji from "@/components/Emoji"
@@ -43,6 +43,7 @@ import Translation from "@/components/Translation"
 
 import { existsNamespace } from "@/lib/utils/existsNamespace"
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
+import { getLocaleTimestamp } from "@/lib/utils/time"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 
 import { InfoGrid } from "@/layouts/Staking"
@@ -334,12 +335,16 @@ export const getStaticProps = (async ({ locale }) => {
   const contentNotTranslated = !existsNamespace(locale!, requiredNamespaces[2])
 
   const lastDeployDate = getLastDeployDate()
+  const lastDeployLocaleTimestamp = getLocaleTimestamp(
+    locale as Lang,
+    lastDeployDate
+  )
 
   return {
     props: {
       ...(await serverSideTranslations(locale!, requiredNamespaces)),
       contentNotTranslated,
-      lastDeployDate,
+      lastDeployLocaleTimestamp,
     },
   }
 }) satisfies GetStaticProps<BasePageProps>

--- a/src/pages/stablecoins.tsx
+++ b/src/pages/stablecoins.tsx
@@ -12,7 +12,7 @@ import {
   SimpleGrid,
 } from "@chakra-ui/react"
 
-import { BasePageProps } from "@/lib/types"
+import { BasePageProps, Lang } from "@/lib/types"
 
 import ButtonLink from "@/components/Buttons/ButtonLink"
 import CalloutBanner from "@/components/CalloutBanner"
@@ -39,6 +39,7 @@ import Translation from "@/components/Translation"
 import { existsNamespace } from "@/lib/utils/existsNamespace"
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
 import { runOnlyOnce } from "@/lib/utils/runOnlyOnce"
+import { getLocaleTimestamp } from "@/lib/utils/time"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 
 import { BASE_TIME_UNIT } from "@/lib/constants"
@@ -93,6 +94,10 @@ const ethereumStablecoinsDataFetch = runOnlyOnce(fetchEthereumStablecoinsData)
 
 export const getStaticProps = (async ({ locale }) => {
   const lastDeployDate = getLastDeployDate()
+  const lastDeployLocaleTimestamp = getLocaleTimestamp(
+    locale as Lang,
+    lastDeployDate
+  )
 
   const requiredNamespaces = getRequiredNamespacesForPage("/stablecoins")
 
@@ -177,7 +182,7 @@ export const getStaticProps = (async ({ locale }) => {
     props: {
       ...(await serverSideTranslations(locale!, requiredNamespaces)),
       contentNotTranslated,
-      lastDeployDate,
+      lastDeployLocaleTimestamp,
       markets,
       marketsHasError,
     },
@@ -526,7 +531,11 @@ const StablecoinsPage = ({ markets, marketsHasError }) => {
                   </Text>
                   <Flex direction="column">
                     <Box>
-                      <ButtonLink mb={4} me={4} href="https://matcha.xyz/tokens/ethereum/0x6b175474e89094c44da98b954eedeac495271d0f?sellChain=1&sellAddress=0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee">
+                      <ButtonLink
+                        mb={4}
+                        me={4}
+                        href="https://matcha.xyz/tokens/ethereum/0x6b175474e89094c44da98b954eedeac495271d0f?sellChain=1&sellAddress=0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+                      >
                         {t("page-stablecoins-dai-banner-swap-button")}
                       </ButtonLink>
                     </Box>

--- a/src/pages/staking/deposit-contract.tsx
+++ b/src/pages/staking/deposit-contract.tsx
@@ -17,7 +17,12 @@ import {
   useToken,
 } from "@chakra-ui/react"
 
-import type { BasePageProps, ChildOnlyProp, TranslationKey } from "@/lib/types"
+import type {
+  BasePageProps,
+  ChildOnlyProp,
+  Lang,
+  TranslationKey,
+} from "@/lib/types"
 
 import Breadcrumbs from "@/components/Breadcrumbs"
 import ButtonLink, {
@@ -37,6 +42,7 @@ import Translation from "@/components/Translation"
 
 import { existsNamespace } from "@/lib/utils/existsNamespace"
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
+import { getLocaleTimestamp } from "@/lib/utils/time"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 
 import { DEPOSIT_CONTRACT_ADDRESS } from "@/data/addresses"
@@ -219,12 +225,16 @@ export const getStaticProps = (async ({ locale }) => {
   const contentNotTranslated = !existsNamespace(locale!, requiredNamespaces[2])
 
   const lastDeployDate = getLastDeployDate()
+  const lastDeployLocaleTimestamp = getLocaleTimestamp(
+    locale as Lang,
+    lastDeployDate
+  )
 
   return {
     props: {
       ...(await serverSideTranslations(locale!, requiredNamespaces)),
       contentNotTranslated,
-      lastDeployDate,
+      lastDeployLocaleTimestamp,
     },
   }
 }) satisfies GetStaticProps<BasePageProps>

--- a/src/pages/staking/index.tsx
+++ b/src/pages/staking/index.tsx
@@ -9,6 +9,7 @@ import type {
   ChildOnlyProp,
   EpochResponse,
   EthStoreResponse,
+  Lang,
   StakingStatsData,
 } from "@/lib/types"
 
@@ -37,6 +38,7 @@ import Translation from "@/components/Translation"
 import { existsNamespace } from "@/lib/utils/existsNamespace"
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
 import { runOnlyOnce } from "@/lib/utils/runOnlyOnce"
+import { getLocaleTimestamp } from "@/lib/utils/time"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 
 import { BASE_TIME_UNIT } from "@/lib/constants"
@@ -209,6 +211,10 @@ type Props = BasePageProps & {
 
 export const getStaticProps = (async ({ locale }) => {
   const lastDeployDate = getLastDeployDate()
+  const lastDeployLocaleTimestamp = getLocaleTimestamp(
+    locale as Lang,
+    lastDeployDate
+  )
 
   const requiredNamespaces = getRequiredNamespacesForPage("/staking")
 
@@ -221,7 +227,7 @@ export const getStaticProps = (async ({ locale }) => {
       ...(await serverSideTranslations(locale!, requiredNamespaces)),
       contentNotTranslated,
       data,
-      lastDeployDate,
+      lastDeployLocaleTimestamp,
     },
     // Updated once a day
     revalidate: BASE_TIME_UNIT * 24,

--- a/src/pages/wallets/find-wallet.tsx
+++ b/src/pages/wallets/find-wallet.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "next-i18next"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { Box, calc, Center, Flex, Text, useDisclosure } from "@chakra-ui/react"
 
-import type { BasePageProps, ChildOnlyProp, Wallet } from "@/lib/types"
+import type { BasePageProps, ChildOnlyProp, Lang, Wallet } from "@/lib/types"
 
 import BannerNotification from "@/components/BannerNotification"
 import Breadcrumbs from "@/components/Breadcrumbs"
@@ -21,6 +21,7 @@ import PageMetadata from "@/components/PageMetadata"
 
 import { existsNamespace } from "@/lib/utils/existsNamespace"
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
+import { getLocaleTimestamp } from "@/lib/utils/time"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 import {
   getNonSupportedLocaleWallets,
@@ -56,6 +57,10 @@ type Props = BasePageProps & {
 
 export const getStaticProps = (async ({ locale }) => {
   const lastDeployDate = getLastDeployDate()
+  const lastDeployLocaleTimestamp = getLocaleTimestamp(
+    locale as Lang,
+    lastDeployDate
+  )
 
   const requiredNamespaces = getRequiredNamespacesForPage(
     "/wallets/find-wallet"
@@ -79,7 +84,7 @@ export const getStaticProps = (async ({ locale }) => {
     props: {
       ...(await serverSideTranslations(locale!, requiredNamespaces)),
       contentNotTranslated,
-      lastDeployDate,
+      lastDeployLocaleTimestamp,
       wallets,
     },
     // Updated once a day

--- a/src/pages/wallets/index.tsx
+++ b/src/pages/wallets/index.tsx
@@ -11,7 +11,7 @@ import {
   Text as ChakraText,
 } from "@chakra-ui/react"
 
-import { BasePageProps, ChildOnlyProp } from "@/lib/types"
+import { BasePageProps, ChildOnlyProp, Lang } from "@/lib/types"
 
 import ButtonLink from "@/components/Buttons/ButtonLink"
 import Callout from "@/components/Callout"
@@ -34,6 +34,7 @@ import Translation from "@/components/Translation"
 
 import { existsNamespace } from "@/lib/utils/existsNamespace"
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
+import { getLocaleTimestamp } from "@/lib/utils/time"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 
 import { walletOnboardingSimData } from "@/data/WalletSimulatorData"
@@ -132,6 +133,10 @@ const CalloutCardContainer = (props: ChildOnlyProp) => (
 
 export const getStaticProps = (async ({ locale }) => {
   const lastDeployDate = getLastDeployDate()
+  const lastDeployLocaleTimestamp = getLocaleTimestamp(
+    locale as Lang,
+    lastDeployDate
+  )
 
   const requiredNamespaces = getRequiredNamespacesForPage("/wallets")
 
@@ -141,7 +146,7 @@ export const getStaticProps = (async ({ locale }) => {
     props: {
       ...(await serverSideTranslations(locale!, requiredNamespaces)),
       contentNotTranslated,
-      lastDeployDate,
+      lastDeployLocaleTimestamp,
     },
   }
 }) satisfies GetStaticProps<BasePageProps>

--- a/src/pages/what-is-ethereum.tsx
+++ b/src/pages/what-is-ethereum.tsx
@@ -54,6 +54,7 @@ import { existsNamespace } from "@/lib/utils/existsNamespace"
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
 import { trackCustomEvent } from "@/lib/utils/matomo"
 import { runOnlyOnce } from "@/lib/utils/runOnlyOnce"
+import { getLocaleTimestamp } from "@/lib/utils/time"
 import {
   getLocaleForNumberFormat,
   getRequiredNamespacesForPage,
@@ -192,6 +193,10 @@ type Props = BasePageProps & {
 
 export const getStaticProps = (async ({ locale }) => {
   const lastDeployDate = getLastDeployDate()
+  const lastDeployLocaleTimestamp = getLocaleTimestamp(
+    locale as Lang,
+    lastDeployDate
+  )
 
   const requiredNamespaces = getRequiredNamespacesForPage("/what-is-ethereum")
 
@@ -203,7 +208,7 @@ export const getStaticProps = (async ({ locale }) => {
     props: {
       ...(await serverSideTranslations(locale!, requiredNamespaces)),
       contentNotTranslated,
-      lastDeployDate,
+      lastDeployLocaleTimestamp,
       data,
     },
   }


### PR DESCRIPTION
This PR updates how `getLocaleTimestamp` is used across layouts and pages, to calculate the new `lastEditLocaleTimestamp` & `lastDeployLocaleTimestamp` values on build time instead of executing this logic on runtime, and updates the corresponding components, interfaces and types to use them properly.

## Description

- pages
  - updates `src/pages/[...slug].tsx`
  - updates `src/pages/_app.tsx`
  - updates `src/pages/assets.tsx`
  - updates `src/pages/bug-bounty.tsx`
  - updates `src/pages/community.tsx`
  - updates `src/pages/contributing/translation-program/acknowledgements.tsx`
  - updates `src/pages/contributing/translation-program/contributors.tsx`
  - updates `src/pages/dapps.tsx`
  - updates `src/pages/developers/index.tsx`
  - updates `src/pages/developers/learning-tools.tsx`
  - updates `src/pages/developers/local-environment.tsx`
  - updates `src/pages/developers/tutorials.tsx`
  - updates `src/pages/eth.tsx`
  - updates `src/pages/gas.tsx`
  - updates `src/pages/get-eth.tsx`
  - updates `src/pages/index.tsx`
  - updates `src/pages/index.tsx`
  - updates `src/pages/layer-2.tsx`
  - updates `src/pages/learn.tsx`
  - updates `src/pages/learn.tsx`
  - updates `src/pages/quizzes.tsx`
  - updates `src/pages/roadmap/vision.tsx`
  - updates `src/pages/roadmap/vision.tsx`
  - updates `src/pages/run-a-node.tsx`
  - updates `src/pages/stablecoins.tsx`
  - updates `src/pages/staking/deposit-contract.tsx`
  - updates `src/pages/staking/index.tsx`
  - updates `src/pages/wallets/find-wallet.tsx`
  - updates `src/pages/wallets/index.tsx`
  - updates `src/pages/what-is-ethereum.tsx`
- components
  - updates `src/components/FileContributors.tsx` (uses `lastEditLocaleTimestamp`)
  - updates `src/components/Footer.tsx` (uses `lastDeployLocaleTimestamp`)
- layouts  
  - updates `src/layouts/Docs.tsx`
  - updates `src/layouts/Roadmap.tsx`
  - updates `src/layouts/RootLayout.tsx`
  - updates `src/layouts/Static.tsx`
  - updates `src/layouts/Tutorial.tsx` 
  - updates `src/layouts/Upgrade.tsx`
 - interfaces
   - updates `MdPageContent`
 - types
   - updates `Root`
   - updates `BasePageProps`  
 - removes `lastUpdatedDate` & `lastDeployDate` page props