### PR TITLE
Typo fix: "returns `true` of the client is mining" → "returns `true` if the client is mining"

### DIFF
--- a/public/content/developers/docs/apis/json-rpc/index.md
+++ b/public/content/developers/docs/apis/json-rpc/index.md
@@ -445,7 +445,7 @@ None
 
 **Returns**
 
-`Boolean` - returns `true` of the client is mining, otherwise `false`.
+`Boolean` - returns `true` if the client is mining, otherwise `false`.
 
 **Example**
 


### PR DESCRIPTION
## Description
This pull request fixes a small typo in the content. The word "of" was changed to "if", improving readability.

## Related Issue
N/A – This is a minor typo fix and doesn't correspond to a previously opened issue.

## Type of Change
Bug fix (non-breaking change which fixes a typo)

## Content

![Screenshot 2025-06-21 071249](https://github.com/user-attachments/assets/612b9806-eccc-46a2-90cd-a9eb267fc1fa)
