### PR TITLE
Add Solidity docs to Translatathon ecosystem content

### DIFF
--- a/public/content/contributing/translation-program/translatathon/details/index.md
+++ b/public/content/contributing/translation-program/translatathon/details/index.md
@@ -123,6 +123,9 @@ EthStaker
 - https://crowdin.com/project/ethstaker-website
 - https://crowdin.com/project/ethstaker-knowledge-base
 
+Solidity Language Docs
+- https://crowdin.com/project/solidity-language-docs
+
 ### Evaluation process
 
 All translations will be subject to QA and feedback, where professional linguists will evaluate submissions based on quality and accuracy.


### PR DESCRIPTION
## Description

Add a link to the Solidity Language Docs Crowdin project to the list of Translatathon ecosystem content

## Related Issue

No related issues
