### PR TITLE
feat: adds twFlipForRtl cn export to useRtlFlip

### DIFF
--- a/src/hooks/useRtlFlip.ts
+++ b/src/hooks/useRtlFlip.ts
@@ -6,7 +6,7 @@ import { isLangRightToLeft } from "@/lib/utils/translations"
 
 type UseDirection = {
   flipForRtl: "scaleX(-1)" | undefined // transform (deprecated)
-  twFlipForRtl: "-scale-x-1" | undefined // className
+  twFlipForRtl: "-scale-x-1" | "" // className
   isRtl: boolean
   direction: "ltr" | "rtl"
 }
@@ -21,7 +21,7 @@ export const useRtlFlip = (): UseDirection => {
   const isRtl = isLangRightToLeft(locale as Lang)
   return {
     flipForRtl: isRtl ? "scaleX(-1)" : undefined, // transform (deprecated)
-    twFlipForRtl: isRtl ? "-scale-x-1" : undefined, // className (preferred)
+    twFlipForRtl: isRtl ? "-scale-x-1" : "", // className (preferred)
     isRtl,
     direction: isRtl ? "rtl" : "ltr",
   }

--- a/src/hooks/useRtlFlip.ts
+++ b/src/hooks/useRtlFlip.ts
@@ -5,6 +5,7 @@ import type { Lang } from "@/lib/types"
 import { isLangRightToLeft } from "@/lib/utils/translations"
 
 type UseDirection = {
+  /** @deprecated */
   flipForRtl: "scaleX(-1)" | undefined // transform (deprecated)
   twFlipForRtl: "-scale-x-1" | "" // className
   isRtl: boolean

--- a/src/hooks/useRtlFlip.ts
+++ b/src/hooks/useRtlFlip.ts
@@ -5,7 +5,8 @@ import type { Lang } from "@/lib/types"
 import { isLangRightToLeft } from "@/lib/utils/translations"
 
 type UseDirection = {
-  flipForRtl: "scaleX(-1)" | undefined
+  flipForRtl: "scaleX(-1)" | undefined // transform (deprecated)
+  twFlipForRtl: "-scale-x-1" | undefined // className
   isRtl: boolean
   direction: "ltr" | "rtl"
 }
@@ -13,13 +14,14 @@ type UseDirection = {
 /**
  * Custom hook that determines the direction and transformation for right-to-left (RTL) languages.
  * @example const { flipForRtl } = useRtlFlip(); transform={flipForRtl}
- * @returns An object containing the CSS transformation, RTL flag, and direction.
+ * @returns An object containing the Tailwind className, RTL flag, and direction.
  */
 export const useRtlFlip = (): UseDirection => {
   const { locale } = useRouter()
   const isRtl = isLangRightToLeft(locale as Lang)
   return {
-    flipForRtl: isRtl ? "scaleX(-1)" : undefined,
+    flipForRtl: isRtl ? "scaleX(-1)" : undefined, // transform (deprecated)
+    twFlipForRtl: isRtl ? "-scale-x-1" : undefined, // className (preferred)
     isRtl,
     direction: isRtl ? "rtl" : "ltr",
   }


### PR DESCRIPTION
## Description
- Updates the `useRtlFlip` custom hook to return `txFlipForRtl` with tailwind class `-scale-x-1` to horizontally flip elements
- Marked as the preferred method over using the transform value, and mark existing as deprecated
- Keeps existing `flipForRtl` export unchanged for temporary backward compatibility

## Related Issue
Tailwindcss migration

@pettinarip Would this be useful or do you see another approach here?