### PR TITLE
fix: keyboard shortcut conflict

### DIFF
--- a/src/components/LanguagePicker/index.tsx
+++ b/src/components/LanguagePicker/index.tsx
@@ -44,7 +44,7 @@ const LanguagePicker = ({
    * @param {string} event - The keydown event.
    */
   useEventListener("keydown", (e) => {
-    if (e.key !== "\\") return
+    if (e.key !== "\\" || e.metaKey || e.ctrlKey) return
     e.preventDefault()
     onOpen()
   })


### PR DESCRIPTION
## Description
- Patches the keyboard shortcut for the Language Picker to exclude usage of the meta (cmd/win) or ctrl keys when using the `\` shortcut
- Avoids <kbd>cmd</kbd>/<kbd>ctrl</kbd>-<kbd>\\</kbd> from opening lang menu; reserved for color mode change