### PR TITLE
migrate: useDisclosure hook

### DIFF
--- a/src/components/ExpandableInfo.tsx
+++ b/src/components/ExpandableInfo.tsx
@@ -11,12 +11,13 @@ import {
   HStack,
   Icon,
   Stack,
-  useDisclosure,
   VStack,
 } from "@chakra-ui/react"
 
 import { Image, type ImageProps } from "@/components/Image"
 import Text from "@/components/OldText"
+
+import { useDisclosure } from "@/hooks/useDisclosure"
 
 export type ExpandableInfoProps = ChakraProps & {
   children?: ReactNode

--- a/src/components/FeedbackWidget/useFeedbackWidget.ts
+++ b/src/components/FeedbackWidget/useFeedbackWidget.ts
@@ -1,9 +1,9 @@
 import { useEffect, useMemo, useRef, useState } from "react"
 import { useRouter } from "next/router"
-import { useDisclosure } from "@chakra-ui/react"
 
 import { trackCustomEvent } from "@/lib/utils/matomo"
 
+import { useDisclosure } from "@/hooks/useDisclosure"
 import { useSurvey } from "@/hooks/useSurvey"
 
 export const useFeedbackWidget = () => {

--- a/src/components/LanguagePicker/index.tsx
+++ b/src/components/LanguagePicker/index.tsx
@@ -14,7 +14,6 @@ import {
   type MenuListProps,
   type MenuProps,
   Text,
-  type UseDisclosureReturn,
   useEventListener,
 } from "@chakra-ui/react"
 
@@ -29,6 +28,8 @@ import MenuItem from "./MenuItem"
 import { MobileCloseBar } from "./MobileCloseBar"
 import NoResultsCallout from "./NoResultsCallout"
 import { useLanguagePicker } from "./useLanguagePicker"
+
+import { type UseDisclosureReturn } from "@/hooks/useDisclosure"
 
 type LanguagePickerProps = Omit<MenuListProps, "children"> & {
   children: React.ReactNode

--- a/src/components/LanguagePicker/useLanguagePicker.tsx
+++ b/src/components/LanguagePicker/useLanguagePicker.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from "react"
 import { useRouter } from "next/router"
 import { useTranslation } from "next-i18next"
-import { useDisclosure, type UseDisclosureReturn } from "@chakra-ui/react"
 
 import type {
   I18nLocale,
@@ -16,6 +15,8 @@ import { filterRealLocales, languages } from "@/lib/utils/translations"
 import progressDataJson from "@/data/translationProgress.json"
 
 import { DEFAULT_LOCALE } from "@/lib/constants"
+
+import { useDisclosure, type UseDisclosureReturn } from "@/hooks/useDisclosure"
 
 const progressData = progressDataJson satisfies ProjectProgressData[]
 

--- a/src/components/Nav/Desktop/index.tsx
+++ b/src/components/Nav/Desktop/index.tsx
@@ -9,7 +9,6 @@ import {
   Icon,
   MenuButton,
   Text,
-  useDisclosure,
   useEventListener,
 } from "@chakra-ui/react"
 
@@ -19,6 +18,7 @@ import LanguagePicker from "@/components/LanguagePicker"
 import { DESKTOP_LANGUAGE_BUTTON_NAME } from "@/lib/constants"
 
 import useColorModeValue from "@/hooks/useColorModeValue"
+import { useDisclosure } from "@/hooks/useDisclosure"
 
 type DesktopNavMenuProps = {
   toggleColorMode: () => void

--- a/src/components/Nav/index.tsx
+++ b/src/components/Nav/index.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useRef } from "react"
 import { useTranslation } from "next-i18next"
-import { Box, Flex, Hide, Show, useDisclosure } from "@chakra-ui/react"
+import { Box, Flex, Hide, Show } from "@chakra-ui/react"
 
 import { EthHomeIcon } from "@/components/icons"
 import { BaseLink } from "@/components/Link"
@@ -14,6 +14,7 @@ import DesktopNavMenu from "./Desktop"
 import Menu from "./Menu"
 import { useNav } from "./useNav"
 
+import { useDisclosure } from "@/hooks/useDisclosure"
 import { useIsClient } from "@/hooks/useIsClient"
 
 const MobileNavMenu = lazy(() => import("./Mobile"))

--- a/src/components/Nav/useNav.ts
+++ b/src/components/Nav/useNav.ts
@@ -19,7 +19,6 @@ import {
   BsUiChecksGrid,
 } from "react-icons/bs"
 import { PiFlask, PiUsersFourLight } from "react-icons/pi"
-import { useDisclosure } from "@chakra-ui/react"
 
 import { EthereumIcon } from "@/components/icons/EthereumIcon"
 
@@ -30,6 +29,7 @@ import { FROM_QUERY } from "@/lib/constants"
 import type { NavSections } from "./types"
 
 import useColorModeValue from "@/hooks/useColorModeValue"
+import { useDisclosure } from "@/hooks/useDisclosure"
 
 export const useNav = () => {
   const { asPath } = useRouter()

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -9,7 +9,6 @@ import {
   IconButtonProps,
   Portal,
   ThemeTypings,
-  type UseDisclosureReturn,
   useMergeRefs,
 } from "@chakra-ui/react"
 import { useDocSearchKeyboardEvents } from "@docsearch/react"
@@ -24,6 +23,8 @@ import { sanitizeHitUrl } from "@/lib/utils/url"
 import SearchButton from "./SearchButton"
 
 import "@docsearch/css"
+
+import { type UseDisclosureReturn } from "@/hooks/useDisclosure"
 
 const SearchModal = dynamic(() => import("./SearchModal"))
 

--- a/src/components/Simulator/SimulatorModal.tsx
+++ b/src/components/Simulator/SimulatorModal.tsx
@@ -1,11 +1,9 @@
 import React from "react"
-import {
-  type ModalContentProps,
-  type ModalProps,
-  UseDisclosureReturn,
-} from "@chakra-ui/react"
+import { type ModalContentProps, type ModalProps } from "@chakra-ui/react"
 
 import Modal from "../Modal"
+
+import { type UseDisclosureReturn } from "@/hooks/useDisclosure"
 
 type SimulatorModalProps = ModalContentProps &
   Pick<ModalProps, "size"> & {

--- a/src/components/TableOfContents/TableOfContentsMobile.tsx
+++ b/src/components/TableOfContents/TableOfContentsMobile.tsx
@@ -1,22 +1,15 @@
 import React from "react"
 import { useTranslation } from "next-i18next"
 import { MdExpandMore } from "react-icons/md"
-import {
-  Box,
-  chakra,
-  Fade,
-  Flex,
-  Icon,
-  List,
-  useDisclosure,
-  useToken,
-} from "@chakra-ui/react"
+import { Box, chakra, Fade, Flex, Icon, List, useToken } from "@chakra-ui/react"
 
 import type { ToCItem } from "@/lib/types"
 
 import { outerListProps } from "@/lib/utils/toc"
 
 import ItemsList from "./ItemsList"
+
+import { useDisclosure } from "@/hooks/useDisclosure"
 
 export type TableOfContentsMobileProps = {
   items?: Array<ToCItem>

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -7,10 +7,11 @@ import {
   PopoverProps,
   PopoverTrigger,
   Portal,
-  useDisclosure,
 } from "@chakra-ui/react"
 
 import { isMobile } from "@/lib/utils/isMobile"
+
+import { useDisclosure } from "@/hooks/useDisclosure"
 
 export interface TooltipProps extends PopoverProps {
   content: ReactNode

--- a/src/hooks/useDisclosure.ts
+++ b/src/hooks/useDisclosure.ts
@@ -8,9 +8,13 @@ type UseDisclosureProps = {
   id?: string
 }
 
-type GetButtonPropsProps = Record<string, unknown> & { onClick?: () => void }
+type GetButtonPropsProps = Record<string, string | undefined> & {
+  onClick?: () => void
+}
 
-type GetDisclosurePropsProps = Record<string, unknown> & { id?: string }
+type GetDisclosurePropsProps = Record<string, string | undefined> & {
+  id?: string
+}
 
 type UseDisclosureReturn = {
   isOpen: boolean
@@ -19,10 +23,10 @@ type UseDisclosureReturn = {
   onToggle: () => void
   getButtonProps: (props?: GetButtonPropsProps) => {
     "aria-expanded": boolean
-    "aria-controls": unknown
+    "aria-controls"?: string
     onClick: () => void
   }
-  getDisclosureProps: (props: GetDisclosurePropsProps) => {
+  getDisclosureProps: (props?: GetDisclosurePropsProps) => {
     hidden: boolean
     id: string
   }
@@ -31,7 +35,7 @@ type UseDisclosureReturn = {
 const generateId = (prefix = "id") =>
   `${prefix}-${Math.random().toString(36).slice(2, 11)}`
 
-const useId = (idProp, prefix) => {
+const useId = (idProp?: string, prefix?: string) => {
   const [dynamicId, setDynamicId] = useState(idProp || generateId(prefix))
 
   useEffect(() => {

--- a/src/hooks/useDisclosure.ts
+++ b/src/hooks/useDisclosure.ts
@@ -47,7 +47,7 @@ const useId = (idProp?: string, prefix?: string) => {
   return dynamicId
 }
 
-export const useDisclosure = ({
+const useDisclosure = ({
   onClose: onCloseProp,
   onOpen: onOpenProp,
   isOpen: isOpenProp,
@@ -97,3 +97,5 @@ export const useDisclosure = ({
     getDisclosureProps,
   }
 }
+
+export { useDisclosure, type UseDisclosureProps, type UseDisclosureReturn }

--- a/src/hooks/useDisclosure.ts
+++ b/src/hooks/useDisclosure.ts
@@ -1,0 +1,95 @@
+import { useCallback, useEffect, useState } from "react"
+
+type UseDisclosureProps = {
+  isOpen?: boolean
+  defaultIsOpen?: boolean
+  onClose?(): void
+  onOpen?(): void
+  id?: string
+}
+
+type GetButtonPropsProps = Record<string, unknown> & { onClick?: () => void }
+
+type GetDisclosurePropsProps = Record<string, unknown> & { id?: string }
+
+type UseDisclosureReturn = {
+  isOpen: boolean
+  onOpen: () => void
+  onClose: () => void
+  onToggle: () => void
+  getButtonProps: (props?: GetButtonPropsProps) => {
+    "aria-expanded": boolean
+    "aria-controls": unknown
+    onClick: () => void
+  }
+  getDisclosureProps: (props: GetDisclosurePropsProps) => {
+    hidden: boolean
+    id: string
+  }
+}
+
+const generateId = (prefix = "id") =>
+  `${prefix}-${Math.random().toString(36).slice(2, 11)}`
+
+const useId = (idProp, prefix) => {
+  const [dynamicId, setDynamicId] = useState(idProp || generateId(prefix))
+
+  useEffect(() => {
+    if (!idProp) {
+      setDynamicId(generateId(prefix))
+    }
+  }, [idProp, prefix])
+
+  return dynamicId
+}
+
+export const useDisclosure = ({
+  onClose: onCloseProp,
+  onOpen: onOpenProp,
+  isOpen: isOpenProp,
+  defaultIsOpen: defaultIsOpenProp,
+  id: idProp,
+}: UseDisclosureProps = {}): UseDisclosureReturn => {
+  const [isOpen, setIsOpen] = useState(isOpenProp || !!defaultIsOpenProp)
+  const id = useId(idProp, "disclosure")
+
+  const onClose = useCallback(() => {
+    setIsOpen(false)
+    onCloseProp == null ? void 0 : onCloseProp()
+  }, [onCloseProp])
+
+  const onOpen = useCallback(() => {
+    setIsOpen(true)
+    onOpenProp == null ? void 0 : onOpenProp()
+  }, [onOpenProp])
+
+  const onToggle = useCallback(() => {
+    const action = isOpen ? onClose : onOpen
+    action()
+  }, [isOpen, onClose, onOpen])
+
+  const getButtonProps = (props: GetButtonPropsProps = {}) => ({
+    ...props,
+    "aria-expanded": isOpen,
+    "aria-controls": id,
+    onClick: () => {
+      props.onClick?.()
+      onToggle()
+    },
+  })
+
+  const getDisclosureProps = (props: GetDisclosurePropsProps = {}) => ({
+    ...props,
+    hidden: !isOpen,
+    id,
+  })
+
+  return {
+    isOpen,
+    onOpen,
+    onClose,
+    onToggle,
+    getButtonProps,
+    getDisclosureProps,
+  }
+}

--- a/src/pages/quizzes.tsx
+++ b/src/pages/quizzes.tsx
@@ -3,7 +3,7 @@ import { GetStaticProps, InferGetStaticPropsType, NextPage } from "next"
 import { useTranslation } from "next-i18next"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { FaGithub } from "react-icons/fa"
-import { Box, Flex, Icon, Stack, Text, useDisclosure } from "@chakra-ui/react"
+import { Box, Flex, Icon, Stack, Text } from "@chakra-ui/react"
 
 import { BasePageProps, Lang, QuizKey, QuizStatus } from "@/lib/types"
 
@@ -28,6 +28,7 @@ import { ethereumBasicsQuizzes, usingEthereumQuizzes } from "@/data/quizzes"
 
 import { INITIAL_QUIZ } from "@/lib/constants"
 
+import { useDisclosure } from "@/hooks/useDisclosure"
 import HeroImage from "@/public/images/heroes/quizzes-hub-hero.png"
 
 const handleGHAdd = () =>

--- a/src/pages/wallets/find-wallet.tsx
+++ b/src/pages/wallets/find-wallet.tsx
@@ -3,15 +3,7 @@ import { GetStaticProps, InferGetStaticPropsType } from "next"
 import { useRouter } from "next/router"
 import { useTranslation } from "next-i18next"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
-import {
-  Box,
-  calc,
-  Center,
-  Flex,
-  Show,
-  Text,
-  useDisclosure,
-} from "@chakra-ui/react"
+import { Box, calc, Center, Flex, Show, Text } from "@chakra-ui/react"
 
 import type { BasePageProps, ChildOnlyProp, Lang, Wallet } from "@/lib/types"
 
@@ -45,6 +37,7 @@ import {
 } from "@/lib/constants"
 
 import { WalletSupportedLanguageContext } from "@/contexts/WalletSupportedLanguageContext"
+import { useDisclosure } from "@/hooks/useDisclosure"
 import { useWalletTable } from "@/hooks/useWalletTable"
 import HeroImage from "@/public/images/wallets/wallet-hero.png"
 


### PR DESCRIPTION
## Description
- Builds on custom internal `useDisclosure` hook introduced in #13456
- Deprecates all usage of Chakra-UI `useDisclosure` hook, updating imports to use new custom `src/hooks/useDisclosure.ts`

## Related Issue
shadcn migration