### PR TITLE
Update: ERC-20 Token Standard description [Fixes #13218]

### DIFF
--- a/public/content/developers/docs/standards/tokens/erc-20/index.md
+++ b/public/content/developers/docs/standards/tokens/erc-20/index.md
@@ -151,6 +151,8 @@ print("Addr Balance:", addr_balance)
 
 ### ERC-20 token reception issue {#reception-issue}
 
+**As of 06/20/2024 at least $83,656,418 worth of ERC-20 tokens were lost due to this issue. Note that a pure ERC-20 implementation is prone to this problem unless you implement a set of additional restrictions on top of the standard as listed below.**
+
 When ERC-20 tokens are sent to a smart contract that is not designed to handle ERC-20 tokens, those tokens can be permanently lost. This happens because the receiving contract does not have the functionality to recognize or respond to the incoming tokens, and there’s no mechanism in the ERC-20 standard to notify the receiving contract about the incoming tokens. The main ways this issue takes form is through:
 
 1.	Token transfer mechanism
@@ -161,6 +163,15 @@ When ERC-20 tokens are sent to a smart contract that is not designed to handle E
 	-	If the receiving contract lacks a mechanism to handle tokens (e.g., a fallback function or a dedicated function to manage token reception), the tokens are effectively stuck in the contract’s address
 3.	No built-in handling
 	-	The ERC-20 standard does not include a mandatory function for receiving contracts to implement, leading to a situation where many contracts are unable to manage incoming tokens properly
+
+**Possible Solutions**
+
+While it is not possible to prevent this issue with ERC-20 completely there are methods that would allow to significantly reduce the possibility of a tokens loss for the end user:
+
+- The most common problem is when a user sends tokens to the token contract address itself (e.g. USDT deposited to the address of USDT token contract). It is recommended to restrict `transfer(..)` function to revert such transfer attempts. Consider adding `require(_to != address(this));` check within the implementation of the `transfer(..)` function.
+- The `transfer(..)` function in general is not designed for depositing tokens to contracts. `approve(..) & transferFrom(..)` pattern is used to deposit ERC-20 tokens to contracts instead. It is possible to restrict the transfer function to disallow depositing tokens to any contracts with it, however it may break compatibility with contracts that assume tokens can be deposited to contracts with the `trasnfer(..)` function (e.g. Uniswap liqudity pools).
+- Always assume that ERC-20 tokens can end up in your contract even if your contract is not supposed to ever receive any. There is no way to prevent or reject accidental deposits on the recipients end. It is recommended to implement a function that would allow to extract accidentally deposited ERC-20 tokens.
+- Consider using alternative token standards.
 
 Some alternative standards have come out of this issue such as [ERC-223](/developers/docs/standards/tokens/erc-223)
 


### PR DESCRIPTION
## Description

I've updated the description of the **ERC-20 token reception issue block** on the **ERC-20 TOKEN STANDARD** page. 


## Related Issue
Closes https://github.com/ethereum/ethereum-org-website/issues/13218
