### PR TITLE
intl: add translations for eth-vs-btc common strings

### DIFF
--- a/src/intl/am/common.json
+++ b/src/intl/am/common.json
@@ -431,5 +431,8 @@
   "withdrawals": "ቀብድ ማውጣት",
   "wrapped-ether": "የታሸገ ኢተር",
   "yes": "አዎ",
-  "zero-knowledge-proofs": "የዜሮ-ዕውቀት ማረጋገጫዎች"
+  "zero-knowledge-proofs": "የዜሮ-ዕውቀት ማረጋገጫዎች",
+  "ethereum-vs-bitcoin": "ኢቴሬም ከ ቢትኮይን",
+  "nav-ethereum-vs-bitcoin-description": "በኢቴሬም እና በቢትኮይን መካከል ያለውን ልዩነት ይረዱ"
+
 }

--- a/src/intl/ar/common.json
+++ b/src/intl/ar/common.json
@@ -432,5 +432,8 @@
   "withdrawals": "عمليات سحب تجميد العملات",
   "wrapped-ether": "Wrapped Ether",
   "yes": "نعم",
-  "zero-knowledge-proofs": "براهين المعرفة الصفرية"
+  "zero-knowledge-proofs": "براهين المعرفة الصفرية",
+  "ethereum-vs-bitcoin": "الإيثيريوم مقابل البيتكوين",
+  "nav-ethereum-vs-bitcoin-description": "فهم الاختلافات بين الإيثيريوم والبيتكوين"
+
 }

--- a/src/intl/az/common.json
+++ b/src/intl/az/common.json
@@ -431,5 +431,8 @@
   "withdrawals": "Payın çıxarılması",
   "wrapped-ether": "Tokenləşdirilmiş Ether",
   "yes": "Bəli",
-  "zero-knowledge-proofs": "Sıfır biliklərlə təsdiqləmə"
+  "zero-knowledge-proofs": "Sıfır biliklərlə təsdiqləmə",
+  "ethereum-vs-bitcoin": "Ethereum və Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Ethereum və Bitcoin arasındakı fərqləri anlayın"
+
 }

--- a/src/intl/be/common.json
+++ b/src/intl/be/common.json
@@ -431,5 +431,8 @@
   "withdrawals": "Вывад ставак",
   "wrapped-ether": "Wrapped Ether",
   "yes": "Так",
-  "zero-knowledge-proofs": "Доказ з нулявым раскрыццём"
+  "zero-knowledge-proofs": "Доказ з нулявым раскрыццём",
+  "ethereum-vs-bitcoin": "Ethereum супраць Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Зразумейце адрозненні паміж Ethereum і Bitcoin"
+
 }

--- a/src/intl/bg/common.json
+++ b/src/intl/bg/common.json
@@ -431,5 +431,8 @@
   "withdrawals": "Тегления на залози",
   "wrapped-ether": "Опакован Етер",
   "yes": "Да",
-  "zero-knowledge-proofs": "Доказателства за нулево знание"
+  "zero-knowledge-proofs": "Доказателства за нулево знание",
+  "ethereum-vs-bitcoin": "Етереум срещу Биткойн",
+  "nav-ethereum-vs-bitcoin-description": "Разберете разликите между Етереум и Биткойн"
+
 }

--- a/src/intl/bn/common.json
+++ b/src/intl/bn/common.json
@@ -432,5 +432,8 @@
   "withdrawals": "স্টেকিং উইথড্রয়াল",
   "wrapped-ether": "র‍্যাপড ইথার",
   "yes": "হ্যাঁ",
-  "zero-knowledge-proofs": "শূন্য-জ্ঞান প্রমাণ"
+  "zero-knowledge-proofs": "শূন্য-জ্ঞান প্রমাণ",
+  "ethereum-vs-bitcoin": "ইথেরিয়াম বনাম বিটকয়েন",
+  "nav-ethereum-vs-bitcoin-description": "ইথেরিয়াম এবং বিটকয়েনের মধ্যে পার্থক্য বুঝুন"
+
 }

--- a/src/intl/bs/common.json
+++ b/src/intl/bs/common.json
@@ -428,5 +428,8 @@
   "withdrawals": "Povlačenje uloga",
   "wrapped-ether": "Wrapped Ether",
   "yes": "Da",
-  "zero-knowledge-proofs": "Dokazi sa nula-znanjem"
+  "zero-knowledge-proofs": "Dokazi sa nula-znanjem",
+  "ethereum-vs-bitcoin": "Ethereum protiv Bitcoina",
+  "nav-ethereum-vs-bitcoin-description": "Razumjeti razlike između Ethereuma i Bitcoina"
+
 }

--- a/src/intl/ca/common.json
+++ b/src/intl/ca/common.json
@@ -443,5 +443,8 @@
   "withdrawals": "Retirada d'apilaments",
   "wrapped-ether": "Ether embolicat",
   "yes": "Sí",
-  "zero-knowledge-proofs": "Proves de coneixement zero"
+  "zero-knowledge-proofs": "Proves de coneixement zero",
+  "ethereum-vs-bitcoin": "Ethereum vs. Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Entendre les diferències entre Ethereum i Bitcoin"
+
 }

--- a/src/intl/cs/common.json
+++ b/src/intl/cs/common.json
@@ -444,5 +444,8 @@
   "withdrawals": "Uzamčení výběrů",
   "wrapped-ether": "Zabalený Ether",
   "yes": "Ano",
