### PR TITLE
seo: use descriptive link label

### DIFF
--- a/src/intl/en/page-index.json
+++ b/src/intl/en/page-index.json
@@ -17,7 +17,7 @@
   "page-index-bento-networks-action": "Explore benefits",
   "page-index-bento-networks-content": "Ethereum is the hub for blockchain innovation. The best projects are built on Ethereum.",
   "page-index-bento-networks-title": "The network of networks",
-  "page-index-bento-stablecoins-action": "Learn more",
+  "page-index-bento-stablecoins-action": "Discover stablecoins",
   "page-index-bento-stablecoins-content": "Stablecoins are currencies that maintain stable value. Their price matches the U.S. dollar or other steady assets.",
   "page-index-bento-stablecoins-title": "Crypto without volatility",
   "page-index-builders-action-primary": "Builder's Portal",


### PR DESCRIPTION
## Description
- Applies descriptive label to `/stablecoins/` link on homepage

## Related Issue
<img width="870" height="602" alt="image" src="https://github.com/user-attachments/assets/a981b5ad-a656-4d34-a153-adbf23e418ce" />

https://developer.chrome.com/docs/lighthouse/seo/link-text