### PR TITLE
fix: workflow pnpm version conflict

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -29,8 +29,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/crowdin-ci.yml
+++ b/.github/workflows/crowdin-ci.yml
@@ -20,8 +20,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/generate-review-report.yml
+++ b/.github/workflows/generate-review-report.yml
@@ -12,8 +12,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/get-crowdin-contributors.yml
+++ b/.github/workflows/get-crowdin-contributors.yml
@@ -14,8 +14,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/get-leaderboard-reports.yml
+++ b/.github/workflows/get-leaderboard-reports.yml
@@ -14,8 +14,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/get-translation-progress.yml
+++ b/.github/workflows/get-translation-progress.yml
@@ -14,8 +14,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/import-community-events.yml
+++ b/.github/workflows/import-community-events.yml
@@ -14,8 +14,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/update-chains.yml
+++ b/.github/workflows/update-chains.yml
@@ -15,8 +15,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Set up Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Description
- Canonical `pnpm` version is declared using `packageManager` field inside `package.json`
- Workflows attempt to re-declare a `pnpm` version, which is conflicting with canonical version noted in `package.json` causing an error
- PR removes re-declaration of `pnpm` version from each workflow

## Related Issue
Fixes:

> Error: Multiple versions of pnpm specified: - version 10 in the GitHub Action config with the key "version" - version pnpm@10.12.4 in the package.json with the key "packageManager" Remove one of these versions to avoid version mismatch errors like ERR_PNPM_BAD_PM_VERSION


https://github.com/ethereum/ethereum-org-website/actions/runs/19112202062
https://github.com/ethereum/ethereum-org-website/actions/runs/19174577161
https://github.com/ethereum/ethereum-org-website/actions/runs/19174593316