### PR TITLE
Receipt logs may contain arbitrary amount of data

### DIFF
--- a/public/content/developers/docs/apis/json-rpc/index.md
+++ b/public/content/developers/docs/apis/json-rpc/index.md
@@ -1559,8 +1559,9 @@ params: [
   - `blockHash`: `DATA`, 32 Bytes - hash of the block where this log was in. `null` when its pending. `null` when its pending log.
   - `blockNumber`: `QUANTITY` - the block number where this log was in. `null` when its pending. `null` when its pending log.
   - `address`: `DATA`, 20 Bytes - address from which this log originated.
-  - `data`: `DATA` - contains zero or more 32 Bytes non-indexed arguments of the log.
+  - `data`: `DATA` - variable-length non-indexed log data. (In _solidity_: zero or more 32 Bytes non-indexed log arguments.)
   - `topics`: `Array of DATA` - Array of 0 to 4 32 Bytes `DATA` of indexed log arguments. (In _solidity_: The first topic is the _hash_ of the signature of the event (e.g. `Deposit(address,bytes32,uint256)`), except you declared the event with the `anonymous` specifier.)
+
 - **Example**
 
 ```js


### PR DESCRIPTION
`data` may contain arbitrary data if using EVM assembly directly, the restriction to a multiple of 32 Bytes is not generally correct.

Example of 48 bytes of `data`:

- https://etherscan.io/tx/0x3618e5f15ea20435ea3b76b3d65e268085a8995f6989b463891e66bc21bb30dc#eventlog#132

Which is generated with a manual `LOG0` instruction:

- https://etherscan.io/address/0x0d0e364aa7852291883c162b22d6d81f6355428f#code

```solidity
function _logRfqOrder(bytes32 makerConsiderationHash, bytes32 takerConsiderationHash, uint128 makerFilledAmount)
        private
    {
        assembly ("memory-safe") {
            mstore(0x00, RFQ_ORDER_TYPEHASH)
            mstore(0x20, makerConsiderationHash)
            let ptr := mload(0x40)
            mstore(0x40, takerConsiderationHash)
            let orderHash := keccak256(0x00, 0x60)
            mstore(0x40, ptr)
            mstore(0x10, makerFilledAmount)
            mstore(0x00, orderHash)
            log0(0x00, 0x30)
        }
    }
```
