### PR TITLE
fix: hydration warning, un-nest ul from p tag

### DIFF
--- a/app/[locale]/what-is-ethereum/page.tsx
+++ b/app/[locale]/what-is-ethereum/page.tsx
@@ -804,20 +804,18 @@ const Page = async ({ params }: { params: PageParams }) => {
                   <div className="space-y-6">
                     <p>{t("page-what-is-ethereum-start-business-desc-1")}</p>
                     <p>{t("page-what-is-ethereum-start-business-desc-2")} </p>
-                    <p>
-                      {t("page-what-is-ethereum-start-business-desc-3")}
-                      <UnorderedList className="[&>li]:mb-0">
-                        <ListItem>
-                          {t("page-what-is-ethereum-start-business-benefit-1")}
-                        </ListItem>
-                        <ListItem>
-                          {t("page-what-is-ethereum-start-business-benefit-2")}
-                        </ListItem>
-                        <ListItem>
-                          {t("page-what-is-ethereum-start-business-benefit-3")}
-                        </ListItem>
-                      </UnorderedList>
-                    </p>
+                    <p>{t("page-what-is-ethereum-start-business-desc-3")}</p>
+                    <UnorderedList className="[&>li]:mb-0">
+                      <ListItem>
+                        {t("page-what-is-ethereum-start-business-benefit-1")}
+                      </ListItem>
+                      <ListItem>
+                        {t("page-what-is-ethereum-start-business-benefit-2")}
+                      </ListItem>
+                      <ListItem>
+                        {t("page-what-is-ethereum-start-business-benefit-3")}
+                      </ListItem>
+                    </UnorderedList>
                     <p>
                       {t.rich("page-what-is-ethereum-start-business-example", {
                         a: (chunks) => (


### PR DESCRIPTION
## Description
- un-nest `ul` from `p` tag

## Related Issue
Fixes hydration warning for nesting `ul` inside `p` tag