### PR TITLE
Patch search button

### DIFF
--- a/src/components/Nav/Desktop/index.tsx
+++ b/src/components/Nav/Desktop/index.tsx
@@ -52,7 +52,7 @@ const DesktopNavMenu = ({ toggleColorMode }: DesktopNavMenuProps) => {
         aria-label={themeIconAriaLabel}
         variant="ghost"
         isSecondary
-        className="group px-2 xl:px-3 [&>svg]:transition-all [&>svg]:duration-500 [&>svg]:hover:rotate-12 [&>svg]:hover:text-primary-hover"
+        className="group px-2 xl:px-3 [&>svg]:transition-transform [&>svg]:duration-500 [&>svg]:hover:rotate-12 [&>svg]:hover:text-primary-hover"
         onClick={toggleColorMode}
       >
         <ThemeIcon className="transform-transform duration-500 group-hover:rotate-12 group-hover:transition-transform group-hover:duration-500" />
@@ -64,7 +64,7 @@ const DesktopNavMenu = ({ toggleColorMode }: DesktopNavMenuProps) => {
           name={DESKTOP_LANGUAGE_BUTTON_NAME}
           ref={languagePickerRef}
           variant="ghost"
-          className="gap-0 px-2 text-body transition-colors duration-500 active:bg-primary-low-contrast active:text-primary-hover data-[state='open']:bg-primary-low-contrast data-[state='open']:text-primary-hover xl:px-3 [&_svg]:transition-transform [&_svg]:duration-500 [&_svg]:hover:rotate-12"
+          className="gap-0 px-2 text-body transition-transform duration-500 active:bg-primary-low-contrast active:text-primary-hover data-[state='open']:bg-primary-low-contrast data-[state='open']:text-primary-hover xl:px-3 [&_svg]:transition-transform [&_svg]:duration-500 [&_svg]:hover:rotate-12"
         >
           <BsTranslate className="me-2 align-middle text-2xl" />
           <span className="hidden lg:inline-block">

--- a/src/components/Search/SearchButton.tsx
+++ b/src/components/Search/SearchButton.tsx
@@ -15,8 +15,7 @@ const SearchButton = forwardRef<HTMLButtonElement, ButtonProps>(
         ref={ref}
         aria-label={t("aria-toggle-search-button")}
         className={cn(
-          "px-2 ease-in-out [&>svg]:transition-all [&>svg]:duration-500 [&>svg]:hover:rotate-12 [&>svg]:hover:text-primary-hover",
-          "group me-3 border border-disabled hover:border-primary-hover",
+          "group px-2 ease-in-out [&>svg]:transition-all [&>svg]:duration-500 [&>svg]:hover:rotate-12 [&>svg]:hover:text-primary-hover",
           className
         )}
         variant="ghost"


### PR DESCRIPTION
## Description
- Remove outline from tablet nav-bar search button
- Remove transition for `color` property on nav buttons; transition only `transform` property

## Related issue
None filed, fixes outline seen here:

<img width="707" alt="image" src="https://github.com/user-attachments/assets/179ac741-a701-4061-9fa5-4493acf20093">
