### PR TITLE
Use 301 for default-locale redirects

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,8 +1,28 @@
+import { NextRequest, NextResponse } from "next/server"
 import createMiddleware from "next-intl/middleware"
 
 import { routing } from "./src/i18n/routing"
+import { DEFAULT_LOCALE } from "./src/lib/constants"
 
-export default createMiddleware(routing)
+const handleI18nRouting = createMiddleware(routing)
+
+export default function middleware(request: NextRequest) {
+  const response = handleI18nRouting(request)
+
+  // Upgrade default-locale strip redirects from 307 to 301 for SEO
+  if (response.status === 307) {
+    const pathname = request.nextUrl.pathname
+    const defaultPrefix = `/${DEFAULT_LOCALE}`
+    if (
+      pathname === defaultPrefix ||
+      pathname.startsWith(`${defaultPrefix}/`)
+    ) {
+      return new NextResponse(null, { status: 301, headers: response.headers })
+    }
+  }
+
+  return response
+}
 
 // Simplified matcher pattern
 export const config = {


### PR DESCRIPTION
## Description

Converts 307→301 when pathname starts with `/${DEFAULT_LOCALE}`.
