### PR TITLE
Updated further reading section of DA page

### DIFF
--- a/public/content/developers/docs/data-availability/index.md
+++ b/public/content/developers/docs/data-availability/index.md
@@ -81,4 +81,5 @@ The core Ethereum protocol is primarily concerned with data availability, not da
 - [Data availability committees.](https://medium.com/starkware/data-availability-e5564c416424)
 - [Proof-of-stake data availability committees.](https://blog.matter-labs.io/zkporter-a-breakthrough-in-l2-scaling-ed5e48842fbf)
 - [Solutions to the data retrievability problem](https://notes.ethereum.org/@vbuterin/data_sharding_roadmap#Who-would-store-historical-data-under-sharding)
-- [Data Availability Or: How Rollups Learned To Stop Worrying And Love Ethereum](https://ethereum2077.substack.com/p/data-availability-in-ethereum-rollups) 
+- [Data Availability Or: How Rollups Learned To Stop Worrying And Love Ethereum](https://research.2077.xyz/data-availability-or-how-rollups-learned-to-stop-worrying-and-love-ethereum)
+- [EIP-7623: Increasing Calldata Cost](https://research.2077.xyz/eip-7623-increase-calldata-cost)


### PR DESCRIPTION
- Updated a resource in the further reading section to reflect content moving from [Ethereum 2077](https://ethereum2077.substack.com/) to [2077 Research](https://research.2077.xyz/). 
- Added an explainer on [EIP-7623](https://eips.ethereum.org/EIPS/eip-7623)--a proposal to increase cost of calldata and push rollups towards using blobs (as well as bound maximum block sizes)
