### PR TITLE
docs: update outdated GitHub doc links

### DIFF
--- a/docs/api-keys.md
+++ b/docs/api-keys.md
@@ -4,8 +4,8 @@
 
 We recommend setting this up when running the project locally, as we use the GitHub API to fetch repository data for many projects & files.
 
-> - [Follow these instructions](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) to create a personal GitHub API token
->   - When selecting scopes in step 8, leave everything unchecked (the data we fetch doesn't require any [scope](https://docs.github.com/en/developers/apps/scopes-for-oauth-apps#available-scopes))
+> - [Follow these instructions](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) to create a personal GitHub API token
+>   - When selecting scopes in step 8, leave everything unchecked (the data we fetch doesn't require any [scope](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps#available-scopes))
 > - In local repo root directory: Make a copy of `.env.example` and name it `.env`
 > - Copy & paste your new GitHub API token into `.env`
 


### PR DESCRIPTION
## Description

noticed that two documentation URLs in the project were pointing to deprecated pages.
updated them to the current official locations.