### PR TITLE
Fix circular dep issue with `Translation` component

### DIFF
--- a/src/components/Glossary/GlossaryTooltip/GlossaryTooltip.stories.tsx
+++ b/src/components/Glossary/GlossaryTooltip/GlossaryTooltip.stories.tsx
@@ -1,6 +1,8 @@
 import { Center } from "@chakra-ui/react"
 import { Meta, StoryObj } from "@storybook/react"
 
+import { renderGlossaryTooltipContent } from "@/components/TooltipLink"
+
 import GlossaryTooltipComponent from "."
 
 const meta = {
@@ -9,6 +11,7 @@ const meta = {
   args: {
     termKey: "bridge",
     children: "bridge",
+    renderContent: renderGlossaryTooltipContent,
   },
   decorators: [
     (Story) => (

--- a/src/components/Glossary/GlossaryTooltip/index.tsx
+++ b/src/components/Glossary/GlossaryTooltip/index.tsx
@@ -1,9 +1,7 @@
 import React, { ReactNode } from "react"
 import { useRouter } from "next/router"
 
-import InlineLink from "@/components/Link"
 import Tooltip, { type TooltipProps } from "@/components/Tooltip"
-import Translation from "@/components/Translation"
 
 import { trackCustomEvent } from "@/lib/utils/matomo"
 import { cleanPath } from "@/lib/utils/url"
@@ -11,11 +9,13 @@ import { cleanPath } from "@/lib/utils/url"
 type GlossaryTooltipProps = Omit<TooltipProps, "content"> & {
   children: ReactNode
   termKey: string
+  renderContent: (termKey: string) => ReactNode
 }
 
 const GlossaryTooltip = ({
   children,
   termKey,
+  renderContent,
   ...props
 }: GlossaryTooltipProps) => {
   const { asPath } = useRouter()
@@ -24,34 +24,7 @@ const GlossaryTooltip = ({
     <span className="inline-block">
       <Tooltip
         {...props}
-        content={
-          <div className="flex flex-col items-stretch gap-2 text-start">
-            <h6>
-              <Translation
-                id={termKey + "-term"}
-                options={{ ns: "glossary-tooltip" }}
-                // Override the default `a` tag transformation to avoid circular
-                // dependency issues
-                transform={{ a: InlineLink }}
-              />
-            </h6>
-            {/**
-             * `as="span"` prevents hydration warnings for strings that contain
-             * elements that cannot be nested inside `p` tags, like `ul` tags
-             * (found in some Glossary definition).
-             * TODO: Develop a better solution to handle this case.
-             */}
-            <span>
-              <Translation
-                id={termKey + "-definition"}
-                options={{ ns: "glossary-tooltip" }}
-                // Override the default `a` tag transformation to avoid circular
-                // dependency issues
-                transform={{ a: InlineLink }}
-              />
-            </span>
-          </div>
-        }
+        content={renderContent(termKey)}
         onBeforeOpen={() => {
           trackCustomEvent({
             eventCategory: "Glossary Tooltip",

--- a/src/components/TooltipLink.tsx
+++ b/src/components/TooltipLink.tsx
@@ -2,11 +2,32 @@ import React, { ReactNode } from "react"
 
 import GlossaryTooltip from "./Glossary/GlossaryTooltip"
 import InlineLink from "./Link"
+import Translation from "./Translation"
 
 interface Props {
   href?: string
   children?: ReactNode
+  renderTooltipContent?: (termKey: string) => ReactNode
 }
+
+export const renderGlossaryTooltipContent = (termKey: string) => (
+  <div className="flex flex-col items-stretch gap-2 text-start">
+    <h6>
+      <Translation
+        id={termKey + "-term"}
+        options={{ ns: "glossary-tooltip" }}
+        transform={{ a: InlineLink }}
+      />
+    </h6>
+    <span>
+      <Translation
+        id={termKey + "-definition"}
+        options={{ ns: "glossary-tooltip" }}
+        transform={{ a: InlineLink }}
+      />
+    </span>
+  </div>
+)
 
 /**
  * Link component to use in markdown templates.
@@ -18,24 +39,34 @@ interface Props {
  * inside of our MD files. The native link syntax has a better UX with Crowdin
  * translations.
  */
-function TooltipLink(props: Props) {
-  const { href } = props
+
+function TooltipLink({
+  href,
+  children,
+  renderTooltipContent = renderGlossaryTooltipContent,
+  ...props
+}: Props) {
   if (!href) {
-    return <InlineLink {...props} />
+    return <InlineLink {...props}>{children}</InlineLink>
   }
 
   const regex = new RegExp(/\/glossary\/#(.+)/)
   const matches = href.match(regex)
 
-  // get the `termKey` from the `href`
-  // e.g. in `/glossary/#new-term` => "new-term" is the `termKey`
   if (matches?.length) {
     const termKey = matches[1]
-
-    return <GlossaryTooltip termKey={termKey}>{props.children}</GlossaryTooltip>
+    return (
+      <GlossaryTooltip termKey={termKey} renderContent={renderTooltipContent}>
+        {children}
+      </GlossaryTooltip>
+    )
   }
 
-  return <InlineLink {...props} />
+  return (
+    <InlineLink href={href} {...props}>
+      {children}
+    </InlineLink>
+  )
 }
 
 export default TooltipLink

--- a/src/components/Translation.tsx
+++ b/src/components/Translation.tsx
@@ -13,12 +13,6 @@ type TranslationProps = {
   transform?: HtmrOptions["transform"]
 }
 
-// Custom components mapping to be used by `htmr` when parsing the translation
-// text
-const defaultTransform = {
-  a: TooltipLink,
-}
-
 // Renders the translation string for the given translation key `id`. It
 // fallback to English if it doesn't find the given key in the current language
 const Translation = ({ id, options, transform = {} }: TranslationProps) => {
@@ -27,6 +21,12 @@ const Translation = ({ id, options, transform = {} }: TranslationProps) => {
 
   const { t } = useTranslation(requiredNamespaces)
   const translatedText = t(id, options)
+
+  // Custom components mapping to be used by `htmr` when parsing the translation
+  // text
+  const defaultTransform = {
+    a: TooltipLink,
+  }
 
   // Use `htmr` to parse html content in the translation text
   return htmr(translatedText, {

--- a/src/data/WalletSimulatorData.tsx
+++ b/src/data/WalletSimulatorData.tsx
@@ -7,6 +7,8 @@ import {
   UnorderedList,
 } from "@chakra-ui/react"
 
+import { renderGlossaryTooltipContent } from "@/components/TooltipLink"
+
 import Emoji from "../components/Emoji"
 import GlossaryTooltip from "../components/Glossary/GlossaryTooltip"
 import Link from "../components/Link"
@@ -217,10 +219,21 @@ export const walletOnboardingSimData: SimulatorData = {
           <>
             <Text>
               Your wallet helps you manage your funds,{" "}
-              <GlossaryTooltip termKey="nft">NFTs</GlossaryTooltip>,{" "}
-              <GlossaryTooltip termKey="web3">Web3</GlossaryTooltip> identity
-              and more. Here we&apos;ll go over how to receive and send some
-              tokens on Ethereum.
+              <GlossaryTooltip
+                termKey="nft"
+                renderContent={renderGlossaryTooltipContent}
+              >
+                NFTs
+              </GlossaryTooltip>
+              ,{" "}
+              <GlossaryTooltip
+                termKey="web3"
+                renderContent={renderGlossaryTooltipContent}
+              >
+                Web3
+              </GlossaryTooltip>{" "}
+              identity and more. Here we&apos;ll go over how to receive and send
+              some tokens on Ethereum.
             </Text>
             <Text>
               Let&apos;s first look at how to receive ether (ETH),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Moves `Translation` dep out of `GlossaryTooltip` to avoid circular dep issue and pass content using a render prop.
