### PR TITLE
Added Armiarma to the nodes and clients section under the tracking nodes in the network segment.

### DIFF
--- a/public/content/developers/docs/nodes-and-clients/index.md
+++ b/public/content/developers/docs/nodes-and-clients/index.md
@@ -50,7 +50,6 @@ Multiple trackers offer a real-time overview of nodes in the Ethereum network. N
 - [Nodewatch](https://www.nodewatch.io/) by Chainsafe, crawling consensus nodes
 - [Monitoreth](https://monitoreth.io/) - by MigaLabs, A distributed network monitoring tool
 
-
 ## Node types {#node-types}
 
 If you want to [run your own node](/developers/docs/nodes-and-clients/run-a-node/), you should understand that there are different types of node that consume data differently. In fact, clients can run three different types of nodes: light, full and archive. There are also options of different sync strategies which enable faster synchronization time. Synchronization refers to how quickly it can get the most up-to-date information on Ethereum's state.

--- a/public/content/developers/docs/nodes-and-clients/index.md
+++ b/public/content/developers/docs/nodes-and-clients/index.md
@@ -48,6 +48,8 @@ Multiple trackers offer a real-time overview of nodes in the Ethereum network. N
 - [Map of nodes](https://etherscan.io/nodetracker) by Etherscan
 - [Ethernodes](https://ethernodes.org/) by Bitfly
 - [Nodewatch](https://www.nodewatch.io/) by Chainsafe, crawling consensus nodes
+- [Armiarma](https://github.com/migalabs/armiarma) - by MigaLabs, A distributed network monitoring tool
+
 
 ## Node types {#node-types}
 

--- a/public/content/developers/docs/nodes-and-clients/index.md
+++ b/public/content/developers/docs/nodes-and-clients/index.md
@@ -48,7 +48,7 @@ Multiple trackers offer a real-time overview of nodes in the Ethereum network. N
 - [Map of nodes](https://etherscan.io/nodetracker) by Etherscan
 - [Ethernodes](https://ethernodes.org/) by Bitfly
 - [Nodewatch](https://www.nodewatch.io/) by Chainsafe, crawling consensus nodes
-- [Armiarma](https://github.com/migalabs/armiarma) - by MigaLabs, A distributed network monitoring tool
+- [Monitoreth](https://monitoreth.io/)a) - by MigaLabs, A distributed network monitoring tool
 
 
 ## Node types {#node-types}

--- a/public/content/developers/docs/nodes-and-clients/index.md
+++ b/public/content/developers/docs/nodes-and-clients/index.md
@@ -48,7 +48,7 @@ Multiple trackers offer a real-time overview of nodes in the Ethereum network. N
 - [Map of nodes](https://etherscan.io/nodetracker) by Etherscan
 - [Ethernodes](https://ethernodes.org/) by Bitfly
 - [Nodewatch](https://www.nodewatch.io/) by Chainsafe, crawling consensus nodes
-- [Monitoreth](https://monitoreth.io/)a) - by MigaLabs, A distributed network monitoring tool
+- [Monitoreth](https://monitoreth.io/) - by MigaLabs, A distributed network monitoring tool
 
 
 ## Node types {#node-types}


### PR DESCRIPTION
This pull request adds armiarma developed by Migalabs to the Ethereum documentation:

Armiarma: A tool designed to identify participants in the Ethereum network, listed under the [Nodes and Clients](https://ethereum.org/en/developers/docs/nodes-and-clients/#network-overview) section.

This tool is open-source and contribute to better understanding the network and its participants.

There is no related issue for this pull request, as this addition introduces new tools to the existing documentation and does not resolve an open issue.


