### PR TITLE
Add temporary translations for new menu strings

### DIFF
--- a/src/intl/am/common.json
+++ b/src/intl/am/common.json
@@ -322,6 +322,8 @@
   "nav-staking-solo-description": "የቤት ሃርድዌርን ያሂዱ እና በግል የ Ethereum አውታረ መረብን ደህንነት እና ያልተማከለ ሁኔታ ላይ ይጨምሩ",
   "nav-staking-solo-label": "የብቻ ስታኪንግ",
   "nav-start-building-description": "ለአዲስ መጪዎች ጠቃሚ መረጃ",
+  "nav-start-with-crypto-title": "እዚህ መጀመር",
+  "nav-start-with-crypto-description": "የእርስዎ መጀመሪያ እርምጃዎች በEthereum",
   "nav-translation-program-description": "ethereum.org ወደ ሁሉም ቋንቋዎች ለመተርጎም የትብብር ጥረት",
   "nav-tutorials-description": "የተመረጡ የማህበረሰብ አጋዥ ስልጠናዎች ዝርዝር",
   "nav-use-cases-description": "ለEthereum አጠቃቀም የተለያዩ ሀሳቦችን ያግኙ",

--- a/src/intl/ar/common.json
+++ b/src/intl/ar/common.json
@@ -323,6 +323,8 @@
   "nav-staking-solo-description": "يمكنك التشغيل على جهازك المنزلي، وتعزيز أمان ولامركزية شبكة إيثريوم بشكلٍ شخصي",
   "nav-staking-solo-label": "تجميد العملات الفردي",
   "nav-start-building-description": "معلومات مفيدة للمستجدين",
+  "nav-start-with-crypto-title": "ابدأ من هنا",
+  "nav-start-with-crypto-description": "خطواتك الأولى باستخدام إثريوم",
   "nav-translation-program-description": "جهد تعاوني لترجمة موقع ethereum.org إلى جميع اللغات",
   "nav-tutorials-description": "قائمة منسقة من تعليمات الاستخدام المجتمعية",
   "nav-use-cases-description": "اكتشف أفكارًا مختلفة لاستخدام إيثريوم",

--- a/src/intl/az/common.json
+++ b/src/intl/az/common.json
@@ -322,6 +322,8 @@
   "nav-staking-solo-description": "Ev avadanlıqlarını işə salın və Ethereum şəbəkəsinin təhlükəsizliyinə və mərkəzsizləşdirilməsinə şəxsən əlavə edin",
   "nav-staking-solo-label": "Solo payçılıq",
   "nav-start-building-description": "Yeni başlayanlar üçün faydalı məlumat",
+  "nav-start-with-crypto-title": "Buradan başlayın",
+  "nav-start-with-crypto-description": "Ethereum ilə ilk addımlarınız",
   "nav-translation-program-description": "ethereum.org saytının bütün dillərə tərcümə edilməsi üçün birgə səy",
   "nav-tutorials-description": "İcma təlimatlarının seçilmiş siyahısı",
   "nav-use-cases-description": "Ethereum-un istifadəsi üçün fərqli ideyalar kəşf edin",

--- a/src/intl/be/common.json
+++ b/src/intl/be/common.json
@@ -322,6 +322,8 @@
   "nav-staking-solo-description": "Запусціце хатняе абсталяванне і асабіста палепшыце бяспеку і дэцэнтралізацыю сеткі Ethereum",
   "nav-staking-solo-label": "Адзіночны стэйкінг",
   "nav-start-building-description": "Карысная інфармацыя для тых, хто пачынае",
+  "nav-start-with-crypto-title": "Пачніце тут",
+  "nav-start-with-crypto-description": "Вашы першыя крокі з Ethereum",
   "nav-translation-program-description": "Сумесныя намаганні па перакладу ethereum.org на ўсе мовы",
   "nav-tutorials-description": "Куратарскі спіс навучальных матэрыялаў супольніцтва",
   "nav-use-cases-description": "Пазнаёмцеся з рознымі ідэямі выкарыстання Ethereum",

--- a/src/intl/bg/common.json
+++ b/src/intl/bg/common.json
@@ -322,6 +322,8 @@
   "nav-staking-solo-description": "Работете с домашен хардуер и лично допринасяйте за сигурността и децентрализацията на мрежата Етереум",
   "nav-staking-solo-label": "Самостоятелно залагане",
   "nav-start-building-description": "Полезна информация за начинаещи",
+  "nav-start-with-crypto-title": "Започнете тук",
+  "nav-start-with-crypto-description": "Вашите първи стъпки с Ethereum",
   "nav-translation-program-description": "Доброволно сътрудничество за превеждане на ethereum.org на всички езици",
   "nav-tutorials-description": "Списък на общността с подбрани обучения",
   "nav-use-cases-description": "Открийте различни идеи за използване на Eтереум",

--- a/src/intl/bn/common.json
+++ b/src/intl/bn/common.json
@@ -323,6 +323,8 @@
   "nav-staking-solo-description": "হোম হার্ডওয়্যার চালান এবং ব্যক্তিগতভাবে ইথেরিয়াম নেটওয়ার্কের নিরাপত্তা এবং বিকেন্দ্রীকরণ যোগ করুন",
   "nav-staking-solo-label": "স্বতন্ত্র স্টেকিং",
   "nav-start-building-description": "নতুনদের সাহায্যের জন্য তথ্য",
+  "nav-start-with-crypto-title": "এখান থেকে শুরু করুন",
+  "nav-start-with-crypto-description": "Ethereum ব্যবহারের আপনার প্রথম ধাপ",
   "nav-translation-program-description": "ethereum.org ওয়েবসাইটকে সমস্ত ভাষায় অনুবাদ করার জন্য সকলে মিলে করা এক প্রয়াস",
   "nav-tutorials-description": "কমিউনিটির টিউটোরিয়ালের একত্রিত করা তালিকা",
   "nav-use-cases-description": "ইথেরিয়াম ব্যবহারের বিভিন্ন আইডিয়া খুঁজে নিন",

--- a/src/intl/bs/common.json
+++ b/src/intl/bs/common.json
@@ -319,6 +319,8 @@
   "nav-staking-solo-description": "Pokrenite kućni hardver i lično dodajte sigurnost i decentralizaciju Ethereum mreže",
   "nav-staking-solo-label": "Samostalno ulaganje",
   "nav-start-building-description": "Korisne informacije za novake",
+  "nav-start-with-crypto-title": "Počnite ovdje",
+  "nav-start-with-crypto-description": "Vaši prvi koraci koristeći Ethereum",
   "nav-translation-program-description": "Zajednički trud da se ethereum.org prevede na sve jezike",
   "nav-tutorials-description": "Prilagođena lista tutorijala za zajednicu",
   "nav-use-cases-description": "Otkrijte različite ideje upotrebe Ethereuma",

--- a/src/intl/ca/common.json
+++ b/src/intl/ca/common.json
@@ -333,6 +333,8 @@
   "nav-staking-solo-description": "Executeu el maquinari domèstic i afegiu personalment la seguretat i la descentralització de la xarxa Ethereum",
   "nav-staking-solo-label": "Apilament en solitari",
   "nav-start-building-description": "Informació útil per als nouvinguts",
+  "nav-start-with-crypto-title": "Comença aquí",
+  "nav-start-with-crypto-description": "Els vostres primers passos amb Ethereum",
   "nav-translation-program-description": "Un esforç de col·laboració per a traduir ethereum.org a tots els idiomes",
   "nav-tutorials-description": "Llista verificada de tutorials de la comunitat",
   "nav-use-cases-description": "Descobriu diferents idees per a l'ús de Ethereum",

--- a/src/intl/cs/common.json
+++ b/src/intl/cs/common.json
@@ -334,6 +334,8 @@
   "nav-staking-solo-description": "Spusťte domácí hardware a osobně přidejte k zabezpečení a decentralizaci sítě Ethereum",
   "nav-staking-solo-label": "Samostatné uzamčení",
   "nav-start-building-description": "Užitečné informace pro nováčky",
