### PR TITLE
stroke-linejoin -> strokeLinejoin

### DIFF
--- a/src/components/icons/EthHomeIcon.tsx
+++ b/src/components/icons/EthHomeIcon.tsx
@@ -10,37 +10,37 @@ export const EthHomeIcon = createIconBase({
         d="M57.5054 181V135.84L1.64064 103.171L57.5054 181Z"
         fill="#F0CDC2"
         stroke="#1616B4"
-        stroke-linejoin="round"
+        strokeLinejoin="round"
       />
       <path
         d="M57.6906 181V135.84L113.555 103.171L57.6906 181Z"
         fill="#C9B3F5"
         stroke="#1616B4"
-        stroke-linejoin="round"
+        strokeLinejoin="round"
       />
       <path
         d="M57.5055 124.615V66.9786L1 92.2811L57.5055 124.615Z"
         fill="#88AAF1"
         stroke="#1616B4"
-        stroke-linejoin="round"
+        strokeLinejoin="round"
       />
       <path
         d="M57.6903 124.615V66.9786L114.196 92.2811L57.6903 124.615Z"
         fill="#C9B3F5"
         stroke="#1616B4"
-        stroke-linejoin="round"
+        strokeLinejoin="round"
       />
       <path
         d="M1.00006 92.2811L57.5054 1V66.9786L1.00006 92.2811Z"
         fill="#F0CDC2"
         stroke="#1616B4"
-        stroke-linejoin="round"
+        strokeLinejoin="round"
       />
       <path
         d="M114.196 92.2811L57.6906 1V66.9786L114.196 92.2811Z"
         fill="#B8FAF6"
         stroke="#1616B4"
-        stroke-linejoin="round"
+        strokeLinejoin="round"
       />
     </>
   ),


### PR DESCRIPTION
Fixes

```
Warning: Invalid DOM property `stroke-linejoin`. Did you mean `strokeLinejoin`?
    at path
    at svg
    at IconBase
    at Comp (webpack-internal:///./src/components/icons/icon-base.tsx:23:21)
    at a
    at LinkComponent (/Users/corwinsmith/Documents/work/ethereum-org-website/node_modules/next/dist/client/link.js:121:19)
    at BaseLink (/Users/corwinsmith/Documents/work/ethereum-org-website/node_modules/next-intl/dist/development/navigation/shared/BaseLink.js:20:5)
    at Link (/Users/corwinsmith/Documents/work/ethereum-org-website/node_modules/next-intl/dist/development/navigation/shared/createSharedNavigationFns.js:36:7)
    at Link (webpack-internal:///./src/components/ui/Link.tsx:48:102)
    at div
    at nav
    at div
    at Nav (webpack-internal:///./src/components/Nav/index.tsx:60:94)
    at div
    at BaseLayout (webpack-internal:///./src/layouts/BaseLayout.tsx:33:23)
    at Provider (file:///Users/corwinsmith/Documents/work/ethereum-org-website/node_modules/@radix-ui/react-context/dist/index.mjs:27:15)
    at TooltipProvider (file:///Users/corwinsmith/Documents/work/ethereum-org-website/node_modules/@radix-ui/react-tooltip/dist/index.mjs:29:5)
    at G (/Users/corwinsmith/Documents/work/ethereum-org-website/node_modules/next-themes/dist/index.js:1:947)
    at B (/Users/corwinsmith/Documents/work/ethereum-org-website/node_modules/next-themes/dist/index.js:1:861)
    at ThemeProvider (webpack-internal:///./src/components/ThemeProvider.tsx:21:30)
    at IntlProvider (/Users/corwinsmith/Documents/work/ethereum-org-website/node_modules/use-intl/dist/development/_IntlProvider.js:16:5)
    at NextIntlClientProvider (/Users/corwinsmith/Documents/work/ethereum-org-website/node_modules/next-intl/dist/development/shared/NextIntlClientProvider.js:16:5)
    at App (webpack-internal:///./src/pages/_app.tsx:34:16)
    at StyleRegistry (/Users/corwinsmith/Documents/work/ethereum-org-website/node_modules/styled-jsx/dist/index/index.js:449:36)
    at eU (/Users/corwinsmith/Documents/work/ethereum-org-website/node_modules/next/dist/compiled/next-server/pages.runtime.dev.js:8:20489)
    at eH (/Users/corwinsmith/Documents/work/ethereum-org-website/node_modules/next/dist/compiled/next-server/pages.runtime.dev.js:17:1788)
    at eJ (/Users/corwinsmith/Documents/work/ethereum-org-website/node_modules/next/dist/compiled/next-server/pages.runtime.dev.js:17:3091)
    at div
    at e9 (/Users/corwinsmith/Documents/work/ethereum-org-website/node_modules/next/dist/compiled/next-server/pages.runtime.dev.js:26:761)
    ```