### PR TITLE
rotate energy consumption labels

### DIFF
--- a/src/components/EnergyConsumptionChart/index.tsx
+++ b/src/components/EnergyConsumptionChart/index.tsx
@@ -212,9 +212,10 @@ const EnergyConsumptionChart = () => {
           font: {
             size: 10,
           },
-          autoSkip: false, // avoid long labels to be hidden
-          padding: 0, // removes default padding betwen x-labels and chart
-          maxRotation: 0, // turns off rotation
+          autoSkip: false,
+          padding: 0,
+          maxRotation: 0,
+          minRotation: 45,
         },
       },
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Rotates the labels to 45 degrees on energy consumption chart for longer labels

## Related Issue

Fixes https://github.com/ethereum/ethereum-org-website/issues/12099
