### PR TITLE
fix: ETHGlobal Discord link

### DIFF
--- a/public/content/community/online/index.md
+++ b/public/content/community/online/index.md
@@ -22,7 +22,7 @@ Hundreds of thousands of Ethereum enthusiasts gather in these online forums to s
 ## Chat rooms {#chat-rooms}
 
 <SocialListItem socialIcon="discord"><Link to="https://discord.com/invite/Nz6rtfJ8Cu">Ethereum Cat Herders</Link> - community oriented around offering project management support to Ethereum development</SocialListItem>
-<SocialListItem socialIcon="discord"><Link to="https://ethglobal.co/discord">Ethereum Hackers</Link> - Discord chat run by ETHGlobal: an online community for Ethereum hackers all over the world</SocialListItem>
+<SocialListItem socialIcon="discord"><Link to="https://ethglobal.com/discord">Ethereum Hackers</Link> - Discord chat run by ETHGlobal: an online community for Ethereum hackers all over the world</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/5W5tVb3">CryptoDevs</Link> - Ethereum development focused Discord community</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ethstaker">EthStaker Discord</Link> - community-run guidance, education, support, and resources for existing and potential stakers</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ethereum-org">Ethereum.org website team</Link> - stop by and chat ethereum.org web development and design with the team and folks from the community</SocialListItem>

--- a/public/content/translations/de/community/online/index.md
+++ b/public/content/translations/de/community/online/index.md
@@ -22,7 +22,7 @@ Hunderttausende von Ethereum-Enthusiasten treffen sich in diesen Online-Foren, u
 ## Chat-Räume {#chat-rooms}
 
 <SocialListItem socialIcon="discord"><Link to="https://discord.com/invite/Nz6rtfJ8Cu">Ethereum Cat Herders</Link> - Gemeinschaft orientiert am Angebot von Projekt-Management-Unterstützung für Ethereum-Entwickler</SocialListItem>
-<SocialListItem socialIcon="discord"><Link to="https://ethglobal.co/discord">Ethereum-Hacker</Link> - Von ETHGlobal geführter Discord Chat: Eine Online-Gemeinschaft für Ethereum-Hacker auf der ganzen Welt</SocialListItem>
+<SocialListItem socialIcon="discord"><Link to="https://ethglobal.com/discord">Ethereum-Hacker</Link> - Von ETHGlobal geführter Discord Chat: Eine Online-Gemeinschaft für Ethereum-Hacker auf der ganzen Welt</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/5W5tVb3">CryptoDevs</Link> - Auf Ethereum Entwicklung fokussierte Discord-Community</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ethstaker">EthStaker Discord</Link> – Beratung, Bildung, Unterstützung und Ressourcen für bestehende und potenzielle Staker auf Community-Ebene </SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="/discord/">Ethereum.org Website-Team</Link> - Kommen Sie vorbei and schreiben Sie mit dem Team und anderen aus der Gemeinschaft über Ethereum.org Web-Entwicklung und Design</SocialListItem>

--- a/public/content/translations/el/community/online/index.md
+++ b/public/content/translations/el/community/online/index.md
@@ -22,7 +22,7 @@ lang: el
 ## Αίθουσες συνομιλίας {#chat-rooms}
 
 <SocialListItem socialIcon="discord"><Link to="https://discord.com/invite/Nz6rtfJ8Cu">Ethereum Cat Herders</Link> - κοινότητα προσανατολισμένη στην προσφορά υποστήριξης διαχείρισης έργου για την ανάπτυξη του Ethereum.</SocialListItem>
