### PR TITLE
Fix `maxDeposit` and `maxMint` on the 4626 page

### DIFF
--- a/public/content/developers/docs/standards/tokens/erc-4626/index.md
+++ b/public/content/developers/docs/standards/tokens/erc-4626/index.md
@@ -62,7 +62,7 @@ This function returns the amount of `assets` that would be exchanged by the vaul
 function maxDeposit(address receiver) public view returns (uint256 maxAssets)
 ```
 
-This function returns the maximum amount of underlying assets that can be deposited in a single [`deposit`](#deposit) call by the `receiver`.
+This function returns the maximum amount of underlying assets that can be deposited in a single [`deposit`](#deposit) call, with the shares minted for the `receiver`.
 
 #### previewDeposit {#previewdeposit}
 
@@ -86,7 +86,7 @@ This function deposits `assets` of underlying tokens into the vault and grants o
 function maxMint(address receiver) public view returns (uint256 maxShares)
 ```
 
-This function returns the maximum amount of shares that can be minted in a single [`mint`](#mint) call by the `receiver`.
+This function returns the maximum amount of shares that can be minted in a single [`mint`](#mint) call, with the shares minted for the `receiver`.
 
 #### previewMint {#previewmint}
 


### PR DESCRIPTION
## Description

Fix the description of the `maxDeposit` and `maxMint` sections to match faithfully the 4626 standard.

See the [original EIP](https://github.com/ethereum/ercs/blob/master/ERCS/erc-4626.md#maxdeposit), in that it specifies that the function return is calculated with `receiver` being the receiver of the shares, and not necessarily the caller:

The idea is to allow enabling blocklists at the vault level. If you are going to restrict holding vault shares by certain addresses, you would stop it both at transfer and deposit/mint. The maxDeposit/maxMint should reflect that.

It is a bit arbitrary, because blocklists could also be implemented on the function caller, and not just the token receiver, but that's what it is.
