### PR TITLE
fix: correct terminology in accounts page for consistency between tra…

### DIFF
--- a/public/content/developers/docs/accounts/index.md
+++ b/public/content/developers/docs/accounts/index.md
@@ -4,7 +4,7 @@ description: An explanation of Ethereum accounts – their data structures and t
 lang: en
 ---
 
-An Ethereum account is an entity with an ether (ETH) balance that can send transactions on Ethereum. Accounts can be user-controlled or deployed as smart contracts.
+An Ethereum account is an entity with an ether (ETH) balance that can send messages on Ethereum. Accounts can be user-controlled or deployed as smart contracts.
 
 ## Prerequisites {#prerequisites}
 
@@ -34,7 +34,7 @@ Both account types have the ability to:
 **Contract**
 
 - Creating a contract has a cost because you're using network storage
-- Can only send transactions in response to receiving a transaction
+- Can only send messages in response to receiving a transaction
 - Transactions from an external account to a contract account can trigger code which can execute many different actions, such as transferring tokens or even creating a new contract
 - Contract accounts don't have private keys. Instead, they are controlled by the logic of the smart contract code
 


### PR DESCRIPTION
# Fix Terminology Consistency Between Accounts and Transactions Pages

## Description
This PR addresses the terminology inconsistency between the accounts and transactions documentation pages

## Changes
- Changed "can send transactions" to "can send messages" in the accounts page description of contract accounts' capabilities
- Updated the "Key differences" section to maintain consistent terminology

## Rationale
According to Ethereum's technical specifications, only Externally Owned Accounts (EOAs) can initiate true "transactions," while smart contracts can only send "messages." This change makes the documentation more accurately reflect this technical distinction and prevents reader confusion.

## Background
The transactions page correctly defines transactions as actions initiated by externally-owned accounts, while the accounts page previously suggested that smart contracts could also send transactions, creating an inconsistency. This PR resolves the issue by using more precise terminology.

## Related Issue
Fixes #12897