### PR TITLE
fix(fetchGitHistory): update github token env key name

### DIFF
--- a/src/lib/api/fetchGitHistory.ts
+++ b/src/lib/api/fetchGitHistory.ts
@@ -11,7 +11,7 @@ async function fetchWithRateLimit(filepath: string): Promise<Commit[]> {
   url.searchParams.set("path", filepath)
   url.searchParams.set("sha", "master")
 
-  const gitHubToken = process.env.GITHUB_TOKEN_READ_ONLY
+  const gitHubToken = process.env.NEXT_PUBLIC_GITHUB_TOKEN_READ_ONLY
 
   // If no token available, return empty array
   if (!gitHubToken) return []


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In the `fetchGitHistory` function, a `GITHUB_TOKEN_READ_ONLY` env is set to a variable, when it should be `NEXT_PUBLIC_GITHUB_READ_ONLY` as shown in `.env.example` and used in other api functions.

Should a new user need to navigate to a developer tutorial page in the dev server, they will not see a fetch error and not become confused as to the token key usage or setup.

