### PR TITLE
Adding ProbeLab's Weekly Reports

### DIFF
--- a/public/content/developers/docs/nodes-and-clients/index.md
+++ b/public/content/developers/docs/nodes-and-clients/index.md
@@ -49,6 +49,7 @@ Multiple trackers offer a real-time overview of nodes in the Ethereum network. N
 - [Ethernodes](https://ethernodes.org/) by Bitfly
 - [Nodewatch](https://www.nodewatch.io/) by Chainsafe, crawling consensus nodes
 - [Monitoreth](https://monitoreth.io/) - by MigaLabs, A distributed network monitoring tool
+- [Weekly Network Health Reports](https://probelab.io) - by ProbeLab, Using the [Nebula crawler](https://github.com/dennis-tra/nebula) and other tools
 
 ## Node types {#node-types}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The ProbeLab team (https://probelab.io) is crawling the CL of Ethereum, using the Nebula crawler (https://github.com/dennis-tra/nebula) and creating weekly reports that include several metrics for the P2P network. We believe the metrics would be of interest to the community and the developers.

The latest report can be found here: https://probelab.io/ethereum/discv5/2024-50/ and the methodology here: https://probelab.io/ethereum/discv5/methodology/.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

There is no issue related to this PR, as the work to deploy and run the crawler has already been done and reports are live (published every Monday).