### PR TITLE
fix: remove doubled word in ethereum-for-web2-auth tutorial

### DIFF
--- a/public/content/developers/tutorials/ethereum-for-web2-auth/index.md
+++ b/public/content/developers/tutorials/ethereum-for-web2-auth/index.md
@@ -37,7 +37,7 @@ Ethereum is a decentralized system.
 
 ![Ethereum logon](./fig-02-eth-logon.png)
 
-Users have a a private key (typically held in a browser extension). From the private key you can derive a public key, and from that a 20-byte address. When users need to log into a system, they are requested to sign a message with a nonce (a single-use value). The server can verify the signature was created by that address.
+Users have a private key (typically held in a browser extension). From the private key you can derive a public key, and from that a 20-byte address. When users need to log into a system, they are requested to sign a message with a nonce (a single-use value). The server can verify the signature was created by that address.
 
 ![Getting extra data from attestations](./fig-03-eas-data.png)
 


### PR DESCRIPTION
## Description

Fixed a typo in the "Using Ethereum for web2 authentication" tutorial where "a a" appeared instead of "a" on line 40.

**Changes:**
- File: [public/content/developers/tutorials/ethereum-for-web2-auth/index.md](cci:7://file:///c:/Users/oreem/.gemini/antigravity/playground/void-lagoon/temp_repos/ethereum-org-website/public/content/developers/tutorials/ethereum-for-web2-auth/index.md:0:0-0:0)
- Line: 40
- Change: `Users have a a private key` → `Users have a private key`

## Related Issue

N/A - This is a simple typo fix that doesn't require a prior issue.