### PR TITLE
fix incorrect translation

### DIFF
--- a/public/content/translations/zh/contributing/page-contributing-translation-program-contributors.json
+++ b/public/content/translations/zh/contributing/page-contributing-translation-program-contributors.json
@@ -4,7 +4,7 @@
   "page-contributing-translation-program-contributors-our-translators-1": "社区是 ethereum.org 翻译计划的核心。",
   "page-contributing-translation-program-contributors-our-translators-2": "由于有成千上万的社区成员为我们的项目提供翻译，因此很难对每个人表示感谢。",
   "page-contributing-translation-program-contributors-our-translators-3": "所有翻译人员都是根据他们在 Crowdin 中选择的名字按字母顺序排列的。如果您是一名翻译人员，并希望使用您的真实姓名、昵称、ENS域名等，您可以在 Crowdin 中更改您的全名。",
-  "page-contributing-translation-program-contributors-meta-title": "我们的译文",
+  "page-contributing-translation-program-contributors-meta-title": "我们的翻译人员",
   "page-contributing-translation-program-contributors-meta-description": "我们的翻译贡献者列表。",
   "page-contributing-translation-program-contributors-number-of-contributors": "贡献者数量："
 }


### PR DESCRIPTION
Found there are two different zh translation to the key "page-contributing-translation-program-contributors-meta-title", and one of it is incorrect.

The commit here is to make the translation consistent and correct.

## Related Issue
https://github.com/ethereum/ethereum-org-website/issues/16645
