### PR TITLE
Update community-events.json

### DIFF
--- a/src/data/community-events.json
+++ b/src/data/community-events.json
@@ -189,15 +189,6 @@
     "description": "Unleashing the Potential of ZK Technology in an Afternoon. This is a warm-up gathering in the DEVCON ZK field."
   },
   {
-    "title": "TOKEN2049",
-    "startDate": "2024-04-18",
-    "endDate": "2024-04-19",
-    "href": "https://token2049.com",
-    "location": "Dubai, UAE",
-    "description": "TOKEN2049 is organized annually in Dubai and Singapore, where founders and executives in the web3 industry share their view on the industry",
-    "imageUrl": "https://static.wixstatic.com/media/df5f7a_8ec2fa25938e484a8cc2dc11ef6ed2f7~mv2.png/v1/fill/w_2500,h_1352,al_c/df5f7a_8ec2fa25938e484a8cc2dc11ef6ed2f7~mv2.png"
-  },
-  {
     "title": "ETHTallinn",
     "startDate": "2024-04-19",
     "endDate": "2024-04-21",
@@ -399,14 +390,6 @@
     "href": "https://ethsafari.xyz/",
     "location": "Nairobi & Kilifi, Kenya",
     "description": "Welcome to the largest Ethereum event happening in Africa! Join the BlockTrain from Nairobi to celebrate an ETH-festival held underneath ancient Boabab trees in Kilifi."
-  },
-  {
-    "title": "TOKEN2049",
-    "startDate": "2024-09-18",
-    "endDate": "2024-09-19",
-    "href": "https://token2049.com",
-    "location": "Singapore, SG",
-    "description": "TOKEN2049 is organized annually in Dubai and Singapore, where founders and executives in the web3 industry share their view on the industry"
   },
   {
     "title": "ETHGlobal Singapore",


### PR DESCRIPTION
Removing Token2049 from the list of Ethereum Community Events
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- This is not an Etheruem event: it is a commercial crypto conference 
- Given the commercial and corporate nature of the conference, it would not be appropriate for it to be considered a community event

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
