### PR TITLE
Update link to Fluffy on the Portal Network page

### DIFF
--- a/public/content/translations/es/developers/docs/networking-layer/portal-network/index.md
+++ b/public/content/translations/es/developers/docs/networking-layer/portal-network/index.md
@@ -68,7 +68,7 @@ Los desarrolladores de Portal Network también eligieron el diseño para constru
 Los clientes de Portal Network son:
 
 - [Trin](https://github.com/ethereum/trin): escrito en Rust
-- [Fluffy](https://nimbus.team/docs/fluffy.html): escrito en Nim
+- [Fluffy](https://fluffy.guide): escrito en Nim
 - [Ultralight](https://github.com/ethereumjs/ultralight): escrito en Typescript
 - [Shisui](https://github.com/GrapeBaBa/shisui): escrito en Go
 

--- a/public/content/translations/fa/developers/docs/networking-layer/portal-network/index.md
+++ b/public/content/translations/fa/developers/docs/networking-layer/portal-network/index.md
@@ -68,7 +68,7 @@ JSON-RPC API یک انتخاب ایده‌آل برای درخواست داده�
 کاربران شبکه پورتال عبارتند از:
 
 - [Trin](https://github.com/ethereum/trin): نوشته شده در Rust
-- [Fluffy](https://nimbus.team/docs/fluffy.html): نوشته شده به زبان Nim
+- [Fluffy](https://fluffy.guide): نوشته شده به زبان Nim
 - [فوق سبک](https://github.com/ethereumjs/ultralight): نوشته شده در تایپ اسکریپت
 - [Shisui](https://github.com/GrapeBaBa/shisui): نوشته شده در Go
 

--- a/public/content/translations/fr/developers/docs/networking-layer/portal-network/index.md
+++ b/public/content/translations/fr/developers/docs/networking-layer/portal-network/index.md
@@ -74,7 +74,7 @@ Les développeurs du Portal Network ont également fait le choix de concevoir tr
 Les clients du Portal Network sont :
 
 - [Trin](https://github.com/ethereum/trin) : écrit en Rust
-- [Fluffy](https://nimbus.team/docs/fluffy.html) : écrit en Nim
+- [Fluffy](https://fluffy.guide) : écrit en Nim
 - [Ultralight](https://github.com/ethereumjs/ultralight) : écrit en Typescript
 - [Shisui](https://github.com/optimism-java/shisui) : écrit en Go
 


### PR DESCRIPTION
This change updates the link to point to our Fluffy book/documentation site.