### PR TITLE
feat(DS): add Blockquote markdown component

### DIFF
--- a/src/components/MdComponents/index.tsx
+++ b/src/components/MdComponents/index.tsx
@@ -106,7 +106,7 @@ export const Paragraph = (props: ChildOnlyProp) => (
 
 export const Blockquote = (props: ChildOnlyProp) => (
   <blockquote
-    className="mb-4 mt-8 border-l-2 border-accent-a bg-accent-a/10 p-6 [&>:first-child]:mt-0 [&>:last-child]:mb-0"
+    className="mb-4 mt-8 border-s-2 border-accent-a bg-accent-a/10 p-6 [&>:first-child]:mt-0 [&>:last-child]:mb-0"
     {...props}
   />
 )


### PR DESCRIPTION
## Description
Per @ryangoree:

- Adds a `Blockquote` component for quotes/callouts in markdown pages.
  __Before:__
  <img width="830" height="227" alt="image" src="https://github.com/user-attachments/assets/582c63e2-6dc9-4dd8-91b4-8e992e9108d7" />
  
  __After:__
  <img width="832" height="274" alt="image" src="https://github.com/user-attachments/assets/7bbd276e-fe32-4b73-b5b5-4228ff47aedf" />
