### PR TITLE
Adjust the position of numbers in the OrderedList component

### DIFF
--- a/src/components/OrderedList.tsx
+++ b/src/components/OrderedList.tsx
@@ -21,7 +21,7 @@ const liCustomType: SystemStyleObject = {
   insetInlineStart: "-3rem",
   width: "34px",
   height: "1.6rem",
-  pt: "9px", // adjusts number up and down,
+  pt: "5px", // adjusts number up and down,
   lineHeight: "100%",
   borderRadius: "50%",
   background: "grayBackground",


### PR DESCRIPTION
## Description

Adjust the top margin of the numbers in the OrderedList component from 9px to 5px, making the position of the numbers more centered and visually more harmonious.
This adjustment makes the position of the numbers in the ellipse more natural and improves the overall visual effect.

<img width="537" alt="network" src="https://github.com/user-attachments/assets/e6359401-f7c0-4ad0-a731-401cf0f86a27">
