### PR TITLE
Updated ETHCluj event date

### DIFF
--- a/src/data/community-events.json
+++ b/src/data/community-events.json
@@ -1004,10 +1004,10 @@
   },
   {
     "title": "ETHCluj",
-    "startDate": "2025-06-19",
-    "endDate": "2025-06-21",
+    "startDate": "2025-06-26",
+    "endDate": "2025-06-28",
     "href": "https://www.ethcluj.org/",
-    "location": "Cluj-Napoca, ROU",
+    "location": "Cluj-Napoca, Romania",
     "description": "ETHCluj 2025 - Ethereum for everyone conference ",
     "imageUrl": "https://framerusercontent.com/images/rHUxnoTTgyhaJqvDh9ZbOPH2Dd0.jpg"
   },


### PR DESCRIPTION
ETHCluj date shifted by one week. Updated according to the official website: [ethcluj.org](https://www.ethcluj.org) 

## Description

Updated ETHCluj start and end dates in `community-events.json`. Also changed the country code (ROU) to country full name (Romania) just as Eth Bucharest. 

## Related Issue
#14484