### PR TITLE
Fix nerolation link

### DIFF
--- a/src/data/consensus-bounty-hunters.json
+++ b/src/data/consensus-bounty-hunters.json
@@ -80,7 +80,7 @@
     "score": 1750
   },
   {
-    "username": "@nerolation",
+    "username": "nerolation",
     "name": "Toni Wahrstätter",
     "score": 1000
   },


### PR DESCRIPTION
The link to my github profile is broken on the consensus bounty page.