### PR TITLE
🔧 Change ETHJKT Link from Meetup to Official Website

### DIFF
--- a/src/data/community-meetups.json
+++ b/src/data/community-meetups.json
@@ -195,7 +195,7 @@
     "title": "Ethereum Jakarta",
     "emoji": ":indonesia:",
     "location": "Jakarta",
-    "link": "https://www.meetup.com/ethereum-jkt/"
+    "link": "https://ethjkt.com/"
   },
   {
     "title": "Ethereum Italia Hub (Telegram Group)",


### PR DESCRIPTION
Summary
This PR updates the Ethereum Jakarta (ETHJKT) community link on the ethereum.org website. Previously, the link pointed to our Meetup page. We are now directing users to our official website at https://ethjkt.com for up-to-date events, community resources, and initiatives.

Changes Made

Updated the ETHJKT community link in the respective JSON/YAML or markdown content file.

Ensured the new link points to: https://ethjkt.com

Why this change?
The official website provides a more comprehensive and updated representation of Ethereum Jakarta, including upcoming events, past activities, media, and partnership opportunities.

Checklist

 Updated URL points to https://ethjkt.com

 Verified link works

Additional Notes
ETHJKT is growing rapidly, and this change ensures visitors are directed to the most accurate source for information and engagement.