### PR TITLE
theme: use 16px font for alert descriptions

### DIFF
--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -67,7 +67,7 @@ const AlertDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("text-sm [&_p]:leading-relaxed", className)}
+    className={cn("[&_p]:leading-relaxed", className)}
     {...props}
   />
 ))


### PR DESCRIPTION
## Description
Proposal: Use 16px font size as default for `ui/alert` component

## Example screenshot
<img width="1623" alt="image" src="https://github.com/user-attachments/assets/f69d5007-d3d9-49d8-a78a-a40b6728d4cd">

## Preview link
https://deploy-preview-13953--ethereumorg.netlify.app/en/get-eth
https://ethereum.org/en/get-eth