### PR TITLE
feat: use 7d growthepie endpoint

### DIFF
--- a/src/lib/api/fetchGrowThePie.ts
+++ b/src/lib/api/fetchGrowThePie.ts
@@ -14,27 +14,19 @@ const TXCOUNT = "txcount"
 const ACTIVE_ADDRESSES = "aa_last7d"
 
 export const fetchGrowThePie = async (): Promise<GrowThePieData> => {
-  const url = "https://api.growthepie.xyz/v1/fundamentals.json"
+  const url = "https://api.growthepie.xyz/v1/fundamentals_7d.json"
 
-  const response = await fetch(url, { cache: "no-store" })
+  const response = await fetch(url)
   if (!response.ok) {
     console.log(response.status, response.statusText)
     throw new Error("Failed to fetch growthepie data")
   }
   const data: DataItem[] = await response.json()
 
-  // Get the date 7 days ago
-  const sevenDaysAgo = new Date()
-  sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7)
-
-  // Filter data to only include the last 7 days and the metrics we need
-  const filteredData = data.filter((item) => {
-    const itemDate = new Date(item.date)
-    return (
-      itemDate >= sevenDaysAgo &&
-      [TXCOSTS_MEDIAN_USD, TXCOUNT, ACTIVE_ADDRESSES].includes(item.metric_key)
-    )
-  })
+  // Filter data to only include the metrics we need
+  const filteredData = data.filter((item) =>
+    [TXCOSTS_MEDIAN_USD, TXCOUNT, ACTIVE_ADDRESSES].includes(item.metric_key)
+  )
 
   const mostRecentDate = filteredData.reduce((latest, item) => {
     const itemDate = new Date(item.date)


### PR DESCRIPTION
## Description
- Switches to `-7d` growthepie data endpoint: ~37KB JSON response size
- Remove `{ cache: "no-store" }`—new response <2MB limit
- Remove manual 7-day filtering logic

<img width="1335" alt="image" src="https://github.com/user-attachments/assets/6d098f9d-a4bf-49de-b880-380d06baec23" />

## Related Issue
Ongoing data fetching management