### PR TITLE
Cleanup excessive tags on Tutorials page

### DIFF
--- a/public/content/developers/tutorials/hello-world-smart-contract-fullstack/index.md
+++ b/public/content/developers/tutorials/hello-world-smart-contract-fullstack/index.md
@@ -9,7 +9,7 @@ tags:
     "alchemy",
     "smart contracts",
     "deploying",
-    "blockexplorer",
+    "block explorer",
     "frontend",
     "transactions",
   ]

--- a/public/content/developers/tutorials/how-to-use-slither-to-find-smart-contract-bugs/index.md
+++ b/public/content/developers/tutorials/how-to-use-slither-to-find-smart-contract-bugs/index.md
@@ -3,7 +3,7 @@ title: How to use Slither to find smart contract bugs
 description: How to use Slither to automatically find bugs in smart contracts
 author: Trailofbits
 lang: en
-tags: ["solidity", "smart contracts", "security", "testing", "static analysis"]
+tags: ["solidity", "smart contracts", "security", "testing"]
 skill: advanced
 published: 2020-06-09
 source: Building secure contracts

--- a/public/content/developers/tutorials/ipfs-decentralized-ui/index.md
+++ b/public/content/developers/tutorials/ipfs-decentralized-ui/index.md
@@ -2,7 +2,7 @@
 title: IPFS for decentralized user interfaces
 description: This tutorial teaches the reader how to use IPFS to store the user interface for a dapp. Although the application's data and business logic are decentralized, without a censorship resistant user interface users might lose access to it anyway.
 author: Ori Pomerantz
-tags: ["ipfs", "user interface"]
+tags: ["ipfs"]
 skill: beginner
 lang: en
 published: 2024-06-29

--- a/public/content/developers/tutorials/kickstart-your-dapp-frontend-development-with-create-eth-app/index.md
+++ b/public/content/developers/tutorials/kickstart-your-dapp-frontend-development-with-create-eth-app/index.md
@@ -3,7 +3,7 @@ title: Kickstart your dapp frontend development with create-eth-app
 description: An overview of how to use create-eth-app and its features
 author: "Markus Waas"
 tags:
-  ["create-eth-app", "frontend", "javascript", "ethers.js", "the graph", "defi"]
+  ["frontend", "javascript", "ethers.js", "the graph", "defi"]
 skill: beginner
 lang: en
 published: 2020-04-27

--- a/public/content/developers/tutorials/server-components/index.md
+++ b/public/content/developers/tutorials/server-components/index.md
@@ -4,7 +4,7 @@ description: After reading this tutorial, you will be able to write TypeScript s
 
 author: Ori Pomerantz
 lang: en
-tags: ["agent", "server", "offchain", "centralized"]
+tags: ["agent", "server", "offchain"]
 skill: beginner
 published: 2024-07-15
 ---

--- a/public/content/developers/tutorials/the-graph-fixing-web3-data-querying/index.md
+++ b/public/content/developers/tutorials/the-graph-fixing-web3-data-querying/index.md
@@ -9,7 +9,6 @@ tags:
     "smart contracts",
     "querying",
     "the graph",
-    "create-eth-app",
     "react",
   ]
 skill: intermediate

--- a/src/data/externalTutorials.json
+++ b/src/data/externalTutorials.json
@@ -135,7 +135,7 @@
     "tags": [
       "solidity",
       "remix",
-      "ethersjs",
+      "ethers.js",
       "smart contracts",
       "openzeppelin",
       "alchemy",
@@ -159,7 +159,7 @@
     "tags": [
       "solidity",
       "hardhat",
-      "ethersjs",
+      "ethers.js",
       "smart contracts",
       "react",
       "nextjs",
@@ -236,7 +236,7 @@
       "hardhat",
       "nextjs",
       "moralis",
-      "ethersjs",
+      "ethers.js",
       "video"
     ],
     "skillLevel": "beginner",
@@ -280,8 +280,7 @@
       "hardhat",
       "nextjs",
       "moralis",
-      "web3modal",
-      "ethersjs"
+      "ethers.js"
     ],
     "skillLevel": "beginner",
     "timeToRead": "14",
@@ -511,8 +510,7 @@
       "smart contracts",
       "solidity",
       "yul",
-      "storage",
-      "memory"
+      "storage"
     ],
     "skillLevel": "beginner",
     "lang": "en",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Cleanup excessive tags on Tutorials page
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/ethereum/ethereum-org-website/issues/14816
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
