### PR TITLE
fix: convert js example to ts string export

### DIFF
--- a/src/data/CreateWallet.ts
+++ b/src/data/CreateWallet.ts
@@ -1,6 +1,4 @@
-// ? Should this become a `*.ts` file?
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const ethers = require("ethers")
+const createWallet = `const ethers = require("ethers")
 
 // Create a wallet instance from a mnemonic...
 const mnemonic =
@@ -51,3 +49,6 @@ wallet.sendTransaction(tx)
 // https://github.com/ethers-io/ethers.js/blob/master/docs/v5/api/signer/README.md#methods
 // Content is licensed under the Creative Commons License:
 // https://choosealicense.com/licenses/cc-by-4.0/
+`
+
+export default createWallet

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -45,9 +45,10 @@ import {
   isLangRightToLeft,
 } from "@/lib/utils/translations"
 
+import CreateWalletContent from "@/data/CreateWallet"
+
 import { BASE_TIME_UNIT } from "@/lib/constants"
 
-import CreateWalletContent from "!!raw-loader!@/data/CreateWallet.js"
 import SimpleDomainRegistryContent from "!!raw-loader!@/data/SimpleDomainRegistry.sol"
 import SimpleTokenContent from "!!raw-loader!@/data/SimpleToken.sol"
 import SimpleWalletContent from "!!raw-loader!@/data/SimpleWallet.sol"


### PR DESCRIPTION
## Description
- rm comments at top, which were being rendered in code example on homepage
- Export as string literal instead of importing `.js` as raw.

## Related Issue
<img width="594" alt="image" src="https://github.com/user-attachments/assets/47b2e74a-f102-4799-abd0-aeae6221d4f1">
oops =)