### PR TITLE
Add link to new stateless information page

### DIFF
--- a/public/content/roadmap/statelessness/index.md
+++ b/public/content/roadmap/statelessness/index.md
@@ -101,3 +101,4 @@ Weak statelessness, history expiry and state expiry are all in the research phas
 - [The original stateless client concept notes](https://ethresear.ch/t/the-stateless-client-concept/172)
 - [More on state expiry](https://hackmd.io/@vbuterin/state_size_management#A-more-moderate-solution-state-expiry)
 - [Even more on state expiry](https://hackmd.io/@vbuterin/state_expiry_paths#Option-2-per-epoch-state-expiry)
+- [Stateless Ethereum Information Page](https://stateless.fyi)


### PR DESCRIPTION
Add link to new Stateless Information Page (stateless.fyi) in roadmap section.

## Description

This is for onchain days. It's not important.

## Related Issue

https://github.com/ethereum/ethereum-org-website/issues/14887

