### PR TITLE
issue:14910 added functionality to highlight robust and maturing networks

### DIFF
--- a/src/pages/layer-2/index.tsx
+++ b/src/pages/layer-2/index.tsx
@@ -70,7 +70,7 @@ export const getStaticProps = (async ({ locale }) => {
       )
     }
 
-    return randomL2s.sort(() => 0.5 - Math.random()).slice(0, 9)
+    return randomL2s.sort(() => 0.5 - Math.random()).slice(0, 3)
   }
 
   const randomL2s = layer2Data.sort(() => 0.5 - Math.random()).slice(0, 9)
@@ -417,7 +417,7 @@ const Layer2Hub = ({
       <div id="layer-2-cta" className="w-full px-8 py-9">
         <div className="mx-auto flex max-w-[640px] flex-col gap-6 rounded bg-main-gradient p-8">
           <div className="flex flex-col gap-6">
-            {userRandomL2s.slice(0, 3).map((l2, idx) => {
+            {userRandomL2s.map((l2, idx) => {
               return (
                 <div
                   key={idx}


### PR DESCRIPTION
Added functionality to highlight robust and maturing networks on Page: https://ethereum.org/en/layer-2/

<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a function to to filter the L2LayerData, if it is "Robust". If the length is 0, then it checks for network that have reached "Maturing" and return max 3 of them at random.

<!--- Describe your changes in detail -->

## Related Issue
#14910 

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
<img width="863" alt="image" src="https://github.com/user-attachments/assets/deaa2dab-611f-4526-847e-cfed42dfa307" />

