### PR TITLE
fix: resolve localization keys for learning-tools page metadata

### DIFF
--- a/app/[locale]/developers/learning-tools/page.tsx
+++ b/app/[locale]/developers/learning-tools/page.tsx
@@ -48,10 +48,8 @@ export async function generateMetadata({
   return await getMetadata({
     locale,
     slug: ["developers", "learning-tools"],
-    title: t("page-developers-learning-tools:page-learning-tools-meta-title"),
-    description: t(
-      "page-developers-learning-tools:page-learning-tools-meta-desc"
-    ),
+    title: t("page-learning-tools-meta-title"),
+    description: t("page-learning-tools-meta-desc"),
   })
 }
 


### PR DESCRIPTION
Fixes the issue where the developers/learning-tools page shows raw localization keys instead of translated text for title and meta description.

## Changes
- Updated generateMetadata function to use correct translation keys without namespace prefix
- Fixed title key from 'page-developers-learning-tools:page-learning-tools-meta-title' to 'page-learning-tools-meta-title'
- Fixed description key from 'page-developers-learning-tools:page-learning-tools-meta-desc' to 'page-learning-tools-meta-desc'

Closes #15826

🤖 Generated with [Claude Code](https://claude.ai/code)