### PR TITLE
Fix: button spacing

### DIFF
--- a/src/pages/get-eth.tsx
+++ b/src/pages/get-eth.tsx
@@ -368,7 +368,7 @@ const GetEthPage = ({
           </Text>
           <Text>{t("page-get-eth-dexs-desc-3")}</Text>
           <Text>{t("page-get-eth-need-wallet")}</Text>
-          <ButtonLink href="/wallets/find-wallet/">
+          <ButtonLink href="/wallets/find-wallet/" mb={8}>
             {t("page-get-eth-get-wallet-btn")}
           </ButtonLink>
           <InfoBanner isWarning>


### PR DESCRIPTION
 ### Description:
This PR addresses issue #13498 by adding missing padding around the button on the Ethereum.org page. 
### Changes :
- Added required spacing around the button on the "What are DEXs?" section of the page.
### Screenshots :
![Issues_Solved](https://github.com/user-attachments/assets/9ec9b129-74c7-42a1-b84a-387933cc5322)
