### PR TITLE
fix: mdx escape syntax

### DIFF
--- a/public/content/developers/tutorials/erc20-annotated-code/index.md
+++ b/public/content/developers/tutorials/erc20-annotated-code/index.md
@@ -252,7 +252,7 @@ import "../../math/SafeMath.sol";
   to use the blockchain. Note that this is an old version, if you want to integrate with OpenGSN
   [use this tutorial](https://docs.opengsn.org/javascript-client/tutorial.html).
 - [The SafeMath library](https://ethereumdev.io/using-safe-math-library-to-prevent-from-overflows/), which prevents
-  arithmetic overflows/underflows for Solidity versions **<0.8.0**. In Solidity ≥0.8.0, arithmetic operations automatically
+  arithmetic overflows/underflows for Solidity versions **&lt;0.8.0**. In Solidity ≥0.8.0, arithmetic operations automatically
   revert on overflow/underflow, making SafeMath unnecessary. This contract uses SafeMath for backward compatibility with
   older compiler versions.
 


### PR DESCRIPTION
## Description
- Escapes less-than symbol syntax

## Related Issue
Fixes build issue:
```
5:40:12 PM: [Error: [next-mdx-remote] error compiling MDX:
5:40:12 PM: Unexpected character `0` (U+0030) before name, expected a character that can start a name, such as a letter, `$`, or `_`
5:40:12 PM: More information: https://mdxjs.com/docs/troubleshooting-mdx] {
5:40:12 PM:   digest: '4260701211'
5:40:12 PM: }
```