### PR TITLE
fix:The bold item in the menu of mobile devices

### DIFF
--- a/src/components/Nav/Mobile/LvlAccordion.tsx
+++ b/src/components/Nav/Mobile/LvlAccordion.tsx
@@ -137,7 +137,7 @@ const LvlAccordion = ({
                         {label}
                       </Text>
                       <Text
-                        fontWeight="regular"
+                        fontWeight="normal"
                         fontSize="sm"
                         color={menuColors.lvl[lvl].subtext}
                       >


### PR DESCRIPTION

Update Font Weight for "Emerging Use Cases" Subtext on Mobile Devices

Description
This pull request addresses a styling update for mobile devices. Specifically, the font weight of the subtext under the heading "Emerging Use Cases" in the menu has been changed from regular to normal. This adjustment enhances the visual consistency and readability of the menu items on smaller screens.

Fixes #13499

<img width="465" alt="Screenshot 2024-08-06 at 12 46 58 AM" src="https://github.com/user-attachments/assets/0a0edf8f-35c9-4369-8e6f-bc357a3efb13">



-Bug FIx
Changes:Updated the font weight of the subtext for "Emerging Use Cases" in the menu specifically for mobile devices.
To reproduce
Go to https://ethereum.org/en/
Click on the menu on Mobile device
Select "Use"
Select "use cases"
Error Fixed- "Emerging usecases" the subtext has been unbolded (to normal)
