### PR TITLE
fix: h1 line height

### DIFF
--- a/src/pages/get-eth.tsx
+++ b/src/pages/get-eth.tsx
@@ -167,7 +167,7 @@ const GetEthPage = ({
             priority
           />
           <div className="mx-8 mb-8 mt-8 flex flex-col items-center text-center lg:mx-0 lg:mb-0 lg:mt-24">
-            <h1 className="my-8 text-4xl leading-6 md:text-5xl">
+            <h1 className="my-8 text-4xl md:text-5xl">
               {t("page-get-eth-where-to-buy-title")}
             </h1>
             <p className="mb-0 max-w-[45ch] text-center text-xl leading-snug text-body-medium">


### PR DESCRIPTION
## Target: `staging`

## Description
- Removes `leading-6` class (`line-height: 1.5rem;`) to fix the line height issue on `/get-eth` h1

## Related Issue
Reported in QA