### PR TITLE
Corrected Priority Fee section to reflect validator incentives

### DIFF
--- a/public/content/developers/docs/gas/index.md
+++ b/public/content/developers/docs/gas/index.md
@@ -81,7 +81,7 @@ It's also important to note it is unlikely we will see extended spikes of full b
 
 ### Priority fee (tips) {#priority-fee}
 
-The priority fee (tip) incentivizes validators to include a transaction in the block. Without tips, validators would find it economically viable to mine empty blocks, as they would receive the same block reward. Small tips give validators a minimal incentive to include a transaction. For transactions to be preferentially executed ahead of other transactions in the same block, a higher tip can be added to try to outbid competing transactions.
+The priority fee (tip) incentivizes validators to maximise the number of transactions in a block, constrained only by the block gas limit. Without tips, a rational validator could include fewer - or even zero - transactions without any direct execution-layer or consensus-layer penalty, as staking rewards are independent of how many transactions are in a block. Additionally, tips allow users to outbid others for priority within the same block, effectively signalling urgency. 
 
 ### Max fee {#maxfee}
 


### PR DESCRIPTION
## Summary 

Clarified language to reflect there is **no penalty** for including zero transactions: staking rewards are independent of transaction inclusion. 

## Description

- Validators still have indirect economic incentive to include transactions in block due to the deflationary effects of burning base fees, thus the sentence:"Without tips, validators would _find it economically viable_ to mine empty blocks, as they would receive the _same block reward_." was not completely accurate. 

- - Changes include more specific language to reflect validators do not receive any direct loss or penalty from consensus/execution-layer rewards.

- Block rewards also outdated terminology.
