### PR TITLE
update community meetup title and url

### DIFF
--- a/src/data/community-meetups.json
+++ b/src/data/community-meetups.json
@@ -258,10 +258,10 @@
     "link": "https://www.meetup.com/Cape-Town-Ethereum-Meetup/"
   },
   {
-    "title": "Jeju Blockchain Meetup",
+    "title": "Ethereum Jeju",
     "emoji": ":south_korea:",
     "location": "Jeju",
-    "link": "https://www.meetup.com/Jeju-Blockchain-Meetup"
+    "link": "https://www.meetup.com/Ethereum-Jeju"
   },
   {
     "title": "Seoul Ethereum Meetup",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Updated the title and link for the Jeju Blockchain Meetup in the community-meetups.json file to reflect the new name and URL.
- The title was changed from "Jeju Blockchain Meetup" to "Ethereum Jeju".
- The link was updated from "https://www.meetup.com/Jeju-Blockchain-Meetup" to "https://www.meetup.com/Ethereum-Jeju".

## Related Issue
