### PR TITLE
content: add Shisui to list of Portal clients

### DIFF
--- a/public/content/developers/docs/networking-layer/portal-network/index.md
+++ b/public/content/developers/docs/networking-layer/portal-network/index.md
@@ -70,6 +70,7 @@ The Portal Network clients are:
 - [Trin](https://github.com/ethereum/trin): written in Rust
 - [Fluffy](https://nimbus.team/docs/fluffy.html): written in Nim
 - [Ultralight](https://github.com/ethereumjs/ultralight): written in Typescript
+- [Shisui](https://github.com/GrapeBaBa/shisui): written in Go
 
 Having multiple independent client implementations enhances the resilience and decentralization of the Ethereum network.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Updated content on the doc about the Portal Network to include the client [Shisui](https://github.com/GrapeBaBa/shisui). 

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A