### PR TITLE
Removing Broken Link on Introduction to smart contracts page

### DIFF
--- a/public/content/smart-contracts/index.md
+++ b/public/content/smart-contracts/index.md
@@ -76,7 +76,6 @@ They can perform computations, create currency, store data, mint [NFTs](/glossar
 ## Further reading {#further-reading}
 
 - [How Smart Contracts Will Change the World](https://www.youtube.com/watch?v=pA6CGuXEKtQ)
-- [Smart Contracts: The Blockchain Technology That Will Replace Lawyers](https://blockgeeks.com/guides/smart-contracts/)
 - [Smart contracts for developers](/developers/docs/smart-contracts/)
 - [Learn to write smart-contracts](/developers/learning-tools/)
 - [Mastering Ethereum - What is a Smart Contract?](https://github.com/ethereumbook/ethereumbook/blob/develop/07smart-contracts-solidity.asciidoc#what-is-a-smart-contract)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The link to the article 'Smart Contracts: The Blockchain Technology That Will Replace Lawyers' on the Ethereum website points to the Blockgeeks website, but the destination website is offline, making the content inaccessible.

The original article can be found on the webarchive but there is no other site that has published it. 

That's why I suggest removing it from the page.

<!--- Describe your changes in detail -->

## Related Issue
#14482 

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
