### PR TITLE
fix: developer docs back-to-top link translation id (close: #15231)

### DIFF
--- a/src/layouts/Docs.tsx
+++ b/src/layouts/Docs.tsx
@@ -67,7 +67,7 @@ const H4 = (props: HTMLAttributes<HTMLHeadingElement>) => (
 const BackToTop = (props: ChildOnlyProp) => (
   <div className="display-none mt-12 flex border-t pt-8" {...props}>
     <InlineLink href="#top">
-      <Translation id="back-to-top" /> ↑
+      <Translation id="page-developers-docs:back-to-top" /> ↑
     </InlineLink>
   </div>
 )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- The `back-to-top` link currently has an invalid translation-id, which prevents the text from displaying correctly. The correct ID should be `page-developers-docs:back-to-top`.

- Before:
![image](https://github.com/user-attachments/assets/7a1e32bd-a965-46e3-9484-da3aa2307557)

- After (EN & FR):
![image](https://github.com/user-attachments/assets/4a8a22cf-eb6f-4f3f-8527-c2f96cdd2788)
![image](https://github.com/user-attachments/assets/e198b107-48c6-476b-96f5-c617e77c58d4)

<!--- Describe your changes in detail -->

## Related Issue

- Close: #15231
- A potentially related issue was mentioned in the issue thread discussion.
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
