### PR TITLE
fix: change description text color to body medium for better contrast on enterprise page

### DIFF
--- a/app/[locale]/enterprise/_components/FeatureCard.tsx
+++ b/app/[locale]/enterprise/_components/FeatureCard.tsx
@@ -48,7 +48,7 @@ const FeatureCard = ({
       <Icon className="text-7xl text-primary" />
       <h3 className="text-xl">{header}</h3>
       {content.map((p, i) => (
-        <p key={i} className="mb-8 last:mb-0">
+        <p key={i} className="mb-8 last:mb-0 text-body-medium">
           {p}
         </p>
       ))}


### PR DESCRIPTION
Fixes #15772

Changes the description text color from body to body medium on the 4 top feature boxes of the enterprise page for better visual contrast and readability.

## Changes
- Updated `FeatureCard` component to use `text-body-medium` class
- Affects feature descriptions on /en/enterprise/ page
- Improves visual hierarchy while maintaining accessibility

Generated with [Claude Code](https://claude.ai/code)