### PR TITLE
Update GoldRush description for clarity

### DIFF
--- a/public/content/developers/docs/frameworks/index.md
+++ b/public/content/developers/docs/frameworks/index.md
@@ -126,7 +126,7 @@ Before diving into frameworks, we recommend you first read through our introduct
 - [Documentation](https://catapulta.sh/docs)
 - [Github](https://github.com/catapulta-sh)
 
-**GoldRush (powered by Covalent) -** **_GoldRush (powered by Covalent) offers the most comprehensive blockchain data API suite for developers, analysts, and enterprises. Whether you are building a DeFi dashboard, a wallet, a trading bot, an AI agent or a compliance platform, the data APIs provide fast, accurate, and developer-friendly access to the essential onchain data you need_**
+**GoldRush (powered by Covalent) -** **_GoldRush offers the most comprehensive blockchain data API suite for developers, analysts, and enterprises. Whether you are building a DeFi dashboard, a wallet, a trading bot, an AI agent or a compliance platform, the data APIs provide fast, accurate, and developer-friendly access to the essential onchain data you need_**
 
 - [Website](https://goldrush.dev/)
 - [Documentation](https://goldrush.dev/docs/chains/ethereum)


### PR DESCRIPTION
Removed redundant mention of 'powered by Covalent' in the GoldRush description.

