### PR TITLE
Reorder consensus mechanisms to have proof-of-stake first

### DIFF
--- a/src/data/developer-docs-links.yaml
+++ b/src/data/developer-docs-links.yaml
@@ -97,7 +97,6 @@
                       href: /developers/docs/consensus-mechanisms/pow/mining/mining-algorithms/dagger-hashimoto/
                     - id: docs-nav-ethash
                       href: /developers/docs/consensus-mechanisms/pow/mining/mining-algorithms/ethash/
-        
         - id: docs-nav-proof-of-authority
           href: /developers/docs/consensus-mechanisms/poa/
 - id: docs-nav-ethereum-stack

--- a/src/data/developer-docs-links.yaml
+++ b/src/data/developer-docs-links.yaml
@@ -63,19 +63,6 @@
       href: /developers/docs/consensus-mechanisms/
       description: docs-nav-consensus-mechanisms-description
       items:
-        - id: docs-nav-proof-of-work
-          href: /developers/docs/consensus-mechanisms/pow/
-          items:
-            - id: docs-nav-mining
-              href: /developers/docs/consensus-mechanisms/pow/mining/
-              items:
-                - id: docs-nav-mining-algorithms
-                  href: /developers/docs/consensus-mechanisms/pow/mining/mining-algorithms/
-                  items:
-                    - id: docs-nav-dagger-hashimoto
-                      href: /developers/docs/consensus-mechanisms/pow/mining/mining-algorithms/dagger-hashimoto/
-                    - id: docs-nav-ethash
-                      href: /developers/docs/consensus-mechanisms/pow/mining/mining-algorithms/ethash/
         - id: docs-nav-proof-of-stake
           href: /developers/docs/consensus-mechanisms/pos/
           items:
@@ -97,6 +84,20 @@
               href: /developers/docs/consensus-mechanisms/pos/block-proposal/
             - id: docs-nav-pos-faqs
               href: /developers/docs/consensus-mechanisms/pos/faqs/
+        - id: docs-nav-proof-of-work
+          href: /developers/docs/consensus-mechanisms/pow/
+          items:
+            - id: docs-nav-mining
+              href: /developers/docs/consensus-mechanisms/pow/mining/
+              items:
+                - id: docs-nav-mining-algorithms
+                  href: /developers/docs/consensus-mechanisms/pow/mining/mining-algorithms/
+                  items:
+                    - id: docs-nav-dagger-hashimoto
+                      href: /developers/docs/consensus-mechanisms/pow/mining/mining-algorithms/dagger-hashimoto/
+                    - id: docs-nav-ethash
+                      href: /developers/docs/consensus-mechanisms/pow/mining/mining-algorithms/ethash/
+        
         - id: docs-nav-proof-of-authority
           href: /developers/docs/consensus-mechanisms/poa/
 - id: docs-nav-ethereum-stack


### PR DESCRIPTION
Reorder doc links to have proof-of-stake first in consensus mechanisms as this is what Ethereum uses today. 