### PR TITLE
Remove non braking space character visible in french version

### DIFF
--- a/public/content/translations/fr/security/index.md
+++ b/public/content/translations/fr/security/index.md
@@ -19,7 +19,7 @@ L'intérêt grandissant pour la cryptomonnaie amène avec lui un risque croissan
 Une mauvaise compréhension de la façon dont fonctionnent les cryptomonnaies peut amener à des erreurs coûteuses. Par exemple, si quelqu'un prétend être un agent d'un service client qui peut vous rendre vos ETH perdus en échange de vos clés privées, ils s'attaquent aux personnes ne comprenant pas qu'Ethereum est un réseau décentralisé manquant de ce genre de fonctionnalité. S'informer sur le fonctionnement d'Ethereum est un investissement qui en vaut la peine.
 
 <DocLink href="/what-is-ethereum/">
-  Qu'est-ce qu'Ethereum&nbsp;?
+  Qu'est-ce qu'Ethereum ?
 </DocLink>
 
 <DocLink href="/eth/">

--- a/src/intl/fr/page-learn.json
+++ b/src/intl/fr/page-learn.json
@@ -12,7 +12,7 @@
   "hero-button-lets-get-started": "C'est parti !",
   "what-is-crypto-1": "Vous avez peut-être entendu parler de cryptomonnaies, de blockchains et de Bitcoin. Les liens ci-dessous vous aideront à apprendre ce qu'ils sont et comment ils s'articulent avec Ethereum.",
   "what-is-crypto-2": "Les cryptomonnaies, comme le Bitcoin, permettent à n'importe qui de transférer de l'argent à l'échelle mondiale. Ethereum le permet également, mais il peut également exécuter du code qui permet aux gens de créer des applications et des organisations. Il est à la fois résilient et flexible : n'importe quel programme informatique peut être exécuté sur Ethereum. Apprenez-en davantage et découvrez comment commencer :",
-  "what-is-ethereum-card-title": "Qu'est-ce qu'Ethereum&nbsp;?",
+  "what-is-ethereum-card-title": "Qu'est-ce qu'Ethereum ?",
   "what-is-ethereum-card-description": "Si vous êtes nouveau, commencez ici pour savoir pourquoi Ethereum est important.",
   "what-is-ethereum-card-image-alt": "Illustration d'une personne jetant un coup d'œil à un bazar, destinée à représenter Ethereum.",
   "what-is-eth-card-title": "Qu'est-ce que l'ETH ?",


### PR DESCRIPTION


## Description

I have updated some typo issue in the french version documentation because the Non-breaking Space character "&nbsp;?" was appearing on the website. 

I have updated page-learn.json and index.md because it's not needed anymore. 

<img width="320" alt="Capture d’écran 2025-03-08 à 14 42 22" src="https://github.com/user-attachments/assets/80d828df-c42c-45dc-97cf-a3e2b8ae3f5c" />



## Related Issue
[Bug report: Non-breaking Space character appearing on the french version documentation. #15035](https://github.com/ethereum/ethereum-org-website/issues/15035)
