### PR TITLE
[Tailwind] add plugin to extend `inset` utility classes

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -309,6 +309,25 @@ const config = {
         }
       )
     }),
+    plugin(function ({ matchUtilities, theme }) {
+      /**
+       * Extend the `inset` utility by including `inset-start` and `inset-end`.
+       *
+       * This allows the ability to strictly declare a left or right value that
+       * is i18n aware.
+       */
+      matchUtilities(
+        {
+          "inset-start": (value) => ({
+            "inset-inline-start": value,
+          }),
+          "inset-end": (value) => ({
+            "inset-inline-end": value,
+          }),
+        },
+        { values: theme("inset") }
+      )
+    }),
   ],
 } satisfies Config
 


### PR DESCRIPTION
Adds plugin to the tailwind config to extend the `inset` utility to include utilities for `inset-inline-start` and `inset-inline-end`.

Currently, there is only `inset-x-*` to establish both the left and right position with a single value. 

Adding `inset-start-*` and `inset-end-*` generates utilities with existing spacing values that define only left or right position, and are `i18n` aware. 