### PR TITLE
Homepage: enable atom feeds

### DIFF
--- a/src/lib/api/fetchRSS.ts
+++ b/src/lib/api/fetchRSS.ts
@@ -1,6 +1,6 @@
 import { parseString } from "xml2js"
 
-import type { RSSChannel, RSSItem, RSSResult } from "../types"
+import type { AtomResult, RSSChannel, RSSItem, RSSResult } from "../types"
 import { isValidDate } from "../utils/date"
 
 /**
@@ -12,45 +12,102 @@ export const fetchRSS = async (xmlUrl: string | string[]) => {
   const urls = Array.isArray(xmlUrl) ? xmlUrl : [xmlUrl]
   const allItems: RSSItem[][] = []
   for (const url of urls) {
-    const rssItems = (await fetchXml(url)) as RSSResult
-    if (!rssItems.rss) continue
-    const [mainChannel] = rssItems.rss.channel as RSSChannel[]
-    const [source] = mainChannel.title
-    const [sourceUrl] = mainChannel.link
-    const channelImage = mainChannel.image ? mainChannel.image[0].url[0] : ""
+    const response = (await fetchXml(url)) as RSSResult | AtomResult
+    if ("rss" in response) {
+      const [mainChannel] = response.rss.channel as RSSChannel[]
+      const [source] = mainChannel.title
+      const [sourceUrl] = mainChannel.link
+      const channelImage = mainChannel.image ? mainChannel.image[0].url[0] : ""
 
-    const parsedRssItems = mainChannel.item
-      // Filter out items with invalid dates
-      .filter((item) => {
-        if (!item.pubDate) return false
-        const [pubDate] = item.pubDate
-        return isValidDate(pubDate)
-      })
-      // Sort by pubDate (most recent is first in array
-      .sort((a, b) => {
-        const dateA = new Date(a.pubDate[0])
-        const dateB = new Date(b.pubDate[0])
-        return dateB.getTime() - dateA.getTime()
-      })
-      // Map to RSSItem object
-      .map((item) => {
-        const getImgSrc = () => {
-          if (item.enclosure) return item.enclosure[0].$.url
-          if (item["media:content"]) return item["media:content"][0].$.url
-          return channelImage
-        }
-        return {
-          pubDate: item.pubDate[0],
-          title: item.title[0],
-          link: item.link[0],
-          imgSrc: getImgSrc(),
-          source,
-          sourceUrl,
-          sourceFeedUrl: url,
-        } as RSSItem
-      })
+      const parsedRssItems = mainChannel.item
+        // Filter out items with invalid dates
+        .filter((item) => {
+          if (!item.pubDate) return false
+          const [pubDate] = item.pubDate
+          return isValidDate(pubDate)
+        })
+        // Sort by pubDate (most recent is first in array
+        .sort((a, b) => {
+          const dateA = new Date(a.pubDate[0])
+          const dateB = new Date(b.pubDate[0])
+          return dateB.getTime() - dateA.getTime()
+        })
+        // Map to RSSItem object
+        .map((item) => {
+          const getImgSrc = () => {
+            if (item.enclosure) return item.enclosure[0].$.url
+            if (item["media:content"]) return item["media:content"][0].$.url
+            return channelImage
+          }
+          return {
+            pubDate: item.pubDate[0],
+            title: item.title[0],
+            link: item.link[0],
+            imgSrc: getImgSrc(),
+            source,
+            sourceUrl,
+            sourceFeedUrl: url,
+          } as RSSItem
+        })
 
-    allItems.push(parsedRssItems)
+      allItems.push(parsedRssItems)
+    } else if ("feed" in response) {
+      const [source] = response.feed.title
+      const [sourceUrl] = response.feed.id
+      const feedImage = response.feed.icon?.[0]
+
+      const parsedAtomItems = response.feed.entry
+        // Filter out items with invalid dates
+        .filter((entry) => {
+          if (!entry.updated) return false
+          const [published] = entry.updated
+          return isValidDate(published)
+        })
+        // Sort by published (most recent is first in array
+        .sort((a, b) => {
+          const dateA = new Date(a.updated[0])
+          const dateB = new Date(b.updated[0])
+          return dateB.getTime() - dateA.getTime()
+        })
+        // Map to RSSItem object
+        .map((entry) => {
+          const getImgSrc = (): string => {
+            const imgRegEx = /https?:\/\/[^"]*?\.(jpe?g|png|webp)/g
+            const content = entry.content?.[0]?._ || ""
+            const summary = entry.summary?.[0]?._ || ""
+            const contentMatch = content.match(imgRegEx)
+            const summaryMatch = summary.match(imgRegEx)
+            if (contentMatch) return contentMatch[0]
+            if (summaryMatch) return summaryMatch[0]
+            return feedImage || ""
+          }
+          const getLink = (): string => {
+            if (!entry.link) {
+              console.warn(`No link found for RSS url: ${url}`)
+              return ""
+            }
+            const link = entry.link[0]
+            if (typeof link === "string") return link
+            return link.$.href || ""
+          }
+          const getTitle = (): string => {
+            const title = entry.title[0]
+            if (typeof title === "string") return title
+            return title._ || ""
+          }
+          return {
+            pubDate: entry.updated[0],
+            title: getTitle(),
+            link: getLink(),
+            imgSrc: getImgSrc(),
+            source,
+            sourceUrl,
+            sourceFeedUrl: url,
+          } as RSSItem
+        })
+
+      allItems.push(parsedAtomItems)
+    }
   }
   return allItems as RSSItem[][]
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -201,15 +201,13 @@ export const COMMUNITY_BLOGS: CommunityBlog[] = [
     feed: SOLIDITY_FEED,
   },
   {
-    name: "Privacy and Scaling Explorations",
     href: "https://mirror.xyz/privacy-scaling-explorations.eth",
-    // feed: "https://mirror.xyz/privacy-scaling-explorations.eth/feed/atom", // Old xml format
+    feed: "https://mirror.xyz/privacy-scaling-explorations.eth/feed/atom",
   },
-  // {
-  //   href: "https://stark.mirror.xyz/",
-  //   feed: "https://stark.mirror.xyz/feed/atom", // Old xml format
-  // },
-  // TODO: Add support for old xml format, re-enable above when ready
+  {
+    href: "https://stark.mirror.xyz/",
+    feed: "https://stark.mirror.xyz/feed/atom",
+  },
 ]
 
 export const BLOG_FEEDS = COMMUNITY_BLOGS.map(({ feed }) => feed).filter(

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -803,21 +803,21 @@ export type RSSResult = {
   }
 }
 
-export type AtomItem = {
-  _?: string
-  $: {
-    type?: string
-    href?: string
-    rel?: string
-  }
-}
+export type AtomElement =
+  | string
+  | {
+      _?: string // children
+      $: {
+        href?: string
+      }
+    }
 export type AtomEntry = {
   id: string[]
-  title: (AtomItem | string)[]
+  title: AtomElement[]
   updated: string[]
-  content?: AtomItem[]
-  link?: (AtomItem | string)[]
-  summary?: AtomItem[]
+  content?: AtomElement[]
+  link?: AtomElement[]
+  summary?: AtomElement[]
 }
 
 export type AtomResult = {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -803,6 +803,36 @@ export type RSSResult = {
   }
 }
 
+export type AtomItem = {
+  _?: string
+  $: {
+    type?: string
+    href?: string
+    rel?: string
+  }
+}
+export type AtomEntry = {
+  id: string[]
+  title: (AtomItem | string)[]
+  updated: string[]
+  content?: AtomItem[]
+  link?: (AtomItem | string)[]
+  summary?: AtomItem[]
+}
+
+export type AtomResult = {
+  feed: {
+    id: string[]
+    title: string[]
+    updated: string[]
+    generator: string[]
+    link: string[]
+    subtitle: string[]
+    icon?: string[]
+    entry: AtomEntry[]
+  }
+}
+
 export type CommunityBlog = {
   href: string
 } & ({ name: string; feed?: string } | { name?: string; feed: string })


### PR DESCRIPTION
## Extends `homepage` branch found in:
- #13528 

## Description
- Add support for atom feeds
- Activate PSE and Josh Stark feeds which were pending this upgrade

<img width="1046" alt="image" src="https://github.com/user-attachments/assets/bca216bc-7a50-4c9d-9af3-bd07baeff621">

## Related Issue
Homepage epic
