### PR TITLE
removing new to crypto tag

### DIFF
--- a/src/data/wallets/wallet-data.ts
+++ b/src/data/wallets/wallet-data.ts
@@ -1311,7 +1311,7 @@ export const walletsData: WalletData[] = [
     social_recovery: false,
     onboard_documentation: "",
     documentation: "",
-    new_to_crypto: true,
+    new_to_crypto: false,
   },
   {
     last_updated: "2022-08-31",


### PR DESCRIPTION
rabby wallet was mistakenly assigned "new to crypto" tag, so just removing it.

