### PR TITLE
Fix color themes sync

### DIFF
--- a/src/@chakra-ui/theme.ts
+++ b/src/@chakra-ui/theme.ts
@@ -7,7 +7,15 @@ import semanticTokens from "./semanticTokens"
 const config: ThemeConfig = {
   cssVarPrefix: "eth",
   initialColorMode: "system",
-  useSystemColorMode: true,
+  /**
+   * Disable Chakra's system color subscription, as it works differently from
+   * `next-themes` and causes a desync with it.
+   *
+   * Chakra will always change the color mode based on the system preference.
+   * While `next-themes` will only change to the system preference if the user
+   * has `system` as their active theme.
+   */
+  useSystemColorMode: false,
 }
 
 /**


### PR DESCRIPTION
## Description

Disables Chakra's system color subscription for better compatibility with `next-themes`.