### PR TITLE
Migrate Staking Guides to shadcn

### DIFF
--- a/src/components/Staking/StakingGuides.tsx
+++ b/src/components/Staking/StakingGuides.tsx
@@ -1,5 +1,4 @@
 import { useTranslation } from "next-i18next"
-import { Stack } from "@/components/ui/flex"
 
 import CardList, { type CardListItem } from "@/components/CardList"
 

--- a/src/components/Staking/StakingGuides.tsx
+++ b/src/components/Staking/StakingGuides.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "next-i18next"
-import { Stack } from "@chakra-ui/react"
+import { Stack } from "@/components/ui/flex"
 
 import CardList, { type CardListItem } from "@/components/CardList"
 
@@ -29,7 +29,7 @@ const StakingGuides = () => {
     },
   ]
 
-  return <Stack as={CardList} direction="column" gap={4} items={guides} />
+  return <CardList className="flex flex-col gap-4" items={guides} />
 }
 
 export default StakingGuides


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Changed original Stack with CardList attributes into a CardList with Stack attributes, i.e., from

```<Stack as={CardList} direction="column" gap={4} items={guides}>``` 

to 

```<CardList className="flex flex-col gap-4" items={guides} />```

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#13946 
