### PR TITLE
Fix typos and grammar in various tutorial files

### DIFF
--- a/public/content/contributing/adding-glossary-terms/index.md
+++ b/public/content/contributing/adding-glossary-terms/index.md
@@ -6,7 +6,7 @@ description: Our criteria for adding new terms to the ethereum.org glossary
 
 # Adding glossary terms {#contributing-to-ethereumorg-}
 
-This space is changing every day. New terms are constantly entering the lexicon of Ethereum users, and we need your help providing an accurate, up to date reference for all things Ethereum. Check out the current [glossary](/glossary/) and see below if you want to help!
+This space is changing every day. New terms are constantly entering the lexicon of Ethereum users, and we need your help providing an accurate, up-to-date reference for all things Ethereum. Check out the current [glossary](/glossary/) and see below if you want to help!
 
 ## Criteria {#criteria}
 

--- a/public/content/decentralized-identity/index.md
+++ b/public/content/decentralized-identity/index.md
@@ -125,7 +125,7 @@ One concern with storing attestations on-chain is that they might contain inform
 
 The solution is to issue attestations, held by users off-chain in digital wallets, but signed with the issuer's DID stored on-chain. These attestations are encoded as [JSON Web Tokens](https://en.wikipedia.org/wiki/JSON_Web_Token) and contain the issuer's digital signature—which allows for easy verification of off-chain claims.
 
-Here's an hypothetical scenario to explain off-chain attestations:
+Here's a hypothetical scenario to explain off-chain attestations:
 
 1. A university (the issuer) generates an attestation (a digital academic certificate), signs with its keys, and issues it to Bob (the identity owner).
 

