### PR TITLE
docs: fix wrong anchor ID in PoS section

### DIFF
--- a/public/content/developers/docs/blocks/index.md
+++ b/public/content/developers/docs/blocks/index.md
@@ -25,7 +25,7 @@ To preserve the transaction history, blocks are strictly ordered (every new bloc
 
 Once a block is put together by a randomly selected validator on the network, it is propagated to the rest of the network; all nodes add this block to the end of their blockchain, and a new validator is selected to create the next block. The exact block-assembly process and commitment/consensus process is currently specified by Ethereum’s “proof-of-stake” protocol.
 
-## Proof-of-stake protocol {#proof-of-work-protocol}
+## Proof-of-stake protocol {#proof-of-stake-protocol}
 
 Proof-of-stake means the following:
 


### PR DESCRIPTION
## Description

<img width="442" height="30" alt="Снимок экрана 2025-08-08 в 09 40 26" src="https://github.com/user-attachments/assets/6477db92-d3c9-40b9-bc62-e92ddd00b04e" />

spotted a misleading anchor - it said proof-of-work, but the section's about proof-of-stake.
fixed it to match.

