### PR TITLE
Replace URL on the roadmap page 

### DIFF
--- a/src/data/roadmap/releases.tsx
+++ b/src/data/roadmap/releases.tsx
@@ -170,7 +170,7 @@ export const releasesData: Release[] = [
         </ul>
       </div>
     ),
-    href: "https://eips.ethereum.org/EIPS/eip-7594",
+    href: "https://eips.ethereum.org/EIPS/eip-7607",
   },
   {
     image: GuidesHubHeroImage,

--- a/src/data/roadmap/releases.tsx
+++ b/src/data/roadmap/releases.tsx
@@ -114,11 +114,14 @@ export const releasesData: Release[] = [
     releaseDate: "2025-05-07",
     content: (
       <div>
-        <p className="font-bold">Enhance EOA wallets with smart contract functionality</p>
+        <p className="font-bold">
+          Enhance EOA wallets with smart contract functionality
+        </p>
         <ul>
           <li>
             Users can set their address to be represented by a code of an
-            existing smart contract and gain benefits such as transaction batching, transaction fee sponsorship or better recovery mechanisms
+            existing smart contract and gain benefits such as transaction
+            batching, transaction fee sponsorship or better recovery mechanisms
           </li>
         </ul>
         <p className="font-bold">Increase the max effective balance</p>
@@ -167,7 +170,7 @@ export const releasesData: Release[] = [
         </ul>
       </div>
     ),
-    href: "/roadmap/fusaka",
+    href: "https://eips.ethereum.org/EIPS/eip-7594",
   },
   {
     image: GuidesHubHeroImage,


### PR DESCRIPTION
## Description

Replaced the url of the 'Learn more' button of the Fusaka upgrade slide into PeerDAS EIP URL

## Related Issue
Closes: #15410