### PR TITLE
feat: migrate GhostCard to tailwind

### DIFF
--- a/src/components/GhostCard.tsx
+++ b/src/components/GhostCard.tsx
@@ -15,10 +15,10 @@ const GhostCard: React.FC<GhostCardProps> = ({
 }) => {
   return (
     <div className={cn("relative self-stretch", className)}>
-      <div className="absolute bottom-2 left-2 -z-10 h-full w-full rounded-sm border-[1px] border-border bg-background-highlight dark:bg-gray-400" />
+      <div className="absolute bottom-2 left-2 z-hide h-full w-full rounded-sm border-border-high-contrast bg-background-medium" />
       <Card
         className={cn(
-          "text-card-foreground z-10 h-full w-full rounded-sm border-[1px] border-border bg-white p-6 text-left dark:bg-gray-600"
+          "text-card-foreground z-10 h-full w-full rounded-sm border bg-background-highlight p-6 text-left"
         )}
         {...props}
       >

--- a/src/components/GhostCard.tsx
+++ b/src/components/GhostCard.tsx
@@ -1,37 +1,31 @@
 import React from "react"
-import { Box, BoxProps } from "@chakra-ui/react"
 
-export type GhostCardProps = BoxProps
+import { cn } from "@/lib/utils/cn"
 
-const GhostCard = ({ children, ...rest }: GhostCardProps) => (
-  <Box position="relative" alignSelf="stretch" {...rest}>
-    <Box
-      zIndex="hide"
-      position="absolute"
-      backgroundColor="ghostCardGhost"
-      bottom="2"
-      insetInlineStart="2"
-      border="1px solid"
-      borderColor="border"
-      borderRadius="2px"
-      height="full"
-      width="full"
-    />
-    <Box
-      className="ghost-card-base"
-      height="full"
-      width="full"
-      borderRadius="2px"
-      zIndex={2}
-      padding="6"
-      background="ghostCardBackground"
-      border="1px solid"
-      borderColor="border"
-      textAlign="start"
-    >
-      {children}
-    </Box>
-  </Box>
-)
+import { Card } from "./ui/card"
+
+interface GhostCardProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode
+}
+
+const GhostCard: React.FC<GhostCardProps> = ({
+  children,
+  className,
+  ...props
+}) => {
+  return (
+    <div className={cn("relative self-stretch", className)}>
+      <div className="absolute bottom-2 left-2 -z-10 h-full w-full rounded-sm border-[1px] border-border bg-background-highlight dark:bg-gray-400" />
+      <Card
+        className={cn(
+          "text-card-foreground z-10 h-full w-full rounded-sm border-[1px] border-border bg-white p-6 text-left dark:bg-gray-600"
+        )}
+        {...props}
+      >
+        {children}
+      </Card>
+    </div>
+  )
+}
 
 export default GhostCard

--- a/src/pages/dapps.tsx
+++ b/src/pages/dapps.tsx
@@ -1854,15 +1854,7 @@ const DappsPage = () => {
       </FullWidthContainer>
       <Content>
         <ImageContainer id="what-are-dapps">
-          <GhostCard
-            mt={2}
-            sx={{
-              ".ghost-card-base": {
-                display: "flex",
-                justifyContent: "center",
-              },
-            }}
-          >
+          <GhostCard className="mt-2 flex items-center">
             <Image
               bgSize="cover"
               bgRepeat="no-repeat"

--- a/src/pages/gas.tsx
+++ b/src/pages/gas.tsx
@@ -273,12 +273,7 @@ const GasPage = () => {
               </InlineLink>
             </Text>
           </Box>
-          <GhostCard
-            flex="40%"
-            maxW="640px"
-            alignSelf="center"
-            mt={{ base: 16, lg: 2 }}
-          >
+          <GhostCard className="mt-16 max-w-[640px] self-center md:w-2/5 lg:mt-2">
             <Emoji text=":cat:" className="text-5xl" />
             <H3>{t("page-gas-attack-of-the-cryptokitties-header")}</H3>
             <Text>{t("page-gas-attack-of-the-cryptokitties-text")}</Text>

--- a/src/pages/stablecoins.tsx
+++ b/src/pages/stablecoins.tsx
@@ -463,11 +463,7 @@ const StablecoinsPage = ({ markets, marketsHasError }) => {
               </Box>
             ))}
           </Box>
-          <GhostCard
-            maxW="640px"
-            me={{ base: 0, lg: 8 }}
-            mt={{ base: 16, lg: 2 }}
-          >
+          <GhostCard className="mb-0 mt-16 max-w-[640px] lg:mb-8 lg:mt-2">
             <Emoji text=":pizza:" className="text-5xl" />
             <H3>{t("page-stablecoins-bitcoin-pizza")}</H3>
             <Text>{t("page-stablecoins-bitcoin-pizza-body")} </Text>

--- a/src/pages/stablecoins.tsx
+++ b/src/pages/stablecoins.tsx
@@ -463,7 +463,7 @@ const StablecoinsPage = ({ markets, marketsHasError }) => {
               </Box>
             ))}
           </Box>
-          <GhostCard className="mb-0 mt-16 max-w-[640px] lg:mb-8 lg:mt-2">
+          <GhostCard className="me-0 mt-16 max-w-[640px] lg:me-8 lg:mt-2">
             <Emoji text=":pizza:" className="text-5xl" />
             <H3>{t("page-stablecoins-bitcoin-pizza")}</H3>
             <Text>{t("page-stablecoins-bitcoin-pizza-body")} </Text>


### PR DESCRIPTION
Migrates `GhostCard` component to tailwind ShadCN from Chakra

## Description
This PR updates the `GhostCard` to use ShadcnUI's card component instead of Chakra component. Styles have been updated for both light and dark version.

## Related Issue
#13946 