### PR TITLE
docs: removed dead link to ethallowance.com

### DIFF
--- a/public/content/guides/how-to-revoke-token-access/index.md
+++ b/public/content/guides/how-to-revoke-token-access/index.md
@@ -18,7 +18,6 @@ The only protections are to refrain from using untested new projects, only appro
 
 Several websites let you view and revoke smart contracts connected to your address. Visit the website and connect your wallet:
 
-- [Ethallowance](https://ethallowance.com/) (Ethereum)
 - [Etherscan](https://etherscan.io/tokenapprovalchecker) (Ethereum)
 - [Blockscout](https://eth.blockscout.com/apps/revokescout) (Ethereum)
 - [Revoke](https://revoke.cash/) (multiple networks)


### PR DESCRIPTION
## Description

removed the reference to `https://ethallowance.com/` since the service is no longer available.