### PR TITLE
fix: full width BannerNotification

### DIFF
--- a/src/components/Banners/BannerNotification.tsx
+++ b/src/components/Banners/BannerNotification.tsx
@@ -14,7 +14,7 @@ const BannerNotification = ({
   return (
     <aside
       className={cn(
-        "flex items-center justify-center gap-2 bg-primary-action px-8 py-4 text-white [&_a]:text-white [&_a]:hover:text-white/80",
+        "flex w-full items-center justify-center gap-2 bg-primary-action px-8 py-4 text-white [&_a]:text-white [&_a]:hover:text-white/80",
         className
       )}
       {...props}


### PR DESCRIPTION
## Description
Makes banner notification full width

## Related Issue
Fixes:
<img width="1523" alt="image" src="https://github.com/user-attachments/assets/5e8648d1-2664-4155-9712-ecd705c401bb" />
