### PR TITLE
Fix: wallet attributes icon alignments

### DIFF
--- a/src/components/FindWalletProductTable/WalletSubComponent.tsx
+++ b/src/components/FindWalletProductTable/WalletSubComponent.tsx
@@ -91,26 +91,34 @@ const WalletSubComponent = ({
                       const featureColor = wallet[item.filterKey]
                         ? "text-body"
                         : "text-disabled"
+                      // Split last word off filterLabel to force non-wrapping
+                      // connection between the last word and info Tooltip icon
+                      const filterLabelSplit = item.filterLabel.split(" ")
+                      const filterLabelLastWord = filterLabelSplit.pop()
+                      const filterLabelRoot = filterLabelSplit.join(" ")
                       return (
                         <li key={idx} className="mb-2 flex flex-row gap-2">
-                          <span>
+                          <span className="translate-y-0.5">
                             {wallet[item.filterKey] ? (
-                              <GreenCheckProductGlyphIcon className="size-4 text-primary" />
+                              <GreenCheckProductGlyphIcon className="size-4" />
                             ) : (
-                              <WarningProductGlyphIcon className="text-secondary size-4" />
+                              <WarningProductGlyphIcon className="size-4" />
                             )}
                           </span>
-                          <p className={`leading-1 ${featureColor}`}>
-                            {item.filterLabel}{" "}
-                            <Tooltip
-                              content={
-                                <p className="text-body">{item.description}</p>
-                              }
-                            >
-                              <span className="whitespace-nowrap">
-                                <MdInfoOutline color={featureColor} />
-                              </span>
-                            </Tooltip>
+                          <p className={cn("leading-1", featureColor)}>
+                            {filterLabelRoot && `${filterLabelRoot} `}
+                            <span className="whitespace-nowrap">
+                              {filterLabelLastWord}
+                              <Tooltip
+                                content={
+                                  <p className="text-body">
+                                    {item.description}
+                                  </p>
+                                }
+                              >
+                                <MdInfoOutline className="ms-1 translate-y-0.5" />
+                              </Tooltip>
+                            </span>
                           </p>
                         </li>
                       )


### PR DESCRIPTION
## Targets branch: `walletTableAbstraction`

## Description
- Prevent Info tooltip icon from wrapping on its own by forcing nowrap connection to last word in label
- Fine adjustments to positioning of icons to improve alignment

<img width="948" alt="image" src="https://github.com/user-attachments/assets/c65454e5-3258-49d7-b338-96cebc72321d">

## Related Issue
- #13807
(surfaced during review of product table refactor)

Fixes issues seen here:
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/a533765e-83d4-46e2-a1ec-bc0e88b5c0d8">
