### PR TITLE
fix: stablecoin accordion indicator

### DIFF
--- a/src/components/StablecoinAccordion/AccordionCustomItem.tsx
+++ b/src/components/StablecoinAccordion/AccordionCustomItem.tsx
@@ -34,18 +34,6 @@ export const RightColumnPanel = (props: ChildOnlyProp) => (
   />
 )
 
-const MoreOrLessLink = ({ isOpen }: { isOpen: boolean }) => {
-  const { t } = useTranslation("page-stablecoins")
-
-  return (
-    <div className="me-6 text-md text-primary">
-      {isOpen
-        ? t("page-stablecoins-accordion-less")
-        : t("page-stablecoins-accordion-more")}
-    </div>
-  )
-}
-
 interface AccordionCustomItemProps {
   /**
    * The category name of each accordion section
@@ -66,8 +54,7 @@ export const AccordionCustomItem = (props: AccordionCustomItemProps) => {
   return (
     <AccordionItem value={contentObj.title} className="border">
       <AccordionTrigger
-        hideIcon
-        className="items-center justify-between px-0 py-0 text-body-medium hover:text-body-medium md:px-0"
+        className="items-center justify-between py-0 ps-0 text-body-medium hover:text-body-medium"
         onClick={handleOpen}
       >
         <Flex
@@ -97,7 +84,6 @@ export const AccordionCustomItem = (props: AccordionCustomItemProps) => {
             </p>
           </div>
         </Flex>
-        <MoreOrLessLink isOpen={open} />
       </AccordionTrigger>
       <AccordionContent className="-mx-px -mb-px mt-0 border border-border bg-background p-0 text-md md:p-0">
         <Flex className="flex-col justify-between p-8 lg:flex-row">

--- a/src/intl/en/page-stablecoins.json
+++ b/src/intl/en/page-stablecoins.json
@@ -38,8 +38,6 @@
   "page-stablecoins-accordion-earn-requirements-description": "Stablecoins are a great method of payment for work and services because the value is stable. But you'll need a wallet to be paid.",
   "page-stablecoins-accordion-earn-text-preview": "You can earn stablecoins by working on projects within the Ethereum ecosystem.",
   "page-stablecoins-accordion-earn-title": "Earn",
-  "page-stablecoins-accordion-less": "Less",
-  "page-stablecoins-accordion-more": "More",
   "page-stablecoins-accordion-requirements": "What you'll need",
   "page-stablecoins-accordion-swap-dapp-intro": "If you’ve already got ETH and a <a href=\"/glossary/#wallet\">wallet</a>, you can use these dapps to swap for stablecoins.",
   "page-stablecoins-accordion-swap-dapp-link": "More on decentralized exchanges",


### PR DESCRIPTION
## Description
- Updates StablecoinAccordion to use default chevron icon from design system instead of more/less
- Fixes bug where opening two or more items in succession was not switching "Less" back to "More"
- Removes now-unused "More"/"Less" intl strings

## Related issue
- Fixes #15398 