### PR TITLE
fix: differentiate events with locale [Fixes #11521]

### DIFF
--- a/src/components/FindWalletProductTable/hooks/useWalletFilters.tsx
+++ b/src/components/FindWalletProductTable/hooks/useWalletFilters.tsx
@@ -1,4 +1,5 @@
 import { useRef } from "react"
+import { useLocale } from "next-intl"
 
 import { FilterOption } from "@/lib/types"
 
@@ -36,6 +37,7 @@ import { DEFAULT_LOCALE } from "@/lib/constants"
 import { useTranslation } from "@/hooks/useTranslation"
 
 export const useWalletFilters = (): FilterOption[] => {
+  const locale = useLocale()
   const { t } = useTranslation("page-wallets-find-wallet")
   const prevNetworkArray = useRef<string[]>([])
   return [
@@ -95,7 +97,7 @@ export const useWalletFilters = (): FilterOption[] => {
                     ) => {
                       trackCustomEvent({
                         eventCategory: "WalletFilterSidebar",
-                        eventAction: `${t("page-find-wallet-android")}`,
+                        eventAction: `${locale} - ${t("page-find-wallet-android")}`,
                         eventName: `android ${newInputState}`,
                       })
                       updateFilterState(
@@ -136,7 +138,7 @@ export const useWalletFilters = (): FilterOption[] => {
                     ) => {
                       trackCustomEvent({
                         eventCategory: "WalletFilterSidebar",
-                        eventAction: `${t("page-find-wallet-iOS")}`,
+                        eventAction: `${locale} - ${t("page-find-wallet-iOS")}`,
                         eventName: `iOS ${newInputState}`,
                       })
                       updateFilterState(
@@ -168,7 +170,7 @@ export const useWalletFilters = (): FilterOption[] => {
                 updateFilterState={(filterIndex, itemIndex, newInputState) => {
                   trackCustomEvent({
                     eventCategory: "WalletFilterSidebar",
-                    eventAction: `${t("page-find-wallet-desktop")}`,
+                    eventAction: `${locale} - ${t("page-find-wallet-desktop")}`,
                     eventName: `desktop ${newInputState}`,
                   })
                   updateFilterState(filterIndex, itemIndex, newInputState)
@@ -204,7 +206,7 @@ export const useWalletFilters = (): FilterOption[] => {
                     ) => {
                       trackCustomEvent({
                         eventCategory: "WalletFilterSidebar",
-                        eventAction: `${t("page-find-wallet-linux")}`,
+                        eventAction: `${locale} - ${t("page-find-wallet-linux")}`,
                         eventName: `linux ${newInputState}`,
                       })
                       updateFilterState(
@@ -245,7 +247,7 @@ export const useWalletFilters = (): FilterOption[] => {
                     ) => {
                       trackCustomEvent({
                         eventCategory: "WalletFilterSidebar",
-                        eventAction: `${t("page-find-wallet-windows")}`,
+                        eventAction: `${locale} - ${t("page-find-wallet-windows")}`,
                         eventName: `windows ${newInputState}`,
                       })
                       updateFilterState(
@@ -286,7 +288,7 @@ export const useWalletFilters = (): FilterOption[] => {
                     ) => {
                       trackCustomEvent({
                         eventCategory: "WalletFilterSidebar",
-                        eventAction: `${t("page-find-wallet-macOS")}`,
+                        eventAction: `${locale} - ${t("page-find-wallet-macOS")}`,
                         eventName: `macOS ${newInputState}`,
                       })
                       updateFilterState(
@@ -318,7 +320,7 @@ export const useWalletFilters = (): FilterOption[] => {
                 updateFilterState={(filterIndex, itemIndex, newInputState) => {
                   trackCustomEvent({
                     eventCategory: "WalletFilterSidebar",
-                    eventAction: `${t("page-find-wallet-browser")}`,
+                    eventAction: `${locale} - ${t("page-find-wallet-browser")}`,
                     eventName: `browser ${newInputState}`,
                   })
                   updateFilterState(filterIndex, itemIndex, newInputState)
@@ -354,7 +356,7 @@ export const useWalletFilters = (): FilterOption[] => {
                     ) => {
                       trackCustomEvent({
                         eventCategory: "WalletFilterSidebar",
-                        eventAction: `${t("page-find-wallet-chromium")}`,
+                        eventAction: `${locale} - ${t("page-find-wallet-chromium")}`,
                         eventName: `chromium ${newInputState}`,
                       })
                       updateFilterState(
@@ -395,7 +397,7 @@ export const useWalletFilters = (): FilterOption[] => {
                     ) => {
                       trackCustomEvent({
                         eventCategory: "WalletFilterSidebar",
-                        eventAction: `${t("page-find-wallet-firefox")}`,
+                        eventAction: `${locale} - ${t("page-find-wallet-firefox")}`,
                         eventName: `firefox ${newInputState}`,
                       })
                       updateFilterState(
@@ -427,7 +429,7 @@ export const useWalletFilters = (): FilterOption[] => {
                 updateFilterState={(filterIndex, itemIndex, newInputState) => {
                   trackCustomEvent({
                     eventCategory: "WalletFilterSidebar",
-                    eventAction: `${t("page-find-wallet-hardware")}`,
+                    eventAction: `${locale} - ${t("page-find-wallet-hardware")}`,
                     eventName: `hardware ${newInputState}`,
                   })
                   updateFilterState(filterIndex, itemIndex, newInputState)
@@ -522,7 +524,7 @@ export const useWalletFilters = (): FilterOption[] => {
                 updateFilterState={(filterIndex, itemIndex, newInputState) => {
                   trackCustomEvent({
                     eventCategory: "WalletFilterSidebar",
-                    eventAction: `${t("page-find-wallet-buy-crypto")}`,
+                    eventAction: `${locale} - ${t("page-find-wallet-buy-crypto")}`,
                     eventName: `buy_crypto ${newInputState}`,
                   })
                   updateFilterState(filterIndex, itemIndex, newInputState)
@@ -549,7 +551,7 @@ export const useWalletFilters = (): FilterOption[] => {
                 updateFilterState={(filterIndex, itemIndex, newInputState) => {
                   trackCustomEvent({
                     eventCategory: "WalletFilterSidebar",
-                    eventAction: `${t("page-find-wallet-sell-for-fiat")}`,
+                    eventAction: `${locale} - ${t("page-find-wallet-sell-for-fiat")}`,
                     eventName: `withdraw_crypto ${newInputState}`,
                   })
                   updateFilterState(filterIndex, itemIndex, newInputState)
@@ -582,7 +584,7 @@ export const useWalletFilters = (): FilterOption[] => {
                 updateFilterState={(filterIndex, itemIndex, newInputState) => {
                   trackCustomEvent({
                     eventCategory: "WalletFilterSidebar",
-                    eventAction: `${t("page-find-wallet-connect-to-dapps")}`,
+                    eventAction: `${locale} - ${t("page-find-wallet-connect-to-dapps")}`,
                     eventName: `connect_to_dapps ${newInputState}`,
                   })
                   updateFilterState(filterIndex, itemIndex, newInputState)
@@ -609,7 +611,7 @@ export const useWalletFilters = (): FilterOption[] => {
                 updateFilterState={(filterIndex, itemIndex, newInputState) => {
                   trackCustomEvent({
                     eventCategory: "WalletFilterSidebar",
-                    eventAction: `${t("page-find-wallet-nft-support")}`,
+                    eventAction: `${locale} - ${t("page-find-wallet-nft-support")}`,
                     eventName: `nft_support ${newInputState}`,
                   })
                   updateFilterState(filterIndex, itemIndex, newInputState)
@@ -636,7 +638,7 @@ export const useWalletFilters = (): FilterOption[] => {
                 updateFilterState={(filterIndex, itemIndex, newInputState) => {
                   trackCustomEvent({
                     eventCategory: "WalletFilterSidebar",
-                    eventAction: `${t("page-find-wallet-staking")}`,
+                    eventAction: `${locale} - ${t("page-find-wallet-staking")}`,
                     eventName: `staking ${newInputState}`,
                   })
                   updateFilterState(filterIndex, itemIndex, newInputState)
@@ -663,7 +665,7 @@ export const useWalletFilters = (): FilterOption[] => {
                 updateFilterState={(filterIndex, itemIndex, newInputState) => {
                   trackCustomEvent({
                     eventCategory: "WalletFilterSidebar",
-                    eventAction: `${t("page-find-wallet-layer-2")}`,
+                    eventAction: `${locale} - ${t("page-find-wallet-layer-2")}`,
                     eventName: `layer_2 ${newInputState}`,
                   })
                   updateFilterState(filterIndex, itemIndex, newInputState)
@@ -690,7 +692,7 @@ export const useWalletFilters = (): FilterOption[] => {
                 updateFilterState={(filterIndex, itemIndex, newInputState) => {
                   trackCustomEvent({
                     eventCategory: "WalletFilterSidebar",
-                    eventAction: `${t("page-find-wallet-swaps")}`,
+                    eventAction: `${locale} - ${t("page-find-wallet-swaps")}`,
                     eventName: `swaps ${newInputState}`,
                   })
                   updateFilterState(filterIndex, itemIndex, newInputState)
@@ -717,7 +719,7 @@ export const useWalletFilters = (): FilterOption[] => {
                 updateFilterState={(filterIndex, itemIndex, newInputState) => {
                   trackCustomEvent({
                     eventCategory: "WalletFilterSidebar",
-                    eventAction: `${t("page-find-wallet-hardware-wallet-support")}`,
+                    eventAction: `${locale} - ${t("page-find-wallet-hardware-wallet-support")}`,
                     eventName: `hardware_support ${newInputState}`,
                   })
                   updateFilterState(filterIndex, itemIndex, newInputState)
@@ -744,7 +746,7 @@ export const useWalletFilters = (): FilterOption[] => {
                 updateFilterState={(filterIndex, itemIndex, newInputState) => {
                   trackCustomEvent({
                     eventCategory: "WalletFilterSidebar",
-                    eventAction: `${t("page-find-wallet-ens-support")}`,
+                    eventAction: `${locale} - ${t("page-find-wallet-ens-support")}`,
                     eventName: `ens_support ${newInputState}`,
                   })
                   updateFilterState(filterIndex, itemIndex, newInputState)
@@ -777,7 +779,7 @@ export const useWalletFilters = (): FilterOption[] => {
                 updateFilterState={(filterIndex, itemIndex, newInputState) => {
                   trackCustomEvent({
                     eventCategory: "WalletFilterSidebar",
-                    eventAction: `${t("page-find-wallet-open-source")}`,
+                    eventAction: `${locale} - ${t("page-find-wallet-open-source")}`,
                     eventName: `open_source ${newInputState}`,
                   })
                   updateFilterState(filterIndex, itemIndex, newInputState)
@@ -804,7 +806,7 @@ export const useWalletFilters = (): FilterOption[] => {
                 updateFilterState={(filterIndex, itemIndex, newInputState) => {
                   trackCustomEvent({
                     eventCategory: "WalletFilterSidebar",
-                    eventAction: `${t("page-find-wallet-non-custodial")}`,
+                    eventAction: `${locale} - ${t("page-find-wallet-non-custodial")}`,
                     eventName: `non_custodial ${newInputState}`,
                   })
                   updateFilterState(filterIndex, itemIndex, newInputState)
@@ -837,7 +839,7 @@ export const useWalletFilters = (): FilterOption[] => {
                 updateFilterState={(filterIndex, itemIndex, newInputState) => {
                   trackCustomEvent({
                     eventCategory: "WalletFilterSidebar",
-                    eventAction: `${t("page-find-wallet-multisig")}`,
+                    eventAction: `${locale} - ${t("page-find-wallet-multisig")}`,
                     eventName: `multisig ${newInputState}`,
                   })
                   updateFilterState(filterIndex, itemIndex, newInputState)
@@ -864,7 +866,7 @@ export const useWalletFilters = (): FilterOption[] => {
                 updateFilterState={(filterIndex, itemIndex, newInputState) => {
                   trackCustomEvent({
                     eventCategory: "WalletFilterSidebar",
-                    eventAction: `${t("page-find-wallet-social-recovery")}`,
+                    eventAction: `${locale} - ${t("page-find-wallet-social-recovery")}`,
                     eventName: `social_recovery ${newInputState}`,
                   })
                   updateFilterState(filterIndex, itemIndex, newInputState)
@@ -897,7 +899,7 @@ export const useWalletFilters = (): FilterOption[] => {
                 updateFilterState={(filterIndex, itemIndex, newInputState) => {
                   trackCustomEvent({
                     eventCategory: "WalletFilterSidebar",
-                    eventAction: `${t("page-find-wallet-rpc-importing")}`,
+                    eventAction: `${locale} - ${t("page-find-wallet-rpc-importing")}`,
                     eventName: `rpc_importing ${newInputState}`,
                   })
                   updateFilterState(filterIndex, itemIndex, newInputState)
@@ -924,7 +926,7 @@ export const useWalletFilters = (): FilterOption[] => {
                 updateFilterState={(filterIndex, itemIndex, newInputState) => {
                   trackCustomEvent({
                     eventCategory: "WalletFilterSidebar",
-                    eventAction: `${t("page-find-wallet-token-importing")}`,
+                    eventAction: `${locale} - ${t("page-find-wallet-token-importing")}`,
                     eventName: `erc_20_support ${newInputState}`,
                   })
                   updateFilterState(filterIndex, itemIndex, newInputState)


### PR DESCRIPTION
Adds `locale` prefix to all wallet `eventAction` labels to differentiate by locale.

cc: @konopkja 