### PR TITLE
Add RANDAO explanation to Node Architecture page

### DIFF
--- a/public/content/developers/docs/nodes-and-clients/node-architecture/index.md
+++ b/public/content/developers/docs/nodes-and-clients/node-architecture/index.md
@@ -14,7 +14,7 @@ The diagram below shows the relationship between the two Ethereum clients. The t
 
 _There are several options for the execution client including Erigon, Nethermind, and Besu_.
 
-For this two-client structure to work, consensus clients must pass bundles of transactions to the execution client. The execution client executes the transactions locally to validate that the transactions do not violate any Ethereum rules and that the proposed update to Ethereum’s state is correct. When a node is selected to be a block producer its consensus client instance requests bundles of transactions from the execution client to include in the new block and execute them to update the global state. The consensus client drives the execution client via a local RPC connection using the [Engine API](https://github.com/ethereum/execution-apis/blob/main/src/engine/common.md). 
+For this two-client structure to work, consensus clients must pass bundles of transactions to the execution client. The execution client executes the transactions locally to validate that the transactions do not violate any Ethereum rules and that the proposed update to Ethereum’s state is correct. When a node is selected to be a block producer its consensus client instance requests bundles of transactions from the execution client to include in the new block and execute them to update the global state. The consensus client drives the execution client via a local RPC connection using the [Engine API](https://github.com/ethereum/execution-apis/blob/main/src/engine/common.md).
 
 ## What does the execution client do? {#execution-client}
 
@@ -37,20 +37,20 @@ The consensus client does not participate in attesting to or proposing blocks - 
 
 ## Validators {#validators}
 
-Staking and running the validator software makes a node eligible to be selected to propose a new block. Node operators can add a validator to their consensus clients by depositing 32 ETH in the deposit contract. The validator client comes bundled with the consensus client and can be added to a node at any time. The validator handles attestations and block proposals. It also enables a node to accrue rewards or lose ETH via penalties or slashing. 
+Staking and running the validator software makes a node eligible to be selected to propose a new block. Node operators can add a validator to their consensus clients by depositing 32 ETH in the deposit contract. The validator client comes bundled with the consensus client and can be added to a node at any time. The validator handles attestations and block proposals. It also enables a node to accrue rewards or lose ETH via penalties or slashing.
 
 [More on staking](/staking/).
 
 ## Components of a node comparison {#node-comparison}
 
-| Execution Client                                   | Consensus Client                                                 | Validator                    |
-| -------------------------------------------------- | ---------------------------------------------------------------- | ---------------------------- |
-| Gossips transactions over its P2P network          | Gossips blocks and attestations over its P2P network             | Proposes blocks              |
-| Executes/re-executes transactions                  | Runs the fork choice algorithm                                   | Accrues rewards/penalties    |
-| Verifies incoming state changes                    | Keeps track of the head of the chain                             | Makes attestations           |
-| Manages state and receipts tries                   | Manages the Beacon state (contains consensus and execution info) | Requires 32 ETH to be staked |
+| Execution Client                                   | Consensus Client                                                                                                                                          | Validator                    |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| Gossips transactions over its P2P network          | Gossips blocks and attestations over its P2P network                                                                                                      | Proposes blocks              |
+| Executes/re-executes transactions                  | Runs the fork choice algorithm                                                                                                                            | Accrues rewards/penalties    |
+| Verifies incoming state changes                    | Keeps track of the head of the chain                                                                                                                      | Makes attestations           |
+| Manages state and receipts tries                   | Manages the Beacon state (contains consensus and execution info)                                                                                          | Requires 32 ETH to be staked |
 | Creates execution payload                          | Keeps track of accumulated randomness in RANDAO (an algorithm that provides verifiable randomness for validator selection and other consensus operations) | Can be slashed               |
-| Exposes JSON-RPC API for interacting with Ethereum | Keeps track of justification and finalization                    |                              |
+| Exposes JSON-RPC API for interacting with Ethereum | Keeps track of justification and finalization                                                                                                             |                              |
 
 ## Further reading {#further-reading}
 

--- a/public/content/developers/docs/nodes-and-clients/node-architecture/index.md
+++ b/public/content/developers/docs/nodes-and-clients/node-architecture/index.md
@@ -49,7 +49,7 @@ Staking and running the validator software makes a node eligible to be selected 
 | Executes/re-executes transactions                  | Runs the fork choice algorithm                                   | Accrues rewards/penalties    |
 | Verifies incoming state changes                    | Keeps track of the head of the chain                             | Makes attestations           |
 | Manages state and receipts tries                   | Manages the Beacon state (contains consensus and execution info) | Requires 32 ETH to be staked |
-| Creates execution payload                          | Keeps track of accumulated randomness in RANDAO                  | Can be slashed               |
+| Creates execution payload                          | Keeps track of accumulated randomness in RANDAO (an algorithm that provides verifiable randomness for validator selection and other consensus operations) | Can be slashed               |
 | Exposes JSON-RPC API for interacting with Ethereum | Keeps track of justification and finalization                    |                              |
 
 ## Further reading {#further-reading}


### PR DESCRIPTION
## Description

Add detailed explanation for RANDAO in the Node Architecture documentation to improve first-time reader experience.

## Motivation and Context

Fixes #12059 

The Node Architecture page mentioned RANDAO in the node comparison table without providing any context or explanation, making it difficult for newcomers to understand what RANDAO is and its purpose in Ethereum's consensus mechanism. This was identified as a user experience issue in the GitHub issue.

## Changes

- Enhanced RANDAO description in the node comparison table from:
  ```
  Keeps track of accumulated randomness in RANDAO
  ```
  to:
  ```
  Keeps track of accumulated randomness in RANDAO (an algorithm that provides verifiable randomness for validator selection and other consensus operations)
  ```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update