+  "nav-start-with-crypto-title": "Začněte zde",
+  "nav-start-with-crypto-description": "Vaše první kroky s Ethereum",
   "nav-translation-program-description": "Společné úsilí o překlad ethereum.org do všech jazyků",
   "nav-tutorials-description": "Seznam vybraných komunitních výukových programů",
   "nav-use-cases-description": "Objevte různé nápady na využití Etherea",

--- a/src/intl/da/common.json
+++ b/src/intl/da/common.json
@@ -322,6 +322,8 @@
   "nav-staking-solo-description": "Kør hjemmehardware og tilføj personligt til sikkerheden og decentraliseringen af Ethereum-netværket.",
   "nav-staking-solo-label": "Solo-staking",
   "nav-start-building-description": "Nyttig information for nytilkomne",
+  "nav-start-with-crypto-title": "Start her",
+  "nav-start-with-crypto-description": "Dine første skridt med Ethereum",
   "nav-translation-program-description": "Et samarbejde om at oversætte ethereum.org til alle sprog",
   "nav-tutorials-description": "Organiseret liste over fællesskabsvejledning",
   "nav-use-cases-description": "Se forskellige ideer til brug af Ethereum",

--- a/src/intl/de/common.json
+++ b/src/intl/de/common.json
@@ -333,6 +333,8 @@
   "nav-staking-solo-description": "Benutzen Sie Hardware zu Hause und tragen Sie persönlich zur Sicherheit und Dezentralisierung des Ethereum-Netzwerks bei",
   "nav-staking-solo-label": "Solo-Staking",
   "nav-start-building-description": "Hilfreiche Informationen für neue Mitglieder",
+  "nav-start-with-crypto-title": "Hier starten",
+  "nav-start-with-crypto-description": "Ihre ersten Schritte mit Ethereum",
   "nav-translation-program-description": "Eine gemeinsame Bemühung, ethereum.org in alle Sprachen zu übersetzen",
   "nav-tutorials-description": "Verwaltete Liste mit Community-Tutorials",
   "nav-use-cases-description": "Entdecken Sie verschiedene Ideen zur Nutzung von Ethereum",

--- a/src/intl/el/common.json
+++ b/src/intl/el/common.json
@@ -334,6 +334,8 @@
   "nav-staking-solo-description": "Εκτελέστε την οικιακή σας συσκευή και επιληφθείτε προσωπικά για την ασφάλεια και την αποκέντρωση του δικτύου Ethereum",
   "nav-staking-solo-label": "Ατομική αποθήκευση κεφαλαίου",
   "nav-start-building-description": "Χρήσιμες πληροφορίες για νεοαφιχθέντες",
+  "nav-start-with-crypto-title": "Ξεκινήστε εδώ",
+  "nav-start-with-crypto-description": "Τα πρώτα σας βήματα με το Ethereum",
   "nav-translation-program-description": "Συλλογική προσπάθεια μετάφρασης του ethereum.org σε όλες τις γλώσσες",
   "nav-tutorials-description": "Επιμελημένος κατάλογος της κοινότητας με οδηγούς εκμάθησης",
   "nav-use-cases-description": "Ανακαλύψτε διαφορετικές ιδέες για τη χρήση του Ethereum",

--- a/src/intl/es/common.json
+++ b/src/intl/es/common.json
@@ -334,6 +334,8 @@
   "nav-staking-solo-description": "Ejecute hardware doméstico y contribuya personalmente a la seguridad y a la descentralización de la red Ethereum.",
   "nav-staking-solo-label": "Participación en solitario",
   "nav-start-building-description": "Información útil para principiantes",
+  "nav-start-with-crypto-title": "Empieza aquí",
+  "nav-start-with-crypto-description": "Tus primeros pasos con Ethereum",
   "nav-translation-program-description": "Una iniciativa de colaboración para traducir ethereum.org a todos los idiomas",
   "nav-tutorials-description": "Lista seleccionada de tutoriales de la comunidad",
   "nav-use-cases-description": "Descubra diferentes ideas de usos de Ethereum",

--- a/src/intl/fa/common.json
+++ b/src/intl/fa/common.json
@@ -333,6 +333,8 @@
   "nav-staking-solo-description": "سخت‌افزار خانگی را اجرا کنید و شخصاً امنیت و تمرکززدایی شبکه اتریوم را بیشتر کنید",
   "nav-staking-solo-label": "سهام گذاری انفرادی",
   "nav-start-building-description": "اطلاعات مفید برای افراده تازه وارد",
+  "nav-start-with-crypto-title": "از اینجا شروع کنید",
+  "nav-start-with-crypto-description": "اولین گام‌های شما با اتریوم",
   "nav-translation-program-description": "تلاش جمعی برای ترجمه ethereum.org به همه زبان‌ها",
   "nav-tutorials-description": "لیست تهیه‌شده از آموزش‌های انجمن",
   "nav-use-cases-description": "ایده‌های مختلف برای استفاده از اتریوم را کشف کنید",

--- a/src/intl/fi/common.json
+++ b/src/intl/fi/common.json
@@ -322,6 +322,8 @@
   "nav-staking-solo-description": "Ylläpidä kotilaitteistoa ja lisää henkilökohtaisesti Ethereum-verkon tietoturvaa ja hajautusta",
   "nav-staking-solo-label": "Panostus soolona",
   "nav-start-building-description": "Tarpeellista tietoa aloittelijoille",
+  "nav-start-with-crypto-title": "Aloita tästä",
+  "nav-start-with-crypto-description": "Ensiaskeleesi Ethereumilla",
   "nav-translation-program-description": "Yhteistyöprojekti ethereum.org-sivuston kääntämiseksi kaikille kielille",
   "nav-tutorials-description": "Huolellisesti valikoituja yhteisöoppaita",
   "nav-use-cases-description": "Löydä erilaisia ideoita Ethereumin käyttöön",

--- a/src/intl/fil/common.json
+++ b/src/intl/fil/common.json
@@ -322,6 +322,8 @@
   "nav-staking-solo-description": "Patakbuhin ang home hardware at personal na magdagdag sa seguridad at decentralization ng Ethereum network",
   "nav-staking-solo-label": "Solo staking",
   "nav-start-building-description": "Kapaki-pakinabang na impormasyon para sa mga baguhan",
+  "nav-start-with-crypto-title": "Magsimula rito",
+  "nav-start-with-crypto-description": "Ang iyong unang mga hakbang sa paggamit ng Ethereum",
   "nav-translation-program-description": "Isang sama-samang pagsisikap upang isalin ang ethereum.org sa lahat ng wika",
   "nav-tutorials-description": "Isang piniling listahan ng mga tutorial ng komunidad",
   "nav-use-cases-description": "Matuklasan ang iba't ibang ideya ng paggamit ng Ethereum",

--- a/src/intl/fr/common.json
+++ b/src/intl/fr/common.json
@@ -334,6 +334,8 @@
   "nav-staking-solo-description": "Faites fonctionner votre propre matériel et contribuez ainsi à la sécurité et la décentralisation du réseau Ethereum",
   "nav-staking-solo-label": "Mise en jeu en solo",
   "nav-start-building-description": "Informations utiles pour les nouveaux venus",
+  "nav-start-with-crypto-title": "Commencez ici",
+  "nav-start-with-crypto-description": "Vos premiers pas avec Ethereum",
   "nav-translation-program-description": "Un effort collaboratif pour traduire ethereum.org dans toutes les langues",
   "nav-tutorials-description": "Liste de tutoriels de la communauté",
   "nav-use-cases-description": "Découvrez des idées originales d'utilisation d'Ethereum",

--- a/src/intl/ga/common.json
+++ b/src/intl/ga/common.json
@@ -334,6 +334,8 @@
   "nav-staking-solo-description": "Úsáid chrua-earraí baile agus cuir le slándáil agus le dílárú líonra Ethereum ar bhonn pearsanta",
   "nav-staking-solo-label": "Geallchur aonair",
   "nav-start-building-description": "Eolas úsáideach do dhaoine nua",
+  "nav-start-with-crypto-title": "Tosaigh anseo",
+  "nav-start-with-crypto-description": "Do chéad chéimeanna le Ethereum",
   "nav-translation-program-description": "Iarracht chomhoibríoch ethereum.org a aistriú go dtí gach teanga",
   "nav-tutorials-description": "Liosta coimeádta de ranganna teagaisc pobail",
   "nav-use-cases-description": "Faigh amach smaointe éagsúla maidir le húsáid Ethereum",

