### PR TITLE
build: bump @netlify/plugin-nextjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
   "devDependencies": {
     "@chromatic-com/playwright": "^0.12.4",
     "@chromatic-com/storybook": "1.5.0",
-    "@netlify/plugin-nextjs": "^5.10.0",
+    "@netlify/plugin-nextjs": "^5.12.0",
     "@playwright/test": "^1.52.0",
     "@storybook/addon-essentials": "8.6.14",
     "@storybook/addon-interactions": "8.6.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,8 +232,8 @@ importers:
         specifier: 1.5.0
         version: 1.5.0(@chromatic-com/playwright@0.12.5(@playwright/test@1.53.1)(@types/react@18.2.57)(bufferutil@4.0.9)(esbuild@0.25.5)(prettier@3.5.3)(typescript@5.8.3)(utf-8-validate@5.0.10))(react@18.3.1)
       '@netlify/plugin-nextjs':
-        specifier: ^5.10.0
-        version: 5.11.2
+        specifier: ^5.12.0
+        version: 5.12.0
       '@playwright/test':
         specifier: ^1.52.0
         version: 1.53.1
@@ -1628,8 +1628,8 @@ packages:
   '@napi-rs/wasm-runtime@0.2.10':
     resolution: {integrity: sha512-bCsCyeZEwVErsGmyPNSzwfwFn4OdxBj0mmv6hOFucB/k81Ojdu68RbZdxYsRQUPc9l6SU5F/cG+bXgWs3oUgsQ==}
 
-  '@netlify/plugin-nextjs@5.11.2':
-    resolution: {integrity: sha512-9Hgd/J5nP2U/Vv0teytq9uUAGppiKV9t5tzpsuMLqeqUGD9STxXwKmyZd2v8Z4THSW9rw4+8w7dH7LVlFoym2A==}
+  '@netlify/plugin-nextjs@5.12.0':
+    resolution: {integrity: sha512-SXQY/nCiSOSAZWNls/DQxrICldUR7PHSMUw2J2/ZejH1dk12Vwd3+SzSihHrRW9PNcErZkC2g3seM7bWZlvBRg==}
     engines: {node: '>=18.0.0'}
 
   '@next/bundle-analyzer@14.2.29':
@@ -9931,7 +9931,7 @@ snapshots:
       '@tybys/wasm-util': 0.9.0
     optional: true
 
-  '@netlify/plugin-nextjs@5.11.2': {}
+  '@netlify/plugin-nextjs@5.12.0': {}
 
   '@next/bundle-analyzer@14.2.29(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
     dependencies:


### PR DESCRIPTION
## Description
- bump @netlify/plugin-nextjs to v5.12.0

## Related Issue
Fixes "Outdated plugins" warning in Netlify build logs