### PR TITLE
fix lodestar's data dir flag name

### DIFF
--- a/public/content/developers/docs/nodes-and-clients/run-a-node/index.md
+++ b/public/content/developers/docs/nodes-and-clients/run-a-node/index.md
@@ -346,7 +346,7 @@ Install Lodestar software by compiling it or downloading the Docker image. Learn
 
 ```sh
 lodestar beacon \
-    --rootDir="/data/ethereum" \
+    --dataDir="/data/ethereum" \
     --network=mainnet \
     --eth1.enabled=true \
     --execution.urls="http://127.0.0.1:8551" \


### PR DESCRIPTION
the "Spin up your own Ethereum node" page's instruction for running a lodestar client has a wrong flag for `dataDir` (it says `rootDir`).

the correct flag is `dataDir` : https://chainsafe.github.io/lodestar/run/beacon-management/beacon-cli#--datadir