### PR TITLE
fix: remove /content redirect breaking static images

### DIFF
--- a/redirects.config.js
+++ b/redirects.config.js
@@ -18,7 +18,6 @@ module.exports = [
   ["/garden", "/roadmap/"],
   ["/download", "/wallets/find-wallet/"],
   ["/how", "/guides/"],
-  ["/content/:path*", "/:path*"],
   ["/nfts", "/nft/"],
   ["/daos", "/dao/"],
   ["/layer2", "/layer-2/"],


### PR DESCRIPTION
## Description
Removes redirect rule `/content/:path*` → `/:path*` that was intercepting requests to static files in `public/content/`.

## Problem
Images in markdown content (e.g., `/content/web3/web1.png`) were failing to load with error "The requested resource isn't a valid image... received null" because the redirect was stripping the `/content` prefix, causing 308 redirects to non-existent paths.