### PR TITLE
refactor: consolidate css imports into global.css

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -42,7 +42,7 @@
           // Other relative imports. Put same-folder imports and `.` last.
           ["^\\./(?=.*/)(?!/?$)", "^\\.(?!/?$)", "^\\./?$"],
           // Style imports.
-          ["^.+s?css$"],
+          ["^.+\\.s?css$"],
           // Side effect imports.
           ["^\\u0000"]
         ]

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,10 +6,7 @@ import { AppPropsWithLayout } from "@/lib/types"
 
 import ThemeProvider from "@/components/ThemeProvider"
 
-import "@docsearch/css"
 import "@/styles/global.css"
-import "@/styles/fonts.css"
-import "@/styles/docsearch.css"
 
 import { BaseLayout } from "@/layouts/BaseLayout"
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,6 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
+@import "@docsearch/css";
+@import "@/styles/fonts.css";
+@import "@/styles/docsearch.css";
+
 @layer base {
   :root {
     --font-inter: Inter, sans-serif;


### PR DESCRIPTION
## Description
- Consolidates all css imports into the `global.css` file
- Moves other global `css` imports as an `@import` statement within `global.css`

cc: @pettinarip Not sure if we would also like to revert the recent updates to the ESLint rule changes with this PR. Happy to, just drop a note if you'd prefer one way or the other.