### PR TITLE
docs: Fix incorrect Devcon year Update index.md

### DIFF
--- a/public/content/history/index.md
+++ b/public/content/history/index.md
@@ -32,7 +32,7 @@ Since 2021, upgrades to the **execution layer** are named according to the city 
 | Berlin       | 2015        | 0             | Apr 15, 2021 |
 | London       | 2016        | I             | Aug 5, 2021  |
 | Shanghai     | 2017        | II            | Apr 12, 2023 |
-| **Cancun**   | 2018        | III           | Mar 13, 2024 |
+| **Cancun**   | 2019        | III           | Mar 13, 2024 |
 | _Prague_     | 2019        | IV            | TBD          |
 | _Osaka_      | 2020        | V             | TBD          |
 | _Bogota_     | 2022        | VI            | TBD          |

--- a/public/content/history/index.md
+++ b/public/content/history/index.md
@@ -29,12 +29,12 @@ Since 2021, upgrades to the **execution layer** are named according to the city 
 
 | Upgrade Name | Devcon Year | Devcon Number | Upgrade Date |
 | ------------ | ----------- | ------------- | ------------ |
-| Berlin       | 2015        | 0             | Apr 15, 2021 |
-| London       | 2016        | I             | Aug 5, 2021  |
-| Shanghai     | 2017        | II            | Apr 12, 2023 |
-| **Cancun**   | 2019        | III           | Mar 13, 2024 |
-| _Prague_     | 2019        | IV            | TBD          |
-| _Osaka_      | 2020        | V             | TBD          |
+| Berlin       | 2014        | 0             | Apr 15, 2021 |
+| London       | 2015        | I             | Aug 5, 2021  |
+| Shanghai     | 2016        | II            | Apr 12, 2023 |
+| **Cancun**   | 2017        | III           | Mar 13, 2024 |
+| _Prague_     | 2018        | IV            | TBD          |
+| _Osaka_      | 2019        | V             | TBD          |
 | _Bogota_     | 2022        | VI            | TBD          |
 | _Bangkok_    | 2024        | VII           | TBD          |
 


### PR DESCRIPTION
## Description

I noticed a small typo in the 2024 section under the Execution upgrade naming table.
For the Cancun upgrade, the Devcon year was listed as 2018, but it should be **2019**. 

Corrected.

P.S. Thanks for Ethereum!