### PR TITLE
HOTFIX docsearch transform

### DIFF
--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -117,10 +117,8 @@ const Search = forwardRef<Props, "button">(
                 items.map((item: DocSearchHit) => {
                   const newItem: DocSearchHit = structuredClone(item)
                   newItem.url = sanitizeHitUrl(item.url)
-                  const newTitle = sanitizeHitTitle(
-                    item._highlightResult.hierarchy.lvl0?.value || ""
-                  )
-                  newItem._highlightResult.hierarchy.lvl0.value = newTitle
+                  const newTitle = sanitizeHitTitle(item.hierarchy.lvl0 || "")
+                  newItem.hierarchy.lvl0 = newTitle
                   return newItem
                 })
               }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes the docsearch `transformItems` function with the correct item properties.

Fixes #13603