-  "zero-knowledge-proofs": "Důkazy s nulovou znalostí"
+  "zero-knowledge-proofs": "Důkazy s nulovou znalostí",
+  "ethereum-vs-bitcoin": "Ethereum vs. Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Pochopte rozdíly mezi Ethereem a Bitcoinem"
+
 }

--- a/src/intl/da/common.json
+++ b/src/intl/da/common.json
@@ -431,5 +431,8 @@
   "withdrawals": "Udtrækning af Indsatser",
   "wrapped-ether": "Indpakket Ether",
   "yes": "Ja",
-  "zero-knowledge-proofs": "Vidensløse beviser"
+  "zero-knowledge-proofs": "Vidensløse beviser",
+  "ethereum-vs-bitcoin": "Ethereum vs. Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Forstå forskellene mellem Ethereum og Bitcoin"
+
 }

--- a/src/intl/de/common.json
+++ b/src/intl/de/common.json
@@ -456,5 +456,8 @@
   "withdrawals": "Staking-Auszahlungen",
   "wrapped-ether": "Wrapped Ether",
   "yes": "Ja",
-  "zero-knowledge-proofs": "Null-Wissen-Beweise"
+  "zero-knowledge-proofs": "Null-Wissen-Beweise",
+  "ethereum-vs-bitcoin": "Ethereum vs. Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Verstehe die Unterschiede zwischen Ethereum und Bitcoin"
+
 }

--- a/src/intl/el/common.json
+++ b/src/intl/el/common.json
@@ -449,5 +449,8 @@
   "withdrawals": "Αναλήψεις από αποθηκευμένο κεφάλαιο",
   "wrapped-ether": "Wrapped Ether",
   "yes": "Ναι",
-  "zero-knowledge-proofs": "Απόδειξη μηδενικής γνώσης"
+  "zero-knowledge-proofs": "Απόδειξη μηδενικής γνώσης",
+  "ethereum-vs-bitcoin": "Ethereum έναντι Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Κατανοήστε τις διαφορές μεταξύ Ethereum και Bitcoin"
+
 }

--- a/src/intl/en/common.json
+++ b/src/intl/en/common.json
@@ -485,5 +485,8 @@
   "region-wake-island-usa": "Wake Island (USA)",
   "region-bonaire-netherlands": "Bonaire (Netherlands)",
   "region-saba-netherlands": "Saba (Netherlands)",
-  "region-sint-eustatius-netherlands": "Sint Eustatius (Netherlands)"
+  "region-sint-eustatius-netherlands": "Sint Eustatius (Netherlands)",
+  "ethereum-vs-bitcoin": "Ethereum vs Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Understand the differences between Ethereum and Bitcoin"
+
 }

--- a/src/intl/es/common.json
+++ b/src/intl/es/common.json
@@ -444,5 +444,8 @@
   "withdrawals": "Retiradas de participaciones",
   "wrapped-ether": "Wrapped Ether (eter envuelto)",
   "yes": "Sí",
-  "zero-knowledge-proofs": "Pruebas de conocimiento cero"
+  "zero-knowledge-proofs": "Pruebas de conocimiento cero",
+  "ethereum-vs-bitcoin": "Ethereum vs. Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Entiende las diferencias entre Ethereum y Bitcoin"
+
 }

--- a/src/intl/fa/common.json
+++ b/src/intl/fa/common.json
@@ -443,5 +443,8 @@
   "withdrawals": "برداشت‌ها از سهام‌گذاری",
   "wrapped-ether": "رپد اتر",
   "yes": "بله",
-  "zero-knowledge-proofs": "اثبات‌های دانش-صفر"
+  "zero-knowledge-proofs": "اثبات‌های دانش-صفر",
+  "ethereum-vs-bitcoin": "اتریوم در مقابل بیت‌کوین",
+  "nav-ethereum-vs-bitcoin-description": "درک تفاوت‌های بین اتریum و بیت‌کوین"
+
 }

--- a/src/intl/fi/common.json
+++ b/src/intl/fi/common.json
@@ -431,5 +431,8 @@
   "withdrawals": "Panostamisen nostot",
   "wrapped-ether": "Wrapped Ether",
   "yes": "Kyllä",
-  "zero-knowledge-proofs": "Nollatietotodistukset"
+  "zero-knowledge-proofs": "Nollatietotodistukset",
+  "ethereum-vs-bitcoin": "Ethereum vs. Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Ymmärrä Ethereumin ja Bitcoinin väliset erot"
+
 }

--- a/src/intl/fil/common.json
+++ b/src/intl/fil/common.json
@@ -431,5 +431,8 @@
   "withdrawals": "Mga pag-withdraw ng stake",
   "wrapped-ether": "Wrapped na Ether",
   "yes": "Oo",
-  "zero-knowledge-proofs": "Zero-knowledge proofs"
+  "zero-knowledge-proofs": "Zero-knowledge proofs",
+  "ethereum-vs-bitcoin": "Ethereum vs. Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Unawain ang mga pagkakaiba sa pagitan ng Ethereum at Bitcoin"
+
 }

--- a/src/intl/fr/common.json
+++ b/src/intl/fr/common.json
@@ -457,5 +457,8 @@
   "withdrawals": "Retraits de la mise en jeu",
   "wrapped-ether": "Ether enveloppé",
   "yes": "Oui",
