### PR TITLE
docs: fix grammatical error: "alongside with" → "alongside"

### DIFF
--- a/public/content/eips/index.md
+++ b/public/content/eips/index.md
@@ -48,7 +48,7 @@ If you would like to become an EIP editor, please check [EIP-5069](https://eips.
 
 EIP editors decide when a proposal is ready to become an EIP, and help EIP authors move their proposals forward. [Ethereum Cat Herders](https://www.ethereumcatherders.com/) help organize meetings between the EIP editors and the community (see [EIPIP](https://github.com/ethereum-cat-herders/EIPIP)).
 
-Full standardization process alongside with chart is described in [EIP-1](https://eips.ethereum.org/EIPS/eip-1)
+Full standardization process alongside chart is described in [EIP-1](https://eips.ethereum.org/EIPS/eip-1)
 
 ## Learn more {#learn-more}
 


### PR DESCRIPTION
## Description

I noticed a grammatical issue in the text: the phrase **"alongside with"** is incorrect because "alongside" already means "together with," making "with" redundant. I’ve removed "with" to make the sentence grammatically correct.  

Thanks!
