### PR TITLE
Fix: Remove duplicate 'minute read' text in tutorial metadata

### DIFF
--- a/src/components/TutorialMetadata.tsx
+++ b/src/components/TutorialMetadata.tsx
@@ -79,7 +79,7 @@ const TutorialMetadata = ({
         )}
         <div>
           <Emoji className="me-2 text-sm" text=":stopwatch:" />
-          {timeToRead} {t("comp-tutorial-metadata-minute-read")} minute read
+          {timeToRead} {t("comp-tutorial-metadata-minute-read")}
         </div>
       </Flex>
       {address && (


### PR DESCRIPTION
## Description
This PR fixes the issue where the time-to-read label was being duplicated in the UI. 

The problem was in the TutorialMetadata component where both the translated string from `comp-tutorial-metadata-minute-read` AND a hardcoded "minute read" text were being displayed together, causing strings like:
- "28 minute read minute read" in English
- "28 minute de citit minute read" in Romanian

The fix simply removes the hardcoded "minute read" text since it's already included in the translation string.

## Related Issue
Fixes #15174