### PR TITLE
feat: add hash link for homepage events

### DIFF
--- a/src/components/CommunityEvents/index.tsx
+++ b/src/components/CommunityEvents/index.tsx
@@ -85,6 +85,7 @@ const CommunityEvents = ({ events }: CommunityEventsProps) => {
         sm: "2rem 0 0",
         lg: "2rem 2rem 0",
       }}
+      id="community-events"
     >
       <Center w={{ base: "100%", lg: "40%" }}>
         <Box pe={8} ps={{ base: 8, lg: 0 }}>


### PR DESCRIPTION
## Description
- Adds an `id` to the CommunityEvents component to allow a `https://ethereum.org/{lang}/#community-event` link that goes directly to this section of the homepage.

## Related Issue
cc: @isabelladebrito 