### PR TITLE
docs: fix broken and outdated links

### DIFF
--- a/public/content/community/get-involved/index.md
+++ b/public/content/community/get-involved/index.md
@@ -17,7 +17,7 @@ Start by reading about the ethereum.org mission and values in our [code of condu
 - Check out [projects related to your area of expertise or programming language of choice](/developers/docs/programming-languages/)
 - Watch or participate in the [Consensus and Execution Layer calls](https://www.youtube.com/@EthereumProtocol/streams)
 - [Ecosystem Support Program's wishlist](https://esp.ethereum.foundation/wishlist/) - tooling, documentation, and infrastructure areas where the Ethereum Ecosystem Support Program is actively seeking grant applications
-- [Web3Bridge](https://www.web3bridge.com/) - join the aspiring web3 community in their initiative to identify, train, and support hundreds of developers and community members throughout Africa
+- [Web3Bridge](https://www.web3bridgeafrica.com) - join the aspiring web3 community in their initiative to identify, train, and support hundreds of developers and community members throughout Africa
 - Join the [Eth R&D Discord](https://discord.com/invite/VmG7Uxc)
 - Join the [Ethereum Cat Herders Discord](https://discord.com/invite/Nz6rtfJ8Cu)
 
@@ -126,7 +126,6 @@ The Ethereum ecosystem is on a mission to fund public goods and impactful projec
 - [HausDAO](https://daohaus.club) [@nowdaoit](https://twitter.com/nowdaoit) - _Community governance of DAOhaus_
 - [LexDAO](https://lexdao.org) [@lex_DAO](https://twitter.com/lex_DAO) - _Legal engineering_
 - [MetaCartel Ventures](https://metacartel.xyz) [@VENTURE_DAO](https://twitter.com/VENTURE_DAO) - _Venture for pre-seed crypto projects_
-- [MetaGame](https://metagame.wtf) [@MetaFam](https://twitter.com/MetaFam) - _MMORPG Game Mechanics for Real Life_
 - [MetaFactory](https://metafactory.ai) [@TheMetaFactory](https://twitter.com/TheMetaFactory) - _Digiphysical Apparel Brands_
 - [MolochDAO](https://molochdao.com) [@MolochDAO](https://twitter.com/MolochDAO) - _Community focused on funding Ethereum development_
 - [Raid Guild](https://raidguild.org) [@RaidGuild](https://twitter.com/RaidGuild) - _Collective of Web3 builders_


### PR DESCRIPTION
## Description

I updated the Web3Bridge link to the new official site and removed the MetaGame link since the project has been discontinued.

## Related Issue

N/A
