### PR TITLE
fix: /assets metadata string key

### DIFF
--- a/app/[locale]/assets/page.tsx
+++ b/app/[locale]/assets/page.tsx
@@ -48,6 +48,6 @@ export async function generateMetadata({
     locale,
     slug: ["assets"],
     title: t("page-assets-meta-title"),
-    description: t("page-assets-meta-description"),
+    description: t("page-assets-meta-desc"),
   })
 }


### PR DESCRIPTION
## Description
Fixes string key

<img width="351" height="154" alt="image" src="https://github.com/user-attachments/assets/ddb839dd-3daa-4237-9a59-720e4033aa99" />


## Related Issue
Fixes:

<img width="542" height="353" alt="image" src="https://github.com/user-attachments/assets/0901b03b-c882-4414-8beb-33fa511c7f46" />

