### PR TITLE
chore: remove duplicate font import

### DIFF
--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -38,16 +38,6 @@ const ThemeProvider = ({ children }: Pick<ThemeProviderProps, "children">) => {
         colorModeManager={colorModeManager}
         resetCSS={false}
       >
-        {/* TODO: Can these CSS Vars be moved to `global.css`? */}
-        <style jsx global>
-          {`
-            :root {
-              --font-inter: Inter, sans-serif;
-              --font-mono: "IBM Plex Mono", Courier, monospace;
-            }
-          `}
-        </style>
-
         {children}
       </ChakraBaseProvider>
     </NextThemesProvider>


### PR DESCRIPTION
## Description
- Fonts imported in `global.css`
- Duplicate font import in `ThemeProvider` removed