### PR TITLE
Update Unichain Grants links

### DIFF
--- a/app/[locale]/founders/page.tsx
+++ b/app/[locale]/founders/page.tsx
@@ -194,7 +194,7 @@ const Page = async ({ params }: { params: PageParams }) => {
           tags: ["active", "grantProgram", "auditGrants", "toolingInfra"],
           description: t("page-founders-funding-unichain-description"),
           highlights: [t("page-founders-funding-unichain-highlight-1")],
-          href: "https://uniswapfoundation.mirror.xyz/CR1Boh_s3T7FDGwn2TQyyHYNMO_wp4jJDdtKR4U4CgE",
+          href: "https://www.uniswapfoundation.org/build",
           ctaLabel: t.rich("page-founders-cta-visit-name", {
             name: "Unichain",
           }),
@@ -268,7 +268,7 @@ const Page = async ({ params }: { params: PageParams }) => {
           tags: ["active", "auditGrants"],
           description: t("page-founders-partnerships-unichain-description"),
           highlights: [t("page-founders-partnerships-unichain-highlight-1")],
-          href: "https://www.uniswapfoundation.org/grants",
+          href: "https://www.uniswapfoundation.org/build",
           ctaLabel: t.rich("page-founders-cta-visit-name", {
             name: "Unichain",
           }),


### PR DESCRIPTION
This PR updates Unichain links in the EF founders page to ensure they point to the correct and current URLs.

The addition includes:
- Updated  Unichain Grants link to the current Uniswap Foundation Build Page with https://www.uniswapfoundation.org/build where they can access directly to Unichain grants information.

_This helps community members access the most up-to-date information about Unichain and ensures a better user experience when navigating the founders page._

This is a minor content improvement to update outdated links with current information. No specific issue was opened for this change as it's a straightforward link update to maintain content accuracy.
