### PR TITLE
fix: correct path passed to SideNav

### DIFF
--- a/src/layouts/Docs.tsx
+++ b/src/layouts/Docs.tsx
@@ -1,3 +1,5 @@
+import { join } from "path"
+
 import { MDXRemoteProps } from "next-mdx-remote"
 import type { HTMLAttributes } from "react"
 
@@ -120,6 +122,7 @@ export const DocsLayout = ({
 }: DocsLayoutProps) => {
   const isPageIncomplete = !!frontmatter.incomplete
   const absoluteEditPath = getEditPath(slug)
+  const slugWithSlashes = join("/", slug, "/")
 
   return (
     <div className="flex w-full flex-col border-b">
@@ -133,7 +136,7 @@ export const DocsLayout = ({
         className="flex justify-between bg-background-highlight lg:pe-8"
         dir={contentNotTranslated ? "ltr" : "unset"}
       >
-        <SideNav path={slug} />
+        <SideNav path={slugWithSlashes} />
         <MainArticle className="min-w-0 flex-1 px-8 pb-8 pt-8 md:px-16 md:pb-16 md:pt-12">
           <H1 id="top">{frontmatter.title}</H1>
           <FileContributors

--- a/src/layouts/Docs.tsx
+++ b/src/layouts/Docs.tsx
@@ -1,5 +1,3 @@
-import { join } from "path"
-
 import { MDXRemoteProps } from "next-mdx-remote"
 import type { HTMLAttributes } from "react"
 
@@ -36,6 +34,7 @@ import YouTube from "@/components/YouTube"
 
 import { cn } from "@/lib/utils/cn"
 import { getEditPath } from "@/lib/utils/editPath"
+import { addSlashes } from "@/lib/utils/url"
 
 const baseHeadingClasses = "font-bold scroll-mt-40 break-words"
 
@@ -122,7 +121,6 @@ export const DocsLayout = ({
 }: DocsLayoutProps) => {
   const isPageIncomplete = !!frontmatter.incomplete
   const absoluteEditPath = getEditPath(slug)
-  const slugWithSlashes = join("/", slug, "/")
 
   return (
     <div className="flex w-full flex-col border-b">
@@ -136,7 +134,7 @@ export const DocsLayout = ({
         className="flex justify-between bg-background-highlight lg:pe-8"
         dir={contentNotTranslated ? "ltr" : "unset"}
       >
-        <SideNav path={slugWithSlashes} />
+        <SideNav path={addSlashes(slug)} />
         <MainArticle className="min-w-0 flex-1 px-8 pb-8 pt-8 md:px-16 md:pb-16 md:pt-12">
           <H1 id="top">{frontmatter.title}</H1>
           <FileContributors


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes a bug where nav items failed to open due to incorrect `path` props
<!--- Describe your changes in detail -->

## Screen Records
prod:

https://github.com/user-attachments/assets/4e1afd4c-c44c-4816-8187-643c5266ed98

localhost:

https://github.com/user-attachments/assets/6a87a1a8-bc1e-4858-ad5b-7271086d69db

## Related Issue
n/a
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
