### PR TITLE
Update tutorial name and add some missing punctuation

### DIFF
--- a/public/content/community/research/index.md
+++ b/public/content/community/research/index.md
@@ -111,7 +111,7 @@ There are now several Layer 2 protocols that scale Ethereum using different tech
 #### Recent research {#recent-research-2}
 
 - [Arbitrum's fair-ordering for sequencers](https://eprint.iacr.org/2021/1465)
-- [ethresear.ch Layer 2](https://ethresear.ch/c/layer-2/32)
+- [Ethresear.ch Layer 2](https://ethresear.ch/c/layer-2/32)
 - [Rollup-centric roadmap](https://ethereum-magicians.org/t/a-rollup-centric-ethereum-roadmap/4698)
 - [L2Beat](https://l2beat.com/)
 
@@ -189,7 +189,7 @@ Ethereum wallets can be browser extensions, desktop and mobile apps or smart con
 
 - [Introduction to wallets](/wallets/)
 - [Introduction to wallet security](/security/)
-- [ethresear.ch Security](https://ethresear.ch/tag/security)
+- [Ethresear.ch Security](https://ethresear.ch/tag/security)
 - [EIP-2938 Account Abstraction](https://eips.ethereum.org/EIPS/eip-2938)
 - [EIP-4337 Account Abstraction](https://eips.ethereum.org/EIPS/eip-4337)
 
@@ -364,7 +364,7 @@ Oracles import off-chain data onto the blockchain in a permissionless and decent
 
 - [Introduction to Oracles](/developers/docs/oracles/)
 
-#### Recent Research {#recent-research-18}
+#### Recent research {#recent-research-18}
 
 - [Survey of blockchain oracles](https://arxiv.org/pdf/2004.07140.pdf)
 - [Chainlink white paper](https://chain.link/whitepaper)
@@ -381,7 +381,7 @@ Hacks on Ethereum generally exploit vulnerabilities in individual applications r
 
 #### Recent research {#recent-research-19}
 
-- [ethresear.ch Applications](https://ethresear.ch/c/applications/18)
+- [Ethresear.ch Applications](https://ethresear.ch/c/applications/18)
 
 ### Technology stack {#technology-stack}
 

--- a/public/content/contributing/index.md
+++ b/public/content/contributing/index.md
@@ -19,7 +19,7 @@ We are a welcoming community that will help you grow and educate in the Ethereum
 - [Work on an open issue](https://github.com/ethereum/ethereum-org-website/issues) – Work we've identified that needs doing
 
 **Design**
-- [Help design the website](/contributing/design/) Designers of all levels can contribute to improve the website
+- [Help design the website](/contributing/design/) – Designers of all levels can contribute to improve the website
 
 **Content**
 - [Create/edit content](/contributing/#how-to-update-content) – Suggest new pages or make tweaks to what's here already
@@ -94,7 +94,7 @@ If your contribution gets merged into ethereum.org, you will have a chance to cl
 
 ### How to claim
 1. Join our [Discord server](https://discord.gg/ethereum-org).
-2. Paste a link to your contribution in the `#🥇 | proof-of-contribution` channel
+2. Paste a link to your contribution in the `#🥇 | proof-of-contribution` channel.
 3. Wait for a member of our team to send you a link to your OAT.
 4. Claim your OAT!
 

--- a/public/content/developers/docs/networking-layer/network-addresses/index.md
+++ b/public/content/developers/docs/networking-layer/network-addresses/index.md
@@ -23,7 +23,7 @@ For an Ethereum node, the multiaddr contains the node-ID (a hash of their public
 
 ## Enode {#enode}
 
-An enode is a way to identify an Ethereum node using a URL address format. The hexadecimal node-ID is encoded in the username portion of the URL separated from the host using an @ sign. The hostname can only be given as an IP address; DNS names are not allowed. The port in the hostname section is the TCP listening port. If the TCP and UDP (discovery) ports differ, the UDP port is specified as a query parameter "discport"
+An enode is a way to identify an Ethereum node using a URL address format. The hexadecimal node-ID is encoded in the username portion of the URL separated from the host using an @ sign. The hostname can only be given as an IP address; DNS names are not allowed. The port in the hostname section is the TCP listening port. If the TCP and UDP (discovery) ports differ, the UDP port is specified as a query parameter "discport".
 
 In the following example, the node URL describes a node with IP address `10.3.58.6`, TCP port `30303` and UDP discovery port `30301`.
 
@@ -35,6 +35,6 @@ Ethereum Node Records (ENRs) are a standardized format for network addresses on 
 
 ## Further Reading {#further-reading}
 
-[EIP-778: Ethereum Node Records (ENR)](https://eips.ethereum.org/EIPS/eip-778)
-[Network addresses in Ethereum](https://dean.eigenmann.me/blog/2020/01/21/network-addresses-in-ethereum/)
-[LibP2P: Multiaddr-Enode-ENR?!](https://consensys.net/diligence/blog/2020/09/libp2p-multiaddr-enode-enr/)
+- [EIP-778: Ethereum Node Records (ENR)](https://eips.ethereum.org/EIPS/eip-778)
+- [Network addresses in Ethereum](https://dean.eigenmann.me/blog/2020/01/21/network-addresses-in-ethereum/)
+- [LibP2P: Multiaddr-Enode-ENR?!](https://consensys.net/diligence/blog/2020/09/libp2p-multiaddr-enode-enr/)

--- a/public/content/developers/docs/nodes-and-clients/run-a-node/index.md
+++ b/public/content/developers/docs/nodes-and-clients/run-a-node/index.md
@@ -312,7 +312,7 @@ reth node \
     --authrpc.port 8551
 ```
 
-See [Configuring Reth](https://reth.rs/run/config.html?highlight=data%20directory#configuring-reth) to learn more about data default data directories. [Reth's documentation](https://reth.rs/run/mainnet.html) contains additional options and configuration details.
+See [Configuring Reth](https://reth.rs/run/config.html?highlight=data%20directory#configuring-reth) to learn more about default data directories. [Reth's documentation](https://reth.rs/run/mainnet.html) contains additional options and configuration details.
 
 #### Starting the consensus client {#starting-the-consensus-client}
 

--- a/public/content/developers/docs/standards/tokens/erc-223/index.md
+++ b/public/content/developers/docs/standards/tokens/erc-223/index.md
@@ -129,7 +129,7 @@ contract RecipientContract is IERC223Recipient {
     {
         // It is important to understand that within this function
         // msg.sender is the address of a token that is being received,
-        // msg.value  is always 0 as the token contract does not own or send Ether in most cases,
+        // msg.value  is always 0 as the token contract does not own or send ether in most cases,
         // _from      is the sender of the token transfer,
         // _value     is the amount of tokens that was deposited.
         require(msg.sender == tokenA);
@@ -155,7 +155,7 @@ If an ERC-20 token is sent to the `RecipientContract`, the tokens will be transf
 
 ### What if we want to execute some function after the token deposit is completed? {#function-execution}
 
-There are multiple ways of doing so. In this example we will follow the method which makes ERC-223 transfers identical to Ether transfers:
+There are multiple ways of doing so. In this example we will follow the method which makes ERC-223 transfers identical to ether transfers:
 
 ```solidity
 contract RecipientContract is IERC223Recipient {
@@ -178,7 +178,7 @@ contract RecipientContract is IERC223Recipient {
 }
 ```
 
-When the `RecipientContract` will receive a ERC-223 token the contract will execute a function encoded as `_data` parameter of the token transaction, identical to how Ether transactions encode function calls as transaction `data`. Read [the data field](https://ethereum.org/en/developers/docs/transactions/#the-data-field) for more information.
+When the `RecipientContract` will receive a ERC-223 token the contract will execute a function encoded as `_data` parameter of the token transaction, identical to how ether transactions encode function calls as transaction `data`. Read [the data field](https://ethereum.org/en/developers/docs/transactions/#the-data-field) for more information.
 
 In the above example an ERC-223 token must be transferred to the address of the `RecipientContract` with the `transfer(address,uin256,bytes calldata _data)` function. If the data parameter will be `0xc2985578` (the signature of a `foo()` function) then the function foo() will be invoked after the token deposit is received and the event Foo() will be fired.
 

--- a/public/content/developers/docs/standards/tokens/erc-4626/index.md
+++ b/public/content/developers/docs/standards/tokens/erc-4626/index.md
@@ -176,7 +176,7 @@ Returns the total amount of vault shares the `owner` currently has.
 
 #### Deposit Event
 
-**MUST** be emitted when tokens are deposited into the vault via the [`mint`](#mint) and [`deposit`](#deposit) methods
+**MUST** be emitted when tokens are deposited into the vault via the [`mint`](#mint) and [`deposit`](#deposit) methods.
 
 ```solidity
 event Deposit(

--- a/public/content/developers/docs/transactions/index.md
+++ b/public/content/developers/docs/transactions/index.md
@@ -23,7 +23,7 @@ Transactions require a fee and must be included in a validated block. To make th
 
 A submitted transaction includes the following information:
 
-- `from` – the address of the sender, that will be signing the transaction. This will be an externally-owned account as contract accounts cannot send transactions.
+- `from` – the address of the sender, that will be signing the transaction. This will be an externally-owned account as contract accounts cannot send transactions
 - `to` – the receiving address (if an externally-owned account, the transaction will transfer value. If a contract account, the transaction will execute the contract code)
 - `signature` – the identifier of the sender. This is generated when the sender's private key signs the transaction and confirms the sender has authorized this transaction
 - `nonce` - a sequentially incrementing counter which indicates the transaction number from the account
@@ -170,7 +170,7 @@ Any gas not used in a transaction is refunded to the user account.
 
 Gas is required for any transaction that involves a smart contract.
 
-Smart contracts can also contain functions known as [`view`](https://docs.soliditylang.org/en/latest/contracts.html#view-functions) or [`pure`](https://docs.soliditylang.org/en/latest/contracts.html#pure-functions) functions, which do not alter the state of the contract. As such, calling these functions from an EOA will not require any gas. The underlying RPC call for this scenario is [`eth_call`](/developers/docs/apis/json-rpc#eth_call)
+Smart contracts can also contain functions known as [`view`](https://docs.soliditylang.org/en/latest/contracts.html#view-functions) or [`pure`](https://docs.soliditylang.org/en/latest/contracts.html#pure-functions) functions, which do not alter the state of the contract. As such, calling these functions from an EOA will not require any gas. The underlying RPC call for this scenario is [`eth_call`](/developers/docs/apis/json-rpc#eth_call).
 
 Unlike when accessed using `eth_call`, these `view` or `pure` functions are also commonly called internally (i.e. from the contract itself or from another contract) which does cost gas.
 
@@ -209,7 +209,7 @@ Where the fields are defined as:
 - `TransactionType` - a number between 0 and 0x7f, for a total of 128 possible transaction types.
 - `TransactionPayload` - an arbitrary byte array defined by the transaction type.
 
-Based on the `TransactionType` value, a transaction can be classified as
+Based on the `TransactionType` value, a transaction can be classified as:
 
 1. **Type 0 (Legacy) Transactions:** The original transaction format used since Ethereum's launch. They do not include features from [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) such as dynamic gas fee calculations or access lists for smart contracts. Legacy transactions lack a specific prefix indicating their type in their serialized form, starting with the byte `0xf8` when using [Recursive Length Prefix (RLP)](/developers/docs/data-structures-and-encoding/rlp) encoding. The TransactionType value for these transactions is `0x0`.
 

--- a/public/content/guides/how-to-use-a-bridge/index.md
+++ b/public/content/guides/how-to-use-a-bridge/index.md
@@ -10,7 +10,7 @@ If there is a lot of traffic on Ethereum, it can become expensive. One solution 
 
 **Prerequisite:** 
 
-- have a crypto wallet, you can follow this tutorial: [How to: "Register" an Ethereum account](/guides/how-to-create-an-ethereum-account/)
+- have a crypto wallet, you can follow this tutorial: [How to create an Ethereum account](/guides/how-to-create-an-ethereum-account/)
 - add funds to your wallet
 
 ## 1. Determine which layer 2 network you want to use

--- a/public/content/roadmap/statelessness/index.md
+++ b/public/content/roadmap/statelessness/index.md
@@ -16,7 +16,7 @@ Cheaper hard drives can be used to store older data but those are too slow to ke
 
 There are several ways to reduce the amount of data each node has to store, each requiring Ethereum's core protocol to be updated to a different extent:
 
-- **History expiry**: enable nodes to discard state data older than X blocks, but does not change how Ethereum client's handle state data
+- **History expiry**: enable nodes to discard state data older than X blocks, but does not change how Ethereum client's handle state data.
 - **State expiry**: allow state data that is not used frequently to become inactive. Inactive data can be ignored by clients until it is resurrected.
 - **Weak statelessness**: only block producers need access to full state data, other nodes can verify blocks without a local state database.
 - **Strong statelessness**: no nodes need access to the full state data.

--- a/src/intl/en/page-contributing-translation-program-acknowledgements.json
+++ b/src/intl/en/page-contributing-translation-program-acknowledgements.json
@@ -30,7 +30,7 @@
   "page-contributing-translation-program-acknowledgements-total-words": "Total Words",
   "page-contributing-translation-program-acknowledgements-oats-title": "OATs",
   "page-contributing-translation-program-acknowledgements-1": "Contributors to the Translation Program are eligible for different OATs (onchain achievement tokens) – non-fungible tokens that prove their participation in the ethereum.org Translation Program.",
-  "page-contributing-translation-program-acknowledgements-2": "We have a number of different OATs available for translators, based on their activity",
+  "page-contributing-translation-program-acknowledgements-2": "We have a number of different OATs available for translators, based on their activity.",
   "page-contributing-translation-program-acknowledgements-3": "If you have contributed to the translation effort in Crowdin, you have an OAT waiting for you!",
   "page-contributing-translation-program-acknowledgements-how-to-claim-title": "How to claim",
   "page-contributing-translation-program-acknowledgements-how-to-claim-1": "Join our",

--- a/src/intl/en/page-learn.json
+++ b/src/intl/en/page-learn.json
@@ -85,7 +85,7 @@
   "ethereum-whitepaper-card-button": "Read whitepaper",
   "more-on-ethereum-protocol-title": "More on the Ethereum protocol",
   "more-on-ethereum-protocol-ethereum-for-developers": "Ethereum for developers",
-  "more-on-ethereum-protocol-consensus": "Ethereum's proof-of-stake based consensus mechanism'",
+  "more-on-ethereum-protocol-consensus": "Ethereum's proof-of-stake based consensus mechanism",
   "more-on-ethereum-protocol-evm": "Ethereum's embedded computer (The EVM)",
   "more-on-ethereum-protocol-nodes-and-clients": "Ethereum nodes and clients",
   "ethereum-community-description": "The success of Ethereum is thanks to its incredibly dedicated community. Thousands of inspiring and driven people help push Ethereum’s vision forward, while also providing security to the network through staking and governance. Come and join us!",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changed the name of tutorial as the tutorial is now not named like that 

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
