### PR TITLE
Update index.md of Merkle-Patricia Trie doc

### DIFF
--- a/public/content/developers/docs/data-structures-and-encoding/patricia-merkle-trie/index.md
+++ b/public/content/developers/docs/data-structures-and-encoding/patricia-merkle-trie/index.md
@@ -34,8 +34,8 @@ There is a difference between looking something up in the 'trie' and the underly
 The update and delete operations for radix tries can be defined as follows:
 
 ```
-    def update(node,path,value):
-        curnode = db.get(node) if node else [ NULL ] * 17
+    def update(node_hash,path,value):
+        curnode = db.get(node_hash) if node else [ NULL ] * 17
         newnode = curnode.copy()
         if path == '':
             newnode[-1] = value
@@ -45,11 +45,11 @@ The update and delete operations for radix tries can be defined as follows:
         db.put(hash(newnode),newnode)
         return hash(newnode)
 
-    def delete(node,path):
+    def delete(node_hash,path):
         if node is NULL:
             return NULL
         else:
-            curnode = db.get(node)
+            curnode = db.get(node_hash)
             newnode = curnode.copy()
             if path == '':
                 newnode[-1] = NULL

--- a/public/content/developers/docs/data-structures-and-encoding/patricia-merkle-trie/index.md
+++ b/public/content/developers/docs/data-structures-and-encoding/patricia-merkle-trie/index.md
@@ -137,10 +137,10 @@ Examples:
 Here is the extended code for getting a node in the Merkle Patricia trie:
 
 ```
-    def get_helper(node,path):
-        if path == []: return node
-        if node = '': return ''
-        curnode = rlp.decode(node if len(node) < 32 else db.get(node))
+    def get_helper(node_hash,path):
+        if path == []: return node_hash
+        if node_hash == '': return ''
+        curnode = rlp.decode(node_hash if len(node_hash) < 32 else db.get(node_hash))
         if len(curnode) == 2:
             (k2, v2) = curnode
             k2 = compact_decode(k2)
@@ -151,13 +151,13 @@ Here is the extended code for getting a node in the Merkle Patricia trie:
         elif len(curnode) == 17:
             return get_helper(curnode[path[0]],path[1:])
 
-    def get(node,path):
+    def get(node_hash,path):
         path2 = []
         for i in range(len(path)):
             path2.push(int(ord(path[i]) / 16))
             path2.push(ord(path[i]) % 16)
         path2.push(16)
-        return get_helper(node,path2)
+        return get_helper(node_hash,path2)
 ```
 
 ### Example Trie {#example-trie}

--- a/public/content/developers/docs/data-structures-and-encoding/patricia-merkle-trie/index.md
+++ b/public/content/developers/docs/data-structures-and-encoding/patricia-merkle-trie/index.md
@@ -34,19 +34,19 @@ There is a difference between looking something up in the 'trie' and the underly
 The update and delete operations for radix tries can be defined as follows:
 
 ```
-    def update(node_hash,path,value):
-        curnode = db.get(node_hash) if node else [ NULL ] * 17
+    def update(node_hash, path, value):
+        curnode = db.get(node_hash) if node_hash else [ NULL ] * 17
         newnode = curnode.copy()
         if path == '':
             newnode[-1] = value
         else:
-            newindex = update(curnode[path[0]],path[1:],value)
+            newindex = update(curnode[path[0]], path[1:], value)
             newnode[path[0]] = newindex
-        db.put(hash(newnode),newnode)
+        db.put(hash(newnode), newnode)
         return hash(newnode)
 
-    def delete(node_hash,path):
-        if node is NULL:
+    def delete(node_hash, path):
+        if node_hash is NULL:
             return NULL
         else:
             curnode = db.get(node_hash)
@@ -54,13 +54,13 @@ The update and delete operations for radix tries can be defined as follows:
             if path == '':
                 newnode[-1] = NULL
             else:
-                newindex = delete(curnode[path[0]],path[1:])
+                newindex = delete(curnode[path[0]], path[1:])
                 newnode[path[0]] = newindex
 
             if all(x is NULL for x in newnode):
                 return NULL
             else:
-                db.put(hash(newnode),newnode)
+                db.put(hash(newnode), newnode)
                 return hash(newnode)
 ```
 


### PR DESCRIPTION
### Description

Refactored the variable name `node` to `node_hash` to remove ambiguity. This change improves code clarity by explicitly indicating that the variable holds the hash of a node, not the node itself.

### Changes
- Replaced `node` with `node_hash` throughout the `update` and `delete` functions.