### PR TITLE
fix: subnav z-index [Fixes #15712]

### DIFF
--- a/app/[locale]/resources/page.tsx
+++ b/app/[locale]/resources/page.tsx
@@ -75,7 +75,7 @@ const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
       />
 
       <Stack className="gap-4 px-2 py-6 md:gap-8 md:px-4 lg:px-8 xl:gap-11">
-        <div className="sticky top-5 flex flex-col items-center gap-3 text-center md:top-6 md:px-2">
+        <div className="sticky top-5 z-docked flex flex-col items-center gap-3 text-center md:top-6 md:px-2">
           <div className="my-2 text-body-medium">
             {t("page-resources-whats-on-this-page")}
           </div>


### PR DESCRIPTION
## Description
- Add z-index to subnav bar, `z-docked` (`z-index: 10;`)

<img width="721" height="336" alt="image" src="https://github.com/user-attachments/assets/0ab2b44b-7da9-41e2-9a4b-90e78a40763f" />


## Related Issue
- Fixes #15712
- Closes #15717