### PR TITLE
Update ethstaked data endpoint

### DIFF
--- a/src/lib/api/fetchTotalEthStaked.ts
+++ b/src/lib/api/fetchTotalEthStaked.ts
@@ -10,10 +10,7 @@ export const fetchTotalEthStaked = async (): Promise<MetricReturnData> => {
     return { error: "Dune API key not found" }
   }
 
-  const url = new URL(
-    "api/v1/endpoints/pablop/eth-staked/results",
-    DUNE_API_URL
-  )
+  const url = new URL("api/v1/query/3915587/results", DUNE_API_URL)
 
   try {
     const ethStakedResponse = await fetch(url, {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updates the endpoint of the `ethstaked` data to point to the public query instead of the specific endpoint of the user. This will allow us to query it using api keys generated by others and not just this user.