-<SocialListItem socialIcon="discord"><Link to="https://ethglobal.co/discord">Ethereum Hackers</Link> - συνομιλία στο Discord που διευθύνεται από την ETHGlobal: μια διαδικτυακή κοινότητα για χάκερ Ethereum σε όλο τον κόσμο</SocialListItem>
+<SocialListItem socialIcon="discord"><Link to="https://ethglobal.com/discord">Ethereum Hackers</Link> - συνομιλία στο Discord που διευθύνεται από την ETHGlobal: μια διαδικτυακή κοινότητα για χάκερ Ethereum σε όλο τον κόσμο</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/5W5tVb3">CryptoDevs</Link> - Η κοινότητα Discord εστιασμένη στην ανάπτυξη του Ethereum.</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ethstaker">EthStaker Discord</Link> - καθοδήγηση, εκπαίδευση, υποστήριξη και πόροι από την κοινότητα για υπάρχοντες και πιθανούς συμμετέχοντες.</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ethereum-org">Ομάδα ιστότοπου Ethereum.org</Link> - ελάτε και συζητήστε για την ανάπτυξη και τον σχεδιασμό του ιστότοπου ethereum.org με την ομάδα και τους ανθρώπους από την κοινότητα.</SocialListItem>

--- a/public/content/translations/es/community/online/index.md
+++ b/public/content/translations/es/community/online/index.md
@@ -22,7 +22,7 @@ Cientos de miles de entusiastas de Ethereum se reúnen en estos foros en línea 
 ## Salas de chat {#chat-rooms}
 
 <SocialListItem socialIcon="discord"><Link to="https://discord.com/invite/Nz6rtfJ8Cu">Ethereum Cat Herders</Link>: chat orientado a la comunidad donde se ofrece apoyo a la gestión de proyectos de desarrollo de Ethereum</SocialListItem>
-<SocialListItem socialIcon="discord"><Link to="https://ethglobal.co/discord">Ethereum Hackers</Link>: un chat en Discord ejecutado por ETHGlobal: una comunidad en línea para los hackers de Ethereum repartidos por todo el mundo</SocialListItem>
+<SocialListItem socialIcon="discord"><Link to="https://ethglobal.com/discord">Ethereum Hackers</Link>: un chat en Discord ejecutado por ETHGlobal: una comunidad en línea para los hackers de Ethereum repartidos por todo el mundo</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/5W5tVb3">CryptoDevs</Link>: chat de Discord centrado en el desarrollo de Ethereum</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ethstaker">Discord de EthStaker</Link>: guía, educación, apoyo y recursos gestionados por la comunidad para participantes existentes y potenciales</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ethereum-org">Equipo del sitio web Ethereum.org</Link>: pase por este chat y hable sobre el desarrollo y diseño del sitio web de ethereum.org web con el equipo encargado y con otros compañeros de la comunidad</SocialListItem>

--- a/public/content/translations/fa/community/online/index.md
+++ b/public/content/translations/fa/community/online/index.md
@@ -22,7 +22,7 @@ lang: fa
 ## اتاق‌های گفتگو {#chat-rooms}
 
 <SocialListItem socialIcon="discord"><Link to="https://discord.com/invite/Nz6rtfJ8Cu">Cat Herderهای اتریوم</Link> - جامعه‌ای با محوریت ارائه‌ی کمک در بحث مدیریت پروژه برای توسعه‌ی اتریوم</SocialListItem>
-<SocialListItem socialIcon="discord"><Link to="https://ethglobal.co/discord">هکرهای اتریوم</Link> - فضای گفتگوی Discord تحت مدیریت ETHGlobal: یک انجمن آنلاین برای هکرهای اتریوم در سراسر جهان</SocialListItem>
+<SocialListItem socialIcon="discord"><Link to="https://ethglobal.com/discord">هکرهای اتریوم</Link> - فضای گفتگوی Discord تحت مدیریت ETHGlobal: یک انجمن آنلاین برای هکرهای اتریوم در سراسر جهان</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/5W5tVb3">CryptoDevs</Link> - انجمن Discord متمرکز بر توسعه‌ی اتریوم</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ethstaker">دیسکورد EthStaker </Link> - راهنمایی، آموزش، حمایت و مجموعه منابعی برای سهام گذاران کنونی و آینده که از سوی اعضای جامعه Ethstaker تهیه شده و اداره میشود</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ethereum-org">تیم وب سایت Ethereum.org</Link> - با تیم و افراد جامعه توسعه و طراحی وب ethereum.org گفتگو کنید</SocialListItem>

