### PR TITLE
Update Lido staking data: audits and client diversity numbers

### DIFF
--- a/src/data/staking-products.json
+++ b/src/data/staking-products.json
@@ -994,6 +994,66 @@
           "url": "https://docs.lido.fi/security/audits/"
         },
         {
+          "name": "Cyfrin Lido CircuitBreaker Security Audit",
+          "date": "2026-04-01",
+          "url": "https://github.com/lidofinance/audits/blob/main/Cyfrin%20CircuitBreaker%20Audit%20Report%2004-2026.pdf"
+        },
+        {
+          "name": "MixBytes Lido CircuitBreaker Security Audit",
+          "date": "2026-04-01",
+          "url": "https://github.com/lidofinance/audits/blob/main/MixBytes%20CircuitBreaker%20Audit%20Report%2004-2026.pdf"
+        },
+        {
+          "name": "Composable Security Lido Oracle v7.1 Security Audit",
+          "date": "2026-03-01",
+          "url": "https://github.com/lidofinance/audits/blob/main/Composable%20Security%20Lido%20Oracle%20V7_1%20Audit%20Report.pdf"
+        },
+        {
+          "name": "MixBytes Lido DeFi Wrapper MellowStrategyAdapter Security Audit",
+          "date": "2026-03-01",
+          "url": "https://github.com/lidofinance/audits/blob/main/MixBytes%20Lido%20DeFi%20Wrapper%20MellowStrategyAdapter%20Security%20Audit%20Report%2003-2026.pdf"
+        },
+        {
+          "name": "MixBytes Triggerable Withdrawals Easy Track Security Audit",
+          "date": "2026-03-01",
+          "url": "https://github.com/lidofinance/audits/blob/main/MixBytes%20Lido%20Easy%20Track%20Security%20Audit%20Report%2003-26.pdf"
+        },
+        {
+          "name": "Certora Lido V3 Security Assessment Fix Review",
+          "date": "2026-03-01",
+          "url": "https://github.com/lidofinance/audits/blob/main/Certora%20Lido%20V3%20Smart%20Contracts%20Security%20Assessment%20Report%20fix%20review%2003-26.pdf"
+        },
+        {
+          "name": "MixBytes Lido V3 Security Audit (fix review)",
+          "date": "2026-03-01",
+          "url": "https://github.com/lidofinance/audits/blob/main/MixBytes%20Lido%20v3%20Security%20Audit%20Report%2003-26.pdf"
+        },
+        {
+          "name": "MixBytes Lido EasyTrack stVaults Security Audit",
+          "date": "2026-03-01",
+          "url": "https://github.com/lidofinance/audits/blob/main/MixBytes%20Lido%20Easy%20Track%20stVaults%20Security%20Audit%20Report%2003-26.pdf"
+        },
+        {
+          "name": "Sigma Prime Lido BLS Library Security Audit",
+          "date": "2026-01-01",
+          "url": "https://github.com/lidofinance/audits/blob/main/Sigma%20Prime%20-%20Lido%20BLS%20Library%20Security%20Assessment%20Report%20v2.0%20-%2001-2026.pdf"
+        },
+        {
+          "name": "MixBytes CSM Performance Oracle Security Audit",
+          "date": "2026-01-01",
+          "url": "https://github.com/lidofinance/audits/blob/main/MixBytes%20CSM%20Performance%20Oracle%20Security%20Audit%20Report%2001-26.pdf"
+        },
+        {
+          "name": "MixBytes Lido DeFi Wrapper Security Audit",
+          "date": "2026-01-01",
+          "url": "https://github.com/lidofinance/audits/blob/main/MixBytes%20Lido%20DeFi%20Wrapper%20Security%20Audit%20Report%2001-2026.pdf"
+        },
+        {
+          "name": "Ackee Blockchain Vault Wrapper Audit",
+          "date": "2026-01-01",
+          "url": "https://github.com/lidofinance/audits/blob/main/Ackee%20Blockchain%20Vault%20Wrapper%20Report%2001-2026.pdf"
+        },
+        {
           "name": "Certora Lido V3 Audit",
           "date": "2025-12-01",
           "url": "https://github.com/lidofinance/audits/blob/main/Certora%20Lido%20V3%20Audit%20Report%20-%2012-2025.pdf"

--- a/src/data/staking-products.json
+++ b/src/data/staking-products.json
@@ -991,37 +991,36 @@
       "audits": [
         {
           "name": "All Audits",
-          "date": "07-2026",
           "url": "https://docs.lido.fi/security/audits/"
         },
         {
           "name": "Certora Lido V3 Audit",
-          "date": "12-2025",
+          "date": "2025-12-01",
           "url": "https://github.com/lidofinance/audits/blob/main/Certora%20Lido%20V3%20Audit%20Report%20-%2012-2025.pdf"
         },
         {
           "name": "MixBytes Lido V3 Security Audit",
-          "date": "12-2025",
+          "date": "2025-12-01",
           "url": "https://github.com/lidofinance/audits/blob/main/MixBytes%20Lido%20V3%20Security%20Audit%20Report%20-%2012-2025.pdf"
         },
         {
           "name": "Consensys Diligence Lido V3 Security Audit",
-          "date": "11-2025",
+          "date": "2025-11-01",
           "url": "https://github.com/lidofinance/audits/blob/main/Consensys%20Diligence%20Lido%20V3%20Security%20Audit%20-%2011-2025.pdf"
         },
         {
           "name": "Ackee Blockchain Community Staking Module v2 Audit",
-          "date": "09-2025",
+          "date": "2025-09-01",
           "url": "https://github.com/lidofinance/audits/blob/main/Ackee%20Blockchain%20Community%20Staking%20Module%20v2%20Audit%20Report%2009-2025.pdf"
         },
         {
           "name": "Code4rena Community Staking Module v2 Audit",
-          "date": "08-2025",
+          "date": "2025-08-01",
           "url": "https://github.com/lidofinance/audits/blob/main/Code4rena%20CSM%20V2%20Audit%20Report%2008-2025.pdf"
         },
         {
           "name": "OpenZeppelin Dual Governance Audit",
-          "date": "11-2024",
+          "date": "2024-11-01",
           "url": "https://github.com/lidofinance/audits/blob/main/OpenZeppelin%20Dual%20Governance%20Audit%20Report%2011-2024.pdf"
         }
       ],

--- a/src/data/staking-products.json
+++ b/src/data/staking-products.json
@@ -990,16 +990,39 @@
       "url": "https://lido.fi/",
       "audits": [
         {
-          "name": "Quantstamp",
-          "url": "https://github.com/lidofinance/audits/blob/main/QSP%20Lido%20Report%2012-2020.pdf"
+          "name": "All Audits",
+          "date": "07-2026",
+          "url": "https://docs.lido.fi/security/audits/"
         },
         {
-          "name": "MixBytes()",
-          "url": "https://github.com/lidofinance/audits/blob/main/MixBytes%20ETH2%20Oracle%20Security%20Audit%20Report%2004-2021.pdf"
+          "name": "Certora Lido V3 Audit",
+          "date": "12-2025",
+          "url": "https://github.com/lidofinance/audits/blob/main/Certora%20Lido%20V3%20Audit%20Report%20-%2012-2025.pdf"
         },
         {
-          "name": "Sigma Prime",
-          "url": "https://github.com/lidofinance/audits/blob/main/Sigma%20Prime%20-%20Lido%20Finance%20Security%20Assessment%20Report%20v2.1.pdf"
+          "name": "MixBytes Lido V3 Security Audit",
+          "date": "12-2025",
+          "url": "https://github.com/lidofinance/audits/blob/main/MixBytes%20Lido%20V3%20Security%20Audit%20Report%20-%2012-2025.pdf"
+        },
+        {
+          "name": "Consensys Diligence Lido V3 Security Audit",
+          "date": "11-2025",
+          "url": "https://github.com/lidofinance/audits/blob/main/Consensys%20Diligence%20Lido%20V3%20Security%20Audit%20-%2011-2025.pdf"
+        },
+        {
+          "name": "Ackee Blockchain Community Staking Module v2 Audit",
+          "date": "09-2025",
+          "url": "https://github.com/lidofinance/audits/blob/main/Ackee%20Blockchain%20Community%20Staking%20Module%20v2%20Audit%20Report%2009-2025.pdf"
+        },
+        {
+          "name": "Code4rena Community Staking Module v2 Audit",
+          "date": "08-2025",
+          "url": "https://github.com/lidofinance/audits/blob/main/Code4rena%20CSM%20V2%20Audit%20Report%2008-2025.pdf"
+        },
+        {
+          "name": "OpenZeppelin Dual Governance Audit",
+          "date": "11-2024",
+          "url": "https://github.com/lidofinance/audits/blob/main/OpenZeppelin%20Dual%20Governance%20Audit%20Report%2011-2024.pdf"
         }
       ],
       "minEth": 0,
@@ -1015,16 +1038,14 @@
       "hasBugBounty": true,
       "isTrustless": true,
       "hasPermissionlessNodes": true,
-      "pctMajorityExecutionClient": null,
-      "pctMajorityConsensusClient": 42.83,
+      "pctMajorityExecutionClient": 40.13,
+      "pctMajorityConsensusClient": 37.66,
       "platforms": ["Browser", "Wallet"],
       "ui": ["GUI"],
       "socials": {
         "discord": "https://discord.com/invite/vgdPfhZ",
         "twitter": "https://twitter.com/lidofinance",
-        "telegram": "https://t.me/lidofinance",
-        "reddit": "https://www.reddit.com/r/lidofinance/",
-        "github": "https://github.com/lidofinance/lido-dao"
+        "github": "https://github.com/lidofinance/core"
       },
       "matomo": {
         "eventCategory": "StakingProductCard",


### PR DESCRIPTION
Refreshes the Lido entry in `src/data/staking-products.json` with current data. The branch has been rebased onto the latest `dev`.

## Changes

- **Audits** — replaced the outdated list with a curated, current set:
  - Evergreen "All Audits" pointer → https://docs.lido.fi/security/audits/
  - Certora Lido V3 Audit (12-2025)
  - MixBytes Lido V3 Security Audit (12-2025)
  - Consensys Diligence Lido V3 Security Audit (11-2025)
  - Ackee Blockchain Community Staking Module v2 Audit (09-2025)
  - Code4rena Community Staking Module v2 Audit (08-2025)
  - OpenZeppelin Dual Governance Audit (11-2024)
- **Client diversity** — majority execution-layer client **40.13%**, majority consensus-layer client **37.66%** (both ≤ 50%, so both render as ✅).
- **Socials** — dropped inactive Telegram/Reddit links; updated GitHub to `lidofinance/core`.

## Note on scope

This PR originally also flipped `hasPermissionlessNodes` to `true` for Lido (following the end of the CSM Early Adoption phase), which was the contentious part. That change has since been merged separately in #18691, so it is already `true` on `dev` and is **no longer part of this diff**. After rebasing, this PR only refreshes the audits and client-diversity numbers.

Closes #14824
