### PR TITLE
Add Account Abstraction Roadmap article

### DIFF
--- a/public/content/roadmap/account-abstraction/index.md
+++ b/public/content/roadmap/account-abstraction/index.md
@@ -124,3 +124,4 @@ Smart contract wallets are already available, but more upgrades are required to 
 - [EIP-4337 documentation](https://eips.ethereum.org/EIPS/eip-4337)
 - [EIP-2771 documentation](https://eips.ethereum.org/EIPS/eip-2771)
 - ["Basics of Account Abstraction" -- What is Account Abstraction Part I](https://www.alchemy.com/blog/account-abstraction)
+- [Charting Ethereum's Account Abstraction Roadmap I: EIP-3074 & EIP-7702](https://research.2077.xyz/charting-ethereums-account-abstraction-roadmap-i-eip-3074-eip-7702)


### PR DESCRIPTION
Adding a comprehensive article about Ethereum's Account Abstraction roadmap and proposals.

[Charting Ethereum's Account Abstraction Roadmap](https://research.2077.xyz/charting-ethereums-account-abstraction-roadmap-i-eip-3074-eip-7702) - An in-depth exploration of Ethereum's Account Abstraction evolution, analyzing key proposals like EIP-3074 and EIP-7702.