### PR TITLE
Fix Broken Link on Decentralized finance (DeFi).

### DIFF
--- a/public/content/defi/index.md
+++ b/public/content/defi/index.md
@@ -168,7 +168,7 @@ If exchange B's supply dropped suddenly and the user wasn't able to buy enough t
 
 To be able to do the above example in the traditional finance world, you'd need an enormous amount of money. These money-making strategies are only accessible to those with existing wealth. Flash loans are an example of a future where having money is not necessarily a prerequisite for making money.
 
-<ButtonLink isSecondary href="https://aave.com/flash-loans/">
+<ButtonLink isSecondary href="https://aave.com/docs/concepts/flash-loans">
   More on flash loans
 </ButtonLink>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Bug: The link to 'More on flash loans' on the Ethereum website leads to a 404 error page instead of the intended Aave documentation. This broken link prevents users from accessing detailed information about flash loans.

This PR replace the following links:
old link: https://aave.com/flash-loans
new link: https://aave.com/docs/concepts/flash-loans


<!--- Describe your changes in detail -->

## Related Issue

#14481 