### PR TITLE
Fixed broken active link in developer docs navbar [Fixes #10813]

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -58,11 +58,12 @@ export const BaseLink = forwardRef(function Link(
   ref
 ) {
   const { asPath } = useRouter()
+  const cleanAsPath = asPath.replace(/#.*/, "");
   const { flipForRtl } = useRtlFlip()
 
   let href = (to ?? hrefProp) as string
 
-  const isActive = url.isHrefActive(href, asPath, isPartiallyActive)
+  const isActive = url.isHrefActive(href, cleanAsPath, isPartiallyActive)
   const isDiscordInvite = url.isDiscordInvite(href)
   const isPdf = url.isPdf(href)
   const isExternal = url.isExternal(href)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There was an issue checking `isHrefActive` in `Link.tsx` because of the unremoved hashtags from the URL.

I don't know if that's the best way to deal with it or if this fix breaks assumptions on other components that assume hashtags remain in that check.

I am not really a good developer, so it will be great if someone double checks (patch [source](https://github.com/vercel/next.js/issues/25202#issuecomment-966658956))

## Related Issue
Fixes #10813
