### PR TITLE
Fix error on the Verkle trees page

### DIFF
--- a/public/content/roadmap/verkle-trees/index.md
+++ b/public/content/roadmap/verkle-trees/index.md
@@ -33,7 +33,7 @@ Under the polynomial commitment scheme, the witnesses have manageable sizes that
 
 <ExpandableCard title="Exactly how much can Verkle trees reduce witness size?" eventCategory="/roadmap/verkle-trees" eventName="clicked exactly how much can Verkle trees reduce witness size?">
 
-The witness size varies depending on the number of leaves it includes. Assuming the witness covers 1000 leaves, a witness for a Merkle trie would be about 3.5MB (assuming 7 levels to the trie). A witness for the same data in a Verkle tree (assuming 4 levels to the tree) would be about 150 kB - **about 23x smaller**. This reduction in witness size will allow stateless client witnesses to be acceptably small. Polynomial witnesses are 0.128 -1 kB depending on which specific polynomial commitment is used).
+The witness size varies depending on the number of leaves it includes. Assuming the witness covers 1000 leaves, a witness for a Merkle trie would be about 3.5MB (assuming 7 levels to the trie). A witness for the same data in a Verkle tree (assuming 4 levels to the tree) would be about 150 kB - **about 23x smaller**. This reduction in witness size will allow stateless client witnesses to be acceptably small. Polynomial witnesses are 0.128 -1 kB depending on which specific polynomial commitment is used.
 
 </ExpandableCard>
 


### PR DESCRIPTION
## Description

There is an error on the Verkle trees page, the paragraph below ends with a closing bracket with no corresponding opening bracket
https://ethereum.org/en/roadmap/verkle-trees/#why-do-verkle-trees-enable-smaller-witnesses

<img width="738" alt="Screenshot 2024-07-11 at 16 56 20" src="https://github.com/ethereum/ethereum-org-website/assets/37338979/4b9395a7-a3df-4b1f-95d0-fd40fb362594">

## Related Issue

No related issue
