### PR TITLE
Add ETH Riyadh 2024 event information

### DIFF
--- a/src/data/community-events.json
+++ b/src/data/community-events.json
@@ -628,5 +628,13 @@
     "startDate": "2024-12-02",
     "endDate": "2024-12-03",
     "imageUrl": "https://www.ethvenice.com/images/logo.png"
+  },
+  {
+    "title": "ETH Riyadh 2024",
+    "to": "https://ethriyadh.com/",
+    "location": "Riyadh, Saudi Arabia",
+    "description": "ETH Riyadh 2024 unites Middle Eastern developers and blockchain enthusiasts to explore and advance Ethereum technology. Join us for an exciting event that fosters collaboration and innovation in the blockchain ecosystem.",
+    "startDate": "12/1/2024",
+    "endDate": "12/3/2024"
   }
 ]


### PR DESCRIPTION
This commit wants to add the ETH Riyadh 2024 event details to the ETH Events website. The event will take place in Riyadh, Saudi Arabia, from December 1st to December 3rd, 2024. It will focus on uniting Middle Eastern developers and blockchain enthusiasts to collaborate and innovate within the Ethereum ecosystem.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
