### PR TITLE
fixed ui on find-wallet [Fixes #13421]

### DIFF
--- a/src/components/FindWallet/WalletFilterPersona.tsx
+++ b/src/components/FindWallet/WalletFilterPersona.tsx
@@ -55,15 +55,23 @@ const WalletFilterPersona = ({
 
   return (
     <Grid
+      css={{
+        "&::-webkit-scrollbar": {
+          height: "4px",
+        },
+        "&::-webkit-scrollbar-thumb": {
+          backgroundColor: "darkgray",
+        },
+      }}
       gap={showMobileSidebar ? 2 : 4}
-      autoColumns={{ base: "200px", lg: "minmax(0, 1fr)" }}
+      autoColumns={{ base: "220px", lg: "minmax(0, 1fr)" }}
       templateColumns={
         showMobileSidebar
           ? "repeat(2, 1fr)"
-          : { base: "200px", lg: "minmax(0, 1fr)" }
+          : { base: "220px", lg: "minmax(0, 1fr)" }
       }
       mb={showMobileSidebar ? 4 : 2}
-      overflowX="auto"
+      overflowX="scroll"
     >
       {personas.map((persona, idx) => {
         return (


### PR DESCRIPTION
## Description
fixed ui on find-wallet Fixes #13421 

<img width="392" alt="Screenshot 2024-07-18 at 3 09 20 PM" src="https://github.com/user-attachments/assets/04958bb5-c6ea-40dd-bf9d-7b781d654a37">


<!--- Describe your changes in detail -->
1) Made changes in scroll-bar css to show it by default.
2) Increased the width of cards for overflowing on right size

<!-- Suggestion -->
We can also provide arrows like this indicating more items in the grid, clicking on arrow will scroll the cards
<img width="392" alt="Screenshot 2024-07-18 at 3 09 20 PM" src="https://github.com/user-attachments/assets/04958bb5-c6ea-40dd-bf9d-7b781d654a37">


