### PR TITLE
docs: removed dead Ethereum2077 blog link

### DIFF
--- a/public/content/eips/index.md
+++ b/public/content/eips/index.md
@@ -61,7 +61,6 @@ If you’re interested to read more about EIPs, check out the [EIPs website](htt
 ### Community education projects {#community-projects}
 
 - [PEEPanEIP](https://www.youtube.com/playlist?list=PL4cwHXAawZxqu0PKKyMzG_3BJV_xZTi1F) — *PEEPanEIP is an educational video series that discusses Ethereum Improvement Proposal (EIPs) and key features of upcoming upgrades.*
-- [EIPs For Nerds](https://ethereum2077.substack.com/t/eip-research) — *EIPs For Nerds provides comprehensive, ELI5-style overviews of various Ethereum Improvement Proposals (EIPs), including core EIPs and application/infrastructure-layer EIPs (ERCs), to educate readers and shape consensus around proposed changes to the Ethereum protocol.* 
 - [EIPs.wtf](https://www.eips.wtf/) — *EIPs.wtf provides extra information for Ethereum Improvement Proposals (EIPs), including their status, implementation details, related pull requests, and community feedback.* 
 - [EIP.Fun](https://eipfun.substack.com/) — *EIP.Fun provides the latest news on Ethereum Improvement Proposals (EIPs), updates on EIP meetings, and more.*
 - [EIPs Insight](https://eipsinsight.com/) — *EIPs Insight is a representation of state of Ethereum Improvement Proposals (EIPs) process & statistics as per information collected from different resources.*


### PR DESCRIPTION
## Description

noticed the Ethereum2077 Substack project no longer exists and all posts were deleted.
removed the outdated link to avoid pointing to a dead resource.
