### PR TITLE
[Storybook] fix(useQuizWidget): run chromatic check for shuffling question set

### DIFF
--- a/src/components/Quiz/QuizWidget/useQuizWidget.tsx
+++ b/src/components/Quiz/QuizWidget/useQuizWidget.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react"
+import isChromatic from "chromatic"
 import shuffle from "lodash/shuffle"
 import { useTranslation } from "next-i18next"
 
@@ -51,7 +52,9 @@ export const useQuizWidget = ({
       const rawQuestion: RawQuestion = questionBank[id]
       return { id, ...rawQuestion }
     })
-    const shuffledQuestions = shuffle(questions)
+
+    // ! Do not shuffle questions in Chromatic to keep the modal story snapshot stable
+    const shuffledQuestions = isChromatic() ? questions : shuffle(questions)
     const quiz: Quiz = {
       title: t(rawQuiz.title),
       questions: shuffledQuestions,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes issue where the Chromatic Snapshot for the quiz modal kept updating because the first question rendered was always random. Uses the `isChromatic()` check to determine if `shuffle()` is triggered. The `layer-2` quiz key is used, therefore the first question to appear should always be `Layer 2 blockchain networks are for:`

The shuffle will still run when viewing the story in the daskboard.

The question set should not be shuffled when rendered in the Chromatic snapshot. Snapshots should at least be stable if they are not rendering pure functions with static prop data.
