### PR TITLE
patch: markdown syntax

### DIFF
--- a/public/content/contributing/style-guide/content-standardization/index.md
+++ b/public/content/contributing/style-guide/content-standardization/index.md
@@ -75,7 +75,7 @@ Smart contract is a common noun and should only be capitalized at the beginning 
 - Smart contract
 - smart contract
 
-** Incorrect usage:**
+**Incorrect usage:**
 
 - Smart Contract
 


### PR DESCRIPTION
## Description
Patch bold markdown syntax

## Related issue
https://ethereum.org/contributing/style-guide/content-standardization#smart-contract
<img width="865" height="732" alt="image" src="https://github.com/user-attachments/assets/408f6428-eda7-417f-9e12-564bd0a08766" />

