### PR TITLE
Handle missing dateOfLaunch by displaying dash placeholder [Fixes #16305]

### DIFF
--- a/app/[locale]/apps/[application]/page.tsx
+++ b/app/[locale]/apps/[application]/page.tsx
@@ -129,6 +129,11 @@ const Page = async ({
     return t("page-apps-days-ago", { days: diffInDays })
   }
 
+  const getDisplayYear = (dateString: string) => {
+    if (!isValidDate(dateString)) return "—"
+    return new Date(app.dateOfLaunch).getFullYear()
+  }
+
   const commitHistoryCache: CommitHistory = {}
   const { contributors } = await getAppPageContributorInfo(
     "apps/[application]",
@@ -326,11 +331,7 @@ const Page = async ({
                 <p className="text-sm text-body-medium">
                   {t("page-apps-info-founded")}
                 </p>
-                <p className="text-sm">
-                  {app.dateOfLaunch
-                    ? new Date(app.dateOfLaunch).getFullYear()
-                    : "—"}
-                </p>
+                <p className="text-sm">{getDisplayYear(app.dateOfLaunch)}</p>
               </div>
               <div>
                 <p className="text-sm text-body-medium">


### PR DESCRIPTION
## Description

Many Apps in the App Explorer are missing the Founding date, but no check is done, so it's manipulated and displayed as `NaN`.

Apps where I can reproduce the issue:
https://ethereum.org/apps/eternal-ai/
https://ethereum.org/apps/virtuals/
https://ethereum.org/apps/human-passport/
https://ethereum.org/apps/zk-open-passport/
https://ethereum.org/apps/zk-open-passport/

## Solution

I am going to treat the missing Founding Data the same way Last Update Data is treated: displaying a `-` (dash) as a placeholder.

## Problem and Solution Demo

Before:
<img width="798" height="1102" alt="Screenshot 2025-10-06 at 15 51 55" src="https://github.com/user-attachments/assets/6f4f7d0c-6452-4c98-9f4b-a366d72307fe" />


After:
<img width="785" height="1085" alt="Screenshot 2025-10-06 at 15 57 46" src="https://github.com/user-attachments/assets/d9ea9804-65ba-4fdc-9acf-936a0c20a54f" />


## How to test

- Confirm the issue in production [https://ethereum.org/apps/huddle01/](https://ethereum.org/apps/huddle01/)
- Confirm the issue is fixed in preview [https://deploy-preview-16443--ethereumorg.netlify.app/apps/huddle01/](https://deploy-preview-16443--ethereumorg.netlify.app/apps/huddle01/)


## Related Issue

Issue: https://github.com/ethereum/ethereum-org-website/issues/16305#issuecomment-3368374814
