### PR TITLE
Update Codecov workflow to use download-artifact v6

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -63,7 +63,7 @@ jobs:
         run: pnpm install
 
       - name: Download Playwright test results
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           name: playwright-report
           path: ./tests/e2e/__results__


### PR DESCRIPTION
bump actions/download-artifact from v5 to v6 in .github/workflows/_codecov.yml
keeps the Codecov job aligned with the latest GitHub Actions release