### PR TITLE
Add DeGov.Ai DAOs and Launcher to Ethereum website

### DIFF
--- a/public/content/dao/index.md
+++ b/public/content/dao/index.md
@@ -135,6 +135,7 @@ _Typically used for decentralized development and governance of protocols and [d
 - [Ethereum community DAOs](/community/get-involved/#decentralized-autonomous-organizations-daos)
 - [DAOHaus's list of DAOs](https://app.daohaus.club/explore)
 - [Tally.xyz list of DAOs](https://www.tally.xyz)
+- [DeGov.Ai list of DAOs](https://apps.degov.ai/)
 
 ### Start a DAO {#start-a-dao}
 
@@ -143,6 +144,7 @@ _Typically used for decentralized development and governance of protocols and [d
 - [Create an Aragon-powered DAO](https://aragon.org/product)
 - [Start a colony](https://colony.io/)
 - [Create a DAO with DAOstack's holographic consensus](https://alchemy.daostack.io/daos/create)
+- [Launch a DAO with the DeGov Launcher](https://docs.degov.ai/integration/deploy)
 
 ## Further reading {#further-reading}
 

--- a/public/content/dao/index.md
+++ b/public/content/dao/index.md
@@ -135,7 +135,7 @@ _Typically used for decentralized development and governance of protocols and [d
 - [Ethereum community DAOs](/community/get-involved/#decentralized-autonomous-organizations-daos)
 - [DAOHaus's list of DAOs](https://app.daohaus.club/explore)
 - [Tally.xyz list of DAOs](https://www.tally.xyz)
-- [DeGov.Ai list of DAOs](https://apps.degov.ai/)
+- [DeGov.AI list of DAOs](https://apps.degov.ai/)
 
 ### Start a DAO {#start-a-dao}
 


### PR DESCRIPTION
Hi, David from DeGov.AI here.

Here's the reason for this pull request:
1. Add DeGov.AI list of DAOs 
2. Add DeGov.AI Launcher for new DAOs looking to launch a DAO platform for free.

## Description
DeGov.AI is an AI-powered governance platform designed for DAOs that use the OpenZeppelin Governor framework. What sets DeGov.AI apart is its [agent governance](https://docs.degov.ai/governance/agent/overview/) feature, which allows AI agents to participate in the governance process, enhancing decision-making and community engagement.

This update introduces a list of DAOs currently supported by DeGov.AI, with plans for exponential growth in the coming months (development began approximately five months ago). 

It also includes the DeGov.AI Launcher instance, which is free to use, with details provided in the attached document.

For DeGov.AI


## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
