### PR TITLE
fix: wallet language filtering [Fixes #13385]

### DIFF
--- a/src/hooks/useWalletTable.tsx
+++ b/src/hooks/useWalletTable.tsx
@@ -1,8 +1,6 @@
-import { useContext, useState } from "react"
+import { useState } from "react"
 
 import type { DropdownOption, Wallet, WalletFilter } from "@/lib/types"
-
-import { WalletSupportedLanguageContext } from "@/contexts/WalletSupportedLanguageContext"
 
 export type WalletMoreInfoData = Wallet & { moreInfo: boolean; key: string }
 
@@ -10,10 +8,12 @@ type UseWalletTableProps = {
   walletData: Wallet[]
   filters: WalletFilter
   t: (x: string) => string
+  supportedLanguage: string
 }
 
 export const useWalletTable = ({
   filters,
+  supportedLanguage,
   t,
   walletData,
 }: UseWalletTableProps) => {
@@ -127,9 +127,6 @@ export const useWalletTable = ({
       return { ...wallet, moreInfo: false, key: wallet.name }
     })
   )
-
-  // Context API for language filter
-  const { supportedLanguage } = useContext(WalletSupportedLanguageContext)
 
   const updateMoreInfo = (key) => {
     const temp = [...walletCardData]

--- a/src/pages/wallets/find-wallet.tsx
+++ b/src/pages/wallets/find-wallet.tsx
@@ -120,7 +120,7 @@ const FindWalletPage = ({
     filteredWallets,
     updateMoreInfo,
     walletCardData,
-  } = useWalletTable({ filters, t, walletData: wallets })
+  } = useWalletTable({ filters, supportedLanguage, t, walletData: wallets })
 
   const updateFilterOption = (key) => {
     const updatedFilters = { ...filters }


### PR DESCRIPTION
## Description
- Pass `supportedLanguage` to `useWalletTable` instead of relying on `useContext` provider.

Forces the table to update when language filter changes

## Related Issue
- Fixes #13385