### PR TITLE
Add link to the Execution API Inspector page.

### DIFF
--- a/public/content/developers/docs/apis/json-rpc/index.md
+++ b/public/content/developers/docs/apis/json-rpc/index.md
@@ -26,7 +26,7 @@ An internal API is also used for inter-client communication within a node - that
 
 ## Execution client spec {#spec}
 
-[Read the full JSON-RPC API spec on GitHub](https://github.com/ethereum/execution-apis). This API is documented on the [Execution API webpage](https://ethereum.github.io/execution-apis/api-documentation/) with Inspector to try out all the available methods.
+[Read the full JSON-RPC API spec on GitHub](https://github.com/ethereum/execution-apis). This API is documented on the [Execution API webpage](https://ethereum.github.io/execution-apis/api-documentation/) and includes an Inspector to try out all the available methods.
 
 ## Conventions {#conventions}
 

--- a/public/content/developers/docs/apis/json-rpc/index.md
+++ b/public/content/developers/docs/apis/json-rpc/index.md
@@ -26,7 +26,7 @@ An internal API is also used for inter-client communication within a node - that
 
 ## Execution client spec {#spec}
 
-[Read the full JSON-RPC API spec on GitHub](https://github.com/ethereum/execution-apis).
+[Read the full JSON-RPC API spec on GitHub](https://github.com/ethereum/execution-apis). This API is documented on the [Execution API webpage](https://ethereum.github.io/execution-apis/api-documentation/) with Inspector to try out all the available methods.
 
 ## Conventions {#conventions}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Interestingly, on the JSON RPC spec page which is describing execution APIs have a link to Beacon API docs page(in Consensus section) but not the Execution API page.
## Description
Execution API docs page consist of the Inspector which can assist like Postman (GUI tool) for trying out various APIs.
<!--- Describe your changes in detail -->

## Related Issue
I didn't open an issue first because that increases the duration of action, especially for such a small change. If PR is found to be inappropriate, can be just closed directly.
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
