### PR TITLE
docs: fix outdated NIST SP 800-154 link

### DIFF
--- a/public/content/developers/tutorials/guide-to-smart-contract-security-tools/index.md
+++ b/public/content/developers/tutorials/guide-to-smart-contract-security-tools/index.md
@@ -48,7 +48,7 @@ Start with Slither's built-in detectors to ensure that no simple bugs are presen
 To effectively test and verify your code, you must identify the areas that need attention. As your resources spent on security are limited, scoping the weak or high-value parts of your codebase is important to optimize your effort. Threat modeling can help. Consider reviewing:
 
 - [Rapid Risk Assessments](https://infosec.mozilla.org/guidelines/risk/rapid_risk_assessment.html) (our preferred approach when time is short)
-- [Guide to Data-Centric System Threat Modeling](https://csrc.nist.gov/publications/detail/sp/800-154/draft) (aka NIST 800-154)
+- [Guide to Data-Centric System Threat Modeling](https://csrc.nist.gov/pubs/sp/800/154/ipd) (aka NIST 800-154)
 - [Shostack threat modeling](https://www.amazon.com/Threat-Modeling-Designing-Adam-Shostack/dp/1118809998)
 - [STRIDE](<https://wikipedia.org/wiki/STRIDE_(security)>) / [DREAD](<https://wikipedia.org/wiki/DREAD_(risk_assessment_model)>)
 - [PASTA](https://wikipedia.org/wiki/Threat_model#P.A.S.T.A.)


### PR DESCRIPTION
## Description

found that the old draft link was no longer valid. updated it to the current page:
`https://csrc.nist.gov/publications/detail/sp/800-154/draft` to `https://csrc.nist.gov/pubs/sp/800/154/ipd`

