### PR TITLE
deprecate: primary-light/dark color tokens

### DIFF
--- a/src/styles/docsearch.css
+++ b/src/styles/docsearch.css
@@ -101,7 +101,7 @@
 }
 .DocSearch-Hit[aria-selected="true"] a {
   --docsearch-hit-active-color: theme(backgroundColor.background.DEFAULT);
-  @apply border-transparent bg-primary-hover shadow-[4px_4px_0_0_var(--primary-light)];
+  @apply border-transparent bg-primary-hover shadow-[4px_4px_0_0_var(--primary-visited)];
 }
 
 .DocSearch-Hit-content-wrapper {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -13,12 +13,6 @@
     --font-inter: Inter, sans-serif;
     --font-mono: "IBM Plex Mono", Courier, monospace;
 
-    /* Semantic Colors: Light mode */
-    /* ! Deprecating primary-light */
-    --primary-light: var(--blue-100);
-    /* ! Deprecating primary-dark */
-    --primary-dark: var(--blue-700);
-
     /* Misc sematics: light mode */
     --tooltip-shadow: rgba(0, 0, 0, 0.24);
     --switch-background: var(--gray-300);
@@ -52,12 +46,6 @@
   }
 
   [data-theme="dark"] {
-    /* Semantic Colors: Dark mode */
-    /* ! Deprecating primary-light */
-    --primary-light: hsla(var(--orange-100));
-    /* ! Deprecating primary-dark */
-    --primary-dark: hsla(var(--orange-800));
-
     /* Misc sematics: dark mode */
     --tooltip-shadow: rgba(255, 255, 255, 0.24);
     --switch-background: rgba(255, 255, 255, 0.24);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -155,10 +155,6 @@ const config = {
           visited: "hsla(var(--primary-visited))",
           action: "hsla(var(--primary-action))",
           "action-hover": "hsla(var(--primary-action-hover))",
-          /** @deprecated */
-          light: "hsla(var(--primary-light))",
-          /** @deprecated */
-          dark: "hsla(var(--primary-dark))",
         },
 
         accent: {


### PR DESCRIPTION
## Description
- deprecate: primary-light/dark color tokens

## Related Issue
Design system; theming updates and color token purging