### PR TITLE
fix: home page metadata

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -13,6 +13,7 @@ import { dataLoader } from "@/lib/utils/data/dataLoader"
 import { isValidDate } from "@/lib/utils/date"
 import { existsNamespace } from "@/lib/utils/existsNamespace"
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
+import { getMetadata } from "@/lib/utils/metadata"
 import { polishRSSList } from "@/lib/utils/rss"
 import { getLocaleTimestamp } from "@/lib/utils/time"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
@@ -127,13 +128,21 @@ const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
   )
 }
 
-export async function generateMetadata() {
-  const t = await getTranslations()
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>
+}) {
+  const { locale } = await params
 
-  return {
+  const t = await getTranslations({ locale })
+
+  return await getMetadata({
+    locale,
+    slug: [""],
     title: t("page-index.page-index-meta-title"),
     description: t("page-index.page-index-meta-description"),
-  }
+  })
 }
 
 export default Page

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -135,13 +135,13 @@ export async function generateMetadata({
 }) {
   const { locale } = await params
 
-  const t = await getTranslations({ locale })
+  const t = await getTranslations({ locale, namespace: "page-index" })
 
   return await getMetadata({
     locale,
     slug: [""],
-    title: t("page-index.page-index-meta-title"),
-    description: t("page-index.page-index-meta-description"),
+    title: t("page-index-meta-title"),
+    description: t("page-index-meta-description"),
   })
 }
 

--- a/src/lib/utils/metadata.ts
+++ b/src/lib/utils/metadata.ts
@@ -3,6 +3,7 @@ import { getTranslations } from "next-intl/server"
 
 import { DEFAULT_OG_IMAGE, SITE_URL } from "@/lib/constants"
 
+import { isLocaleValidISO639_1 } from "./translations"
 import { getFullUrl } from "./url"
 
 import { routing } from "@/i18n/routing"
@@ -71,10 +72,9 @@ export const getMetadata = async ({
       languages: {
         "x-default": xDefault,
         ...Object.fromEntries(
-          routing.locales.map((locale) => [
-            locale,
-            getFullUrl(locale, slugString),
-          ])
+          routing.locales
+            .filter(isLocaleValidISO639_1)
+            .map((locale) => [locale, getFullUrl(locale, slugString)])
         ),
       },
     },


### PR DESCRIPTION
## Description

- updates the home page to display correct metadata
- filters the `alternates` paths by valid `ISO639_1` locales (missing part in #15200 implementation)