### PR TITLE
Add ephemery testnet to networks

### DIFF
--- a/public/content/developers/docs/networks/index.md
+++ b/public/content/developers/docs/networks/index.md
@@ -82,6 +82,31 @@ Hoodi is a testnet for testing validating and staking. The Hoodi network is open
 - [Hoodi Faucet](https://hoodi.ethpandaops.io/)
 - [PoW faucet](https://hoodi-faucet.pk910.de/)
 
+#### Ephemery {#ephemery}
+
+Ephemery is a unique kind of testnet that fully resets every month. The execution and consensus state reverts back to genesis every 28 days, which means anything that happens on the testnet is ephemeral. This makes it ideal for a short term testing, fast node bootstrap and 'hello world' kind of applications that don't need permanence. 
+
+- Always fresh state, short term testing of validators and apps
+- Includes only basic set of contracts
+- Open validator set and easy to access large amounts of funds
+- Smallest node requirements and quickest sync, <5GB on average
+
+##### Resources
+
+- [Website](https://ephemery.dev/)
+- [Github]( https://github.com/ephemery-testnet/ephemery-resources)
+- [Community chat](https://matrix.to/#/#staker-testnet:matrix.org)
+- [Blockscout](https://explorer.ephemery.dev/)
+- [Otterscan](https://otter.bordel.wtf/)
+- [Beacon explorer](https://beaconlight.ephemery.dev/)
+- [Checkpoint Sync](https://checkpoint-sync.ephemery.ethpandaops.io)
+- [Launchpad]( https://launchpad.ephemery.dev/)
+
+#### Faucets
+
+- [Bordel Faucet](https://faucet.bordel.wtf/)
+- [Pk910 PoW Faucet](https://ephemery-faucet.pk910.de/)
+
 #### Holesky {#holesky}
 
 The Holesky testnet will be [deprecated in September 2025](https://blog.ethereum.org/en/2025/03/18/hoodi-holesky). Staking operators and infrastructure providers should use Hoodi for validator testing instead.


### PR DESCRIPTION
The Ephemery network is currently missing from the list of public testnets. It's a special one and mostly operated by community so it could be described in more detail. 

The PR is adding the basic description highlighting use cases and all relevant resources. 