### PR TITLE
fix: correct Spanish translation of UX/UI in footer [FIXES #15173]

### DIFF
--- a/src/intl/es/common.json
+++ b/src/intl/es/common.json
@@ -239,7 +239,7 @@
   "nav-did-description": "Cree y sea propietario de sus identificadores descentralizados propios",
   "nav-docs-description": "Documentación de ayuda para entender y construir en Ethereum",
   "nav-docs-design-description": "Descripción de los retos de diseño únicos de Web3, mejores prácticas y hallazgos de investigaciones de los usuarios",
-  "nav-docs-design-label": "Lo esencial del diseño de la UX/IU",
+  "nav-docs-design-label": "Lo esencial del diseño de la UX/UI",
   "nav-docs-foundation-description": "Los fundamentos para desarrollar en Ethereum",
   "nav-docs-foundation-label": "Temas fundamentales",
   "nav-docs-overview-description": "El sitio donde buscar documentación para desarrolladores",


### PR DESCRIPTION
## Description

This PR fixes the incorrect translation in the Spanish version footer where "UX/IU" is used instead of the globally recognized standard "UX/UI". While "IU" (Interfaz de Usuario) is technically the correct Spanish abbreviation for User Interface, the standard order "UX/UI" is widely recognized in technical and design contexts, including in Spanish-speaking environments.

## Changes Made

* Changed "Lo esencial del diseño de la UX/IU" to "Lo esencial del diseño de la UX/UI" in `src/intl/es/common.json`

## Additional Context

As pointed out by native Spanish speakers in the original issue, although "IU" is technically correct in Spanish, "UX/UI" has become the internationally recognized standard even in Spanish technical documentation and design fields. This change improves consistency with industry standards and professional terminology.

## Related Issue

Fixes #15173