### PR TITLE
feat: skip importing events that have completed

### DIFF
--- a/src/scripts/events/ethereum-events-import.ts
+++ b/src/scripts/events/ethereum-events-import.ts
@@ -69,6 +69,8 @@ export async function EthereumEventsImport(year: number) {
       start = Date.parse(`${startDate}, ${year} GMT`)
       end = Date.parse(`${endDate}, ${year} GMT`)
       if (Number.isNaN(start) || Number.isNaN(end)) continue
+      // Skip events that have already ended
+      if (end < Date.now()) continue
     } catch (e) {
       console.log("Invalid date", i[0])
       continue


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Updates `src/scripts/events/ethereum-events-import.ts` script to skip events with end dates that have already passed

## Related Issue
Monthly community event imports pulling in completed events