### PR TITLE
feat: Add Lido CSM Node Operators guide [Fixes #16826]

### DIFF
--- a/src/components/Staking/StakingGuides.tsx
+++ b/src/components/Staking/StakingGuides.tsx
@@ -26,6 +26,11 @@ const StakingGuides = () => {
       link: "https://docs.stakewise.io/docs/guides/staking#solo-staking-with-stakewise",
       description: t("page-staking-guide-description-mac-linux-windows"),
     },
+    {
+      title: t("page-staking-guide-title-lido-csm"),
+      link: "https://docs.lido.fi/run-on-lido/csm/",
+      description: t("page-staking-guide-description-linux"),
+    },
   ]
 
   return <CardList className="flex flex-col gap-4" items={guides} />

--- a/src/intl/ca/page-staking.json
+++ b/src/intl/ca/page-staking.json
@@ -49,6 +49,7 @@
   "page-staking-guide-title-somer-esat": "Somer Esat",
   "page-staking-guide-title-rocket-pool": "Operadors de nodes de Rocket Pool",
   "page-staking-guide-title-stakewise": "Operadors de Nodes StakeWise",
+  "page-staking-guide-title-lido-csm":"Operadors de Nodes de Lido CSM",
   "page-staking-guide-description-linux": "Linux (CLI)",
   "page-staking-guide-description-mac-linux": "Linux, macOS (CLI)",
   "page-staking-guide-description-mac-linux-windows": "Linux, Windows, MacOS (CLI)",

--- a/src/intl/cs/page-staking.json
+++ b/src/intl/cs/page-staking.json
@@ -48,6 +48,7 @@
   "page-staking-guide-title-somer-esat": "Somer Esat",
   "page-staking-guide-title-rocket-pool": "Operátoři uzlů Rocket Pool",
   "page-staking-guide-title-stakewise": "Operátoři uzlů StakeWise",
+  "page-staking-guide-title-lido-csm":"Operátoři uzlů Lido CSM",
   "page-staking-guide-description-linux": "Linux (CLI)",
   "page-staking-guide-description-mac-linux": "Linux, macOS (CLI)",
   "page-staking-guide-description-mac-linux-windows": "Linux, Windows, MacOS (CLI)",

--- a/src/intl/de/page-staking.json
+++ b/src/intl/de/page-staking.json
@@ -49,6 +49,7 @@
   "page-staking-guide-title-somer-esat": "Somer Esat",
   "page-staking-guide-title-rocket-pool": "Rocket Pool – Node-Betreiber",
   "page-staking-guide-title-stakewise": "StakeWise-Knotenbetreiber",
+  "page-staking-guide-title-lido-csm":"Lido CSM – Node-Betreiber",
   "page-staking-guide-description-linux": "Linux (CLI)",
   "page-staking-guide-description-mac-linux": "Linux, macOS (CLI)",
   "page-staking-guide-description-mac-linux-windows": "Linux, Windows, MacOS (CLI)",

--- a/src/intl/el/page-staking.json
+++ b/src/intl/el/page-staking.json
@@ -49,6 +49,7 @@
   "page-staking-guide-title-somer-esat": "Somer Esat",
   "page-staking-guide-title-rocket-pool": "Χειριστές κόμβου Rocket Pool",
   "page-staking-guide-title-stakewise": "Διαχειριστές κόμβου StakeWise",
+  "page-staking-guide-title-lido-csm":"Χειριστές κόμβου Lido CSM",
   "page-staking-guide-description-linux": "Linux (CLI)",
   "page-staking-guide-description-mac-linux": "Linux, macOS (CLI)",
   "page-staking-guide-description-mac-linux-windows": "Linux, Windows, MacOS (CLI)",

--- a/src/intl/en/page-staking.json
+++ b/src/intl/en/page-staking.json
@@ -49,6 +49,7 @@
   "page-staking-guide-title-somer-esat": "Somer Esat",
   "page-staking-guide-title-rocket-pool": "Rocket Pool Node Operators",
   "page-staking-guide-title-stakewise": "StakeWise Node Operators",
+  "page-staking-guide-title-lido-csm":"Lido CSM Node Operators",
   "page-staking-guide-description-linux": "Linux (CLI)",
   "page-staking-guide-description-mac-linux": "Linux, macOS (CLI)",
   "page-staking-guide-description-mac-linux-windows": "Linux, Windows, MacOS (CLI)",

--- a/src/intl/es/page-staking.json
+++ b/src/intl/es/page-staking.json
@@ -49,6 +49,7 @@
   "page-staking-guide-title-somer-esat": "Somer Esat",
   "page-staking-guide-title-rocket-pool": "Operadores del nodo Rocket Pool",
   "page-staking-guide-title-stakewise": "Operadores de nodos StakeWise",
