### PR TITLE
fix: Matomo ab testing assignment distribution

### DIFF
--- a/app/api/ab-config/route.ts
+++ b/app/api/ab-config/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server"
 
-import { IS_PREVIEW_DEPLOY } from "@/lib/utils/env"
+import { IS_PREVIEW_DEPLOY, IS_PROD } from "@/lib/utils/env"
 
 import type { ABTestConfig, MatomoExperiment } from "@/lib/ab-testing/types"
 
@@ -33,7 +33,8 @@ const getPreviewConfig = () => ({
 
 export async function GET() {
   // Preview mode: Show menu with original default
-  if (IS_PREVIEW_DEPLOY) return NextResponse.json(getPreviewConfig())
+  if (!IS_PROD || IS_PREVIEW_DEPLOY)
+    return NextResponse.json(getPreviewConfig())
 
   try {
     const matomoUrl = process.env.NEXT_PUBLIC_MATOMO_URL


### PR DESCRIPTION
## Description
- use additional privacy-preserving header data to increase entropy of users when being assigned an AB test group
- Uses improved hash function to help evenly distribute users based on fingerprint


## Related Issue
AB Testing