### PR TITLE
docs: fix broken Solidity links

### DIFF
--- a/public/content/developers/tutorials/smart-contract-security-guidelines/index.md
+++ b/public/content/developers/tutorials/smart-contract-security-guidelines/index.md
@@ -22,7 +22,7 @@ Documentation can be written at different levels, and should be updated while im
 
 - **A plain English description of the system**, describing what the contracts do and any assumptions on the codebase.
 - **Schema and architectural diagrams**, including the contract interactions and the state machine of the system. [Slither printers](https://github.com/crytic/slither/wiki/Printer-documentation) can help to generate these schemas.
-- **Thorough code documentation**, the [Natspec format](https://solidity.readthedocs.io/en/develop/natspec-format.html) can be used for Solidity.
+- **Thorough code documentation**, the [Natspec format](https://docs.soliditylang.org/en/develop/natspec-format.html) can be used for Solidity.
 
 ### Onchain vs offchain computation {#onchain-vs-offchain-computation}
 
@@ -62,7 +62,7 @@ The architecture of your codebase should make your code easy to review. Avoid ar
 ### Avoid known pitfalls {#avoid-known-pitfalls}
 
 - **Be aware of the most common security issues.** There are many online resources to learn about common issues, such as [Ethernaut CTF](https://ethernaut.openzeppelin.com/), [Capture the Ether](https://capturetheether.com/), or [Not so smart contracts](https://github.com/crytic/not-so-smart-contracts/).
-- **Be aware of the warnings sections in the [Solidity documentation](https://solidity.readthedocs.io/en/latest/).** The warnings sections will inform you about non-obvious behavior of the language.
+- **Be aware of the warnings sections in the [Solidity documentation](https://docs.soliditylang.org/en/latest/).** The warnings sections will inform you about non-obvious behavior of the language.
 
 ### Dependencies {#dependencies}
 


### PR DESCRIPTION
## Description

some Solidity references were pointing to the old `readthedocs` domain.
updated them to the current official site:

* `solidity.readthedocs.io/en/develop/natspec-format.html` → `docs.soliditylang.org/en/develop/natspec-format.html`
* `solidity.readthedocs.io/en/latest/` → `docs.soliditylang.org/en/latest/`
