### PR TITLE
fix: update to use public env var for preview deploy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,7 @@ NEXT_PUBLIC_MATOMO_URL=
 NEXT_PUBLIC_MATOMO_SITE_ID=
 
 # Used to avoid loading Matomo in our preview deploys
-IS_PREVIEW_DEPLOY=false
+NEXT_PUBLIC_IS_PREVIEW_DEPLOY=false
 
 # Build pages only for the specified langs. Leave it empty to build all the langs
 # e.g. `en,fr` will only build English and French pages

--- a/docs/ab-testing.md
+++ b/docs/ab-testing.md
@@ -165,7 +165,7 @@ NEXT_PUBLIC_MATOMO_SITE_ID=4
 MATOMO_API_TOKEN=your_api_token_here
 
 # Preview mode flag
-IS_PREVIEW_DEPLOY=false
+NEXT_PUBLIC_IS_PREVIEW_DEPLOY=false
 ```
 
 ## Best Practices


### PR DESCRIPTION
## Description
Recent AB testing updates use a public form (with `NEXT_PUBLIC_` prefix) for the Matomo API call, and replaced all usage of the non-prefixed env var. PR updates references in `/docs` and `.env.example`
