### PR TITLE
Delete Invalid Invite

### DIFF
--- a/public/content/community/support/index.md
+++ b/public/content/community/support/index.md
@@ -73,7 +73,6 @@ Here are some popular examples:
 - [ethers.js](https://discord.gg/6jyGVDK6Jx)
 - [web3.js](https://discord.gg/GsABYQu4sC)
 - [Hardhat](https://discord.gg/xtrMGhmbfZ)
-- [Truffle](https://discord.gg/8uKcsccEYE)
 - [Alchemy](http://alchemy.com/discord)
 - [Tenderly](https://discord.gg/fBvDJYR)
 


### PR DESCRIPTION
Truffle invite is invalid and it has also been sunset https://consensys.io/blog/consensys-announces-the-sunset-of-truffle-and-ganache-and-new-hardhat