### PR TITLE
Fix regex to match only numbers

### DIFF
--- a/src/components/Nav/Menu/useNavMenu.ts
+++ b/src/components/Nav/Menu/useNavMenu.ts
@@ -18,7 +18,7 @@ export const useNavMenu = (sections: NavSections) => {
 
   // Focus corresponding nav section when number keys pressed
   useEventListener("keydown", (event) => {
-    if (!document || !event.key.match(/[1-9]/) || isModified(event)) return
+    if (!document || !event.key.match(/^[1-9]$/) || isModified(event)) return
     if (event.target instanceof HTMLInputElement) return
     if (event.target instanceof HTMLTextAreaElement) return
     if (event.target instanceof HTMLSelectElement) return


### PR DESCRIPTION
Currently, if you press the `F1`-`F12` keys, you get the following error message: `Uncaught DOMException: Failed to execute 'querySelector' on 'Document': '#main-navigation li:nth-of-type(NaN) button' is not a valid selector.`

## Description

Fixes the regex used to navigate the nav menu to match only numbers.