### PR TITLE
Add Alloy, successor to ethers-rs

### DIFF
--- a/public/content/developers/docs/programming-languages/rust/index.md
+++ b/public/content/developers/docs/programming-languages/rust/index.md
@@ -46,8 +46,9 @@ Need a more basic primer first? Check out [ethereum.org/learn](/learn/) or [ethe
 - [Solaris](https://github.com/paritytech/sol-rs) - _Solidity Smart Contracts unit test harness using the native Parity Client EVM._
 - [SputnikVM](https://github.com/rust-blockchain/evm) - _Rust Ethereum Virtual Machine Implementation_
 - [Wavelet](https://wavelet.perlin.net/docs/smart-contracts) - _Wavelet smart contract in Rust_
-- [Foundry](https://github.com/gakonst/foundry)- _Toolkit for Ethereum application development_
-- [Ethers_rs](https://github.com/gakonst/ethers-rs)- _Ethereum library and wallet implementation_
+- [Foundry](https://github.com/foundry-rs/foundry) - _Toolkit for Ethereum application development_
+- [Alloy](https://alloy.rs) - _High-performance, well-tested & documented libraries for interacting with Ethereum and other EVM-based chains._
+- [Ethers_rs](https://github.com/gakonst/ethers-rs) - _Ethereum library and wallet implementation_
 - [SewUp](https://github.com/second-state/SewUp) - _A library to help you build your Ethereum webassembly contract with Rust and just like develop in a common backend_
 - [Substreams](https://github.com/streamingfast/substreams) - _Parallelized blockchain data indexing technology_
 - [Reth](https://github.com/paradigmxyz/reth) Reth (short for Rust Ethereum) is a new Ethereum full-node implementation

--- a/public/content/translations/de/developers/docs/programming-languages/rust/index.md
+++ b/public/content/translations/de/developers/docs/programming-languages/rust/index.md
@@ -48,8 +48,9 @@ Sind Sie an einigen grundlegenden Informationen interessiert? Dann sehen Sie sic
 - [Solaris](https://github.com/paritytech/sol-rs) - _Testumgebung für Solidity Smart Contracts Einheitstests unter Verwendung der nativen Parity Client EVM._
 - [SputnikVM](https://github.com/rust-blockchain/evm) – _Implementierung der virtuellen Maschine von Rust Ethereum_
 - [Wavelet](https://wavelet.perlin.net/docs/smart-contracts) - _Wavelet Smart Contract in Rust_
-- [Foundry](https://github.com/gakonst/foundry) – _Toolkit für die Entwicklung von Ethereum-Anwendungen_
-- [Ethers_rs](https://github.com/gakonst/ethers-rs) – _Ethereum-Bibliothek und Wallet-Implementierung_
+- [Foundry](https://github.com/foundry-rs/foundry) - _Toolkit für die Entwicklung von Ethereum-Anwendungen_
+- [Alloy](https://alloy.rs) - _Leistungsstarke, gut getestete und dokumentierte Bibliotheken für die Interaktion mit Ethereum und anderen EVM-basierten Ketten._
+- [Ethers_rs](https://github.com/gakonst/ethers-rs) - _Ethereum-Bibliothek und Wallet-Implementierung_
 - [SewUp](https://github.com/second-state/SewUp) – _Eine Bibliothek, die Ihnen hilft, Ihren Ethereum-Webassembly-Vertrag mit Rust zu erstellen und genau wie in einem gemeinsamen Backend zu entwickeln_
 - [Substreams](https://github.com/streamingfast/substreams) - _Indexierungstechnologie für parallele Blockchain-Daten_
 - [Reth](https://github.com/paradigmxyz/reth) Reth (kurz für Rust Ethereum) ist eine neue Implementierung eines vollständigen Knotens auf Ethereum

--- a/public/content/translations/es/developers/docs/programming-languages/rust/index.md
+++ b/public/content/translations/es/developers/docs/programming-languages/rust/index.md
@@ -46,8 +46,9 @@ Utiliza Ethereum para crear aplicaciones descentralizadas (o "dapps"), que aprov
 - [Solaris:](https://github.com/paritytech/sol-rs) _arnés de pruebas unitarias de contratos inteligentes de Solidity usando la Parity Client EVM nativa._
 - [SputnikVM:](https://github.com/rust-blockchain/evm) _implementación de máquina virtual de Ethereum de Rust_
 - [Wavelet:](https://wavelet.perlin.net/docs/smart-contracts) _contrato inteligente de Wavelet en Rust_
-- [Foundry:](https://github.com/gakonst/foundry) _kit de herramientas de desarrollo de aplicaciones de Ethereum_
-- [Ethers_rs:](https://github.com/gakonst/ethers-rs) _implementación de billetera y biblioteca de Ethereum_
+- [Foundry:](https://github.com/foundry-rs/foundry) - _kit de herramientas de desarrollo de aplicaciones de Ethereum_
+- [Alloy:](https://alloy.rs) - _Bibliotecas de alto rendimiento, bien probadas y documentadas para interactuar con Ethereum y otras cadenas basadas en EVM._
+- [Ethers_rs:](https://github.com/gakonst/ethers-rs) - _implementación de billetera y biblioteca de Ethereum_
 - [SewUp:](https://github.com/second-state/SewUp) _biblioteca para ayudarlo a crear su contrato de Ethereum WebAssembly con Rust y desarrollar en un backend común_
 - [Substreams:](https://github.com/streamingfast/substreams) _tecnología de indexación de datos de cadena de bloques con paralelización_
 - [Reth](https://github.com/paradigmxyz/reth): Reth (abreviatura de Rust Ethereum) es una nueva implementación de nodo completo de Ethereum

--- a/public/content/translations/fr/developers/docs/programming-languages/rust/index.md
+++ b/public/content/translations/fr/developers/docs/programming-languages/rust/index.md
@@ -47,7 +47,8 @@ Besoin d’une approche plus élémentaire ? Consultez [ethereum.org/learn](/le
 - [Solaris](https://github.com/paritytech/sol-rs) - _Exploiter le test unitaire des contrats intelligents Solidity utilisant l'EVM natif du client Parity._
 - [SputnikVM](https://github.com/rust-blockchain/evm) - _Implémentation en Rust de machines virtuelles Ethereum_
 - [Wavelet](https://wavelet.perlin.net/docs/smart-contracts) - _Contrats intelligents Wavelet sous Rust_
-- [Foundry](https://github.com/gakonst/foundry)- _Boîte à outils pour le développement d'applications Ethereum_
+- [Foundry](https://github.com/foundry-rs/foundry)- _Boîte à outils pour le développement d'applications Ethereum_
+- [Alloy](https://alloy.rs) - _Bibliothèques hautes performances, bien testées et documentées pour interagir avec Ethereum et d'autres chaînes basées sur EVM._
 - [Ethers_rs](https://github.com/gakonst/ethers-rs) - _Bibliothèque Ethereum et implémentation de portefeuille_
 - [SewUp](https://github.com/second-state/SewUp) - _Bibliothèque pour vous aider aussi bien à créer votre contrat Webassembly Ethereum avec Rust que développer un backend commun._
 - [Substreams](https://github.com/streamingfast/substreams) - _Il s'agit de protocoles d'indexation décentralisés des données qui sont soumises à une période d'immobilisation _

--- a/public/content/translations/hu/developers/docs/programming-languages/rust/index.md
+++ b/public/content/translations/hu/developers/docs/programming-languages/rust/index.md
@@ -46,8 +46,9 @@ Szükséged van egy méginkább kezdőknek szóló alapozóra? Tekintse meg az [
 - [Solaris](https://github.com/paritytech/sol-rs) – _Solidity okosszerződések egységtesztelésének irányítása a natív Parity kliens EVM használatával._
 - [SputnikVM](https://github.com/rust-blockchain/evm) – _Rust Ethereum virtuálisgép-implementáció_
 - [Wavelet](https://wavelet.perlin.net/docs/smart-contracts) – _Wavelet okosszerződés Rust-ban_
-- [Foundry](https://github.com/gakonst/foundry) – _Eszközkészlet az Ethereum alkalmazások fejlesztéséhez_
-- [Ethers_rs](https://github.com/gakonst/ethers-rs) – _Ethereum könyvtár- és tárcaimplementáció_
+- [Foundry](https://github.com/foundry-rs/foundry) – _Eszközkészlet az Ethereum alkalmazások fejlesztéséhez_
+- [Alloy](https://alloy.rs) - _Nagy teljesítményű, jól tesztelt és dokumentált könyvtárak az Ethereummal és más EVM-alapú láncokkal való interakcióhoz._
+- [Ethers_rs](https://github.com/gakonst/ethers-rs) - _Ethereum könyvtár- és tárcaimplementáció_
 - [SewUp](https://github.com/second-state/SewUp) – _Egy könyvtár, amely segít az Ethereum webassembly szerződés Rust-ban való megépítésében, mintha egy általános backend lenne_
 - [Substreams](https://github.com/streamingfast/substreams) – _Párhuzamos blokkláncadat-indexálási technológia_
 - [Reth](https://github.com/paradigmxyz/reth) A Rust Ethereum rövidítése, ami egy új teljescsomópont-implementáció az Ethereumon

--- a/public/content/translations/it/developers/docs/programming-languages/rust/index.md
+++ b/public/content/translations/it/developers/docs/programming-languages/rust/index.md
@@ -46,8 +46,9 @@ Hai prima bisogno di nozioni di base? Dai un'occhiata a [ethereum.org/learn](/le
 - [Solaris](https://github.com/paritytech/sol-rs) - _Test unitario dei contratti intelligenti in Solidity che sfrutta l'utilizzo dell'EVM nativa del Client di Parity._
 - [SputnikVM](https://github.com/rust-blockchain/evm) - _Implementazione della Macchina Virtuale di Ethereum in Rust_
 - [Wavelet](https://wavelet.perlin.net/docs/smart-contracts) - _Smart Contract Wavelet in Rust_
-- [Foundry](https://github.com/gakonst/foundry)- _Toolkit per lo sviluppo di applicazioni Ethereum_
-- [Ethers_rs](https://github.com/gakonst/ethers-rs)- _Implementazione di librerie e portafogli di Ethereum_
+- [Foundry](https://github.com/foundry-rs/foundry) - _Toolkit per lo sviluppo di applicazioni Ethereum_
+- [Alloy](https://alloy.rs) - _Librerie ad alte prestazioni, ben testate e documentate per interagire con Ethereum e altre catene basate su EVM._
+- [Ethers_rs](https://github.com/gakonst/ethers-rs) - _Implementazione di librerie e portafogli di Ethereum_
 - [SewUp](https://github.com/second-state/SewUp) - _Una libreria per aiutarti a creare il tuo contratto webassembly di Ethereum con Rust e sviluppare in un backend comune_
 - [Substreams](https://github.com/streamingfast/substreams): _tecnologia d'indicizzazione parallelizzata dei dati della blockchain_
 - [Reth](https://github.com/paradigmxyz/reth) Reth (abbreviazione di Rust Ethereum, pronuncia) è una nuova implementazione a nodo completo su Ethereum

--- a/public/content/translations/ja/developers/docs/programming-languages/rust/index.md
+++ b/public/content/translations/ja/developers/docs/programming-languages/rust/index.md
@@ -46,8 +46,9 @@ incomplete: true
 - [Solaris](https://github.com/paritytech/sol-rs) - _ネイティブParityクライアントEVMを使用したSolidityスマートコントラクトのユニットテストハーネス_
 - [SputnikVM](https://github.com/rust-blockchain/evm) - _Rustのイーサリアム仮想マシンの実装_
 - [Wavelet](https://wavelet.perlin.net/docs/smart-contracts) - _Rustで書かれたWaveletスマートコントラクト_
-- [Foundry](https://github.com/gakonst/foundry)- _イーサリアムアプリケーション開発のためのツールキット_
-- [Ethers_rs](https://github.com/gakonst/ethers-rs)- _イーサリアムライブラリとウォレットの実装_
+- [Foundry](https://github.com/foundry-rs/foundry) - _イーサリアムアプリケーション開発のためのツールキット_
+- [Alloy](https://alloy.rs) - _Ethereum やその他の EVM ベースのチェーンと対話するための、高性能で十分にテストされ、文書化されたライブラリ。_
+- [Ethers_rs](https://github.com/gakonst/ethers-rs) - _イーサリアムライブラリとウォレットの実装_
 - [SewUp](https://github.com/second-state/SewUp) - _Rustを使用したイーサリアムWebAssemblyコントラクトの構築と、一般的なバックエンドと同様の開発をサポートするライブラリ_
 - [Substreams](https://github.com/streamingfast/substreams) - _並列化ブロックチェーンデータインデックス技術_
 - [Reth](https://github.com/paradigmxyz/reth)Reth(Rust Ethereumの略称)は、新しいイーサリアムのフルノード実装

--- a/public/content/translations/pt-br/developers/docs/programming-languages/rust/index.md
+++ b/public/content/translations/pt-br/developers/docs/programming-languages/rust/index.md
@@ -48,8 +48,9 @@ Precisa de uma introdução geral? Confira [ethereum.org/learn](/learn/) ou [eth
 - [Solaris](https://github.com/paritytech/sol-rs) — _Agente de teste unitário dos contratos inteligentes no Solidity usando o EVM nativo do cliente Parity._
 - [SputnikVM](https://github.com/rust-blockchain/evm) — _Implementação da Máquina Virtual do Ethereum no Rust_
 - [Wavelet](https://wavelet.perlin.net/docs/smart-contracts) - _smart contract Wavelet em Rust_
-- [Foundry](https://github.com/gakonst/foundry) — _Conjunto de ferramentas para o desenvolvimento de aplicativos Ethereum_
-- [Ethers_rs](https://github.com/gakonst/ethers-rs) — _Implementação da biblioteca e da carteira Ethereum_
+- [Foundry](https://github.com/foundry-rs/foundry) - _Conjunto de ferramentas para o desenvolvimento de aplicativos Ethereum_
+- [Alloy](https://alloy.rs) - _Bibliotecas de alto desempenho, bem testadas e documentadas para interação com Ethereum e outras cadeias baseadas em EVM._
+- [Ethers_rs](https://github.com/gakonst/ethers-rs) - _Implementação da biblioteca e da carteira Ethereum_
 - [SewUp](https://github.com/second-state/SewUp) — _Uma biblioteca para ajudar você a construir seu contrato Webassembly do Ethereum com o Rust e desenvolvê-lo em um back-end comum_
 - [Reth](https://github.com/paradigmxyz/reth) Reth (abreviação de Rust Ethereum, pronúncia) é uma nova implementação de nó completo do Ethereum
 

--- a/public/content/translations/ro/developers/docs/programming-languages/rust/index.md
+++ b/public/content/translations/ro/developers/docs/programming-languages/rust/index.md
@@ -47,8 +47,9 @@ Aveţi nevoie de o scurtă introducere? Accesaţi [ethereum.org/learn](/learn/) 
 - [Solaris](https://github.com/paritytech/sol-rs)
 - [SputnikVM](https://github.com/sorpaas/rust-evm) - _Implementare Rust a mașinii virtuale Ethereum_
 - [Wavelet](https://wavelet.perlin.net/docs/smart-contracts) - _Contract inteligent Wavelet în Rust_
-- [Foundry](https://github.com/gakonst/foundry)- _Toolkit for Ethereum application development_
-- [Ethers_rs](https://github.com/gakonst/ethers-rs)- _Ethereum library and wallet implementation_
+- [Foundry](https://github.com/foundry-rs/foundry) - _Set de instrumente pentru dezvoltarea aplicațiilor Ethereum_
+- [Alloy](https://alloy.rs) - _Biblioteci de înaltă performanță, bine testate și documentate pentru interacțiunea cu Ethereum și alte lanțuri bazate pe EVM._
+- [Ethers_rs](https://github.com/gakonst/ethers-rs) - _Biblioteca Ethereum și implementarea portofelului_
 - [evm_rs](https://github.com/rust-blockchain/evm)- _Ethereum virtual machine implementation in rust_
 - [SewUp](https://github.com/second-state/SewUp) - _A library to help you build your Ethereum webassembly contract with Rust and just like develop in a common backend_
 

--- a/public/content/translations/tr/developers/docs/programming-languages/rust/index.md
+++ b/public/content/translations/tr/developers/docs/programming-languages/rust/index.md
@@ -48,8 +48,9 @@ Başlamadan önce temel bilgilere mi ihtiyacınız var? [ethereum.org/learn](/le
 - [Solaris](https://github.com/paritytech/sol-rs) - _Yerli Parity İstemci EVM'si kullanılarak Solidity Akıllı Sözleşme birim testi teçhizatı._
 - [SputnikVM](https://github.com/rust-blockchain/evm) - _Rust Ethereum Sanal Makinesi Uygulaması_
 - [Wavelet](https://wavelet.perlin.net/docs/smart-contracts) - _Rust'ta Wavelet sakıllı sözleşme_
-- [Foundry](https://github.com/gakonst/foundry)- _Ethereum uygulama geliştirme için araç takımı_
-- [Ethers_rs](https://github.com/gakonst/ethers-rs)- _Ethereum kütüphanesi ve cüzdan uygulaması_
+- [Foundry](https://github.com/foundry-rs/foundry) - _Ethereum uygulama geliştirme için araç takımı_
+- [Alloy](https://alloy.rs) - _Ethereum ve diğer EVM tabanlı zincirlerle etkileşime geçmek için yüksek performanslı, iyi test edilmiş ve belgelenmiş kütüphaneler._
+- [Ethers_rs](https://github.com/gakonst/ethers-rs) - _Ethereum kütüphanesi ve cüzdan uygulaması_
 - [SewUp](https://github.com/second-state/SewUp) - _Tıpkı ortak bir arka uçta geliştiriyormuş gibi Rust ile Ethereum webassembly sözleşmenizi oluşturmanıza yardımcı olacak bir kütüphane_
 - [Alt akımlar](https://github.com/streamingfast/substreams) - _Paralel hale getirilmiş blok zincir veri endeksleme teknolojisi_
 - [Reth](https://github.com/paradigmxyz/reth) Reth (Rust Ethereum'un söyleyişinin kısaltması) artık yeni bir Ethereum tam düğüm işlenmesidir

--- a/public/content/translations/zh/developers/docs/programming-languages/rust/index.md
+++ b/public/content/translations/zh/developers/docs/programming-languages/rust/index.md
@@ -46,8 +46,9 @@ incomplete: true
 - [Solaris](https://github.com/paritytech/sol-rs) - _使用本机 Parity 客户端以太坊虚拟机的 Solidity 智能合约单元测试工具。_
 - [SputnikVM](https://github.com/rust-blockchain/evm) - _以太坊虚拟机的 Rust 实现_
 - [Wavelet](https://wavelet.perlin.net/docs/smart-contracts) - _Rust 语言的 Wavelet 智能合约_
-- [Foundry](https://github.com/gakonst/foundry) - _以太坊应用程序开发工具包_
-- [Ethers_rs](https://github.com/gakonst/ethers-rs)- _以太坊库和钱包的实现_
+- [Foundry](https://github.com/foundry-rs/foundry) - _以太坊应用程序开发工具包_
+- [Alloy](https://alloy.rs) - _用于与以太坊和其他基于 EVM 的链交互的高性能、经过充分测试和记录的库。_
+- [Ethers_rs](https://github.com/gakonst/ethers-rs) - _以太坊库和钱包的实现_
 - [SewUp](https://github.com/second-state/SewUp) - _一个帮助用户用 Rust 语言构建以太坊 Webassembly 合约的库，正如在公共后端中开发一样_
 - [Substreams](https://github.com/streamingfast/substreams) - _并行化区块链数据索引技术_
 - [Reth](https://github.com/paradigmxyz/reth) - Reth 即 Rust Ethereum 简称的发音，是新的以太坊全节点实现


### PR DESCRIPTION
[`ethers-rs`](https://github.com/gakonst/ethers-rs) is on the verge of deprecation. **Alloy** is a high-performance rewrite of `ethers-rs` from the ground up with exciting new features.

## Description

- Add **Alloy** reference to Rust documentation.
- Fix the link for **Foundry**.
- Kept `ethers-rs` reference for old projects.
