### PR TITLE
fix: asset page svg download url

### DIFF
--- a/src/components/AssetDownload/index.tsx
+++ b/src/components/AssetDownload/index.tsx
@@ -65,7 +65,12 @@ const AssetDownload = ({
           {extname(imgSrc).slice(1).toUpperCase()})
         </ButtonLink>
         {svgUrl && (
-          <ButtonLink href={svgUrl} onClick={matomoHandler} target="_blank">
+          <ButtonLink
+            href={svgUrl}
+            onClick={matomoHandler}
+            target="_blank"
+            locale={false}
+          >
             {t("page-assets-download-download")} (SVG)
           </ButtonLink>
         )}


### PR DESCRIPTION
## Description

gm 🌞

Within the [assets page](https://ethereum.org/en/assets/), images with an accompanying SVG download route to a 404 page when clicked. For example:

<img width="691" alt="Screenshot 2025-01-29 at 9 39 55 AM" src="https://github.com/user-attachments/assets/bcb08d66-2dfc-4b95-b847-f59cd90aaba6" />

The `locale` in the URL appears to be the issue. Assets are rendering fine when I disable the `locale` in the corresponding `ButtonLink` component.

<img width="626" alt="Screenshot 2025-01-29 at 9 39 33 AM" src="https://github.com/user-attachments/assets/5debfa35-b41f-4af3-9113-24d4f6b23ca6" />

---

Looks like this may close #14600. The linked PR in that issue might be overkill?