### PR TITLE
cosmetic:Fixed mobile view for action card

### DIFF
--- a/src/components/ActionCard.tsx
+++ b/src/components/ActionCard.tsx
@@ -41,7 +41,7 @@ const ActionCard = ({
   return (
     <LinkBox
       className={cn(
-        "flex flex-col sm:flex-col md:flex-row shadow-table hover:scale-[1.02] hover:rounded hover:bg-background-highlight hover:shadow-table-box-hover hover:duration-100 focus:scale-[1.02] focus:rounded focus:shadow-table-box-hover focus:duration-100",
+        "flex flex-col md:flex-row shadow-table hover:scale-[1.02] hover:rounded hover:bg-background-highlight hover:shadow-table-box-hover hover:duration-100 focus:scale-[1.02] focus:rounded focus:shadow-table-box-hover focus:duration-100",
         className
       )}
       {...props}

--- a/src/components/ActionCard.tsx
+++ b/src/components/ActionCard.tsx
@@ -41,7 +41,7 @@ const ActionCard = ({
   return (
     <LinkBox
       className={cn(
-        "flex shadow-table hover:scale-[1.02] hover:rounded hover:bg-background-highlight hover:shadow-table-box-hover hover:duration-100 focus:scale-[1.02] focus:rounded focus:shadow-table-box-hover focus:duration-100",
+        "flex flex-col sm:flex-col md:flex-row shadow-table hover:scale-[1.02] hover:rounded hover:bg-background-highlight hover:shadow-table-box-hover hover:duration-100 focus:scale-[1.02] focus:rounded focus:shadow-table-box-hover focus:duration-100",
         className
       )}
       {...props}
@@ -57,7 +57,7 @@ const ActionCard = ({
           src={image}
           alt={alt || ""}
           width={imageWidth}
-          className="max-h-full object-cover p-4"
+          className="max-h-full object-cover p-4 self-center"
         />
       </Flex>
       <div className="flex flex-col justify-center p-6">


### PR DESCRIPTION
Image in ActionCard not fitting properly on mobile
## Description
When viewed in the mobile screen the alignment and size of the image was wrong fixed the alignment 

- Before 
![413749694-efb47659-7e8a-4130-a0df-5fef5c184c46](https://github.com/user-attachments/assets/c06ae20d-2fc7-4b2c-853b-c0d106e0fa04)


- After 
[
![Screenshot 2025-04-04 at 00 18 19](https://github.com/user-attachments/assets/e684280b-330a-418e-9998-a3daf2de9909)
](url)


## Related Issue
Link to issue - https://github.com/ethereum/ethereum-org-website/issues/14920
