### PR TITLE
Update crowdin-ci.yml

### DIFF
--- a/.github/workflows/crowdin-ci.yml
+++ b/.github/workflows/crowdin-ci.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       # Set up environment
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
         uses: actions/setup-node@v3


### PR DESCRIPTION
Line 19:
Replaced GitHub Action version:
uses: actions/checkout@v3 → uses: actions/checkout@v4

https://github.com/actions/checkout/releases/tag/v4