### PR TITLE
Update Binance US exchange availability by state

### DIFF
--- a/src/hooks/useCentralizedExchanges.ts
+++ b/src/hooks/useCentralizedExchanges.ts
@@ -118,7 +118,25 @@ const exchanges: ExchangeDetails = {
     name: "Binance US",
     url: "https://www.binance.us/",
     image: binance,
-    usaExceptions: ["HI", "ID", "NY", "TX", "VT"],
+    // Updated Dec 4th 2024 https://support.binance.us/hc/en-us/articles/360046786914-List-of-supported-states-and-regions
+    usaExceptions: [
+      "AK", // Alaska
+      "AS", // American Samoa
+      "CT", // Connecticut
+      "GA", // Georgia
+      "GU", // Guam
+      "ME", // Maine
+      "MP", // Northern Mariana Islands
+      "NY", // New York
+      "NC", // North Carolina
+      "ND", // North Dakota
+      "OH", // Ohio
+      "OR", // Oregon
+      "TX", // Texas
+      "VI", // U.S. Virgin Islands
+      "VT", // Vermont
+      "WA", // Washington
+    ],
   },
   bitbuy: {
     name: "Bitbuy",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updated the `usaExceptions` list for `binanceus` to reflect the most current list of unsupported states and territories, including:
- Alaska (AK)
- American Samoa (AS)
- Connecticut (CT)
- Georgia (GA)
- Guam (GU)
- Maine (ME)
- Northern Mariana Islands (MP)
- New York (NY)
- North Carolina (NC)
- North Dakota (ND)
- Ohio (OH)
- Oregon (OR)
- Texas (TX)
- U.S. Virgin Islands (VI)
- Vermont (VT)
- Washington (WA)

## Related Issue
None
