### PR TITLE
docs: Fix typo in Terms of Use Update index.md

### DIFF
--- a/public/content/terms-of-use/index.md
+++ b/public/content/terms-of-use/index.md
@@ -33,7 +33,7 @@ Your continued use of the Websites following the posting of revised Terms of Use
 
 **Accessing the Websites and Account Security**
 
-We reserve the right to withdraw or amend the Websites, and any service or material we provide on the Websites, in our sole discretion without notice. We do not guarantee that our Websites or any content on them will always be available or be interrupted. We will not be liable if for any reason all or any part of the Websites are unavailable at any time or for any period. From time to time, we may restrict access to some parts of the Websites, or entire Websites, to users.
+We reserve the right to withdraw or amend the Websites, and any service or material we provide on the Websites, in our sole discretion without notice. We do not guarantee that our Websites or any content on them will always be available or not be interrupted. We will not be liable if for any reason all or any part of the Websites are unavailable at any time or for any period. From time to time, we may restrict access to some parts of the Websites, or entire Websites, to users.
 
 You are responsible for:
 


### PR DESCRIPTION
## Description

A small typo in the **Terms of Use** section. The sentence:  
> "We do not guarantee that our Websites or any content on them will always be available or be interrupted."  

is missing the word **"not"** before "be interrupted." This change ensures the sentence is logically consistent and correctly conveys that interruptions may occur.  

The corrected version should read:  
> "We do not guarantee that our Websites or any content on them will always be available or **not** be interrupted."  

