### PR TITLE
Install OpenZeppelin 4.* in NFT tutorial

### DIFF
--- a/public/content/developers/tutorials/how-to-write-and-deploy-an-nft/index.md
+++ b/public/content/developers/tutorials/how-to-write-and-deploy-an-nft/index.md
@@ -184,7 +184,7 @@ Open up the my-nft project in your favorite editor (we like [VSCode](https://cod
    }
    ```
 
-3. Because we are inheriting classes from the OpenZeppelin contracts library, in your command line run `npm install @openzeppelin/contracts` to install the library into our folder.
+3. Because we are inheriting classes from the OpenZeppelin contracts library, in your command line run `npm install @openzeppelin/contracts^4.0.0` to install the library into our folder.
 
 So, what does this code _do_ exactly? Let’s break it down, line-by-line.
 


### PR DESCRIPTION
`Counter.sol` is imported in the contract, but was removed from OpenZeppelin 5.0.0, so then compilation fails. Installing older version helps.