### PR TITLE
Fix `ref` warning

### DIFF
--- a/src/components/LazyLoadComponent.tsx
+++ b/src/components/LazyLoadComponent.tsx
@@ -17,6 +17,8 @@ const LazyLoadComponent = <T extends React.ElementType>({
   const ref = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
+    const obsRef = ref.current
+
     const observer = new IntersectionObserver(([entry]) => {
       // Update the state when observer callback fires
       if (entry.isIntersecting) {
@@ -25,17 +27,17 @@ const LazyLoadComponent = <T extends React.ElementType>({
       }
     }, intersectionOptions)
 
-    if (ref.current) {
-      observer.observe(ref.current)
+    if (obsRef) {
+      observer.observe(obsRef)
     }
 
     // Clean up the observer on component unmount
     return () => {
-      if (ref.current) {
+      if (obsRef) {
         observer.disconnect()
       }
     }
-  }, [])
+  }, [intersectionOptions])
 
   return (
     <div ref={ref}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes the following warnings:
```
9:47:07 AM: 34:15  Warning: The ref value 'ref.current' will likely have changed by the time this effect cleanup function runs. If this ref points to a node rendered by React, copy 'ref.current' to a variable inside the effect, and use that variable in the cleanup function.  react-hooks/exhaustive-deps
9:47:07 AM: 38:6  Warning: React Hook useEffect has a missing dependency: 'intersectionOptions'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps
```
