### PR TITLE
perf: use Next image for avatars

### DIFF
--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -6,6 +6,8 @@ import * as AvatarPrimitive from "@radix-ui/react-avatar"
 
 import { cn } from "@/lib/utils/cn"
 
+import { Image } from "../Image"
+
 import { Center } from "./flex"
 import { BaseLink, type LinkProps } from "./Link"
 import { LinkBox, LinkOverlay } from "./link-box"
@@ -162,7 +164,18 @@ const Avatar = React.forwardRef<
             <BaseLink {...commonLinkProps}>{label}</BaseLink>
           </LinkOverlay>
           <AvatarBase size={size}>
-            <AvatarImage src={src} />
+            {src ? (
+              <Image
+                className="object-fill"
+                width={64}
+                height={64}
+                sizes="4rem"
+                src={src}
+                alt={name}
+              />
+            ) : (
+              <AvatarImage />
+            )}
             <AvatarFallback>{fallbackInitials}</AvatarFallback>
           </AvatarBase>
         </Center>
@@ -173,7 +186,18 @@ const Avatar = React.forwardRef<
   return (
     <AvatarBase ref={ref} size={size} className={className} asChild>
       <BaseLink title={dataTest} {...commonLinkProps}>
-        <AvatarImage src={src} />
+        {src ? (
+          <Image
+            className="object-fill"
+            width={64}
+            height={64}
+            sizes="4rem"
+            src={src}
+            alt={name}
+          />
+        ) : (
+          <AvatarImage />
+        )}
         <AvatarFallback>{fallbackInitials}</AvatarFallback>
       </BaseLink>
     </AvatarBase>


### PR DESCRIPTION
## Description
ui/avatar has been using radix component for image rendering, foregoing next image optimization

- Uses internal Image component to render github contributor avatars; domain allow-listed in next config

## Related Issue
Resolves:
<img width="598" alt="image" src="https://github.com/user-attachments/assets/39b65fb4-aa0d-4ec1-bbd8-cbfe2c140064" />
