### PR TITLE
Add alt text to centralized exchange card images

### DIFF
--- a/src/hooks/useCentralizedExchanges.ts
+++ b/src/hooks/useCentralizedExchanges.ts
@@ -392,7 +392,7 @@ export const useCentralizedExchanges = () => {
             description,
             link: exchanges[exchange].url,
             image: exchanges[exchange].image,
-            alt: exchanges[exchange].name,
+            alt: t("common:item-logo", { item: exchanges[exchange].name }),
           }
         })
     )

--- a/src/intl/en/common.json
+++ b/src/intl/en/common.json
@@ -142,6 +142,7 @@
   "how-to-use-a-bridge": "How to bridge tokens to layer 2",
   "how-to-use-a-wallet": "How to use a wallet",
   "image": "image",
+  "item-logo": "{item} logo",
   "in-this-section": "In this section",
   "individuals": "Individuals",
   "jobs": "Jobs",


### PR DESCRIPTION
## Summary
- add descriptive alt text for the centralized exchange cards so the logos announce properly

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f017a436e88322991f8dc11bb5b73f