### PR TITLE
fix: hover-off transition on color toggle

### DIFF
--- a/src/components/Nav/Desktop/index.tsx
+++ b/src/components/Nav/Desktop/index.tsx
@@ -59,6 +59,11 @@ const DesktopNavMenu = ({ toggleColorMode }: DesktopNavMenuProps) => {
         variant="ghost"
         isSecondary
         px={{ base: "2", xl: "3" }}
+        sx={{
+          "& > svg": {
+            transition: "transform 0.5s, color 0.2s",
+          },
+        }}
         _hover={desktopHoverFocusStyles}
         _focus={desktopHoverFocusStyles}
         onClick={toggleColorMode}


### PR DESCRIPTION
## Description
- Adds transition to default state to enable animation when leaving hover state for color toggle nav button

https://github.com/user-attachments/assets/041bb2ad-b2e9-4a77-aafb-677d8871e8de

## Related Issue
None filed