### PR TITLE
Fix typos and grammar in README.md

### DIFF
--- a/public/content/translations/pt-br/developers/tutorials/a-developers-guide-to-ethereum-part-one/index.md
+++ b/public/content/translations/pt-br/developers/tutorials/a-developers-guide-to-ethereum-part-one/index.md
@@ -59,7 +59,7 @@ Os desenvolvedores do Python que querem interagir com o Ethereum provavelmente u
 
 <FeaturedText>Nota: "Nó Ethereum" e "Cliente Ethereum" são usados de forma intercambiável. Em ambos os casos, refere-se ao software que um participante da rede Ethereum executa. Este software pode ler dados de blocos, receber atualizações quando novos blocos são adicionados à cadeia, transmitir novas transações e mais. Tecnicamente, o cliente é o software, o nódulo é o computador que executa o software.</FeaturedText>
 
-[Clientes Ethereum](/developers/docs/nodes-and-clients/) podem ser configurados para serem acessíveis por [IPC](https://wikipedia.org/wiki/Inter-process_communication), HTTPS ou Websockets, então Web3. y precisará espelhar esta configuração. Web3.py refere-se a estas opções de conexão como **provedores**. Você vai querer escolher um dos três provedores para vincular a instância da Web3.py ao seu nó.
+[Clientes Ethereum](/developers/docs/nodes-and-clients/) podem ser configurados para serem acessíveis por [IPC](https://wikipedia.org/wiki/Inter-process_communication), HTTPS ou Websockets, então Web3.py precisará espelhar esta configuração. Web3.py refere-se a estas opções de conexão como **provedores**. Você vai querer escolher um dos três provedores para vincular a instância da Web3.py ao seu nó.
 
 ![Um diagrama mostrando como web3.py usa IPC para conectar seu aplicativo a um nódulo Ethereum](./web3py-and-nodes.png)
 
@@ -234,7 +234,7 @@ Out[9]: AttributeDict({
 })
 ```
 
-Sãp fornecidas muitas informações sobre um bloco, mas há apenas alguns pontos para salientar aqui:
+São fornecidas muitas informações sobre um bloco, mas há apenas alguns pontos para salientar aqui:
 
 - O número de bloco é zero — não importa quanto tempo você configurou o provedor de teste. Ao contrário da rede Ethereum real, que minera um novo bloco aproximadamente a cada 12 segundos, essa simulação esperará até que você a instrua a fazer alguma coisa.
 - `transactions` é uma lista vazia, pelo mesmo motivo: ainda não fizemos nada. Este primeiro bloco é um **bloco vazio**, apenas para iniciar a cadeia.


### PR DESCRIPTION
## Fix: Improve Portuguese Translation in Web3.py Documentation

## Description

Corrected minor typos and formatting inconsistencies.

- Fix: Corrected Web3. y to Web3.py 
- Fix: Corrected Sãp to São

## Related Issue
