### PR TITLE
playwright: get latest Netlify branch deploy, rm awaiting new build

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -9,14 +9,17 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Wait for Netlify Deploy
+      - name: Get Netlify Deploy URL for branch
         id: netlify_deploy
-        uses: pettinarip/wait-for-netlify-action@v1.0.2
-        with:
-          site_id: "e8f2e766-888b-4954-8500-1b647d84db99"
-          max_timeout: 3600
+        if: |
+          github.ref_name == 'dev' || github.ref_name == 'staging' || github.ref_name == 'master'
+        run: |
+          npm install node-fetch@2
+          npx ts-node -O '{ "module": "commonjs" }' src/scripts/get-netlify-branch-deploy.ts
         env:
+          NETLIFY_SITE_ID: "e8f2e766-888b-4954-8500-1b647d84db99"
           NETLIFY_TOKEN: ${{ secrets.NETLIFY_TOKEN }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
 
       - uses: actions/setup-node@v4
         with:

--- a/src/scripts/get-netlify-branch-deploy.ts
+++ b/src/scripts/get-netlify-branch-deploy.ts
@@ -1,0 +1,53 @@
+// Fetches the latest published Netlify deploy for the current branch and outputs its URL for GitHub Actions
+
+import fs from "fs"
+
+import fetch from "node-fetch"
+
+const siteId = process.env.NETLIFY_SITE_ID
+const branch = process.env.GITHUB_REF_NAME
+const token = process.env.NETLIFY_TOKEN
+
+if (!siteId || !branch || !token) {
+  console.error("Missing NETLIFY_SITE_ID, GITHUB_REF_NAME, or NETLIFY_TOKEN")
+  process.exit(1)
+}
+
+type NetlifyDeploy = {
+  state: string
+  branch: string
+  published: boolean
+  deploy_ssl_url?: string
+  deploy_url?: string
+}
+;(async () => {
+  const url = `https://api.netlify.com/api/v1/sites/${siteId}/deploys?branch=${branch}`
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  if (!res.ok) {
+    console.error(
+      "Failed to fetch Netlify deploys:",
+      res.status,
+      await res.text()
+    )
+    process.exit(1)
+  }
+  const deploys: NetlifyDeploy[] = await res.json()
+  // Find the latest published deploy for this branch
+  const latest = deploys.find(
+    (d) => d.state === "ready" && d.branch === branch && d.published
+  )
+  if (!latest) {
+    console.error("No published deploy found for branch:", branch)
+    process.exit(1)
+  }
+  // Use GitHub Actions recommended output syntax (GITHUB_OUTPUT)
+  const output = `url=${latest.deploy_ssl_url || latest.deploy_url}`
+  if (process.env.GITHUB_OUTPUT) {
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, output + "\n")
+  } else {
+    // Fallback for local/dev
+    console.log(output)
+  }
+})()


### PR DESCRIPTION
## Description
- Adds script to fetch latest Netlify branch deploy
- Removes awaiting of a new branch deployment

## Related Issue
Even with manual dispatch of playwright e2e test workflow (#16372), workflow is triggering a new build:
https://github.com/ethereum/ethereum-org-website/actions/runs/18041407774/job/51341063177

cc: @pettinarip 