### PR TITLE
fix: correct translation keys for developers learning tools page meta title

### DIFF
--- a/app/[locale]/developers/learning-tools/page.tsx
+++ b/app/[locale]/developers/learning-tools/page.tsx
@@ -48,10 +48,8 @@ export async function generateMetadata({
   return await getMetadata({
     locale,
     slug: ["developers", "learning-tools"],
-    title: t("page-developers-learning-tools:page-learning-tools-meta-title"),
-    description: t(
-      "page-developers-learning-tools:page-learning-tools-meta-desc"
-    ),
+    title: t("page-learning-tools-meta-title"),
+    description: t("page-learning-tools-meta-desc"),
   })
 }
 


### PR DESCRIPTION
Fix broken page title that was showing "page-developers-learning-tools-meta-title" instead of "Developer learning tools".

The issue was caused by incorrect translation key syntax in the generateMetadata function. The namespace was being double-referenced, causing the translation to fail and display the raw key instead of the translated text.

- Remove namespace prefix from translation keys since namespace is already set in getTranslations
- Change "page-developers-learning-tools:page-learning-tools-meta-title" to "page-learning-tools-meta-title"
- Change "page-developers-learning-tools:page-learning-tools-meta-desc" to "page-learning-tools-meta-desc"

Fixes #15731

Generated with [Claude Code](https://claude.ai/code)