### PR TITLE
chore: remove unused import, fix console warning

### DIFF
--- a/src/components/Glossary/GlossaryDefinition/index.tsx
+++ b/src/components/Glossary/GlossaryDefinition/index.tsx
@@ -1,5 +1,5 @@
 import { ComponentProps } from "react"
-import { Box, type HeadingProps, Text, VStack } from "@chakra-ui/react"
+import { type HeadingProps, Text, VStack } from "@chakra-ui/react"
 
 import Heading from "@/components/Heading"
 import IdAnchor from "@/components/IdAnchor"


### PR DESCRIPTION
## Description
- Removes unused component import

## Related Issue
Resolves:

```
12:41:48 AM: ./src/components/Glossary/GlossaryDefinition/index.tsx
12:41:48 AM: 2:10  Warning: 'Box' is defined but never used.  unused-imports/no-unused-imports-ts
```
