### PR TITLE
fix: dir-responsive margin

### DIFF
--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -38,7 +38,7 @@ const EventCard: React.FC<EventCardProps> = ({
   return (
     <Card className={cn("flex h-full flex-col rounded-md border", className)}>
       <CardHeader className="flex flex-row items-center justify-center rounded-t-md border-b border-primary bg-[#FCFCFC] p-2 dark:bg-[#272627]">
-        <BsCalendar3 className="mr-2 h-6 w-6 text-primary" />
+        <BsCalendar3 className="me-2 h-6 w-6 text-primary" />
         <span className="!mt-0 text-right text-sm text-primary">
           {formatedDate}
         </span>


### PR DESCRIPTION
## Description
- Update `mr` (`margin-right`) to `me` (`margin-inline-end`) to fix `dir`-responsive margin on calendar icon for `EventCard`

## Related Issue
<img width="1118" alt="image" src="https://github.com/user-attachments/assets/564265f8-72d3-4a7c-93c1-790d4f28807e">
