### PR TITLE
fix: add missing "events" breadcrumb

### DIFF
--- a/src/intl/en/common.json
+++ b/src/intl/en/common.json
@@ -97,6 +97,7 @@
   "ethereum-upgrades": "Ethereum upgrades",
   "ethereum-wallets": "Ethereum wallets",
   "ethereum-whitepaper": "Ethereum Whitepaper",
+  "events": "Events",
   "feedback-card-prompt-article": "Was this article helpful?",
   "feedback-card-prompt-page": "Was this page helpful?",
   "feedback-card-prompt-tutorial": "Was this tutorial helpful?",


### PR DESCRIPTION
## Description
- Adds missing "events" breadcrumb string

cc: @lukassim 