### PR TITLE
migration-RollupProductDevDoc.tsx-to-tailwind

### DIFF
--- a/src/components/RollupProductDevDoc.tsx
+++ b/src/components/RollupProductDevDoc.tsx
@@ -15,7 +15,7 @@ const RollupProductDevDoc = ({ rollupType }: RollupProductDevDocProps) => {
       {rollups[rollupType].map(
         ({ name, noteKey, website, developerDocs, l2beat }, idx) => {
           return (
-            <div key={idx} className="bg-rollupDevDocList my-4">
+            <div key={idx} className="my-4 bg-background-highlight">
               <div className="p-4 pb-0">
                 <div>
                   <h4 className="my-4 text-md font-medium leading-relaxed md:text-xl">
@@ -26,7 +26,7 @@ const RollupProductDevDoc = ({ rollupType }: RollupProductDevDocProps) => {
                       * <Translation id={`page-layer-2:${noteKey}`} />
                     </p>
                   )}
-                  <ul className="list-disc pl-5">
+                  <ul className="list-disc">
                     <li>
                       <InlineLink href={website}>
                         <Translation id="rollup-component-website" />

--- a/src/components/RollupProductDevDoc.tsx
+++ b/src/components/RollupProductDevDoc.tsx
@@ -1,3 +1,5 @@
+import { ListItem, UnorderedList } from "@/components/ui/list"
+
 import { layer2Data, Rollups, RollupType } from "@/data/layer-2/layer-2"
 
 import InlineLink from "./Link"
@@ -26,23 +28,23 @@ const RollupProductDevDoc = ({ rollupType }: RollupProductDevDocProps) => {
                       * <Translation id={`page-layer-2:${noteKey}`} />
                     </p>
                   )}
-                  <ul className="list-disc">
-                    <li>
+                  <UnorderedList>
+                    <ListItem>
                       <InlineLink href={website}>
                         <Translation id="rollup-component-website" />
                       </InlineLink>
-                    </li>
-                    <li>
+                    </ListItem>
+                    <ListItem>
                       <InlineLink href={developerDocs}>
                         <Translation id="rollup-component-developer-docs" />
                       </InlineLink>
-                    </li>
-                    <li>
+                    </ListItem>
+                    <ListItem>
                       <InlineLink href={l2beat}>
                         <Translation id="rollup-component-technology-and-risk-summary" />
                       </InlineLink>
-                    </li>
-                  </ul>
+                    </ListItem>
+                  </UnorderedList>
                 </div>
               </div>
             </div>

--- a/src/components/RollupProductDevDoc.tsx
+++ b/src/components/RollupProductDevDoc.tsx
@@ -1,9 +1,6 @@
-import { Box, Flex, Heading, ListItem, UnorderedList } from "@chakra-ui/react"
-
 import { layer2Data, Rollups, RollupType } from "@/data/layer-2/layer-2"
 
 import InlineLink from "./Link"
-import Text from "./OldText"
 import Translation from "./Translation"
 
 const rollups = layer2Data as Rollups
@@ -14,51 +11,45 @@ export type RollupProductDevDocProps = {
 
 const RollupProductDevDoc = ({ rollupType }: RollupProductDevDocProps) => {
   return (
-    <Box>
+    <div>
       {rollups[rollupType].map(
         ({ name, noteKey, website, developerDocs, l2beat }, idx) => {
           return (
-            <Flex key={idx} my={4} background="rollupDevDocList">
-              <Box p={4} pb={0}>
-                <Box>
-                  <Heading
-                    as="h4"
-                    fontSize={{ base: "md", md: "xl" }}
-                    fontWeight="500"
-                    lineHeight="1.4"
-                    my={4}
-                  >
+            <div key={idx} className="bg-rollupDevDocList my-4">
+              <div className="p-4 pb-0">
+                <div>
+                  <h4 className="my-4 text-md font-medium leading-relaxed md:text-xl">
                     {name}
-                  </Heading>
+                  </h4>
                   {noteKey.length > 0 && (
-                    <Text>
+                    <p>
                       * <Translation id={`page-layer-2:${noteKey}`} />
-                    </Text>
+                    </p>
                   )}
-                  <UnorderedList>
-                    <ListItem>
+                  <ul className="list-disc pl-5">
+                    <li>
                       <InlineLink href={website}>
                         <Translation id="rollup-component-website" />
                       </InlineLink>
-                    </ListItem>
-                    <ListItem>
+                    </li>
+                    <li>
                       <InlineLink href={developerDocs}>
                         <Translation id="rollup-component-developer-docs" />
                       </InlineLink>
-                    </ListItem>
-                    <ListItem>
+                    </li>
+                    <li>
                       <InlineLink href={l2beat}>
                         <Translation id="rollup-component-technology-and-risk-summary" />
                       </InlineLink>
-                    </ListItem>
-                  </UnorderedList>
-                </Box>
-              </Box>
-            </Flex>
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
           )
         }
       )}
-    </Box>
+    </div>
   )
 }
 

--- a/src/components/RollupProductDevDoc.tsx
+++ b/src/components/RollupProductDevDoc.tsx
@@ -24,7 +24,7 @@ const RollupProductDevDoc = ({ rollupType }: RollupProductDevDocProps) => {
                     {name}
                   </h4>
                   {noteKey.length > 0 && (
-                    <p>
+                    <p className="mb-4">
                       * <Translation id={`page-layer-2:${noteKey}`} />
                     </p>
                   )}


### PR DESCRIPTION
migration-RollupProductDevDoc.tsx-to-tailwind
## Description

i migrationed  `RollupProductDevDoc.tsx` to tailwind

**### Snapshot**

localhost:
<img width="1512" alt="截屏2024-10-31 11 13 00" src="https://github.com/user-attachments/assets/9065876b-91ed-4766-a66f-5852eb1b5c27">

ethereum.org:
<img width="1512" alt="截屏2024-10-31 11 13 05" src="https://github.com/user-attachments/assets/5d64dee7-bf31-4b27-86b8-172bb5a98041">


## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/ethereum/ethereum-org-website/issues/13946
