### PR TITLE
fix: fix centered labels in code examples section on homepage

### DIFF
--- a/src/pages/[locale]/index.tsx
+++ b/src/pages/[locale]/index.tsx
@@ -493,7 +493,7 @@ const HomePage = ({
                   <button
                     key={title}
                     className={cn(
-                      "flex flex-col gap-y-0.5 border-t px-6 py-4 hover:bg-background-highlight max-md:hidden",
+                      "flex flex-col gap-y-0.5 border-t px-6 py-4 text-start hover:bg-background-highlight max-md:hidden",
                       isModalOpen &&
                         idx === activeCode &&
                         "bg-background-highlight"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added `text-start`
<!--- Describe your changes in detail -->

## Related Issue
N/A
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
