### PR TITLE
fix: update community page 'why get involved' section styling

### DIFF
--- a/app/[locale]/community/_components/community.tsx
+++ b/app/[locale]/community/_components/community.tsx
@@ -161,9 +161,11 @@ const CommunityPage = () => {
       <HubHero {...heroContent} />
       <Divider />
       <Flex className="-mt-px w-full flex-row-reverse items-center border-b border-b-border-high-contrast py-8 ps-0 lg:py-0 lg:ps-8">
-        <Content>
+        <div className="mb-12 w-full px-8 py-4">
           <Flex className="flex-col items-center">
-            <H2 className="lg:text-4xl">{t("page-community-why-get-involved-title")}</H2>
+            <H2 className="lg:text-4xl">
+              {t("page-community-why-get-involved-title")}
+            </H2>
           </Flex>
           <CardContainer>
             {whyGetInvolvedCards.map((card, idx) => (
@@ -176,7 +178,7 @@ const CommunityPage = () => {
               />
             ))}
           </CardContainer>
-        </Content>
+        </div>
       </Flex>
       <div className="w-full bg-background-highlight pb-16 shadow-table-item-box">
         <div className="w-full px-4 py-4 lg:px-8">

--- a/app/[locale]/community/_components/community.tsx
+++ b/app/[locale]/community/_components/community.tsx
@@ -160,10 +160,10 @@ const CommunityPage = () => {
     <Page>
       <HubHero {...heroContent} />
       <Divider />
-      <Flex className="-mt-px h-full w-full flex-row-reverse items-center border-b border-b-border-high-contrast bg-[#ccfcff] py-8 ps-0 lg:h-[720px] lg:py-0 lg:ps-8 dark:bg-[#293233]">
+      <Flex className="-mt-px w-full flex-row-reverse items-center border-b border-b-border-high-contrast py-8 ps-0 lg:py-0 lg:ps-8">
         <Content>
-          <Flex className="mb-8 flex-col items-center">
-            <H2>{t("page-community-why-get-involved-title")}</H2>
+          <Flex className="flex-col items-center">
+            <H2 className="lg:text-4xl">{t("page-community-why-get-involved-title")}</H2>
           </Flex>
           <CardContainer>
             {whyGetInvolvedCards.map((card, idx) => (


### PR DESCRIPTION
This PR implements the design changes requested in issue #15718 for the community page "why get involved" section.

## Changes
- Remove background color from the section
- Remove fixed height from the section
- Make h2 4xl on desktop and remove mb-8 margin from parent h2 container

## Implementation
- Removed `bg-[#ccfcff]` and `dark:bg-[#293233]` background colors
- Removed `h-full` and `lg:h-[720px]` fixed heights
- Added `lg:text-4xl` to H2 component for desktop 4xl sizing
- Removed `mb-8` margin from h2 parent container

Fixes #15718

Generated with [Claude Code](https://claude.ai/code)