--- a/src/intl/gl/common.json
+++ b/src/intl/gl/common.json
@@ -320,6 +320,8 @@
   "nav-staking-solo-description": "Executar hardware doméstico e engadir persoalmente a seguridade e descentralización da rede Ethereum",
   "nav-staking-solo-label": "Participación individual",
   "nav-start-building-description": "Información útil para os que acaban de chegar",
+  "nav-start-with-crypto-title": "Comeza aquí",
+  "nav-start-with-crypto-description": "Os teus primeiros pasos con Ethereum",
   "nav-translation-program-description": "Un esforzo conxunto para traducir ethereum.org a todos os idiomas",
   "nav-tutorials-description": "Unha lista coidadosamente elaborada de tutoriais da comunidade",
   "nav-use-cases-description": "Descubra diferentes ideas de uso de Ethereum",

--- a/src/intl/gu/common.json
+++ b/src/intl/gu/common.json
@@ -319,6 +319,8 @@
   "nav-staking-solo-description": "હોમ હાર્ડવેર ચલાવો અને Ethereum નેટવર્કની સુરક્ષા અને વિકેન્દ્રીકરણમાં વ્યક્તિગત રીતે ઉમેરો",
   "nav-staking-solo-label": "સોલો સ્ટેકિંગ",
   "nav-start-building-description": "નવા આવનારાઓ માટે ઉપયોગી માહિતી",
+  "nav-start-with-crypto-title": "અહીંથી શરૂઆત કરો",
+  "nav-start-with-crypto-description": "Ethereum વાપરવાની તમારી પ્રથમ પગલાં",
   "nav-translation-program-description": "ethereum.org ને બધી ભાષાઓમાં અનુવાદિત કરવાનો સહયોગી પ્રયાસ",
   "nav-tutorials-description": "સમુદાય ટ્યુટોરિયલ્સની ક્યૂરેટ કરેલ સૂચિ",
   "nav-use-cases-description": "ઈથિરિયમના ઉપયોગ માટેના વિવિધ ખ્યાલો શોધો",

--- a/src/intl/ha/common.json
+++ b/src/intl/ha/common.json
@@ -321,6 +321,8 @@
   "nav-staking-solo-description": "Gudanar da kayan aikin gida kuma da kuma kaina ana ƙara tsaro da rarraba 'yancin kan sadarwar Ethereum",
   "nav-staking-solo-label": "Adana na kai kadai",
   "nav-start-building-description": "Muhimman bayanai ga masu shigowa yanzu",
+  "nav-start-with-crypto-title": "Fara a nan",
+  "nav-start-with-crypto-description": "Matakan ka na farko da Ethereum",
   "nav-translation-program-description": "Ƙoƙarin haɗin gwiwa don fassara ethereum.org zuwa dukkanin harsuna",
   "nav-tutorials-description": "Jerin da ayyukan da aka tsara na koyarwa al'umma",
   "nav-use-cases-description": "Nemo dabaru daban-daban don amfanin Ethereum",

--- a/src/intl/he/common.json
+++ b/src/intl/he/common.json
@@ -320,6 +320,8 @@
   "nav-staking-solo-description": "הפעל חומרה ביתית והוסף באופן אישי לאבטחה ולביזור של רשת Ethereum",
   "nav-staking-solo-label": "הפקד לבד",
   "nav-start-building-description": "מידע שימושי למתחילים",
+  "nav-start-with-crypto-title": "התחילו כאן",
+  "nav-start-with-crypto-description": "הצעדים הראשונים שלכם עם Ethereum",
   "nav-translation-program-description": "מאמץ משותף לתרגם את ethereum.org לכל השפות",
   "nav-tutorials-description": "הרשימה המפוקחת של מדריכי הקהילה",
   "nav-use-cases-description": "גלה רעיונות שימוש באתריום שונים",

--- a/src/intl/hi/common.json
+++ b/src/intl/hi/common.json
@@ -323,6 +323,8 @@
   "nav-staking-solo-description": "होम हार्डवेयर चलाएं और व्यक्तिगत रूप से इथेरियम नेटवर्क की सुरक्षा और विकेंद्रीकरण में जोड़ें",
   "nav-staking-solo-label": "एकल स्टेकिंग",
   "nav-start-building-description": "नए लोगों के लिए उपयोगी जानकारी",
+  "nav-start-with-crypto-title": "यहाँ से शुरू करें",
+  "nav-start-with-crypto-description": "Ethereum का उपयोग करने के आपके पहले कदम",
   "nav-translation-program-description": "Ethereum.org का सभी भाषाओं में अनुवाद करने की एक सहयोगी कोशिश",
   "nav-tutorials-description": "कम्युनिटी ट्यूटोरियल की क्यूरेट की गई लिस्ट",
   "nav-use-cases-description": "एथेरियम के इस्तेमाल के अलग-अलग तरीके जानें",

--- a/src/intl/hr/common.json
+++ b/src/intl/hr/common.json
@@ -322,6 +322,8 @@
   "nav-staking-solo-description": "Pokrenite kućni hardver i osobno doprinesite sigurnosti i decentralizaciji Ethereumove mreže",
   "nav-staking-solo-label": "Samostalan staking",
   "nav-start-building-description": "Korisne informacije za početnike",
+  "nav-start-with-crypto-title": "Počnite ovdje",
+  "nav-start-with-crypto-description": "Vaši prvi koraci uz Ethereum",
   "nav-translation-program-description": "Suradnja u prevođenju web-mjesta ethereum.org na sve jezike",
   "nav-tutorials-description": "Odabrani popis praktičnih vodiča zajednice",
   "nav-use-cases-description": "Otkrijte različite ideje kako se koristiti Ethereumom",

--- a/src/intl/hu/common.json
+++ b/src/intl/hu/common.json
@@ -334,6 +334,8 @@
   "nav-staking-solo-description": "Működtessen az otthonából hardvert és támogassa személyesen az Ethereum hálózatának biztonságát és decentralizálását",
   "nav-staking-solo-label": "Egyéni letétbe helyezés",
   "nav-start-building-description": "Hasznos információk az újoncok számára",
+  "nav-start-with-crypto-title": "Kezdje itt",
+  "nav-start-with-crypto-description": "Első lépései az Ethereummal",
   "nav-translation-program-description": "Közös együttműködés, hogy az ethereum.org weboldalt minden nyelvre lefordítsuk",
   "nav-tutorials-description": "A közösségi útmutatók válogatott listája",
   "nav-use-cases-description": "Különböző ötletek az Ethereum használatához",

--- a/src/intl/hy-am/common.json
+++ b/src/intl/hy-am/common.json
@@ -320,6 +320,8 @@
   "nav-staking-solo-description": "Գործարկեք տնային սարքավորումները և անձամբ ավելացրեք Ethereum ցանցի անվտանգությունն ու ապակենտրոնացումը",
   "nav-staking-solo-label": "Միայնակ խաղադրույք",
   "nav-start-building-description": "Օգտակար տեղեկություններ սկսնակների համար",
+  "nav-start-with-crypto-title": "እዚህ መጀመር",
+  "nav-start-with-crypto-description": "የእርስዎ መጀመሪያ እርምጃዎች በEthereum",
   "nav-translation-program-description": "Թարգմանչական համագործակցություն ethereum.org-ի հետ բոլոր լեզուներով",
   "nav-tutorials-description": "Համայնքի ուղեցույցների համադրված ցուցակ",
   "nav-use-cases-description": "Բացահայտեք Ethereum-ի օգտագործման տարբեր գաղափարները",

--- a/src/intl/id/common.json
+++ b/src/intl/id/common.json
@@ -334,6 +334,8 @@
   "nav-staking-solo-description": "Jalankan perangkat keras di beranda dan secara pribadi berkontribusi pada keamanan dan desentralisasi jaringan Ethereum",
   "nav-staking-solo-label": "Penaruhan solo",
   "nav-start-building-description": "Informasi yang berguna bagi pendatang baru",
