### PR TITLE
Update link to Fluffy on the Portal Network page

### DIFF
--- a/public/content/developers/docs/networking-layer/portal-network/index.md
+++ b/public/content/developers/docs/networking-layer/portal-network/index.md
@@ -74,7 +74,7 @@ The Portal Network developers also made the design choice to build three separat
 The Portal Network clients are:
 
 - [Trin](https://github.com/ethereum/trin): written in Rust
-- [Fluffy](https://nimbus.team/docs/fluffy.html): written in Nim
+- [Fluffy](https://fluffy.guide): written in Nim
 - [Ultralight](https://github.com/ethereumjs/ultralight): written in Typescript
 - [Shisui](https://github.com/optimism-java/shisui): written in Go
 


### PR DESCRIPTION
## Description

When browsing the portal network page in the developer docs I found that the link to the Fluffy portal network client is broken. This change updates the link to point to our Fluffy book/documentation site.

