### PR TITLE
fix: eth page video graphic path

### DIFF
--- a/src/components/EthVideo.tsx
+++ b/src/components/EthVideo.tsx
@@ -2,8 +2,8 @@ import { Box, useColorModeValue } from "@chakra-ui/react"
 
 const EthVideo = () => {
   const src = useColorModeValue(
-    "images/ethereum-hero-light.mp4",
-    "images/ethereum-hero-dark.mp4"
+    "/images/ethereum-hero-light.mp4",
+    "/images/ethereum-hero-dark.mp4"
   )
 
   return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

It fixes `ethereum-hero-light.mp4` inappropriate path at `What is ETH?` page. Resolves [#13349]
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
