### PR TITLE
Patch: include mocks in Netlify deploys

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -37,3 +37,6 @@
     path = "en/developers/docs/intro-to-ethereum/"
   [[plugins.inputs.audits]]
     path = "en/developers/tutorials/creating-a-wagmi-ui-for-your-contract/"
+
+[functions]
+  included_files = ["src/data/mocks/**/*"]


### PR DESCRIPTION
Currently our page revalidation does not work in preview deploy contexts (or envs using `USE_MOCK_DATA`) because the mocks are not found.

## Description

This PR includes the mock files.