### PR TITLE
fix: metadataBase to use SITE_URL

### DIFF
--- a/src/lib/utils/metadata.ts
+++ b/src/lib/utils/metadata.ts
@@ -1,7 +1,7 @@
 import type { Metadata } from "next"
 import { getTranslations } from "next-intl/server"
 
-import { DEFAULT_OG_IMAGE } from "@/lib/constants"
+import { DEFAULT_OG_IMAGE, SITE_URL } from "@/lib/constants"
 
 import { getFullUrl } from "./url"
 
@@ -65,7 +65,7 @@ export const getMetadata = async ({
   return {
     title,
     description,
-    metadataBase: new URL(url),
+    metadataBase: new URL(SITE_URL),
     alternates: {
       canonical: url,
       languages: {


### PR DESCRIPTION
## Description
Fixes broken og image paths for share links

Uses SITE_URL as the metadataBase URL... realtively image paths will then build on that.
Other URLs utilize `getFullUrl`

## Related Issue

Image paths were inappropriately being taken from the current path, resulting in `ethereum.org/en/images/...` or `ethereum.org/en/staking/images...`  instead of `ethereum.org/images/...` breaking share link images

