### PR TITLE
ui: round inner meter in ui/progress

### DIFF
--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -16,7 +16,7 @@ const Progress = React.forwardRef<
     {...props}
   >
     <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-disabled transition-all"
+      className="h-full w-full flex-1 rounded-full bg-disabled transition-all"
       style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
     />
   </ProgressPrimitive.Root>


### PR DESCRIPTION
## Description
- Updates base `ui/progress` component with `rounded-full` on the inner progress bar element

<img width="793" alt="image" src="https://github.com/user-attachments/assets/57448d54-5c10-434d-b048-a974446d2a26">

^ Maintains this appearance from previous Chakra-UI `Progress`

cc: @nloureiro I didn't see this component in the DS, but noticed we previously had the rounded approach on the inside bar. Came across it when updating colors on the Quizzes page, so if we don't want to change the base component here, I can just close it out and apply to that usage only.