+  "nav-start-with-crypto-title": "Mulai di sini",
+  "nav-start-with-crypto-description": "Langkah pertama Anda menggunakan Ethereum",
   "nav-translation-program-description": "Upaya kolaboratif untuk menerjemahkan ethereum.org ke semua bahasa",
   "nav-tutorials-description": "Daftar pilihan tutorial komunitas",
   "nav-use-cases-description": "Temukan berbagai ide untuk penggunaan Ethereum",

--- a/src/intl/ig/common.json
+++ b/src/intl/ig/common.json
@@ -322,6 +322,8 @@
   "nav-staking-solo-description": "Gbaa ngwaike ụlọ ma tinye onwe gị na nchekwa na decentralization nke netwọk Ethereum",
   "nav-staking-solo-label": "Solo staking",
   "nav-start-building-description": "Ozi bara uru maka ndị bịara ọhụrụ\n​",
+  "nav-start-with-crypto-title": "Bido ebe a",
+  "nav-start-with-crypto-description": "Nzụta mbụ gị na Ethereum",
   "nav-translation-program-description": "Mgbalị imekọ ihe ọnụ iji tụgharịa asụsụ ethereum.org na asụsụ niile",
   "nav-tutorials-description": "Ndepụta nke nkuzi obodo",
   "nav-use-cases-description": "Chọpụta echiche dị iche iche maka iji Ethereum",

--- a/src/intl/it/common.json
+++ b/src/intl/it/common.json
@@ -334,6 +334,8 @@
   "nav-staking-solo-description": "Opera hardware domestico e aggiungi personalmente alla sicurezza e decentralizzazione della rete di Ethereum",
   "nav-staking-solo-label": "Staking in solo",
   "nav-start-building-description": "Informazioni utili per i novellini",
+  "nav-start-with-crypto-title": "Inizia qui",
+  "nav-start-with-crypto-description": "I tuoi primi passi con Ethereum",
   "nav-translation-program-description": "Uno sforzo collaborativo per tradurre ethereum.org in tutte le lingue",
   "nav-tutorials-description": "Elenco curato di tutorial della community",
   "nav-use-cases-description": "Scoprire diverse idee per l'utilizzo di Ethereum",

--- a/src/intl/ja/common.json
+++ b/src/intl/ja/common.json
@@ -334,6 +334,8 @@
   "nav-staking-solo-description": "家庭用ハードウェアを稼働させ、イーサリアムネットワークのセキュリティと分散化に個人で貢献",
   "nav-staking-solo-label": "ソロステーキング",
   "nav-start-building-description": "初心者向けの有用な情報",
+  "nav-start-with-crypto-title": "ここから始める",
+  "nav-start-with-crypto-description": "Ethereum を使い始める第一歩",
   "nav-translation-program-description": "ethereum.orgをすべての言語に翻訳するための共同作業",
   "nav-tutorials-description": "コミュニティチュートリアルの精選されたリスト",
   "nav-use-cases-description": "イーサリアム利用のさまざまなアイデアを発見",

--- a/src/intl/ka/common.json
+++ b/src/intl/ka/common.json
@@ -322,6 +322,8 @@
   "nav-staking-solo-description": "გაუშვით სახლის აპარატურა და პირადად დაამატეთ ეთერეუმ ქსელის უსაფრთხოება და დეცენტრალიზაცია",
   "nav-staking-solo-label": "სოლო სტეიკინგი",
   "nav-start-building-description": "სასარგებლო ინფორმაცია ახალი წევრებისათვის",
+  "nav-start-with-crypto-title": "დაიწყეთ აქ",
+  "nav-start-with-crypto-description": "თქვენი პირველი ნაბიჯები Ethereum-ით",
   "nav-translation-program-description": "ურთიერთთანამშრომლობითი ძალისხმევა ethereum.org-ის ყველა ენაზე გადათარგმნის კუთხით",
   "nav-tutorials-description": "საზოგადოების სასწავლო ვიდეოების კურირებული სია",
   "nav-use-cases-description": "აღმოაჩინეთ ეთერეუმის გამოყენების განსხვავებული იდეები",

--- a/src/intl/kk/common.json
+++ b/src/intl/kk/common.json
@@ -319,6 +319,8 @@
   "nav-staking-solo-description": "Үй жабдықтарын іске қосыңыз және Ethereum желісінің қауіпсіздігі мен орталықсыздандыруына жеке қосыңыз",
   "nav-staking-solo-label": "Соло стейкинг",
   "nav-start-building-description": "Жаңа келгендер үшін пайдалы ақпарат",
+  "nav-start-with-crypto-title": "Мұнда бастаңыз",
+  "nav-start-with-crypto-description": "Ethereum-мен алғашқы қадамдарыңыз",
   "nav-translation-program-description": "ethereum.org сайтын барлық тілдерге аударуға бірге әрекеттену",
   "nav-tutorials-description": "Қауымдастық нұсқаулығының таңдалған тізімі",
   "nav-use-cases-description": "Ethereum пайдаланудың әртүрлі идеяларын ашыңыз",

--- a/src/intl/km/common.json
+++ b/src/intl/km/common.json
@@ -321,6 +321,8 @@
   "nav-staking-solo-description": "ដំណើរការហាដវែរនៅផ្ទះ ហើយបន្ថែមដោយផ្ទាល់ទៅសុវត្ថិភាព និងវិមជ្ឈការនៃបណ្តាញ Ethereum",
   "nav-staking-solo-label": "ការភ្នាល់ទោល",
   "nav-start-building-description": "ព័ត៌មានសំខាន់ៗសម្រាប់អ្នកចូលរួមថ្មី",
+  "nav-start-with-crypto-title": "ចាប់ផ្តើមនៅទីនេះ",
+  "nav-start-with-crypto-description": "ជំហានដំបូងរបស់អ្នកជាមួយ Ethereum",
   "nav-translation-program-description": "ការខិតខំប្រឹងប្រែងរួមគ្នាដើម្បីបកប្រែ ethereum.org ឱ្យបានគ្រប់ភាសាទាំងអស់",
   "nav-tutorials-description": "បញ្ជីត្រៀមទុកនៃការបង្រៀនសហគមន៍",
   "nav-use-cases-description": "ស្វែងយល់ពីគំនិតផ្សេងៗគ្នាសម្រាប់ការប្រើ Ethereum",

--- a/src/intl/kn/common.json
+++ b/src/intl/kn/common.json
@@ -332,6 +332,8 @@
   "nav-staking-solo-description": "ನಿಮ್ಮ ಮನೆಯ ಹಾರ್ಡ್‌ವೇರ್ ಅನ್ನು ಚಲಾಯಿಸಿ ಮತ್ತು ವೈಯಕ್ತಿಕವಾಗಿ ಎಥೆರಿಯಮ್ ನೆಟ್‌ವರ್ಕ್‌ನ ಭದ್ರತೆ ಮತ್ತು ವಿಕೇಂದ್ರೀಕರಣಕ್ಕೆ ಸೇರಿಸಿ",
   "nav-staking-solo-label": "ಏಕವ್ಯಕ್ತಿ ಸ್ಟೇಕಿಂಗ್",
   "nav-start-building-description": "ಹೊಸಬರಿಗೆ ಉಪಯುಕ್ತ ಮಾಹಿತಿ",
+  "nav-start-with-crypto-title": "ಇಲ್ಲಿ ಪ್ರಾರಂಭಿಸಿ",
+  "nav-start-with-crypto-description": "Ethereum ಬಳಸುವ ನಿಮ್ಮ ಪ್ರಥಮ ಹೆಜ್ಜೆಗಳು",
   "nav-translation-program-description": "Ethereum.org ಅನ್ನು ಎಲ್ಲಾ ಭಾಷೆಗಳಿಗೆ ಭಾಷಾಂತರಿಸಲು ಸಹಯೋಗದ ಪ್ರಯತ್ನ",
   "nav-tutorials-description": "ಸಮುದಾಯ ಬೋಧನೆಗಳ ಕ್ಯುರೇಟೆಡ್ ಪಟ್ಟಿ",
   "nav-use-cases-description": "ಎಥೆರಿಯಮ್ ಬಳಕೆಗೆ ವಿವಿಧ ವಿಚಾರಗಳನ್ನು ಕಂಡುಕೊಳ್ಳಿ",

