### PR TITLE
Fix grammar and spelling errors in `typescript.md` and Indonesian translations (`index.md`)

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -14,7 +14,7 @@ const someVar: string = 'string'
 const someVar = 'string'
 ```
 
-Do declare a type for an unassigned variable when a type can not be inferred.
+Do declare a type for an unassigned variable when a type cannot be inferred.
 
 ```
 const someVar: string

--- a/public/content/translations/ms/dao/index.md
+++ b/public/content/translations/ms/dao/index.md
@@ -34,7 +34,7 @@ Ini membuka begitu banyak peluang baharu untuk kerjasama dan penyelarasan global
 | Undian diperlukan oleh ahli untuk sebarang perubahan dilaksanakan.                                                             | Bergantung kepada struktur, perubahan boleh dituntut daripada parti tunggal, atau undian boleh ditawarkan.  |
 | Undi dikira, dan hasil dilaksanakan secara automatik tanpa perantara yang dipercayai.                                          | Jika undi dibenarkan, undian akan dikira secara dalaman, dan hasil undian mesti dikendalikan secara manual. |
 | Perkhidmatan yang ditawarkan dikendalikan secara automatik dengan cara terdesentralisasi (contohnya pengedaran dana dermawan). | Memerlukan pengendalian manusia, atau automasi terkawal secara pusat, terdedah pada manipulasi.             |
-| Semua aktiviti iadalah telus dan umum sepenuhnya.                                                                              | Aktiviti biasanya peribadi, dan terhad kepada orang ramai.                                                  |
+| Semua aktiviti adalah telus dan umum sepenuhnya.                                                                               | Aktiviti biasanya peribadi, dan terhad kepada orang ramai.                                                  |
 
 ### Contoh DAO {#dao-examples}
 

--- a/public/content/translations/ms/defi/index.md
+++ b/public/content/translations/ms/defi/index.md
@@ -139,7 +139,7 @@ Ini membolehkan anda meminjam wang tanpa semakan kredit atau menyerahkan makluma
 
 #### Akses kepada dana global {#access-global-funds}
 
-Apabila anda menggunakan pemberi pinjaman teragih, anda mempunyai akses kepada dana yang didepositkan dari seluruh dunia, bukan hanya dana dalam jagaan bank atau institusi pilihan anda. Ini menjadikan pinjaman lebih mudah diakses dan manjadikan kadar faedah lebih baik.
+Apabila anda menggunakan pemberi pinjaman teragih, anda mempunyai akses kepada dana yang didepositkan dari seluruh dunia, bukan hanya dana dalam jagaan bank atau institusi pilihan anda. Ini menjadikan pinjaman lebih mudah diakses dan menjadikan kadar faedah lebih baik.
 
 #### Kecekapan cukai {#tax-efficiencies}
 
@@ -245,7 +245,7 @@ Contoh yang baik ialah [dana DeFi Pulse Index (DPI)](https://defipulse.com/blog/
 
 ### Biayai idea anda {#crowdfunding}
 
-Ethereum ialah platform yang cermerlang untuk pendanaan awam:
+Ethereum ialah platform yang cemerlang untuk pendanaan awam:
 
 - Pembiaya yang berpotensi boleh datang dari mana-mana sahaja – Ethereum dan tokennya terbuka kepada sesiapa sahaja, di mana-mana sahaja di dunia.
 - Ia telus supaya pengumpul dana dapat membuktikan jumlah wang yang telah dikumpulkan. Anda juga boleh menjejaki cara dana dibelanjakan kemudiannya.


### PR DESCRIPTION
### PR Description

This pull request includes the following changes:

1. **`typescript.md`**:
   - Corrected grammar in a comment:
     - Changed: `type can not `
     - To: `type cannot `

2. **`index.md` **:
   - Fixed a spelling issue:
     - Changed: `manjadikan `
     - To: `menjadikan `
   - Adjusted wording for clarity:
     - Changed: `cermerlang `
     - To: `cemerlang `

3. **`index.md` **:
   - Corrected duplication:
      - Changed: `iadalah `
      - To: `adalah `

These edits aim to improve accuracy and consistency in both English and Indonesian documentation.