--- a/public/content/translations/fr/community/online/index.md
+++ b/public/content/translations/fr/community/online/index.md
@@ -22,7 +22,7 @@ Des centaines de milliers de passionnés d'Ethereum se rassemblent sur ces forum
 ## Salons de discussion {#chat-rooms}
 
 <SocialListItem socialIcon="discord"><Link to="https://discord.com/invite/Nz6rtfJ8Cu">Ethereum Cat Herders</Link> - communauté orientée autour de l'offre de soutien à la gestion de projet concernant le développement d'Ethereum</SocialListItem>
-<SocialListItem socialIcon="discord"><Link to="https://ethglobal.co/discord">Hackers Ethereum</Link> - Salon Discord administré par ETHGlobal : une communauté en ligne pour les hackers Ethereum dans le monde entier</SocialListItem>
+<SocialListItem socialIcon="discord"><Link to="https://ethglobal.com/discord">Hackers Ethereum</Link> - Salon Discord administré par ETHGlobal : une communauté en ligne pour les hackers Ethereum dans le monde entier</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/5W5tVb3">CryptoDevs</Link> - Communauté Discord axée sur le développement Ethereum</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ethstaker">Le serveur Discord d'EthStaker</Link> - orientation par la communauté, éducation, soutien et ressources pour les stakeurs et stakeurs potentiels.</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ethereum-org">Équipe du site web Ethereum.org</Link> - consultez et discutez du développement et du design du site web ethereum.org avec l'équipe et les membres de la communauté</SocialListItem>

--- a/public/content/translations/hu/community/online/index.md
+++ b/public/content/translations/hu/community/online/index.md
@@ -22,7 +22,7 @@ Ethereum rajongók százezrei gyűlnek össze ezeken az online fórumokon, hogy 
 ## Csevegőszobák {#chat-rooms}
 
 <SocialListItem socialIcon="discord"><Link to="https://discord.com/invite/Nz6rtfJ8Cu">Ethereum Cat Herders</Link> – projektmanagement-támogatás az Ethereum-fejlesztésekhez</SocialListItem>
-<SocialListItem socialIcon="discord"><Link to="https://ethglobal.co/discord">Ethereum Hackers</Link> – az ETHGlobal által üzemeltetett Discord chat: online közösség az Ethereum hackereknek világszinten</SocialListItem>
+<SocialListItem socialIcon="discord"><Link to="https://ethglobal.com/discord">Ethereum Hackers</Link> – az ETHGlobal által üzemeltetett Discord chat: online közösség az Ethereum hackereknek világszinten</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/5W5tVb3">CryptoDevs</Link> – Ethereum-fejlesztésre fókuszáló Discord-közösség</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ethstaker">EthStaker Discord</Link> – közösségi vezetésű útmutatás, oktatás, támogatás és források a meglévő és lehetséges letéteseknek</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ethereum-org">Ethereum.org website team</Link> – beszélgessen az ethereum.org web fejlesztésről és dizájnról a közösség tagjaival</SocialListItem>

--- a/public/content/translations/it/community/online/index.md
+++ b/public/content/translations/it/community/online/index.md
@@ -22,7 +22,7 @@ Centinaia di migliaia di appassionati di Ethereum si riuniscono in questi forum 
 ## Stanze di chat {#chat-rooms}
 
 <SocialListItem socialIcon="discord"><Link to="https://discord.com/invite/Nz6rtfJ8Cu">Ethereum Cat Herders</Link> - community orientata all'offerta di assistenza per la gestione dei progetti per lo sviluppo di Ethereum</SocialListItem>