--- a/src/intl/ko/common.json
+++ b/src/intl/ko/common.json
@@ -323,6 +323,8 @@
   "nav-staking-solo-description": "가정용 컴퓨터를 실행하고 이더리움 네트워크의 보안과 탈중앙화에 기여해 보세요.",
   "nav-staking-solo-label": "솔로 스테이킹",
   "nav-start-building-description": "신규 사용자를 위한 유용한 정보",
+  "nav-start-with-crypto-title": "여기서 시작하세요",
+  "nav-start-with-crypto-description": "Ethereum 사용 첫 단계",
   "nav-translation-program-description": "ethereum.org를 모든 언어로 번역하기 위한 공동의 노력",
   "nav-tutorials-description": "엄선된 커뮤니티 튜토리얼 목록",
   "nav-use-cases-description": "이더리움 사용에 대한 다른 아이디어 살펴보기",

--- a/src/intl/lt/common.json
+++ b/src/intl/lt/common.json
@@ -320,6 +320,8 @@
   "nav-staking-solo-description": "Paleiskite namų įrangą ir asmeniškai prisidėkite prie Ethereum tinklo saugumo ir decentralizacijos",
   "nav-staking-solo-label": "Savarankiškas palaikymas",
   "nav-start-building-description": "Naudinga informacija naujokams",
+  "nav-start-with-crypto-title": "Pradėkite čia",
+  "nav-start-with-crypto-description": "Pirmieji žingsniai su Ethereum",
   "nav-translation-program-description": "Bendros pastangos išversti puslapį ethereum.org į visas kalbas",
   "nav-tutorials-description": "Sudarytas bendruomenės vadovėlių sąrašas",
   "nav-use-cases-description": "Atraskite kitokio Ethereum panaudojimo idėjų",

--- a/src/intl/ml/common.json
+++ b/src/intl/ml/common.json
@@ -322,6 +322,8 @@
   "nav-staking-solo-description": "ഹോം ഹാർഡ്‌വെയർ പ്രവർത്തിപ്പിച്ച് വ്യക്തിപരമായി Ethereum നെറ്റ്‌വർക്കിൻ്റെ സുരക്ഷയും വികേന്ദ്രീകരണവും ചേർക്കുക",
   "nav-staking-solo-label": "സോളോ സ്റ്റെയ്ക്കിങ്",
   "nav-start-building-description": "നവാഗതർക്കുള്ള ഉപയോഗപ്രദമായ വിവരങ്ങൾ",
+  "nav-start-with-crypto-title": "ഇവിടെ നിന്ന് ആരംഭിക്കുക",
+  "nav-start-with-crypto-description": "Ethereum ഉപയോഗിക്കാൻ നിങ്ങളുടെ ആദ്യ നടപടികൾ",
   "nav-translation-program-description": "എല്ലാ ഭാഷകളിലേക്കും ethereum.org വിവർത്തനം ചെയ്യാനുള്ള ഒരു കൂട്ടായ പരിശ്രമം",
   "nav-tutorials-description": "കമ്മ്യൂണിറ്റി ട്യൂട്ടോറിയലുകളുടെ ക്യൂറേറ്റ് ചെയ്‌ത ലിസ്റ്റ്",
   "nav-use-cases-description": "Ethereum ഉപയോഗത്തിനുള്ള വ്യത്യസ്‌ത ആശയങ്ങൾ കണ്ടെത്തുക",

--- a/src/intl/mr/common.json
+++ b/src/intl/mr/common.json
@@ -321,6 +321,8 @@
   "nav-staking-solo-description": "होम हार्डवेअर चालवा आणि वैयक्तिकरित्या इथरियम नेटवर्कची सुरक्षा आणि विकेंद्रीकरण जोडा",
   "nav-staking-solo-label": "सोलो स्टॅकिंग",
   "nav-start-building-description": "नवोदितांसाठी उपयुक्त माहिती",
+  "nav-start-with-crypto-title": "इथून सुरू करा",
+  "nav-start-with-crypto-description": "Ethereum वापरण्याची तुमची पहिली पावले",
   "nav-translation-program-description": "Ethereum.org सर्व भाषांमध्ये अनुवादित करण्याचा एक सहयोगी प्रयत्न",
   "nav-tutorials-description": "सामुदायिक ट्यूटोरियलची क्युरेट केलेली यादी",
   "nav-use-cases-description": "इथरियमच्या वापरासाठी विविध कल्पना शोधा",

--- a/src/intl/ms/common.json
+++ b/src/intl/ms/common.json
@@ -322,6 +322,8 @@
   "nav-staking-solo-description": "Jalankan perkakasan laman utama dan tambah pada keselamatan dan keteragihan rangkaian Ethereum secara peribadi",
   "nav-staking-solo-label": "Pertaruhan solo",
   "nav-start-building-description": "Maklumat berguna untuk pengguna baharu",
+  "nav-start-with-crypto-title": "Mulakan di sini",
+  "nav-start-with-crypto-description": "Langkah pertama anda menggunakan Ethereum",
   "nav-translation-program-description": "Usahasama untuk menterjemah ethereum.org kepada semua bahasa",
   "nav-tutorials-description": "Senarai tutorial komuniti yang dipilih susun",
   "nav-use-cases-description": "Terokai idea lain untuk penggunaan Ethereum",

--- a/src/intl/nb/common.json
+++ b/src/intl/nb/common.json
@@ -321,6 +321,8 @@
   "nav-staking-solo-description": "Kjør hjemmemaskinvare og legg personlig til sikkerheten og desentraliseringen av Ethereum-nettverket",
   "nav-staking-solo-label": "Solo-staking",
   "nav-start-building-description": "Nyttig informasjon for nykommere",
+  "nav-start-with-crypto-title": "Start her",
+  "nav-start-with-crypto-description": "Dine første steg med Ethereum",
   "nav-translation-program-description": "Et samarbeid for å oversette ethereum.org til alle språk",
   "nav-tutorials-description": "Kuratert liste over opplæringsprogrammer for fellesskapet",
   "nav-use-cases-description": "Oppdag forskjellige ideer for bruk av Ethereum",

--- a/src/intl/ne-np/common.json
+++ b/src/intl/ne-np/common.json
@@ -318,6 +318,8 @@
   "nav-staking-solo-description": "गृह हार्डवेयर चलाउनुहोस् र व्यक्तिगत रूपमा Ethereum नेटवर्कको सुरक्षा र विकेन्द्रीकरणमा थप्नुहोस्",
   "nav-staking-solo-label": "एकल स्टेकिंग",
   "nav-start-building-description": "नवागन्तुकहरूका लागि उपयोगी जानकारी",
+  "nav-start-with-crypto-title": "यहाँबाट सुरु गर्नुहोस्",
+  "nav-start-with-crypto-description": "Ethereum प्रयोग गर्ने तपाईंका पहिलो कदमहरू",
   "nav-translation-program-description": "सबै भाषाहरूमा ethereum.org लाई अनुवाद गर्ने एउटा सहकार्यात्मक प्रयास",
   "nav-tutorials-description": "सामुदायिक ट्युटोरियलहरूका क्युरेट गरिएको सूची",
   "nav-use-cases-description": "Ethereum प्रयोगको लागि विभिन्न विचारहरू",

--- a/src/intl/nl/common.json
+++ b/src/intl/nl/common.json
@@ -331,6 +331,8 @@
   "nav-staking-solo-description": "Voer home-hardware uit en voeg persoonlijk toe aan de beveiliging en decentralisatie van het Ethereum-netwerk",
   "nav-staking-solo-label": "Solo staking",
   "nav-start-building-description": "Nuttige informatie voor nieuwkomers",
+  "nav-start-with-crypto-title": "Begin hier",
+  "nav-start-with-crypto-description": "Je eerste stappen met Ethereum",
   "nav-translation-program-description": "Een collaboratieve inspanning om ethereum.org in alle talen te vertalen",
   "nav-tutorials-description": "Samengestelde lijst van gemeenschapstutorials",
   "nav-use-cases-description": "Ontdek verschillende ideeën voor het gebruik van Ethereum",

