### PR TITLE
Hide listen to player on non-english pages

### DIFF
--- a/src/components/ListenToPlayer/index.tsx
+++ b/src/components/ListenToPlayer/index.tsx
@@ -2,6 +2,7 @@
 
 import { useContext, useEffect, useState } from "react"
 import { Howl } from "howler"
+import { useLocale } from "next-intl"
 import { Portal } from "@radix-ui/react-portal"
 
 import PlayerWidget from "@/components/ListenToPlayer/PlayerWidget"
@@ -16,6 +17,7 @@ import { FeedbackWidgetContext } from "@/contexts/FeedbackWidgetContext"
 import { useTranslation } from "@/hooks/useTranslation"
 
 const ListenToPlayer = ({ slug }: { slug: string }) => {
+  const locale = useLocale()
   const { setShowFeedbackWidget } = useContext(FeedbackWidgetContext)
   const { playlist, index } = getPlaylistBySlug(slug)
 
@@ -208,6 +210,8 @@ const ListenToPlayer = ({ slug }: { slug: string }) => {
   }
 
   if (!playlist.length || index === -1) return null
+
+  if (locale !== "en") return null
 
   return (
     <>

--- a/src/components/ListenToPlayer/index.tsx
+++ b/src/components/ListenToPlayer/index.tsx
@@ -120,6 +120,9 @@ const ListenToPlayer = ({ slug }: { slug: string }) => {
     }
   }, [playbackSpeed, sound])
 
+  // Only show the player if the locale is English and there is a playlist, renders null early
+  if (!playlist.length || index === -1 || locale !== "en") return null
+
   const handlePlayPause = () => {
     if (!sound) return
 
@@ -208,10 +211,6 @@ const ListenToPlayer = ({ slug }: { slug: string }) => {
       eventName: `speed (${speed})`,
     })
   }
-
-  if (!playlist.length || index === -1) return null
-
-  if (locale !== "en") return null
 
   return (
     <>


### PR DESCRIPTION
## Description

- Hides the listen to player on non english pages since this content is only in english at the moment
