### PR TITLE
Remove trailing comma after the last property in manifest.json

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -38,5 +38,5 @@
       ]
     }
   ],
-  "description": "Ethereum is a global, decentralized platform for money and new kinds of applications. On Ethereum, you can write code that controls money, and build applications accessible anywhere in the world.",
+  "description": "Ethereum is a global, decentralized platform for money and new kinds of applications. On Ethereum, you can write code that controls money, and build applications accessible anywhere in the world."
 }


### PR DESCRIPTION
The manifest.json file contains a trailing comma after the last property ("description"), which is not allowed in JSON.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
