### PR TITLE
hotfix /apps redirect making /developers/docs/dapps unreachable

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -161,7 +161,7 @@
 /*/use /:splat/apps/ 301!
 
 # Exception: don't redirect developers/docs/dapps paths
-/*/developers/docs/dapps* 200!
+/*/developers/docs/dapps* /:splat/developers/docs/dapps:splat 200!
 
 /*/dapps /:splat/apps/ 301!
 

--- a/public/_redirects
+++ b/public/_redirects
@@ -160,6 +160,9 @@
 
 /*/use /:splat/apps/ 301!
 
+# Exception: don't redirect developers/docs/dapps paths
+/*/developers/docs/dapps* 200!
+
 /*/dapps /:splat/apps/ 301!
 
 /*/contributing/translation-program/translation-guide/ /:splat/contributing/translation-program/faq/ 301!

--- a/src/components/Translatathon/TranslatathonCalendar.tsx
+++ b/src/components/Translatathon/TranslatathonCalendar.tsx
@@ -35,7 +35,7 @@ const events = [
       "https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=NWU3ZzE3czNyazViYXVqcjNqZnQ5dHYxMmMgY185ZTRiMWIyNzYwNzQzNDYzODE2MTAwYTE2OWQxNDI0MzAzNTJhN2NmYzMzNDRiMWU3ODVkYjUyMzg1YzlmZDM2QGc&tmsrc=c_9e4b1b2760743463816100a169d142430352a7cfc3344b1e785db52385c9fd36%40group.calendar.google.com",
   },
   {
-    date: "2024-08-25T12:00:00Z",
+    date: "2025-08-25T12:00:00Z",
     title: "Translatathon kickoff call",
     calendarLink:
       "https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=MzBzYzQ0ODU5YnZkNHNiY251bDl0M2M2bnMgY185ZTRiMWIyNzYwNzQzNDYzODE2MTAwYTE2OWQxNDI0MzAzNTJhN2NmYzMzNDRiMWU3ODVkYjUyMzg1YzlmZDM2QGc&tmsrc=c_9e4b1b2760743463816100a169d142430352a7cfc3344b1e785db52385c9fd36%40group.calendar.google.com",


### PR DESCRIPTION
Current redirect structure is redirection /developers/docs/dapps to /developers/docs/apps

This PR adds condition to maintain /developers/docs/dapps as a valid path

https://deploy-preview-16097--ethereumorg.netlify.app/en/developers/docs/dapps