### PR TITLE
Hotfix reading time for tutorials

### DIFF
--- a/app/[locale]/[...slug]/page.tsx
+++ b/app/[locale]/[...slug]/page.tsx
@@ -63,6 +63,7 @@ export default async function Page({
     lastEditLocaleTimestamp,
     isTranslated,
     contributors,
+    timeToRead,
   } = await getPageData({
     locale,
     slug,
@@ -97,8 +98,7 @@ export default async function Page({
         lastEditLocaleTimestamp={lastEditLocaleTimestamp}
         contentNotTranslated={!isTranslated}
         contributors={contributors}
-        // TODO: Remove this once we have a real timeToRead value
-        timeToRead={2}
+        timeToRead={Math.round(timeToRead.minutes)}
       >
         {content}
       </Layout>

--- a/src/lib/md/data.ts
+++ b/src/lib/md/data.ts
@@ -1,4 +1,5 @@
 import { MDXRemoteProps } from "next-mdx-remote"
+import readingTime, { ReadTimeResults } from "reading-time"
 
 import {
   CommitHistory,
@@ -32,6 +33,7 @@ interface PageData {
   lastEditLocaleTimestamp: string
   contributors: FileContributor[]
   isTranslated: boolean
+  timeToRead: ReadTimeResults
 }
 
 export async function getPageData({
@@ -76,6 +78,8 @@ export async function getPageData({
     lastUpdatedDate
   )
 
+  const timeToRead = readingTime(markdown)
+
   return {
     content,
     frontmatter,
@@ -83,5 +87,6 @@ export async function getPageData({
     lastEditLocaleTimestamp,
     contributors,
     isTranslated,
+    timeToRead,
   }
 }


### PR DESCRIPTION
## Description

Removes hardcoded read time for tutorials and calculate it using `reading-time` lib.