### PR TITLE
fix: Change Rocket Pool entry price

### DIFF
--- a/src/data/staking-products.json
+++ b/src/data/staking-products.json
@@ -40,7 +40,7 @@
           "url": "https://github.com/trailofbits/publications/blob/master/reviews/RocketPool.pdf"
         }
       ],
-      "minEth": 10.4,
+      "minEth": 8,
       "tokens": [
         {
           "name": "Rocket Pool ETH",


### PR DESCRIPTION
## Description

_tl;dr: Update of Rocket Pool entry price 10.4 ETH -> 8 ETH._

On Ethereum.org website, [the Node tools section](https://ethereum.org/en/staking/solo/#node-and-client-tools) is saying that entry price for stacking on Rocket Pool is 10.4 ETH.
It used to be true since RP was asking for 8 ETH + equivalent of 2.4 ETH converted in RPL (Rocket Pool token) but since recent update ("[Saturn 0](https://docs.rocketpool.net/guides/saturn-0/whats-new)") that's not the case anymore.

People can create 8 ETH ([source](https://rocketpool.net/node-staking/rocket-pool-vs-solo-staking)) node only (without RPL) on Rocket Pool, so correct entry price is only 8 ETH now.