### PR TITLE
Fix: Updated ERC-20 interface syntax and corrected return types

### DIFF
--- a/public/content/developers/docs/standards/tokens/erc-20/index.md
+++ b/public/content/developers/docs/standards/tokens/erc-20/index.md
@@ -52,11 +52,11 @@ From [EIP-20](https://eips.ethereum.org/EIPS/eip-20):
 ### Methods {#methods}
 
 ```solidity
-function name() public view returns (string)
-function symbol() public view returns (string)
+function name() public view returns (string memory)
+function symbol() public view returns (string memory)
 function decimals() public view returns (uint8)
 function totalSupply() public view returns (uint256)
-function balanceOf(address _owner) public view returns (uint256 balance)
+function balanceOf(address _owner) public view returns (uint256)
 function transfer(address _to, uint256 _value) public returns (bool success)
 function transferFrom(address _from, address _to, uint256 _value) public returns (bool success)
 function approve(address _spender, uint256 _value) public returns (bool success)


### PR DESCRIPTION
### **Correct ERC-20 interface syntax and types in documentation**

Basically, what I added was the "memory" keyword to "string" return types ("name( )" and "symbol( )", which is requires in Solidity versions 0.5.0 and above. This matters because the current version on the website uses outdated or incomplete syntac ("string" without memory location) which might cause an error in modern Solidity versions. 

## These changes align with the official [EIP-20] and solidity version 0.5.0's standards
[EIP-20 Token Standard](https://eips.ethereum.org/EIPS/eip-20)
[Solidity 0.5.0 Breaking Changes](https://docs.soliditylang.org/en/v0.5.0/050-breaking-changes.html#explicit-data-location)