### PR TITLE
chore: remove unused token

### DIFF
--- a/src/styles/semantic-tokens.css
+++ b/src/styles/semantic-tokens.css
@@ -35,7 +35,6 @@
 
     --accent-a: var(--blue-600);
     --accent-a-hover: var(--blue-500);
-    --accent-a-low-contrast: var(--blue-50); /* TODO: VERIFY */
 
     --accent-b: var(--pink-600);
     --accent-b-hover: var(--pink-500);
@@ -137,11 +136,9 @@
     --primary-low-contrast: var(--purple-900);
     --primary-hover: var(--purple-300);
     --primary-visited: var(--purple-500);
-    /* TODO: hover same as action in dark mode: */
 
     --accent-a: var(--blue-400);
     --accent-a-hover: var(--blue-300);
-    --accent-a-low-contrast: var(--blue-900); /* TODO: VERIFY */
 
     --accent-b: var(--pink-400);
     --accent-b-hover: var(--pink-300);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -170,7 +170,6 @@ const config = {
           a: {
             DEFAULT: "hsla(var(--accent-a))",
             hover: "hsla(var(--accent-a-hover))",
-            "low-contrast": "hsla(var(--accent-a-low-contrast))", // TODO: VERIFY
           },
           b: {
             DEFAULT: "hsla(var(--accent-b))",


### PR DESCRIPTION
## Description
- Token `accent-a-low-constrast` was added in development of the `ValuesMarquee` component, but was ultimately not used. PR removes all traces
- Removed `TODO` about color clash: `primary-action`/`primary-action-hover` applied specifically to `solid` buttons and should not clash with text link `primary`, `primary-hover`, and `primary-visited`

## Related Issue
Ongoing theming cleanup