### PR TITLE
fix: change AppCard image from object-cover to object-contain

### DIFF
--- a/app/[locale]/apps/_components/AppCard.tsx
+++ b/app/[locale]/apps/_components/AppCard.tsx
@@ -64,7 +64,7 @@ const AppCard = ({
         <Image
           src={app.image}
           alt={app.name}
-          className="h-full w-full rounded-xl object-cover"
+          className="h-full w-full rounded-xl object-contain"
           width={imageSize * 16}
           height={imageSize * 16}
         />


### PR DESCRIPTION
- AppCard imagef rom object-cover to object-contain to fit app logos in