--- a/src/intl/pcm/common.json
+++ b/src/intl/pcm/common.json
@@ -322,6 +322,8 @@
   "nav-staking-solo-description": "Make yu run home hardware and add to di security and disentralizashon of di Ethereum Netwok yorsef",
   "nav-staking-solo-label": "Solo Stakin",
   "nav-start-building-description": "Informashon wey dey yusful for otondo",
+  "nav-start-with-crypto-title": "Start here",
+  "nav-start-with-crypto-description": "Ya first steps wit Ethereum",
   "nav-translation-program-description": "One joint effoti to make sure dem translate ethereum.org to all di languages",
   "nav-tutorials-description": "List wey dem kurate for komunity tutorials",
   "nav-use-cases-description": "Diskova difrent idias wey dem fit use Ethereum for",

--- a/src/intl/pl/common.json
+++ b/src/intl/pl/common.json
@@ -335,6 +335,8 @@
   "nav-staking-solo-description": "Korzystaj z własnego sprzętu i osobiście zwiększaj bezpieczeństwo i decentralizację sieci Ethereum",
   "nav-staking-solo-label": "Stakowanie solo",
   "nav-start-building-description": "Przydatne informacje dla nowych użytkowników",
+  "nav-start-with-crypto-title": "Zacznij tutaj",
+  "nav-start-with-crypto-description": "Twoje pierwsze kroki z Ethereum",
   "nav-translation-program-description": "Wspólny wysiłek na rzecz przetłumaczenia ethereum.org na wszystkie języki",
   "nav-tutorials-description": "Wyselekcjonowana lista samouczków społeczności",
   "nav-use-cases-description": "Odkryj różne pomysły na wykorzystanie Ethereum",

--- a/src/intl/pt-br/common.json
+++ b/src/intl/pt-br/common.json
@@ -334,6 +334,8 @@
   "nav-staking-solo-description": "Execute o hardware local e adicione pessoalmente à segurança e descentralização da rede Ethereum",
   "nav-staking-solo-label": "Participação individual",
   "nav-start-building-description": "Informações úteis para principiantes",
+  "nav-start-with-crypto-title": "Comece aqui",
+  "nav-start-with-crypto-description": "Seus primeiros passos com Ethereum",
   "nav-translation-program-description": "Um esforço colaborativo para traduzir o site ethereum.org para todos os idiomas",
   "nav-tutorials-description": "Lista selecionada de tutoriais da comunidade",
   "nav-use-cases-description": "Descubra como usar o Ethereum de diferentes formas",

--- a/src/intl/pt/common.json
+++ b/src/intl/pt/common.json
@@ -333,6 +333,8 @@
   "nav-staking-solo-description": "Opere hardware doméstico e contribua pessoalmente para a segurança e descentralização da rede Ethereum",
   "nav-staking-solo-label": "Participação individual",
   "nav-start-building-description": "Informações úteis para os principiantes",
+  "nav-start-with-crypto-title": "Comece aqui",
+  "nav-start-with-crypto-description": "Os seus primeiros passos com Ethereum",
   "nav-translation-program-description": "Um esforço de colaboração para traduzir o ethereum.org para todas as línguas",
   "nav-tutorials-description": "Lista selecionada de tutoriais da comunidade",
   "nav-use-cases-description": "Descubra ideias distintas para a utilização do Ethereum",

--- a/src/intl/ro/common.json
+++ b/src/intl/ro/common.json
@@ -333,6 +333,8 @@
   "nav-staking-solo-description": "Rulați hardware-ul obișnuit și contribuiți personal la securitatea și descentralizarea rețelei Ethereum",
   "nav-staking-solo-label": "Miză individuală",
   "nav-start-building-description": "Informații utile pentru nou-veniți",
+  "nav-start-with-crypto-title": "Începeți aici",
+  "nav-start-with-crypto-description": "Primii dvs. pași cu Ethereum",
   "nav-translation-program-description": "Un proiect de colaborare pentru a traduce ethereum.org în toate limbile",
   "nav-tutorials-description": "Listă curatoriată cu tutoriale generate de comunitate",
   "nav-use-cases-description": "Descoperă diferite idei pentru utilizarea Ethereum",

--- a/src/intl/ru/common.json
+++ b/src/intl/ru/common.json
@@ -334,6 +334,8 @@
   "nav-staking-solo-description": "Запустите домашнее оборудование и лично добавьте безопасности и децентрализации сети Ethereum",
   "nav-staking-solo-label": "Одиночный стейкинг",
   "nav-start-building-description": "Полезная информация для новичков",
+  "nav-start-with-crypto-title": "Начните здесь",
+  "nav-start-with-crypto-description": "Ваши первые шаги с Ethereum",
   "nav-translation-program-description": "Общие усилия по переводу ethereum.org на все языки",
   "nav-tutorials-description": "Курируемый список руководств сообщества",
   "nav-use-cases-description": "Узнайте различные идеи по использованию Ethereum",

--- a/src/intl/se/common.json
+++ b/src/intl/se/common.json
@@ -322,6 +322,8 @@
   "nav-staking-solo-description": "Kör hårdvara hemma och bidra personligen till säkerheten och decentraliseringen av Ethereum-nätverket",
   "nav-staking-solo-label": "Soloutsättning",
   "nav-start-building-description": "Användbar information för nybörjare",
+  "nav-start-with-crypto-title": "Börja här",
+  "nav-start-with-crypto-description": "Dina första steg med Ethereum",
   "nav-translation-program-description": "Ett samarbetsprojekt för att översätta ethereum.org till alla språk",
   "nav-tutorials-description": "Kurerad lista över community-guider",
   "nav-use-cases-description": "Upptäck olika idéer för Ethereum-användning",

--- a/src/intl/sk/common.json
+++ b/src/intl/sk/common.json
@@ -322,6 +322,8 @@
   "nav-staking-solo-description": "Spustiť domáci hardvér a osobne prispieť k bezpečnosti a decentralizácii siete Ethereum",
   "nav-staking-solo-label": "Sólo stakovanie",
   "nav-start-building-description": "Užitočné informácie pre nováčikov",
+  "nav-start-with-crypto-title": "Začnite tu",
+  "nav-start-with-crypto-description": "Vaše prvé kroky s Ethereom",
   "nav-translation-program-description": "Spoločné úsilie o preklad webovej lokality ethereum.org do všetkých jazykov",
   "nav-tutorials-description": "Zoznam komunitných výukových materiálov",
   "nav-use-cases-description": "Objavte rôzne nápady na využitie Etherea",

--- a/src/intl/sl/common.json
+++ b/src/intl/sl/common.json
@@ -322,6 +322,8 @@
   "nav-staking-solo-description": "zagnati domačo strojno opremo in osebno prispevati k varnosti in decentralizaciji omrežja Ethereum",
   "nav-staking-solo-label": "Samostojno zastavljanje",
   "nav-start-building-description": "Koristne informacije za novince",
+  "nav-start-with-crypto-title": "Začnite tukaj",
+  "nav-start-with-crypto-description": "Vaši prvi koraki z Ethereumom",
   "nav-translation-program-description": "Skupna prizadevanja za prevod spletnega mesta ethereum.org v vse jezike",
   "nav-tutorials-description": "Pregledan seznam vadnic skupnosti",
   "nav-use-cases-description": "Odkrijte različne zamisli za uporabo Ethereuma",

--- a/src/intl/sn/common.json
+++ b/src/intl/sn/common.json
@@ -331,6 +331,8 @@
   "nav-staking-solo-description": "Shandisa muchina wekumba kuwedzera kuchengetedzeka nekupararira kwemasaisai eEthereum",
   "nav-staking-solo-label": "Kuita staking kwemunhu ega",
   "nav-start-building-description": "Ruzivo rwakakoshera vachangotanga",
+  "nav-start-with-crypto-title": "Tanga pano",
+  "nav-start-with-crypto-description": "Matanho ako ekutanga ne Ethereum",
   "nav-translation-program-description": "Mushandirapamwe wekushandura ethereum.org kuenda kumitauro yese",
   "nav-tutorials-description": "Muunganidzwa wedzidzidzo zvevachangotanga zvinobva muboka",
   "nav-use-cases-description": "Sangana nemazano matsva emashandirwo angaitwa Ethereum",

