### PR TITLE
docs (`stack.md`): remove part about Algolia

### DIFF
--- a/docs/stack.md
+++ b/docs/stack.md
@@ -10,7 +10,7 @@
 - [React](https://reactjs.org/) - A JavaScript library for building component-based user interfaces
 - [Typescript](https://www.typescriptlang.org/) - TypeScript is a strongly typed programming language that builds on JavaScript
 - [Chakra UI](https://chakra-ui.com/) - A UI library (Migration in progress)
-- [Algolia](https://www.algolia.com/) - Site indexing, rapid intra-site search results, and search analytics. [Learn more on how we implement Algolia for site search](./docs/ALGOLIA_DOCSEARCH.md).
+- [Algolia](https://www.algolia.com/) - Site indexing, rapid intra-site search results, and search analytics.
   - Primary implementation: `/src/components/Search/index.ts`
 - [Crowdin](https://crowdin.com/) - crowdsourcing for our translation efforts (See "Translation initiative" below)
 - [GitHub Actions](https://github.com/features/actions) - Manages CI/CD, and issue tracking


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We do not have ALGOLIA_DOCSEARCH.md already so we need to remoce this ded 'text' not to mislead the user.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