-  "zero-knowledge-proofs": "Preuves à divulgation nulle de connaissance"
+  "zero-knowledge-proofs": "Preuves à divulgation nulle de connaissance",
+  "ethereum-vs-bitcoin": "Ethereum vs Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Comprendre les différences entre Ethereum et Bitcoin"
+
 }

--- a/src/intl/ga/common.json
+++ b/src/intl/ga/common.json
@@ -444,5 +444,8 @@
   "withdrawals": "Aistarraingtí geallchuir",
   "wrapped-ether": "Éitear fillte",
   "yes": "Tá",
-  "zero-knowledge-proofs": "Cruthúnais nialais-eolais"
+  "zero-knowledge-proofs": "Cruthúnais nialais-eolais",
+  "ethereum-vs-bitcoin": "Ethereum vs. Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Tuig na difríochtaí idir Ethereum agus Bitcoin"
+
 }

--- a/src/intl/gl/common.json
+++ b/src/intl/gl/common.json
@@ -429,5 +429,8 @@
   "withdrawals": "Retiradas de participación",
   "wrapped-ether": "Éter envolto",
   "yes": "Si",
-  "zero-knowledge-proofs": "Probas de coñecemento cero"
+  "zero-knowledge-proofs": "Probas de coñecemento cero",
+  "ethereum-vs-bitcoin": "Ethereum vs. Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Comprenda as diferenzas entre Ethereum e Bitcoin"
+
 }

--- a/src/intl/gu/common.json
+++ b/src/intl/gu/common.json
@@ -428,5 +428,8 @@
   "withdrawals": "સ્ટેકીંગ ઉપાડ",
   "wrapped-ether": "આવરિત ઈથર",
   "yes": "હા",
-  "zero-knowledge-proofs": "શૂન્ય-જાણકારી પુરાવાઓ"
+  "zero-knowledge-proofs": "શૂન્ય-જાણકારી પુરાવાઓ",
+  "ethereum-vs-bitcoin": "Ethereum વિ Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Ethereum અને Bitcoin વચ્ચેનો તફાવત સમજો"
+
 }

--- a/src/intl/ha/common.json
+++ b/src/intl/ha/common.json
@@ -430,5 +430,8 @@
   "withdrawals": "Cire Ajiya",
   "wrapped-ether": "Nade Ether",
   "yes": "Eh",
-  "zero-knowledge-proofs": "Hujjojin ilimin sifili"
+  "zero-knowledge-proofs": "Hujjojin ilimin sifili",
+  "ethereum-vs-bitcoin": "Ethereum vs Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Fahimci bambance-bambance tsakanin Ethereum da Bitcoin"
+
 }

--- a/src/intl/he/common.json
+++ b/src/intl/he/common.json
@@ -429,5 +429,8 @@
   "withdrawals": "משיכות הימור",
   "wrapped-ether": "אתר עטוף",
   "yes": "כן",
-  "zero-knowledge-proofs": "הוכחות אפס ידע"
+  "zero-knowledge-proofs": "הוכחות אפס ידע",
+  "ethereum-vs-bitcoin": "אתריום מול ביטקוין",
+  "nav-ethereum-vs-bitcoin-description": "הבן את ההבדלים בין אתריום לביטקוין"
+
 }

--- a/src/intl/hi/common.json
+++ b/src/intl/hi/common.json
@@ -432,5 +432,8 @@
   "withdrawals": "स्टेकिंग निकालना",
   "wrapped-ether": "लपेटा हुआ ईथर",
   "yes": "हाँ",
-  "zero-knowledge-proofs": "शून्य-ज्ञान प्रमाण"
+  "zero-knowledge-proofs": "शून्य-ज्ञान प्रमाण",
+  "ethereum-vs-bitcoin": "एथेरियम बनाम बिटकॉइन",
+  "nav-ethereum-vs-bitcoin-description": "एथेरियम और बिटकॉइन के बीच के अंतर को समझें"
+
 }

--- a/src/intl/hr/common.json
+++ b/src/intl/hr/common.json
@@ -431,5 +431,8 @@
   "withdrawals": "Povlačenje uloga",
   "wrapped-ether": "Zamotan Ether",
   "yes": "Da",
-  "zero-knowledge-proofs": "Dokazi nultog znanja"
+  "zero-knowledge-proofs": "Dokazi nultog znanja",
+  "ethereum-vs-bitcoin": "Ethereum protiv Bitcoina",
+  "nav-ethereum-vs-bitcoin-description": "Razumjeti razlike između Ethereuma i Bitcoina"
+
 }

--- a/src/intl/hu/common.json
+++ b/src/intl/hu/common.json
@@ -444,5 +444,8 @@
   "withdrawals": "A letétbe helyezés visszavonása",
   "wrapped-ether": "Becsomagolt ether (WETH)",
   "yes": "Igen",
-  "zero-knowledge-proofs": "Felfedés nélküli bizonyítás"
+  "zero-knowledge-proofs": "Felfedés nélküli bizonyítás",
+  "ethereum-vs-bitcoin": "Ethereum vs. Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Az Ethereum és a Bitcoin közötti különbségek megértése"
+
 }

--- a/src/intl/hy-am/common.json
+++ b/src/intl/hy-am/common.json
@@ -429,5 +429,8 @@
   "withdrawals": "Գումարի դուրսբերումներ",
   "wrapped-ether": "Փաթաթված Էթեր",
   "yes": "Այո՛",
