### PR TITLE
hotfix(seo): disable next-intl middleware alternate links

### DIFF
--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -7,6 +7,7 @@ export const routing = defineRouting({
   locales: LOCALES_CODES,
   defaultLocale: DEFAULT_LOCALE,
   localePrefix: "as-needed",
+  alternateLinks: false,
 })
 
 // Lightweight wrappers around Next.js' navigation APIs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Disables automatic hreflang alternate links generation in next-intl middleware.

## Problem
The middleware was generating `Link` HTTP headers with hreflang alternates only for the default locale (English), while HTML `<link>` tags were generated for all locales via `getMetadata()`. This inconsistency caused SEO tools to report missing reciprocal hreflang tags.
