### PR TITLE
hot-fix: growThePieBlockspaceData fallback handling

### DIFF
--- a/app/[locale]/layer-2/networks/page.tsx
+++ b/app/[locale]/layer-2/networks/page.tsx
@@ -90,8 +90,13 @@ const Page = async ({ params }: { params: PageParams }) => {
         emerging: 1,
       }
 
-      const maturityDiff =
-        maturityOrder[b.networkMaturity] - maturityOrder[a.networkMaturity]
+      const aMaturityValue = a.networkMaturity
+        ? maturityOrder[a.networkMaturity]
+        : 0
+      const bMaturityValue = b.networkMaturity
+        ? maturityOrder[b.networkMaturity]
+        : 0
+      const maturityDiff = bMaturityValue - aMaturityValue
 
       if (maturityDiff === 0) {
         return (b.tvl || 0) - (a.tvl || 0)

--- a/src/lib/api/fetchGrowThePieBlockspace.ts
+++ b/src/lib/api/fetchGrowThePieBlockspace.ts
@@ -3,20 +3,28 @@ import { layer2Data } from "@/data/networks/networks"
 export const fetchGrowThePieBlockspace = async () => {
   const blockspaceData = {}
   for (const network of layer2Data) {
-    const response = await fetch(
-      `https://api.growthepie.com/v1/chains/blockspace/${network.growthepieID}.json`
-    )
-    if (!response.ok) {
-      continue
-    }
-    const data = await response.json()
+    try {
+      const response = await fetch(
+        `https://api.growthepie.com/v1/chains/blockspace/${network.growthepieID}.json`
+      )
+      if (!response.ok) {
+        continue
+      }
+      const data = await response.json()
 
-    blockspaceData[network.growthepieID] = {
-      nft: data.overview["30d"].nft.data[4],
-      defi: data.overview["30d"].defi.data[4],
-      social: data.overview["30d"].social.data?.[4] || 0,
-      token_transfers: data.overview["30d"].token_transfers.data[4],
-      unlabeled: data.overview["30d"].unlabeled.data[4],
+      blockspaceData[network.growthepieID] = {
+        nft: data.overview["30d"].nft.data[4],
+        defi: data.overview["30d"].defi.data[4],
+        social: data.overview["30d"].social.data?.[4] || 0,
+        token_transfers: data.overview["30d"].token_transfers.data[4],
+        unlabeled: data.overview["30d"].unlabeled.data[4],
+      }
+    } catch (error) {
+      console.warn(
+        `Failed to fetch blockspace data for ${network.growthepieID}:`,
+        error
+      )
+      continue
     }
   }
 


### PR DESCRIPTION
## Description
- Wraps `fetchGrowThePieBlockspace` logic in try/catch block with fallback handling to avoid breaking page with missing data

Interim patch while awaiting #16801

## Related Issue
500 error on https://ethereum.org/layer-2/networks
```
ERROR  Error in dataLoader for key "growThePieBlockspaceData": TypeError: Cannot read properties of undefined (reading 'data')
```