### PR TITLE
Use `dark` class for color mode selector

### DIFF
--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -27,7 +27,7 @@ const ThemeProvider = ({ children }: Pick<ThemeProviderProps, "children">) => {
   const theme = useMemo(() => merge(customTheme, { direction }), [direction])
   return (
     <NextThemesProvider
-      attribute="data-theme"
+      attribute="class"
       defaultTheme="system"
       enableSystem
       disableTransitionOnChange

--- a/src/styles/docsearch.css
+++ b/src/styles/docsearch.css
@@ -38,7 +38,8 @@
   --docsearch-modal-width: 650px;
   --docsearch-hit-height: fit-content;
 }
-html[data-theme="dark"] {
+
+.dark {
   --docsearch-modal-background: theme(backgroundColor.background.DEFAULT);
   --docsearch-highlight-color: theme(colors.primary.hover);
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -118,7 +118,7 @@
     --table-item-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
   }
 
-  [data-theme="dark"] {
+  .dark {
     /* Semantic Colors: Dark mode */
     --primary: var(--orange-500);
     --primary-high-contrast: var(--orange-100);


### PR DESCRIPTION
## Description
- Refactors to use `.dark` class for color mode management
- Fixes syncing of color theme between in-app toggling and system color preference changes

## Preview URL
- https://deploy-preview-13661--ethereumorg.netlify.app/

## Related Issue
Tailwind migration