### PR TITLE
fix: update incorrect link

### DIFF
--- a/public/content/developers/docs/intro-to-ethereum/index.md
+++ b/public/content/developers/docs/intro-to-ethereum/index.md
@@ -107,7 +107,7 @@ A reusable snippet of code (a program) which a developer publishes into EVM stat
 ## Further reading {#further-reading}
 
 - [Ethereum Whitepaper](/whitepaper/)
-- [How does Ethereum work, anyway?](https://www.preethikasireddy.com/post/how-does-ethereum-work-anyway) - _Preethi Kasireddy_ (**NB** this resource is still valuable but be aware that it predates [The Merge](/roadmap/merge) and therefore still refers to Ethereum's proof-of-work mechanism - Ethereum is actually now secured using [proof-of-stake](/developers/docs/consensus-mechanisms/pos))
+- [How does Ethereum work, anyway?](https://preethikasireddy.medium.com/how-does-ethereum-work-anyway-22d1df506369) - _Preethi Kasireddy_ (**NB** this resource is still valuable but be aware that it predates [The Merge](/roadmap/merge) and therefore still refers to Ethereum's proof-of-work mechanism - Ethereum is actually now secured using [proof-of-stake](/developers/docs/consensus-mechanisms/pos))
 
 _Know of a community resource that helped you? Edit this page and add it!_
 


### PR DESCRIPTION
The old link "How does Ethereum work, anyway?" in the [FURTHER READING](https://ethereum.org/en/developers/docs/intro-to-ethereum/#further-reading) section of the "Intro to Ethereum" page is no longer accessible, because the domain "preethikasireddy.com" expired a long time.

Now this link is replaced with the correct link to this article hosted on medium.com.

This PR has been discussed in this issue https://github.com/ethereum/ethereum-org-website/issues/13209
