### PR TITLE
remove: chainshot uni from bootcamps

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2224,16 +2224,6 @@
       ]
     },
     {
-      "login": "Dan-Nolan",
-      "name": "Dan Nolan",
-      "avatar_url": "https://avatars2.githubusercontent.com/u/4423365?v=4",
-      "profile": "https://www.chainshot.com/",
-      "contributions": [
-        "content",
-        "doc"
-      ]
-    },
-    {
       "login": "marekkirejczyk",
       "name": "Marek Kirejczyk",
       "avatar_url": "https://avatars3.githubusercontent.com/u/197522?v=4",

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2224,6 +2224,16 @@
       ]
     },
     {
+      "login": "Dan-Nolan",
+      "name": "Dan Nolan",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/4423365?v=4",
+      "profile": "https://www.chainshot.com/",
+      "contributions": [
+        "content",
+        "doc"
+      ]
+    },
+    {
       "login": "marekkirejczyk",
       "name": "Marek Kirejczyk",
       "avatar_url": "https://avatars3.githubusercontent.com/u/197522?v=4",

--- a/src/intl/ar/page-developers-learning-tools.json
+++ b/src/intl/ar/page-developers-learning-tools.json
@@ -6,8 +6,6 @@
   "page-learning-tools-browse-docs": "تصفح المستندات",
   "page-learning-tools-capture-the-ether-description": "Capture the Ether (احصل على عملات الإثير) هي لعبة تقوم فيها باختراق عقود إثيريوم الذكية للتعرف على الأمان.",
   "page-learning-tools-capture-the-ether-logo-alt": "شعار Capture the Ether",
-  "page-learning-tools-chainshot-description": "المعسكر التدريبي لمبرمجي إثيريوم عن بعد بقيادة معلم ودورات إضافية.",
-  "page-learning-tools-chainshot-logo-alt": "شعار ChainShot",
   "page-learning-tools-coding": "تعلم عن طريق البرمجة",
   "page-learning-tools-coding-subtitle": "هذه الأدوات ستساعدك على تجربة إيثيريوم إذا كنت تفضل تجربة تعلم أكثر تفاعلية.",
   "page-learning-tools-consensys-academy-description": "معسكر تدريبي لمبرمجي إثيريوم على الإنترنت.",

--- a/src/intl/az/page-developers-learning-tools.json
+++ b/src/intl/az/page-developers-learning-tools.json
@@ -6,8 +6,6 @@
   "page-learning-tools-browse-docs": "Sənədləri nəzərdən keçirin",
   "page-learning-tools-capture-the-ether-description": "Ether ələ keçirin, təhlükəsizlik haqqında öyrənmək üçün Ethereum ağıllı müqavilələrini sındırdığınız bir oyundur.",
   "page-learning-tools-capture-the-ether-logo-alt": "Ether-in loqosunu ələ keçirin",
-  "page-learning-tools-chainshot-description": "Uzaqdan, müəllim tərəfindən rəhbərlik olunan Ethereum tərtibatçı təlim düşərgələri və əlavə kurslar.",
-  "page-learning-tools-chainshot-logo-alt": "ChainShot loqosu",
   "page-learning-tools-coding": "Kodlaşdırma ilə öyrənin",
   "page-learning-tools-coding-subtitle": "Əgər daha interaktiv öyrənmə təcrübəsinə üstünlük verirsinizsə, bu alətlər Ethereum ilə təcrübə aparmağa kömək edəcək.",
   "page-learning-tools-consensys-academy-description": "Onlayn Ethereum tərtibatçı təlim düşərgəsi.",

--- a/src/intl/bg/page-developers-learning-tools.json
+++ b/src/intl/bg/page-developers-learning-tools.json
@@ -4,8 +4,6 @@
   "page-learning-tools-browse-docs": "Потърсете документите",
   "page-learning-tools-capture-the-ether-description": "Уловете Етер (Capture the Ether) е игра, в която хаквате умните договори на Етереум, за да научите за сигурността.",
   "page-learning-tools-capture-the-ether-logo-alt": "Хванете логото на Етер",
-  "page-learning-tools-chainshot-description": "Място за разработчици с дистанционно насочвене от инструктор на Етереум и допълнителни курсове.",
-  "page-learning-tools-chainshot-logo-alt": "Лого на ChainShot",
   "page-learning-tools-coding": "Учете се, като кодирате",
   "page-learning-tools-coding-subtitle": "Тези пособия ще ви помогнат да експериментирате с Етереум, ако предпочитате по-интерактивно обучение.",
   "page-learning-tools-consensys-academy-description": "Онлайн лагер за изграждане на Етереум.",

--- a/src/intl/bn/page-developers-learning-tools.json
+++ b/src/intl/bn/page-developers-learning-tools.json
@@ -6,8 +6,6 @@
   "page-learning-tools-browse-docs": "নথিসমূহ ব্রাউজ করুন",
   "page-learning-tools-capture-the-ether-description": "ক্যাপচার দ্য ইথার এমন একটি গেম যেখানে আপনি নিরাপত্তা সম্পর্কে জানতে ইথেরিয়াম স্মার্ট কন্ট্র্যাক্ট হ্যাক করেন।",
   "page-learning-tools-capture-the-ether-logo-alt": "ক্যাপচার দ্য ইথার লোগো",
-  "page-learning-tools-chainshot-description": "দূরবর্তী, প্রশিক্ষকের নেতৃত্বে ইথেরিয়াম ডেভেলপার বুটক্যাম্প এবং অতিরিক্ত কোর্সসমূহ।",
-  "page-learning-tools-chainshot-logo-alt": "ChainShot লোগো",
   "page-learning-tools-coding": "কোডিং-এর সাহায্যে শিখুন",
   "page-learning-tools-coding-subtitle": "আপনি যদি আরও ইন্টারেক্টিভ শেখার অভিজ্ঞতা পছন্দ করেন তবে এই টুলগুলি আপনাকে ইথেরিয়াম নিয়ে পরীক্ষা করতে সহায়তা করবে।",
   "page-learning-tools-consensys-academy-description": "অনলাইন ইথেরিয়াম ডেভেলপার বুটক্যাম্প.",

--- a/src/intl/ca/page-developers-learning-tools.json
+++ b/src/intl/ca/page-developers-learning-tools.json
@@ -6,8 +6,6 @@
   "page-learning-tools-browse-docs": "Cerqueu documents",
   "page-learning-tools-capture-the-ether-description": "Capture the Ether és un joc en què pirateja els contractes intel·ligents d'Ethereum per aprendre més sobre la seva seguretat.",
   "page-learning-tools-capture-the-ether-logo-alt": "Logotip de Capture the Ether",
-  "page-learning-tools-chainshot-description": "Bootcamp i cursos addicionals a distància amb instructor per a desenvolupadors d'Ethereum.",
-  "page-learning-tools-chainshot-logo-alt": "Logotip de ChainShot",
   "page-learning-tools-coding": "Apreneu programant",
   "page-learning-tools-coding-subtitle": "Aquestes eines us ajudaran a experimentar amb Ethereum si us ve de gust una experiència d'aprenentatge més interactiva.",
   "page-learning-tools-consensys-academy-description": "Bootcamp en línia per a desenvolupadors d'Ethereum.",

--- a/src/intl/cs/page-developers-learning-tools.json
+++ b/src/intl/cs/page-developers-learning-tools.json
@@ -6,8 +6,6 @@
   "page-learning-tools-browse-docs": "Procházet dokumentaci",
   "page-learning-tools-capture-the-ether-description": "Capture the Ether je hra, ve které se učíte o zabezpečení Etherea hackováním chytrých kontraktů.",
   "page-learning-tools-capture-the-ether-logo-alt": "Logo Capture the Ether",
-  "page-learning-tools-chainshot-description": "Online vývojářský bootcamp o Ethereu vedený instruktory a další kurzy.",
-  "page-learning-tools-chainshot-logo-alt": "Logo ChainShot",
   "page-learning-tools-coding": "Učte se psaním kódu",
   "page-learning-tools-coding-subtitle": "Tyto nástroje vám pomohou experimentovat s Ethereem, pokud dáváte přednost interaktivnějšímu vzdělávání.",
   "page-learning-tools-consensys-academy-description": "On-line bootcamp pro vývojáře Etherea.",

--- a/src/intl/de/page-developers-learning-tools.json
+++ b/src/intl/de/page-developers-learning-tools.json
@@ -6,8 +6,6 @@
   "page-learning-tools-browse-docs": "Dokumente durchsuchen",
   "page-learning-tools-capture-the-ether-description": "Capture the Ether ist ein Spiel, in dem Sie Smart Contracts auf Ethereum hacken, um mehr über Sicherheit zu lernen.",
   "page-learning-tools-capture-the-ether-logo-alt": "Erobern Sie das Ether-Logo",
-  "page-learning-tools-chainshot-description": "Externes, von Instruktoren geleitetes Ethereum-Entwickler-Bootcamp und zusätzliche Kurse.",
-  "page-learning-tools-chainshot-logo-alt": "ChainShot-Logo",
   "page-learning-tools-coding": "Lernen durch Programmieren",
   "page-learning-tools-coding-subtitle": "Diese Tools werden Ihnen helfen, mit Ethereum zu experimentieren, wenn Sie ein eher interaktives Lernerlebnis bevorzugen.",
   "page-learning-tools-consensys-academy-description": "Online Ethereum Entwickler-Bootcamp.",

--- a/src/intl/el/page-developers-learning-tools.json
+++ b/src/intl/el/page-developers-learning-tools.json
@@ -6,8 +6,6 @@
   "page-learning-tools-browse-docs": "Περιήγηση στα έγγραφα",
   "page-learning-tools-capture-the-ether-description": "Το Capture the Ether είναι ένα παιχνίδι στο οποίο μπορείτε να παραβιάσετε έξυπνα συμβόλαια του Ethereum για να μάθετε περισσότερα για την ασφάλεια.",
   "page-learning-tools-capture-the-ether-logo-alt": "Λογότυπο Capture the Ether",
-  "page-learning-tools-chainshot-description": "Δικτυακά, με επικεφαλή προγραμματιστή εκπαιδευτή του Ethereum και επιπλέον μαθήματα.",
-  "page-learning-tools-chainshot-logo-alt": "ChainShot λογότυπο",
   "page-learning-tools-coding": "Μάθετε προγραμματίζοντας",
   "page-learning-tools-coding-subtitle": "Αυτά τα εργαλεία θα σας βοηθήσουν να πειραματιστείτε με το Ethereum αν προτιμάτε μια πιο διαδραστική εμπειρία μάθησης.",
   "page-learning-tools-consensys-academy-description": "Ζωντανή συνάντηση προγραμματισμού Ethereum.",

--- a/src/intl/en/page-developers-learning-tools.json
+++ b/src/intl/en/page-developers-learning-tools.json
@@ -8,8 +8,6 @@
   "page-learning-tools-capture-the-ether-logo-alt": "Capture the Ether logo",
   "page-learning-tools-node-guardians-description": "Node Guardians is a gamified educational platform that immerses web3 developers in fantasy-themed quests to master Solidity, Cairo, Noir, and Huff programming.",
   "page-learning-tools-node-guardians-logo-alt": "Node Guardians logo",
-  "page-learning-tools-chainshot-description": "Remote, instructor-led Ethereum developer bootcamp and additional courses.",
-  "page-learning-tools-chainshot-logo-alt": "ChainShot logo",
   "page-learning-tools-coding": "Learn by coding",
   "page-learning-tools-coding-subtitle": "These tools will help you experiment with Ethereum if you prefer a more interactive learning experience.",
   "page-learning-tools-consensys-academy-description": "Online Ethereum developer bootcamp.",

--- a/src/intl/es/page-developers-learning-tools.json
+++ b/src/intl/es/page-developers-learning-tools.json
@@ -6,8 +6,6 @@
   "page-learning-tools-browse-docs": "Examinar documentos",
   "page-learning-tools-capture-the-ether-description": "Capture the Ether es un juego en el que puede hackear contratos inteligentes de Ethereum para aprender sobre seguridad.",
   "page-learning-tools-capture-the-ether-logo-alt": "Logo de Capture the Ether",
-  "page-learning-tools-chainshot-description": "Cursos intensivos remotos con instructores para desarrolladores de Ethereum.",
-  "page-learning-tools-chainshot-logo-alt": "Logo de ChainShot",
   "page-learning-tools-coding": "Aprender mediante codificación",
   "page-learning-tools-coding-subtitle": "Estas herramientas le ayudarán a experimentar con Ethereum si prefiere una experiencia de aprendizaje más interactiva.",
   "page-learning-tools-consensys-academy-description": "Curso online intensivo para desarrolladores de Ethereum.",

--- a/src/intl/fa/page-developers-learning-tools.json
+++ b/src/intl/fa/page-developers-learning-tools.json
@@ -6,8 +6,6 @@
   "page-learning-tools-browse-docs": "مرور اسناد",
   "page-learning-tools-capture-the-ether-description": "گرفتن اتر بازی‌‌ای است که در آن شما با هک کردن قراردادهای هوشمند اتریوم، درباره امنیت اطلاعات کسب می‌کنید.",
   "page-learning-tools-capture-the-ether-logo-alt": "لوگوی Capture the Ether",
-  "page-learning-tools-chainshot-description": "کارگاه از راه دور و مربی محور توسعه‌دهندگان اتریوم و دروس تکمیلی.",
-  "page-learning-tools-chainshot-logo-alt": "لوگوی ChainShot",
   "page-learning-tools-coding": "آموزش از طریق کدنویسی",
   "page-learning-tools-coding-subtitle": "اگر خواهان تجربه یک یادگیری تعاملی با اتریوم هستید، این ابزارها به شما کمک خواهند کرد.",
   "page-learning-tools-consensys-academy-description": "کارگاه آنلاین توسعه اتریوم.",

--- a/src/intl/fi/page-developers-learning-tools.json
+++ b/src/intl/fi/page-developers-learning-tools.json
@@ -6,8 +6,6 @@
   "page-learning-tools-browse-docs": "Selaa dokumentteja",
   "page-learning-tools-capture-the-ether-description": "Capture the Ether -pelissä opitaan Ethereumin älysopimuksista ja niiden tietoturvan varmistamisesta hyökkäämällä niihin.",
   "page-learning-tools-capture-the-ether-logo-alt": "Capture the Ether -logo",
-  "page-learning-tools-chainshot-description": "Etäohjattu Ethereum-kehittäjien peruskurssi ja jatkokurssit.",
-  "page-learning-tools-chainshot-logo-alt": "ChainShot logo",
   "page-learning-tools-coding": "Opi koodaamalla",
   "page-learning-tools-coding-subtitle": "Näillä sovelluksilla voit oppia Ethereumista kädet savessa -tyyliin, jos interaktiivisuus sopii sinulle paremmin.",
   "page-learning-tools-consensys-academy-description": "Ethereum-intensiivikurssi kehittäjille verkossa.",

--- a/src/intl/fil/page-developers-learning-tools.json
+++ b/src/intl/fil/page-developers-learning-tools.json
@@ -6,8 +6,6 @@
   "page-learning-tools-browse-docs": "I-browse ang mga dokumento",
   "page-learning-tools-capture-the-ether-description": "Ang Capture the Ether ay isang laro kung saan hina-hack mo ang mga smart contract ng Ethereum upang matuto tungkol sa seguridad.",
   "page-learning-tools-capture-the-ether-logo-alt": "Logo ng Capture the Ether",
-  "page-learning-tools-chainshot-description": "Remote at instructor-led na bootcamp para sa Ethereum developer at mga karagdagang kurso.",
-  "page-learning-tools-chainshot-logo-alt": "Logo ng Chainshot",
   "page-learning-tools-coding": "Matuto sa pamamagitan ng coding",
   "page-learning-tools-coding-subtitle": "Tutulungan ka ng mga tool na ito na mag-eksperimento sa Ethereum kung gusto mo ng mas interactive na karanasan sa pag-aaral.",
   "page-learning-tools-consensys-academy-description": "Online bootcamp para sa mga Ethereum developer.",

--- a/src/intl/fr/page-developers-learning-tools.json
+++ b/src/intl/fr/page-developers-learning-tools.json
@@ -6,8 +6,6 @@
   "page-learning-tools-browse-docs": "Parcourir la documentation",
   "page-learning-tools-capture-the-ether-description": "Capture l'Ether est un jeu dans lequel vous piratez les contrats intelligents Ethereum pour en apprendre plus sur la sécurité.",
   "page-learning-tools-capture-the-ether-logo-alt": "Logo capture l'Ether",
-  "page-learning-tools-chainshot-description": "La formation courte des développeurs Ethereum à distance et les cours additionnels sont dispensés par un instructeur.",
-  "page-learning-tools-chainshot-logo-alt": "Logo ChainShot",
   "page-learning-tools-coding": "Apprendre en codant",
   "page-learning-tools-coding-subtitle": "Ces outils vous aideront à vous familiariser avec Ethereum si vous préférez une expérience d'apprentissage plus interactive.",
   "page-learning-tools-consensys-academy-description": "Camp de démarrage des développeurs Ethereum en ligne.",

--- a/src/intl/hi/page-developers-learning-tools.json
+++ b/src/intl/hi/page-developers-learning-tools.json
@@ -6,8 +6,6 @@
   "page-learning-tools-browse-docs": "दस्तावेज़ ब्राउज़ करें",
   "page-learning-tools-capture-the-ether-description": "Capture the Ether एक ऐसा गेम है जिसमें आप सुरक्षा के बारे में जानने के लिए इथेरियम स्मार्ट अनुबंध को हैक करते हैं।",
   "page-learning-tools-capture-the-ether-logo-alt": "Capture the Ether लोगो",
-  "page-learning-tools-chainshot-description": "रिमोट, इंस्ट्रक्टर के नेतृत्व वाला इथेरियम डेवलपर बूटकैंप और अतिरिक्त पाठ्यक्रम।",
-  "page-learning-tools-chainshot-logo-alt": "ChainShot का लोगो",
   "page-learning-tools-coding": "कोडिंग द्वारा सीखें",
   "page-learning-tools-coding-subtitle": "यदि आप सीखने के अधिक संवादात्मक अनुभव को पसंद करते हैं, तो ये उपकरण आपको इथेरियम के साथ प्रयोग करने में मदद करेंगे।",
   "page-learning-tools-consensys-academy-description": "ऑनलाइन इथेरियम डेवलपर बूटकैंप.",

--- a/src/intl/hr/page-developers-learning-tools.json
+++ b/src/intl/hr/page-developers-learning-tools.json
@@ -2,7 +2,6 @@
   "page-learning-tools-bootcamps": "Kampovi za napredovanje programera",
   "page-learning-tools-bootcamps-desc": "Plaćeni internetski tečajevi koji će vam pomoći.",
   "page-learning-tools-browse-docs": "Pregledavajte dokumente",
-  "page-learning-tools-chainshot-logo-alt": "ChainShot logo",
   "page-learning-tools-coding": "Učite kodirajući",
   "page-learning-tools-coding-subtitle": "Ovi alati pomoći će vam da eksperimentirate s Ethereumom ako više volite interaktivno iskustvo učenja.",
   "page-learning-tools-consensys-academy-description": "Mrežni kampovi za Ethereum programere.",

--- a/src/intl/hu/page-developers-learning-tools.json
+++ b/src/intl/hu/page-developers-learning-tools.json
@@ -6,8 +6,6 @@
   "page-learning-tools-browse-docs": "Dokumentációk böngészése",
   "page-learning-tools-capture-the-ether-description": "A Capture the Ether egy játék, melyben Ethereum-okosszerződéseket hackelhet meg, miközben a biztonságról tanul.",
   "page-learning-tools-capture-the-ether-logo-alt": "Capture the Ether-logó",
-  "page-learning-tools-chainshot-description": "Távoktatásos, oktató által vezetett Ethereum fejlesztői bootcamp és további tanfolyamok.",
-  "page-learning-tools-chainshot-logo-alt": "ChainShot logo",
   "page-learning-tools-coding": "Tanulás programozással",
   "page-learning-tools-coding-subtitle": "Ezek az eszközök segítenek, hogy az Ethereummal kísérletezzen, ha interaktív tanulási élményt szeretne.",
   "page-learning-tools-consensys-academy-description": "Online Ethereum fejlesztő bootcamp.",

--- a/src/intl/id/page-developers-learning-tools.json
+++ b/src/intl/id/page-developers-learning-tools.json
@@ -6,8 +6,6 @@
   "page-learning-tools-browse-docs": "Jelajahi dokumen",
   "page-learning-tools-capture-the-ether-description": "Capture the Ether adalah sebuah game di mana Anda meretas kontrak pintar Ethereum untuk belajar tentang keamanan.",
   "page-learning-tools-capture-the-ether-logo-alt": "Logo Capture the Ether",
-  "page-learning-tools-chainshot-description": "Kamp pelatihan pengembang Ethereum jarak jauh, yang dipandu oleh instruktur dan kursus tambahan.",
-  "page-learning-tools-chainshot-logo-alt": "Logo ChainShot",
   "page-learning-tools-coding": "Belajar melalui pengodean",
   "page-learning-tools-coding-subtitle": "Peralatan ini akan membantu Anda bereksperimen dengan Ethereum jika Anda lebih suka pengalaman belajar yang lebih interaktif.",
   "page-learning-tools-consensys-academy-description": "Kamp pelatihan pengembang Ethereum online.",

--- a/src/intl/ig/page-developers-learning-tools.json
+++ b/src/intl/ig/page-developers-learning-tools.json
@@ -6,8 +6,7 @@
   "page-learning-tools-browse-docs": "Chọgharịa akwụkwọ dijitalụ",
   "page-learning-tools-capture-the-ether-description": "Weghara Ether bụ egwuregwu nke ị nataghi ikike Ethereum smart contracts iji mụta maka nchekwa.",
   "page-learning-tools-capture-the-ether-logo-alt": "Weghara akara ngosi Ether",
-  "page-learning-tools-chainshot-description": "Ebe dịpụrụ adịpụ, buutcam Ethereum onye nkuzi na-eduzi yana nkuzi ndị ọzọ.",
-  "page-learning-tools-chainshot-logo-alt": "Akara ngosi ChainShot",
+ 
   "page-learning-tools-coding": "Muta ihe site na iji ndokwa",
   "page-learning-tools-coding-subtitle": "Ngwa ndị a ga enyere gị aka ịnwale Ethereum ma ọ bụrụ na ịchọrọ ahụmịhe mmụta mmekọrịta karịa.",
   "page-learning-tools-consensys-academy-description": "Buutcam Onye mmepụta Ethereum dị n'ịntanetị.",

--- a/src/intl/it/page-developers-learning-tools.json
+++ b/src/intl/it/page-developers-learning-tools.json
@@ -6,8 +6,6 @@
   "page-learning-tools-browse-docs": "Sfoglia le documentazioni",
   "page-learning-tools-capture-the-ether-description": "\"Capture the Ether\" è un gioco in cui violi i contratti intelligenti di Ethereum per imparare sulla sicurezza.",
   "page-learning-tools-capture-the-ether-logo-alt": "Logo di Capture the Ether",
-  "page-learning-tools-chainshot-description": "Bootcamp per sviluppatori di Ethereum da remoto con istruttore e corsi aggiuntivi.",
-  "page-learning-tools-chainshot-logo-alt": "Logo di ChainShot",
   "page-learning-tools-coding": "Impara scrivendo codice",
   "page-learning-tools-coding-subtitle": "Questi strumenti ti aiuteranno a sperimentare con Ethereum se preferisci un'esperienza d'apprendimento più interattiva.",
   "page-learning-tools-consensys-academy-description": "Bootcamp online per sviluppatori di Ethereum.",

--- a/src/intl/ja/page-developers-learning-tools.json
+++ b/src/intl/ja/page-developers-learning-tools.json
@@ -6,8 +6,6 @@
   "page-learning-tools-browse-docs": "ドキュメントを参照",
   "page-learning-tools-capture-the-ether-description": "Capture the Etherは、イーサリアムのスマートコントラクトをハッキングして、セキュリティについて学ぶゲームです。",
   "page-learning-tools-capture-the-ether-logo-alt": "イーサロゴをキャプチャ",
-  "page-learning-tools-chainshot-description": "リモート、インストラクター主導のイーサリアムデベロッパーのブートキャンプおよびその他のコース。",
-  "page-learning-tools-chainshot-logo-alt": "ChainShot ロゴ",
   "page-learning-tools-coding": "コーディングで学ぶ",
   "page-learning-tools-coding-subtitle": "よりインタラクティブな学習体験を希望される場合、これらのツールはイーサリアムの実験に役立ちます。",
   "page-learning-tools-consensys-academy-description": "オンラインのイーサリアムデベロッパーブートキャンプ",

--- a/src/intl/kn/page-developers-learning-tools.json
+++ b/src/intl/kn/page-developers-learning-tools.json
@@ -6,8 +6,6 @@
   "page-learning-tools-browse-docs": "ದಾಖಲೆ ಬ್ರೌಸ್ ಮಾಡಿ",
   "page-learning-tools-capture-the-ether-description": "ಕ್ಯಾಪ್ಚರ್ ದಿ ಈಥರ್ ಎಂಬುದು ಭದ್ರತೆಯ ಬಗ್ಗೆ ಕಲಿಯಲು ನೀವು ಎಥೆರಿಯಮ್ ಸ್ಮಾರ್ಟ್ ಒಪ್ಪಂದಗಳನ್ನು ಹ್ಯಾಕ್ ಮಾಡುವ ಆಟವಾಗಿದೆ.",
   "page-learning-tools-capture-the-ether-logo-alt": "ಕ್ಯಾಪ್ಚರ್ ದಿ ಈಥರ್ ಲೋಗೋ",
-  "page-learning-tools-chainshot-description": "ರಿಮೋಟ್, ಬೋಧಕ ನೇತೃತ್ವದ ಎಥೆರಿಯಮ್ ಡೆವಲಪರ್ ಬೂಟ್ ಕ್ಯಾಂಪ್ ಮತ್ತು ಹೆಚ್ಚುವರಿ ಕೋರ್ಸ್ ಗಳು.",
-  "page-learning-tools-chainshot-logo-alt": "ChainShot ಚೈನ್ ಶಾಟ್ ಲೋಗೋ",
   "page-learning-tools-coding": "ಕೋಡಿಂಗ್ ಮೂಲಕ ಕಲಿಯಿರಿ",
   "page-learning-tools-coding-subtitle": "ನೀವು ಹೆಚ್ಚು ಸಂವಾದಾತ್ಮಕ ಕಲಿಕೆಯ ಅನುಭವವನ್ನು ಬಯಸಿದರೆ ಈ ಉಪಕರಣಗಳು ಎಥೆರಿಯಮ್ನೊಂದಿಗೆ ಪ್ರಯೋಗ ಮಾಡಲು ನಿಮಗೆ ಸಹಾಯ ಮಾಡುತ್ತದೆ.",
   "page-learning-tools-consensys-academy-description": "ಆನ್ ಲೈನ್ ಇಥಿರಿಯಮ್ ಡೆವಲಪರ್ ಬೂಟ್ ಕ್ಯಾಂಪ್.",

--- a/src/intl/ko/page-developers-learning-tools.json
+++ b/src/intl/ko/page-developers-learning-tools.json
@@ -6,8 +6,6 @@
   "page-learning-tools-browse-docs": "문서 찾아보기",
   "page-learning-tools-capture-the-ether-description": "이더를 잡아라(Capture the Ether)는 이더리움 스마트 계약을 해킹함으로써 보안에 대해 배울 수 있는 게임입니다.",
   "page-learning-tools-capture-the-ether-logo-alt": "Capture the Ether 로고",
-  "page-learning-tools-chainshot-description": "강사 주도하에 원격으로 이루어지는 이더리움 개발자 부트캠프 및 추가 강의.",
-  "page-learning-tools-chainshot-logo-alt": "ChainShot 로고",
   "page-learning-tools-coding": "코딩으로 학습",
   "page-learning-tools-coding-subtitle": "양방향 학습 환경을 선호하는 경우, 해당 도구를 이용해 이더리움을 경험해 볼 수 있습니다.",
   "page-learning-tools-consensys-academy-description": "온라인 이더리움 개발자 부트캠프.",

--- a/src/intl/ml/page-developers-learning-tools.json
+++ b/src/intl/ml/page-developers-learning-tools.json
@@ -2,7 +2,6 @@
   "page-learning-tools-bootcamps": "ഡവലപ്പർ ബൂട്ട്‌ക്യാമ്പുകൾ",
   "page-learning-tools-bootcamps-desc": "നിങ്ങളെ വേഗത്തിലാക്കുന്നതിന് പണമടച്ചുള്ള ഓൺലൈൻ കോഴ്‌സുകൾ.",
   "page-learning-tools-browse-docs": "ഡോക്സ് ബ്രൗസ് ചെയ്യുക",
-  "page-learning-tools-chainshot-logo-alt": "ചെയിൻ‌ഷോട്ട് ലോഗോ",
   "page-learning-tools-coding": "കോഡിംഗ് ഉപയോഗിച്ച് പഠിക്കൂ",
   "page-learning-tools-coding-subtitle": "കുറച്ചുകൂടി സംവേദനാത്മകമായ പഠന അനുഭവം നൽകാൻ, ഈ ഉപകരണങ്ങൾ താങ്കളെ സഹായിക്കും.",
   "page-learning-tools-consensys-academy-description": "ഓൺലൈൻ Ethereum ഡവലപ്പർ ബൂട്ട്‌ക്യാമ്പ്.",

--- a/src/intl/mr/page-developers-learning-tools.json
+++ b/src/intl/mr/page-developers-learning-tools.json
@@ -6,8 +6,6 @@
   "page-learning-tools-browse-docs": "दस्तऐवज ब्राउझ करा",
   "page-learning-tools-capture-the-ether-description": "कॅप्चर द इथर हा एक गेम आहे ज्यामध्ये तुम्ही सुरक्षिततेबद्दल जाणून घेण्यासाठी Ethereum स्मार्ट कॉन्ट्रॅक्ट हॅक करता.",
   "page-learning-tools-capture-the-ether-logo-alt": "इथर लोगो कॅप्चर करा",
-  "page-learning-tools-chainshot-description": "रिमोट, इंस्ट्रक्टर-नेतृत्वातील Ethereum विकसक बूटकॅम्प आणि अतिरिक्त अभ्यासक्रम.",
-  "page-learning-tools-chainshot-logo-alt": "ChainShot लोगो",
   "page-learning-tools-coding": "कोडिंग करून शिका",
   "page-learning-tools-coding-subtitle": "तुम्ही अधिक परस्परसंवादी शिक्षण अनुभवाला प्राधान्य दिल्यास ही साधने तुम्हाला Ethereum सह प्रयोग करण्यात मदत करतील.",
   "page-learning-tools-consensys-academy-description": "ऑनलाइन Ethereum विकसक बूटकॅम्प.",

--- a/src/intl/ms/page-developers-learning-tools.json
+++ b/src/intl/ms/page-developers-learning-tools.json
@@ -6,8 +6,6 @@
   "page-learning-tools-browse-docs": "Terokai dokumentasi",
   "page-learning-tools-capture-the-ether-description": "Capture the Ether ialah sebuah permainan di mana anda boleh menggodam kontrak pintar Ethereum untuk pelajari lebih lanjut tentang keselamatan.",
   "page-learning-tools-capture-the-ether-logo-alt": "Logo Capture the Ether",
-  "page-learning-tools-chainshot-description": "Jarak jauh, bootcamp pemaju Ethereum terbimbing pengajar dan kursus tambahan.",
-  "page-learning-tools-chainshot-logo-alt": "Logo ChainShot",
   "page-learning-tools-coding": "Belajar melalui pengekodan",
   "page-learning-tools-coding-subtitle": "Peralatan ini akan membantu anda untuk bereksperimen dengan Ethereum jika anda mahukan pengalaman pembelajaran yang interaktif.",
   "page-learning-tools-consensys-academy-description": "Bootcamp pemaju Ethereum dalam talian.",

--- a/src/intl/nl/page-developers-learning-tools.json
+++ b/src/intl/nl/page-developers-learning-tools.json
@@ -6,8 +6,6 @@
   "page-learning-tools-browse-docs": "Doorzoek documenten",
   "page-learning-tools-capture-the-ether-description": "Capture the Ether is een spel waarin u slimme contracten van Ethereum hackt om meer te weten te komen over beveiliging.",
   "page-learning-tools-capture-the-ether-logo-alt": "Logo van Capture the Ether",
-  "page-learning-tools-chainshot-description": "Door instructeur geleide bootcamp op afstand voor Ethereum-ontwikkelaars en extra cursussen.",
-  "page-learning-tools-chainshot-logo-alt": "ChainShot-logo",
   "page-learning-tools-coding": "Leer door te coderen",
   "page-learning-tools-coding-subtitle": "Deze tools zullen u helpen te experimenteren met Ethereum als u de voorkeur geeft aan een meer interactieve leerervaring.",
   "page-learning-tools-consensys-academy-description": "Online bootcamp voor Ethereum-ontwikkelaars.",

--- a/src/intl/pcm/page-developers-learning-tools.json
+++ b/src/intl/pcm/page-developers-learning-tools.json
@@ -6,8 +6,6 @@
   "page-learning-tools-browse-docs": "Browser docs",
   "page-learning-tools-capture-the-ether-description": "Capture the Ether na game in which you fit hack Ethereum contracts to learn about security.",
   "page-learning-tools-capture-the-ether-logo-alt": "Capture di Ether logo",
-  "page-learning-tools-chainshot-description": "Remote,instructor-led Ethereum developer bootcamp and additional courses.",
-  "page-learning-tools-chainshot-logo-alt": "Chainshot logo",
   "page-learning-tools-coding": "Learn by kodin",
   "page-learning-tools-coding-subtitle": "These tools fit help you experiment with Ethereum if you prefer a more interactive learning experience.",
   "page-learning-tools-consensys-academy-description": "Online Ethereum developer bootcamp.",

--- a/src/intl/pl/page-developers-learning-tools.json
+++ b/src/intl/pl/page-developers-learning-tools.json
@@ -6,8 +6,6 @@
   "page-learning-tools-browse-docs": "Przeglądaj dokumenty",
   "page-learning-tools-capture-the-ether-description": "Capture the Ether jest grą, w której hakujesz smart kontrakty Ethereum, aby nauczyć się o ich bezpieczeństwie.",
   "page-learning-tools-capture-the-ether-logo-alt": "Logo Capture the Ether",
-  "page-learning-tools-chainshot-description": "Zdalny, prowadzony przez instruktora bootcamp Ethereum i dodatkowe kursy.",
-  "page-learning-tools-chainshot-logo-alt": "Logo ChainShot",
   "page-learning-tools-coding": "Nauka przez kodowanie",
   "page-learning-tools-coding-subtitle": "Jeżeli wolisz naukę poprzez interakcję, te narzędzia pomogą ci w eksperymentowaniu z Ethereum.",
   "page-learning-tools-consensys-academy-description": "Szkolenia deweloperskie z Ethereum online.",

--- a/src/intl/pt-br/page-developers-learning-tools.json
+++ b/src/intl/pt-br/page-developers-learning-tools.json
@@ -6,8 +6,6 @@
   "page-learning-tools-browse-docs": "Navegar pela documentação",
   "page-learning-tools-capture-the-ether-description": "Capture the Ether é um jogo em que você codifica os contratos inteligentes do Ethereum para aprender sobre segurança.",
   "page-learning-tools-capture-the-ether-logo-alt": "Logotipo do jogo Capture the Ether",
-  "page-learning-tools-chainshot-description": "Treinamento remoto inicial para desenvolvedores Ethereum e cursos adicionais.",
-  "page-learning-tools-chainshot-logo-alt": "Logotipo da ChainShot",
   "page-learning-tools-coding": "Aprenda programando",
   "page-learning-tools-coding-subtitle": "Essas ferramentas vão ajudá-lo a experimentar com Ethereum, se você preferir uma jornada de aprendizado mais interativa.",
   "page-learning-tools-consensys-academy-description": "Bootcamp on-line para desenvolvedores Ethereum.",

--- a/src/intl/pt/page-developers-learning-tools.json
+++ b/src/intl/pt/page-developers-learning-tools.json
@@ -6,8 +6,6 @@
   "page-learning-tools-browse-docs": "Procurar documentos",
   "page-learning-tools-capture-the-ether-description": "Capture o Ether é um jogo em que o jogador hackeia contratos inteligentes Ethereum para se inteirar dos aspetos relacionados com a segurança.",
   "page-learning-tools-capture-the-ether-logo-alt": "Capturar o logótipo Ether",
-  "page-learning-tools-chainshot-description": "Bootcamp online para programadores Ethereum ministrado por instrutores, além de outros cursos adicionais.",
-  "page-learning-tools-chainshot-logo-alt": "Logótipo ChainShot",
   "page-learning-tools-coding": "Aprenda programando",
   "page-learning-tools-coding-subtitle": "Estas ferramentas ajudá-lo-ão a experimentar a Ethereum se preferir uma experiência de aprendizagem mais interativa.",
   "page-learning-tools-consensys-academy-description": "Bootcamp online para programadores de Ethereum.",

--- a/src/intl/ro/page-developers-learning-tools.json
+++ b/src/intl/ro/page-developers-learning-tools.json
@@ -6,8 +6,6 @@
   "page-learning-tools-browse-docs": "Parcurgeți documentația",
   "page-learning-tools-capture-the-ether-description": "Prinde Ether-ul este un joc în care piratați contractele inteligente Ethereum pentru a învăța despre securitate.",
   "page-learning-tools-capture-the-ether-logo-alt": "Sigla pentru Prinde Ether-ul",
-  "page-learning-tools-chainshot-description": "Cursuri intensive la distanță pentru dezvoltători, susținute de instructori, și alte cursuri.",
-  "page-learning-tools-chainshot-logo-alt": "Sigla ChainShot",
   "page-learning-tools-coding": "Învațați scriind cod",
   "page-learning-tools-coding-subtitle": "Aceste instrumente vă vor ajuta să experimentați în Ethereum, dacă preferați o modalitate de învățare mai interactivă.",
   "page-learning-tools-consensys-academy-description": "Curs intensiv online pentru dezvoltatori în Ethereum.",

--- a/src/intl/ru/page-developers-learning-tools.json
+++ b/src/intl/ru/page-developers-learning-tools.json
@@ -6,8 +6,6 @@
   "page-learning-tools-browse-docs": "Просмотр документов",
   "page-learning-tools-capture-the-ether-description": "Capture the Ether — это игра, в которой вы взламываете умные контракты Ethereum, чтобы узнать больше об их защите.",
   "page-learning-tools-capture-the-ether-logo-alt": "Логотип Capture the Ether",
-  "page-learning-tools-chainshot-description": "Удаленный учебный онлайн-лагерь для разработчиков Ethereum под руководством инструктора и дополнительные курсы.",
-  "page-learning-tools-chainshot-logo-alt": "Логотип ChainShot",
   "page-learning-tools-coding": "Учитесь на программировании",
   "page-learning-tools-coding-subtitle": "Эти инструменты позволят вам поэкспериментировать с Ethereum, если вы предпочитаете более интерактивное обучение.",
   "page-learning-tools-consensys-academy-description": "Онлайн-лагерь для разработчиков Ethereum.",

--- a/src/intl/sl/page-developers-learning-tools.json
+++ b/src/intl/sl/page-developers-learning-tools.json
@@ -4,8 +4,6 @@
   "page-learning-tools-browse-docs": "Prebrskajte dokumente",
   "page-learning-tools-capture-the-ether-description": "Ujemite Ether je igra, v kateri vdirate v Ethereumove pametne pogodbe, da se seznanite z varnostjo.",
   "page-learning-tools-capture-the-ether-logo-alt": "Ujemite Ether logotip",
-  "page-learning-tools-chainshot-description": "Ethereum razvijalski bootcamp in dodatni tečaji na daljavo, pod vodstvom inštruktorja.",
-  "page-learning-tools-chainshot-logo-alt": "Logotip ChainShot",
   "page-learning-tools-coding": "Učenje s kodiranjem",
   "page-learning-tools-coding-subtitle": "Ta orodja vam bodo pomagala eksperimentirati z Ethereumom, če imate raje interaktivno učno izkušnjo.",
   "page-learning-tools-consensys-academy-description": "Spletni izobraževalni tabor za razvijalce na Ethereumu.",

--- a/src/intl/sr/page-developers-learning-tools.json
+++ b/src/intl/sr/page-developers-learning-tools.json
@@ -6,8 +6,6 @@
   "page-learning-tools-browse-docs": "Pregledajte dokumenta",
   "page-learning-tools-capture-the-ether-description": "Capture the Ether je igra u kojoj hakuješ Ethereum pametne ugovore kako bi saznao/la više o bezbednosti.",
   "page-learning-tools-capture-the-ether-logo-alt": "Uhvati Ether logo",
-  "page-learning-tools-chainshot-description": "Na daljinu, instruktorski vođen Ethereum bootcamp za programere i dodatni kursevi.",
-  "page-learning-tools-chainshot-logo-alt": "ChainShot logo",
   "page-learning-tools-coding": "Nauči kodiranjem",
   "page-learning-tools-coding-subtitle": "Ovi alati će vam pomoći da eksperimentišete sa Ethereum-om ako više volite interaktivnije iskustvo učenja.",
   "page-learning-tools-consensys-academy-description": "Onlajn Ethereum bootcamp za programere.",

--- a/src/intl/sw/page-developers-learning-tools.json
+++ b/src/intl/sw/page-developers-learning-tools.json
@@ -6,8 +6,6 @@
   "page-learning-tools-browse-docs": "Vinjari nyaraka",
   "page-learning-tools-capture-the-ether-description": "Kamata Ether ni mchezo ambao utadukua mikataba erevu ya Ethereum ili kujifunza kuhusu usalama.",
   "page-learning-tools-capture-the-ether-logo-alt": "Kamata nembo ya Ether",
-  "page-learning-tools-chainshot-description": "Kambi za mtandaoni zinazoendeshwa na walimu walio wasanidi programu za Ethereum na kozi nyingine za ziada.",
-  "page-learning-tools-chainshot-logo-alt": "Nembo ya ChainShot",
   "page-learning-tools-coding": "Jifunze kwa usimbuaji",
   "page-learning-tools-coding-subtitle": "Vifaa hivi vitakusaidia kufanya majaribio ya Ethereum kama ungependa maingiliano zaidi wakati wa kujifunza.",
   "page-learning-tools-consensys-academy-description": "Kamabi ya kujifunzia ya usanidi programu za Ethereum mtandaoni.",

--- a/src/intl/tr/page-developers-learning-tools.json
+++ b/src/intl/tr/page-developers-learning-tools.json
@@ -6,8 +6,6 @@
   "page-learning-tools-browse-docs": "Dokümanlara göz atın",
   "page-learning-tools-capture-the-ether-description": "Capture the Ether, güvenlik hakkında bilgi edinmek için Ethereum akıllı sözleşmelerini hacklediğiniz bir oyundur.",
   "page-learning-tools-capture-the-ether-logo-alt": "Capture the Ether logosu",
-  "page-learning-tools-chainshot-description": "Uzaktan, eğitmen liderliğindeki Ethereum geliştirici eğitim kampı ve ek kurslar.",
-  "page-learning-tools-chainshot-logo-alt": "ChainShot logo",
   "page-learning-tools-coding": "Kodlayarak öğrenin",
   "page-learning-tools-coding-subtitle": "Etkileşimli bir öğrenim modelini tercih ediyorsanız, bu araçlar Ethereum' u denemenizde yardımcı olacaktır.",
   "page-learning-tools-consensys-academy-description": "Online Ethereum geliştirici eğitim programı.",

--- a/src/intl/uk/page-developers-learning-tools.json
+++ b/src/intl/uk/page-developers-learning-tools.json
@@ -6,8 +6,6 @@
   "page-learning-tools-browse-docs": "Переглянути документи",
   "page-learning-tools-capture-the-ether-description": "Capture the Ether — це гра, у якій ви зламуєте смартконтракти Ethereum для вивчення принципів безпеки.",
   "page-learning-tools-capture-the-ether-logo-alt": "Захоплення логотипу Ether",
-  "page-learning-tools-chainshot-description": "Дистанційна навчальна сесія та додаткові курси для розробників Ethereum під керівництвом інструкторів.",
-  "page-learning-tools-chainshot-logo-alt": "ChainShot logo",
   "page-learning-tools-coding": "Кодуй і навчайся",
   "page-learning-tools-coding-subtitle": "Ці інструменти дадуть змогу експериментувати з мережею Ethereum, якщо ви віддаєте перевагу більш інтерактивному навчанню.",
   "page-learning-tools-consensys-academy-description": "Онлайн-посібник для розробників Ethereum.",

--- a/src/intl/vi/page-developers-learning-tools.json
+++ b/src/intl/vi/page-developers-learning-tools.json
@@ -6,8 +6,6 @@
   "page-learning-tools-browse-docs": "Duyệt tài liệu",
   "page-learning-tools-capture-the-ether-description": "Capture the Ether là một trò chơi trong đó, người chơi tìm hiểu về bảo mật bằng cách xâm nhập các hợp đồng thông minh Ethereum.",
   "page-learning-tools-capture-the-ether-logo-alt": "Logo của Capture the Ether",
-  "page-learning-tools-chainshot-description": "Ngoài ra, còn có chương trình đào tạo tăng cường dành cho nhà phát triển Ethereum do người hướng dẫn từ xa dẫn dắt và các khóa học bổ sung.",
-  "page-learning-tools-chainshot-logo-alt": "Logo của ChainShot",
   "page-learning-tools-coding": "Tìm hiểu bằng cách mã hoá",
   "page-learning-tools-coding-subtitle": "Nếu bạn muốn có một môi trường học tập giàu tính tương tác hơn, thì những công cụ này sẽ giúp bạn trải nghiệm với Ethereum.",
   "page-learning-tools-consensys-academy-description": "Developer bootcamp trực tuyến về Ethereum.",

--- a/src/intl/zh-tw/page-developers-learning-tools.json
+++ b/src/intl/zh-tw/page-developers-learning-tools.json
@@ -6,8 +6,6 @@
   "page-learning-tools-browse-docs": "瀏覽文件",
   "page-learning-tools-capture-the-ether-description": "「捕捉以太」這個遊戲可以讓你破解以太坊智慧型合約，藉此學習安全議題。",
   "page-learning-tools-capture-the-ether-logo-alt": "捕捉以太標誌",
-  "page-learning-tools-chainshot-description": "由講師教授的遠距以太坊開發者訓練營及額外課程。",
-  "page-learning-tools-chainshot-logo-alt": "ChainShot 標誌",
   "page-learning-tools-coding": "透過編寫程式學習",
   "page-learning-tools-coding-subtitle": "如果你偏好互動性高的學習體驗，這些工具會幫助你試用以太坊功能。",
   "page-learning-tools-consensys-academy-description": "線上以太坊開發者訓練營。",

--- a/src/intl/zh/page-developers-learning-tools.json
+++ b/src/intl/zh/page-developers-learning-tools.json
@@ -6,8 +6,6 @@
   "page-learning-tools-browse-docs": "浏览文档",
   "page-learning-tools-capture-the-ether-description": "Capture the Ether 是一款在破解智能合约的过程中学习其安全性的游戏。",
   "page-learning-tools-capture-the-ether-logo-alt": "Capture the Ether 徽标",
-  "page-learning-tools-chainshot-description": "有教师指导的远程以太坊开发者训练营和其他课程。",
-  "page-learning-tools-chainshot-logo-alt": "ChainShot徽标",
   "page-learning-tools-coding": "通过编码来学习",
   "page-learning-tools-coding-subtitle": "如果你更喜欢在互动中学习，这些工具会帮你实践理解以太坊。",
   "page-learning-tools-consensys-academy-description": "线上以太坊开发者训练营。",

--- a/src/pages/developers/learning-tools.tsx
+++ b/src/pages/developers/learning-tools.tsx
@@ -28,7 +28,6 @@ import BloomTechImage from "@/public/images/dev-tools/bloomtech.png"
 import BuildSpaceImage from "@/public/images/dev-tools/buildspace.png"
 import CaptureTheEtherImage from "@/public/images/dev-tools/capturetheether.png"
 import ChainIDEImage from "@/public/images/dev-tools/chainIDE.png"
-import ChainShotImage from "@/public/images/dev-tools/chainshot.png"
 import ConsensysImage from "@/public/images/dev-tools/consensys.png"
 import CryptoZombieImage from "@/public/images/dev-tools/crypto-zombie.png"
 import DappWorldImage from "@/public/images/dev-tools/dapp-world.png"
@@ -296,19 +295,6 @@ const LearningToolsPage = () => {
   ]
 
   const bootcamps: Array<LearningTool> = [
-    {
-      name: "ChainShot",
-      description: t(
-        "page-developers-learning-tools:page-learning-tools-chainshot-description"
-      ),
-      url: "https://www.chainshot.com",
-      image: ChainShotImage,
-      alt: t(
-        "page-developers-learning-tools:page-learning-tools-chainshot-logo-alt"
-      ),
-      background: "#111f29",
-      subjects: ["Solidity", "Vyper", "web3"],
-    },
     {
       name: "ConsenSys Academy",
       description: t(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Updated the bootcamps list in the https://ethereum.org/en/developers/learning-tools/

## Description
<!--- Describe your changes in detail -->
In this PR i have remove all the instances of Chainshot University as now it is acquired by Alchemy University and it is already there onthe list.
I have removed it in all the languages json file.

## Related Issue
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes: https://github.com/ethereum/ethereum-org-website/issues/13294
