### PR TITLE
replaced product roadmap url on about page #13401

### DIFF
--- a/public/content/about/index.md
+++ b/public/content/about/index.md
@@ -95,7 +95,7 @@ This means the website needs to handle many different user journeys, from “a d
 
 To make our work more accessible and to foster more community collaboration, the ethereum.org core team publishes an overview of our quarterly roadmap goals.
 
-[View our 2024 Q1 product roadmap](https://github.com/ethereum/ethereum-org-website/issues/12005)
+[View our 2024 Q3 product roadmap](https://github.com/ethereum/ethereum-org-website/issues/13399)
 
 **How's that sound?** We always appreciate feedback on our roadmap - if there's something you think we should work on, please let us know! We welcome ideas and PRs from anyone in the community.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Replaced Product Roadmap URL on /about page from [View our 2024 Q1 product roadmap](https://github.com/ethereum/ethereum-org-website/issues/12005) to [View our 2024 Q3 product roadmap](https://github.com/ethereum/ethereum-org-website/issues/13399).

Issue Fixes: #13401 
<!--- Please link to the issue here: -->
