### PR TITLE
docs: add RLP link to SSZ documentation

### DIFF
--- a/public/content/developers/docs/data-structures-and-encoding/ssz/index.md
+++ b/public/content/developers/docs/data-structures-and-encoding/ssz/index.md
@@ -5,7 +5,7 @@ lang: en
 sidebarDepth: 2
 ---
 
-**Simple serialize (SSZ)** is the serialization method used on the Beacon Chain. It replaces the RLP serialization used on the execution layer everywhere across the consensus layer except the peer discovery protocol. SSZ is designed to be deterministic and also to Merkleize efficiently. SSZ can be thought of as having two components: a serialization scheme and a Merkleization scheme that is designed to work efficiently with the serialized data structure.
+**Simple serialize (SSZ)** is the serialization method used on the Beacon Chain. It replaces the RLP serialization used on the execution layer everywhere across the consensus layer except the peer discovery protocol. To learn more about RLP serialization, see [Recursive-length prefix (RLP)](/developers/docs/data-structures-and-encoding/rlp/). SSZ is designed to be deterministic and also to Merkleize efficiently. SSZ can be thought of as having two components: a serialization scheme and a Merkleization scheme that is designed to work efficiently with the serialized data structure.
 
 ## How does SSZ work? {#how-does-ssz-work}
 


### PR DESCRIPTION
## Description
This PR adds a link to the RLP serialization documentation from the SSZ documentation page. This improves navigation between related documentation pages and helps users understand the relationship between these two serialization methods.

The changes include:
- Added a link to the RLP documentation in the SSZ documentation page
- The link text is "Recursive-length prefix (RLP)"
- The link points to `/developers/docs/data-structures-and-encoding/rlp/`

## Related Issue
This PR fixes [#15161](https://github.com/ethereum/ethereum-org-website/issues/15161), which requested adding a redirect link from the SSZ documentation to the RLP documentation page.