### PR TITLE
Fix broken link to Optimism dapps portal

### DIFF
--- a/public/content/translations/tr/contributing/adding-layer-2s/index.md
+++ b/public/content/translations/tr/contributing/adding-layer-2s/index.md
@@ -78,7 +78,7 @@ _Veri kullanılabilirliği veya güvenlik için Ethereum kullanmayan diğer öl�
 
 **Katman 2 ekosistemindeki dapp'lere bağlantılar**
 
-- Kullanıcıların bu katman 2'de neler yapabilecekleri hakkında bilgi sağlayabilmek istiyoruz. (örn. https://portal.arbitrum.io/, https://www.optimism.io/apps)
+- Kullanıcıların bu katman 2'de neler yapabilecekleri hakkında bilgi sağlayabilmek istiyoruz. (örn. https://portal.arbitrum.io/, https://community.optimism.io/)
 
 **Token sözleşme listeleri**
 


### PR DESCRIPTION
Replaced the outdated Optimism dapps portal link (https://www.optimism.io/apps) with the current official portal (https://community.optimism.io/) in the Turkish translation file for adding Layer 2s. This ensures users are directed to the correct resource for exploring dapps on Optimism.