### PR TITLE
Fix Incorrect Terminology and Client Count in Portal Network Documentation

### DIFF
--- a/public/content/developers/docs/networking-layer/portal-network/index.md
+++ b/public/content/developers/docs/networking-layer/portal-network/index.md
@@ -57,7 +57,7 @@ The benefits of this network design are:
 - Minimized or zero syncing
 - Accessible to resource-constrained devices (<1 GB RAM, <100 MB disk space, 1 CPU)
 
-The diagram below shows the functions of existing clients that can be delivered by the Portal Network, enabling users to access these functions on very low-resource devices.
+The table below shows the functions of existing clients that can be delivered by the Portal Network, enabling users to access these functions on very low-resource devices.
 
 ### The Portal Networks
 
@@ -69,7 +69,7 @@ The diagram below shows the functions of existing clients that can be delivered 
 
 ## Client diversity by default {#client-diversity-as-default}
 
-The Portal Network developers also made the design choice to build three separate Portal Network clients from day one.
+The Portal Network developers also made the design choice to build four separate Portal Network clients from day one.
 
 The Portal Network clients are:
 


### PR DESCRIPTION
## Description


**Changes Proposed:**
1. **Diagram to Table Correction**:
   - The section incorrectly refers to a "diagram" when the content is clearly structured as a table. Updated the terminology to accurately describe the content as a **table**.

2. **Client Count Correction**:
   - The documentation states that there are **three Portal Network clients**, but the list provided includes **four clients** (Trin, Fluffy, Ultralight, and Shisui). Updated the text to reflect the correct number of clients listed on the site.


**Changes Made:**
- Replaced "diagram" with "table" in the relevant section.
- Updated the text to state "four Portal Network clients" instead of "three."

