### PR TITLE
docs: fix outdated Solidity syntax in contract

### DIFF
--- a/public/content/developers/docs/smart-contracts/compiling/index.md
+++ b/public/content/developers/docs/smart-contracts/compiling/index.md
@@ -20,7 +20,7 @@ pragma solidity 0.4.24;
 
 contract Greeter {
 
-    function greet() public constant returns (string) {
+    function greet() public view returns (string memory) {
         return "Hello";
     }
 


### PR DESCRIPTION
## Description

updated the contract to match current Solidity standards.

* replaced `constant` with `view`
* changed `returns (string)` to `returns (string memory)`

this resolves compilation warnings on newer Solidity versions.

