### PR TITLE
Typo Update accordion.tsx

### DIFF
--- a/tailwind/ui/accordion.tsx
+++ b/tailwind/ui/accordion.tsx
@@ -33,7 +33,7 @@ const AccordionTrigger = React.forwardRef<
     >
       {children}
       {!hideIcon && (
-        <ChevronNext className="size-[1em] shrink-0 text-2xl transition-transform duration-200" />
+        <ChevronNext className="w-[1em] h-[1em] shrink-0 text-2xl transition-transform duration-200" />
       )}
     </AccordionPrimitive.Trigger>
   </AccordionPrimitive.Header>


### PR DESCRIPTION
## Description

There is a minor typo in the `className` of the `ChevronNext` icon inside the `AccordionTrigger` component.

- In this line:
  ```tsx
  <ChevronNext className="size-[1em] shrink-0 text-2xl transition-transform duration-200" />
  ```
  The `size-[1em]` class is incorrect because `size-[...]` is not a valid Tailwind CSS class. It should likely be `w-[1em] h-[1em]` to set the width and height to `1em`.

**Correction:**
```tsx
<ChevronNext className="w-[1em] h-[1em] shrink-0 text-2xl transition-transform duration-200" />
```

This change correctly applies `1em` size to both the width and height of the icon.

Fixed.