-<SocialListItem socialIcon="discord"><Link to="https://ethglobal.co/discord">Ethereum Hackers</Link> - Chat Discord gestita da ETHGlobal: una community online per gli hacker di Ethereum in tutto il mondo</SocialListItem>
+<SocialListItem socialIcon="discord"><Link to="https://ethglobal.com/discord">Ethereum Hackers</Link> - Chat Discord gestita da ETHGlobal: una community online per gli hacker di Ethereum in tutto il mondo</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/5W5tVb3">CryptoDevs</Link> - Community Discord focalizzata sullo sviluppo di Ethereum</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ethstaker">EthStaker Discord</Link>: guida, istruzione, assistenza e risorse gestite dalla comunità per gli staker esistenti e potenziali</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ethereum-org">Ethereum.org website team</Link> - date un'occhiata e chattate sullo sviluppo e la progettazione di ethereum.org con il team e le persone della community</SocialListItem>

--- a/public/content/translations/ja/community/online/index.md
+++ b/public/content/translations/ja/community/online/index.md
@@ -22,7 +22,7 @@ lang: ja
 ## チャットルーム {#chat-rooms}
 
 <SocialListItem socialIcon="discord"><Link to="https://discord.com/invite/Nz6rtfJ8Cu">Ethereum Cat Herders</Link> - イーサリアム開発プロジェクトの管理支援に関するコミュニティ</SocialListItem>
-<SocialListItem socialIcon="discord"><Link to="https://ethglobal.co/discord">Ethereum Hackers</Link> - ETHGlobalが運営するDiscordチャット: 世界中のイーサリアムハッカーのオンラインコミュニティ</SocialListItem>
+<SocialListItem socialIcon="discord"><Link to="https://ethglobal.com/discord">Ethereum Hackers</Link> - ETHGlobalが運営するDiscordチャット: 世界中のイーサリアムハッカーのオンラインコミュニティ</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/5W5tVb3">CryptoDevs</Link> - イーサリアム開発に関するDiscordコミュニティ</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ethstaker">EthStaker Discord</Link> - コミュニティが運営するステーカーおよびステーカーになるこを考えている人向けのガイダンス、教育、サポート、リソース</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ethereum-org">ethereum.orgウェブサイトチーム</Link> - ethereum.orgウェブ開発とデザインのコミュニティチャット</SocialListItem>

--- a/public/content/translations/nl/community/online/index.md
+++ b/public/content/translations/nl/community/online/index.md
@@ -22,7 +22,7 @@ Honderdduizenden liefhebbers van Ethereum verzamelen zich in deze online fora om
 ## Chatruimtes {#chat-rooms}
 
 <SocialListItem socialIcon="discord"><Link to="https://discord.com/invite/Nz6rtfJ8Cu">Ethereum Cat Herders</Link> - gemeenschap gericht op het aanbieden van projectbeheerondersteuning voor Ethereum-ontwikkeling</SocialListItem>
-<SocialListItem socialIcon="discord"><Link to="https://ethglobal.co/discord">Ethereum Hackers</Link> - Discord-chat beheerd door ETHGlobal: een online gemeenschap voor Ethereum-hackers over de hele wereld</SocialListItem>
+<SocialListItem socialIcon="discord"><Link to="https://ethglobal.com/discord">Ethereum Hackers</Link> - Discord-chat beheerd door ETHGlobal: een online gemeenschap voor Ethereum-hackers over de hele wereld</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/5W5tVb3">CryptoDevs</Link> - Ethereum-ontwikkeling gericht op de Discord-gemeenschap</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ethstaker">EthStaker Discord</Link> - gemeenschap gericht op het aanbieden van projectbeheerondersteuning voor Ethereum-ontwikkeling</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ethereum-org">Websiteteam van Ethereum.org</Link> - kom langs en chat over webontwikkeling en -ontwerp van ethereum.org met het team en de mensen van de gemeenschap</SocialListItem>

--- a/public/content/translations/pl/community/online/index.md
+++ b/public/content/translations/pl/community/online/index.md
@@ -22,7 +22,7 @@ Setki tysięcy entuzjastów Ethereum gromadzi się na tych forach internetowych,
 ## Czaty {#chat-rooms}
 
 <SocialListItem socialIcon="discord"><Link to="https://discord.com/invite/Nz6rtfJ8Cu">Ethereum Cat Herders</Link> — społeczność skoncentrowana na oferowaniu wsparcia w zarządzaniu projektami rozwoju Ethereum</SocialListItem>
