### PR TITLE
patch: rm old/geoblocked links

### DIFF
--- a/src/pages/get-eth.tsx
+++ b/src/pages/get-eth.tsx
@@ -41,7 +41,6 @@ import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 import { useBreakpointValue } from "@/hooks/useBreakpointValue"
 import uniswap from "@/public/images/dapps/uni.png"
 import dapps from "@/public/images/doge-computer.png"
-import oneinch from "@/public/images/exchanges/1inch.png"
 import bancor from "@/public/images/exchanges/bancor.png"
 import kyber from "@/public/images/exchanges/kyber.png"
 import hero from "@/public/images/get-eth.png"
@@ -116,12 +115,6 @@ const GetEthPage = ({
       title: "Uniswap",
       link: "https://app.uniswap.org/#/swap",
       image: uniswap,
-      alt: "",
-    },
-    {
-      title: "1inch",
-      link: "https://1inch.exchange/#/",
-      image: oneinch,
       alt: "",
     },
     {

--- a/src/pages/stablecoins.tsx
+++ b/src/pages/stablecoins.tsx
@@ -603,17 +603,6 @@ const StablecoinsPage = ({ markets, marketsHasError }) => {
               <H3>{t("page-stablecoins-interest-earning-dapps")}</H3>
               <p className="mb-6">{t("page-stablecoins-saving")}</p>
             </div>
-
-            <Flex className="mx-auto w-full flex-col justify-center rounded-sm border border-border-high-contrast p-8 lg:mx-0">
-              <Emoji className="mb-4 text-[5rem]" text=":bank:" />
-              <p className="mb-6 text-7xl">{t("page-stablecoins-bank-apy")}</p>
-              <em className="mb-6">
-                {t("page-stablecoins-bank-apy-source")}{" "}
-                <InlineLink href="https://www.nytimes.com/2020/09/18/your-money/savings-interest-rates.html">
-                  {t("page-stablecoins-bank-apy-source-link")}
-                </InlineLink>
-              </em>
-            </Flex>
           </Flex>
           <div className="mb-16 grid grid-cols-[repeat(auto-fill,_minmax(min(100%,_280px),_1fr))] gap-8">
             {dapps.map((dapp, idx) => (


### PR DESCRIPTION
## Description
- stablecoins page bank apr data severely outdated with paywalled link—removed.
- 1inch link geo/vpn-blocked—removed.

<img width="803" alt="image" src="https://github.com/user-attachments/assets/540b7252-52a8-4ce2-9681-b80fad1501aa" />

(Third link in screenshot from old event; already removed)