### PR TITLE
fix: order of workflow actions—install deps before netlify step

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -9,6 +9,16 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+
+      - name: Install dependencies
+        run: pnpm install
+
       - name: Get Netlify Deploy URL for branch
         id: netlify_deploy
         if: |
@@ -19,16 +29,6 @@ jobs:
           NETLIFY_SITE_ID: "e8f2e766-888b-4954-8500-1b647d84db99"
           NETLIFY_TOKEN: ${{ secrets.NETLIFY_TOKEN }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: lts/*
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-
-      - name: Install dependencies
-        run: pnpm install
 
       - name: Install Playwright with all browsers
         run: npx playwright install --with-deps


### PR DESCRIPTION
## Description
Reorders steps for playwright E2E Testing workflow to install dependencies prior to Netlify involvement

## Related Issue
https://github.com/ethereum/ethereum-org-website/actions/runs/18140948786/job/51631376977#step:3:44
