### PR TITLE
fix: re-entrancy attack definition link formatting in glossary

### DIFF
--- a/src/intl/en/glossary.json
+++ b/src/intl/en/glossary.json
@@ -298,7 +298,7 @@
   "recovery-phrase-term": "Seed phrase/recovery phrase",
   "recovery-phrase-definition": "A list of words given to you when you create a digital wallet. It acts like a  password that can help you get back into your wallet if you lose access, making sure you don't lose your digital money or tokens.",
   "re-entrancy-attack-term": "Re-entrancy attack",
-  "re-entrancy-attack-definition": "An attack that consists of an attacker contract calling a victim contract function in such a way that during execution the victim calls the attacker contract again, recursively. This can result, for example, in the theft of funds by skipping parts of the victim contract that update balances or count withdrawal amounts.<a href=\"/developers/docs/smart-contracts/security/#reentrancy\">More on re-entrancy</a>.",
+  "re-entrancy-attack-definition": "An attack that consists of an attacker contract calling a victim contract function in such a way that during execution the victim calls the attacker contract again, recursively. This can result, for example, in the theft of funds by skipping parts of the victim contract that update balances or count withdrawal amounts. <a href=\"/developers/docs/smart-contracts/security/#reentrancy\">More on re-entrancy</a>.",
   "reward-term": "Reward",
   "reward-definition": "An amount of ether <a href=\"/developers/docs/consensus-mechanisms/pos/rewards-and-penalties\">awarded to validators</a> that perform certain functions, including proposing a block or participating in a sync-committee, in each slot.",
   "rlp-term": "Recursive Length Prefix (RLP)",

--- a/src/intl/en/glossary.json
+++ b/src/intl/en/glossary.json
@@ -298,7 +298,7 @@
   "recovery-phrase-term": "Seed phrase/recovery phrase",
   "recovery-phrase-definition": "A list of words given to you when you create a digital wallet. It acts like a  password that can help you get back into your wallet if you lose access, making sure you don't lose your digital money or tokens.",
   "re-entrancy-attack-term": "Re-entrancy attack",
-  "re-entrancy-attack-definition": "An attack that consists of an attacker contract calling a victim contract function in such a way that during execution the victim calls the attacker contract again, recursively. This can result, for example, in the theft of funds by skipping parts of the victim contract that update balances or count withdrawal amounts.< href=\"/developers/docs/smart-contracts/security/#re-entrancy\">More on re-entrancy</a>.",
+  "re-entrancy-attack-definition": "An attack that consists of an attacker contract calling a victim contract function in such a way that during execution the victim calls the attacker contract again, recursively. This can result, for example, in the theft of funds by skipping parts of the victim contract that update balances or count withdrawal amounts.<a href=\"/developers/docs/smart-contracts/security/#reentrancy\">More on re-entrancy</a>.",
   "reward-term": "Reward",
   "reward-definition": "An amount of ether <a href=\"/developers/docs/consensus-mechanisms/pos/rewards-and-penalties\">awarded to validators</a> that perform certain functions, including proposing a block or participating in a sync-committee, in each slot.",
   "rlp-term": "Recursive Length Prefix (RLP)",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
There's an issue with the `re-entrancy attack` glossary definition where the hyperlink is not properly formatted. I have corrected the `<a>` tag, ensuring the link to further information on re-entrancy is displayed correctly. See the screenshot below for reference.

![reentrancy-link](https://github.com/user-attachments/assets/c2b1ab16-7440-45b3-8c2a-c642213128b9)


## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
None
