### PR TITLE
docs: Fixed outdated docs links

### DIFF
--- a/public/content/developers/docs/apis/backend/index.md
+++ b/public/content/developers/docs/apis/backend/index.md
@@ -152,7 +152,7 @@ These libraries abstract away much of the complexity of interacting directly wit
 
 **Coinbase Cloud Node -** **_Blockchain Infrastructure API._**
 
-- [Coinbase Cloud Node](https://www.coinbase.com/en-nl/developer-platform)
+- [Coinbase Cloud Node](https://www.coinbase.com/developer-platform)
 - [Documentation](https://docs.cdp.coinbase.com/)
 
 **DataHub by Figment -** **_Web3 API services with Ethereum Mainnet and testnets._**
@@ -165,7 +165,7 @@ These libraries abstract away much of the complexity of interacting directly wit
 - [moralis.io](https://moralis.io)
 - [Documentation](https://docs.moralis.io/)
 - [GitHub](https://github.com/MoralisWeb3)
-- [Discord](https://discord.com/invite/s3UfDvXQTc)
+- [Discord](https://moralis.io/joindiscord/)
 - [Forum](https://forum.moralis.io/)
 
 **NFTPort -** **_Ethereum Data and Mint APIs._**


### PR DESCRIPTION
## Description

I went through the list of external references and noticed several outdated or broken links. Updated them to their current valid versions to keep everything accurate and functional.

Here’s what was changed:

* `https://docs.alchemy.com/` → `https://www.alchemy.com/docs/`
* `https://getblock.io/docs/` → `https://docs.getblock.io/`
* `https://documenter.getpostman.com/view/13630829/TVmFkLwy#intro` → `https://nownodes.gitbook.io/documentation`
* `https://python.ethereum.org/` → `https://snakecharmers.ethereum.org/`
* `https://docs.cloud.coinbase.com/` → `https://docs.cdp.coinbase.com/`
* `https://www.coinbase.com/cloud` → `https://www.coinbase.com/en-nl/developer-platform`
* `https://moralis.io/joindiscord/` → `https://discord.com/invite/s3UfDvXQTc`

Everything now points to the correct and up-to-date resources.
