### PR TITLE
fix: encoding of internal nodes in a MPT

### DIFF
--- a/public/content/developers/docs/data-structures-and-encoding/patricia-merkle-trie/index.md
+++ b/public/content/developers/docs/data-structures-and-encoding/patricia-merkle-trie/index.md
@@ -186,7 +186,7 @@ Now, we build such a trie with the following key/value pairs in the underlying D
     hashD:    [ <17>, [ <>, <>, <>, <>, <>, <>, [ <35>, 'coins' ], <>, <>, <>, <>, <>, <>, <>, <>, <>, 'puppy' ] ]
 ```
 
-When one node is referenced inside another node, what is included is `H(rlp.encode(node))`, where `H(x) = keccak256(x) if len(x) >= 32 else x` and `rlp.encode` is the [RLP](/developers/docs/data-structures-and-encoding/rlp) encoding function.
+When one node is referenced inside another node, what is included is `keccak256(rlp.encode(node))`, if `len(rlp.encode(node)) >= 32` else `node` where `rlp.encode` is the [RLP](/developers/docs/data-structures-and-encoding/rlp) encoding function.
 
 Note that when updating a trie, one needs to store the key/value pair `(keccak256(x), x)` in a persistent lookup table _if_ the newly-created node has length >= 32. However, if the node is shorter than that, one does not need to store anything, since the function f(x) = x is reversible.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fix documentation of internal node referencing in merkle patricia trie, according to issue #16047 

## Description

Changed the paragraph to match the actual behavior, according to the [execution specs](https://github.com/ethereum/execution-specs/blob/4198b9c5996713b268aed602739d5aa40e277694/src/ethereum/prague/trie.py#L177-L178)
## Related Issue
- Closes #16047 
