### PR TITLE
Fix go to top [Fixes #15412]

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -320,7 +320,7 @@ const Footer = ({ lastDeployLocaleTimestamp }: FooterProps) => {
         <Button
           variant="outline"
           isSecondary
-          onClick={() => scrollIntoView("div.mx-auto")}
+          onClick={() => scrollIntoView("body")}
         >
           <IoChevronUpSharp /> Go to top
         </Button>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -320,7 +320,7 @@ const Footer = ({ lastDeployLocaleTimestamp }: FooterProps) => {
         <Button
           variant="outline"
           isSecondary
-          onClick={() => scrollIntoView("top")}
+          onClick={() => scrollIntoView("div.mx-auto")}
         >
           <IoChevronUpSharp /> Go to top
         </Button>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -320,7 +320,7 @@ const Footer = ({ lastDeployLocaleTimestamp }: FooterProps) => {
         <Button
           variant="outline"
           isSecondary
-          onClick={() => scrollIntoView("__next")}
+          onClick={() => scrollIntoView("top")}
         >
           <IoChevronUpSharp /> Go to top
         </Button>

--- a/src/components/ui/buttons/Button.tsx
+++ b/src/components/ui/buttons/Button.tsx
@@ -105,7 +105,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     ref
   ) => {
     const handleOnClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-      toId && scrollIntoView(toId)
+      toId && scrollIntoView("#" + toId)
       customEventOptions && trackCustomEvent(customEventOptions)
 
       onClick?.(e)

--- a/src/layouts/BaseLayout.tsx
+++ b/src/layouts/BaseLayout.tsx
@@ -51,7 +51,7 @@ export const BaseLayout = ({
        * layout on initial load.
        */}
       <SkipLink />
-      <div className="mx-auto max-w-screen-2xl" id="top">
+      <div className="mx-auto max-w-screen-2xl">
         <Nav />
 
         {/* TODO: FIX TRANSLATION BANNER LOGIC FOR https://github.com/ethereum/ethereum-org-website/issues/11305 */}

--- a/src/layouts/BaseLayout.tsx
+++ b/src/layouts/BaseLayout.tsx
@@ -51,7 +51,7 @@ export const BaseLayout = ({
        * layout on initial load.
        */}
       <SkipLink />
-      <div className="mx-auto max-w-screen-2xl">
+      <div className="mx-auto max-w-screen-2xl" id="top">
         <Nav />
 
         {/* TODO: FIX TRANSLATION BANNER LOGIC FOR https://github.com/ethereum/ethereum-org-website/issues/11305 */}

--- a/src/lib/utils/scrollIntoView.ts
+++ b/src/lib/utils/scrollIntoView.ts
@@ -1,8 +1,8 @@
 export const scrollIntoView = (
-  toId: string,
+  selector: string,
   options: ScrollIntoViewOptions = { behavior: "smooth", block: "start" }
 ): void => {
-  const element = document.getElementById(toId)
+  const element = document.querySelector(selector)
 
   if (!element) return
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The "Go to top" button was not functioning due to a missing anchor target.

This PR:
- Adds an `id="top"` to the `main` container in `BaseLayout.tsx`
- Updates the `href` used by the "Go to top" button in `Footer.tsx` to point to `#top`

## Related Issue
Fixes [#15412](https://github.com/ethereum/ethereum-org-website/issues/15412)
