### PR TITLE
fix: wallet filter device boolean tracking

### DIFF
--- a/src/components/FindWallet/WalletFilterFeature.tsx
+++ b/src/components/FindWallet/WalletFilterFeature.tsx
@@ -176,7 +176,7 @@ const WalletFilterFeature = ({
                                     eventAction: `${filterOption.title}`,
                                     eventName: `Toggle ${
                                       item.title
-                                    } ${!item.showOptions}`,
+                                    } to ${item.showOptions}`,
                                   })
                                 }
                           }


### PR DESCRIPTION
## Description
- Fixes reversal of true/false for "Toggle Desktop/Browser/Mobile" Matomo events
- Adds the word "to" to differentiate between old logs (where T/F have flipped meanings) and the new corrected entries.

Example of new usage: If "Mobile" is switched from off to on, it will log `Toggle Mobile to true`.

## Related Issue
None filed; from UX research sync