### PR TITLE
Switch to weekly active addresses and smaller growthepie API endpoint

### DIFF
--- a/src/lib/api/fetchGrowThePie.ts
+++ b/src/lib/api/fetchGrowThePie.ts
@@ -11,12 +11,12 @@ const TXCOSTS_MEDIAN_USD = "txcosts_median_usd"
 const TXCOUNT = "txcount"
 
 export const fetchGrowThePie = async (): Promise<GrowThePieData> => {
-  const url = "https://api.growthepie.xyz/v1/fundamentals_full.json"
+  const url = "https://api.growthepie.xyz/v1/fundamentals.json"
 
   const response = await fetch(url)
   if (!response.ok) {
     console.log(response.status, response.statusText)
-    throw new Error("Failed to fetch GrowThePie data")
+    throw new Error("Failed to fetch growthepie data")
   }
   const data: DataItem[] = await response.json()
 
@@ -27,7 +27,7 @@ export const fetchGrowThePie = async (): Promise<GrowThePieData> => {
 
   const activeAddresses = data
     .filter((item) => item.date === mostRecentDate)
-    .filter((item) => item.metric_key === "daa")
+    .filter((item) => item.metric_key === "aa_last7d")
     .reduce((acc, item) => {
       return {
         ...acc,


### PR DESCRIPTION
Switch to weekly active addresses and smaller growthepie API endpoint

## Description

- switching to "fundamentals" endpoint instead of "fundamentals_full" - it's a smaller endpoint but still has all required data.
- using "aa_last7d" (Active Addresses last 7 days) instead of "daa" (Daily Active Addresses) since you are referring to this datapoint as weekly active addresses on your page
- small naming fix "growthepie" is how we ideally refer to our platform :)