-<SocialListItem socialIcon="discord"><Link to="https://ethglobal.co/discord">Ethereum Hackers</Link> — czat Discord prowadzony przez ETHGlobal: społeczność internetowa dla hakerów Ethereum na całym świecie</SocialListItem>
+<SocialListItem socialIcon="discord"><Link to="https://ethglobal.com/discord">Ethereum Hackers</Link> — czat Discord prowadzony przez ETHGlobal: społeczność internetowa dla hakerów Ethereum na całym świecie</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/5W5tVb3">CryptoDevs</Link> — społeczność Discord skupiająca się na rozwoju Ethereum</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ethstaker">EthStaker Discord</Link> — prowadzone przez społeczność wskazówki, edukacja, wsparcie i zasoby dla obecnych i potencjalnych stakerów</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ethereum-org">Zespół strony internetowej ethereum.org</Link> — wpadnij i porozmawiaj o tworzeniu i projektowaniu strony internetowej ethereum.org z zespołem i ludźmi ze społeczności</SocialListItem>

--- a/public/content/translations/pt-br/community/online/index.md
+++ b/public/content/translations/pt-br/community/online/index.md
@@ -22,7 +22,7 @@ Centenas de milhares de entusiastas do Ethereum se reúnem nestes fóruns na Int
 ## Salas de bate-papo {#chat-rooms}
 
 <SocialListItem socialIcon="discord"><Link to="https://discord.com/invite/Nz6rtfJ8Cu">Ethereum Cat Herders</Link> –Comunidade orientada em torno da oferta de apoio à gestão de projetos para o desenvolvimento do Ethereum</SocialListItem>
-<SocialListItem socialIcon="discord"><Link to="https://ethglobal.co/discord">Ethereum Hackers</Link> – Chat no Discord administrado pela ETHGlobal: uma comunidade online para hackers Ethereum em todo o mundo</SocialListItem>
+<SocialListItem socialIcon="discord"><Link to="https://ethglobal.com/discord">Ethereum Hackers</Link> – Chat no Discord administrado pela ETHGlobal: uma comunidade online para hackers Ethereum em todo o mundo</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/5W5tVb3">CryptoDevs</Link> – Comunidade Discord focada no desenvolvimento do Ethereum</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ethstaker">EthStaker Discord</Link> - orientação, educação, apoio e recursos geridos pela comunidade para stakers existentes e potenciais</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ethereum-org">Equipe do site Ethereum.org</Link> – pare e converse sobre desenvolvimento e design do site ethereum.org com a equipe e pessoas da comunidade</SocialListItem>

--- a/public/content/translations/ru/community/online/index.md
+++ b/public/content/translations/ru/community/online/index.md
@@ -22,7 +22,7 @@ lang: ru
 ## Комнаты чата {#chat-rooms}
 
 <SocialListItem socialIcon="discord"><Link to="https://discord.com/invite/Nz6rtfJ8Cu">Ethereum Cat Herders</Link> — сообщество, нацеленное на помощь с управлением проектами при разработке Ethereum</SocialListItem>
-<SocialListItem socialIcon="discord"><Link to="https://ethglobal.co/discord">Ethereum Hackers</Link> — чат Discord, управляемый ETHGlobal: онлайн-сообщество для хакеров Ethereum со всего мира</SocialListItem>
+<SocialListItem socialIcon="discord"><Link to="https://ethglobal.com/discord">Ethereum Hackers</Link> — чат Discord, управляемый ETHGlobal: онлайн-сообщество для хакеров Ethereum со всего мира</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/5W5tVb3">CryptoDevs</Link> — сообщество Discord, сконцентрированное на разработке Ethereum</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ethstaker">Сообщество EthStaker на Discord</Link> — сообщество для образования, наставничества, поддержки и предоставления ресурсов для существующих и потенциальных стейкеров</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ethereum-org">Команда сайта Ethereum.org</Link> — возможность решить проблемы и поговорить о разработке и дизайне ethereum.org с командой и членами сообщества</SocialListItem>

