### PR TITLE
Fix Chakra buttons font-weight

### DIFF
--- a/src/@chakra-ui/components/Button.ts
+++ b/src/@chakra-ui/components/Button.ts
@@ -14,6 +14,7 @@ const baseStyle = defineStyle({
   borderRadius: "base",
   border: "1px",
   color: "primary.base",
+  fontWeight: "normal",
   lineHeight: "1.6",
   transitionProperty: "common",
   transitionDuration: "normal",


### PR DESCRIPTION
## Description

Since our global styles have recently changed with the adoption of Tailwind, we need to override the default font weight for our Chakra buttons to keep them consistent.