### PR TITLE
refactor(tailwind.config): use current breakpoint set in maxWidth scale

### DIFF
--- a/src/components/Hero/HubHero/HubHero.stories.tsx
+++ b/src/components/Hero/HubHero/HubHero.stories.tsx
@@ -1,7 +1,4 @@
-import type { CSSProperties } from "react"
 import { Meta, StoryObj } from "@storybook/react"
-
-import { screens } from "@/lib/utils/screen"
 
 import { getTranslation } from "@/storybook-utils"
 
@@ -24,10 +21,7 @@ const meta = {
   },
   decorators: [
     (Story) => (
-      <div
-        style={{ "--hero-decorator-max-w": screens["2xl"] } as CSSProperties}
-        className="mx-auto max-w-[var(--hero-decorator-max-w)]"
-      >
+      <div className="mx-auto max-w-2xl">
         <Story />
       </div>
     ),

--- a/src/components/Hero/MdxHero/MdxHero.stories.tsx
+++ b/src/components/Hero/MdxHero/MdxHero.stories.tsx
@@ -1,9 +1,6 @@
-import type { CSSProperties } from "react"
 import { Meta, StoryObj } from "@storybook/react"
 
 import { HStack } from "@/components/ui/flex"
-
-import { screens } from "@/lib/utils/screen"
 
 import { langViewportModes } from "../../../../.storybook/modes"
 
@@ -22,10 +19,7 @@ const meta = {
   },
   decorators: [
     (Story) => (
-      <HStack
-        style={{ "--hero-decorator-max-w": screens["2xl"] } as CSSProperties}
-        className="mx-auto h-[100vh] max-w-[var(--hero-decorator-max-w)]"
-      >
+      <HStack className="mx-auto h-[100vh] max-w-2xl">
         <Story />
       </HStack>
     ),

--- a/src/components/ui/__stories__/Table/Table.stories.tsx
+++ b/src/components/ui/__stories__/Table/Table.stories.tsx
@@ -1,7 +1,4 @@
-import type { CSSProperties } from "react"
 import { Meta, StoryObj } from "@storybook/react"
-
-import { screens } from "@/lib/utils/screen"
 
 import { Flex } from "../../flex"
 import { Table as TableComponent } from "../../table"
@@ -17,10 +14,7 @@ const meta = {
   component: TableComponent,
   decorators: [
     (Story) => (
-      <Flex
-        style={{ "--table-decorator-max-w": screens["md"] } as CSSProperties}
-        className="max-w-[var(--table-decorator-max-w)] flex-col gap-16"
-      >
+      <Flex className="max-w-md flex-col gap-16">
         <Story />
       </Flex>
     ),

--- a/src/pages/roadmap/vision.tsx
+++ b/src/pages/roadmap/vision.tsx
@@ -2,11 +2,7 @@ import { GetStaticProps } from "next"
 import { useRouter } from "next/router"
 import { useTranslation } from "next-i18next"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
-import type {
-  ComponentProps,
-  ComponentPropsWithRef,
-  CSSProperties,
-} from "react"
+import type { ComponentProps, ComponentPropsWithRef } from "react"
 
 import type { BasePageProps, ChildOnlyProp, Lang } from "@/lib/types"
 
@@ -30,7 +26,6 @@ import { List, ListItem } from "@/components/ui/list"
 import { cn } from "@/lib/utils/cn"
 import { existsNamespace } from "@/lib/utils/existsNamespace"
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
-import { screens } from "@/lib/utils/screen"
 import { getLocaleTimestamp } from "@/lib/utils/time"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 
@@ -79,13 +74,7 @@ const CardContainer = ({ className, ...props }: FlexProps) => (
 )
 
 const ProblemCardContainer = (props: ChildOnlyProp) => {
-  return (
-    <CardContainer
-      style={{ "--container-max-w": screens.lg } as CSSProperties}
-      className="mx-auto max-w-[var(--container-max-w)]"
-      {...props}
-    />
-  )
+  return <CardContainer className="mx-auto max-w-lg" {...props} />
 }
 
 const CentreCard = (props: ComponentPropsWithRef<typeof Card>) => (

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -269,6 +269,9 @@ const config = {
         31: "7.75rem", // FeedbackWidget conditional bottom offset
         128: "32rem",
       },
+      maxWidth: {
+        ...screens,
+      },
       keyframes: {
         "accordion-down": {
           from: { height: "0" },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Extends the theming for the `maxWidth` utilities to use the current breakpoint values.

(this actually overrides existing token names)

