### PR TITLE
docs: updated broken MACI documentation link

### DIFF
--- a/public/content/zero-knowledge-proofs/index.md
+++ b/public/content/zero-knowledge-proofs/index.md
@@ -116,6 +116,8 @@ Using MACI _does_ require trusting the coordinator not to collude with bribers o
 
 But in cases where the coordinator remains honest, MACI represents a powerful tool for guaranteeing the sanctity of onchain voting. This explains its popularity among quadratic funding applications (e.g., [clr.fund](https://clr.fund/#/about/maci)) that rely heavily on the integrity of each individual's voting choices.
 
+[Learn more about MACI](ttps://pse.dev/projects/maci).
+
 ## How do zero-knowledge proofs work? {#how-do-zero-knowledge-proofs-work}
 
 A zero-knowledge proof allows you to prove the truth of a statement without sharing the statement’s contents or revealing how you discovered the truth. To make this possible, zero-knowledge protocols rely on algorithms that take some data as input and return ‘true’ or ‘false’ as output.


### PR DESCRIPTION
## Description

noticed that the link to [https://privacy-scaling-explorations.github.io/maci/](https://privacy-scaling-explorations.github.io/maci/) no longer works (returns a 404).
removed it to avoid confusion and keep the documentation clean.
