### PR TITLE
term correction

### DIFF
--- a/public/content/roadmap/future-proofing/index.md
+++ b/public/content/roadmap/future-proofing/index.md
@@ -29,7 +29,7 @@ Similarly, there are updates that can be made to other parts of present-day Ethe
 
 ## Current progress {#current-progress}
 
-Most of the upgrades required for future-proofing Ethereum are **still in the research phase and may be several years away** from being implemented. Upgrades such as removing SELF-DESTRUCT and harmonizing the compression scheme used in the execution and consensus clients are likely to come sooner than quantum resistant cryptography.
+Most of the upgrades required for future-proofing Ethereum are **still in the research phase and may be several years away** from being implemented. Upgrades such as removing SELFDESTRUCT and harmonizing the compression scheme used in the execution and consensus clients are likely to come sooner than quantum resistant cryptography.
 
 **Further reading**
 


### PR DESCRIPTION
Retained `SELFDESTRUCT` keyword rather than SELF-DESTRUCT

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
