### PR TITLE
revert: staking summit listing

### DIFF
--- a/src/data/community-events.json
+++ b/src/data/community-events.json
@@ -234,15 +234,6 @@
     "imageUrl": ""
   },
   {
-    "title": "Staking Summit*",
-    "startDate": "2025-04-28",
-    "endDate": "2025-04-29",
-    "href": "https://stakingsummit.com",
-    "location": "Dubai, UAE",
-    "description": "The premier staking event. The Staking Summit Dubai brings together the top protocols, validators and investors for a two-day, in-person event.",
-    "imageUrl": "https://framerusercontent.com/assets/jMgdXFlxexhLiYYWPd8Kgep6mhk.png"
-  },
-  {
     "title": "TOKEN2049 Dubai*",
     "startDate": "2025-04-30",
     "endDate": "2025-05-01",


### PR DESCRIPTION
## Description
- Removes 2025 staking summit event given reports of unethical behavior https://www.patreon.com/posts/scam-alert-dubai-126772229 and absence of Ethereum-related staking topics ([Website](https://www.stakingsummit.com/) has only mentions of bitcoin staking)
- Event previously with EthStaker involvement, but no associated for this event