### PR TITLE
Grammatical and typo corrections

### DIFF
--- a/docs/applying-storybook.md
+++ b/docs/applying-storybook.md
@@ -22,7 +22,7 @@ It's as easy as running `yarn storybook` to boot up a dedicated localhost to see
 
 A Storybook "story" is an instance of a component in a certain state or with certain parameters applied to show an alternative version of the component.
 
-There may be some exceptions, but generally each component should have only on story file.
+There may be some exceptions, but generally each component should have only one story file.
 
 The stories file will reside with each component. So the base folder structure in `src` will look like this:
 

--- a/docs/deploy-process.md
+++ b/docs/deploy-process.md
@@ -6,7 +6,7 @@ Ethereum.org follows a [Gitflow](https://www.atlassian.com/git/tutorials/compari
 
 The current process for deployment involves a 2-day QA cycle to test a release candidate. A release candidate is created on Tuesday, will have 2 days of testing, and then released to production on Thursday assuming no blocking bugs are found.
 
-The typical workflow will be as follows:
+The typical workflow is as follows:
 
 1. A branch is created off of the `dev` branch, and pull requests for the branch are created into `dev`
 2. Pull requests are reviewed, and merged into `dev`

--- a/docs/event-tracking.md
+++ b/docs/event-tracking.md
@@ -37,7 +37,7 @@ It's helpful to ask yourself how the results of what we track and measure might 
 
 Broadly, events should be grouped by specific topic (e.g. L2 page external links, selected bridge, selected cex).
 
-## Each event comprises of 4 hierarchical values:
+## Each event comprises 4 hierarchical values:
 
 1. Category (other events may share the same category if one feature has several actions)
 2. Action

--- a/docs/review-process.md
+++ b/docs/review-process.md
@@ -42,7 +42,7 @@ Typographical and grammatical errors are medium-priority as small errors of this
 
 ### Adding products
 
-Adding new products is currently a low-to-medium priority (depending on the type of product). These pull requests often take a long time to review as we must extensively research products to ensure we not sending our users to any dubious or unsafe products.
+Adding new products is currently a low-to-medium priority (depending on the type of product). These pull requests often take a long time to review as we must extensively research products to ensure we are not sending our users to any dubious or unsafe products.
 
 **Timeline:** PRs should be closed or merged within 30 days of opening.
 


### PR DESCRIPTION
### Added typo corrections to documentation for the following files

`ethereum-org-website/blob/dev/docs/applying-storybook.md`

The word "on" should be "one." The corrected sentence is:
There may be some exceptions, but generally each component should have only one story file.

Corrected.

`ethereum-org-website/blob/dev/docs/deploy-process.md`

The typical workflow will be as follows:
It should be:
The typical workflow is as follows:

This is because the description refers to the current process, so "is" would be the correct tense instead of "will be."

Corrected.

`ethereum-org-website/blob/dev/docs/event-tracking.md`

"Each event comprises of 4 hierarchical values:"
The correct phrase should be:
"Each event comprises 4 hierarchical values:"
The word "comprise" already means "to include," so "of" is unnecessary.

Corrected.

`ethereum-org-website/blob/dev/docs/review-process.md`

There’s a small typo in the "Adding products" section:
"... ensure we not sending our users to any dubious or unsafe products."
It should be:
"... ensure we are not sending our users to any dubious or unsafe products."
The word "are" is missing.

Corrected.

### Goal

Correct grammatical errors and improve readability of the documentation.