### PR TITLE
fix: typos in documentation files

### DIFF
--- a/public/content/community/language-resources/index.md
+++ b/public/content/community/language-resources/index.md
@@ -135,7 +135,7 @@ If you are bilingual and want to help us reach more people, you can also get inv
 
 - [Ethereum Madrid](https://ethereummadrid.com/) - blockchain, DeFi, and governance courses, events and blog
 - [Cointelegraph](https://es.cointelegraph.com/ethereum-for-beginners) - Ethereum guide for beginners in Spanish
-- [Tutorials online](https://tutoriales.online/curso/solidity) - learn Solidity and programming on Ethereum
+- [Tutoriales online](https://tutoriales.online/curso/solidity) - learn Solidity and programming on Ethereum
 - [Curso Introducción a Ethereum Development](https://youtube.com/playlist?list=PLTqiwJDd_R8y9pfUBjhkVa1IDMwyQz-fU) - Solidity basics, testing and deployment of your first smart contract
 - [Curso Introducción a Seguridad y Hacking en Ethereum](https://youtube.com/playlist?list=PLTqiwJDd_R8yHOvteko_DmUxUTMHnlfci) - understand common vulnerabilities and security issues in real smart contracts
 - [Curso Introducción a DeFi Development](https://youtube.com/playlist?list=PLTqiwJDd_R8zZiP9_jNdaPqA3HqoW2lrS) - learn how DeFi smart contracts work in Solidity and create your own Automated Market Maker

--- a/public/content/community/language-resources/index.md
+++ b/public/content/community/language-resources/index.md
@@ -135,7 +135,7 @@ If you are bilingual and want to help us reach more people, you can also get inv
 
 - [Ethereum Madrid](https://ethereummadrid.com/) - blockchain, DeFi, and governance courses, events and blog
 - [Cointelegraph](https://es.cointelegraph.com/ethereum-for-beginners) - Ethereum guide for beginners in Spanish
-- [Tutoriales online](https://tutoriales.online/curso/solidity) - learn Solidity and programming on Ethereum
+- [Tutorials online](https://tutoriales.online/curso/solidity) - learn Solidity and programming on Ethereum
 - [Curso Introducción a Ethereum Development](https://youtube.com/playlist?list=PLTqiwJDd_R8y9pfUBjhkVa1IDMwyQz-fU) - Solidity basics, testing and deployment of your first smart contract
 - [Curso Introducción a Seguridad y Hacking en Ethereum](https://youtube.com/playlist?list=PLTqiwJDd_R8yHOvteko_DmUxUTMHnlfci) - understand common vulnerabilities and security issues in real smart contracts
 - [Curso Introducción a DeFi Development](https://youtube.com/playlist?list=PLTqiwJDd_R8zZiP9_jNdaPqA3HqoW2lrS) - learn how DeFi smart contracts work in Solidity and create your own Automated Market Maker

--- a/public/content/developers/docs/networking-layer/portal-network/index.md
+++ b/public/content/developers/docs/networking-layer/portal-network/index.md
@@ -82,7 +82,7 @@ Having multiple independent client implementations enhances the resilience and d
 
 If one client experiences issues or vulnerabilities, other clients can continue to operate smoothly, preventing a single point of failure. Additionally, diverse client implementations foster innovation and competition, driving improvements and reducing monoculture risk within the ecosystem.
 
-## Further reading {#futher-reading}
+## Further reading {#further-reading}
 
 - [The Portal Network (Piper Merriam at Devcon Bogota)](https://www.youtube.com/watch?v=0stc9jnQLXA).
 - [The Portal Network discord](https://discord.gg/CFFnmE7Hbs)


### PR DESCRIPTION
Corrected `Tutoriales` to `Tutorials`
Corrected `futher` to `further`