### PR TITLE
Improve torch card placeholder copy 

### DIFF
--- a/app/[locale]/10years/_components/TorchHistorySwiper/index.tsx
+++ b/app/[locale]/10years/_components/TorchHistorySwiper/index.tsx
@@ -19,6 +19,22 @@ type TorchHistorySwiperProps = {
   currentHolderAddress: Address | null
 }
 
+const getOrdinalSuffix = (num: number): string => {
+  const pr = new Intl.PluralRules("en", { type: "ordinal" })
+  const rule = pr.select(num)
+
+  switch (rule) {
+    case "one":
+      return `${num}st`
+    case "two":
+      return `${num}nd`
+    case "few":
+      return `${num}rd`
+    default:
+      return `${num}th`
+  }
+}
+
 const TorchHistorySwiper = ({
   holders,
   currentHolderAddress,
@@ -40,8 +56,8 @@ const TorchHistorySwiper = ({
       // Create placeholder for future holder
       return {
         address: `placeholder-${index}` as Address,
-        name: `Future Bearer ${index + 1}`,
-        role: "Coming soon...",
+        name: `Torchbearer ${index + 1}`,
+        role: `Coming July ${getOrdinalSuffix(20 + index)}!`,
         twitter: "",
         event: {
           from: "0x0000000000000000000000000000000000000000" as Address,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Problem: All future torchbearer placeholders show the same generic "Coming soon!" message, providing no indication of when each person will receive the torch.

Solution: Replace generic messaging with specific dates showing when each torchbearer will receive the torch:

Torchbearer 1: "Coming July 20th!"
Torchbearer 2: "Coming July 21st!"
Torchbearer 3: "Coming July 22nd!"
And so on...

## Related PR

Supersedes #15886
