### PR TITLE
docs: fix outdated Uniswap pool link

### DIFF
--- a/public/content/guides/how-to-id-scam-tokens/index.md
+++ b/public/content/guides/how-to-id-scam-tokens/index.md
@@ -73,7 +73,7 @@ The best practice for avoiding this is to carefully check the URL for the sites 
 
 2. **Real tokens have liquidity**. Another option is to look at liquidity pool size on [Uniswap](https://uniswap.org/), one of the most common token swapping protocols. This protocol works using liquidity pools, into which investors deposit their tokens in hope of a return from trading fees.
 
-Scam tokens typically have tiny liquidity pools, if any, because the scammers don't want to risk real assets. For example, the `ARB`/`ETH` Uniswap pool holds about a million dollars ([see here for the up to date value](https://info.uniswap.org/#/pools/0x755e5a186f0469583bd2e80d1216e02ab88ec6ca)) and buying or selling a small amount is not going to change the price:
+Scam tokens typically have tiny liquidity pools, if any, because the scammers don't want to risk real assets. For example, the `ARB`/`ETH` Uniswap pool holds about a million dollars ([see here for the up to date value](https://app.uniswap.org/explore#/pools/0x755e5a186f0469583bd2e80d1216e02ab88ec6ca)) and buying or selling a small amount is not going to change the price:
 
 ![Buying a legitimate token](./uniswap-real.png)
 


### PR DESCRIPTION
## Description

noticed the link to the Uniswap pool was outdated, so I replaced it with the correct one.
old: `https://info.uniswap.org/#/pools/0x755e5a186f0469583bd2e80d1216e02ab88ec6ca`
new: `https://app.uniswap.org/explore#/pools/0x755e5a186f0469583bd2e80d1216e02ab88ec6ca`

this should now direct users to the right page.
