### PR TITLE
docs: standardize Code of Conduct capitalization

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-# Code of conduct
+# Code of Conduct
 
 ## Mission
 
@@ -23,7 +23,7 @@ The ethereum.org community strives to be:
 - A DEX, CEX or any other form of financial platform
 - A platform that gives financial or legal advice of any kind
 
-## Code of conduct
+## Code of Conduct
 
 ### Pledge
 


### PR DESCRIPTION
## Description

This PR standardizes the capitalization of 'Code of Conduct' in the main heading and section heading to improve consistency with standard documentation practices.

## Changes

- Capitalized 'Code of Conduct' in main heading
- Capitalized 'Code of Conduct' in section heading

## Type of change

- [x] Documentation improvement
- [x] Typo fix

## Testing

- [x] Verified changes are consistent with standard documentation practices

This is a small documentation improvement that enhances consistency across the codebase.