### PR TITLE
Correctly set HTML lang attribute

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -12,11 +12,15 @@ import { isLangRightToLeft } from "@/lib/utils/translations"
 
 class Document extends NextDocument {
   static async getInitialProps(ctx: DocumentContext) {
-    return await NextDocument.getInitialProps(ctx)
+    const initialProps = await NextDocument.getInitialProps(ctx)
+    // TODO: Fix this! Hacky way to get locale to fix search
+    // Get locale from query
+    const locale = ctx.query?.locale || "en"
+    return { ...initialProps, locale }
   }
 
   render() {
-    const { locale } = this.props.__NEXT_DATA__
+    const locale = this.props.locale || "en"
     const dir = isLangRightToLeft(locale as Lang) ? "rtl" : "ltr"
 
     return (


### PR DESCRIPTION
## Description
The `lang` html attribute was always defaulting to "en" regardless of the actual page locale. My understanding is we use the `lang` to split our search indexes, so this bug is causing all languages to be [searchable in English](https://discord.com/channels/420394352083337236/426091468403376128/1349122790258770013), and none of the non-English languages have any search hits at all.

<img width="1036" alt="Screenshot 2025-03-11 at 21 17 54" src="https://github.com/user-attachments/assets/ad178cff-0434-4144-8871-eaf5f8bfcf66" />


Solution is... maybe hacky? I modified _document.tsx to extract the locale from query parameters in getInitialProps. This ensures the `lang` is properly set for the crawler to see.

<img width="703" alt="Screenshot 2025-03-11 at 22 33 07" src="https://github.com/user-attachments/assets/476b05c7-f4a4-45c9-b1ad-eb0489234fd7" />

After testing/merging this PR, we need to run a [recrawl on Docsearch to fix the bug](https://crawler.algolia.com/admin/crawlers/d9cd038f-c91f-471d-99bc-f9a3f370beb3/overview) 
