### PR TITLE
docs: Fix incorrect article Update index.md

### DIFF
--- a/public/content/zero-knowledge-proofs/index.md
+++ b/public/content/zero-knowledge-proofs/index.md
@@ -1,6 +1,6 @@
 ---
 title: Zero-knowledge proofs
-description: An non-technical introduction to zero-knowledge proofs for beginners.
+description: A non-technical introduction to zero-knowledge proofs for beginners.
 lang: en
 ---
 


### PR DESCRIPTION
## Description

I noticed a small typo in the first sentence of the description. The article "An" was incorrectly used before "non-technical." Since "non-technical" starts with a consonant sound (/n/), it should be "A non-technical introduction."

This has been corrected.