### PR TITLE
fix: dark mode staking color tokens

### DIFF
--- a/src/styles/semantic-tokens.css
+++ b/src/styles/semantic-tokens.css
@@ -233,14 +233,14 @@
     --shadow-window-box-5-opacity: 0.06;
 
     /* Staking */
-    --staking-gold: #f2bb2f;
-    --staking-gold-fill: #373228;
-    --staking-green: #49de96;
-    --staking-green-fill: #30342b;
-    --staking-blue: #a9d3f2;
-    --staking-blue-fill: #2b352f;
-    --staking-red: #d6bbb9;
-    --staking-red-fill: #313432;
+    --staking-gold: 43, 86%, 57%;
+    --staking-gold-fill: 36, 16%, 19%;
+    --staking-green: 151, 74%, 58%;
+    --staking-green-fill: 90, 10%, 19%;
+    --staking-blue: 204, 76%, 81%;
+    --staking-blue-fill: 150, 10%, 19%;
+    --staking-red: 6, 24%, 78%;
+    --staking-red-fill: 140, 3%, 19%;
 
     --shadow-widget: -2px 2px 12px 1px rgba(255, 255, 255, 0.04), -6px 6px 12px -3px rgba(255, 255, 255, 0.04), -12px 12px 24px -6px rgba(255, 255, 255, 0.04), -20px 20px 40px -12px rgba(255, 255, 255, 0.04);
   }


### PR DESCRIPTION
## Description
- Tailwind colors tokens wrap our css variables in `hsla(var())` requiring unwrapped `H S L` values; dark mode tokens accidentally passed as hex codes
- Converts dark mode staking css tokens from hex code values to H S L values

<img width="1219" alt="image" src="https://github.com/user-attachments/assets/b7afb1e5-d9ef-4666-bf72-ed489aaea550" />

## Related Issue
Fixes dark mode color bugs on /staking

<img width="1031" alt="image" src="https://github.com/user-attachments/assets/eb755921-b292-47a3-b37d-894239d8ad13" />