### PR TITLE
Remove new_to_crypto flag

### DIFF
--- a/src/data/wallets/wallet-data.ts
+++ b/src/data/wallets/wallet-data.ts
@@ -1199,7 +1199,6 @@ export const walletsData: WalletData[] = [
     social_recovery: false,
     onboard_documentation: "",
     documentation: "https://docs.infinitywallet.io/",
-    new_to_crypto: true,
   },
   {
     last_updated: "2022-08-19",


### PR DESCRIPTION
## Description
- Removes the `new_to_crypto` flag from the Infinity Wallet entry which was added inadvertently in #13665 
