### PR TITLE
fix: remove deprecated State Channel Application tutorial

### DIFF
--- a/src/data/externalTutorials.json
+++ b/src/data/externalTutorials.json
@@ -637,18 +637,6 @@
     "publishDate": "04/24/2024"
   },
   {
-    "url": "https://speedrunethereum.com/challenge/state-channels",
-    "title": "State Channel Application",
-    "description": "Create an app to lock collateral onchain, transact offchain, then finalize onchain.",
-    "author": "Austin Griffith",
-    "authorGithub": "https://github.com/austintgriffith",
-    "tags": ["solidity", "smart contracts", "react", "nextjs", "wagmi", "javascript", "typescript", "frontend", "openzeppelin"],
-    "skillLevel": "intermediate",
-    "timeToRead": "60",
-    "lang": "en",
-    "publishDate": "04/24/2024"
-  },
-  {
     "url": "https://github.com/scaffold-eth/se-2-challenges/tree/challenge-6-multisig",
     "title": "Multisig wallet",
     "description": "Deploy a multi-signature wallet where enough signatures are required to execute a transaction",


### PR DESCRIPTION
Remove the "State Channel Application" tutorial that links to https://speedrunethereum.com/challenge/state-channels which returns 404.

Fixes #15747

Generated with [Claude Code](https://claude.ai/code)