### PR TITLE
Hotfix disable `revalidate`

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -67,7 +67,6 @@ import { getLocaleTimestamp } from "@/lib/utils/time"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 
 import {
-  BASE_TIME_UNIT,
   BLOG_FEEDS,
   BLOGS_WITHOUT_FEED,
   CALENDAR_DISPLAY_COUNT,
@@ -174,7 +173,8 @@ export const getStaticProps = (async ({ locale }) => {
       metricResults,
       rssData: { rssItems, blogLinks },
     },
-    revalidate: BASE_TIME_UNIT * 24,
+    // TODO: re-enable revalidation once we have a workaround for failing builds
+    // revalidate: BASE_TIME_UNIT * 24,
   }
 }) satisfies GetStaticProps<Props>
 

--- a/src/pages/stablecoins.tsx
+++ b/src/pages/stablecoins.tsx
@@ -44,8 +44,6 @@ import { runOnlyOnce } from "@/lib/utils/runOnlyOnce"
 import { getLocaleTimestamp } from "@/lib/utils/time"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 
-import { BASE_TIME_UNIT } from "@/lib/constants"
-
 import {
   fetchEthereumEcosystemData,
   fetchEthereumStablecoinsData,
@@ -189,7 +187,8 @@ export const getStaticProps = (async ({ locale }) => {
       marketsHasError,
     },
     // Updated once a week
-    revalidate: BASE_TIME_UNIT * 24 * 7,
+    // TODO: re-enable revalidation once we have a workaround for failing builds
+    // revalidate: BASE_TIME_UNIT * 24 * 7,
   }
 }) satisfies GetStaticProps<Props>
 

--- a/src/pages/staking/index.tsx
+++ b/src/pages/staking/index.tsx
@@ -40,8 +40,6 @@ import { runOnlyOnce } from "@/lib/utils/runOnlyOnce"
 import { getLocaleTimestamp } from "@/lib/utils/time"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 
-import { BASE_TIME_UNIT } from "@/lib/constants"
-
 import rhino from "@/public/images/upgrades/upgrade_rhino.png"
 
 type BenefitsType = {
@@ -176,7 +174,8 @@ export const getStaticProps = (async ({ locale }) => {
       lastDeployLocaleTimestamp,
     },
     // Updated once a day
-    revalidate: BASE_TIME_UNIT * 24,
+    // TODO: re-enable revalidation once we have a workaround for failing builds
+    // revalidate: BASE_TIME_UNIT * 24,
   }
 }) satisfies GetStaticProps<Props>
 

--- a/src/pages/wallets/find-wallet.tsx
+++ b/src/pages/wallets/find-wallet.tsx
@@ -32,7 +32,6 @@ import {
 } from "@/lib/utils/wallets"
 
 import {
-  BASE_TIME_UNIT,
   DEFAULT_LOCALE,
   NAV_BAR_PX_HEIGHT,
   WALLETS_FILTERS_DEFAULT,
@@ -93,7 +92,8 @@ export const getStaticProps = (async ({ locale }) => {
       wallets,
     },
     // Updated once a day
-    revalidate: BASE_TIME_UNIT * 24,
+    // TODO: re-enable revalidation once we have a workaround for failing builds
+    // revalidate: BASE_TIME_UNIT * 24,
   }
 }) satisfies GetStaticProps<Props>
 


### PR DESCRIPTION
Currently, our revalidate process is always failing due to this bug, which is currently fixed in `dev` #14175. This issue causes the revalidate to never be done and always be triggered on every request, resulting in a lot of unnecessary API calls.

## Description

This PR temporarily stops revalidation until we have #14179 (which will allow us to re-enable it).