### PR TITLE
fix: padding between navbar and dapps page hero

### DIFF
--- a/src/components/PageHero.tsx
+++ b/src/components/PageHero.tsx
@@ -58,7 +58,7 @@ const PageHero = ({
     >
       <Box
         maxW={{ base: "full", lg: "container.sm" }}
-        pt={{ base: isReverse ? 0 : 8, lg: 32 }}
+        pt={{ base: isReverse ? 0 : 8, lg: 16 }}
         pb={{ base: isReverse ? 8 : 0, lg: 32 }}
         ps={{ base: 0, lg: 8 }}
         me={{ base: 0, lg: 4 }}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Reduced Padding Between Navbar and Ethereum-Powered Tools and Services Banner In [Dapps Page](https://ethereum.org/en/dapps/)

before reducing padding top
![image](https://github.com/user-attachments/assets/073cc6bb-93a4-4359-8e3a-cc94bb9ee82c)

after reducing padding top
![image](https://github.com/user-attachments/assets/f312cff8-a068-4bc0-bb70-a2dfbd95ae51)


## Related Issue
- Fixes #11730
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
