### PR TITLE
fix: Select hover border color contrast ratio

### DIFF
--- a/src/components/ui/Select/innerComponents.tsx
+++ b/src/components/ui/Select/innerComponents.tsx
@@ -19,7 +19,7 @@ export const selectVariants = tv({
     container:
       "w-full min-h-10.5 [--border-base-width:1px] relative z-[1] cursor-pointer",
     control:
-      "p-2 flex items-center gap-4 border-[length:var(--border-base-width)] border-current text-[color:var(--my-var)] not-[[data-expanded=true]]:focus-within:outline-3 not-[[data-expanded=true]]:focus-within:outline-primary-hover not-[[data-expanded=true]]:focus-within:outline -outline-offset-2 [&[data-expanded=true]]:bg-background-highlight [&[data-expanded=true]]:text-primary [&[data-expanded=true]]:border-primary-low-contrast hover:text-primary hover:border-primary-low-contrast",
+      "p-2 flex items-center gap-4 border-[length:var(--border-base-width)] border-current text-[color:var(--my-var)] not-[[data-expanded=true]]:focus-within:outline-3 not-[[data-expanded=true]]:focus-within:outline-primary-hover not-[[data-expanded=true]]:focus-within:outline -outline-offset-2 [&[data-expanded=true]]:bg-background-highlight [&[data-expanded=true]]:text-primary [&[data-expanded=true]]:border-primary-low-contrast hover:text-primary hover:border-primary-high-contrast",
     indicatorIcon:
       "text-sm leading-none transition-transform [*[data-expanded=true]_&]:rotate-180",
     menu: "-z-[1] absolute w-full",


### PR DESCRIPTION
## Description
- Replaces use of low-contrast with high-contrast primary color variant for `Select` component hover border color

## Related Issue
Poor contrast ratio, giving a "disappearing" experience on select hovering