### PR TITLE
fix(SendReceive.stories): stop eth price updates during chromatic snapshots

### DIFF
--- a/src/components/Simulator/screens/SendReceive/index.tsx
+++ b/src/components/Simulator/screens/SendReceive/index.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react"
+import isChromatic from "chromatic"
 
 import type { PhoneScreenProps } from "@/lib/types"
 
@@ -24,7 +25,8 @@ import { Success } from "./Success"
 export const SendReceive = ({ nav, ctaLabel }: PhoneScreenProps) => {
   const { progressStepper, step } = nav
   const fetchedPrice = useEthPrice()
-  const ethPrice = fetchedPrice > 1 ? fetchedPrice : FALLBACK_ETH_PRICE
+  const ethPrice =
+    fetchedPrice > 1 && !isChromatic() ? fetchedPrice : FALLBACK_ETH_PRICE
   const ethReceiveAmount = USD_RECEIVE_AMOUNT / ethPrice
   const [chosenAmount, setChosenAmount] = useState(0)
   const ethChosenAmount = chosenAmount / ethPrice


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

For the `SendReceive` component, this adds a check for chromatic to use the Fallback eth price when rendering the calculated value during the Chromatic snapshots. This will prevent API updates that would otherwise run a new snapshot for multiple stories when chromatic runs.
