### PR TITLE
Hotfix get eth page

### DIFF
--- a/app/[locale]/get-eth/page.tsx
+++ b/app/[locale]/get-eth/page.tsx
@@ -15,6 +15,8 @@ import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 
 import GetEthPage from "./_components/get-eth"
 
+import { routing } from "@/i18n/routing"
+
 export default async function Page({
   params,
 }: {
@@ -38,6 +40,10 @@ export default async function Page({
       <GetEthPage lastDataUpdateDate={lastDataUpdateDate} />
     </I18nProvider>
   )
+}
+
+export async function generateStaticParams() {
+  return routing.locales.map((locale) => ({ locale }))
 }
 
 export async function generateMetadata({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Builds `/get-eth` page statically because it needs to run `git log` command and that is not possible on runtime.

Page: https://deploy-preview-15295--ethereumorg.netlify.app/en/get-eth/
