### PR TITLE
adding a clause about alt L1 wallet providers to listing criteria

### DIFF
--- a/public/content/contributing/adding-wallets/index.md
+++ b/public/content/contributing/adding-wallets/index.md
@@ -27,7 +27,7 @@ Wallets are rapidly changing in Ethereum. We've tried to create a fair framework
 - **Point of contact** - A point of contact for the wallet will greatly help us get accurate information when changes are made. This will keep updating ethereum.org manageable when gathering future information.
 - **EIP-1559 (type 2) transactions** - your wallet must support EIP-1559 (type 2) transactions for transactions on Mainnet Ethereum.
 - **Good user experience** - While UX is subjective, if several core team members test the product and find it difficult to use, we reserve the right to reject the wallet and will instead provide useful suggestions to improve. This is done to protect our user base that is mostly comprised of beginners.
-- **Ethereum focused** - A wallet must provide a primary Ethereum-focused experience. This means Ethereum (or any L2) is set as the default network, ERC assets are properly supported, and features are aligned with the Ethereum ecosystem (e.g., ENS, staking, rollups). Wallets that prioritize in the UI alternative layer 1s will not be listed. 
+- **Ethereum focused** - A wallet must provide a primary Ethereum-focused experience. This means Ethereum (or any L2) is set as the default network, ERC assets are properly supported, and features are aligned with the Ethereum ecosystem. Wallets that prioritize in the UI alternative layer 1s will not be listed. 
 
 ### Product removals {#product-removals}
 


### PR DESCRIPTION
To clarify listing priorities, this should be explicitly stated.

Ethereum.org is primarily focused on serving ethereum ecosystem, therefore we should not be listing products that prioritize alternative layer 1s if there are equal or better alternative projects that do optimize their interface to ethereum ecosystem.