### PR TITLE
Sentry traces sample rate

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -29,7 +29,7 @@ function findClosestElementId(
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  tracesSampleRate: 0.1,
+  tracesSampleRate: 0.01,
   debug: environment === "development",
   environment,
   enabled: environment === "production",

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -4,8 +4,9 @@ const environment = process.env.NEXT_PUBLIC_CONTEXT || "development"
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  tracesSampleRate: 0.1,
+  tracesSampleRate: 0.01,
   debug: environment === "development",
   environment,
   enabled: environment === "production",
+  ignoreTransactions: ["middleware"],
 })

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -4,8 +4,9 @@ const environment = process.env.NEXT_PUBLIC_CONTEXT || "development"
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  tracesSampleRate: 0.1,
+  tracesSampleRate: 0.01,
   debug: environment === "development",
   environment,
   enabled: environment === "production",
+  ignoreTransactions: ["middleware"],
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Reduces it to `0.01` and ignores `middleware` transactions.
