### PR TITLE
Fix: Add the missing link for the grow the pie on the L2 networks page

### DIFF
--- a/src/components/Layer2NetworksTable/NetworksSubComponent.tsx
+++ b/src/components/Layer2NetworksTable/NetworksSubComponent.tsx
@@ -236,7 +236,7 @@ const NetworkSubComponent = ({ network }) => {
             <div className="flex flex-col gap-0.5">
               <div>
                 <InlineLink
-                  href={network.growThePieLink}
+                  href={network.growthepieLink}
                   customEventOptions={{
                     eventCategory: "l2_networks",
                     eventAction: "analytics_profiles",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add the missing link for the grow the pie on the L2 networks page
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/ethereum/ethereum-org-website/issues/14840
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
