### PR TITLE
Migrate MatomoOptOut to ShadCN

### DIFF
--- a/src/components/MatomoOptOut.tsx
+++ b/src/components/MatomoOptOut.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react"
-import { Checkbox, Flex } from "@chakra-ui/react"
 
 import Text from "@/components/OldText"
 
 import { MATOMO_LS_KEY } from "@/lib/utils/matomo"
+
+import Checkbox from "../../tailwind/ui/Checkbox"
 
 const MatomoOptOut = () => {
   const [loading, setLoading] = useState<boolean>(true)
@@ -22,9 +23,7 @@ const MatomoOptOut = () => {
     setLoading(false)
   }, [])
 
-  const handleCheckbox = ({
-    target: { checked },
-  }: React.ChangeEvent<HTMLInputElement>): void => {
+  const handleCheckbox = (checked: boolean): void => {
     // Set local opt-out state based on check mark
     // Note: `checked` in the UI refers to being opted-in
     setIsOptedOut(!checked)
@@ -32,18 +31,7 @@ const MatomoOptOut = () => {
     localStorage.setItem(MATOMO_LS_KEY, String(!checked))
   }
   return (
-    <Flex
-      border="1px solid"
-      borderColor="border"
-      bgColor="background.base"
-      borderRadius="base"
-      p={6}
-      direction="column"
-      mb={4}
-      mt={8}
-      align="flex-start"
-      justify="space-between"
-    >
+    <div className="mb-4 mt-8 flex flex-col rounded border border-body-light bg-background p-6">
       <Text color="fail">
         You can opt out of being tracked by Matomo Analytics and prevent the
         website from analysing the actions you take using the website. This will
@@ -53,18 +41,21 @@ const MatomoOptOut = () => {
       {loading ? (
         "Loading preferences..."
       ) : (
-        <Checkbox
-          id="matomo"
-          isChecked={!isOptedOut}
-          onChange={handleCheckbox}
-          me={2}
-        >
-          {isOptedOut
-            ? "You are opted out. Check this box to opt-in."
-            : "You are not opted out. Uncheck this box to opt-out."}
-        </Checkbox>
+        <div className="flex items-center">
+          <Checkbox
+            id="matomo"
+            checked={!isOptedOut}
+            onCheckedChange={handleCheckbox}
+            className="me-2"
+          />
+          <label htmlFor="matomo">
+            {isOptedOut
+              ? "You are opted out. Check this box to opt-in."
+              : "You are not opted out. Uncheck this box to opt-out."}
+          </label>
+        </div>
       )}
-    </Flex>
+    </div>
   )
 }
 

--- a/src/components/MatomoOptOut.tsx
+++ b/src/components/MatomoOptOut.tsx
@@ -1,7 +1,5 @@
 import { useEffect, useState } from "react"
 
-import Text from "@/components/OldText"
-
 import { MATOMO_LS_KEY } from "@/lib/utils/matomo"
 
 import Checkbox from "../../tailwind/ui/Checkbox"
@@ -32,12 +30,12 @@ const MatomoOptOut = () => {
   }
   return (
     <div className="mb-4 mt-8 flex flex-col rounded border border-body-light bg-background p-6">
-      <Text color="fail">
+      <p className="mb-5 text-error">
         You can opt out of being tracked by Matomo Analytics and prevent the
         website from analysing the actions you take using the website. This will
         prevent us from learning from your actions and creating a better website
         experience for you and other users.
-      </Text>
+      </p>
       {loading ? (
         "Loading preferences..."
       ) : (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Migrates `MatomoOptOut` component to ShadCN from Chakra

## Note

As far as I can tell, the current border color for the box in Chakra theme (#e5e5e5) does not exist in DS/Tailwind theme. I've used `body-light` as the closest, but defer to @nloureiro here :) 

![image](https://github.com/user-attachments/assets/ecac7080-8fe3-4131-a80d-4408a4d2a74c)


## Updated Note

Per @pettinarip's [comment here](https://github.com/ethereum/ethereum-org-website/pull/13961#discussion_r1775316271), I've also stopped using the `OldText` component. This means the red color is slightly, though unrecognisably, different (now using `error` from tailwind config instead of the `fail` color in Chakra theme), and the margin bottom (was 1.45rem) is now 1.25rem per our scale.

## Related Issue

#13946
