### PR TITLE
Add ETHBhopal meetup to community meetups data

### DIFF
--- a/src/data/community-meetups.json
+++ b/src/data/community-meetups.json
@@ -574,5 +574,11 @@
     "emoji": ":belgium:",
     "location": "Belgium",
     "link": "https://lu.ma/ethbelgium"
-  }   
+  },
+  {
+  "title": "ETHBhopal",
+  "emoji": ":india:",
+  "location": "Bhopal",
+  "link": "https://x.com/ETHBhopal"
+}
 ]


### PR DESCRIPTION

This PR adds a new Ethereum community meetup based in Bhopal, India to the community-meetups.json file on the Ethereum.org website.

The following details were added:
`{
  "title": "EthBhopal",
  "emoji": ":india:",
  "location": "Bhopal",
  "link": "https://x.com/ETHBhopal"
}
`
This inclusion will help increase visibility for the EthBhopal community and allow developers, enthusiasts, and contributors in the region to connect more easily.