### PR TITLE
fix event tracking: wallet page [Fixes #13420]

### DIFF
--- a/src/components/CardList.tsx
+++ b/src/components/CardList.tsx
@@ -13,6 +13,7 @@ import {
 
 import { BaseLink } from "@/components/Link"
 
+import { MatomoEventOptions, trackCustomEvent } from "@/lib/utils/matomo"
 import * as url from "@/lib/utils/url"
 
 import { useRtlFlip } from "@/hooks/useRtlFlip"
@@ -102,12 +103,14 @@ export type CardListProps = BoxProps & {
   items: CardProps[]
   imageWidth?: number
   clickHandler?: (idx: string | number) => void
+  customEventOptions?: MatomoEventOptions
 }
 
 const CardList = ({
   items,
   imageWidth,
   clickHandler = () => null,
+  customEventOptions,
   ...props
 }: CardListProps) => (
   <Box bg="background.base" w="full" {...props}>
@@ -122,7 +125,10 @@ const CardList = ({
       ) : (
         <Card
           key={idx}
-          onClick={() => clickHandler(idx)}
+          onClick={() => {
+            customEventOptions && trackCustomEvent(customEventOptions)
+            clickHandler(idx)
+          }}
           mb={4}
           {...listItem}
         />

--- a/src/pages/wallets/index.tsx
+++ b/src/pages/wallets/index.tsx
@@ -170,18 +170,18 @@ const WalletsPage = () => {
               href: "/wallets/find-wallet/",
               content: t("page-wallets-find-wallet-link"),
               matomo: {
-                eventCategory: "wallet hero buttons",
+                eventCategory: "Header buttons",
                 eventAction: "click",
-                eventName: "find wallet",
+                eventName: "Find_wallet",
               },
             },
             {
               href: `#${SIMULATOR_ID}`,
               content: "How to use a wallet",
               matomo: {
-                eventCategory: "wallet hero buttons",
+                eventCategory: "Header buttons",
                 eventAction: "click",
-                eventName: "interactive tutorial",
+                eventName: "How_to_use_wallet",
               },
               variant: "outline",
             },
@@ -191,9 +191,9 @@ const WalletsPage = () => {
               href: "/wallets/find-wallet/",
               content: t("page-wallets-find-wallet-link"),
               matomo: {
-                eventCategory: "wallet hero buttons",
+                eventCategory: "Header button",
                 eventAction: "click",
-                eventName: "find wallet",
+                eventName: "Find_wallet",
               },
             },
           ],
@@ -253,11 +253,21 @@ const WalletsPage = () => {
       title: t("page-wallets-protecting-yourself"),
       description: "MyCrypto",
       link: "https://support.mycrypto.com/staying-safe/protecting-yourself-and-your-funds",
+      customEventOptions: {
+        eventCategory: "Link",
+        eventAction: "Clicked_external",
+        eventName: "protecting_yourself",
+      },
     },
     {
       title: t("page-wallets-keys-to-safety"),
       description: t("page-wallets-blog"),
       link: "https://www.coinbase.com/learn/crypto-basics/how-to-secure-crypto",
+      customEventOptions: {
+        eventCategory: "Link",
+        eventAction: "Clicked_external",
+        eventName: "the_keys_to_keeping_crypto_safe",
+      },
     },
   ]
 
@@ -265,10 +275,20 @@ const WalletsPage = () => {
     {
       title: t("additional-reading-how-to-create-an-ethereum-account"),
       link: "/guides/how-to-create-an-ethereum-account/",
+      customEventOptions: {
+        eventCategory: "Link",
+        eventAction: "Clicked",
+        eventName: "Create_eth_acc",
+      },
     },
     {
       title: t("additional-reading-how-to-use-a-wallet"),
       link: "/guides/how-to-use-a-wallet/",
+      customEventOptions: {
+        eventCategory: "Link",
+        eventAction: "Clicked",
+        eventName: "How_to_use_wallet",
+      },
     },
   ]
 
@@ -400,7 +420,14 @@ const WalletsPage = () => {
               >
                 {t("page-wallets-features-desc")}
               </Box>
-              <ButtonLink href="/wallets/find-wallet/">
+              <ButtonLink
+                href="/wallets/find-wallet/"
+                customEventOptions={{
+                  eventCategory: "header buttons",
+                  eventAction: "click",
+                  eventName: "Find_wallet",
+                }}
+              >
                 {t("page-wallets-find-wallet-btn")}
               </ButtonLink>
               <Image


### PR DESCRIPTION
This PR Fixes the event tracking in wallets page.

## Description
<!--- Describe your changes in detail -->
In the wallets page, multiple links and buttons does not have event tracking using matomo.
Following are the buttons which require event tracking: 
1. Find a wallet
2. How to use a wallet
![image](https://github.com/user-attachments/assets/74967eb8-ed63-4edb-8244-cfc77d3d9d01)

3. Internal link name with title: How to create an ethereum account.
4. Internal link name with title: How to use a wallet
![image](https://github.com/user-attachments/assets/0c64be0b-3388-4ca8-bdf9-fd68c0469c6c)

5. External Link with title : Protecting yourself and your funds
6. External link with title: Keys to keep your crypto safe.
![image](https://github.com/user-attachments/assets/e79aaf8a-ca68-4054-b6ee-443737ee7add)


In the ButtonLink the mamoto event tracking already implemented, so i have used the same.
In the Card Component no event tracking has been added, so i added an optional prop to add the event tracking options.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: --> 
Fixes Issue: https://github.com/ethereum/ethereum-org-website/issues/13420