--- a/public/content/translations/sw/community/online/index.md
+++ b/public/content/translations/sw/community/online/index.md
@@ -22,7 +22,7 @@ Mamia ya maelfu ya wapenzi wa Ethereum hukusanyika kwenye majukwaa haya ya mtand
 ## Vyumba vya gumzo {#chat-rooms}
 
 <SocialListItem socialIcon="discord"><Link to="https://discord.com/invite/Nz6rtfJ8Cu">Ethereum Cat Herders</Link> - jamii iliyozama kutoa usaidizi wa usimamizi wa miradi kwa maboresho ya </SocialListItem>
-<SocialListItem socialIcon="discord"><Link to="https://ethglobal.co/discord">Wadukuzi wa Ethereum</Link> - gumzo la Discord linaloendeshwa na ETHGlobal: jamii ya mtandaoni ya wadukuzi wa Ethereum kote duniani</SocialListItem>
+<SocialListItem socialIcon="discord"><Link to="https://ethglobal.com/discord">Wadukuzi wa Ethereum</Link> - gumzo la Discord linaloendeshwa na ETHGlobal: jamii ya mtandaoni ya wadukuzi wa Ethereum kote duniani</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/5W5tVb3">CryptoDevs</Link> - Maboresho ya Ethereum yanalenga jamii ya Discord</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ethstaker">EthStaker Discord</Link> - jamii iliyozama kutoa usaidizi wa usimamizi wa miradi kwa maboresho ya </SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ethereum-org">Timu ya tovuti ya Ethereum.org</Link> - tembelea na upige gumzo kwenye maboresho ya wavuti wa ethereum.org na uunde na timu na watu kutoka katika jamii</SocialListItem>

--- a/public/content/translations/tr/community/online/index.md
+++ b/public/content/translations/tr/community/online/index.md
@@ -22,7 +22,7 @@ Yüz binlerce Ethereum meraklısı, haberleri paylaşmak, son gelişmeler hakkı
 ## Sohbet odaları {#chat-rooms}
 
 <SocialListItem socialIcon="discord"><Link to="https://discord.com/invite/Nz6rtfJ8Cu">Ethereum Kedi Güdücüler</Link> - Ethereum geliştirmeye proje yönetimi desteği sunmaya odaklı topluluk</SocialListItem>
-<SocialListItem socialIcon="discord"><Link to="https://ethglobal.co/discord">Ethereum Bilgisayar Korsanları</Link> - ETHGlobal tarafından yürütülen Discord sohbeti: tüm dünyadaki Ethereum bilgisayar korsanları için çevrimiçi bir topluluk</SocialListItem>
+<SocialListItem socialIcon="discord"><Link to="https://ethglobal.com/discord">Ethereum Bilgisayar Korsanları</Link> - ETHGlobal tarafından yürütülen Discord sohbeti: tüm dünyadaki Ethereum bilgisayar korsanları için çevrimiçi bir topluluk</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/5W5tVb3">CryptoDevs</Link> - Ethereum geliştirme odaklı Discord topluluğu</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ethstaker">EthStaker Discord</Link> - mevcut ve potansiyel kilitleyiciler için topluluk tarafından yönetilen rehberlik, eğitim, destek ve kaynaklar</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="/discord/">Ethereum.org web sitesi ekibi</Link> - uğrayın ve ethereum.org web geliştirme ve tasarımı ekibi ile ve topluluktan insanlarla sohbet edin</SocialListItem>

--- a/public/content/translations/uk/community/online/index.md
+++ b/public/content/translations/uk/community/online/index.md
@@ -22,7 +22,7 @@ lang: uk
 ## Чати {#chat-rooms}
 
 <SocialListItem socialIcon="discord"><Link to="https://discord.com/invite/Nz6rtfJ8Cu">Ethereum Cat Herders</Link> — спільнота, орієнтована на допомогу з управлінням проєктами під час розробки Ethereum</SocialListItem>
