### PR TITLE
fix: remove date from whitepaper page #13645

### DIFF
--- a/src/layouts/Static.tsx
+++ b/src/layouts/Static.tsx
@@ -117,13 +117,15 @@ export const StaticLayout = ({
             <>
               <Breadcrumbs slug={slug} mb="8" />
 
-              <Text
-                color="text200"
-                dir={isLangRightToLeft(locale as Lang) ? "rtl" : "ltr"}
-              >
-                <Translation id="page-last-updated" />:{" "}
-                {lastEditLocaleTimestamp}
-              </Text>
+              {slug !== "/whitepaper" && !asPath.includes("/whitepaper") && (
+                <Text
+                  color="text200"
+                  dir={isLangRightToLeft(locale as Lang) ? "rtl" : "ltr"}
+                >
+                  <Translation id="page-last-updated" />:{" "}
+                  {lastEditLocaleTimestamp}
+                </Text>
+              )}
             </>
           )}
 


### PR DESCRIPTION
# remove date from the whitepaper page

## Description
This pull request modifies the Static Layout component to hide the "Page last updated" text specifically on the Whitepaper page. The change involves adding a conditional check to prevent rendering the timestamp for the /whitepaper route.

The main changes include:
1. Added a condition to check both the `slug` and `asPath` before rendering the "Last Updated" text.
2. The text will now only render if the page is not the Whitepaper page.

## Issue link
https://github.com/ethereum/ethereum-org-website/issues/13645
Fixes 13645 - remove date from whitepaper
