### PR TITLE
[Text] Uppercase proper nouns of social apps (Farcaster and Zora)

### DIFF
--- a/src/intl/en/page-apps.json
+++ b/src/intl/en/page-apps.json
@@ -29,7 +29,7 @@
   "page-apps-category-collectibles-meta-description": "Explore top NFT apps for buying collectibles, trading gaming skins, and discovering new digital assets across leading Ethereum marketplaces.",
   "page-apps-category-social-name": "Social",
   "page-apps-category-social-description": "Social is a category of decentralized applications that allow users to connect with others and share content.",
-  "page-apps-category-social-meta-title": "Social apps on Ethereum: farcaster, zora and more",
+  "page-apps-category-social-meta-title": "Social apps on Ethereum: Farcaster, Zora and more",
   "page-apps-category-social-meta-description": "Explore best messaging and social apps on Ethereum.",
   "page-apps-category-gaming-name": "Gaming",
   "page-apps-category-gaming-description": "Gaming is a category of decentralized applications that allow users to play games and earn rewards.",


### PR DESCRIPTION
They themselves write the name of their social networks in uppercase and they are proper names, so it looks like writing those in lowercase is wrong.