### PR TITLE
fix: sorting using pre-translated dates

### DIFF
--- a/src/lib/utils/rss.ts
+++ b/src/lib/utils/rss.ts
@@ -4,12 +4,13 @@ import type { Lang, RSSItem } from "../types"
 import { isValidDate } from "./date"
 import { getLocaleTimestamp } from "./time"
 
-export const sortByPubDate = (items: RSSItem[]) =>
+// Sort by original pubDate string (not yet localized)
+export const sortByPubDateRaw = (items: (RSSItem & { pubDateRaw: string })[]) =>
   items.sort((a, b) => {
-    const dateA = new Date(a.pubDate)
-    const dateB = new Date(b.pubDate)
+    const dateA = new Date(a.pubDateRaw)
+    const dateB = new Date(b.pubDateRaw)
     if (isNaN(dateA.getTime()) || isNaN(dateB.getTime())) {
-      console.error("Invalid date found:", a.pubDate, b.pubDate)
+      console.error("Invalid date found:", a.pubDateRaw, b.pubDateRaw)
       return 0
     }
     return dateB.getTime() - dateA.getTime()
@@ -20,7 +21,7 @@ export const postProcess = (rssItems: RSSItem[], locale: Lang) =>
     const pubDate = isValidDate(item.pubDate)
       ? getLocaleTimestamp(locale, item.pubDate)
       : ""
-    const formattedItem = { ...item, pubDate }
+    const formattedItem = { ...item, pubDate, pubDateRaw: item.pubDate }
 
     switch (item.sourceFeedUrl) {
       case VITALIK_FEED:
@@ -47,5 +48,5 @@ export const polishRSSList = (items: RSSItem[][], locale: Lang) => {
 
   const latestItems = latestOfEach.flat()
   const readyForSorting = postProcess(latestItems, locale)
-  return sortByPubDate(readyForSorting)
+  return sortByPubDateRaw(readyForSorting)
 }


### PR DESCRIPTION
fixes `Invalid date found: 2024年8月22日 2024年9月13日` error pattern

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
