### PR TITLE
fix: keep mint success UI after rerender

### DIFF
--- a/app/[locale]/10years/_components/NFTMintCard/Mint.tsx
+++ b/app/[locale]/10years/_components/NFTMintCard/Mint.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react"
 import { Address } from "viem"
 import {
   useEnsName,
@@ -14,7 +15,12 @@ import Connected from "./Connected"
 import { useNetworkContract } from "@/hooks/useNetworkContract"
 import { getErrorMessage } from "@/lib/torch"
 
-export default function Mint({ address }: { address: Address }) {
+interface MintProps {
+  address: Address
+  onSuccess?: (txHash: string) => void
+}
+
+export default function Mint({ address, onSuccess }: MintProps) {
   const { data: ensName } = useEnsName({ address })
   const { contractData, isSupportedNetwork } = useNetworkContract()
 
@@ -38,6 +44,12 @@ export default function Mint({ address }: { address: Address }) {
       enabled: !!hash,
     },
   })
+
+  useEffect(() => {
+    if (isConfirmed && hash && onSuccess) {
+      onSuccess(hash)
+    }
+  }, [isConfirmed, hash, onSuccess])
 
   const handleMintClick = async () => {
     mint({

--- a/app/[locale]/10years/_components/NFTMintCard/Prechecks.tsx
+++ b/app/[locale]/10years/_components/NFTMintCard/Prechecks.tsx
@@ -1,13 +1,16 @@
+import { useState } from "react"
 import { Address } from "viem"
 import { useReadContract } from "wagmi"
 
 import MintAlreadyMinted from "./views/MintAlreadyMinted"
+import MintSuccess from "./views/MintSuccess"
 import Mint from "./Mint"
 
 import { useNetworkContract } from "@/hooks/useNetworkContract"
 
 export default function Prechecks({ address }: { address: Address }) {
   const { contractData, isSupportedNetwork } = useNetworkContract()
+  const [successTxHash, setSuccessTxHash] = useState<string | null>(null)
 
   const { data: hasMinted, error: hasMintedError } = useReadContract({
     address: contractData.address,
@@ -19,13 +22,21 @@ export default function Prechecks({ address }: { address: Address }) {
     },
   })
 
+  const handleMintSuccess = (txHash: string) => {
+    setSuccessTxHash(txHash)
+  }
+
   if (hasMintedError) {
     return <div className="flex justify-center">Error checking minted</div>
+  }
+
+  if (successTxHash) {
+    return <MintSuccess txHash={successTxHash} />
   }
 
   if (hasMinted) {
     return <MintAlreadyMinted />
   }
 
-  return <Mint address={address} />
+  return <Mint address={address} onSuccess={handleMintSuccess} />
 }


### PR DESCRIPTION
**Problem:** After minting, users saw "Already minted" warning instead of success celebration when component rerenders.

**Solution:** Add `onSuccess` callback to persist success state in current session.