### PR TITLE
changes in content

### DIFF
--- a/public/content/developers/docs/smart-contracts/testing/index.md
+++ b/public/content/developers/docs/smart-contracts/testing/index.md
@@ -130,7 +130,7 @@ Many unit testing frameworks allow you to create assertions—simple statements 
 
 ##### 3. Measure code coverage
 
-[Code coverage](https://en.m.wikipedia.org/wiki/Code_coverage) is a testing metric that tracks the number of branches, lines, and statements in your code executed during tests. Tests should have good code coverage, otherwise you may get "false negatives" which happen a contract passes all tests, but vulnerabilities still exist in the code. Recording high code coverage, however, gives the assurance all statements/functions in a smart contract were sufficiently tested for correctness.
+[Code coverage](https://en.m.wikipedia.org/wiki/Code_coverage) is a testing metric that tracks the number of branches, lines, and statements in your code executed during tests. Tests should have good code coverage to minimize the risk of untested vulnerabilities. Without sufficient coverage, you might falsely assume your contract is secure because all tests pass, while vulnerabilities still exist in untested code paths. Recording high code coverage, however, gives the assurance all statements/functions in a smart contract were sufficiently tested for correctness.
 
 ##### 4. Use well-developed testing frameworks
 


### PR DESCRIPTION
The following content seems to be partially correct and could use some clarification. The path to the content is:
public/content/developers/docs/smart-contracts/testing
The content is:
"Tests should have good code coverage, otherwise you may get "false negatives" which happen a contract passes all tests, but vulnerabilities still exist in the code."
The rewrite for the above text should go like:
"Tests should have good code coverage to minimize the risk of untested vulnerabilities. Without sufficient coverage, you might falsely assume your contract is secure because all tests pass, while vulnerabilities still exist in untested code paths."
Explanation:

Code Coverage and "False Negatives":
Code coverage measures how much of your code is executed during testing. High code coverage ensures that most (or all) lines of your code have been tested at least once.
Low code coverage can indeed lead to untested portions of code where vulnerabilities or bugs may reside. This might create a false sense of security, as your tests pass without actually verifying the behavior of the untested code.

Misinterpretation of "False Negatives":
Technically, a false negative in testing occurs when the test fails to detect an issue that exists. In the context of your statement, what you're describing is not a "false negative" but rather uncovered vulnerabilities or bugs due to inadequate test coverage.
