### PR TITLE
fix: remove outdated subtext

### DIFF
--- a/public/content/developers/docs/nodes-and-clients/node-architecture/index.md
+++ b/public/content/developers/docs/nodes-and-clients/node-architecture/index.md
@@ -12,8 +12,6 @@ The diagram below shows the relationship between the two Ethereum clients. The t
 
 ![](node-architecture-text-background.png)
 
-_This image is borrowed from geth.ethereum.org and uses the Geth logo to represent execution clients - there are other options for the execution client including Erigon, Nethermind and Besu_
-
 For this two-client structure to work, consensus clients must be able to pass bundles of transactions to the execution client. Executing the transactions locally is how the client validates that the transactions do not violate any Ethereum rules and that the proposed update to Ethereum’s state is correct. Likewise, when the node is selected to be a block producer the consensus client must be able to request bundles of transactions from Geth to include in the new block and execute them to update the global state. This inter-client communication is handled by a local RPC connection using the [engine API](https://github.com/ethereum/execution-apis/blob/main/src/engine/common.md).
 
 ## What does the execution client do? {#execution-client}


### PR DESCRIPTION
## Description

- Remove irrelevant image subtext
- Applied change to English only as it's low-priority, and this let's the Crowdin process handle the non-English version updates.

## Related Issue

<img width="924" alt="image" src="https://github.com/ethereum/ethereum-org-website/assets/54227730/798fd169-d76d-444b-9bff-f7f94a13c6bf">

The subtext ^ here was in reference to an older image:

<img width="886" alt="image" src="https://github.com/ethereum/ethereum-org-website/assets/54227730/9346c387-9918-445c-8179-566eabfb413c">
