### PR TITLE
Hotfix incorrect quizkey

### DIFF
--- a/public/content/translations/cs/staking/solo/index.md
+++ b/public/content/translations/cs/staking/solo/index.md
@@ -203,4 +203,4 @@ Chcete-li odemknout a získat zpět celý zůstatek, musíte také dokončit pro
 - [Krok za krokem: Jak se připojit k testovací síti Ethereum 2.0](https://kb.beaconcha.in/guides/tutorial-eth2-multiclient) – _ Butta_
 - [Tipy pro prevenci trestu Eth2](https://medium.com/prysmatic-labs/eth2-slashing-prevention-tips-f6faa5025f50) – _Raul Jordan 2020 _
 
-<QuizWidget quizKey="solo-staking" />
+<QuizWidget quizKey="staking-solo" />

--- a/public/content/translations/zh/staking/solo/index.md
+++ b/public/content/translations/zh/staking/solo/index.md
@@ -203,4 +203,4 @@ Staking Launchpad 是一个开源应用程序，可帮助你成为质押人。 �
 - [加入以太坊 2.0 测试网的详细步骤](https://kb.beaconcha.in/guides/tutorial-eth2-multiclient) - _Butta_
 - [以太坊 2 防止罚没小技巧](https://medium.com/prysmatic-labs/eth2-slashing-prevention-tips-f6faa5025f50) - _Raul Jordan 2020_
 
-<QuizWidget quizKey="solo-staking" />
+<QuizWidget quizKey="staking-solo" />


### PR DESCRIPTION
Fixes bug seen in https://ethereum.org/cs/staking/solo/

The current quiz key used in the `cs` and `zh` versions is incorrect.