### PR TITLE
Patch home hero story

### DIFF
--- a/src/components/Hero/HomeHero/HomeHero.stories.tsx
+++ b/src/components/Hero/HomeHero/HomeHero.stories.tsx
@@ -20,5 +20,8 @@ const meta = {
 export default meta
 
 export const HomeHero: StoryObj<typeof meta> = {
-  render: () => <HomeHeroComponent />,
+  // This story is disabled because HomeHero is a React Server Component
+  // and Storybook's support for RSC is still experimental and not stable
+  // render: () => <HomeHeroComponent />,
+  render: () => <div>HomeHero</div>,
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Disables the home hero story due to the lack of RSC support in SB.
