### PR TITLE
fix: Correct invalid duration-25 value in TailwindCSS classes

### DIFF
--- a/src/components/DataTable/index.tsx
+++ b/src/components/DataTable/index.tsx
@@ -137,7 +137,7 @@ const DataTable = <TData, TValue>({
       </div>
       <Table {...props}>
         <TableBody
-          className={`duration-25 transition-opacity ${
+          className={`duration-75 transition-opacity ${
             isVisible ? "opacity-100" : "opacity-0"
           }`}
         >


### PR DESCRIPTION

## Description

My update resolves an issue where the non-standard value `duration-25` was used in a TailwindCSS class. TailwindCSS only supports predefined duration values such as `duration-75`, `duration-100`, `duration-200`, etc.  

The incorrect `duration-25` value has been replaced with a valid option to ensure compatibility with the framework. This adjustment aligns the code with TailwindCSS conventions and avoids potential styling inconsistencies.  

Thanks!

