### PR TITLE
Change portal network image to table

### DIFF
--- a/public/content/developers/docs/networking-layer/portal-network/index.md
+++ b/public/content/developers/docs/networking-layer/portal-network/index.md
@@ -59,7 +59,10 @@ The benefits of this network design are:
 
 The diagram below shows the functions of existing clients that can be delivered by the Portal Network, enabling users to access these functions on very low-resource devices.
 
-![portal network table](portal-network-table2.png)
+### The Portal Networks
+| Beacon light client | State network | Transaction gossip | History network |
+| ------------------- | ------------- | ------------------ | --------------- |
+| <ul><li>Beacon chain light</li><li>Protocol data</li></ul> | <ul><li>Account and contract storage</li></ul> | <ul><li>Lightweight mempool</li></ul> | <ul><li>Headers</li><li>Block bodies</li><li>Receipts</li></ul> |
 
 ## Client diversity by default {#client-diversity-as-default}
 

--- a/public/content/developers/docs/networking-layer/portal-network/index.md
+++ b/public/content/developers/docs/networking-layer/portal-network/index.md
@@ -60,9 +60,12 @@ The benefits of this network design are:
 The diagram below shows the functions of existing clients that can be delivered by the Portal Network, enabling users to access these functions on very low-resource devices.
 
 ### The Portal Networks
-| Beacon light client | State network | Transaction gossip | History network |
-| ------------------- | ------------- | ------------------ | --------------- |
-| <ul><li>Beacon chain light</li><li>Protocol data</li></ul> | <ul><li>Account and contract storage</li></ul> | <ul><li>Lightweight mempool</li></ul> | <ul><li>Headers</li><li>Block bodies</li><li>Receipts</li></ul> |
+
+| Beacon light client | State network                | Transaction gossip  | History network |
+| ------------------- | ---------------------------- | ------------------- | --------------- |
+| Beacon chain light  | Account and contract storage | Lightweight mempool | Headers         |
+| Protocol data       |                              |                     | Block bodies    |
+|                     |                              |                     | Receipts        |
 
 ## Client diversity by default {#client-diversity-as-default}
 


### PR DESCRIPTION
## Description

- Converts an image of a table to a table on the [portal-networks](https://ethereum.org/en/developers/docs/networking-layer/portal-network) page

## Related Issue

Fixes: https://github.com/ethereum/ethereum-org-website/issues/13360
