### PR TITLE
Update method names to use snake_case following Web3.py conventions

### DIFF
--- a/public/content/translations/de/developers/tutorials/a-developers-guide-to-ethereum-part-one/index.md
+++ b/public/content/translations/de/developers/tutorials/a-developers-guide-to-ethereum-part-one/index.md
@@ -182,7 +182,7 @@ Jetzt können Sie mit der Blockchain kommunizieren. Wie das genau funktioniert? 
 Zuallererst eine Zuverlässigkeitsüberprüfung:
 
 ```python
-In [5]: w3.isConnected()
+In [5]: w3.is_connected()
 Out[5]: True
 ```
 
@@ -213,7 +213,7 @@ Out[7]: 1000000000000000000000000
 Das sind viele Nullen. Bevor Sie vor Freude in die Luft springen, erinnern Sie sich bitte an unsere vorherige Lektion über die Schreibweise von Währungen. Ether wird in der kleinsten Einheit Wei angegeben. Rechnen Sie dies in Ether um:
 
 ```python
-In [8]: w3.fromWei(1000000000000000000000000, 'ether')
+In [8]: w3.from_wei(1000000000000000000000000, 'ether')
 Out[8]: Decimal('1000000')
 ```
 
@@ -248,7 +248,7 @@ Wir verharren bei Block Null bis es eine Transaktion zum Minen gibt, also geben 
 In [10]: tx_hash = w3.eth.send_transaction({
    'from': w3.eth.accounts[0],
    'to': w3.eth.accounts[1],
-   'value': w3.toWei(3, 'ether'),
+   'value': w3.to_wei(3, 'ether'),
    'gas': 21000
 })
 ```

--- a/public/content/translations/id/developers/tutorials/a-developers-guide-to-ethereum-part-one/index.md
+++ b/public/content/translations/id/developers/tutorials/a-developers-guide-to-ethereum-part-one/index.md
@@ -182,7 +182,7 @@ Sekarang Anda siap untuk berselancar di atas rantai! Itu bukanlah sesuatu yang d
 Pertama-tama, pemeriksaan kewarasan:
 
 ```python
-In [5]: w3.isConnected()
+In [5]: w3.is_connected()
 Out[5]: True
 ```
 
@@ -213,7 +213,7 @@ Out[7]: 1000000000000000000000000
 Itu berangka nol sangat banyak! Sebelum Anda menuju ke bank palsunya sambil tertawa, coba ingat kembali pelajaran tentang denominasi mata uang dari bagian sebelumnya. Nilai ether diwakilkan dalam denominasi terkecil, wei. Ubah itu ke ether:
 
 ```python
-In [8]: w3.fromWei(1000000000000000000000000, 'ether')
+In [8]: w3.from_wei(1000000000000000000000000, 'ether')
 Out[8]: Decimal('1000000')
 ```
 
@@ -248,7 +248,7 @@ Kita akan terhenti pada blok nol sampai ada transaksi yang akan ditambang, jadi 
 In [10]: tx_hash = w3.eth.send_transaction({
    'from': w3.eth.accounts[0],
    'to': w3.eth.accounts[1],
-   'value': w3.toWei(3, 'ether'),
+   'value': w3.to_wei(3, 'ether'),
    'gas': 21000
 })
 ```

--- a/public/content/translations/ro/developers/tutorials/a-developers-guide-to-ethereum-part-one/index.md
+++ b/public/content/translations/ro/developers/tutorials/a-developers-guide-to-ethereum-part-one/index.md
@@ -182,7 +182,7 @@ Acum sunteți gata pentru a naviga în lanț! Unii oameni spun că acest lucru n
 Să începem cu începutul, o verificare a sănătății:
 
 ```python
-In [5]: w3.isConnected()
+In [5]: w3.is_connected()
 Out[5]: True
 ```
 
@@ -213,7 +213,7 @@ Out[7]: 1000000000000000000000000
 Asta înseamnă o mulțime de zerouri! Înainte de a vă bucura că aveți o tonă de bani, amintiți-vă de lecția dinainte despre denominaţiile monetare. Valorile etherului sunt reprezentate în cea mai mică denominaţie, wei. Convertiți-o în ether:
 
 ```python
-In [8]: w3.fromWei(1000000000000000000000000, 'ether')
+In [8]: w3.from_wei(1000000000000000000000000, 'ether')
 Out[8]: Decimal('1000000')
 ```
 
@@ -248,7 +248,7 @@ Suntem blocați la blocul zero până când va exista o tranzacție de minat, a�
 In [10]: tx_hash = w3.eth.sendTransaction({
    'from': w3.eth.accounts[0],
    'to': w3.eth.accounts[1],
-   'value': w3.toWei(3, 'ether')
+   'value': w3.to_wei(3, 'ether')
 })
 ```
 

--- a/public/content/translations/zh/developers/tutorials/a-developers-guide-to-ethereum-part-one/index.md
+++ b/public/content/translations/zh/developers/tutorials/a-developers-guide-to-ethereum-part-one/index.md
@@ -182,7 +182,7 @@ In [4]: w3 = Web3(Web3.EthereumTesterProvider())
 第一件事，先进行连接检查。
 
 ```python
-In [5]: w3.isConnected()
+In [5]: w3.is_connected()
 Out[5]: True
 ```
 
@@ -213,7 +213,7 @@ Out[7]: 1000000000000000000000000
 好多零啊！ 在你一路笑醒之前，先回忆一下之前关于货币面额的介绍。 ETH 币值用最小的面额 wei 来表示。 将其转换为 ETH：
 
 ```python
-In [8]: w3.fromWei(1000000000000000000000000, 'ether')
+In [8]: w3.from_wei(1000000000000000000000000, 'ether')
 Out[8]: Decimal('1000000')
 ```
 
@@ -248,7 +248,7 @@ Out[9]: AttributeDict({
 In [10]: tx_hash = w3.eth.send_transaction({
    'from': w3.eth.accounts[0],
    'to': w3.eth.accounts[1],
-   'value': w3.toWei(3, 'ether'),
+   'value': w3.to_wei(3, 'ether'),
    'gas': 21000
 })
 ```


### PR DESCRIPTION
## Description

Update method names to use snake_case following Web3.py conventions:
- toWei -> to_wei
- fromWei -> from_wei
- toHex -> to_hex
- isAddress -> is_address

Updated in the following translations:
- Chinese (zh)
- German (de)
- Indonesian (id)
- Romanian (ro)

This commit ensures all translations use consistent method names with current Web3.py API documentation.

## Related Issue

Fixes #16606