### PR TITLE
fix(matomo): remove /en prefix normalization for English content

### DIFF
--- a/src/components/Matomo.tsx
+++ b/src/components/Matomo.tsx
@@ -5,7 +5,6 @@ import { usePathname } from "next/navigation"
 import { init, push } from "@socialgouv/matomo-next"
 
 import { IS_PREVIEW_DEPLOY } from "@/lib/utils/env"
-import { normalizePathForMatomo } from "@/lib/utils/matomo"
 
 export default function Matomo() {
   const pathname = usePathname()
@@ -41,11 +40,8 @@ export default function Matomo() {
       return setPreviousPath(pathname)
     }
 
-    const normalizedPreviousPath = normalizePathForMatomo(previousPath)
-    const normalizedPathname = normalizePathForMatomo(pathname)
-
-    push(["setReferrerUrl", normalizedPreviousPath])
-    push(["setCustomUrl", normalizedPathname])
+    push(["setReferrerUrl", previousPath])
+    push(["setCustomUrl", pathname])
     push(["deleteCustomVariables", "page"])
     setPreviousPath(pathname)
     // In order to ensure that the page title had been updated,

--- a/src/lib/utils/matomo.ts
+++ b/src/lib/utils/matomo.ts
@@ -2,29 +2,9 @@ import { push } from "@socialgouv/matomo-next"
 
 import type { MatomoEventOptions } from "@/lib/types"
 
-import { DEFAULT_LOCALE, LOCALES_CODES } from "@/lib/constants"
-
 import { IS_PROD } from "./env"
 
 export const MATOMO_LS_KEY = "ethereum-org.matomo-opt-out"
-
-/**
- * Normalizes paths to ensure consistent Matomo tracking.
- * With localePrefix: "as-needed", English paths don't have /en prefix,
- * but we want to track them as /en paths for analytics consistency.
- */
-export const normalizePathForMatomo = (pathname: string): string => {
-  const hasLocalePrefix = LOCALES_CODES.some((locale) =>
-    pathname.startsWith(`/${locale}/`)
-  )
-
-  if (hasLocalePrefix) {
-    return pathname
-  }
-
-  // For paths without locale prefix (English content), add /en prefix
-  return `/${DEFAULT_LOCALE}${pathname}`
-}
 
 export const trackCustomEvent = ({
   eventCategory,
@@ -43,9 +23,7 @@ export const trackCustomEvent = ({
 
   // Set custom URL removing any query params or hash fragments
   if (window) {
-    const normalizedPathname = normalizePathForMatomo(window.location.pathname)
-    const normalizedUrl = window.location.origin + normalizedPathname
-    push([`setCustomUrl`, normalizedUrl])
+    push([`setCustomUrl`, window.location.href.split(/[?#]/)[0]])
   }
   push([`trackEvent`, eventCategory, eventAction, eventName, eventValue])
 }


### PR DESCRIPTION
## Description

## Summary
- Removes `normalizePathForMatomo` function that was adding `/en` prefix to English paths
- Fixes analytics data being split between `/` and `/en/` in Matomo
