### PR TITLE
fix: apply flip to parent of svg

### DIFF
--- a/src/components/Homepage/useHome.ts
+++ b/src/components/Homepage/useHome.ts
@@ -146,14 +146,14 @@ export const useHome = () => {
     {
       label: t("page-index:page-index-popular-topics-whitepaper"),
       Svg: Whitepaper,
-      className: cn(isRtl && "[&_svg]:-scale-x-100"),
+      className: cn(isRtl && "[&_div_div:has(svg)]:-scale-x-100"),
       href: "/whitepaper/",
       eventName: "whitepaper",
     },
     {
       label: t("page-index:page-index-popular-topics-roadmap"),
       Svg: RoadmapSign,
-      className: cn(isRtl && "[&_svg]:-scale-x-100"),
+      className: cn(isRtl && "[&_div_div:has(svg)]:-scale-x-100 "),
       href: "/roadmap/",
       eventName: "roadmap",
     },


### PR DESCRIPTION
## Description
- apply RTL flip to parent of svg to avoid conflicting transitions on the `svg` element
- Fixes issue where hovering on RTL pages would flip the icon back to "LTR" orientation

## Related Issue
None filed