### PR TITLE
Removed Atom Editor from IDE List page

### DIFF
--- a/public/content/developers/docs/ides/index.md
+++ b/public/content/developers/docs/ides/index.md
@@ -41,12 +41,6 @@ Most established IDEs have built plugins to enhance the Ethereum development exp
 - [Code samples](https://github.com/Azure-Samples/blockchain/blob/master/blockchain-workbench/application-and-smart-contract-samples/readme.md)
 - [GitHub](https://github.com/microsoft/vscode)
 
-**Atom -** **_A hackable text editor for the 21st Century_**
-
-- [Atom](https://atom.io/)
-- [GitHub](https://github.com/atom)
-- [Ethereum packages](https://atom.io/packages/search?utf8=%E2%9C%93&q=keyword%3Aethereum&commit=Search)
-
 **JetBrains IDEs (IntelliJ IDEA, etc.) -** **_Essential tools for software developers and teams_**
 
 - [JetBrains](https://www.jetbrains.com/)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Removed the Atom editor, as it is no longer supported or maintained.
## Description

<!--- Describe your changes in detail -->

## Related Issue
- Fixes #13711