### PR TITLE
fix: Label Ready as closed source

### DIFF
--- a/src/data/wallets/wallet-data.ts
+++ b/src/data/wallets/wallet-data.ts
@@ -149,7 +149,7 @@ export const walletsData: WalletData[] = [
     supported_chains: ["Ethereum Mainnet"],
   },
   {
-    last_updated: "2025-07-08",
+    last_updated: "2025-07-15",
     name: "Ready Wallet",
     image: ReadyImage,
     twBackgroundColor: "bg-[#FFFFFF]",


### PR DESCRIPTION
## Description

Update Ready's status as a closed source wallet.

## Related Issue

Resolves https://github.com/ethereum/ethereum-org-website/issues/15829.
