### PR TITLE
Fix localized menu & breadcrumb links

### DIFF
--- a/src/components/Nav/Menu/SubMenu.tsx
+++ b/src/components/Nav/Menu/SubMenu.tsx
@@ -1,5 +1,4 @@
 import { AnimatePresence, motion } from "framer-motion"
-import NextLink from "next/link"
 import {
   Content,
   Item,
@@ -71,32 +70,30 @@ const SubMenu = ({ lvl, items, activeSection, onClose }: LvlContentProps) => {
                   <Item key={label} asChild>
                     <ListItem className={cn("mb-2 last:mb-0", itemClasses())}>
                       {isLink ? (
-                        <NextLink href={action.href!} passHref legacyBehavior>
-                          <NavigationMenuLink asChild>
-                            <Button
-                              variant="ghost"
-                              className={buttonClasses}
-                              data-active={isActivePage}
-                              onClick={() => {
-                                onClose()
-                                trackCustomEvent({
-                                  eventCategory: "Desktop navigation menu",
-                                  eventAction: `Menu - ${activeSection} - ${locale}`,
-                                  eventName: action.href!,
-                                })
-                              }}
-                              asChild
-                            >
-                              <BaseLink>
-                                {lvl === 1 && Icon ? (
-                                  <Icon className="me-4 h-6 w-6" />
-                                ) : null}
+                        <NavigationMenuLink asChild>
+                          <Button
+                            variant="ghost"
+                            className={buttonClasses}
+                            data-active={isActivePage}
+                            onClick={() => {
+                              onClose()
+                              trackCustomEvent({
+                                eventCategory: "Desktop navigation menu",
+                                eventAction: `Menu - ${activeSection} - ${locale}`,
+                                eventName: action.href!,
+                              })
+                            }}
+                            asChild
+                          >
+                            <BaseLink href={action.href!}>
+                              {lvl === 1 && Icon ? (
+                                <Icon className="me-4 h-6 w-6" />
+                              ) : null}
 
-                                <ItemContent item={item} lvl={lvl} />
-                              </BaseLink>
-                            </Button>
-                          </NavigationMenuLink>
-                        </NextLink>
+                              <ItemContent item={item} lvl={lvl} />
+                            </BaseLink>
+                          </Button>
+                        </NavigationMenuLink>
                       ) : (
                         <>
                           <Trigger asChild>

--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -1,9 +1,11 @@
 import * as React from "react"
-import Link, { LinkProps } from "next/link"
+import { ComponentProps } from "react"
 import { LuChevronRight, LuMoreHorizontal } from "react-icons/lu"
 import { Slot } from "@radix-ui/react-slot"
 
 import { cn } from "@/lib/utils/cn"
+
+import { Link } from "@/i18n/routing"
 
 interface BreadcrumbProps extends React.ComponentPropsWithoutRef<"nav"> {
   separator?: React.ReactNode
@@ -46,7 +48,7 @@ BreadcrumbItem.displayName = "BreadcrumbItem"
 const BreadcrumbLink = React.forwardRef<
   HTMLAnchorElement,
   React.ComponentPropsWithoutRef<"a"> &
-    LinkProps & {
+    ComponentProps<typeof Link> & {
       asChild?: boolean
     }
 >(({ asChild, className, ...props }, ref) => {


### PR DESCRIPTION
Current bug:
- visit a non-default locale version of the site https://ethereum.org/es/
- navigate to a different page using the menu
- you will get redirected to the default locale version

## Description

This PR fixes the issue by using the i18n Link component exported by `next-intl`.
