### PR TITLE
Update further reading section on scaling page

### DIFF
--- a/public/content/developers/docs/scaling/index.md
+++ b/public/content/developers/docs/scaling/index.md
@@ -109,6 +109,7 @@ _Note the explanation in the video uses the term "Layer 2" to refer to all off-c
 - [Zero-Knowledge Blockchain Scalability](https://ethworks.io/assets/download/zero-knowledge-blockchain-scaling-ethworks.pdf)
 - [Why rollups + data shards are the only sustainable solution for high scalability](https://polynya.medium.com/why-rollups-data-shards-are-the-only-sustainable-solution-for-high-scalability-c9aabd6fbb48)
 - [What kind of Layer 3s make sense?](https://vitalik.eth.limo/general/2022/09/17/layer_3.html)
-- [Data Availability Or: How Rollups Learned To Stop Worrying And Love Ethereum](https://ethereum2077.substack.com/p/data-availability-in-ethereum-rollups)
+- [Data Availability Or: How Rollups Learned To Stop Worrying And Love Ethereum](https://research.2077.xyz/data-availability-or-how-rollups-learned-to-stop-worrying-and-love-ethereum)
+- [The Practical Guide to Ethereum Rollups](https://research.2077.xyz/the-practical-guide-to-ethereum-rollups)
 
 _Know of a community resource that helped you? Edit this page and add it!_


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

- Updated a resource in the further reading section to reflect content moving from [Ethereum 2077](https://ethereum2077.substack.com/) to [2077 Research](https://research.2077.xyz/).
- Added a comprehensive article analyzing the different types of rollups (including newer designs like sovereign rollups)