### PR TITLE
Hotfix: revert noindex for untranslated content

### DIFF
--- a/src/lib/md/metadata.ts
+++ b/src/lib/md/metadata.ts
@@ -12,7 +12,7 @@ export const getMdMetadata = async ({
 }) => {
   const slug = slugArray.join("/")
 
-  const { markdown, isTranslated } = await importMd(locale, slug)
+  const { markdown } = await importMd(locale, slug)
   const { frontmatter } = await compile({
     markdown,
     slugArray: slug.split("/"),
@@ -35,7 +35,6 @@ export const getMdMetadata = async ({
     description,
     image,
     author,
-    noIndex: !isTranslated,
   })
   return metadata
 }

--- a/src/lib/utils/metadata.ts
+++ b/src/lib/utils/metadata.ts
@@ -3,8 +3,6 @@ import { getTranslations } from "next-intl/server"
 
 import { DEFAULT_OG_IMAGE, SITE_URL } from "@/lib/constants"
 
-import { isPageTranslated } from "../i18n/pageTranslation"
-
 import { isLocaleValidISO639_1 } from "./translations"
 import { getFullUrl } from "./url"
 
@@ -119,8 +117,5 @@ export const getMetadata = async ({
     return { ...base, robots: { index: false } }
   }
 
-  const isTranslated = await isPageTranslated(locale, slugString)
-
-  // If the page is not translated, do not index the page
-  return isTranslated ? base : { ...base, robots: { index: false } }
+  return base
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Reverts adding `noindex` in untranslated pages applied in #16601.
