### PR TITLE
hot-fix: homepage recent posts images

### DIFF
--- a/src/components/Image/CardImage.tsx
+++ b/src/components/Image/CardImage.tsx
@@ -17,7 +17,6 @@ const CardImage = ({ src, className, ...props }: CardImageProps) => (
       e.currentTarget.src = EventFallback.src
     }}
     referrerPolicy="no-referrer"
-    crossOrigin="anonymous"
     className={className}
     {...props}
   />


### PR DESCRIPTION
## Description
- Revert usage of `crossOrigin="anonymous"`; causing rejection from servers upon image request with fallback image being displayed for all blog posts

## Related issue
Fixes:
<img width="1551" alt="image" src="https://github.com/user-attachments/assets/d8cfe2c1-b1f1-4b99-9d6a-9ee743a1fe4d" />
