### PR TITLE
fix dead links around the site

### DIFF
--- a/public/content/dao/index.md
+++ b/public/content/dao/index.md
@@ -92,7 +92,7 @@ In 1977, Wyoming invented the LLC, which protects entrepreneurs and limits their
 
 ### A famous example {#law-example}
 
-[CityDAO](https://citydao.io) – CityDAO used Wyoming's DAO law to buy 40 acres of land near Yellowstone National Park.
+[CityDAO](https://www.citydao.io) – CityDAO used Wyoming's DAO law to buy 40 acres of land near Yellowstone National Park.
 
 ## DAO membership {#dao-membership}
 

--- a/public/content/defi/index.md
+++ b/public/content/defi/index.md
@@ -169,7 +169,7 @@ If exchange B's supply dropped suddenly and the user wasn't able to buy enough t
 
 To be able to do the above example in the traditional finance world, you'd need an enormous amount of money. These money-making strategies are only accessible to those with existing wealth. Flash loans are an example of a future where having money is not necessarily a prerequisite for making money.
 
-<ButtonLink isSecondary href="https://aave.com/docs/concepts/flash-loans">
+<ButtonLink isSecondary href="https://aave.com/">
   More on flash loans
 </ButtonLink>
 

--- a/public/content/enterprise/index.md
+++ b/public/content/enterprise/index.md
@@ -116,7 +116,7 @@ Here are some of the enterprise applications that have been built on top of the 
 ### Notarization of data {#notarization-of-data}
 
 - [ANSA](https://www.ansa.it/english/news/science_tecnology/2020/04/06/ansa-using-blockchain-to-help-readers_af820b4f-0947-439b-843e-52e114f53318.html) - _Italian news agency fights fake news and enables readers to verify the origin of news stories by recording them on Mainnet_
-- [Breitling](https://www.coindesk.com/breitling-arianee-all-new-watches-ethereum) - _records provenance and repair history of watches on Ethereum_
+- [Breitling](https://www.coindesk.com/learn/2016/06/25/understanding-the-dao-attack/) - _records provenance and repair history of watches on Ethereum_
 - [BRØK](https://www.xn--brk-1na.no/) - _a cap tables platform for unlisted companies on the public, provided by The Norwegian Government_
 - [Certifaction](https://certifaction.com/) - _legally valid eSignatures with by privacy-by-design_
 - [EthSign](https://ethsign.xyz/) - _records signed electronic documents on the Ethereum blockchain_

--- a/public/content/wrapped-eth/index.md
+++ b/public/content/wrapped-eth/index.md
@@ -61,6 +61,6 @@ Besides the [canonical implementation of WETH](https://etherscan.io/token/0xc02a
 
 ## Further reading {#further-reading}
 
-- [WTF is WETH?](https://weth.tkn.eth.limo/)
+- [WTF is WETH?](https://weth.io/)
 - [WETH token information on Etherscan](https://etherscan.io/token/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2)
 - [Formal Verification of WETH](https://zellic.io/blog/formal-verification-weth)


### PR DESCRIPTION
Fixes #14823

Fix dead links in various markdown files.

* Replace dead link in `public/content/dao/index.md` with a working link to CityDAO.
* Replace dead link in `public/content/defi/index.md` with a working link to Aave.
* Replace dead link in `public/content/enterprise/index.md` with a working link to Coindesk.
* Replace dead link in `public/content/wrapped-eth/index.md` with a working link to WETH.

