### PR TITLE
build: skip "Cache hit gfissues" log output

### DIFF
--- a/src/lib/utils/data/cacheAsyncFn.ts
+++ b/src/lib/utils/data/cacheAsyncFn.ts
@@ -34,7 +34,8 @@ export function cacheAsyncFn<T>(
         options?.cacheTimeout && cacheAge > options.cacheTimeout
 
       if (!isCacheExpired) {
-        console.log("Cache hit", key)
+        const quietKeys: string[] = ["gfissues"]
+        !quietKeys.includes(key) && console.log("Cache hit", key)
         return cachedItem.value as T
       }
       console.log("Cache expired", key)


### PR DESCRIPTION
## Description
- skip "Cache hit gfissues" log output
- removes potentially >30k logs during build.

## Related Issue
None filed; 34,360 logs of "Cache hit gfissues" in build logs:

<img width="538" alt="image" src="https://github.com/user-attachments/assets/451b170c-5a91-4395-a29b-16d32d40cb58" />

https://app.netlify.com/sites/ethereumorg/deploys/67e5fa6c532a270008eaf31f
