### PR TITLE
Fix torch history card date display and placeholder messaging

### DIFF
--- a/app/[locale]/10years/_components/TorchHistoryCard.tsx
+++ b/app/[locale]/10years/_components/TorchHistoryCard.tsx
@@ -74,7 +74,10 @@ const TorchHistoryCard: React.FC<TorchHistoryCardProps> = ({
         {!isPlaceholder && (
           <>
             <div className="text-xs text-gray-500">
-              From {formatDate(from)} to {formatDate(to)}
+              {isCurrentHolder 
+                ? `From ${formatDate(from)}`
+                : `From ${formatDate(from)} to ${formatDate(to)}`
+              }
             </div>
             <BaseLink
               href={getTxEtherscanUrl(transactionHash)}

--- a/app/[locale]/10years/_components/TorchHistorySwiper/index.tsx
+++ b/app/[locale]/10years/_components/TorchHistorySwiper/index.tsx
@@ -19,6 +19,22 @@ type TorchHistorySwiperProps = {
   currentHolderAddress: Address | null
 }
 
+const getOrdinalSuffix = (num: number): string => {
+  const lastDigit = num % 10;
+  const lastTwoDigits = num % 100;
+  
+  if (lastTwoDigits >= 11 && lastTwoDigits <= 13) {
+    return `${num}th`;
+  }
+  
+  switch (lastDigit) {
+    case 1: return `${num}st`;
+    case 2: return `${num}nd`;
+    case 3: return `${num}rd`;
+    default: return `${num}th`;
+  }
+};
+
 const TorchHistorySwiper = ({
   holders,
   currentHolderAddress,
@@ -40,8 +56,8 @@ const TorchHistorySwiper = ({
       // Create placeholder for future holder
       return {
         address: `placeholder-${index}` as Address,
-        name: `Future Bearer ${index + 1}`,
-        role: "Coming soon...",
+        name: `Torchbearer ${index + 1}`,
+        role: `Coming ${getOrdinalSuffix(20 + index)}!`,
         twitter: "",
         event: {
           from: "0x0000000000000000000000000000000000000000" as Address,

--- a/app/[locale]/10years/_components/TorchHistorySwiper/index.tsx
+++ b/app/[locale]/10years/_components/TorchHistorySwiper/index.tsx
@@ -20,20 +20,16 @@ type TorchHistorySwiperProps = {
 }
 
 const getOrdinalSuffix = (num: number): string => {
-  const lastDigit = num % 10;
-  const lastTwoDigits = num % 100;
+  const pr = new Intl.PluralRules('en', { type: 'ordinal' });
+  const rule = pr.select(num);
   
-  if (lastTwoDigits >= 11 && lastTwoDigits <= 13) {
-    return `${num}th`;
-  }
-  
-  switch (lastDigit) {
-    case 1: return `${num}st`;
-    case 2: return `${num}nd`;
-    case 3: return `${num}rd`;
+  switch (rule) {
+    case "one": return `${num}st`;
+    case "two": return `${num}nd`;
+    case "few": return `${num}rd`;
     default: return `${num}th`;
   }
-};
+}
 
 const TorchHistorySwiper = ({
   holders,
@@ -57,7 +53,7 @@ const TorchHistorySwiper = ({
       return {
         address: `placeholder-${index}` as Address,
         name: `Torchbearer ${index + 1}`,
-        role: `Coming ${getOrdinalSuffix(20 + index)}!`,
+        role: `Coming July ${getOrdinalSuffix(20 + index)}!`,
         twitter: "",
         event: {
           from: "0x0000000000000000000000000000000000000000" as Address,


### PR DESCRIPTION
## Fix 1: Redundant date display for current torchbearers

Problem: Currently, torch history cards display "From [date] to [date]" even when the torchbearer still holds the NFT. When someone is the current holder, both dates are identical, creating confusing and redundant text.

Solution: Conditionally render the date text based on isCurrentHolder prop:

Current holders: Show "From [date]" only
Previous holders: Show "From [date] to [date]" range

## Fix 2: Generic placeholder messaging

Problem: All future torchbearer placeholders show the same generic "Coming soon!" message, providing no indication of when each person will receive the torch.

Solution: Replace generic messaging with specific dates showing when each torchbearer will receive the torch:

Torchbearer 1: "Coming 20th!"
Torchbearer 2: "Coming 21st!"
Torchbearer 3: "Coming 22nd!"
And so on...

<img width="858" height="589" alt="image" src="https://github.com/user-attachments/assets/c322dfab-f25b-49e1-b6bc-149fd0b11869" />