### PR TITLE
patch: use fallback/original variant for non-EN A/B tests

### DIFF
--- a/src/components/AB/TestWrapper.tsx
+++ b/src/components/AB/TestWrapper.tsx
@@ -1,6 +1,9 @@
+import { getLocale } from "next-intl/server"
 import type { ReactNode } from "react"
 
 import { IS_PREVIEW_DEPLOY, IS_PROD } from "@/lib/utils/env"
+
+import { DEFAULT_LOCALE } from "@/lib/constants"
 
 import { ClientABTestWrapper } from "./ClientABTestWrapper"
 import { ABTestDebugPanel } from "./TestDebugPanel"
@@ -20,6 +23,9 @@ const ABTestWrapper = async ({
   variants,
   fallback,
 }: ABTestWrapperProps) => {
+  const locale = await getLocale()
+  if (locale !== DEFAULT_LOCALE) return <>{fallback || variants[0]}</>
+
   try {
     // Get deterministic assignment
     const assignment = await getABTestAssignment(testKey)

--- a/src/components/AB/TestWrapper.tsx
+++ b/src/components/AB/TestWrapper.tsx
@@ -16,15 +16,18 @@ type ABTestWrapperProps = {
   testKey: string
   variants: ABTestVariants
   fallback?: ReactNode
+  enableAllLocales?: boolean
 }
 
 const ABTestWrapper = async ({
   testKey,
   variants,
   fallback,
+  enableAllLocales,
 }: ABTestWrapperProps) => {
   const locale = await getLocale()
-  if (locale !== DEFAULT_LOCALE) return <>{fallback || variants[0]}</>
+  if (locale !== DEFAULT_LOCALE && !enableAllLocales)
+    return <>{fallback || variants[0]}</>
 
   try {
     // Get deterministic assignment


### PR DESCRIPTION
## Description
- Within `ABTestWrapper` component, check locale—if non-English, return fallback/original variant
- Adds `enableAllLocales` boolean prop to override and allow test component to render for all locales

## Related Issue
A/B test cases to use English by default—should avoid rendering English test cases on non-English locales