### PR TITLE
chore: update shapeshift supported chains

### DIFF
--- a/src/data/wallets/wallet-data.ts
+++ b/src/data/wallets/wallet-data.ts
@@ -2140,7 +2140,7 @@ export const walletsData: WalletData[] = [
     supported_chains: ["Ethereum Mainnet"],
   },
   {
-    last_updated: "2024-10-07",
+    last_updated: "2025-01-07",
     name: "ShapeShift Mobile",
     image: ShapeShiftImage,
     twBackgroundColor: "bg-[#386FF9]",
@@ -2159,7 +2159,7 @@ export const walletsData: WalletData[] = [
       "tr",
       "uk",
     ],
-    twitter: "https://twitter.com/shapeshift",
+    twitter: "https://x.com/shapeshift",
     discord: "https://discord.gg/shapeshift",
     reddit: "",
     telegram: "https://t.me/shapeshiftofficial",
@@ -2196,7 +2196,12 @@ export const walletsData: WalletData[] = [
     social_recovery: false,
     onboard_documentation: "https://docs.shapeshift.com/",
     documentation: "https://docs.shapeshift.com/",
-    supported_chains: ["Ethereum Mainnet"],
+    supported_chains: [
+      "Ethereum Mainnet",
+      "Arbitrum One",
+      "OP Mainnet",
+      "Base",
+    ],
   },
   {
     last_updated: "2024-06-20",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Updates the supported chains for the ShapeShift wallet, based on chains effectively supported in the app/wallet and limited to the ones supported currently by ethereum.org
* Updates the Twitter link to use `x.com` instead of `twitter.com`
* Updates the `last_updated` date.

<!--- Describe your changes in detail -->

## Related Issue

#14617 

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
