### PR TITLE
[hot fix] Use Beaconcha.in endpoint for total ETH staked

### DIFF
--- a/app/[locale]/enterprise/page.tsx
+++ b/app/[locale]/enterprise/page.tsx
@@ -64,8 +64,8 @@ import { parseActivity } from "./utils"
 
 import { fetchEthereumStablecoinsMcap } from "@/lib/api/fetchEthereumStablecoinsMcap"
 import { fetchEthPrice } from "@/lib/api/fetchEthPrice"
+import { fetchEthStakedBeaconchain } from "@/lib/api/fetchEthStakedBeaconchain"
 import { fetchGrowThePie } from "@/lib/api/fetchGrowThePie"
-import { fetchTotalEthStaked } from "@/lib/api/fetchTotalEthStaked"
 import EthGlyph from "@/public/images/assets/svgs/eth-diamond-rainbow.svg"
 import heroImage from "@/public/images/heroes/enterprise-hero-white.png"
 
@@ -97,7 +97,7 @@ const loadData = dataLoader(
     ["growThePieData", fetchGrowThePie],
     ["ethereumStablecoins", fetchEthereumStablecoinsMcap],
     ["ethPrice", fetchEthPrice],
-    ["totalEthStaked", fetchTotalEthStaked],
+    ["totalEthStaked", fetchEthStakedBeaconchain],
   ],
   BASE_TIME_UNIT * 1000
 )

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -90,10 +90,10 @@ import { routing } from "@/i18n/routing"
 import { getABTestAssignment } from "@/lib/ab-testing/server"
 import { fetchCommunityEvents } from "@/lib/api/calendarEvents"
 import { fetchEthPrice } from "@/lib/api/fetchEthPrice"
+import { fetchEthStakedBeaconchain } from "@/lib/api/fetchEthStakedBeaconchain"
 import { fetchGrowThePie } from "@/lib/api/fetchGrowThePie"
 import { fetchAttestantPosts } from "@/lib/api/fetchPosts"
 import { fetchRSS } from "@/lib/api/fetchRSS"
-import { fetchTotalEthStaked } from "@/lib/api/fetchTotalEthStaked"
 import { fetchTotalValueLocked } from "@/lib/api/fetchTotalValueLocked"
 import EventFallback from "@/public/images/events/event-placeholder.png"
 
@@ -142,7 +142,7 @@ const REVALIDATE_TIME = BASE_TIME_UNIT * 1
 const loadData = dataLoader(
   [
     ["ethPrice", fetchEthPrice],
-    ["totalEthStaked", fetchTotalEthStaked],
+    ["totalEthStaked", fetchEthStakedBeaconchain],
     ["totalValueLocked", fetchTotalValueLocked],
     ["growThePieData", fetchGrowThePie],
     ["communityEvents", fetchCommunityEvents],

--- a/app/[locale]/staking/page.tsx
+++ b/app/[locale]/staking/page.tsx
@@ -31,25 +31,25 @@ const fetchBeaconchainData = async (): Promise<StakingStatsData> => {
   const { href: ethstore } = new URL("api/v1/ethstore/latest", base)
   const { href: epoch } = new URL("api/v1/epoch/latest", base)
 
-  // Get total ETH staked and current APR from ethstore endpoint
+  // Get current APR from ethstore endpoint
   const ethStoreResponse = await fetch(ethstore)
   if (!ethStoreResponse.ok)
     throw new Error("Network response from Beaconcha.in ETHSTORE was not ok")
   const ethStoreResponseJson: EthStoreResponse = await ethStoreResponse.json()
   const {
-    data: { apr, effective_balances_sum_wei },
+    data: { apr },
   } = ethStoreResponseJson
-  const totalEffectiveBalance = effective_balances_sum_wei * 1e-18
-  const totalEthStaked = Math.floor(totalEffectiveBalance)
 
-  // Get total active validators from latest epoch endpoint
+  // Get total eligible ETH staked and total active validators from latest epoch endpoint
   const epochResponse = await fetch(epoch)
   if (!epochResponse.ok)
     throw new Error("Network response from Beaconcha.in EPOCH was not ok")
   const epochResponseJson: EpochResponse = await epochResponse.json()
   const {
-    data: { validatorscount },
+    data: { validatorscount, eligibleether: eligibleGwei },
   } = epochResponseJson
+
+  const totalEthStaked = Math.floor(eligibleGwei * 1e-9)
 
   return { totalEthStaked, validatorscount, apr }
 }

--- a/src/lib/api/fetchEthStakedBeaconchain.ts
+++ b/src/lib/api/fetchEthStakedBeaconchain.ts
@@ -1,0 +1,19 @@
+import type { EpochResponse, MetricReturnData } from "@/lib/types"
+
+export const fetchEthStakedBeaconchain =
+  async (): Promise<MetricReturnData> => {
+    // Fetch Beaconcha.in data
+    const base = "https://beaconcha.in"
+    const { href } = new URL("api/v1/epoch/latest", base)
+
+    // Get total eligible ETH staked from latest epoch endpoint
+    const response = await fetch(href)
+    if (!response.ok)
+      throw new Error("Network response from Beaconcha.in EPOCH was not ok")
+    const json: EpochResponse = await response.json()
+    const { eligibleether: eligibleGwei } = json.data
+
+    const totalEthStaked = Math.floor(eligibleGwei * 1e-9)
+
+    return { value: totalEthStaked, timestamp: Date.now() }
+  }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -521,6 +521,7 @@ export type EthStakedResponse = {
 
 export type EpochResponse = Data<{
   validatorscount: number
+  eligibleether: number
 }>
 
 export type StakingStatsData = {


### PR DESCRIPTION
## Description
- Removes usage of Dune Analytics API for fetching total ETH staked
- Adds isolated lib/api fetch utility to get "eligible ETH" from Beaconcha.in "epoch" endpoint
- Implement new fetch value on homepage and /enterprise page
- Update /staking fetch to use same pattern (`eligibleether` value) instead of `effective_balances_sum_wei` to align with homepage, /enterprise page, and Beaconcha.in homepage

## Related Issue
Production deploys breaking as a result of hitting Dune API request limits