-  "zero-knowledge-proofs": "Զրոյական գիտելիքի ապացույցներ"
+  "zero-knowledge-proofs": "Զրոյական գիտելիքի ապացույցներ",
+  "ethereum-vs-bitcoin": "Ethereum ընդդեմ Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Հասկացեք Ethereum-ի և Bitcoin-ի միջև եղած տարբերությունները"
+
 }

--- a/src/intl/id/common.json
+++ b/src/intl/id/common.json
@@ -444,5 +444,8 @@
   "withdrawals": "Penarikan penaruhan",
   "wrapped-ether": "Ether Terbungkus",
   "yes": "Ya",
-  "zero-knowledge-proofs": "Zero-Knowledge Proofs"
+  "zero-knowledge-proofs": "Zero-Knowledge Proofs",
+  "ethereum-vs-bitcoin": "Ethereum vs. Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Pahami perbedaan antara Ethereum dan Bitcoin"
+
 }

--- a/src/intl/ig/common.json
+++ b/src/intl/ig/common.json
@@ -431,5 +431,8 @@
   "withdrawals": "Mwepụ ego etinyere",
   "wrapped-ether": "Eta(Ether) akpụrụ na ụdị akara",
   "yes": "Ee",
-  "zero-knowledge-proofs": "Ihe akaebe ihe ọmụma efu"
+  "zero-knowledge-proofs": "Ihe akaebe ihe ọmụma efu",
+  "ethereum-vs-bitcoin": "Ethereum vs Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Ghọta ndịiche dị n'etiti Ethereum na Bitcoin"
+
 }

--- a/src/intl/it/common.json
+++ b/src/intl/it/common.json
@@ -444,5 +444,8 @@
   "withdrawals": "Prelievi di staking",
   "wrapped-ether": "Wrapped Ether",
   "yes": "Sì",
-  "zero-knowledge-proofs": "Dimostrazioni a conoscenza zero"
+  "zero-knowledge-proofs": "Dimostrazioni a conoscenza zero",
+  "ethereum-vs-bitcoin": "Ethereum vs. Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Comprendi le differenze tra Ethereum e Bitcoin"
+
 }

--- a/src/intl/ja/common.json
+++ b/src/intl/ja/common.json
@@ -444,5 +444,8 @@
   "withdrawals": "ステーキングの引き出し",
   "wrapped-ether": "ラップドイーサ",
   "yes": "はい",
-  "zero-knowledge-proofs": "ゼロ知識証明"
+  "zero-knowledge-proofs": "ゼロ知識証明",
+  "ethereum-vs-bitcoin": "イーサリアム vs ビットコイン",
+  "nav-ethereum-vs-bitcoin-description": "イーサリアムとビットコインの違いを理解する"
+
 }

--- a/src/intl/ka/common.json
+++ b/src/intl/ka/common.json
@@ -431,5 +431,8 @@
   "withdrawals": "სტეიკინგის გატანა",
   "wrapped-ether": "შეფუთული ეთერი",
   "yes": "კი",
-  "zero-knowledge-proofs": "ნულოვანი ცოდნის მტკიცებულებები"
+  "zero-knowledge-proofs": "ნულოვანი ცოდნის მტკიცებულებები",
+  "ethereum-vs-bitcoin": "Ethereum vs. Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "გაიგეთ განსხვავებები Ethereum-სა და Bitcoin-ს შორის"
+
 }

--- a/src/intl/kk/common.json
+++ b/src/intl/kk/common.json
@@ -428,5 +428,8 @@
   "withdrawals": "Ставкаларды шығару",
   "wrapped-ether": "Wrapped Ether",
   "yes": "Иә",
-  "zero-knowledge-proofs": "Нөлдік жария етілген дәлелдер"
+  "zero-knowledge-proofs": "Нөлдік жария етілген дәлелдер",
+  "ethereum-vs-bitcoin": "Ethereum мен Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Ethereum мен Bitcoin арасындағы айырмашылықтарды түсініңіз"
+
 }

--- a/src/intl/km/common.json
+++ b/src/intl/km/common.json
@@ -430,5 +430,8 @@
   "withdrawals": "ការដកប្រាក់តម្កល់",
   "wrapped-ether": "Wrapped Ether",
   "yes": "បាទ/ចាស",
-  "zero-knowledge-proofs": "ពិធីសារផ្ទៀងផ្ទាត់ Zero-knowledge proofs"
+  "zero-knowledge-proofs": "ពិធីសារផ្ទៀងផ្ទាត់ Zero-knowledge proofs",
+  "ethereum-vs-bitcoin": "Ethereum ទល់នឹង Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "ស្វែងយល់ពីភាពខុសគ្នារវាង Ethereum និង Bitcoin"
+
 }

--- a/src/intl/kn/common.json
+++ b/src/intl/kn/common.json
@@ -442,5 +442,8 @@
   "withdrawals": "ಪಣ ಹಿಂತೆಗೆದುಕೊಳ್ಳುವುದು",
   "wrapped-ether": "ವ್ರ್ಯಾಪ್ ಮಾಡಲಾದ ಎಥೆರ್",
   "yes": "ಹೌದು",
-  "zero-knowledge-proofs": "ಶೂನ್ಯ ಜ್ಞಾನ ಪುರಾವೆಗಳು"
+  "zero-knowledge-proofs": "ಶೂನ್ಯ ಜ್ಞಾನ ಪುರಾವೆಗಳು",
+  "ethereum-vs-bitcoin": "Ethereum vs Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Ethereum ಮತ್ತು Bitcoin ನಡುವಿನ ವ್ಯತ್ಯಾಸಗಳನ್ನು ಅರ್ಥಮಾಡಿಕೊಳ್ಳಿ"
+
 }