+  "page-staking-guide-title-lido-csm":"Operadores de nodos Lido CSM",
   "page-staking-guide-description-linux": "Linux (interfaz de línea de comandos o CLI)",
   "page-staking-guide-description-mac-linux": "Linux, macOS (ILC)",
   "page-staking-guide-description-mac-linux-windows": "Linux, Windows, MacOS (CLI)",

--- a/src/intl/fr/page-staking.json
+++ b/src/intl/fr/page-staking.json
@@ -49,6 +49,7 @@
   "page-staking-guide-title-somer-esat": "Somer Esat",
   "page-staking-guide-title-rocket-pool": "Opérateurs de nœud Rocket Pool",
   "page-staking-guide-title-stakewise": "Opérateurs de nœuds StakeWise",
+  "page-staking-guide-title-lido-csm":"Opérateurs de nœuds Lido CSM",
   "page-staking-guide-description-linux": "Linux (CLI)",
   "page-staking-guide-description-mac-linux": "Linux, macOS (CLI)",
   "page-staking-guide-description-mac-linux-windows": "Linux, Windows, MacOS (CLI)",

--- a/src/intl/ga/page-staking.json
+++ b/src/intl/ga/page-staking.json
@@ -49,6 +49,7 @@
   "page-staking-guide-title-somer-esat": "Somer Esat",
   "page-staking-guide-title-rocket-pool": "Oibreoirí Nóid Rocket Pool",
   "page-staking-guide-title-stakewise": "Oibreoirí Nód StakeWise",
+  "page-staking-guide-title-lido-csm":"Oibreoirí Nóid Lido CSM",
   "page-staking-guide-description-linux": "Linux (CLI)",
   "page-staking-guide-description-mac-linux": "Linux, macOS (CLI)",
   "page-staking-guide-description-mac-linux-windows": "Linux, Windows, MacOS (CLI)",

--- a/src/intl/hu/page-staking.json
+++ b/src/intl/hu/page-staking.json
@@ -49,6 +49,7 @@
   "page-staking-guide-title-somer-esat": "Somer Esat",
   "page-staking-guide-title-rocket-pool": "Rocket Pool csomópont-operátorok",
   "page-staking-guide-title-stakewise": "StakeWise csomópont-operátorok",
+  "page-staking-guide-title-lido-csm":"Lido CSM csomópont-operátorok",
   "page-staking-guide-description-linux": "Linux (CLI)",
   "page-staking-guide-description-mac-linux": "Linux, macOS (CLI)",
   "page-staking-guide-description-mac-linux-windows": "Linux, Windows, MacOS (CLI)",

--- a/src/intl/id/page-staking.json
+++ b/src/intl/id/page-staking.json
@@ -49,6 +49,7 @@
   "page-staking-guide-title-somer-esat": "Somer Esat",
   "page-staking-guide-title-rocket-pool": "Operator Simpul Kolam Roket",
   "page-staking-guide-title-stakewise": "Operator Node StakeWise",
+  "page-staking-guide-title-lido-csm":"Operator Node Lido CSM",
   "page-staking-guide-description-linux": "Linux (CLI)",
   "page-staking-guide-description-mac-linux": "Linux, macOS (CLI)",
   "page-staking-guide-description-mac-linux-windows": "Linux, Windows, MacOS (CLI)",

--- a/src/intl/it/page-staking.json
+++ b/src/intl/it/page-staking.json
@@ -49,6 +49,7 @@
   "page-staking-guide-title-somer-esat": "Somer Esat",
   "page-staking-guide-title-rocket-pool": "Operatori del nodo Rocket Pool",
   "page-staking-guide-title-stakewise": "Operatori di nodi StakeWise",
+  "page-staking-guide-title-lido-csm":"Operatori di nodi Lido CSM",
   "page-staking-guide-description-linux": "Linux (CLI)",
   "page-staking-guide-description-mac-linux": "Linux, macOS (CLI)",
   "page-staking-guide-description-mac-linux-windows": "Linux, Windows, MacOS (CLI)",

--- a/src/intl/kk/page-staking.json
+++ b/src/intl/kk/page-staking.json
@@ -47,6 +47,7 @@
   "page-staking-guide-title-somer-esat": "Сомер Эсат",
   "page-staking-guide-title-rocket-pool": "Rocket Pool торабының операторлары",
   "page-staking-guide-title-stakewise": "StakeWise торабының операторлары",
+  "page-staking-guide-title-lido-csm":"Lido CSM торабының операторлары",
   "page-staking-guide-description-linux": "Linux (CLI)",
   "page-staking-guide-description-mac-linux": "Linux, macOS (CLI)",
   "page-staking-guide-description-mac-linux-windows": "Linux, Windows, MacOS (CLI)",

--- a/src/intl/nl/page-staking.json
+++ b/src/intl/nl/page-staking.json
@@ -49,6 +49,7 @@
   "page-staking-guide-title-somer-esat": "Somer Esat",
   "page-staking-guide-title-rocket-pool": "Rocket Pool Node-Operators",
   "page-staking-guide-title-stakewise": "StakeWise-nodebeheerders",
