### PR TITLE
Add Project Specific section with Arbitrum and Aztec grants

### DIFF
--- a/public/content/community/grants/index.md
+++ b/public/content/community/grants/index.md
@@ -32,6 +32,8 @@ These general platforms offer broad coverage of grants across the entire Web3 sp
 
 - [Grant Programs Viewer](https://airtable.com/shr86elKgWTSCP4AY) - _Public Airtable database of grant programs_
 - [Web3 Grants Spreadsheet](https://docs.google.com/spreadsheets/d/1c8koZCI-GLnD8MG-eFcXPOBCNu1v8-aXIfwAAvc7AMc/edit#gid=0) - _Google spreadsheet of Web3 grant opportunities_
+- [Arbitrum Grants](https://arbitrum.foundation/grants) — Arbitrum DAO and [The Arbitrum Foundation](https://arbitrum.foundation/)
+- [Aztec Grants Program](https://aztec.network/grants) — Noir language and the [Aztec](https://aztec.network/) network
 
 ### For DeFi projects and financial applications {#for-defi-projects}
 
@@ -62,13 +64,6 @@ These programs focus on funding projects that benefit the broader community, pub
 - [Artizen](https://artizen.fund/) - _Helping creators match fund new projects at the frontier of art, science, technology and culture_
 - [Quadratic Accelerator](https://qacc.giveth.io/) - _Start-up accelerator program that uses quadratic funding to support projects that benefit the public good_
 
-
-## Project Specific {#project-specific}
-
-Grant programs specific to particular blockchain projects and ecosystems:
-
-- [Arbitrum Grants](https://arbitrum.foundation/grants) — Arbitrum DAO and [The Arbitrum Foundation](https://arbitrum.foundation/)
-- [Aztec Grants Program](https://aztec.network/grants) — Noir language and the [Aztec](https://aztec.network/) network
 
 ## Work in Ethereum {#work-in-ethereum}
 

--- a/src/data/community-meetups.json
+++ b/src/data/community-meetups.json
@@ -47,12 +47,6 @@
     "location": "Hong Kong",
     "link": "https://twitter.com/852devxyz"
   },
-    {
-    "title": "ETHDimsum",
-    "emoji": ":hong_kong:",
-    "location": "Guangdong, Hong Kong, Macao",
-    "link": "https://lu.ma/user/usr-lrp0c-hpIYWGoK4"
-  },
   {
     "title": "Ethereum Ecuador",
     "emoji": ":ecuador:",


### PR DESCRIPTION
Resolves #15415

Added new Project Specific section to the grants page with:
- Arbitrum Grants program (Arbitrum DAO and The Arbitrum Foundation)
- Aztec Grants Program (Noir language and Aztec network)

This addresses the request to include project-specific grant programs on the Ethereum grants page.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