--- a/public/content/developers/docs/nodes-and-clients/client-diversity/index.md
+++ b/public/content/developers/docs/nodes-and-clients/client-diversity/index.md
@@ -48,7 +48,7 @@ The two pie charts above show snapshots of the current client diversity for the 
 
 The execution layer data were obtained from [Ethernodes](https://ethernodes.org) on 23-Jan-2022. Data for consensus clients was obtained from [Michael Sproul](https://github.com/sigp/blockprint). Consensus client data is more difficult to obtain because the consensus layer clients do not always have unambiguous traces that can be used to identify them. The data was generated using a classification algorithm that sometimes confuses some of the minority clients (see [here](https://twitter.com/sproulM_/status/1440512518242197516) for more details). In the diagram above, these ambiguous classifications are treated with an either/or label (e.g. Nimbus/Teku). Nevertheless, it is clear that the majority of the network is running Prysm. The data is a snapshot over a fixed set of blocks (in this case Beacon blocks in slots 2048001 to 2164916) and Prysm's dominance has sometimes been higher, exceeding 68%. Despite only being snapshots, the values in the diagram provide a good general sense of the current state of client diversity.
 
-Up to date client diversity data for the consensus layer is now available at [clientdiversity.org](https://clientdiversity.org/).
+Up-to-date client diversity data for the consensus layer is now available at [clientdiversity.org](https://clientdiversity.org/).
 
 ## Execution layer {#execution-layer}
 

--- a/public/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
+++ b/public/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
@@ -73,7 +73,7 @@ Here is a list of some of the most popular Ethereum node providers, feel free to
     - Unlimited access to archive date
     - 24/7 technical support and 99.9% over uptime
     - Faucet available on multi chains
-    - Unlimited endpoint access with an limitless number of API keys
+    - Unlimited endpoint access with a limitless number of API keys
     - Trace/Debug API supported
     - Automated updates
 

--- a/public/content/developers/tutorials/guide-to-smart-contract-security-tools/index.md
+++ b/public/content/developers/tutorials/guide-to-smart-contract-security-tools/index.md
@@ -78,7 +78,7 @@ The broad areas that are frequently relevant for smart contracts include:
 
 - **External interactions.** Contracts interact with each other, and some external contracts should not be trusted. For example, if your contract relies on external oracles, will it remain secure if half the available oracles are compromised?
 
-  - Manticore and Echidna are the best choice for testing external interactions with your contracts. Manticore has an built-in mechanism to stub external contracts.
+  - Manticore and Echidna are the best choice for testing external interactions with your contracts. Manticore has a built-in mechanism to stub external contracts.
 
 - **Standard conformance.** Ethereum standards (e.g. ERC20) have a history of flaws in their design. Be aware of the limitations of the standard you are building on.
   - Slither, Echidna, and Manticore will help you to detect deviations from a given standard.

--- a/public/content/developers/tutorials/how-to-use-manticore-to-find-smart-contract-bugs/index.md
+++ b/public/content/developers/tutorials/how-to-use-manticore-to-find-smart-contract-bugs/index.md
@@ -185,7 +185,7 @@ Here Manticore founds 7 test cases, which correspond to (the filename order may 
 
 _Exploration summary f(!=65) denotes f called with any value different than 65._
 
-As you can notice, Manticore generates an unique test case for every successful or reverted transaction.
+As you can notice, Manticore generates a unique test case for every successful or reverted transaction.
 
 Use the `--quick-mode` flag if you want fast code exploration (it disable bug detectors, gas computation, ...)
 

--- a/public/content/developers/tutorials/how-to-use-slither-to-find-smart-contract-bugs/index.md
+++ b/public/content/developers/tutorials/how-to-use-slither-to-find-smart-contract-bugs/index.md
@@ -120,7 +120,7 @@ class HasAddition(ExpressionVisitor):
             self._result = True
 
 visitor = HasAddition(expression) # expression is the expression to be tested
-print(f'The expression {expression} has a addition: {visitor.result()}')
+print(f'The expression {expression} has an addition: {visitor.result()}')
 ```
 
 ### Control Flow Graph (CFG) {#control-flow-graph-cfg}

--- a/public/content/developers/tutorials/token-integration-checklist/index.md
+++ b/public/content/developers/tutorials/token-integration-checklist/index.md
@@ -41,7 +41,7 @@ Slither includes a utility, [slither-check-erc](https://github.com/crytic/slithe
 
 - **Transfer and transferFrom return a boolean.** Several tokens do not return a boolean on these functions. As a result, their calls in the contract might fail.
 - **The name, decimals, and symbol functions are present if used.** These functions are optional in the ERC20 standard and might not be present.
-- **Decimals returns a uint8.** Several tokens incorrectly return an uint256. If this is the case, ensure the value returned is below 255.
+- **Decimals returns an uint8.** Several tokens incorrectly return an uint256. If this is the case, ensure the value returned is below 255.
 - **The token mitigates the known [ERC20 race condition](https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729).** The ERC20 standard has a known ERC20 race condition that must be mitigated to prevent attackers from stealing tokens.
 - **The token is not an ERC777 token and has no external function call in transfer and transferFrom.** External calls in the transfer functions can lead to reentrancies.
 

--- a/public/content/developers/tutorials/token-integration-checklist/index.md
+++ b/public/content/developers/tutorials/token-integration-checklist/index.md
@@ -41,7 +41,7 @@ Slither includes a utility, [slither-check-erc](https://github.com/crytic/slithe
 
 - **Transfer and transferFrom return a boolean.** Several tokens do not return a boolean on these functions. As a result, their calls in the contract might fail.
 - **The name, decimals, and symbol functions are present if used.** These functions are optional in the ERC20 standard and might not be present.
-- **Decimals returns a uint8.** Several tokens incorrectly return a uint256. If this is the case, ensure the value returned is below 255.
+- **Decimals returns a uint8.** Several tokens incorrectly return an uint256. If this is the case, ensure the value returned is below 255.
 - **The token mitigates the known [ERC20 race condition](https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729).** The ERC20 standard has a known ERC20 race condition that must be mitigated to prevent attackers from stealing tokens.
 - **The token is not an ERC777 token and has no external function call in transfer and transferFrom.** External calls in the transfer functions can lead to reentrancies.
 

--- a/public/content/developers/tutorials/using-websockets/index.md
+++ b/public/content/developers/tutorials/using-websockets/index.md
@@ -41,7 +41,7 @@ To begin, open a WebSocket using the WebSocket URL for your app. You can find yo
 
 ![Where to find your WebSocket URL in your Alchemy dashboard](./use-websockets.gif)
 
-Any of the APIs listed in the [Alchemy API Reference](https://docs.alchemyapi.io/documentation/alchemy-api-reference/) can be used via WebSocket. To do so, use the same payload that would be sent as the body of a HTTP POST request, but instead send that payload through the WebSocket.
+Any of the APIs listed in the [Alchemy API Reference](https://docs.alchemyapi.io/documentation/alchemy-api-reference/) can be used via WebSocket. To do so, use the same payload that would be sent as the body of an HTTP POST request, but instead send that payload through the WebSocket.
 
 ## With Web3 {#with-web3}
 

--- a/public/content/guides/how-to-id-scam-tokens/index.md
+++ b/public/content/guides/how-to-id-scam-tokens/index.md
@@ -73,7 +73,7 @@ The best practice for avoiding this is to carefully check the URL for the sites 
 
 2. **Real tokens have liquidity**. Another option is to look at liquidity pool size on [Uniswap](https://uniswap.org/), one of the most common token swapping protocols. This protocol works using liquidity pools, into which investors deposit their tokens in hope of a return from trading fees.
 
-Scam tokens typically have tiny liquidity pools, if any, because the scammers don't want to risk real assets. For example, the `ARB`/`ETH` Uniswap pool holds about a million dollars ([see here for the up to date value](https://info.uniswap.org/#/pools/0x755e5a186f0469583bd2e80d1216e02ab88ec6ca)) and buying or selling a small amount is not going to change the price:
+Scam tokens typically have tiny liquidity pools, if any, because the scammers don't want to risk real assets. For example, the `ARB`/`ETH` Uniswap pool holds about a million dollars ([see here for the up-to-date value](https://info.uniswap.org/#/pools/0x755e5a186f0469583bd2e80d1216e02ab88ec6ca)) and buying or selling a small amount is not going to change the price:
 
 ![Buying a legitimate token](./uniswap-real.png)
 


### PR DESCRIPTION
This PR addresses several typos and grammar issues in multiple tutorial files across the project. Key changes include:
- Correction of article usage, such as replacing "a" with "an" before words starting with vowel sounds.
- Minor punctuation and phrasing improvements for clarity and consistency.

## Files Updated:
- `index.md` (multiple files)

