### PR TITLE
Adding in third-party consolidation tooling, augmented FAQ

### DIFF
--- a/public/content/roadmap/pectra/maxeb/index.md
+++ b/public/content/roadmap/pectra/maxeb/index.md
@@ -138,7 +138,7 @@ There are several tools available to manage consolidations. The official tool, c
 | Pectra Staking Manager | pectrastaking.com | Yes, pending license | [Pier Two](https://piertwo.com/) | No | Web UI | Wallet Connect, works with SAFE |
 | Pectra Validator Ops CLI Tool | [GitHub](https://github.com/Luganodes/Pectra-Batch-Contract) | Yes, MIT | [Luganodes](https://www.luganodes.com/) | Yes, Quantstamp [May 2025](https://certificate.quantstamp.com/full/luganodes-pectra-batch-contract/23f0765f-969a-4798-9edd-188d276c4a2b/index.html) | Command line | Batching, for many validators at once |
 | Ethereal | [GitHub](https://github.com/wealdtech/ethereal) | Yes, Apache 2.0 | [Jim McDonald](https://www.attestant.io/team/) | No | Command line | Full feature set for validator and node management |
-| Siren | [GitHub](https://github.com/sigp/siren) | Yes, Apache 2.0 | [Sigma Prime](https://sigmaprime.io/) | No | Web UI, Command line | Only works if you're using the Lighthouse consensus client |
+| Siren | [GitHub](https://github.com/sigp/siren) | Yes, Apache 2.0 | [Sigma Prime](https://sigmaprime.io/) | No | Some command line, but primarily web UI | Only works if you're using the Lighthouse consensus client |
 
 ## FAQ {#FAQ}
 

--- a/public/content/roadmap/pectra/maxeb/index.md
+++ b/public/content/roadmap/pectra/maxeb/index.md
@@ -129,17 +129,28 @@ Note: The signing is done by the withdrawal address, not the validator key.
 
 Validators with **Type 1** credentials get automatic, gasless sweeps of their excess balance (anything over 32 ETH) to their withdrawal address. Because **Type 2** allows a validator to compound balances in 1 ETH increments, it will not automatically sweep balances until it reaches 2048 ETH. Partial withdrawals on **Type 2** validators must be manually triggered and will cost gas.
 
+## Consolidation tooling {#consolidation-tooling}
+
+There are several tools available to manage consolidations. The official tool, created by the Ethereum Foundation, is the [Launchpad](https://launchpad.ethereum.org/en/validator-actions). There are also third-party tools created by entities from the staking community that may offer features not provided by the Launchpad. While the tools here are not audited or endorsed by the Ethereum Foundation, the following are open source tools by known members of the community.
+
+| Tool | Website | Open source | Creator | Audited | Interface | Notable features |
+| --- | --- | --- | --- | --- | --- | --- |
+| Pectra Staking Manager | pectrastaking.com | Yes, pending license | [Pier Two](https://piertwo.com/) | No | Web UI | Wallet Connect, works with SAFE |
+| Pectra Validator Ops CLI Tool | [GitHub](https://github.com/Luganodes/Pectra-Batch-Contract) | Yes, MIT | [Luganodes](https://www.luganodes.com/) | Yes, Quantstamp [May 2025](https://certificate.quantstamp.com/full/luganodes-pectra-batch-contract/23f0765f-969a-4798-9edd-188d276c4a2b/index.html) | Command line | Batching, for many validators at once |
+| Ethereal | [GitHub](https://github.com/wealdtech/ethereal) | Yes, Apache 2.0 | [Jim McDonald](https://www.attestant.io/team/) | No | Command line | Full feature set for validator and node management |
+| Siren | [GitHub](https://github.com/sigp/siren) | Yes, Apache 2.0 | [Sigma Prime](https://sigmaprime.io/) | No | Web UI, Command line | Only works if you're using the Lighthouse consensus client |
+
 ## FAQ {#FAQ}
 
-### **Does opting-in change my proposal luck or rewards?**
+### Does opting-in change my proposal luck or rewards?
 
 No. Opting in does not decrease your change of proposal - your duties and proposal selection remain the same. For example, if you have two 32 ETH validators vs one 64 ETH validator, you will have the same total chances of being selected to propose a block and earn rewards.
 
-### **Does opting in change my slashing risk?**
+### Does opting in change my slashing risk?
 
 For smaller or unprofessional operators, the short answer is no. The longer answer is that, for professional operators running many validators per node with fast alerting, consolidating into fewer validators may reduce their ability to react to a slashing and prevent cascade events. The initial slashing *penalty* for all validators has been dramatically reduced from 1 ETH (per 32 ETH) to 0.0078125 ETH (per 32 ETH) to offset this risk.
 
-### **Do I have to exit my validator to convert?**
+### Do I have to exit my validator to convert?
 
 No. You can convert in place without exiting.
 
@@ -175,13 +186,17 @@ Automatic sweeps will only happen with excess balances over 2048. For all other 
 
 No. Converting to **Type 2** is irreversible.
 
+### If I want to consolidate multiple validators, do I have convert each one to Type 2 first?
+
+Nope! Convert one validator to Type 2 then use that as the target. All other validators consolidated into that Type 2 target can be Type 1 or Type 2
+
 ### My validator is offline or below 32 ETH - can I still convert it?
 
 Yes. As long as it's active (not exited) and you can sign with its withdrawal address, you can convert it.
 
 ## Resources {#resources}
 
-- [Electra consensus specs](https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md): This is the ‘truest' version that you should rely on. When in doubt, read the specs
+- [Electra consensus specs](https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md): This is the 'truest' version that you should rely on. When in doubt, read the specs
 - Not everybody is comfortable wading through code, so [this maxEB-GPT](https://chatgpt.com/g/g-67f1650fb48081918f555e0c8d1c2ae9-maxeb-gpt) can help interpret the specs. *Disclaimer: The specs, not the AI, should be relied on as truth, as the AI may misinterpret information or hallucinate answers*
 - [pectrified.com](https://pectrified.com/): View the state of consolidations, deposits, and queue waiting times
 - [Ethereal](https://github.com/wealdtech/ethereal): Community-created CLI tool for managing common validator tasks

--- a/public/content/roadmap/pectra/maxeb/index.md
+++ b/public/content/roadmap/pectra/maxeb/index.md
@@ -135,7 +135,7 @@ There are several tools available to manage consolidations. The official tool, c
 
 | Tool | Website | Open source | Creator | Audited | Interface | Notable features |
 | --- | --- | --- | --- | --- | --- | --- |
-| Pectra Staking Manager | pectrastaking.com | Yes, pending license | [Pier Two](https://piertwo.com/) | No | Web UI | Wallet Connect, works with SAFE |
+| Pectra Staking Manager | pectrastaking.com | Yes, Apache 2.0 | [Pier Two](https://piertwo.com/) | No | Web UI | Wallet Connect, works with SAFE |
 | Pectra Validator Ops CLI Tool | [GitHub](https://github.com/Luganodes/Pectra-Batch-Contract) | Yes, MIT | [Luganodes](https://www.luganodes.com/) | Yes, Quantstamp [May 2025](https://certificate.quantstamp.com/full/luganodes-pectra-batch-contract/23f0765f-969a-4798-9edd-188d276c4a2b/index.html) | Command line | Batching, for many validators at once |
 | Ethereal | [GitHub](https://github.com/wealdtech/ethereal) | Yes, Apache 2.0 | [Jim McDonald](https://www.attestant.io/team/) | No | Command line | Full feature set for validator and node management |
 | Siren | [GitHub](https://github.com/sigp/siren) | Yes, Apache 2.0 | [Sigma Prime](https://sigmaprime.io/) | No | Some command line, but primarily web UI | Only works if you're using the Lighthouse consensus client |


### PR DESCRIPTION
Adding in third-party consolidation tooling, added in a question for FAQ

## Description

There's currently nowhere to get an overview of third-party tooling that provide features that the Launchpad doesn't provide (e.g. using a SAFE as a withdrawal address, batching consolidations, etc). while they're third-party and not endorsed by ethereum.org, it's still good to have community-consensus "legit" tooling listed to minimize scam opportunities

## Related Issue

n/a
