### PR TITLE
fix: markdown table format in developers docs

### DIFF
--- a/public/content/developers/docs/data-structures-and-encoding/patricia-merkle-trie/index.md
+++ b/public/content/developers/docs/data-structures-and-encoding/patricia-merkle-trie/index.md
@@ -95,12 +95,12 @@ When traversing paths in nibbles, we may end up with an odd number of nibbles to
 
 The flagging of both _odd vs. even remaining partial path length_ and _leaf vs. extension node_ as described above reside in the first nibble of the partial path of any 2-item node. They result in the following:
 
-    hex char    bits    |    node type partial     path length
-    ----------------------------------------------------------
-       0        0000    |       extension              even
-       1        0001    |       extension              odd
-       2        0010    |   terminating (leaf)         even
-       3        0011    |   terminating (leaf)         odd
+   | hex char | bits | node type partial  | path length |
+   | -------- | ---- | ------------------ | ----------- |
+   | 0        | 0000 | extension          | even        |
+   | 1        | 0001 | extension          | odd         |
+   | 2        | 0010 | terminating (leaf) | even        |
+   | 3        | 0011 | terminating (leaf) | odd         |
 
 For even remaining path length (`0` or `2`), another `0` "padding" nibble will always follow.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes md table on https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/
<!--- Describe your changes in detail -->

## Screenshots
prod: 
![25af73706c654d45de6bf6860a8edeb](https://github.com/user-attachments/assets/caa242ee-6ccc-4342-9234-9d8ad1c4528e)

deploy preview:
![d5cb57df990a26eb36ba7e22ca34e48](https://github.com/user-attachments/assets/3c4eac02-716c-4743-b5c6-b7aed7585152)

## Related Issue
n/a
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
