### PR TITLE
fix(pages/layer-2): update image path for meta

### DIFF
--- a/src/pages/layer-2.tsx
+++ b/src/pages/layer-2.tsx
@@ -261,7 +261,7 @@ const Layer2Page = () => {
       <PageMetadata
         title={t("layer-2-hero-title")}
         description={t("layer-2-metadata-description")}
-        image="/heroes/layer-2-hub-hero.jpg"
+        image="/images/heroes/layer-2-hub-hero.jpg"
       />
       {/* Hero Section */}
       <HubHero {...heroContent} />


### PR DESCRIPTION

<!--- Describe your changes in detail -->
The Layer 2 Hero image does not appear when sharing the page link to social media.

Fix relative path string for the hero image passed to `PageMetadata`.


<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
