### PR TITLE
change "eth-educators" url path to ethstaker

### DIFF
--- a/src/data/staking-products.json
+++ b/src/data/staking-products.json
@@ -168,7 +168,7 @@
       "platforms": ["Linux"],
       "ui": ["CLI"],
       "socials": {
-        "github": "https://github.com/eth-educators/eth-docker"
+        "github": "https://github.com/ethstaker/eth-docker"
       },
       "matomo": {
         "eventCategory": "StakingProductCard",


### PR DESCRIPTION
The GitHub repository https://github.com/eth-educators has been migrated to https://github.com/ethstaker / https://github.com/ethstaker/eth-docker. 

I searched through the repository for eth-educator related items and only found one :) 
