### PR TITLE
fix: LanguagePicker max height

### DIFF
--- a/src/components/LanguagePicker/index.tsx
+++ b/src/components/LanguagePicker/index.tsx
@@ -125,7 +125,7 @@ const LanguagePickerMenu = ({ languages, onClose, onSelect }) => {
 
   return (
     <Command
-      className="gap-2 p-4"
+      className="max-h-[calc(100vh-12rem)] gap-2 p-4"
       filter={(value: string, search: string) => {
         const item = languages.find((name) => name.localeOption === value)
 
@@ -157,7 +157,7 @@ const LanguagePickerMenu = ({ languages, onClose, onSelect }) => {
         kbdShortcut="\"
       />
 
-      <CommandList className="max-h-[75vh]">
+      <CommandList className="max-h-full">
         <CommandEmpty className="py-0 text-left text-base">
           <NoResultsCallout onClose={onClose} />
         </CommandEmpty>


### PR DESCRIPTION
## Description
- Moves the max-height property to the `Command` parent for the Language Picker component
- Adjusts height to use `calc` allowing menu to drop to just above the feedback widget, regardless of screen height

## Related Issue
Fixes bug where the "Learn more" section at the bottom of the LanguagePicker was falling off the bottom edge of the screen on shorter displays/windows.

<img width="1538" alt="image" src="https://github.com/user-attachments/assets/6507039b-057b-4e06-ba52-59fec2761d5c">

With fix:

<img width="1538" alt="image" src="https://github.com/user-attachments/assets/710629df-bd97-4685-9fd9-6164c2cb29c4">


## Preview link
https://deploy-preview-13942--ethereumorg.netlify.app/en/