### PR TITLE
Fix typo in python example code

### DIFF
--- a/public/content/developers/docs/data-structures-and-encoding/rlp/index.md
+++ b/public/content/developers/docs/data-structures-and-encoding/rlp/index.md
@@ -62,7 +62,7 @@ def encode_length(L, offset):
     elif L < 256**8:
          BL = to_binary(L)
          return chr(len(BL) + offset + 55) + BL
-     raise Exception("input too long")
+    raise Exception("input too long")
 
 def to_binary(x):
     if x == 0:


### PR DESCRIPTION
## Description
The spacing on the line that `raises` was invalid python.  It produces the error 

```
  File "/home/dave/tmp/dev/python/main.py", line 18
    raise Exception("input too long")
                                     ^
IndentationError: unindent does not match any outer indentation level
```

This update fixes the indentation so that a reader can copy and paste the code.

## Related Issue
None, just fixes a type in some docs.