### PR TITLE
feat: add enterprise cta to home activity

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -543,7 +543,18 @@ const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
               </p>
               <ActivityStats metrics={metrics} />
 
-              <div className="mt-12 flex justify-center">
+              <div className="mt-12 flex flex-wrap gap-6 py-8">
+                <ButtonLink
+                  size="lg"
+                  href="/enterprise/"
+                  customEventOptions={{
+                    eventCategory: eventCategory,
+                    eventAction: "ethereum_activity",
+                    eventName: "enterprise",
+                  }}
+                >
+                  {t("page-index-activity-action-primary")} <ChevronNext />
+                </ButtonLink>
                 <ButtonLink
                   size="lg"
                   href="/resources/"

--- a/src/intl/en/page-index.json
+++ b/src/intl/en/page-index.json
@@ -2,7 +2,7 @@
   "page-index-activity-description": "Activity from all Ethereum networks",
   "page-index-activity-tag": "Activity",
   "page-index-activity-header": "The strongest ecosystem",
-  "page-index-activity-action": "More Ethereum activity",
+  "page-index-activity-action": "More ecosystem resources",
   "page-index-activity-action-primary": "Enterprise Ethereum",
   "page-index-bento-header": "A new way to use the internet",
   "page-index-bento-assets-action": "More on NFTs",

--- a/src/intl/en/page-index.json
+++ b/src/intl/en/page-index.json
@@ -3,6 +3,7 @@
   "page-index-activity-tag": "Activity",
   "page-index-activity-header": "The strongest ecosystem",
   "page-index-activity-action": "More Ethereum activity",
+  "page-index-activity-action-primary": "Enterprise Ethereum",
   "page-index-bento-header": "A new way to use the internet",
   "page-index-bento-assets-action": "More on NFTs",
   "page-index-bento-assets-content": "Art, certificates or even real estate can be tokenized. Anything can be a tradable token. Ownership is public and verifiable.",


### PR DESCRIPTION
## Description
- Adds `/enterprise` CTA button link to the #activity section of the homepage as primary action

<img width="1234" alt="image" src="https://github.com/user-attachments/assets/da8f7b30-912d-4cd2-ad34-5750dc413226" />

## Prevew link
https://deploy-preview-15707--ethereumorg.netlify.app/en/#activity