### PR TITLE
docs: Fixed Duplicate

### DIFF
--- a/public/content/contributing/translation-program/content-buckets/index.md
+++ b/public/content/contributing/translation-program/content-buckets/index.md
@@ -101,7 +101,6 @@ Below is a breakdown of the website pages each content bucket contains.
 - [Account abstraction](/roadmap/account-abstraction/)
 - [Verkle trees](/roadmap/verkle-trees/)
 - [Statelessness, state expiry and history expiry](/roadmap/statelessness/)
-- [How The Merge impacted ETH supply](/roadmap/merge/issuance/)
 
 ## 10) Community pages {#community-pages}
 


### PR DESCRIPTION
## Description

<img width="369" alt="Снимок экрана 2025-01-10 в 09 53 30" src="https://github.com/user-attachments/assets/c82a5d91-5b55-4a9b-bc30-d7a7db3a2c00" />

I noticed that the entry "How The Merge Impacted ETH Supply" was listed twice under the Upgrades section.

This seemed like a small oversight, so I've cleaned it up by removing the duplicate.