### PR TITLE
replaced unaccesible link from intro to ethereum page

### DIFF
--- a/public/content/developers/docs/intro-to-ethereum/index.md
+++ b/public/content/developers/docs/intro-to-ethereum/index.md
@@ -107,7 +107,7 @@ A reusable snippet of code (a program) which a developer publishes into EVM stat
 ## Further reading {#further-reading}
 
 - [Ethereum Whitepaper](/whitepaper/)
-- [How does Ethereum work, anyway?](https://www.preethikasireddy.com/post/how-does-ethereum-work-anyway) - _Preethi Kasireddy_ (**NB** this resource is still valuable but be aware that it predates [The Merge](/roadmap/merge) and therefore still refers to Ethereum's proof-of-work mechanism - Ethereum is actually now secured using [proof-of-stake](/developers/docs/consensus-mechanisms/pos))
+- [How does Ethereum work, anyway?](https://medium.com/@preethikasireddy/how-does-ethereum-work-anyway-22d1df506369) - _Preethi Kasireddy_ (**NB** this resource is still valuable but be aware that it predates [The Merge](/roadmap/merge) and therefore still refers to Ethereum's proof-of-work mechanism - Ethereum is actually now secured using [proof-of-stake](/developers/docs/consensus-mechanisms/pos))
 
 _Know of a community resource that helped you? Edit this page and add it!_
 

--- a/public/content/translations/it/developers/docs/intro-to-ethereum/index.md
+++ b/public/content/translations/it/developers/docs/intro-to-ethereum/index.md
@@ -107,7 +107,7 @@ Uno snippet di codice riutilizzabile (programma) che uno sviluppatore pubblica n
 ## Letture consigliate {#further-reading}
 
 - [Ethereum Whitepaper](/whitepaper/)
-- [How does Ethereum work, anyway?](https://www.preethikasireddy.com/post/how-does-ethereum-work-anyway) - _Preethi Kasireddy_ (**NB** questa risorsa è ancora preziosa ma tieni presente che è antecedente a [ La Fusione](/roadmap/merge) e quindi si riferisce ancora al meccanismo proof-of-work di Ethereum: attualmente Ethereum è protetta da un meccanismo [proof-of-stake](/developers/docs/consensus-mechanisms/pos))
+- [How does Ethereum work, anyway?](https://medium.com/@preethikasireddy/how-does-ethereum-work-anyway-22d1df506369) - _Preethi Kasireddy_ (**NB** questa risorsa è ancora preziosa ma tieni presente che è antecedente a [ La Fusione](/roadmap/merge) e quindi si riferisce ancora al meccanismo proof-of-work di Ethereum: attualmente Ethereum è protetta da un meccanismo [proof-of-stake](/developers/docs/consensus-mechanisms/pos))
 
 _Conosci una risorsa della community che ti è stata utile? Modifica questa pagina e aggiungila!_
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

-  Removed unaccessible link from the intro to Ethereum page and replaced it with the working one.
-  The previous link used a domain that was expired, so replaced it with a link of the medium article directly.

## Screenshots

<img width="1440" alt="Screenshot 2024-06-21 at 1 21 35 AM" src="https://github.com/ethereum/ethereum-org-website/assets/119534349/1be07762-22a4-478f-afd6-862fa3b3f91c">


## Related Issue
https://github.com/ethereum/ethereum-org-website/issues/13209

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
