### PR TITLE
fix: spacing on token list in wallet simulator

### DIFF
--- a/src/components/Simulator/WalletHome/TokenBalanceItem.tsx
+++ b/src/components/Simulator/WalletHome/TokenBalanceItem.tsx
@@ -31,6 +31,7 @@ export const TokenBalanceItem = ({
       </Text>
       <Box
         textAlign="end"
+        fontSize="sm"
         lineHeight={1.5}
         fontWeight="bold"
         sx={{ p: { m: 0 } }}


### PR DESCRIPTION
## Description
In the `Create account` and `Send/receive` tokens flows of the wallet simulator, the spacing of the tokens list (UNI token in this case) is quite close to the border. Without scrolling for more tokens in this list, the spacing looks a bit awkward.
for now I've decreased the font size of token list so that it gives some extra margin bottom.

## Preview URL
- https://deploy-preview-13202--ethereumorg.netlify.app/en/wallets/#sim

## Related Issue
- Closes #11465