### PR TITLE
fix: rename env var to not be public

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,7 @@
 # NEXT_PUBLIC_ALGOLIA_BASE_SEARCH_INDEX_NAME=insertValue
 
 # Github token for read-only use with api functions
-# NEXT_PUBLIC_GITHUB_TOKEN_READ_ONLY=insertValue
+# GITHUB_TOKEN_READ_ONLY=insertValue
 
 # Etherscan API key (required for Etherscan API fetches)
 # ETHERSCAN_API_KEY=insertValue

--- a/docs/api-keys.md
+++ b/docs/api-keys.md
@@ -11,7 +11,7 @@ We recommend setting this up when running the project locally, as we use the Git
 
 ```sh
 # .env Example:
-NEXT_PUBLIC_GITHUB_TOKEN_READ_ONLY=48f84de812090000demo00000000697cf6e6a059
+GITHUB_TOKEN_READ_ONLY=48f84de812090000demo00000000697cf6e6a059
 ```
 
 2. Add Etherscan API token (free)

--- a/src/lib/api/fetchGFIs.ts
+++ b/src/lib/api/fetchGFIs.ts
@@ -16,7 +16,7 @@ export const fetchGFIs = async () => {
   try {
     const response = await fetch(url, {
       headers: {
-        Authorization: `token ${process.env.NEXT_PUBLIC_GITHUB_TOKEN_READ_ONLY}`,
+        Authorization: `token ${process.env.GITHUB_TOKEN_READ_ONLY}`,
         Accept: "application/vnd.github.v3+json",
       },
     })

--- a/src/lib/api/fetchGitHistory.ts
+++ b/src/lib/api/fetchGitHistory.ts
@@ -11,7 +11,7 @@ async function fetchWithRateLimit(filepath: string): Promise<Commit[]> {
   url.searchParams.set("path", filepath)
   url.searchParams.set("sha", "master")
 
-  const gitHubToken = process.env.NEXT_PUBLIC_GITHUB_TOKEN_READ_ONLY
+  const gitHubToken = process.env.GITHUB_TOKEN_READ_ONLY
 
   // If no token available, return empty array
   if (!gitHubToken) return []

--- a/src/lib/api/ghRepoData.ts
+++ b/src/lib/api/ghRepoData.ts
@@ -106,7 +106,7 @@ export const ghRepoData = async (githubUrl: string) => {
     `https://api.github.com/repos/${repoOwner}/${repoName}`,
     {
       headers: {
-        Authorization: `Bearer ${process.env.NEXT_PUBLIC_GITHUB_TOKEN_READ_ONLY}`,
+        Authorization: `Bearer ${process.env.GITHUB_TOKEN_READ_ONLY}`,
       },
     }
   )
@@ -121,7 +121,7 @@ export const ghRepoData = async (githubUrl: string) => {
     `https://api.github.com/repos/${repoOwner}/${repoName}/languages`,
     {
       headers: {
-        Authorization: `Bearer ${process.env.NEXT_PUBLIC_GITHUB_TOKEN_READ_ONLY}`,
+        Authorization: `Bearer ${process.env.GITHUB_TOKEN_READ_ONLY}`,
       },
     }
   )


### PR DESCRIPTION
Currently the gh token is only used server side. No need to be exposed to the client.