### PR TITLE
fix: DocLink routing; use internal link component

### DIFF
--- a/src/components/DocLink/index.tsx
+++ b/src/components/DocLink/index.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils/cn"
 
 import Emoji from "../Emoji"
 import { Center, Flex, Stack } from "../ui/flex"
+import InlineLink from "../ui/Link"
 import { LinkBox, LinkOverlay } from "../ui/link-box"
 
 import { useRtlFlip } from "@/hooks/useRtlFlip"
@@ -30,10 +31,12 @@ const DocLink = ({ href, children, isExternal = false }: DocLinkProps) => {
           <Emoji className="me-4 text-md" text=":page_with_curl:" />
         </Center>
         <Stack className="flex-1">
-          <LinkOverlay href={href} className="no-underline">
-            <p className="font-bold text-gray-600 dark:text-gray-200">
-              {children}
-            </p>
+          <LinkOverlay asChild>
+            <InlineLink href={href} hideArrow className="no-underline">
+              <p className="font-bold text-gray-600 dark:text-gray-200">
+                {children}
+              </p>
+            </InlineLink>
           </LinkOverlay>
         </Stack>
 


### PR DESCRIPTION
## Description

Currently when clicking on internal link in Learn page ( https://ethereum.org/en/learn/ ), it ended up in 404 redirect, because of the missing i18n (links are pointed to `https://ethereum.org/quizzes/` and not to `https://ethereum.org/[locale]/quizzes/`m which resulted in 404 page not found. 

I mean links in these sections:
![image](https://github.com/user-attachments/assets/d0da57cb-e034-4f52-a621-6914d11f1a22)

I've fixed it by using the `InlineLink` component in `DocLink` component, which handles the addition of i18n locale to links automatically.