### PR TITLE
Update community-events.json

### DIFF
--- a/src/data/community-events.json
+++ b/src/data/community-events.json
@@ -401,6 +401,14 @@
     "description": "Welcome to the largest Ethereum event happening in Africa! Join the BlockTrain from Nairobi to celebrate an ETH-festival held underneath ancient Boabab trees in Kilifi."
   },
   {
+    "title": "Ethereum Singapore: In the Ether",
+    "startDate": "2024-09-16",
+    "endDate": "2024-09-22",
+    "href": "https://ethereumsingapore.com/",
+    "location": "Singapore, SG",
+    "description": "Come by Singapore for what is set to be one of the largest gatherings of the Ethereum community and we can’t wait to host you!"
+  },
+  {
     "title": "TOKEN2049",
     "startDate": "2024-09-18",
     "endDate": "2024-09-19",


### PR DESCRIPTION
Adding Ethereum Singapore to the events cal
<!--- Provide a general summary of your changes in the Title above -->

## Description

Ethereum Singapore is back for its second year and we are excited to host the global Ethereum community once more! This time we have put together a festival, titled “IN THE ETHER” from 16-22 September 2024, at the iconic Artscience Museum in Singapore. Join us for an [exciting calendar of events](https://lu.ma/ethereum_sg) with our co-hosts right at the heart of Marina Bay!
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
