### PR TITLE
fix: apply default border color to all

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -80,6 +80,10 @@
 }
 
 @layer base {
+  * {
+    @apply border-border;
+  }
+
   body {
     @apply bg-background font-body leading-base text-body;
   }


### PR DESCRIPTION
## Description
- apply default `border-border` class to all elements

## Related Issue
Fixes recent border-color regressions with Chakra theming deprecation