### PR TITLE
Update index.md

### DIFF
--- a/public/content/developers/docs/gas/index.md
+++ b/public/content/developers/docs/gas/index.md
@@ -99,7 +99,7 @@ You can explicitly state how much you are willing to pay to get your transaction
 
 In short, gas fees help keep the Ethereum network secure. By requiring a fee for every computation executed on the network, we prevent bad actors from spamming the network. In order to avoid accidental or hostile infinite loops or other computational wastage in code, each transaction is required to set a limit to how many computational steps of code execution it can use. The fundamental unit of computation is "gas".
 
-Although a transaction includes a limit, any gas not used in a transaction is returned to the user (i.e. `max fee - (base fee + tip)` is returned).
+Although a transaction includes a limit, any gas not used in a transaction is returned to the user (i.e. `(gas limit - gas used )* (max fee - (base fee + tip))` is returned).
 
 ![Diagram showing how unused gas is refunded](../transactions/gas-tx.png)
 _Diagram adapted from [Ethereum EVM illustrated](https://takenobu-hs.github.io/downloads/ethereum_evm_illustrated.pdf)_


### PR DESCRIPTION
At line  102:
  Incorrect Formula For refund :
   max fee - (base fee + tip)

  Corrected Formula For refund: 
    (gas limit−gas used)×(maxfee−(base fee+tip))

  Reason: 
   1.max fee - (base fee + tip) gives the per-unit refund, but the 
    actual refund depends on how much gas was unused.
   2.gas unused = gas limit- gas used .