+  "page-staking-guide-title-lido-csm":"Lido CSM Node-Operators",
   "page-staking-guide-description-linux": "Linux (CLI)",
   "page-staking-guide-description-mac-linux": "Linux, macOS (CLI)",
   "page-staking-guide-description-mac-linux-windows": "Linux, Windows, MacOS (CLI)",

--- a/src/intl/pt-br/page-staking.json
+++ b/src/intl/pt-br/page-staking.json
@@ -49,6 +49,7 @@
   "page-staking-guide-title-somer-esat": "Somer Esat",
   "page-staking-guide-title-rocket-pool": "Operadores de nó Rocket Pool",
   "page-staking-guide-title-stakewise": "Operadores de nós da StakeWise",
+  "page-staking-guide-title-lido-csm":"Operadores de nós da Lido CSM",
   "page-staking-guide-description-linux": "Linux (CLI)",
   "page-staking-guide-description-mac-linux": "Linux, macOS (CLI)",
   "page-staking-guide-description-mac-linux-windows": "Linux, Windows, MacOS (CLI)",

--- a/src/intl/ru/page-staking.json
+++ b/src/intl/ru/page-staking.json
@@ -49,6 +49,7 @@
   "page-staking-guide-title-somer-esat": "Сомер Эсат",
   "page-staking-guide-title-rocket-pool": "Операторы узлов пула Rocket Pool",
   "page-staking-guide-title-stakewise": "Операторы узлов StakeWise",
+  "page-staking-guide-title-lido-csm":"Операторы узлов Lido CSM",
   "page-staking-guide-description-linux": "Linux (CLI)",
   "page-staking-guide-description-mac-linux": "Linux, macOS (CLI)",
   "page-staking-guide-description-mac-linux-windows": "Linux, Windows, MacOS (CLI)",

--- a/src/intl/uk/page-staking.json
+++ b/src/intl/uk/page-staking.json
@@ -49,6 +49,7 @@
   "page-staking-guide-title-somer-esat": "Somer Esat",
   "page-staking-guide-title-rocket-pool": "Оператори вузлів Rocket Pool",
   "page-staking-guide-title-stakewise": "Оператори вузлів StakeWise",
+  "page-staking-guide-title-lido-csm":"Оператори вузлів Lido CSM",
   "page-staking-guide-description-linux": "Linux (CLI)",
   "page-staking-guide-description-mac-linux": "Linux, macOS (CLI)",
   "page-staking-guide-description-mac-linux-windows": "Linux, Windows, macOS (CLI)",

--- a/src/intl/uz/page-staking.json
+++ b/src/intl/uz/page-staking.json
@@ -47,6 +47,7 @@
   "page-staking-guide-title-somer-esat": "Somer Esat",
   "page-staking-guide-title-rocket-pool": "Raketa havzasi tugun operatorlari",
   "page-staking-guide-title-stakewise": "StakeWise tugun operatorlari",
+  "page-staking-guide-title-lido-csm":"Lido CSM tugun operatorlari",
   "page-staking-guide-description-linux": "Linux (CLI)",
   "page-staking-guide-description-mac-linux": "Linux, macOS (CLI)",
   "page-staking-guide-description-mac-linux-windows": "Linux, Windows, MacOS (CLI)",

--- a/src/intl/zh-tw/page-staking.json
+++ b/src/intl/zh-tw/page-staking.json
@@ -49,6 +49,7 @@
   "page-staking-guide-title-somer-esat": "Somer Esat",
   "page-staking-guide-title-rocket-pool": "Rocket Pool 節點營運商",
   "page-staking-guide-title-stakewise": "StakeWise 節點營運商",
+  "page-staking-guide-title-lido-csm":"Lido CSM 節點營運商",
   "page-staking-guide-description-linux": "Linux（命令列介面）",
   "page-staking-guide-description-mac-linux": "Linux，macOS（命令列介面）",
   "page-staking-guide-description-mac-linux-windows": "Linux、Windows、MacOS（命令列介面）",

--- a/src/intl/zh/page-staking.json
+++ b/src/intl/zh/page-staking.json
@@ -49,6 +49,7 @@
   "page-staking-guide-title-somer-esat": "Somer Esat",
   "page-staking-guide-title-rocket-pool": "Rocket Pool 节点运营商",
   "page-staking-guide-title-stakewise": "StakeWise 节点运营商",
+  "page-staking-guide-title-lido-csm":"Lido CSM 节点运营商",
   "page-staking-guide-description-linux": "Linux (CLI)",
   "page-staking-guide-description-mac-linux": "Linux、macOS (CLI)",
   "page-staking-guide-description-mac-linux-windows": "Linux、Windows、MacOS（命令行界面）",


### PR DESCRIPTION
## Description

Adds a link to the Lido CSM Node Operators guide to the https://ethereum.org/staking/solo/#staking-guides

## Related Issue

- https://github.com/ethereum/ethereum-org-website/issues/16826
