### PR TITLE
remove reference to unmaintained eEVM

### DIFF
--- a/public/content/developers/docs/evm/index.md
+++ b/public/content/developers/docs/evm/index.md
@@ -63,7 +63,6 @@ Over Ethereum's nine year history, the EVM has undergone several revisions, and 
 - [Py-EVM](https://github.com/ethereum/py-evm) - _Python_
 - [evmone](https://github.com/ethereum/evmone) - _C++_
 - [ethereumjs-vm](https://github.com/ethereumjs/ethereumjs-vm) - _JavaScript_
-- [eEVM](https://github.com/microsoft/eevm) - _C++_
 - [revm](https://github.com/bluealloy/revm) - _Rust_
 
 ## Further Reading {#further-reading}

--- a/public/content/translations/de/developers/docs/evm/index.md
+++ b/public/content/translations/de/developers/docs/evm/index.md
@@ -63,7 +63,6 @@ Während der siebenjährigen Geschichte von Ethereum hat die EVM mehrere Revisio
 - [Py-EVM](https://github.com/ethereum/py-evm) - _Python_
 - [evmone](https://github.com/ethereum/evmone) - _C++_
 - [ethereumjs-vm](https://github.com/ethereumjs/ethereumjs-vm) - _JavaScript_
-- [eEVM](https://github.com/microsoft/eevm) - _C++_
 - [revm](https://github.com/bluealloy/revm) - _Rust_
 
 ## Weiterführende Informationen {#further-reading}

--- a/public/content/translations/es/developers/docs/evm/index.md
+++ b/public/content/translations/es/developers/docs/evm/index.md
@@ -63,7 +63,6 @@ Durante los nueve años de historia de Ethereum, la EVM ha pasado varias revisio
 - [Py-EVM](https://github.com/ethereum/py-evm) - _Python_.
 - [evmone](https://github.com/ethereum/evmone) - _C++_.
 - [ethereumjs-vm](https://github.com/ethereumjs/ethereumjs-vm) - _JavaScript_.
-- [eEVM](https://github.com/microsoft/eevm) - _C++_.
 - [revm](https://github.com/bluealloy/revm) - _Rust_
 
 ## Más información {#further-reading}

--- a/public/content/translations/fa/developers/docs/evm/index.md
+++ b/public/content/translations/fa/developers/docs/evm/index.md
@@ -63,7 +63,6 @@ EVM به صورت یک [ماشین پشته‌ای](https://wikipedia.org/wiki/S
 - [Py-EVM](https://github.com/ethereum/py-evm) ‏- _‏پایتون_
 - [evmone](https://github.com/ethereum/evmone) ‏- _سی‌پلاس‌پلاس_
 - [ethereumjs-vm](https://github.com/ethereumjs/ethereumjs-vm) ‏- _جاوا اسکریپت_
-- [eEVM](https://github.com/microsoft/eevm) ‏- _سی‌پلاس‌پلاس_
 - [revm](https://github.com/bluealloy/revm) - _Rust_
 
 ## اطلاعات بیشتر {#further-reading}

--- a/public/content/translations/fr/developers/docs/evm/index.md
+++ b/public/content/translations/fr/developers/docs/evm/index.md
@@ -63,7 +63,6 @@ Les [clients d'exécution Ethereum](/developers/docs/nodes-and-clients/#executio
 - [Py-EVM](https://github.com/ethereum/py-evm) - _Python_
 - [evmone](https://github.com/ethereum/evmone) - _C++_
 - [ethereumjs-vm](https://github.com/ethereumjs/ethereumjs-vm) - _JavaScript_
-- [eEVM](https://github.com/microsoft/eevm) - _C++_
 - [revm](https://github.com/bluealloy/revm) - _Rust_
 
 ## Complément d'information {#further-reading}

--- a/public/content/translations/hu/developers/docs/evm/index.md
+++ b/public/content/translations/hu/developers/docs/evm/index.md
@@ -61,7 +61,6 @@ Az [Ethereum végrehajtási kliensek](/developers/docs/nodes-and-clients/#execut
 - [Py-EVM](https://github.com/ethereum/py-evm) - _Python_
 - [evmone](https://github.com/ethereum/evmone) - _C++_
 - [ethereumjs-vm](https://github.com/ethereumjs/ethereumjs-vm) - _JavaScript_
-- [eEVM](https://github.com/microsoft/eevm) - _C++_
 - [revm](https://github.com/bluealloy/revm) - _Rust_
 
 ## További olvasnivaló {#further-reading}

--- a/public/content/translations/id/developers/docs/evm/index.md
+++ b/public/content/translations/id/developers/docs/evm/index.md
@@ -63,7 +63,7 @@ Semua [klien Ethereum](/developers/docs/nodes-and-clients/#execution-clients) me
 - [Py-EVM](https://github.com/ethereum/py-evm) - _Python_
 - [evmone](https://github.com/ethereum/evmone) - _C++_
 - [ethereumjs-vm](https://github.com/ethereumjs/ethereumjs-vm) - _JavaScript_
-- [eEVM](https://github.com/microsoft/eevm) - _C++_
+- [revm](https://github.com/bluealloy/revm) - _Rust_
 
 ## Bacaan Lebih Lanjut {#further-reading}
 

--- a/public/content/translations/it/developers/docs/evm/index.md
+++ b/public/content/translations/it/developers/docs/evm/index.md
@@ -63,7 +63,6 @@ Tutti i [client Ethereum](/developers/docs/nodes-and-clients/#execution-clients)
 - [Py-EVM](https://github.com/ethereum/py-evm) - _Python_
 - [evmone](https://github.com/ethereum/evmone) - _C++_
 - [ethereumjs-vm](https://github.com/ethereumjs/ethereumjs-vm) - _JavaScript_
-- [eEVM](https://github.com/microsoft/eevm) - _C++_
 - [revm](https://github.com/bluealloy/revm) - _Rust_
 
 ## Letture consigliate {#further-reading}

--- a/public/content/translations/ja/developers/docs/evm/index.md
+++ b/public/content/translations/ja/developers/docs/evm/index.md
@@ -63,7 +63,6 @@ EVMのすべての実装は、イーサリアムイエローペーパーに記�
 - [Py-EVM](https://github.com/ethereum/py-evm) - _Python_
 - [evmone](https://github.com/ethereum/evmone) - _C++_
 - [ethereumjs-vm](https://github.com/ethereumjs/ethereumjs-vm) - _JavaScript_
-- [eEVM](https://github.com/microsoft/eevm) - _C++_
 - [revm](https://github.com/bluealloy/revm) - _Rust_
 
 ## 参考文献 {#further-reading}

--- a/public/content/translations/pl/developers/docs/evm/index.md
+++ b/public/content/translations/pl/developers/docs/evm/index.md
@@ -68,7 +68,7 @@ Wszyscy [klienci Ethereum](/developers/docs/nodes-and-clients/#execution-clients
 - [Py-EVM](https://github.com/ethereum/py-evm) - _Python_
 - [evmone](https://github.com/ethereum/evmone) - _C++_
 - [ethereumjs-vm](https://github.com/ethereumjs/ethereumjs-vm) - _JavaScript_
-- [eEVM](https://github.com/microsoft/eevm) - _C++_
+- [revm](https://github.com/bluealloy/revm) - _Rust_
 
 ## Dalsza lektura {#further-reading}
 

--- a/public/content/translations/pt-br/developers/docs/evm/index.md
+++ b/public/content/translations/pt-br/developers/docs/evm/index.md
@@ -63,7 +63,6 @@ Os [clientes de execução Ethereum](/developers/docs/nodes-and-clients/#executi
 - [Py-EVM](https://github.com/ethereum/py-evm) - _Python_
 - [evmone](https://github.com/ethereum/evmone) - _C++_
 - [ethereumjs-vm](https://github.com/ethereumjs/ethereumjs-vm) - _JavaScript_
-- [eEVM](https://github.com/microsoft/eevm) - _C++_
 - [revm](https://github.com/bluealloy/revm) - _Rust_
 
 ## Leitura adicional {#further-reading}

--- a/public/content/translations/ro/developers/docs/evm/index.md
+++ b/public/content/translations/ro/developers/docs/evm/index.md
@@ -63,7 +63,7 @@ Toți [clienții Ethereum](/developers/docs/nodes-and-clients/#execution-clients
 - [Py-EVM](https://github.com/ethereum/py-evm) - _Python_
 - [evmone](https://github.com/ethereum/evmone) - _C++_
 - [ethereumjs-vm](https://github.com/ethereumjs/ethereumjs-vm) - _JavaScript_
-- [eEVM](https://github.com/microsoft/eevm) - _C++_
+- [revm](https://github.com/bluealloy/revm) - _Rust_
 
 ## Referințe suplimentare {#further-reading}
 

--- a/public/content/translations/ru/developers/docs/evm/index.md
+++ b/public/content/translations/ru/developers/docs/evm/index.md
@@ -63,7 +63,6 @@ EVM работает как [стековая машина](https://wikipedia.or
 - [Py-EVM](https://github.com/ethereum/py-evm) — _Python_
 - [evmone](https://github.com/ethereum/evmone) — _C++_
 - [ethereumjs-vm](https://github.com/ethereumjs/ethereumjs-vm) — _JavaScript_
-- [eEVM](https://github.com/microsoft/eevm) — _C++_
 - [revm](https://github.com/bluealloy/revm) - _Rust_
 
 ## Дополнительные ресурсы {#further-reading}

--- a/public/content/translations/tr/developers/docs/evm/index.md
+++ b/public/content/translations/tr/developers/docs/evm/index.md
@@ -63,7 +63,7 @@ Tüm [Ethereum yürütme istemcileri](/developers/docs/nodes-and-clients/#execut
 - [Py-EVM](https://github.com/ethereum/py-evm) - _Python_
 - [evmone](https://github.com/ethereum/evmone) - _C++_
 - [ethereumjs-vm](https://github.com/ethereumjs/ethereumjs-vm) - _JavaScript_
-- [eEVM](https://github.com/microsoft/eevm) - _C++_
+- [revm](https://github.com/bluealloy/revm) - _Rust_
 
 ## Daha Fazla Bilgi {#further-reading}
 

--- a/public/content/translations/zh-tw/developers/docs/evm/index.md
+++ b/public/content/translations/zh-tw/developers/docs/evm/index.md
@@ -63,7 +63,6 @@ Y(S, T)= S'
 - [Py-EVM](https://github.com/ethereum/py-evm) - _Python_
 - [evmone](https://github.com/ethereum/evmone) - _C++_
 - [ethereumjs-vm](https://github.com/ethereumjs/ethereumjs-vm) - _JavaScript_
-- [eEVM](https://github.com/microsoft/eevm) - _C++_
 - [revm](https://github.com/bluealloy/revm) - _Rust_
 
 ## 延伸閱讀 {#further-reading}

--- a/public/content/translations/zh/developers/docs/evm/index.md
+++ b/public/content/translations/zh/developers/docs/evm/index.md
@@ -63,7 +63,6 @@ EVM 的所有实现都必须遵守以太坊黄皮书中描述的规范。
 - [Py-EVM](https://github.com/ethereum/py-evm) - _Python_
 - [evmone](https://github.com/ethereum/evmone) - _C++_
 - [ethereumjs-vm](https://github.com/ethereumjs/ethereumjs-vm) - _JavaScript_
-- [eEVM](https://github.com/microsoft/eevm) - _C++_
 - [revm](https://github.com/bluealloy/revm) - _Rust_
 
 ## 延伸阅读 {#further-reading}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

[eEVM](https://github.com/microsoft/eEVM) is archived and hasn't been updated in a year. I did not find any link to a new code location, so I think this project is not maintained in any more.

This PR removes the link from this page: https://ethereum.org/en/developers/docs/evm/

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
