### PR TITLE
docs: fix outdated Alchemy links

### DIFF
--- a/public/content/developers/tutorials/using-websockets/index.md
+++ b/public/content/developers/tutorials/using-websockets/index.md
@@ -242,4 +242,4 @@ curl https://eth-mainnet.alchemyapi.io/v2/your-api-key
 
 ---
 
-[Sign up with Alchemy](https://auth.alchemy.com/signup) for free, check out [our documentation](https://www.alchemy.com/docs/), and for the latest news, follow us on [Twitter](https://twitter.com/AlchemyPlatform).
+[Sign up with Alchemy](https://auth.alchemy.com) for free, check out [our documentation](https://www.alchemy.com/docs/), and for the latest news, follow us on [Twitter](https://x.com/AlchemyPlatform).


### PR DESCRIPTION
## Description

* `auth.alchemyapi.io/signup` → `auth.alchemy.com/signup`
* `dashboard.alchemyapi.io/` → `dashboard.alchemy.com/`
* `docs.alchemyapi.io/documentation/alchemy-api-reference/` → `alchemy.com/docs/reference/api-overview`
* `docs.alchemyapi.io/` → `alchemy.com/docs/`