### PR TITLE
docs: Add Type 3 (Blob) transactions to transaction types documentation

### DIFF
--- a/public/content/developers/docs/transactions/index.md
+++ b/public/content/developers/docs/transactions/index.md
@@ -217,7 +217,7 @@ Based on the `TransactionType` value, a transaction can be classified as:
 
 3. **Type 2 Transactions**, commonly referred to as EIP-1559 transactions, are transactions introduced in [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559), in Ethereum's [London Upgrade](/history/#london). They have become the standard transaction type on the Ethereum network. These transactions introduce a new fee market mechanism that improves predictability by separating the transaction fee into a base fee and a priority fee. They start with the byte `0x02` and include fields such as `maxPriorityFeePerGas` and `maxFeePerGas`. Type 2 transactions are now the default due to their flexibility and efficiency, especially favored during periods of high network congestion for their ability to help users manage transaction fees more predictably. The TransactionType value for these transactions is `0x2`.
 
-
+4. **Type 3 (Blob) Transactions** were introduced in [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844) as part of Ethereum's [Dencun Upgrade](/history/#dencun). These transactions are designed to handle "blob" data (Binary Large Objects) more efficiently, particularly benefiting Layer 2 rollups by providing a way to post data to the Ethereum network at a lower cost. Blob transactions include additional fields such as `blobVersionedHashes`, `maxFeePerBlobGas`, and `blobGasPrice`. They start with the byte `0x03`, and their TransactionType value is `0x3`. Blob transactions represent a significant improvement in Ethereum's data availability and scaling capabilities.
 
 ## Further reading {#further-reading}
 


### PR DESCRIPTION
## Description

This PR adds documentation for Type 3 (Blob) transactions to the transaction types section. Specifically:

- Adds a new section describing Type 3 (Blob) transactions introduced in EIP-4844
- Includes details about transaction fields specific to blob transactions (`blobVersionedHashes`, `maxFeePerBlobGas`, `blobGasPrice`)
- Explains the relationship with the Dencun upgrade
- Describes the significance of blob transactions for Layer 2 scaling and data availability
- Uses correct transaction type identifier (`0x03`)

## Related Issue

Fixes #13702

This PR addresses the documentation gap identified in the issue where Blob transactions (TransactionType = 3) were missing from the transaction types list.