### PR TITLE
Removed deprecated eth_coinbase from json-rpc docs[#13996]

### DIFF
--- a/public/content/developers/docs/apis/json-rpc/index.md
+++ b/public/content/developers/docs/apis/json-rpc/index.md
@@ -383,31 +383,6 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}
 }
 ```
 
-### eth_coinbase {#eth_coinbase}
-
-Returns the client coinbase address.
-
-**Parameters**
-
-None
-
-**Returns**
-
-`DATA`, 20 bytes - the current coinbase address.
-
-**Example**
-
-```js
-// Request
-curl -X POST --data '{"jsonrpc":"2.0","method":"eth_coinbase","params":[],"id":64}'
-// Result
-{
-  "id":64,
-  "jsonrpc": "2.0",
-  "result": "0x407d73d8a49eeb85d32cf465507dd71d507100c1"
-}
-```
-
 ### eth_chainId {#eth_chainId}
 
 Returns the chain ID used for signing replay-protected transactions.
@@ -1671,10 +1646,10 @@ geth --http --dev console 2>>geth.log
 
 This will start the HTTP RPC interface on `http://localhost:8545`.
 
-We can verify that the interface is running by retrieving the Coinbase address and balance using [curl](https://curl.se). Please note that data in these examples will differ on your local node. If you want to try these commands, replace the request params in the second curl request with the result returned from the first.
+We can verify that the interface is running by retrieving the Coinbase address(by obtaining the first address from the array of accounts) and balance using [curl](https://curl.se). Please note that data in these examples will differ on your local node. If you want to try these commands, replace the request params in the second curl request with the result returned from the first.
 
 ```bash
-curl --data '{"jsonrpc":"2.0","method":"eth_coinbase", "id":1}' -H "Content-Type: application/json" localhost:8545
+curl --data '{"jsonrpc":"2.0","method":"eth_accounts","params":[]", "id":1}' -H "Content-Type: application/json" localhost:8545
 {"id":1,"jsonrpc":"2.0","result":["0x9b1d35635cc34752ca54713bb99d38614f63c955"]}
 
 curl --data '{"jsonrpc":"2.0","method":"eth_getBalance", "params": ["0x9b1d35635cc34752ca54713bb99d38614f63c955", "latest"], "id":2}' -H "Content-Type: application/json" localhost:8545

--- a/public/content/developers/docs/apis/json-rpc/index.md
+++ b/public/content/developers/docs/apis/json-rpc/index.md
@@ -1673,7 +1673,7 @@ geth --http --dev console 2>>geth.log
 
 This will start the HTTP RPC interface on `http://localhost:8545`.
 
-We can verify that the interface is running by retrieving the Coinbase address(by obtaining the first address from the array of accounts) and balance using [curl](https://curl.se). Please note that data in these examples will differ on your local node. If you want to try these commands, replace the request params in the second curl request with the result returned from the first.
+We can verify that the interface is running by retrieving the coinbase address (by obtaining the first address from the array of accounts) and balance using [curl](https://curl.se). Please note that data in these examples will differ on your local node. If you want to try these commands, replace the request params in the second curl request with the result returned from the first.
 
 ```bash
 curl --data '{"jsonrpc":"2.0","method":"eth_accounts","params":[]", "id":1}' -H "Content-Type: application/json" localhost:8545

--- a/public/content/developers/docs/apis/json-rpc/index.md
+++ b/public/content/developers/docs/apis/json-rpc/index.md
@@ -383,6 +383,33 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}
 }
 ```
 
+### eth_coinbase {#eth_coinbase}
+
+Returns the client coinbase address.
+
+> **Note:** This method has been deprecated as of **v1.14.0** and is no longer supported. Attempting to use this method will result in a "Method not supported" error.
+
+**Parameters**
+
+None
+
+**Returns**
+
+`DATA`, 20 bytes - the current coinbase address.
+
+**Example**
+
+```js
+// Request
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_coinbase","params":[],"id":64}'
+// Result
+{
+  "id":64,
+  "jsonrpc": "2.0",
+  "result": "0x407d73d8a49eeb85d32cf465507dd71d507100c1"
+}
+```
+
 ### eth_chainId {#eth_chainId}
 
 Returns the chain ID used for signing replay-protected transactions.


### PR DESCRIPTION
## Description

As discussed in [ethereum/go-ethereum#29747](https://github.com/ethereum/go-ethereum/issues/29747), eth_coinbase no longer returns an address in v1.14.0+ and has been deprecated.
This PR removes the deprecated eth_coinbase RPC method from the JSON-RPC API list.

## Related Issue
- Fixes #13996 