### PR TITLE
fix: mdx syntax

### DIFF
--- a/public/content/developers/docs/networks/index.md
+++ b/public/content/developers/docs/networks/index.md
@@ -89,7 +89,7 @@ Ephemery is a unique kind of testnet that fully resets every month. The executio
 - Always fresh state, short term testing of validators and apps
 - Includes only basic set of contracts
 - Open validator set and easy to access large amounts of funds
-- Smallest node requirements and quickest sync, <5GB on average
+- Smallest node requirements and quickest sync, &lt;5GB on average
 
 ##### Resources
 


### PR DESCRIPTION
Fixes build-breaking MDX error

```
12:23:06 PM: [Error: [next-mdx-remote] error compiling MDX:
12:23:06 PM: Unexpected character `5` (U+0035) before name, expected a character that can start a name, such as a letter, `$`, or `_`
12:23:06 PM: More information: https://mdxjs.com/docs/troubleshooting-mdx] {
12:23:06 PM:   digest: '3504767675'
12:23:06 PM: }
```