### PR TITLE
fix: update UN World Food Programme statistics on Enterprise page

### DIFF
--- a/src/intl/en/page-enterprise.json
+++ b/src/intl/en/page-enterprise.json
@@ -8,7 +8,7 @@
   "page-enterprise-cases-eib-content": "<strong>Issued a €100M digital bond</strong> on public Ethereum. The project was conducted in cooperation with the Banque de France, Goldman Sachs, Santander and Société Générale.",
   "page-enterprise-cases-mediledger-content": "Enables Pfizer and Genentech to verify drug authenticity and ensure pharma compliance.",
   "page-enterprise-cases-sony-content": "Launched the Soneium L2 network on Ethereum's OP Stack, scaling real-world IP with <strong>14M+ accounts and $45M+ TVL</strong>.",
-  "page-enterprise-cases-unwfp-content": "UN <strong>tracks aid for 100,000+ refugees</strong> using a private Ethereum fork, boosting audit capabilities.",
+  "page-enterprise-cases-unwfp-content": "UN <strong>tracks aid for over 4 million people per month</strong> using a private Ethereum fork, boosting audit capabilities.",
   "page-enterprise-cases-visa-content": "Settled over <strong>$225 million</strong> in stablecoin transactions using USDC across Ethereum and other blockchains.",
   "page-enterprise-ecosystem-cta": "See use cases",
   "page-enterprise-ecosystem-description": "Programmable financial systems are here. Join the hundreds of enterprises already building on Ethereum today.",


### PR DESCRIPTION
Update statistics from "100,000+ refugees" to "over 4 million people per month" to reflect accurate data about the Building Blocks program's reach.

Fixes #15778

Generated with [Claude Code](https://claude.ai/code)