### PR TITLE
fix: incorrect method export for POST endpoint

### DIFF
--- a/app/api/gfi-issues-webhook/route.ts
+++ b/app/api/gfi-issues-webhook/route.ts
@@ -13,12 +13,7 @@ const LABELS_TO_EMOJI = {
 
 const GFI_LABEL = "good first issue"
 
-export async function GET(req: Request) {
-  const { method } = req
-
-  if (method !== "POST") {
-    return NextResponse.json({ message: "Method not allowed" }, { status: 405 })
-  }
+export async function POST(req: Request) {
 
   const { action, label, issue } = await req.json()
 


### PR DESCRIPTION
## Description

the handler was exported as `GET`, but inside it checks for `req.method === "POST"`, which is never triggered since GET functions aren’t invoked for POST requests.

i've renamed the function to `POST(...)` so that it correctly handles POST requests, as per [[Next.js App Router documentation](https://nextjs.org/docs/app/building-your-application/routing/handling-requests#handling-different-methods)](https://nextjs.org/docs/app/building-your-application/routing/handling-requests#handling-different-methods).

now the endpoint behaves as expected.