### PR TITLE
docs: update outdated Ethereum book link

### DIFF
--- a/public/content/glossary/index.md
+++ b/public/content/glossary/index.md
@@ -492,7 +492,7 @@ lang: en
 
 ## Sources {#sources}
 
-_Provided in part by [Mastering Ethereum](https://github.com/ethereumbook/ethereumbook) by [Andreas M. Antonopoulos, Gavin Wood](https://ethereumbook.info) under CC-BY-SA_
+_Provided in part by [Mastering Ethereum](https://github.com/ethereumbook/ethereumbook) by [Andreas M. Antonopoulos, Gavin Wood](https://aantonop.com/books/mastering-ethereum) under CC-BY-SA_
 
 <Divider />
 


### PR DESCRIPTION
## Description

noticed the old link to the Ethereum book (`https://ethereumbook.info/`) no longer works.
updated it to the current official source: `https://aantonop.com/books/mastering-ethereum/`.

everything else remains unchanged.
