### PR TITLE
Remove scroll button from UseCases template

### DIFF
--- a/src/layouts/UseCases.tsx
+++ b/src/layouts/UseCases.tsx
@@ -1,10 +1,8 @@
 import { useRouter } from "next/router"
 import { useTranslation } from "next-i18next"
-import { MdExpandMore } from "react-icons/md"
 import {
   Box,
   Flex,
-  Icon,
   ListItem,
   Text,
   UnorderedList,
@@ -20,7 +18,7 @@ import Emoji from "@/components/Emoji"
 import FeedbackCard from "@/components/FeedbackCard"
 import { Image } from "@/components/Image"
 import LeftNavBar from "@/components/LeftNavBar"
-import InlineLink, { BaseLink } from "@/components/Link"
+import InlineLink from "@/components/Link"
 import {
   ContentContainer,
   MobileButton,
@@ -32,8 +30,6 @@ import TableOfContents from "@/components/TableOfContents"
 
 import { getEditPath } from "@/lib/utils/editPath"
 import { getSummaryPoints } from "@/lib/utils/getSummaryPoints"
-
-import { MAIN_CONTENT_ID } from "@/lib/constants"
 
 const HeroContainer = (props: ChildOnlyProp) => (
   <Flex
@@ -236,20 +232,6 @@ export const UseCasesLayout = ({
           }}
         />
       </HeroContainer>
-      <Flex
-        as={BaseLink}
-        to={"#" + MAIN_CONTENT_ID}
-        bg="ednBackground"
-        justifyContent="center"
-        p={4}
-        width="full"
-        _hover={{
-          bg: "background.base",
-        }}
-        hideBelow={lgBp}
-      >
-        <Icon as={MdExpandMore} fontSize="2xl" color="secondary" />
-      </Flex>
       <Page>
         {/* TODO: Switch to `above="lg"` after completion of Chakra Migration */}
         <LeftNavBar


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Removes the scroll to button under the hero on the UseCases template. Was the only template with this and served nor real purpose. 

## Related Issue

- Closes: https://github.com/ethereum/ethereum-org-website/issues/11466#issuecomment-2164204176