-<SocialListItem socialIcon="discord"><Link to="https://ethglobal.co/discord">Ethereum Hackers</Link> — чат Discord, який керується ETHGlobal: онлайн-спільнота для хакерів Ethereum з усього світу</SocialListItem>
+<SocialListItem socialIcon="discord"><Link to="https://ethglobal.com/discord">Ethereum Hackers</Link> — чат Discord, який керується ETHGlobal: онлайн-спільнота для хакерів Ethereum з усього світу</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/5W5tVb3">CryptoDevs</Link> — спільнота Discord, сфокусована на розробці Ethereum</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ethstaker">EthStaker Discord</Link> — спільнота, орієнтована на допомогу під час управління проєктами, пов’язаними з розробкою Ethereum</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ethereum-org">Ethereum.org website team</Link> — можливість поспілкуватися з командою та спільнотою щодо розробки й дизайну ethereum.org</SocialListItem>

--- a/public/content/translations/zh-tw/community/online/index.md
+++ b/public/content/translations/zh-tw/community/online/index.md
@@ -22,7 +22,7 @@ lang: zh-tw
 ## 聊天室 {#chat-rooms}
 
 <SocialListItem socialIcon="discord"><Link to="https://discord.com/invite/Nz6rtfJ8Cu">以太牧貓人組織</Link> - 提供專案管理以支援以太坊的社群</SocialListItem>
-<SocialListItem socialIcon="discord"><Link to="https://ethglobal.co/discord">以太坊駭客</Link> - 由全球以太坊駭客線上社群 ETHGlobal 所管理的 Discord 聊天室</SocialListItem>
+<SocialListItem socialIcon="discord"><Link to="https://ethglobal.com/discord">以太坊駭客</Link> - 由全球以太坊駭客線上社群 ETHGlobal 所管理的 Discord 聊天室</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/5W5tVb3">CryptoDevs</Link> - 專注於以太坊開發的 Discord 社群</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ethstaker">EthStaker Discord</Link> - 給現有及潛在質押者的社群營運指導、教育、支援及資源。</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ethereum-org">Ethereum.org 網站團隊</Link> - 訪問並和團隊及社群大眾聊聊 Ethereum.org 網站開發及設計</SocialListItem>

--- a/public/content/translations/zh/community/online/index.md
+++ b/public/content/translations/zh/community/online/index.md
@@ -22,7 +22,7 @@ lang: zh
 ## 聊天室 {#chat-rooms}
 
 <SocialListItem socialIcon="discord"><Link to="https://discord.com/invite/Nz6rtfJ8Cu">Ethereum Cat Herders</Link> - 专注于为以太坊开发提供项目管理支持的社区。</SocialListItem>
-<SocialListItem socialIcon="discord"><Link to="https://ethglobal.co/discord">Ethereum Hackers</Link> - 由 ETHGlobal 管理的 Discord 聊天室：全世界以太坊黑客的线上社区。</SocialListItem>
+<SocialListItem socialIcon="discord"><Link to="https://ethglobal.com/discord">Ethereum Hackers</Link> - 由 ETHGlobal 管理的 Discord 聊天室：全世界以太坊黑客的线上社区。</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/5W5tVb3">CryptoDevs</Link> - 关注以太坊发展的 Discord 社区</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ethstaker">EthStaker Discord</Link> - 社区为现有和潜在的质押人提供的指导、教育、支持和资源。</SocialListItem>
 <SocialListItem socialIcon="discord"><Link to="https://discord.gg/ethereum-org">Ethereum.org 网站团队</Link> - 拜访社区中的团队和成员并与他们讨论 ethereum.org 的网络开发和设计</SocialListItem>


### PR DESCRIPTION
## Description
- Update ETHGobal Discord link to use `.com` instead of `.co`

## Related Issue
From UX Research sync