### PR TITLE
fix: update claude action permissions for write functionality

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,8 +35,8 @@ jobs:
       )
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
+      contents: write
+      pull-requests: write
       issues: read
       id-token: write
     steps:
@@ -44,6 +44,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Claude PR Action
         uses: anthropics/claude-code-action@beta


### PR DESCRIPTION
## Description
- Recent change in `claude.yml` GitHub action workflow bumping `actions/checkout@v5` to `actions/checkout@v6`
- This updates permissions to allow write access for claude assistant 

## Related Issue
https://github.com/ethereum/ethereum-org-website/actions/runs/19926835840

Attempted fix for: ❌ Error: remote: Permission to ethereum/ethereum-org-website.git denied to github-actions[bot]. fatal: unable to access 'https://github.com/ethereum/ethereum-org-website.git/': The requested URL returned error: 403