### PR TITLE
docs: fix typo and update outdated reference

### DIFF
--- a/public/content/developers/tutorials/erc20-annotated-code/index.md
+++ b/public/content/developers/tutorials/erc20-annotated-code/index.md
@@ -22,7 +22,7 @@ This is annotated source code. If you want to implement ERC-20,
 ## The Interface {#the-interface}
 
 The purpose of a standard like ERC-20 is to allow many tokens implementations that are interoperable across applications, like wallets and decentralized exchanges. To achieve that, we create an
-[interface](https://www.geeksforgeeks.org/solidity-basics-of-interface/). Any code that needs to use the token contract
+[interface](https://www.geeksforgeeks.org/solidity/solidity-basics-of-interface/). Any code that needs to use the token contract
 can use the same definitions in the interface and be compatible with all token contracts that use it, whether it is a wallet such as
 MetaMask, a dapp such as etherscan.io, or a different contract such as liquidity pool.
 
@@ -90,7 +90,7 @@ every node in the blockchain run it. This kind of function does not generate a t
 **Note:** In theory it might appear that a contract's creator could cheat by returning a smaller total supply than the real value, making each token appear
 more valuable than it actually is. However, that fear ignores the true nature of the blockchain. Everything that happens on the blockchain can be verified by
 every node. To achieve this, every contract's machine language code and storage is available on every node. While you are not required to publish the Solidity
-code for your contract, nobody would take you seriously unless you publish the source code and the version of Solidity with which it was complied, so it can
+code for your contract, nobody would take you seriously unless you publish the source code and the version of Solidity with which it was compiled, so it can
 be verified against the machine language code you provided.
 For example, see [this contract](https://eth.blockscout.com/address/0xa530F85085C6FE2f866E7FdB716849714a89f4CD?tab=contract).
 


### PR DESCRIPTION
## Description

fixed a typo in the documentation where "complied" was used instead of "compiled".
also updated the outdated GeeksforGeeks link to the current one.

