### PR TITLE
Fix: rss image parsing logic

### DIFF
--- a/src/lib/api/fetchRSS.ts
+++ b/src/lib/api/fetchRSS.ts
@@ -42,10 +42,10 @@ export const fetchRSS = async (xmlUrl: string | string[]) => {
         // Map to RSSItem object
         .map((item) => {
           const getImgSrc = () => {
-            if (url.includes("medium.com/feed/"))
-              return item["content:encoded"]?.[0].match(
+            if (item["content:encoded"])
+              return item["content:encoded"][0].match(
                 /https?:\/\/[^"]*?\.(jpe?g|png|webp)/g
-              )
+              )?.[0]
             if (item.enclosure) return item.enclosure[0].$.url
             if (item["media:content"]) return item["media:content"][0].$.url
             return channelImage


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The existing logic isn't parsing image properly.

This PR:
1. Use the first url in the matching array, instead of the whole array
2. Use this logic as default
<!--- Describe your changes in detail -->

## Screenshots
Before: 
![1738835324831](https://github.com/user-attachments/assets/a9d965c8-dd96-4239-837e-697e8d660ae0)

After: 
![image](https://github.com/user-attachments/assets/18fcf9d9-33f1-448e-b8f6-77d2594ccae4)

## Related Issue
n/a
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
