### PR TITLE
fix: Docs layout component to resolve content overflow on mobile

### DIFF
--- a/src/layouts/Docs.tsx
+++ b/src/layouts/Docs.tsx
@@ -133,30 +133,26 @@ export const DocsLayout = ({
         dir={contentNotTranslated ? "ltr" : "unset"}
       >
         <SideNav path={relativePath} />
-        <MainArticle className="min-w-0 flex-1 overflow-hidden px-8 pb-8 pt-8 md:px-16 md:pb-16 md:pt-12">
-          <div className="max-w-full break-words">
-            <H1 id="top">{frontmatter.title}</H1>
-            <FileContributors
-              contributors={contributors}
-              lastEditLocaleTimestamp={lastEditLocaleTimestamp}
-            />
-            <TableOfContents
-              editPath={absoluteEditPath}
-              items={tocItems}
-              isMobile
-              maxDepth={frontmatter.sidebarDepth!}
-              hideEditButton={!!frontmatter.hideEditButton}
-            />
-            <div className="prose prose-lg max-w-none break-words">
-              {children}
-            </div>
-            {isPageIncomplete && (
-              <CallToContribute editPath={absoluteEditPath} />
-            )}
-            <BackToTop />
-            <FeedbackCard isArticle />
-            <DocsNav contentNotTranslated={contentNotTranslated} />
+        <MainArticle className="min-w-0 flex-1 px-8 pb-8 pt-8 md:px-16 md:pb-16 md:pt-12">
+          <H1 id="top">{frontmatter.title}</H1>
+          <FileContributors
+            contributors={contributors}
+            lastEditLocaleTimestamp={lastEditLocaleTimestamp}
+          />
+          <TableOfContents
+            editPath={absoluteEditPath}
+            items={tocItems}
+            isMobile
+            maxDepth={frontmatter.sidebarDepth!}
+            hideEditButton={!!frontmatter.hideEditButton}
+          />
+          <div className="prose prose-lg max-w-none break-words">
+            {children}
           </div>
+          {isPageIncomplete && <CallToContribute editPath={absoluteEditPath} />}
+          <BackToTop />
+          <FeedbackCard isArticle />
+          <DocsNav contentNotTranslated={contentNotTranslated} />
         </MainArticle>
         {tocItems && (
           <TableOfContents

--- a/src/layouts/Docs.tsx
+++ b/src/layouts/Docs.tsx
@@ -37,7 +37,8 @@ import YouTube from "@/components/YouTube"
 import { cn } from "@/lib/utils/cn"
 import { getEditPath } from "@/lib/utils/editPath"
 
-const baseHeadingClasses = "font-mono uppercase font-bold scroll-mt-40"
+const baseHeadingClasses =
+  "font-mono uppercase font-bold scroll-mt-40 break-words"
 
 const H1 = (props: HTMLAttributes<HTMLHeadingElement>) => (
   <MdHeading1
@@ -56,7 +57,7 @@ const H2 = (props: HTMLAttributes<HTMLHeadingElement>) => (
   />
 )
 
-const baseSubHeadingClasses = "leading-xs font-semibold"
+const baseSubHeadingClasses = "leading-xs font-semibold break-words"
 
 const H3 = (props: HTMLAttributes<HTMLHeadingElement>) => (
   <MdHeading3 className={cn(baseSubHeadingClasses, "mt-12")} {...props} />
@@ -132,24 +133,30 @@ export const DocsLayout = ({
         dir={contentNotTranslated ? "ltr" : "unset"}
       >
         <SideNav path={relativePath} />
-        <MainArticle className="min-w-0 flex-1 px-8 pb-8 pt-8 md:px-16 md:pb-16 md:pt-12">
-          <H1 id="top">{frontmatter.title}</H1>
-          <FileContributors
-            contributors={contributors}
-            lastEditLocaleTimestamp={lastEditLocaleTimestamp}
-          />
-          <TableOfContents
-            editPath={absoluteEditPath}
-            items={tocItems}
-            isMobile
-            maxDepth={frontmatter.sidebarDepth!}
-            hideEditButton={!!frontmatter.hideEditButton}
-          />
-          {children}
-          {isPageIncomplete && <CallToContribute editPath={absoluteEditPath} />}
-          <BackToTop />
-          <FeedbackCard isArticle />
-          <DocsNav contentNotTranslated={contentNotTranslated} />
+        <MainArticle className="min-w-0 flex-1 overflow-hidden px-8 pb-8 pt-8 md:px-16 md:pb-16 md:pt-12">
+          <div className="max-w-full break-words">
+            <H1 id="top">{frontmatter.title}</H1>
+            <FileContributors
+              contributors={contributors}
+              lastEditLocaleTimestamp={lastEditLocaleTimestamp}
+            />
+            <TableOfContents
+              editPath={absoluteEditPath}
+              items={tocItems}
+              isMobile
+              maxDepth={frontmatter.sidebarDepth!}
+              hideEditButton={!!frontmatter.hideEditButton}
+            />
+            <div className="prose prose-lg max-w-none break-words">
+              {children}
+            </div>
+            {isPageIncomplete && (
+              <CallToContribute editPath={absoluteEditPath} />
+            )}
+            <BackToTop />
+            <FeedbackCard isArticle />
+            <DocsNav contentNotTranslated={contentNotTranslated} />
+          </div>
         </MainArticle>
         {tocItems && (
           <TableOfContents


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Updated docs layout component to address content overflow across pages. Improved text wrapping for better readability on all devices, especially mobile.

Pages where this issue was most noticeable:

- [Ethereum Accounts](https://ethereum.org/en/developers/docs/accounts/)
- [Transactions](https://ethereum.org/en/developers/docs/transactions/)
- [Proof of Work](https://ethereum.org/en/developers/docs/consensus-mechanisms/pow/)
- [JSON-RPC API](https://ethereum.org/en/developers/docs/apis/json-rpc/)
- [Network Addresses](https://ethereum.org/en/developers/docs/networking-layer/network-addresses/)
- [Web3 Secret Storage Definition](https://ethereum.org/en/developers/docs/data-structures-and-encoding/web3-secret-storage/)
- [Merkle Patricia Tree](https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/)


## Related Issue

Resolves #13930 

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
