### PR TITLE
Patch findwallets native search

### DIFF
--- a/src/components/FindWalletProductTable/index.tsx
+++ b/src/components/FindWalletProductTable/index.tsx
@@ -68,6 +68,7 @@ const FindWalletProductTable = ({ wallets }: { wallets: WalletRow[] }) => {
             )}
             filters={filters}
             matomoEventCategory="find-wallet"
+            estimateSize={300}
           />
         </>
       )}

--- a/src/components/ProductTable/List.tsx
+++ b/src/components/ProductTable/List.tsx
@@ -21,6 +21,7 @@ type ListProps<T extends { id: string }> = {
   ) => React.ReactNode
   matomoEventCategory: string
   filters: FilterOption[]
+  estimateSize: number
 }
 
 const List = <T extends { id: string }>({
@@ -28,6 +29,7 @@ const List = <T extends { id: string }>({
   subComponent,
   matomoEventCategory,
   filters,
+  estimateSize,
 }: ListProps<T>) => {
   const [expanded, setExpanded] = useState<Record<string, boolean>>({})
 
@@ -36,7 +38,7 @@ const List = <T extends { id: string }>({
 
   const virtualizer = useWindowVirtualizer({
     count: data.length,
-    estimateSize: () => 300,
+    estimateSize: () => estimateSize,
     overscan: 5,
     scrollMargin: parentOffsetRef.current,
   })
@@ -90,6 +92,26 @@ const List = <T extends { id: string }>({
         height: `${virtualizer.getTotalSize()}px`,
       }}
     >
+      <div aria-hidden="true" style={{ position: "absolute", inset: 0 }}>
+        {data.map((item, index) => (
+          <div
+            key={`search-ghost-${item.id}`}
+            style={{
+              position: "absolute",
+              left: 0,
+              width: "100%",
+              // Approximate vertical position using your estimate and scrollMargin
+              transform: `translateY(${estimateSize * index - virtualizer.options.scrollMargin}px)`,
+              opacity: 0,
+              pointerEvents: "none",
+              // Ensure it contributes text for Ctrl+F but avoids layout
+              height: 0,
+            }}
+          >
+            {(item as unknown as Wallet).name}
+          </div>
+        ))}
+      </div>
       {virtualizer.getVirtualItems().map((virtualItem) => {
         const item = data[virtualItem.index]
 


### PR DESCRIPTION
## Description
With the recent introduction of the virtualized list (#16233), the native browser search (Ctrl+F) no longer works as expected. Items that are not currently visible are unmounted, so they cannot be found via the search.

This PR mitigates the issue by rendering “ghost” elements containing wallet names. This way, all wallet names remain discoverable with the native search. When matched, the user can scroll to the approximate position of the wallet. While not pixel-perfect, this at least ensures that users can locate wallets using the browser’s search functionality.

### TODO
If it works, move the ghost list to its own component and memo it to avoid perf impact.