### PR TITLE
docs: fix outdated Hardhat repository link

### DIFF
--- a/public/content/developers/docs/development-networks/index.md
+++ b/public/content/developers/docs/development-networks/index.md
@@ -35,7 +35,7 @@ A local Ethereum network designed for development. It allows you to deploy your 
 Hardhat Network comes built-in with Hardhat, an Ethereum development environment for professionals.
 
 - [Website](https://hardhat.org/)
-- [GitHub](https://github.com/nomiclabs/hardhat)
+- [GitHub](https://github.com/NomicFoundation/hardhat)
 
 ### Local Beacon Chains {#local-beacon-chains}
 


### PR DESCRIPTION
## Description

noticed that the Hardhat link in our docs/code was pointing to the old repository.
updated it to the official one at NomicFoundation to ensure references are correct.
