### PR TITLE
issue #14561 issue fixed, spelling corrected

### DIFF
--- a/src/intl/en/page-learn.json
+++ b/src/intl/en/page-learn.json
@@ -35,7 +35,7 @@
   "find-a-wallet-card-description": "Browse wallets based on the features that matter to you.",
   "find-a-wallet-button": "List of wallets",
   "ethereum-networks-card-title": "Ethereum networks",
-  "ethereum-networks-card-description": "Save money by using cheaper and faster Ethereume extentions.",
+  "ethereum-networks-card-description": "Save money by using cheaper and faster Ethereum extentions.",
   "ethereum-networks-card-button": "Choose network",
   "things-to-consider-banner-title": "Things to consider when using Ethereum",
   "things-to-consider-banner-1": "Each Ethereum transaction requires a fee in the form of ETH, even if you need to move different tokens built on Ethereum like the stablecoins USDC or DAI.",


### PR DESCRIPTION
Ethereum was misspelt in https://ethereum.org/en/learn/#smart-contracts -> "how do i use ethereum?" ->Card #3

## Description

The typo has been rectified. Now Ethereume is replaced with Ethereum.