### PR TITLE
Fix: Update Links to Source Dashboards in Metrics Section

### DIFF
--- a/src/components/StatsBoxGrid/useStatsBoxGrid.tsx
+++ b/src/components/StatsBoxGrid/useStatsBoxGrid.tsx
@@ -108,7 +108,7 @@ export const useStatsBoxGrid = ({
     },
     {
       apiProvider: "GrowThePie",
-      apiUrl: "https://www.growthepie.xyz/fundamentals/transaction-costs",
+      apiUrl: "https://www.growthepie.xyz/fundamentals/transaction-cost",
       label: t("page-index-network-stats-tx-cost-description"),
       state: medianTxCost,
     },

--- a/src/components/StatsBoxGrid/useStatsBoxGrid.tsx
+++ b/src/components/StatsBoxGrid/useStatsBoxGrid.tsx
@@ -108,7 +108,7 @@ export const useStatsBoxGrid = ({
     },
     {
       apiProvider: "GrowThePie",
-      apiUrl: "https://www.growthepie.xyz/fundamentals/transaction-cost",
+      apiUrl: "https://www.growthepie.xyz/fundamentals/transaction-costs",
       label: t("page-index-network-stats-tx-cost-description"),
       state: medianTxCost,
     },

--- a/src/components/StatsBoxGrid/useStatsBoxGrid.tsx
+++ b/src/components/StatsBoxGrid/useStatsBoxGrid.tsx
@@ -96,25 +96,25 @@ export const useStatsBoxGrid = ({
   const metrics: StatsBoxMetric[] = [
     {
       apiProvider: "DeFi Llama",
-      apiUrl: "https://defillama.com/",
+      apiUrl: "https://defillama.com/chain/Ethereum",
       label: t("page-index-network-stats-value-defi-description"),
       state: valueLocked,
     },
     {
       apiProvider: "Dune Analytics",
-      apiUrl: "https://dune.com/",
+      apiUrl: "https://dune.com/hildobby/eth2-staking",
       label: t("page-index-network-stats-total-eth-staked"),
       state: totalEtherStaked,
     },
     {
       apiProvider: "GrowThePie",
-      apiUrl: "https://growthepie.xyz/",
+      apiUrl: "https://www.growthepie.xyz/fundamentals/transaction-costs",
       label: t("page-index-network-stats-tx-cost-description"),
       state: medianTxCost,
     },
     {
       apiProvider: "GrowThePie",
-      apiUrl: "https://growthepie.xyz/",
+      apiUrl: "https://www.growthepie.xyz/fundamentals/transaction-count",
       label: t("page-index-network-stats-tx-day-description"),
       state: txs,
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR enhances the homepage metrics section by updating the links to direct users to the relevant dashboards, facilitating easier verification of the data. The following updates have been made:

- **Value Locked in DeFi**: Linked to the DeFi Llama dashboard.
- **Value Protecting Ethereum**: Linked to Dune Analytics for total ETH staked 
- **Average Transaction Cost & Transactions in the Last 24h**: Linked to the GrowThePie dashboard.

Fixes: #13916

Please feel free to suggest any changes if needed.