--- a/src/intl/ko/common.json
+++ b/src/intl/ko/common.json
@@ -455,5 +455,8 @@
   "withdrawals": "스테이킹 인출",
   "wrapped-ether": "래핑된 이더",
   "yes": "네",
-  "zero-knowledge-proofs": "영지식 증명"
+  "zero-knowledge-proofs": "영지식 증명",
+  "ethereum-vs-bitcoin": "이더리움 대 비트코인",
+  "nav-ethereum-vs-bitcoin-description": "이더리움과 비트코인의 차이점 이해하기"
+
 }

--- a/src/intl/lt/common.json
+++ b/src/intl/lt/common.json
@@ -429,5 +429,8 @@
   "withdrawals": "Palaikymo lėšų atsiėmimas",
   "wrapped-ether": "Wrapped Ether",
   "yes": "Taip",
-  "zero-knowledge-proofs": "Įrodymas be žinių"
+  "zero-knowledge-proofs": "Įrodymas be žinių",
+  "ethereum-vs-bitcoin": "Ethereum ir Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Supraskite skirtumus tarp Ethereum ir Bitcoin"
+
 }

--- a/src/intl/ml/common.json
+++ b/src/intl/ml/common.json
@@ -431,5 +431,8 @@
   "withdrawals": "സ്റ്റെയ്ക്കിങ് പിൻവലിക്കലുകൾ",
   "wrapped-ether": "സംഗ്രഹിച്ച ഈഥർ",
   "yes": "അതെ",
-  "zero-knowledge-proofs": "പൂജ്യം-അറിവ് പ്രൂഫുകൾ"
+  "zero-knowledge-proofs": "പൂജ്യം-അറിവ് പ്രൂഫുകൾ",
+  "ethereum-vs-bitcoin": "എത്തിറിയം വേഴ്സസ് ബിറ്റ്കോയിൻ",
+  "nav-ethereum-vs-bitcoin-description": "എത്തിറിയവും ബിറ്റ്കോയിനും തമ്മിലുള്ള വ്യത്യാസങ്ങൾ മനസ്സിലാക്കുക"
+
 }

--- a/src/intl/mr/common.json
+++ b/src/intl/mr/common.json
@@ -430,5 +430,8 @@
   "withdrawals": "पैसे काढणे स्टिकिंग",
   "wrapped-ether": "गुंडाळलेला इथर",
   "yes": "होय",
-  "zero-knowledge-proofs": "शून्य-ज्ञान पुरावे"
+  "zero-knowledge-proofs": "शून्य-ज्ञान पुरावे",
+  "ethereum-vs-bitcoin": "इथेरियम विरुद्ध बिटकॉइन",
+  "nav-ethereum-vs-bitcoin-description": "इथेरियम आणि बिटकॉइनमधील फरक समजून घ्या"
+
 }

--- a/src/intl/ms/common.json
+++ b/src/intl/ms/common.json
@@ -431,5 +431,8 @@
   "withdrawals": "Pertaruhan keluaran",
   "wrapped-ether": "Ether Terlindung",
   "yes": "Ya",
-  "zero-knowledge-proofs": "Bukti sifar pengetahuan"
+  "zero-knowledge-proofs": "Bukti sifar pengetahuan",
+  "ethereum-vs-bitcoin": "Ethereum lwn. Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Fahami perbezaan antara Ethereum dan Bitcoin"
+
 }

--- a/src/intl/nb/common.json
+++ b/src/intl/nb/common.json
@@ -430,5 +430,8 @@
   "withdrawals": "Staking uttak",
   "wrapped-ether": "Innpakket Ether",
   "yes": "Ja",
-  "zero-knowledge-proofs": "Null-kunnskap bevis"
+  "zero-knowledge-proofs": "Null-kunnskap bevis",
+  "ethereum-vs-bitcoin": "Ethereum vs. Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Forstå forskjellene mellom Ethereum og Bitcoin"
+
 }

--- a/src/intl/ne-np/common.json
+++ b/src/intl/ne-np/common.json
@@ -427,5 +427,8 @@
   "withdrawals": "स्टेकिंग निकासी",
   "wrapped-ether": "बेरिएको Ether",
   "yes": "हो",
-  "zero-knowledge-proofs": "शून्य-ज्ञान प्रमाणहरू"
+  "zero-knowledge-proofs": "शून्य-ज्ञान प्रमाणहरू",
+  "ethereum-vs-bitcoin": "इथेरियम बनाम बिटकोइन",
+  "nav-ethereum-vs-bitcoin-description": "इथेरियम र बिटकोइन बीचको भिन्नताहरू बुझ्नुहोस्"
+
 }

--- a/src/intl/nl/common.json
+++ b/src/intl/nl/common.json
@@ -441,5 +441,8 @@
   "withdrawals": "Opnames staken",
   "wrapped-ether": "Wrapped Ether",
   "yes": "Ja",
-  "zero-knowledge-proofs": "Zero-knowledge proofs"
+  "zero-knowledge-proofs": "Zero-knowledge proofs",
+  "ethereum-vs-bitcoin": "Ethereum vs. Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "De verschillen tussen Ethereum en Bitcoin begrijpen"
+
 }

