### PR TITLE
fix: dead link in doc

### DIFF
--- a/public/content/developers/docs/smart-contracts/testing/index.md
+++ b/public/content/developers/docs/smart-contracts/testing/index.md
@@ -259,7 +259,7 @@ The major difference is that bug bounty programs are open to the wider developer
 
 - **[Brownie unit testing framework](https://eth-brownie.readthedocs.io/en/v1.0.0_a/tests.html)** - _Brownie utilizes Pytest, a feature-rich test framework that lets you write small tests with minimal code, scales well for large projects, and is highly extendable._
 
-- **[Foundry Tests](https://github.com/foundry-rs/foundry/tree/master/forge)** - _Foundry offers Forge, a fast and flexible Ethereum testing framework capable of executing simple unit tests, gas optimization checks, and contract fuzzing._
+- **[Foundry Tests](https://github.com/foundry-rs/foundry/tree/master/crates/forge)** - _Foundry offers Forge, a fast and flexible Ethereum testing framework capable of executing simple unit tests, gas optimization checks, and contract fuzzing._
 
 - **[Hardhat Tests](https://hardhat.org/hardhat-runner/docs/guides/test-contracts)** - _Framework for testing smart contracts based on ethers.js, Mocha, and Chai._
 


### PR DESCRIPTION
## Description

Hi! While reviewing the documentation, I noticed that a link to Foundry's testing framework (forge) was broken. The original link pointed to an outdated path (https://github.com/foundry-rs/foundry/tree/master/forge), which no longer exists. I’ve updated it to the correct path: https://github.com/foundry-rs/foundry/tree/master/crates/forge.
