### PR TITLE
fix: correct city name from "De Nang" to "Da Nang" in 10 years events

### DIFF
--- a/src/data/tenYearEventRegions.ts
+++ b/src/data/tenYearEventRegions.ts
@@ -997,7 +997,7 @@ const tenYearEventRegions: Record<
       {
         host: "10 years of ETHEREUM Da Nang",
         eventLink: "https://lu.ma/t3vnzx07",
-        city: "De Nang",
+        city: "Da Nang",
         country: "Vietnam",
         countryFlag: "🇻🇳",
       },


### PR DESCRIPTION
This PR fixes the spelling error in the Vietnam event listing for Da Nang city on the 10 Years of Ethereum page.

## Changes
- Fixed spelling error in `src/data/tenYearEventRegions.ts` from "De Nang" to "Da Nang"
- Verified no duplicate Hanoi events exist

Closes #15890

Generated with [Claude Code](https://claude.ai/code)