### PR TITLE
No locale prefix for default locale

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,6 +1,8 @@
 const i18nConfig = require("./i18n.config.json")
 const locales = i18nConfig.map(({ code }) => code)
 
+const defaultLocale = "en"
+
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
   siteUrl: process.env.SITE_URL || "https://ethereum.org",
@@ -8,9 +10,21 @@ module.exports = {
   transform: async (_, path) => {
     const rootPath = path.split("/")[1]
     if (path.endsWith("/404")) return null
-    const isDefaultLocale = !locales.includes(rootPath) || rootPath === "en"
+    const isDefaultLocale =
+      !locales.includes(rootPath) || rootPath === defaultLocale
+
+    // Strip default-locale (en) prefix from paths; drop the `/en` root entry
+    let loc = path
+    if (rootPath === defaultLocale) {
+      // Drop the `/en` root entry to avoid duplicating `/`
+      if (path === `/${defaultLocale}` || path === `/${defaultLocale}/`)
+        return null
+      const defaultLocalePrefix = new RegExp(`^/${defaultLocale}(/|$)`)
+      loc = path.replace(defaultLocalePrefix, "/")
+    }
+
     return {
-      loc: path,
+      loc,
       changefreq: isDefaultLocale ? "weekly" : "monthly",
       priority: isDefaultLocale ? 0.7 : 0.5,
     }

--- a/src/components/Matomo.tsx
+++ b/src/components/Matomo.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation"
 import { init, push } from "@socialgouv/matomo-next"
 
 import { IS_PREVIEW_DEPLOY } from "@/lib/utils/env"
+import { normalizePathForMatomo } from "@/lib/utils/matomo"
 
 export default function Matomo() {
   const pathname = usePathname()
@@ -40,8 +41,11 @@ export default function Matomo() {
       return setPreviousPath(pathname)
     }
 
-    push(["setReferrerUrl", `${previousPath}`])
-    push(["setCustomUrl", pathname])
+    const normalizedPreviousPath = normalizePathForMatomo(previousPath)
+    const normalizedPathname = normalizePathForMatomo(pathname)
+
+    push(["setReferrerUrl", `${normalizedPreviousPath}`])
+    push(["setCustomUrl", normalizedPathname])
     push(["deleteCustomVariables", "page"])
     setPreviousPath(pathname)
     // In order to ensure that the page title had been updated,

--- a/src/components/Matomo.tsx
+++ b/src/components/Matomo.tsx
@@ -44,7 +44,7 @@ export default function Matomo() {
     const normalizedPreviousPath = normalizePathForMatomo(previousPath)
     const normalizedPathname = normalizePathForMatomo(pathname)
 
-    push(["setReferrerUrl", `${normalizedPreviousPath}`])
+    push(["setReferrerUrl", normalizedPreviousPath])
     push(["setCustomUrl", normalizedPathname])
     push(["deleteCustomVariables", "page"])
     setPreviousPath(pathname)

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -7,6 +7,7 @@ export const routing = defineRouting({
   locales: LOCALES_CODES,
   defaultLocale: DEFAULT_LOCALE,
   localeCookie: false,
+  localePrefix: "as-needed",
 })
 
 // Lightweight wrappers around Next.js' navigation APIs

--- a/src/lib/utils/matomo.ts
+++ b/src/lib/utils/matomo.ts
@@ -12,9 +12,8 @@ export const MATOMO_LS_KEY = "ethereum-org.matomo-opt-out"
  * but we want to track them as /en paths for analytics consistency.
  */
 export const normalizePathForMatomo = (pathname: string): string => {
-  // If already has a locale prefix (like /es/, /fr/), keep it as is
-  const hasLocalePrefix = LOCALES_CODES.some(
-    (locale) => locale !== DEFAULT_LOCALE && pathname.startsWith(`/${locale}/`)
+  const hasLocalePrefix = LOCALES_CODES.some((locale) =>
+    pathname.startsWith(`/${locale}/`)
   )
 
   if (hasLocalePrefix) {
@@ -22,7 +21,7 @@ export const normalizePathForMatomo = (pathname: string): string => {
   }
 
   // For paths without locale prefix (English content), add /en prefix
-  return pathname === "/" ? "/en" : `/en${pathname}`
+  return `/${DEFAULT_LOCALE}${pathname}`
 }
 
 export interface MatomoEventOptions {

--- a/src/lib/utils/url.ts
+++ b/src/lib/utils/url.ts
@@ -50,7 +50,9 @@ export const addSlashes = (href: string): string => {
 }
 
 export const getFullUrl = (locale: string | undefined, path: string) =>
-  addSlashes(new URL(join(locale || DEFAULT_LOCALE, path), SITE_URL).href)
+  DEFAULT_LOCALE === locale || !locale
+    ? addSlashes(new URL(path, SITE_URL).href)
+    : addSlashes(new URL(join(locale, path), SITE_URL).href)
 
 // Remove trailing slash from slug and add leading slash
 export const normalizeSlug = (slug: string) => {


### PR DESCRIPTION
Intent to remove unnecessary redirect for most of the visitors.

## Description

Configures next-intl routing to use "as-needed" locale prefix.

## SEO Migration TODO
- [x]  Redirect `/en/*` → `/*`
- [x]  Update `hreflang`s — English should now point to `/` (not `/en`)
- [x]  Update canonical tags
- [x]  Update internal links
- [x]  Update XML Sitemap
    - Remove `/en` URLs.
    - Add `/` URLs for English.
- [ ] Resubmit sitemap in Google Search Console.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Cleaner URLs for the default language: removes the default locale prefix from links and sitemap entries (e.g., “/en” no longer shown for English).
  - Localized URLs now appear only when needed; default-language pages use unprefixed paths.

- Refactor
  - Improved routing configuration to better handle conditional locale prefixes.
  - Standardized URL generation to consistently omit the default locale while preserving non-default locales.
  - Harmonized analytics tracking to use normalized, locale-aware paths for more accurate reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->