### PR TITLE
docs: fix outdated wagmi docs links

### DIFF
--- a/public/content/developers/tutorials/creating-a-wagmi-ui-for-your-contract/index.md
+++ b/public/content/developers/tutorials/creating-a-wagmi-ui-for-your-contract/index.md
@@ -95,7 +95,7 @@ The application is going inside [a `React.StrictMode` component](https://react.d
     <WagmiConfig config={config}>
 ```
 
-The application is also inside [a `WagmiConfig` component](https://wagmi.sh/react/WagmiConfig). [The wagmi (we are going to make it) library](https://wagmi.sh/) connects the React UI definitions with [the viem library](https://viem.sh/) for writing an Ethereum decentralized application.
+The application is also inside [a `WagmiConfig` component](https://wagmi.sh/react/api/WagmiProvider). [The wagmi (we are going to make it) library](https://wagmi.sh/) connects the React UI definitions with [the viem library](https://viem.sh/) for writing an Ethereum decentralized application.
 
 ```tsx
       <RainbowKitProvider chains={chains}>
@@ -134,7 +134,7 @@ This is the standard way to create a React component - define a function that is
   const { isConnected } = useAccount()
 ```
 
-Here we use [`useAccount`](https://wagmi.sh/react/hooks/useAccount) to check if we are connected to a blockchain through a wallet or not.
+Here we use [`useAccount`](https://wagmi.sh/react/api/hooks/useAccount) to check if we are connected to a blockchain through a wallet or not.
 
 By convention, in React functions called `use...` are [hooks](https://www.w3schools.com/react/react_hooks.asp) that return some kind of data. When you use such hooks, not only does your component get the data, but when that data changes the component is re-rendered with the updated information.
 


### PR DESCRIPTION
## Description

some documentation links were pointing to old pages.
updated them to the new API references
