### PR TITLE
fix: noreferrer for all links; block cookies

### DIFF
--- a/src/components/MarkdownImage.tsx
+++ b/src/components/MarkdownImage.tsx
@@ -42,7 +42,7 @@ const MarkdownImage = ({
     // display the wrapper as a `span` to avoid dom nesting warnings as mdx
     // sometimes wraps images in `p` tags
     <span className="flex justify-center">
-      <NextLink href={transformedSrc} target="_blank" rel="noopener">
+      <NextLink href={transformedSrc} target="_blank" rel="noopener noreferrer">
         <Image
           alt={alt}
           width={imageWidth}

--- a/src/components/ui/Link.tsx
+++ b/src/components/ui/Link.tsx
@@ -88,7 +88,7 @@ export const BaseLink = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     return (
       <a
         target="_blank"
-        rel="noopener"
+        rel="noopener noreferrer"
         onClick={() =>
           trackCustomEvent(
             customEventOptions ?? {
@@ -119,7 +119,7 @@ export const BaseLink = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     return (
       <NextLink
         target="_blank"
-        rel="noopener"
+        rel="noopener noreferrer"
         onClick={() =>
           trackCustomEvent(
             customEventOptions ?? {


### PR DESCRIPTION
## Description
- Adds `referrer` to external links currently missing it
- Intent to block third-party cookies from links we load in various places

## Related Issue
Inappropriate third-party cookies being loaded:
<img width="935" alt="image" src="https://github.com/user-attachments/assets/f6774892-1b62-4747-8a43-4d454479c196" />
