### PR TITLE
docs: update outdated Alchemy NFT API docs link

### DIFF
--- a/public/content/developers/docs/standards/tokens/erc-1155/index.md
+++ b/public/content/developers/docs/standards/tokens/erc-1155/index.md
@@ -143,4 +143,4 @@ _Note_: All batch functions including the hook also exist as versions without ba
 - [EIP-1155: Multi Token Standard](https://eips.ethereum.org/EIPS/eip-1155)
 - [ERC-1155: Openzeppelin Docs](https://docs.openzeppelin.com/contracts/5.x/erc1155)
 - [ERC-1155: GitHub Repo](https://github.com/enjin/erc-1155)
-- [Alchemy NFT API](https://docs.alchemy.com/alchemy/enhanced-apis/nft-api)
+- [Alchemy NFT API](https://www.alchemy.com/docs/reference/nft-api-quickstart)


### PR DESCRIPTION
## Description

the old link to the NFT API docs was no longer valid.
updated it to the current reference page to avoid broken redirects and ensure developers can find the right documentation quickly.
