### PR TITLE
Implement Updated Button Component from Design System also Fixes Text Overflow Issues

### DIFF
--- a/src/components/DocsNav.tsx
+++ b/src/components/DocsNav.tsx
@@ -1,9 +1,11 @@
 import { useRouter } from "next/router"
 import { useTranslation } from "next-i18next"
+import { FaChevronLeft, FaChevronRight } from "react-icons/fa"
 import {
   Box,
   Flex,
   FlexProps,
+  Icon,
   LinkBox,
   LinkOverlay,
   Spacer,
@@ -12,7 +14,6 @@ import {
 import { TranslationKey } from "@/lib/types"
 import type { DeveloperDocsLink } from "@/lib/interfaces"
 
-import Emoji from "@/components/Emoji"
 import { BaseLink } from "@/components/Link"
 import Text from "@/components/OldText"
 
@@ -26,9 +27,9 @@ const TextDiv = ({ children, ...props }: FlexProps) => (
   <Flex
     direction="column"
     justify="space-between"
-    maxW="166px"
+    w="100%"
     h="100%"
-    wordwrap="break-word"
+    wordWrap="break-word"
     p={4}
     lineHeight={4}
     {...props}
@@ -63,19 +64,43 @@ const CardLink = ({ docData, isPrev, contentNotTranslated }: CardLinkProps) => {
       h="82px"
       bg="background.base"
       border="1px"
-      borderColor="border"
-      borderRadius={1}
+      borderColor="primary.base"
+      borderRadius={4}
       justify={isPrev ? "flex-start" : "flex-end"}
+      _hover={{
+        borderColor: "primary.hover",
+        "& svg": {
+          fill: "primary.hover",
+        },
+        ".btn-txt": {
+          color: "primary.hover",
+        },
+      }}
     >
-      <Box textDecoration="none" p={4} h="100%" order={isPrev ? 0 : 1}>
-        <Emoji
-          text={isPrev ? ":point_left:" : ":point_right:"}
-          fontSize="5xl"
-          transform={contentNotTranslated ? undefined : flipForRtl}
-        />
+      <Box
+        textDecoration="none"
+        p={4}
+        order={isPrev ? 0 : 1}
+        transform={contentNotTranslated ? undefined : flipForRtl}
+      >
+        {isPrev ? (
+          <Icon
+            fill="primary.base"
+            fontSize="xl"
+            as={FaChevronLeft}
+            name="chevron left"
+          />
+        ) : (
+          <Icon
+            fill="primary.base"
+            fontSize="xl"
+            as={FaChevronRight}
+            name="chevron right"
+          />
+        )}
       </Box>
       <TextDiv {...xPadding} {...(!isPrev && { textAlign: "end" })}>
-        <Text textTransform="uppercase" m="0">
+        <Text m="0" color="primary.base" fontSize="lg" className="btn-txt">
           {t(isPrev ? "previous" : "next")}
         </Text>
         <LinkOverlay
@@ -83,6 +108,9 @@ const CardLink = ({ docData, isPrev, contentNotTranslated }: CardLinkProps) => {
           href={docData.href}
           textAlign={isPrev ? "start" : "end"}
           rel={isPrev ? "prev" : "next"}
+          fontSize="sm"
+          textDecoration="none"
+          _hover={{ textDecoration: "none" }}
           onClick={() => {
             trackCustomEvent({
               eventCategory: "next/previous article DocsNav",


### PR DESCRIPTION

## Pull Request: Implement Updated Button Component from Design System

### Description
This PR addresses the issue where the text on the 'Previous' and 'Next' buttons was coming out of the box in certain languages, like Russian, and was touching the underline. This was especially noticeable on the page `ethereum.org/en/developers/docs/evm/opcodes/`.

### Changes Made
- Implemented the updated button component from the design system, as per the Figma file provided [here](https://www.figma.com/design/NrNxGjBL0Yl1PrNrOT8G2B/ethereum.org-Design-System?node-id=5452-60878&t=GBI9TtaUGLYa8wRF-1).
- Adjusted the styles to ensure the text does not touch the underline and stays within the button boundaries.
- Tested the implementation across different languages to ensure consistent rendering.

### Screenshots
- Light Mode:
  
![image](https://github.com/user-attachments/assets/1da37223-30a2-4a01-bec1-6d3c7ac6bf17)

- Dark Mode:

![Screenshot from 2024-07-28 21-07-15](https://github.com/user-attachments/assets/935bee64-6e86-4a8a-b04f-ed99d7ec154d)

### How to Test
1. Navigate to `ethereum.org/en/developers/docs/evm/opcodes/`.
2. Scroll down to the 'Previous' and 'Next' buttons.
3. Verify that the text stays within the button boundaries and does not touch the underline in various languages.

### Additional Context
- This change aims to provide a more sustainable fix by aligning with the design system.

### Issue Link
Fixes #13405 
---

Feel free to assign the task to me. Looking forward to your feedback!
