### PR TITLE
fix: removed redundant minute read text in tutorials [#14248]

### DIFF
--- a/src/components/TutorialMetadata.tsx
+++ b/src/components/TutorialMetadata.tsx
@@ -94,7 +94,7 @@ const TutorialMetadata = ({
         )}
         <Box>
           <Emoji className="me-2 text-sm" text=":stopwatch:" />
-          {timeToRead} {t("comp-tutorial-metadata-minute-read")} minute read
+          {timeToRead} {t("comp-tutorial-metadata-minute-read")}
         </Box>
       </HStack>
       <HStack


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed redundancy in the read time display text in tutorials. Previously, the text displayed as "t minute read minute read." This change ensures that the text now displays correctly as "t minute read" without duplication.

## Related Issue

Issue solved: #14248 