### PR TITLE
fix: skip attestant xml attempt

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -19,6 +19,7 @@ import { getLocaleTimestamp } from "@/lib/utils/time"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 
 import {
+  ATTESTANT_BLOG,
   BASE_TIME_UNIT,
   BLOG_FEEDS,
   BLOGS_WITHOUT_FEED,
@@ -39,7 +40,8 @@ import { fetchTotalValueLocked } from "@/lib/api/fetchTotalValueLocked"
 
 // API calls
 const fetchXmlBlogFeeds = async () => {
-  return await fetchRSS(BLOG_FEEDS)
+  const xmlUrls = BLOG_FEEDS.filter((feed) => ![ATTESTANT_BLOG].includes(feed))
+  return await fetchRSS(xmlUrls)
 }
 
 // In seconds

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -175,6 +175,7 @@ export const RSS_DISPLAY_COUNT = 6
 
 export const VITALIK_FEED = "https://vitalik.eth.limo/feed.xml"
 export const SOLIDITY_FEED = "https://soliditylang.org/feed.xml"
+export const ATTESTANT_BLOG = "https://www.attestant.io/posts/"
 
 export const COMMUNITY_BLOGS: CommunityBlog[] = [
   {
@@ -197,10 +198,7 @@ export const COMMUNITY_BLOGS: CommunityBlog[] = [
     name: "0xPARC",
     href: "https://0xparc.org/blog",
   },
-  {
-    href: "https://www.attestant.io/posts/",
-    feed: "https://www.attestant.io/posts/",
-  },
+  { href: ATTESTANT_BLOG, feed: ATTESTANT_BLOG },
   { name: "Devcon", href: "https://devcon.org/en/blogs/" },
   {
     href: "https://soliditylang.org/blog/",


### PR DESCRIPTION
## Description
- Adds array of xml fetches to skip, ie non-xml html parsing
- Adds Attestant to this array

## Related Issue
Fixes: `Error parsing XML, invalid RSSResult or AtomResult type: https://www.attestant.io/posts/`

This was expected with existing setup since we were fetching this in a custom manner _and_ also keeping it in the list to attempt an XML fetch, when we know that will fail.