### PR TITLE
Fixed typo: "really dummy" → "real dummy"

### DIFF
--- a/public/content/developers/tutorials/transfers-and-approval-of-erc-20-tokens-from-a-solidity-smart-contract/index.md
+++ b/public/content/developers/tutorials/transfers-and-approval-of-erc-20-tokens-from-a-solidity-smart-contract/index.md
@@ -13,7 +13,7 @@ address: "0x19dE91Af973F404EDF5B4c093983a7c6E3EC8ccE"
 
 In the previous tutorial we studied [the anatomy of an ERC-20 token in Solidity](/developers/tutorials/understand-the-erc-20-token-smart-contract/) on the Ethereum blockchain. In this article we’ll see how we can use a smart contract to interact with a token using the Solidity language.
 
-For this smart contract, we’ll create a really dummy decentralized exchange where a user can trade ether for our newly deployed [ERC-20 token](/developers/docs/standards/tokens/erc-20/).
+For this smart contract, we’ll create a real dummy decentralized exchange where a user can trade ether for our newly deployed [ERC-20 token](/developers/docs/standards/tokens/erc-20/).
 
 For this tutorial we’ll use the code we wrote in the previous tutorial as a base. Our DEX will instantiate an instance of the contract in its constructor and perform the operations of:
 


### PR DESCRIPTION
Description
This pull request fixes a small typo in the content. The phrase "really dummy" was changed to "real dummy", improving grammar and readability.

Related Issue
N/A – This is a minor typo fix and doesn't correspond to a previously opened issue.

Type of Change
 Bug fix (non-breaking change which fixes a typo)