### PR TITLE
chore(update): update backlink in further reading section

### DIFF
--- a/public/content/developers/docs/data-availability/index.md
+++ b/public/content/developers/docs/data-availability/index.md
@@ -81,4 +81,4 @@ The core Ethereum protocol is primarily concerned with data availability, not da
 - [Data availability committees.](https://medium.com/starkware/data-availability-e5564c416424)
 - [Proof-of-stake data availability committees.](https://blog.matter-labs.io/zkporter-a-breakthrough-in-l2-scaling-ed5e48842fbf)
 - [Solutions to the data retrievability problem](https://notes.ethereum.org/@vbuterin/data_sharding_roadmap#Who-would-store-historical-data-under-sharding)
-- [Data Availability Or: How Rollups Learned To Stop Worrying And Love Ethereum](https://ethereum2077.substack.com/p/data-availability-in-ethereum-rollups) 
+- [Data Availability Or: How Rollups Learned To Stop Worrying And Love Ethereum](https://research.2077.xyz/data-availability-or-how-rollups-learned-to-stop-worrying-and-love-ethereum) 


### PR DESCRIPTION
## Description

This pull request updates the link to the "Data Availability Or: How Rollups Learned To Stop Worrying And Love Ethereum" article, pointing it to the new website. We've migrated our articles to the updated platform, and the version hosted on 2077 Research is the most up-to-date. This change ensures users are directed to the latest content, improving the accuracy and accessibility of our information.

## Related Issue

This change is part of the ongoing migration of articles to the new website.
