### PR TITLE
docs(evm): add transient storage details (EIP-1153)  - Introduce a "T…

### DIFF
--- a/public/content/developers/docs/evm/index.md
+++ b/public/content/developers/docs/evm/index.md
@@ -56,6 +56,7 @@ Contracts contain a Merkle Patricia _storage_ trie (as a word-addressable word a
 ### Opcodes
 
 Compiled smart contract bytecode executes as a number of EVM [opcodes](/developers/docs/evm/opcodes), which perform standard stack operations like `XOR`, `AND`, `ADD`, `SUB`, etc. The EVM also implements a number of blockchain-specific stack operations, such as `ADDRESS`, `BALANCE`, `BLOCKHASH`, etc. The opcode set also includes `TSTORE` and `TLOAD`, which provide access to transient storage.
+
 ![A diagram showing where gas is needed for EVM operations](../gas/gas.png)
 _Diagrams adapted from [Ethereum EVM illustrated](https://takenobu-hs.github.io/downloads/ethereum_evm_illustrated.pdf)_
 


### PR DESCRIPTION
…ransient storage" subsection under EVM instructions - Extend contract storage paragraph to mention transient storage - Note TSTORE and TLOAD opcodes for temporary cross-call state - Aligns text content with updated EVM diagram in #16770

This PR updates the Ethereum Virtual Machine (EVM) documentation to reflect the addition of transient storage introduced in [EIP-1153](https://eips.ethereum.org/EIPS/eip-1153).

Changes include:

1. **EVM Instructions Section:**  
   - Added a new subsection "Transient storage" describing its behavior, lifecycle, and difference from memory.  
   - Explained that it is accessed via `TSTORE` and `TLOAD` opcodes.

2. **Contract Storage Section:**  
   - Clarified that contracts can access transient storage during a transaction.  
   - Emphasized that it is temporary and not part of the persistent storage trie.

3. **Opcode Section:**  
   - Mentioned `TSTORE` and `TLOAD` for cross-call temporary state within a transaction.

This aligns the documentation with the updated EVM diagram (merged in PR #16770) and ensures developers understand the new transient storage feature and its opcodes.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
