### PR TITLE
fix: use migrated ButtonLink on layer-2 pages

### DIFF
--- a/src/pages/layer-2/learn.tsx
+++ b/src/pages/layer-2/learn.tsx
@@ -5,7 +5,6 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 
 import type { BasePageProps, Lang } from "@/lib/types"
 
-import { ButtonLink } from "@/components/Buttons"
 import Callout from "@/components/Callout"
 import Card from "@/components/Card"
 import { ContentHero, type ContentHeroProps } from "@/components/Hero"
@@ -14,6 +13,7 @@ import MainArticle from "@/components/MainArticle"
 import PageMetadata from "@/components/PageMetadata"
 import { StandaloneQuizWidget } from "@/components/Quiz/QuizWidget"
 import Translation from "@/components/Translation"
+import { ButtonLink } from "@/components/ui/buttons/Button"
 
 import { existsNamespace } from "@/lib/utils/existsNamespace"
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"

--- a/src/pages/layer-2/networks.tsx
+++ b/src/pages/layer-2/networks.tsx
@@ -4,12 +4,12 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 
 import type { BasePageProps, Lang } from "@/lib/types"
 
-import { ButtonLink } from "@/components/Buttons"
 import Callout from "@/components/Callout"
 import { ContentHero, ContentHeroProps } from "@/components/Hero"
 import Layer2NetworksTable from "@/components/Layer2NetworksTable"
 import MainArticle from "@/components/MainArticle"
 import PageMetadata from "@/components/PageMetadata"
+import { ButtonLink } from "@/components/ui/buttons/Button"
 
 import { dataLoader } from "@/lib/utils/data/dataLoader"
 import { existsNamespace } from "@/lib/utils/existsNamespace"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Updates the ButtonLink component usage to shadcn version

## Related Issue

https://github.com/ethereum/ethereum-org-website/issues/13946