--- a/src/intl/sr/common.json
+++ b/src/intl/sr/common.json
@@ -322,6 +322,8 @@
   "nav-staking-solo-description": "Pokrenite kućni hardver i lično doprinosite bezbednosti i decentralizaciji Ethereum mreže",
   "nav-staking-solo-label": "Samostalno ulaganje",
   "nav-start-building-description": "Korisne informacije za novajlije",
+  "nav-start-with-crypto-title": "Почните овде",
+  "nav-start-with-crypto-description": "Ваши први кораци са Ethereum-ом",
   "nav-translation-program-description": "Zajednički napor da se ethereum.org prevede na sve jezike",
   "nav-tutorials-description": "Uređena lista tutorijala zajednice",
   "nav-use-cases-description": "Otkrijte različite ideje za korišćenje Ethereuma",

--- a/src/intl/sw/common.json
+++ b/src/intl/sw/common.json
@@ -332,6 +332,8 @@
   "nav-staking-solo-description": "Endesha vifaa vya nyumbani na uongeze kibinafsi usalama na ugatuaji wa mtandao wa Ethereum",
   "nav-staking-solo-label": "Usimamishaji binafsi wa hisa",
   "nav-start-building-description": "Taarifa muhimu kwa wanaoanza",
+  "nav-start-with-crypto-title": "Anza hapa",
+  "nav-start-with-crypto-description": "Hatua zako za kwanza ukitumia Ethereum",
   "nav-translation-program-description": "Jitihada za pamoja za kutafsiri ethereum.org hadi lugha zote",
   "nav-tutorials-description": "Orodha iliyorekebishwa ya mafunzo ya jamii",
   "nav-use-cases-description": "Gundua hoja tofauti za matumizi ya Ethereum",

--- a/src/intl/ta/common.json
+++ b/src/intl/ta/common.json
@@ -321,6 +321,8 @@
   "nav-staking-solo-description": "முகப்பு வன்பொருளை இயக்கவும் மற்றும் Ethereum நெட்வொர்க்கின் பாதுகாப்பு மற்றும் பரவலாக்கத்தில் தனிப்பட்ட முறையில் சேர்க்கவும்",
   "nav-staking-solo-label": "சோலோ ஸ்டேக்கிங்",
   "nav-start-building-description": "புதிதாக நிறுவியுள்ளவர்களுக்கான பயனுள்ள தகவல்கள்",
+  "nav-start-with-crypto-title": "இங்கிருந்து தொடங்குங்கள்",
+  "nav-start-with-crypto-description": "Ethereum பயன்படுத்தும் உங்கள் முதல் படிகள்",
   "nav-translation-program-description": "Ethereum.org-ஐ அனைத்து மொழிகளிலும் மொழிபெயர்ப்பு செய்வதற்கான ஒரு கூட்டு முயற்சி",
   "nav-tutorials-description": "சமூக கல்விசார் பாடங்களின் தொகுப்பு",
   "nav-use-cases-description": "Ethereum பயன்பாட்டிற்கான வெவ்வேறு யோசனைகளை கண்டறிதல்",

--- a/src/intl/te/common.json
+++ b/src/intl/te/common.json
@@ -333,6 +333,8 @@
   "nav-staking-solo-description": "హోమ్ హార్డ్‌వేర్ రన్ చేయండి మరియు Ethereum నెట్‌వర్క్ యొక్క భద్రత మరియు వికేంద్రీకరణకు వ్యక్తిగతంగా జోడించండి",
   "nav-staking-solo-label": "సోలోగా స్టేక్ చేయడం",
   "nav-start-building-description": "కొత్తవారికి ఉపయోగకరమైన సమాచారం",
+  "nav-start-with-crypto-title": "ఇక్కడ నుంచి ప్రారంభించండి",
+  "nav-start-with-crypto-description": "Ethereum ఉపయోగించే మీ మొదటి అడుగులు",
   "nav-translation-program-description": "ethereum.orgను అన్ని భాషల్లోకి అనువదించే సమిష్టి కృషి",
   "nav-tutorials-description": "కమ్యూనిటీ ట్యుటోరియల్స్ యొక్క క్యూరేటెడ్ జాబితా",
   "nav-use-cases-description": "Ethereum ఉపయోగం కోసం విభిన్న ఆలోచనలను కనుగొనండి",

--- a/src/intl/th/common.json
+++ b/src/intl/th/common.json
@@ -333,6 +333,8 @@
   "nav-staking-solo-description": "ใช้งานฮาร์ดแวร์ภายในบ้านและเพิ่มความปลอดภัยและการกระจายอำนาจของเครือข่าย Ethereum เป็นการส่วนตัว",
   "nav-staking-solo-label": "การ Stake แบบกองเดี่ยว",
   "nav-start-building-description": "ข้อมูลที่มีประโยชน์สำหรับผู้เริ่มต้นใหม่",
+  "nav-start-with-crypto-title": "เริ่มต้นที่นี่",
+  "nav-start-with-crypto-description": "ก้าวแรกของคุณกับ Ethereum",
   "nav-translation-program-description": "ความพยายามร่วมกันในการแปล ethereum.org เป็นภาษาอื่นๆ ทั้งหมด",
   "nav-tutorials-description": "รายการบทช่วยสอนของชุมชนที่รวบรวมไว้",
   "nav-use-cases-description": "ค้นพบแนวคิดที่แตกต่างกันในการใช้งานอีเธอเรียม",

--- a/src/intl/tk/common.json
+++ b/src/intl/tk/common.json
@@ -319,6 +319,8 @@
   "nav-staking-solo-description": "Öý enjamlaryny işlediň we Ethereum ulgamynyň howpsuzlygyna we merkezden daşlaşdyrylmagyna şahsy goşant goşuň",
   "nav-staking-solo-label": "Ýeke steýking",
   "nav-start-building-description": "Täze gelenler üçin peýdaly maglumatlar",
+  "nav-start-with-crypto-title": "Şu ýerde başla",
+  "nav-start-with-crypto-description": "Ethereum bilen ilkinji ädimleriňiz",
   "nav-translation-program-description": "Ethereum.org websaýtyny ähli dillere terjime etmek üçin bilelikdäki tagalla",
   "nav-tutorials-description": "Jemgyýetçilik okuw sapaklarynyň halypalyk sanawy",
   "nav-use-cases-description": "Ethereum ulanmak üçin dürli pikirleri tapyň",

--- a/src/intl/tl/common.json
+++ b/src/intl/tl/common.json
@@ -320,6 +320,8 @@
   "nav-staking-solo-description": "Magpatakbo ng home hardware at personal na magdagdag sa seguridad at desentralisasyon ng network ng Ethereum",
   "nav-staking-solo-label": "Pag-stake nang mag-isa",
   "nav-start-building-description": "Kapaki-pakinabang na impormasyon para sa mga baguhan",
+  "nav-start-with-crypto-title": "Simulan dito",
+  "nav-start-with-crypto-description": "Ang iyong unang mga hakbang sa paggamit ng Ethereum",
   "nav-translation-program-description": "Isang sama-samang pagsisikap upang isalin ang ethereum.org sa lahat ng wika",
   "nav-tutorials-description": "Isang piniling listahan ng mga tutorial ng komunidad",
   "nav-use-cases-description": "Tumuklas ng iba't ibang ideya para sa paggamit ng Ethereum",

--- a/src/intl/tr/common.json
+++ b/src/intl/tr/common.json
@@ -334,6 +334,8 @@
   "nav-staking-solo-description": "Ev donanımını çalıştırın ve Ethereum ağının güvenliğine ve merkezsizleştirilmesine kişisel olarak katkıda bulunun",
   "nav-staking-solo-label": "Tekli staking",
   "nav-start-building-description": "Yeni başlayanlar için faydalı bilgiler",
