### PR TITLE
update broken TrustToken link to new TUSD website

### DIFF
--- a/src/pages/[locale]/stablecoins.tsx
+++ b/src/pages/[locale]/stablecoins.tsx
@@ -255,7 +255,7 @@ const StablecoinsPage = ({ markets, marketsHasError }) => {
       ],
       links: [
         { text: "USDC", url: "https://www.coinbase.com/usdc" },
-        { text: "TrueUSD", url: "https://www.trusttoken.com/trueusd" },
+        { text: "TrueUSD", url: "https://tusd.io/" },
       ],
     },
     {


### PR DESCRIPTION
Replaced outdated link (https://www.trusttoken.com/) with the current official TUSD site (https://tusd.io/). The old link was broken.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
