### PR TITLE
chore: remove dead link

### DIFF
--- a/public/content/developers/docs/nodes-and-clients/index.md
+++ b/public/content/developers/docs/nodes-and-clients/index.md
@@ -47,7 +47,6 @@ Multiple trackers offer a real-time overview of nodes in the Ethereum network. N
 
 - [Map of nodes](https://etherscan.io/nodetracker) by Etherscan
 - [Ethernodes](https://ethernodes.org/) by Bitfly
-- [Ethereum Node Crawler](https://crawler.ethereum.org/)
 - [Nodewatch](https://www.nodewatch.io/) by Chainsafe, crawling consensus nodes
 
 ## Node types {#node-types}


### PR DESCRIPTION
## Description
- Removes dead link for [Ethereum Node Crawler](https://crawler.ethereum.org/) `https://crawler.ethereum.org/`