--- a/src/intl/pcm/common.json
+++ b/src/intl/pcm/common.json
@@ -431,5 +431,8 @@
   "withdrawals": "To dey stake witdrawals",
   "wrapped-ether": "Ether wey dem wrap",
   "yes": "Na so",
-  "zero-knowledge-proofs": "Zero-knowledge prufs"
+  "zero-knowledge-proofs": "Zero-knowledge prufs",
+  "ethereum-vs-bitcoin": "Ethereum vs Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Understand di difrens between Ethereum and Bitcoin"
+
 }

--- a/src/intl/pl/common.json
+++ b/src/intl/pl/common.json
@@ -449,5 +449,8 @@
   "withdrawals": "Wypłaty ze stakingu",
   "wrapped-ether": "Wrapped Ether",
   "yes": "Tak",
-  "zero-knowledge-proofs": "Dowody wiedzy zerowej"
+  "zero-knowledge-proofs": "Dowody wiedzy zerowej",
+  "ethereum-vs-bitcoin": "Ethereum a Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Zrozum różnice pomiędzy Ethereum i Bitcoinem"
+
 }

--- a/src/intl/pt-br/common.json
+++ b/src/intl/pt-br/common.json
@@ -444,5 +444,8 @@
   "withdrawals": "Saque de staking",
   "wrapped-ether": "Wrapped Ether",
   "yes": "Sim",
-  "zero-knowledge-proofs": "Prova de conhecimento zero"
+  "zero-knowledge-proofs": "Prova de conhecimento zero",
+  "ethereum-vs-bitcoin": "Ethereum vs. Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Entenda as diferenças entre Ethereum e Bitcoin"
+
 }

--- a/src/intl/pt/common.json
+++ b/src/intl/pt/common.json
@@ -443,5 +443,8 @@
   "withdrawals": "Levantamentos de staking",
   "wrapped-ether": "Wrapped Ether",
   "yes": "Sim",
-  "zero-knowledge-proofs": "Provas de conhecimento-zero"
+  "zero-knowledge-proofs": "Provas de conhecimento-zero",
+  "ethereum-vs-bitcoin": "Ethereum vs. Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Compreenda as diferenças entre o Ethereum e a Bitcoin"
+
 }

--- a/src/intl/ro/common.json
+++ b/src/intl/ro/common.json
@@ -443,5 +443,8 @@
   "withdrawals": "Retrageri la mizare",
   "wrapped-ether": "Ether „Wrapped”",
   "yes": "Da",
-  "zero-knowledge-proofs": "Dovezi zero-knowledge"
+  "zero-knowledge-proofs": "Dovezi zero-knowledge",
+  "ethereum-vs-bitcoin": "Ethereum vs. Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Înțelegeți diferențele dintre Ethereum și Bitcoin"
+
 }

--- a/src/intl/ru/common.json
+++ b/src/intl/ru/common.json
@@ -444,5 +444,8 @@
   "withdrawals": "Вывод средств, использованных в стейкинге",
   "wrapped-ether": "Wrapped Ether",
   "yes": "Да",
-  "zero-knowledge-proofs": "Доказательства с нулевым разглашением"
+  "zero-knowledge-proofs": "Доказательства с нулевым разглашением",
+  "ethereum-vs-bitcoin": "Эфириум против Биткоина",
+  "nav-ethereum-vs-bitcoin-description": "Понять различия между Эфириумом и Биткоином"
+
 }

--- a/src/intl/se/common.json
+++ b/src/intl/se/common.json
@@ -431,5 +431,8 @@
   "withdrawals": "Utsättningsuttag",
   "wrapped-ether": "Wrapped Ether",
   "yes": "Ja",
-  "zero-knowledge-proofs": "Nollkunskapsbevis"
+  "zero-knowledge-proofs": "Nollkunskapsbevis",
+  "ethereum-vs-bitcoin": "Ethereum vs. Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Förstå skillnaderna mellan Ethereum och Bitcoin"
+
 }

--- a/src/intl/sk/common.json
+++ b/src/intl/sk/common.json
@@ -431,5 +431,8 @@
   "withdrawals": "Výber stakingu",
   "wrapped-ether": "Wrapped Ether",
   "yes": "Áno",
-  "zero-knowledge-proofs": "Dôkaz nulovou znalosťou"
+  "zero-knowledge-proofs": "Dôkaz nulovou znalosťou",
+  "ethereum-vs-bitcoin": "Ethereum vs. Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Pochopte rozdiely medzi Ethereom a Bitcoinom"
+
 }

--- a/src/intl/sl/common.json
+++ b/src/intl/sl/common.json
@@ -431,5 +431,8 @@
   "withdrawals": "Zastavljanje dvigov",
   "wrapped-ether": "Ovit eter",
   "yes": "Da",
-  "zero-knowledge-proofs": "Dokazi brez znanja"
+  "zero-knowledge-proofs": "Dokazi brez znanja",
+  "ethereum-vs-bitcoin": "Ethereum proti Bitcoinu",
+  "nav-ethereum-vs-bitcoin-description": "Razumevanje razlik med Ethereumom in Bitcoinom"
+
 }

--- a/src/intl/sn/common.json
+++ b/src/intl/sn/common.json
@@ -440,5 +440,8 @@
   "withdrawals": "Kubudisa staking",
   "wrapped-ether": "Wrapped Ether",
   "yes": "Ehe",
