### PR TITLE
Add Uniswap Foundation Grants to community grants list

### DIFF
--- a/public/content/community/grants/index.md
+++ b/public/content/community/grants/index.md
@@ -44,6 +44,7 @@ These general platforms offer broad coverage of grants across the entire Web3 sp
 
 - [LlamaoGrants](https://wiki.defillama.com/wiki/LlamaoGrants) - _DeFi Llama's grant program directory_
 - [AlphaGrowth Grants](https://alphagrowth.io/crypto-web3-grants-list) - _Comprehensive list of crypto and Web3 grants_
+- [Uniswap Foundation Grants](https://www.uniswapfoundation.org/build) - _Unichain and Uniswap v4 grants and support for DeFi builders_
 
 ### For DAO contributors and governance innovators {#for-dao-contributors}
 


### PR DESCRIPTION
This PR adds Uniswap Foundation Grants to the community grants list in the grants page. 

The addition includes:
- Link to the Uniswap Foundation Build page (https://www.uniswapfoundation.org/build)
- Description highlighting UF focus on Unichain and Uniswap v4 grants and support for DeFi builders

_This helps community members discover additional funding opportunities for their DeFi projects._

This is a minor content improvement to expand the grants directory with a well-established grant program. No specific issue was opened for this change as it's a straightforward addition to existing content.
