### PR TITLE
feat: consolideth.app added to consolidation-tooling section

### DIFF
--- a/public/content/roadmap/pectra/maxeb/index.md
+++ b/public/content/roadmap/pectra/maxeb/index.md
@@ -139,7 +139,7 @@ There are several tools available to manage consolidations. The official tool, c
 | Pectra Validator Ops CLI Tool | [GitHub](https://github.com/Luganodes/Pectra-Batch-Contract) | Yes, MIT | [Luganodes](https://www.luganodes.com/) | Yes, Quantstamp [May 2025](https://certificate.quantstamp.com/full/luganodes-pectra-batch-contract/23f0765f-969a-4798-9edd-188d276c4a2b/index.html) | Command line | Batching, for many validators at once |
 | Ethereal | [GitHub](https://github.com/wealdtech/ethereal) | Yes, Apache 2.0 | [Jim McDonald](https://www.attestant.io/team/) | No | Command line | Full feature set for validator and node management |
 | Siren | [GitHub](https://github.com/sigp/siren) | Yes, Apache 2.0 | [Sigma Prime](https://sigmaprime.io/) | No | Some command line, but primarily web UI | Only works if you're using the Lighthouse consensus client |
-| Consolideth.app | [GitHub](https://github.com/Stakely/consolideth) | Yes, MIT licences | [Stakely](https://stakely.io/) | No | Web UI, hosted by stakely and ready to be selfhosted freely| Supports major wallet connections including safe with walletconnect |
+| Consolideth.app | https://consolideth.app/ [GitHub](https://github.com/Stakely/consolideth) | Yes, MIT licences | [Stakely](https://stakely.io/) | No | Web UI, hosted by stakely and ready to be selfhosted freely| Supports major wallet connections including safe with walletconnect |
 
 ## FAQ {#faq}
 


### PR DESCRIPTION
Adding consolideth.app into [consolidation-tooling-consolidation-tooling](https://github.com/ethereum/ethereum-org-website/blob/dev/public/content/roadmap/pectra/maxeb/index.md#consolidation-tooling-consolidation-tooling) 

## Description

We would like to add this tool into the listed tooling related to consolidations. 

from the issue description:

> Simplify. Optimize. Consolidate 🧠
> 
> [Ethereum](https://www.linkedin.com/company/ethereum/) now allows increasing the effective balance per validator up to 2048 ETH thanks to EIP-7251 (Pectra). But manual consolidation is complex, slow, and error-prone.
> 
> That’s why we built Consolideth, an open-source tool for operators who want to streamline their infrastructure without reinventing the wheel.
> 
> A tool to merge your Ethereum validators into larger ones, powered by Stakely. Clean up your staking infrastructure with a few simple steps.
> 
> It supports both mainnet and hoodi networks.

## Related Issue

consolideth.app by stakely | Consolidation tooling new listing:  https://github.com/ethereum/ethereum-org-website/issues/15805
