### PR TITLE
docs: React's updated link

### DIFF
--- a/docs/stack.md
+++ b/docs/stack.md
@@ -7,7 +7,7 @@
   - Configurable in `next.config.js`
   - [NextJS Tutorial](https://nextjs.org/learn)
   - [NextJS Docs](https://nextjs.org/docs)
-- [React](https://reactjs.org/) - A JavaScript library for building component-based user interfaces
+- [React](https://react.dev/) - A JavaScript library for building component-based user interfaces
 - [Typescript](https://www.typescriptlang.org/) - TypeScript is a strongly typed programming language that builds on JavaScript
 - [Chakra UI](https://chakra-ui.com/) - A UI library (Migration in progress)
 - [Algolia](https://www.algolia.com/) - Site indexing, rapid intra-site search results, and search analytics. [Learn more on how we implement Algolia for site search](./site-search.md).


### PR DESCRIPTION
## Description

The link to React has been updated (https://react.dev/) (new domain).
