### PR TITLE
style(Nav): shift hover transition to button children icon and add focus state

### DIFF
--- a/src/components/Nav/Desktop/index.tsx
+++ b/src/components/Nav/Desktop/index.tsx
@@ -35,6 +35,14 @@ const DesktopNavMenu = ({ toggleColorMode }: DesktopNavMenuProps) => {
     "Switch to Light Theme"
   )
 
+  const desktopHoverFocusStyles = {
+    '& > svg': {
+      transform: "rotate(10deg)",
+      color: "primary.hover",
+      transition: "transform 0.5s, color 0.2s"
+    }
+  }
+
   /**
    * Adds a keydown event listener to toggle color mode (ctrl|cmd + \)
    * or open the language picker (\).
@@ -54,16 +62,12 @@ const DesktopNavMenu = ({ toggleColorMode }: DesktopNavMenuProps) => {
   return (
     <HStack hideBelow="md" gap="0">
       <IconButton
-        transition="transform 0.5s, color 0.2s"
         icon={ThemeIcon}
         aria-label={themeIconAriaLabel}
         variant="ghost"
         isSecondary
         px={{ base: "2", xl: "3" }}
-        _hover={{
-          transform: "rotate(10deg)",
-          color: "primary.hover",
-        }}
+        _hover={desktopHoverFocusStyles}
         onClick={toggleColorMode}
       />
 

--- a/src/components/Nav/Desktop/index.tsx
+++ b/src/components/Nav/Desktop/index.tsx
@@ -68,6 +68,7 @@ const DesktopNavMenu = ({ toggleColorMode }: DesktopNavMenuProps) => {
         isSecondary
         px={{ base: "2", xl: "3" }}
         _hover={desktopHoverFocusStyles}
+        _focus={desktopHoverFocusStyles}
         onClick={toggleColorMode}
       />
 


### PR DESCRIPTION
[Old PR](https://github.com/ethereum/ethereum-org-website/pull/13229)

- remove hover animation from `IconButton`
- add hover animation to `IconButton`'s child svg (the icon)
- add same animation to `:focus` state

## Related Issue
[Bug: Click zone on color toggle rotating with icon effect](https://github.com/ethereum/ethereum-org-website/issues/11591)