+  "nav-start-with-crypto-title": "Buradan başlayın",
+  "nav-start-with-crypto-description": "Ethereum kullanmaya ilk adımlarınız",
   "nav-translation-program-description": "Ethereum.org'u tüm dillere çevirmeyi amaçlayan ortak bir çalışma",
   "nav-tutorials-description": "Topluluk eğitimleri için özel olarak hazırlanmış liste",
   "nav-use-cases-description": "Ethereum kullanımına uygun farklı fikirleri keşfedin",

--- a/src/intl/tw/common.json
+++ b/src/intl/tw/common.json
@@ -320,6 +320,8 @@
   "nav-staking-solo-description": "Fa fie nneɛma yɛ dwuma na w’ankasa fa ka ahobammɔ ne nea wɔdi ahyɛ amansa nsa a ɛwɔ Ethereum ahoma torofo no ho",
   "nav-staking-solo-label": "Ɔbaakofo si awowa",
   "nav-start-building-description": "Nsɛm a mfaso wɔ so ma wɔn a wɔaba foforo",
+  "nav-start-with-crypto-title": "Fi ha hyɛ ase",
+  "nav-start-with-crypto-description": "Wo nan a edi kan wɔ Ethereum so",
   "nav-translation-program-description": "Mmɔdenbɔ a wɔbom yɛ sɛ wɔbɛkyerɛ ethereum.org ase akɔ kasa ahoro nyinaa mu",
   "nav-tutorials-description": "Nhyehyɛe a wɔahyehyɛ a ɛfa mpɔtam nkyerɛkyerɛ ho",
   "nav-use-cases-description": "Hwehwɛ adwene ahorow a ɛfa Ethereum dwumadie ho",

--- a/src/intl/uk/common.json
+++ b/src/intl/uk/common.json
@@ -331,6 +331,8 @@
   "nav-staking-solo-description": "Запустіть домашнє обладнання та особисто додайте безпеку й децентралізацію мережі Ethereum.",
   "nav-staking-solo-label": "Одиночний стейкінг",
   "nav-start-building-description": "Корисна інформація для новачків",
+  "nav-start-with-crypto-title": "Почніть тут",
+  "nav-start-with-crypto-description": "Ваші перші кроки з Ethereum",
   "nav-translation-program-description": "Спільна робота над перекладом сайту ethereum.org на всі мови світу",
   "nav-tutorials-description": "Спеціальний список посібників спільноти",
   "nav-use-cases-description": "Відкрийте для себе різні ідеї щодо використання Ethereum",

--- a/src/intl/ur/common.json
+++ b/src/intl/ur/common.json
@@ -319,6 +319,8 @@
   "nav-staking-solo-description": "گھر کا ہارڈویئر چلائیں اور ذاتی طور پر ایتھریم نیٹ ورک کی حفاظت اور وکندریقرت میں اضافہ کریں",
   "nav-staking-solo-label": "سولواسٹیکنگ",
   "nav-start-building-description": "نوآموز افراد کے لیے مفید معلومات",
+  "nav-start-with-crypto-title": "یہاں سے شروع کریں",
+  "nav-start-with-crypto-description": "Ethereum کے ساتھ آپ کے پہلے اقدامات",
   "nav-translation-program-description": "تمام زبانوں میں ethereum.org کا ترجمہ کرنے کی ایک اجتماعی کاوش",
   "nav-tutorials-description": "کمیونٹی ٹیوٹوریلز کی ایک منتخب شدہ فہرست",
   "nav-use-cases-description": "ایتھریئم کے استعمال کے مختلف تصورات دریافت کریں",

--- a/src/intl/uz/common.json
+++ b/src/intl/uz/common.json
@@ -322,6 +322,8 @@
   "nav-staking-solo-description": "Uy jihozlarini ishga tushiring va Ethereum tarmogʻining xavfsizligi va markazsizlashuviga shaxsan qoʻshing",
   "nav-staking-solo-label": "Yakka steyking",
   "nav-start-building-description": "Yangi qoʻshilganlar uchun foydali maʼlumotlar",
+  "nav-start-with-crypto-title": "Bu yerdan boshlang",
+  "nav-start-with-crypto-description": "Ethereum bilan birinchi qadamlariingiz",
   "nav-translation-program-description": "Ethereum.org saytini barcha tillarga tarjima qilishda hamkorlik",
   "nav-tutorials-description": "Hamjamiyat qoʻllanmalari tanlangan roʻyxati",
   "nav-use-cases-description": "Ethereumdan foydalanish uchun turli gʻoyalarni kashf eting",

--- a/src/intl/vi/common.json
+++ b/src/intl/vi/common.json
@@ -334,6 +334,8 @@
   "nav-staking-solo-description": "Việc chạy phần cứng tại nhà và tự mình sẽ gia tăng tính bảo mật và phân quyền của mạng Ethereum",
   "nav-staking-solo-label": "Staking riêng",
   "nav-start-building-description": "Thông tin hữu ích cho người mới bắt đầu",
+  "nav-start-with-crypto-title": "Bắt đầu tại đây",
+  "nav-start-with-crypto-description": "Những bước đầu tiên của bạn với Ethereum",
   "nav-translation-program-description": "Một nỗ lực hợp tác để dịch ethereum.org sang tất cả các ngôn ngữ",
   "nav-tutorials-description": "Danh sách các hướng dẫn cộng đồng được lựa chọn",
   "nav-use-cases-description": "Khám phá những ý tưởng sử dụng Ethereum đa dạng",

--- a/src/intl/yo/common.json
+++ b/src/intl/yo/common.json
@@ -321,6 +321,8 @@
   "nav-staking-solo-description": "Mímú ẹ̀rọ ilé ṣiṣẹ́ àti fífúnra ẹni ṣàfikún sí ààbò àti aláìlákoso ti nẹ́tíwọọkì Ethereum",
   "nav-staking-solo-label": "Ìdókòwò aládaṣe",
   "nav-start-building-description": "Àlàyé tó wúlò fún àwọn ẹni tuntun",
+  "nav-start-with-crypto-title": "Bẹrẹ nibi",
+  "nav-start-with-crypto-description": "Àwọn ìgbésẹ àkọ́kọ́ rẹ pẹ̀lú Ethereum",
   "nav-translation-program-description": "Ìgbìyànjú ìfọwọ́sowọ́pọ̀ láti túmọ̀ ethereum.org sí gbogbo èdè",
   "nav-tutorials-description": "Àtòjọ àṣàyàn àwọn ẹ̀kọ́ àwùjọ",
   "nav-use-cases-description": "Ṣàwárí àwọn ìmọ̀ràn oríṣiríṣi fún lílo Ethereum",

--- a/src/intl/zh-tw/common.json
+++ b/src/intl/zh-tw/common.json
@@ -332,6 +332,8 @@
   "nav-staking-solo-description": "執行家用硬體，親自貢獻於以太坊網路的安全和去中心化",
   "nav-staking-solo-label": "單獨質押",
   "nav-start-building-description": "新手的實用資訊",
+  "nav-start-with-crypto-title": "從這裡開始",
+  "nav-start-with-crypto-description": "使用以太坊的第一步",
   "nav-translation-program-description": "將 ethereum.org 網站翻譯成所有語言的協同合作",
   "nav-tutorials-description": "社群使用教學的精選清單",
   "nav-use-cases-description": "發現使用以太坊的不同想法",

--- a/src/intl/zh/common.json
+++ b/src/intl/zh/common.json
@@ -334,6 +334,8 @@
   "nav-staking-solo-description": "运行家用硬件并自行加入以太坊网络的安全和去中心化",
   "nav-staking-solo-label": "单独质押",
   "nav-start-building-description": "新手实用信息",
+  "nav-start-with-crypto-title": "从这里开始",
+  "nav-start-with-crypto-description": "使用以太坊的第一步",
   "nav-translation-program-description": "一项将以太坊翻译成所有语言的协作计划",
   "nav-tutorials-description": "社区教程精选清单",
   "nav-use-cases-description": "发现和以太坊使用方法相关的各种理念",


### PR DESCRIPTION
## Description

Add temporary translations for 2 new menu strings
  "nav-start-with-crypto-title": "Start here",
  "nav-start-with-crypto-description": "Your first steps using Ethereum",

## Related Issue

No related issue
