### PR TITLE
docs: Update Plural Funding link

### DIFF
--- a/public/content/zero-knowledge-proofs/index.md
+++ b/public/content/zero-knowledge-proofs/index.md
@@ -90,7 +90,7 @@ Defined as “coordinating to limit open competition by deceiving, defrauding, a
 
 Bribery and collusion limit the effectiveness of any process that uses voting as a signaling mechanism (especially where users can prove how they voted). This can have significant consequences, especially where the votes are responsible for allocating scarce resources.
 
-For example, [quadratic funding mechanisms](https://www.radicalxchange.org/concepts/plural-funding/) rely on donations to measure preference for certain options among different public good projects. Each donation counts as a "vote" for a specific project, with projects that receive more votes getting more funds from the matching pool.
+For example, [quadratic funding mechanisms](https://www.radicalxchange.org/wiki/plural-funding/) rely on donations to measure preference for certain options among different public good projects. Each donation counts as a "vote" for a specific project, with projects that receive more votes getting more funds from the matching pool.
 
 Using onchain voting makes quadratic funding susceptible to collusion: blockchain transactions are public, so bribers can inspect a bribee’s onchain activity to see how they “voted”. This way quadratic funding ceases to be an effective means for allocating funds based on the aggregated preferences of the community.
 


### PR DESCRIPTION
## Description

The old link was outdated, so I swapped it for the current wiki page:
[https://www.radicalxchange.org/wiki/plural-funding/](https://www.radicalxchange.org/wiki/plural-funding/)
