### PR TITLE
Add Ethereum for Elixir developers page

### DIFF
--- a/public/content/contributing/translation-program/content-buckets/index.md
+++ b/public/content/contributing/translation-program/content-buckets/index.md
@@ -178,6 +178,7 @@ Below is a breakdown of the website pages each content bucket contains.
 - [Programming languages](/developers/docs/programming-languages/)
 - [Delphi](/developers/docs/programming-languages/delphi/)
 - [.NET](/developers/docs/programming-languages/dot-net/)
+- [Elixir](/developers/docs/programming-languages/elixir/)
 - [Golang](/developers/docs/programming-languages/golang/)
 - [Java](/developers/docs/programming-languages/java/)
 - [JavaScript](/developers/docs/programming-languages/javascript/)

--- a/public/content/developers/docs/programming-languages/elixir/index.md
+++ b/public/content/developers/docs/programming-languages/elixir/index.md
@@ -1,0 +1,55 @@
+---
+title: Ethereum for Elixir Developers
+description: Learn how to develop for Ethereum using Elixir-based projects and tooling.
+lang: en
+incomplete: false
+---
+
+<FeaturedText>Learn how to develop for Ethereum using Elixir-based projects and tooling.</FeaturedText>
+
+Use Ethereum to create decentralized applications (or "dapps") that utilize the benefits of cryptocurrency and blockchain technology. These dapps can be trustless, meaning that once they are deployed to Ethereum, they will always run as programmed. They can control digital assets to create new kinds of financial applications. They can be decentralized, meaning that no single entity or person controls them and are nearly impossible to censor.
+
+## Getting started with smart contracts and the Solidity language {#getting-started-with-smart-contracts-and-solidity}
+
+**Take your first steps to integrating Elixir with Ethereum**
+
+Need a more basic primer first? Check out [ethereum.org/learn](/learn/) or [ethereum.org/developers](/developers/).
+
+- [Blockchain Explained](https://kauri.io/article/d55684513211466da7f8cc03987607d5/blockchain-explained)
+- [Understanding Smart Contracts](https://kauri.io/article/e4f66c6079e74a4a9b532148d3158188/ethereum-101-part-5-the-smart-contract)
+- [Write your First Smart Contract](https://kauri.io/article/124b7db1d0cf4f47b414f8b13c9d66e2/remix-ide-your-first-smart-contract)
+- [Learn How to Compile and Deploy Solidity](https://kauri.io/article/973c5f54c4434bb1b0160cff8c695369/understanding-smart-contract-compilation-and-deployment)
+
+## Beginner articles {#beginner-articles}
+
+- [Finally understanding Ethereum accounts](https://dev.to/q9/finally-understanding-ethereum-accounts-1kpe)
+- [Ethers — A first-class Ethereum Web3 library for Elixir](https://medium.com/@alisinabh/announcing-ethers-a-first-class-ethereum-web3-library-for-elixir-1d64e9409122)
+
+## Intermediate articles {#intermediate-articles}
+
+- [How to sign raw Ethereum contract transactions with Elixir](https://kohlerjp.medium.com/how-to-sign-raw-ethereum-contract-transactions-with-elixir-f8822bcc813b)
+- [Ethereum Smart Contracts and Elixir](https://medium.com/agile-alpha/ethereum-smart-contracts-and-elixir-c7c4b239ddb4)
+
+## Elixir projects and tools {#elixir-projects-and-tools}
+
+### Active {#active}
+
+- [block_keys](https://github.com/ExWeb3/block_keys) - _BIP32 & BIP44 Implementation in Elixir (Multi-Account Hierarchy for Deterministic Wallets)_
+- [ethereumex](https://github.com/mana-ethereum/ethereumex) - _Elixir JSON-RPC client for the Ethereum blockchain_
+- [ethers](https://github.com/ExWeb3/elixir_ethers) - _A comprehensive Web3 library for interacting with smart contracts on Ethereum using Elixir_
+- [ethers_kms](https://github.com/ExWeb3/elixir_ethers_kms) - _A KMS signer library for Ethers (sign transactions with AWS KMS)_
+- [ex_abi](https://github.com/poanetwork/ex_abi) - _Ethereum ABI parser/decoder/encoder implementation in Elixir_
+- [ex_keccak](https://github.com/ExWeb3/ex_keccak) - _Elixir library for computing Keccak SHA3-256 hashes using a NIF built tiny-keccak Rust crate_
+- [ex_rlp](https://github.com/mana-ethereum/ex_rlp) - _Elixir implementation of Ethereum's RLP (Recursive Length Prefix) encoding_
+
+### Archived / No longer maintained {#archived--no-longer-maintained}
+
+- [eth](https://hex.pm/packages/eth) - _Ethereum utilities for Elixir_
+- [exw3](https://github.com/hswick/exw3) - _High level Ethereum RPC Client for Elixir_
+- [mana](https://github.com/mana-ethereum/mana) - _Ethereum full node implementation written in Elixir_
+
+Looking for more resources? Check out [our Developer's home](/developers/).
+
+## Elixir community contributors {#elixir-community-contributors}
+
+The [Elixir's Slack #ethereum channel](https://elixir-lang.slack.com/archives/C5RPZ3RJL) is a host to a rapidly growing community and is the dedicated resource for discussions on any of the above projects and related topics.

--- a/public/content/developers/docs/programming-languages/index.md
+++ b/public/content/developers/docs/programming-languages/index.md
@@ -16,6 +16,7 @@ Select your programming language of choice to find projects, resources, and virt
 - [Ethereum for Dart developers](/developers/docs/programming-languages/dart/)
 - [Ethereum for Delphi developers](/developers/docs/programming-languages/delphi/)
 - [Ethereum for .NET developers](/developers/docs/programming-languages/dot-net/)
+- [Ethereum for Elixir developers](/developers/docs/programming-languages/elixir/)
 - [Ethereum for Go developers](/developers/docs/programming-languages/golang/)
 - [Ethereum for Java developers](/developers/docs/programming-languages/java/)
 - [Ethereum for JavaScript developers](/developers/docs/programming-languages/javascript/)

--- a/src/data/developer-docs-links.yaml
+++ b/src/data/developer-docs-links.yaml
@@ -170,6 +170,8 @@
           href: /developers/docs/programming-languages/delphi/
         - id: docs-nav-dot-net
           href: /developers/docs/programming-languages/dot-net/
+        - id: docs-nav-elixir
+          href: /developers/docs/programming-languages/elixir/
         - id: docs-nav-golang
           href: /developers/docs/programming-languages/golang/
         - id: docs-nav-java

--- a/src/intl/en/page-developers-docs.json
+++ b/src/intl/en/page-developers-docs.json
@@ -33,6 +33,7 @@
   "docs-nav-development-networks-description": "Local blockchain environments used to test dapps before deployment",
   "docs-nav-dex-design-best-practice": "Decentralized Exchange (DEX) design best practices",
   "docs-nav-dot-net": ".NET",
+  "docs-nav-elixir": "Elixir",
   "docs-nav-erc-20": "ERC-20: Fungible Tokens",
   "docs-nav-erc-721": "ERC-721: NFTs",
   "docs-nav-erc-777": "ERC-777",

--- a/src/lib/utils/md.ts
+++ b/src/lib/utils/md.ts
@@ -115,6 +115,7 @@ const getPostSlugs = (dir: string, files: string[] = []) => {
     "/developers/docs/programming-languages/dart",
     "/developers/docs/programming-languages/delphi",
     "/developers/docs/programming-languages/dot-net",
+    "/developers/docs/programming-languages/elixir",
     "/developers/docs/programming-languages/golang",
     "/developers/docs/programming-languages/java",
     "/developers/docs/programming-languages/javascript",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR adds a new page "Ethereum for Elixir developers".

## Description

Similar to other languages, Elixir also can benefit from having a dedicated page in ethereum.org documentations to ease onboarding of Elixir devs to Ethereum.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #13614