### PR TITLE
Update homepage bento arrangement

### DIFF
--- a/src/components/Homepage/useBentoBox.ts
+++ b/src/components/Homepage/useBentoBox.ts
@@ -11,6 +11,13 @@ import MergeImage from "@/public/images/upgrades/merge.png"
 type Breakpoint = "mobile" | "lg" | "xl"
 type Direction = "down" | "up" | "right" | "left"
 type Color = "primary" | "accent-a" | "accent-b" | "accent-c"
+type Category = "stablecoins" | "defi" | "dapps" | "networks" | "assets"
+type CopyDetails = {
+  title: string
+  children: string
+  action: string
+  href: string
+}
 
 const gradientStops = "from-20% to-60%"
 
@@ -88,47 +95,39 @@ const getPosition = (position: number): string =>
 export const useBentoBox = () => {
   const { t } = useTranslation("page-index")
 
+  const getCopy = (category: Category, href: string): CopyDetails => ({
+    title: t(`page-index:page-index-bento-${category}-title`),
+    children: t(`page-index:page-index-bento-${category}-content`),
+    action: t(`page-index:page-index-bento-${category}-action`),
+    href,
+  })
+
   return [
     {
-      title: t("page-index-bento-stablecoins-title"),
-      children: t("page-index:page-index-bento-stablecoins-content"),
-      action: t("page-index:page-index-bento-stablecoins-action"),
-      href: "/stablecoins/",
+      ...getCopy("stablecoins", "/stablecoins/"),
       imgSrc: ImpactImage,
       imgWidth: 400,
       className: cn(colorOptions["primary"], getPosition(0)),
     },
     {
-      title: t("page-index:page-index-bento-defi-title"),
-      children: t("page-index:page-index-bento-defi-content"),
-      action: t("page-index:page-index-bento-defi-action"),
-      href: "/defi/",
+      ...getCopy("defi", "/defi/"),
       imgSrc: ManAndDogImage,
       className: cn(colorOptions["accent-c"], getPosition(1)),
     },
     {
-      title: t("page-index:page-index-bento-dapps-title"),
-      children: t("page-index:page-index-bento-dapps-content"),
-      action: t("page-index:page-index-bento-dapps-action"),
-      href: "/dapps/",
+      ...getCopy("dapps", "/dapps/"),
       imgSrc: MergeImage,
       imgWidth: 320,
       className: cn(colorOptions["accent-b"], getPosition(2)),
     },
     {
-      title: t("page-index:page-index-bento-networks-title"),
-      children: t("page-index:page-index-bento-networks-content"),
-      action: t("page-index:page-index-bento-networks-action"),
-      href: "/layer-2/",
+      ...getCopy("networks", "/layer-2/"),
       imgSrc: ManBabyWomanImage,
       imgWidth: 324,
       className: cn(colorOptions["accent-a"], getPosition(3)),
     },
     {
-      title: t("page-index:page-index-bento-assets-title"),
-      children: t("page-index:page-index-bento-assets-content"),
-      action: t("page-index:page-index-bento-assets-action"),
-      href: "/nft/",
+      ...getCopy("assets", "/nft/"),
       imgSrc: RobotBarImage,
       imgWidth: 324,
       className: cn(colorOptions["primary"], getPosition(4)),

--- a/src/components/Homepage/useBentoBox.ts
+++ b/src/components/Homepage/useBentoBox.ts
@@ -105,23 +105,23 @@ export const useBentoBox = () => {
   return [
     {
       ...getCopy("stablecoins", "/stablecoins/"),
-      imgSrc: ImpactImage,
-      imgWidth: 400,
+      imgSrc: ManAndDogImage,
       className: cn(colorOptions["primary"], getPosition(0)),
     },
     {
       ...getCopy("defi", "/defi/"),
-      imgSrc: ManAndDogImage,
+      imgSrc: ImpactImage,
+      imgWidth: 400,
       className: cn(colorOptions["accent-c"], getPosition(1)),
     },
     {
-      ...getCopy("dapps", "/dapps/"),
+      ...getCopy("networks", "/layer-2/"),
       imgSrc: MergeImage,
       imgWidth: 320,
       className: cn(colorOptions["accent-b"], getPosition(2)),
     },
     {
-      ...getCopy("networks", "/layer-2/"),
+      ...getCopy("dapps", "/dapps/"),
       imgSrc: ManBabyWomanImage,
       imgWidth: 324,
       className: cn(colorOptions["accent-a"], getPosition(3)),


### PR DESCRIPTION
## Description
- Refactors/simplifies the useBentoBox hook logic for readability
- Re-positions copy and images for bento boxes

<img width="1431" alt="image" src="https://github.com/user-attachments/assets/1c3d7b73-3db3-4873-b661-f75841457c0d">

cc: @konopkja 

https://www.figma.com/design/ocV0PiMMzklN6iVtJePxUv/homepage-redesign?node-id=8730-74947&t=6T2tquBliQ58ThwV-1