### PR TITLE
Fix minor typo

### DIFF
--- a/public/content/developers/tutorials/optimism-std-bridge-annotated-code/index.md
+++ b/public/content/developers/tutorials/optimism-std-bridge-annotated-code/index.md
@@ -572,7 +572,7 @@ Only cells that are set to a different value are written to storage.
 ```
 
 To want to be able to upgrade this contract without having to copy all the variables in the storage.
-To do that we use a [`Proxy`](https://docs.openzeppelin.com/contracts/3.x/api/proxy), a contract that uses [`delegatecall`](https://solidity-by-example.org/delegatecall/) to transfer calls to a separate contact whose address is stored by the proxy contract (when you upgrade you tell the proxy to change that address).
+To do that we use a [`Proxy`](https://docs.openzeppelin.com/contracts/3.x/api/proxy), a contract that uses [`delegatecall`](https://solidity-by-example.org/delegatecall/) to transfer calls to a separate contract whose address is stored by the proxy contract (when you upgrade you tell the proxy to change that address).
 When you use `delegatecall` the storage remains the storage of the _calling_ contract, so the values of all the contract state variables are unaffected.
 
 One effect of this pattern is that the storage of the contract that is the _called_ of `delegatecall` is not used and therefore the constructor values passed to it do not matter.


### PR DESCRIPTION
Typo was pointed out in the issue below..

## Description

Simply fixed the issue by correcting the word `contract` that was misspelled as `contact` without the letter `R`.

## Related Issue

#16150
