### PR TITLE
Grammar & Wording Fixes in Docs

### DIFF
--- a/docs/applying-storybook.md
+++ b/docs/applying-storybook.md
@@ -229,4 +229,4 @@ parameters: {
 }
 ```
 
-> 🚨 NOTE: This will be notated ahead of time by the team which stories should not receive snapshots.
+> 🚨 NOTE: This will be noted ahead of time by the team which stories should not receive snapshots.

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -8,7 +8,7 @@ How to prepare your content for translation depends on whether you're working on
 
 **- MDX pages (`public/content/page/`)**
 
-Markdown will be translated as whole pages of content, so no specific action is required. Simply create a new folder within `public/content/` with the name of the page, then place index markdown file (ie. `index.md`) within the new folder.
+Markdown will be translated as whole pages of content, so no specific action is required. Simply create a new folder within `public/content/` with the name of the page, then place an index markdown file (ie. `index.md`) within the new folder.
 
 **- React component page**
 

--- a/docs/header-ids.md
+++ b/docs/header-ids.md
@@ -36,7 +36,7 @@ See a live example on ethereum.org: [https://ethereum.org/en/developers/docs/blo
 
 ### English content
 
-These should be created for header on every new English markdown document.
+These should be created for header in every new English markdown document.
 
 ### Translated content
 

--- a/docs/translation-program.md
+++ b/docs/translation-program.md
@@ -2,6 +2,6 @@
 
 _The Translation Program is an initiative to translate ethereum.org into different languages and make the website accessible to people from all over the world._
 
-If you are looking to get involved as a translator, you can [join our project in Crowdin](https://crowdin.com/project/ethereum-org/) and start translating the website to your language immediately.
+If you are looking to get involved as a translator, you can [join our project in Crowdin](https://crowdin.com/project/ethereum-org/) and start translating the website into your language immediately.
 
 To get more information about the program, learn how to use Crowdin, check on the progress or find some useful tools for translators, please visit the [Translation Program page](https://ethereum.org/en/contributing/translation-program/).


### PR DESCRIPTION


"notated" → "noted" (correct meaning in context)
Fix article usage (File: relevant doc)

"place index markdown file" → "place an index markdown file" (missing article)

"for header on every" → "for headers in every" (plural & correct preposition)

"translating the website to your language" → "translating the website into your language" (correct usage)
