### PR TITLE
refactor: correct example trie structure

### DIFF
--- a/public/content/developers/docs/data-structures-and-encoding/patricia-merkle-trie/index.md
+++ b/public/content/developers/docs/data-structures-and-encoding/patricia-merkle-trie/index.md
@@ -179,8 +179,7 @@ Now, we build such a trie with the following key/value pairs in the underlying D
     rootHash: [ <16>, hashA ]
     hashA:    [ <>, <>, <>, <>, hashB, <>, <>, <>, [ <20 6f 72 73 65>, 'stallion' ], <>, <>, <>, <>, <>, <>, <>, <> ]
     hashB:    [ <00 6f>, hashC ]
-    hashC:    [ <>, <>, <>, <>, <>, <>, hashD, <>, <>, <>, <>, <>, <>, <>, <>, <>, 'verb' ]
-    hashD:    [ <17>, [ <>, <>, <>, <>, <>, <>, [ <35>, 'coins' ], <>, <>, <>, <>, <>, <>, <>, <>, <>, 'puppy' ] ]
+    hashC:    [ <>, <>, <>, <>, <>, <>, [ <17>, [ <>, <>, <>, <>, <>, <>, [ <35>, 'coins' ], <>, <>, <>, <>, <>, <>, <>, <>, <>, 'puppy' ] ], <>, <>, <>, <>, <>, <>, <>, <>, <>, 'verb' ]
 ```
 
 When one node is referenced inside another node, what is included is `H(rlp.encode(node))`, where `H(x) = keccak256(x) if len(x) >= 32 else x` and `rlp.encode` is the [RLP](/developers/docs/data-structures-and-encoding/rlp) encoding function.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

For Merkle-Patricia Trie, when data does not exceed 32 bytes, it is stored in the node directly without hashing. This change fixes the example trie structure to align with this concept.
