### PR TITLE
Add further reading link about stateless ethereum

### DIFF
--- a/public/content/roadmap/statelessness/index.md
+++ b/public/content/roadmap/statelessness/index.md
@@ -91,6 +91,7 @@ Weak statelessness, history expiry and state expiry are all in the research phas
 
 ## Further reading {#further-reading}
 
+- [What is Stateless Ethereum?](https://stateless.fyi/)
 - [Vitalik statelessness AMA](https://www.reddit.com/r/ethereum/comments/o9s15i/impromptu_technical_ama_on_statelessness_and/)
 - [A theory of state size management](https://hackmd.io/@vbuterin/state_size_management)
 - [Resurrection-conflict-minimized state bounding](https://ethresear.ch/t/resurrection-conflict-minimized-state-bounding-take-2/8739)


### PR DESCRIPTION
This PR adds https://stateless.fyi as a further reading doc. This site was announced last Monday in [SIC call #30](https://hackmd.io/@stateless-consensus/sic-call-30#5-New-stateless-team-public-page-and-X-account).
