### PR TITLE
build: update checkout action to v6

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -17,7 +17,7 @@ jobs:
     # Job steps
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           # Tells the checkout which commit hash to reference

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -41,7 +41,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/crowdin-ai-import.yml
+++ b/.github/workflows/crowdin-ai-import.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/crowdin-ci.yml
+++ b/.github/workflows/crowdin-ci.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       # Set up environment
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/generate-review-report.yml
+++ b/.github/workflows/generate-review-report.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/get-crowdin-contributors.yml
+++ b/.github/workflows/get-crowdin-contributors.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/get-leaderboard-reports.yml
+++ b/.github/workflows/get-leaderboard-reports.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/get-translation-progress.yml
+++ b/.github/workflows/get-translation-progress.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Sleep for 60 minutes
         run: sleep 3600
       - name: Wait for Netlify Deploy

--- a/.github/workflows/lychee-cron.yml
+++ b/.github/workflows/lychee-cron.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: dev

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -7,7 +7,7 @@ jobs:
     env:
       CI: true
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v6
         with:
@@ -50,7 +50,7 @@ jobs:
     needs: playwright
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v6

--- a/.github/workflows/update-chains.yml
+++ b/.github/workflows/update-chains.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
Updates `actions/checkout` to v6 in CI workflows. No code changes.

https://github.com/actions/checkout/releases/tag/v6.0.0