-  "zero-knowledge-proofs": "Humbowo usingaburitse ruzivo"
+  "zero-knowledge-proofs": "Humbowo usingaburitse ruzivo",
+  "ethereum-vs-bitcoin": "Ethereum vs Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Nzwisisa kusiyana kuripo pakati peEthereum neBitcoin"
+
 }

--- a/src/intl/sr/common.json
+++ b/src/intl/sr/common.json
@@ -431,5 +431,8 @@
   "withdrawals": "Povlačenje uloga",
   "wrapped-ether": "Umotan Ether",
   "yes": "Da",
-  "zero-knowledge-proofs": "Dokazi s nultim znanjem"
+  "zero-knowledge-proofs": "Dokazi s nultim znanjem",
+  "ethereum-vs-bitcoin": "Ethereum protiv Bitcoina",
+  "nav-ethereum-vs-bitcoin-description": "Razumevanje razlika između Ethereuma i Bitcoina"
+
 }

--- a/src/intl/sw/common.json
+++ b/src/intl/sw/common.json
@@ -442,5 +442,8 @@
   "withdrawals": "Uondoji wa hisa",
   "wrapped-ether": "Ether iliyofungamanishwa",
   "yes": "Ndiyo",
-  "zero-knowledge-proofs": "Ushahidi usio na utambuzi"
+  "zero-knowledge-proofs": "Ushahidi usio na utambuzi",
+  "ethereum-vs-bitcoin": "Ethereum dhidi ya Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Elewa tofauti kati ya Ethereum na Bitcoin"
+
 }

--- a/src/intl/ta/common.json
+++ b/src/intl/ta/common.json
@@ -430,5 +430,8 @@
   "withdrawals": "ஸ்டேக்கிங் பின்வாங்கல்",
   "wrapped-ether": "மூடப்பட்ட ஈதர்",
   "yes": "ஆம்",
-  "zero-knowledge-proofs": "ஜீரோ-நிரூபன சான்றுகள்"
+  "zero-knowledge-proofs": "ஜீரோ-நிரூபன சான்றுகள்",
+  "ethereum-vs-bitcoin": "எத்தேரியம் மற்றும் பிட்காயின்",
+  "nav-ethereum-vs-bitcoin-description": "எத்தேரியம் மற்றும் பிட்காயின் இடையிலான வேறுபாடுகளைப் புரிந்து கொள்ளுங்கள்"
+
 }

--- a/src/intl/te/common.json
+++ b/src/intl/te/common.json
@@ -443,5 +443,8 @@
   "withdrawals": "స్టేకింగ్ విత్‌డ్రాల్స్",
   "wrapped-ether": "చుట్టబడిన ఈథర్",
   "yes": "అవును",
-  "zero-knowledge-proofs": "జీరో-నాలెడ్జ్ రుజువులు"
+  "zero-knowledge-proofs": "జీరో-నాలెడ్జ్ రుజువులు",
+  "ethereum-vs-bitcoin": "Ethereum vs Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Ethereum మరియు Bitcoin మధ్య వ్యత్యాసాలను అర్థం చేసుకోండి"
+
 }

--- a/src/intl/th/common.json
+++ b/src/intl/th/common.json
@@ -443,5 +443,8 @@
   "withdrawals": "การถอน Staking",
   "wrapped-ether": "อีเธอร์ห่อหุ้ม",
   "yes": "ใช่",
-  "zero-knowledge-proofs": "การพิสูจน์ความจริงโดยไม่เปิดเผยข้อมูล"
+  "zero-knowledge-proofs": "การพิสูจน์ความจริงโดยไม่เปิดเผยข้อมูล",
+  "ethereum-vs-bitcoin": "Ethereum vs. Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "ทำความเข้าใจความแตกต่างระหว่าง Ethereum และ Bitcoin"
+
 }

--- a/src/intl/tk/common.json
+++ b/src/intl/tk/common.json
@@ -428,5 +428,8 @@
   "withdrawals": "Steýking pul çekimleri",
   "wrapped-ether": "Örtülen Ether",
   "yes": "Hawa",
-  "zero-knowledge-proofs": "Maglumat bermezden subutnamalar"
+  "zero-knowledge-proofs": "Maglumat bermezden subutnamalar",
+  "ethereum-vs-bitcoin": "Ethereum vs Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Ethereum bilen Bitcoin arasyndaky tapawutlara düşün"
+
 }

--- a/src/intl/tl/common.json
+++ b/src/intl/tl/common.json
@@ -429,5 +429,8 @@
   "withdrawals": "Mga pagbawi ng pag-stake",
   "wrapped-ether": "Nakabalot na Ether",
   "yes": "Oo",
-  "zero-knowledge-proofs": "Mga zero-knowledge proof"
+  "zero-knowledge-proofs": "Mga zero-knowledge proof",
+  "ethereum-vs-bitcoin": "Ethereum vs. Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Unawain ang mga pagkakaiba sa pagitan ng Ethereum at Bitcoin"
+
 }

--- a/src/intl/tr/common.json
+++ b/src/intl/tr/common.json
@@ -444,5 +444,8 @@
   "withdrawals": "Stake çekimleri",
   "wrapped-ether": "Sarılı Ether",
   "yes": "Evet",
