### PR TITLE
BUGFIX: Resolves a visual layout issue where a significant whitespace gap appeared below the site footer.

### DIFF
--- a/src/components/FeedbackWidget/FixedDot.tsx
+++ b/src/components/FeedbackWidget/FixedDot.tsx
@@ -24,7 +24,7 @@ const FixedDot = forwardRef<HTMLButtonElement, FixedDotProps>(
         data-testid="feedback-widget-button"
         aria-label={t("feedback-widget")}
         className={cn(
-          "lg:mt-inherit fixed bottom-4 right-4 z-overlay flex size-12 items-center gap-0 rounded-full text-white shadow-table-item-box",
+          "fixed bottom-4 end-4 z-overlay flex size-12 items-center gap-0 rounded-full text-white shadow-table-item-box",
           "transition-all duration-200 hover:shadow-none hover:transition-transform hover:duration-200",
           !suppressScale && "hover:scale-110",
           offsetBottom && "bottom-31 lg:bottom-4",


### PR DESCRIPTION
BUGFIX: Resolves a visual layout issue where a significant whitespace gap appeared below the site footer.

## Description

The "FeedbackWidget" was using `position: sticky` relative to the document flow. Being the last element in the DOM, the browser reserved physical space for it at the very bottom of the page, extending the scrollable area unnecessarily and making the footer have a big gap.

<!--- Describe your changes in detail -->

## Screenshot

Before:
<img width="1464" height="748" alt="image" src="https://github.com/user-attachments/assets/a40a62ab-1777-4bb8-83b1-d568597dc750" />


After:

<img width="1470" height="749" alt="Screenshot 2025-11-24 at 1 59 25 PM" src="https://github.com/user-attachments/assets/af08cd2a-5e75-4e19-b6a1-56c345a983f7" />



**Fix:**
- Changed the CSS positioning of the `FixedDot` component from `sticky` to `fixed`.
- Updated alignment from flex/margin-based (`me-4 ms-auto`) to coordinate-based (`right-4`).

This change removes the widget from the document flow entirely, allowing it to float above the content without affecting the page height or layout boundaries.

## Testing
1. Navigate to any page with the Feedback Widget enabled.
2. Scroll to the absolute bottom of the page.
3. The footer content ends, and the page scroll stops immediately (no extra white space).
4. The Feedback Widget button is still visible in the bottom-right corner and functions correctly. :)
