### PR TITLE
Add slide-up/slide-down animations for modal open/close and improve overlay fade

### DIFF
--- a/src/components/Homepage/CodeExamples.tsx
+++ b/src/components/Homepage/CodeExamples.tsx
@@ -147,7 +147,6 @@ const CodeExamples = ({ title, codeExamples }: CodeExamplesProps) => {
           ))}
         </Accordion>
       </WindowBox>
-      {isModalOpen && (
         <CodeModal
           isOpen={isModalOpen}
           setIsOpen={setModalOpen}
@@ -166,7 +165,6 @@ const CodeExamples = ({ title, codeExamples }: CodeExamplesProps) => {
             </Codeblock>
           )}
         </CodeModal>
-      )}
     </div>
   )
 }

--- a/src/components/ui/dialog-modal.tsx
+++ b/src/components/ui/dialog-modal.tsx
@@ -10,10 +10,10 @@ import { Center, Flex } from "./flex"
 
 const dialogVariant = tv({
   slots: {
-    content:
-      "data-[state=open]:animate-contentShow w-full grid gap-4 rounded-md bg-background p-8 shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] focus:outline-none z-modal",
-    overlay:
-      "data-[state=open]:animate-overlayShow overflow-y-auto p-4 grid place-items-center fixed inset-0 bg-black/70 z-overlay",
+    content: 
+      "w-full grid gap-4 rounded-md bg-background p-8 shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] focus:outline-none z-modal data-[state=open]:animate-slide-up data-[state=closed]:animate-slide-down",
+    overlay: 
+      "data-[state=open]:animate-overlayShow data-[state=closed]:animate-overlay-fade-out fixed inset-0 z-overlay bg-black/70 grid place-items-end overflow-hidden p-0",
     header: "relative pe-12",
     title: "text-2xl",
     footer: "pt-8",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -313,6 +313,26 @@ const config = {
           "75%": { transform: "rotate(-5deg)" },
           "100%": { transform: "rotate(0deg)" },
         },
+        "slide-up": {
+          "0%": { transform: "translateY(100%)", opacity: "0" },
+          "100%": { transform: "translateY(0)", opacity: "1" },
+        },
+        "slide-down": {
+          "0%": { transform: "translateY(0)", opacity: "1" },
+          "100%": { transform: "translateY(100%)", opacity: "0" },
+        },
+        "overlay-fade-out": {
+          "0%":   { opacity: "1" },
+          "100%": { opacity: "0" },
+        },
+        overlayShow: {
+          from: { opacity: "0" },
+          to:   { opacity: "1" },
+        },
+        overlayFadeOut: {
+          from: { opacity: "1" },
+          to:   { opacity: "0" },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
@@ -332,6 +352,10 @@ const config = {
         "pulse-light": "pulse-light 2s cubic-bezier(0.4, 0, 0.6, 1) infinite",
         "fade-in": "fade-in 150ms ease-in-out",
         wave: "rotate-back-and-forth 1s linear infinite",
+        "slide-up": "slide-up 0.28s cubic-bezier(.16,1,.3,1)",
+        "slide-down": "slide-down 0.22s ease-in",
+        "overlay-fade-out": "overlay-fade-out 0.18s ease-in",
+        overlayShow: "overlayShow 180ms ease-out",
       },
       // Add custom border-radius tailwinds extension for "4xl" as "2rem"
       borderRadius: {


### PR DESCRIPTION

## Description

This PR updates the modal component to improve UX by adding open and close animations for both the modal content and the overlay background.

* **`CodeExamples.tsx`**:

  * Removed conditional rendering of `CodeModal` to allow close animation before unmounting.
* **`dialog-modal.tsx`**:

  * Replaced `animate-contentShow` with `slide-up` and `slide-down` animations.
  * Added `overlay-fade-out` animation for smooth background disappearance.
  * Adjusted overlay positioning (`grid place-items-end`, `overflow-hidden`).

These changes ensure that when the modal closes, it slides down instead of disappearing abruptly.

## Before / After


**▶ Before (open/close without smooth close)**

https://github.com/user-attachments/assets/2889309e-8e34-43a4-8018-f39556ee71bb



**▶ After (slide-up on open, slide-down on close, overlay fade)**

https://github.com/user-attachments/assets/5a8070f8-26c4-4e95-8b08-2aee2376efab