-  "zero-knowledge-proofs": "Sıfır bilgili ispatlar"
+  "zero-knowledge-proofs": "Sıfır bilgili ispatlar",
+  "ethereum-vs-bitcoin": "Ethereum ve Bitcoin Karşılaştırması",
+  "nav-ethereum-vs-bitcoin-description": "Ethereum ve Bitcoin arasındaki farkları anlayın"
+
 }

--- a/src/intl/tw/common.json
+++ b/src/intl/tw/common.json
@@ -429,5 +429,8 @@
   "withdrawals": "Yi w'awowa",
   "wrapped-ether": "Ether yɛ abobɔw",
   "yes": "Ampa",
-  "zero-knowledge-proofs": "Nimdeɛ-kaperɛ ho adanse di"
+  "zero-knowledge-proofs": "Nimdeɛ-kaperɛ ho adanse di",
+  "ethereum-vs-bitcoin": "Ethereum vs Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Hu nsonsonoeɛ a ɛwɔ Ethereum ne Bitcoin ntam"
+
 }

--- a/src/intl/uk/common.json
+++ b/src/intl/uk/common.json
@@ -441,5 +441,8 @@
   "withdrawals": "Виведення ставок",
   "wrapped-ether": "Wrapped Ether",
   "yes": "Так",
-  "zero-knowledge-proofs": "Доведення з нульовим розголошенням"
+  "zero-knowledge-proofs": "Доведення з нульовим розголошенням",
+  "ethereum-vs-bitcoin": "Ethereum vs. Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Зрозумійте відмінності між Ethereum та Bitcoin"
+
 }

--- a/src/intl/ur/common.json
+++ b/src/intl/ur/common.json
@@ -428,5 +428,8 @@
   "withdrawals": "اسٹیکنگ نکلوانا",
   "wrapped-ether": "لپٹا ہوا ایتھر",
   "yes": "جی ہاں",
-  "zero-knowledge-proofs": "بغیر معلومات کے ثبوت"
+  "zero-knowledge-proofs": "بغیر معلومات کے ثبوت",
+  "ethereum-vs-bitcoin": "ایتھریم بمقابلہ بٹ کوائن",
+  "nav-ethereum-vs-bitcoin-description": "ایتھریم اور بٹ کوائن کے درمیان فرق کو سمجھیں"
+
 }

--- a/src/intl/uz/common.json
+++ b/src/intl/uz/common.json
@@ -431,5 +431,8 @@
   "withdrawals": "Staking yechib olish",
   "wrapped-ether": "Oʻralgan Ether",
   "yes": "Ha",
-  "zero-knowledge-proofs": "Nol bilim bilan isbotlashlar"
+  "zero-knowledge-proofs": "Nol bilim bilan isbotlashlar",
+  "ethereum-vs-bitcoin": "Ethereum va Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Ethereum va Bitcoin o'rtasidagi farqlarni tushunish"
+
 }

--- a/src/intl/vi/common.json
+++ b/src/intl/vi/common.json
@@ -444,5 +444,8 @@
   "withdrawals": "Rút tài sản đặt cược",
   "wrapped-ether": "Wrapped Ether",
   "yes": "Có",
-  "zero-knowledge-proofs": "Bằng chứng không tiết lộ thông tin"
+  "zero-knowledge-proofs": "Bằng chứng không tiết lộ thông tin",
+  "ethereum-vs-bitcoin": "Ethereum và Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Hiểu sự khác biệt giữa Ethereum và Bitcoin"
+
 }

--- a/src/intl/yo/common.json
+++ b/src/intl/yo/common.json
@@ -430,5 +430,8 @@
   "withdrawals": "Àwọn àgbàjáde owó ìdókòwò",
   "wrapped-ether": "Ẹ̀dà Ether",
   "yes": "Bẹ́ẹ̀ni",
-  "zero-knowledge-proofs": "Àwọn ẹ̀rí tí kò ní ìmọ̀ kankan"
+  "zero-knowledge-proofs": "Àwọn ẹ̀rí tí kò ní ìmọ̀ kankan",
+  "ethereum-vs-bitcoin": "Ethereum vs Bitcoin",
+  "nav-ethereum-vs-bitcoin-description": "Loye awọn iyatọ laarin Ethereum ati Bitcoin"
+
 }

--- a/src/intl/zh-tw/common.json
+++ b/src/intl/zh-tw/common.json
@@ -457,5 +457,8 @@
   "withdrawals": "質押提款",
   "wrapped-ether": "包裝以太幣",
   "yes": "是",
-  "zero-knowledge-proofs": "零知識證明"
+  "zero-knowledge-proofs": "零知識證明",
+  "ethereum-vs-bitcoin": "以太坊 vs. 比特幣",
+  "nav-ethereum-vs-bitcoin-description": "了解以太坊和比特幣之間的區別"
+
 }

--- a/src/intl/zh/common.json
+++ b/src/intl/zh/common.json
@@ -457,5 +457,8 @@
   "withdrawals": "质押提款",
   "wrapped-ether": "包装以太币",
   "yes": "是",
-  "zero-knowledge-proofs": "零知识证明"
+  "zero-knowledge-proofs": "零知识证明",
+  "ethereum-vs-bitcoin": "以太坊 vs. 比特币",
+  "nav-ethereum-vs-bitcoin-description": "了解以太坊和比特币之间的区别"
+
 }


### PR DESCRIPTION
## Description
- Adds translations for /ethereum-vs-bitcoin/ common.json strings (nav menu)
- Translations via Gemini 2.5 Pro

Note: Strings can be sorted in a separate PR to keep this diff clean