### PR TITLE
feat: add geodework blog to homepage feeds

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -230,6 +230,10 @@ export const COMMUNITY_BLOGS: CommunityBlog[] = [
     href: "https://medium.com/ethereum-cat-herders/newsletter",
     feed: "https://medium.com/feed/ethereum-cat-herders",
   },
+  {
+    href: "http://geodework.com/blog",
+    feed: "http://geodework.com/feed.xml",
+  },
 ]
 
 export const BLOG_FEEDS = COMMUNITY_BLOGS.map(({ feed }) => feed).filter(


### PR DESCRIPTION
## Description
- Adds [Geodework Blog](https://geodework.com/blog) to homepage rss feeds

## Preview link
https://deploy-preview-15404--ethereumorg.netlify.app/en/#recent

<img width="1581" alt="image" src="https://github.com/user-attachments/assets/4f7af5cb-2a84-4a5c-941d-12a3d95418c9" />
