### PR TITLE
fix: rm broken links, simplify to single callout

### DIFF
--- a/public/content/developers/docs/intro-to-ether/index.md
+++ b/public/content/developers/docs/intro-to-ether/index.md
@@ -26,7 +26,7 @@ The ether cryptocurrency supports a pricing mechanism for Ethereum's computing p
 
 Therefore, even if a malicious dapp submitted an infinite loop, the transaction would eventually run out of ether and terminate, allowing the network to return to normal.
 
-It is [common](https://www.reuters.com/article/us-crypto-currencies-lending-insight-idUSKBN25M0GP#:~:text=price%20of%20ethereum) [to](https://abcnews.go.com/Business/bitcoin-slumps-week-low-amid-renewed-worries-chinese/story?id=78399845#:~:text=cryptocurrencies%20including%20ethereum) [conflate](https://www.cnn.com/2021/03/14/tech/nft-art-buying/index.html#:~:text=price%20of%20ethereum) Ethereum and ether — when people reference the "price of Ethereum," they are describing the price of ether.
+It is [common to conflate](https://abcnews.go.com/Business/bitcoin-slumps-week-low-amid-renewed-worries-chinese/story?id=78399845) Ethereum and ether — when people reference the "price of Ethereum," they are describing the price of ether.
 
 ## Minting ether {#minting-ether}
 


### PR DESCRIPTION
## Description
- fixes issues with translations that do not have specific translations for each linked word
- removes broken links; removes unnecessary hash link from link that remains

## Related Issue
Ongoing translation efforts