### PR TITLE
workflow: updates to actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/generate-review-report.yml
+++ b/.github/workflows/generate-review-report.yml
@@ -28,7 +28,7 @@ jobs:
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
 
       - name: Upload output as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: output
           path: ./src/data/crowdin/bucketsAwaitingReviewReport.csv


### PR DESCRIPTION
## Description
- Updates to using `actions/upload-artifact@v4`
- `actions/upload-artifact@v2` deprecated

https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/


## Related issue
Fixes:
<img width="714" alt="image" src="https://github.com/user-attachments/assets/f4544393-720a-4560-873c-0dad411065fb">
