### PR TITLE
fix typo on eth page

### DIFF
--- a/src/intl/en/page-eth.json
+++ b/src/intl/en/page-eth.json
@@ -86,7 +86,7 @@
   "page-eth-tokens-stablecoins-description": "More on the least volatile of Ethereum tokens.",
   "page-eth-tokens-defi-description": "The financial system for Ethereum tokens.",
   "page-eth-tokens-nft-description": "Tokens that represent ownership of items on Ethereum.",
-  "page-eth-tokens-dao-description": "Internet communities often goverened by token holders.",
+  "page-eth-tokens-dao-description": "Internet communities often governed by token holders.",
   "page-eth-whats-defi": "More on DeFi",
   "page-eth-whats-defi-description": "DeFi is the decentralized financial system built on Ethereum. This overview explains what you can do.",
   "page-what-is-ethereum-what-is-ether": "What is ether?"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix typo:
goverened  ->  governed

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/ethereum/ethereum-org-website/issues/14632
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
