### PR TITLE
Fix feedback button animation

### DIFF
--- a/src/components/FeedbackWidget/FixedDot.tsx
+++ b/src/components/FeedbackWidget/FixedDot.tsx
@@ -38,14 +38,14 @@ const FixedDot = forwardRef<HTMLButtonElement, FixedDotProps>(
         />
         <div
           className={cn(
-            "duration-250 transform transition-all",
+            "transform overflow-hidden transition-all duration-200",
             isExpanded ? "scale-100 opacity-100" : "scale-95 opacity-0"
           )}
         >
           <span
             className={cn(
-              "line-clamp-2 hidden h-full items-center font-bold leading-5 text-white",
-              isExpanded && "lg:flex"
+              "line-clamp-2 h-full items-center whitespace-nowrap font-bold leading-5 text-white",
+              isExpanded ? "lg:flex" : "hidden"
             )}
           >
             {t("feedback-widget-prompt")}


### PR DESCRIPTION
The current animation causes the icon to jump outside its container, briefly triggering a horizontal scrollbar.
<img width="456" height="316" alt="image" src="https://github.com/user-attachments/assets/555e62c4-7e0a-4209-b05c-ca2b750aa8ae" />

## Description
Matching the animation timings seems to fix this and have a smooth transition.

https://github.com/user-attachments/assets/cdb812d9-a0c0-44df-b4b0-9d9bd615c344
