### PR TITLE
Hotfix dapps redirect

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -160,6 +160,9 @@
 
 /*/use /:splat/apps/ 301!
 
+# Exception: don't redirect developers/docs/dapps paths
+/*/developers/docs/dapps* 200!
+
 /*/dapps /:splat/apps/ 301!
 
 /*/contributing/translation-program/translation-guide/ /:splat/contributing/translation-program/faq/ 301!


### PR DESCRIPTION
Current redirect structure is redirection /developers/docs/dapps to /developers/docs/apps

This PR adds condition to maintain /developers/docs/dapps as a valid path
