### PR TITLE
communities - empty hive group removed

### DIFF
--- a/public/content/community/online/index.md
+++ b/public/content/community/online/index.md
@@ -63,7 +63,6 @@ If you believe a community should be added or removed based on these guidelines,
 <SocialListItem socialIcon="twitter"><Link href="https://x.com/ethereum">@ethereum</Link> - Main Ethereum account for the community</SocialListItem>
 <SocialListItem socialIcon="twitter"><Link href="https://x.com/ethereumfndn">@ethereumfndn</Link> - Official account of the Ethereum Foundation</SocialListItem>
 <SocialListItem socialIcon="twitter"><Link href="https://x.com/ethdotorg">@ethdotorg</Link> - The portal to Ethereum, built for our growing global community</SocialListItem>
-<SocialListItem socialIcon="webpage"><Link href="https://hive.one/c/ethereum?page=1">List of influential Ethereum twitter accounts</Link></SocialListItem>
 
 <Divider />
 


### PR DESCRIPTION
the link leads to this and does not seam to be changed in the future:

![image](https://github.com/user-attachments/assets/a455e06a-9a38-497a-a637-3f3537d44ed3)
