### PR TITLE
updates a broken link in the docs/ds-implementation.md

### DIFF
--- a/docs/ds-implementation.md
+++ b/docs/ds-implementation.md
@@ -6,7 +6,7 @@ This is part of our [Design System implementation epic](https://github.com/ethe
 
 ## Basics
 
-- Use Chakra tokens for spacing, sizes, and breakpoints. [Chakra theme docs](https://chakra-ui.com/docs/styled-system/theme)
+- Use Chakra tokens for spacing, sizes, and breakpoints. [Chakra theme docs](https://chakra-ui.com/docs/components/theme)
 - For colors use the semantic tokens defined in [this file](https://github.com/ethereum/ethereum-org-website/blob/dev/src/%40chakra-ui/semanticTokens.ts). These tokens will match the color variables used in the DS Figma file
 - Use as many Chakra components and utils as possible
 - Read the [Best Practices doc](https://github.com/ethereum/ethereum-org-website/blob/dev/docs/best-practices.md) for more examples and info


### PR DESCRIPTION
The previous link (/docs/styled-system/theme) was broken and led to a 404 Page Not Found error on the Chakra UI documentation site.

The updated link (/docs/components/theme) correctly redirects to the Theme component documentation, which provides relevant usage and examples. Ensuring correct documentation links improves developer experience and prevents confusion during design system implementation.