### PR TITLE
fix(useNav): remove unused `fromPageParameter`

### DIFF
--- a/src/components/Nav/useNav.ts
+++ b/src/components/Nav/useNav.ts
@@ -1,4 +1,3 @@
-import { useRouter } from "next/router"
 import { useTranslation } from "next-i18next"
 import { useTheme } from "next-themes"
 import {
@@ -29,12 +28,9 @@ import { EthereumIcon } from "@/components/icons/EthereumIcon"
 
 import { trackCustomEvent } from "@/lib/utils/matomo"
 
-import { FROM_QUERY } from "@/lib/constants"
-
 import type { NavSections } from "./types"
 
 export const useNav = () => {
-  const { asPath } = useRouter()
   const { isOpen, onToggle } = useDisclosure()
   const { t } = useTranslation("common")
   const { theme, setTheme } = useTheme()
@@ -472,12 +468,6 @@ export const useNav = () => {
     },
   }
 
-  const splitPath = asPath.split("/")
-  const fromPageParameter =
-    splitPath.length > 1 && splitPath[1] !== "languages"
-      ? `?${FROM_QUERY}=/${splitPath.slice(1).join("/")}`
-      : ""
-
   const toggleColorMode = () => {
     setTheme(theme === "dark" ? "light" : "dark")
     setColorMode(theme === "dark" ? "light" : "dark")
@@ -489,14 +479,12 @@ export const useNav = () => {
   }
 
   const mobileNavProps = {
-    fromPageParameter,
     isOpen,
     toggleColorMode,
     onToggle,
   }
 
   return {
-    fromPageParameter,
     linkSections,
     mobileNavProps,
     toggleColorMode,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Warning stack thrown in the console from `useNav` during development:
```bash
Warning: React does not recognize the `fromPageParameter` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `frompageparameter` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    at button
    at /home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/@emotion/react/dist/emotion-element-48d2c2e4.cjs.dev.js:70:25
    at ChakraComponent (file:///home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/@chakra-ui/system/dist/chunk-5PL47M24.mjs:43:35)
    at file:///home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/@chakra-ui/button/dist/chunk-UVUR7MCU.mjs:27:17
    at file:///home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/@chakra-ui/button/dist/chunk-6QYXN73V.mjs:12:13
    at IconButton (webpack-internal:///./src/components/Buttons/IconButton.tsx:15:23)
    at HamburgerButton (webpack-internal:///./src/components/Nav/Mobile/HamburgerButton.tsx:38:28)
    at MobileNavMenu (webpack-internal:///./src/components/Nav/Mobile/index.tsx:21:26)
    at Lazy
    at Suspense
    at Visibility (file:///home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/@chakra-ui/media-query/dist/chunk-Q2OSBGYW.mjs:8:11)
    at Hide (file:///home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/@chakra-ui/media-query/dist/chunk-E2LBHKJ2.mjs:12:11)
    at div
    at /home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/@emotion/react/dist/emotion-element-48d2c2e4.cjs.dev.js:70:25
    at ChakraComponent (file:///home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/@chakra-ui/system/dist/chunk-5PL47M24.mjs:43:35)
    at Flex2 (file:///home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/@chakra-ui/layout/dist/chunk-KRPLQIP4.mjs:10:11)
    at div
    at /home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/@emotion/react/dist/emotion-element-48d2c2e4.cjs.dev.js:70:25
    at ChakraComponent (file:///home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/@chakra-ui/system/dist/chunk-5PL47M24.mjs:43:35)
    at Flex2 (file:///home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/@chakra-ui/layout/dist/chunk-KRPLQIP4.mjs:10:11)
    at div
    at /home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/@emotion/react/dist/emotion-element-48d2c2e4.cjs.dev.js:70:25
    at ChakraComponent (file:///home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/@chakra-ui/system/dist/chunk-5PL47M24.mjs:43:35)
    at Flex2 (file:///home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/@chakra-ui/layout/dist/chunk-KRPLQIP4.mjs:10:11)
    at nav
    at /home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/@emotion/react/dist/emotion-element-48d2c2e4.cjs.dev.js:70:25
    at ChakraComponent (file:///home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/@chakra-ui/system/dist/chunk-5PL47M24.mjs:43:35)
    at Flex2 (file:///home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/@chakra-ui/layout/dist/chunk-KRPLQIP4.mjs:10:11)
    at div
    at /home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/@emotion/react/dist/emotion-element-48d2c2e4.cjs.dev.js:70:25
    at ChakraComponent (file:///home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/@chakra-ui/system/dist/chunk-5PL47M24.mjs:43:35)
    at renderElement (/home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/react-dom/cjs/react-dom-server.browser.development.js:5946:7)
    at div
    at BaseLayout (webpack-internal:///./src/layouts/BaseLayout.tsx:33:23)
    at EnvironmentProvider (file:///home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/@chakra-ui/react-env/dist/chunk-VMD3UMGK.mjs:26:11)
    at ColorModeProvider (file:///home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/@chakra-ui/color-mode/dist/chunk-AMBGAKG2.mjs:23:5)
    at ThemeProvider (/home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/@emotion/react/dist/emotion-element-48d2c2e4.cjs.dev.js:125:32)
    at ThemeProvider (file:///home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/@chakra-ui/system/dist/chunk-MFVQSVQB.mjs:15:11)
    at ChakraProvider (file:///home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/@chakra-ui/provider/dist/chunk-3DDHO3UN.mjs:17:5)
    at ChakraProvider2 (file:///home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/@chakra-ui/react/dist/chunk-QAITB7GG.mjs:15:5)
    at G (/home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/next-themes/dist/index.js:1:947)
    at B (/home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/next-themes/dist/index.js:1:861)
    at ThemeProvider (webpack-internal:///./src/components/ThemeProvider.tsx:40:30)
    at App (webpack-internal:///./src/pages/_app.tsx:30:16)
    at I18nextProvider (/home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/react-i18next/dist/commonjs/I18nextProvider.js:11:5)
    at AppWithTranslation (/home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/next-i18next/dist/commonjs/appWithTranslation.js:59:22)
    at StyleRegistry (/home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/styled-jsx/dist/index/index.js:449:36)
    at eU (/home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/next/dist/compiled/next-server/pages.runtime.dev.js:8:20468)
    at eH (/home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/next/dist/compiled/next-server/pages.runtime.dev.js:17:1765)
    at eJ (/home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/next/dist/compiled/next-server/pages.runtime.dev.js:17:3068)
    at div
    at e9 (/home/tylerapfledderer/sites/ethereum-org/ethereum-org-website/node_modules/next/dist/compiled/next-server/pages.runtime.dev.js:26:761)
```

This PR addresses an unchecked variable. Either removing `fromPageParameter` var as done here, or revert and comment out if it is planned on being used later.

