### PR TITLE
 fix bug #14620:  incorrect metatitle

### DIFF
--- a/public/content/smart-contracts/index.md
+++ b/public/content/smart-contracts/index.md
@@ -1,6 +1,6 @@
 ---
 title: Smart contracts
-metaTitle: "Smart contracts: What are they and their benefits"
+metaTitle: "Introduction to smart contracts"
 description: A non-technical introduction to smart contracts
 lang: en
 ---


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
change meta data to be accorded with title of the page 
## Related Issue

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Describe the bug
The metatitle of [smart contracts page](https://ethereum.org/en/smart-contracts/) is incorrect

To reproduce
Go to [smart contracts page](https://ethereum.org/en/smart-contracts/)
See error
<!--- Please link to the issue here: -->
https://github.com/ethereum/ethereum-org-website/issues/14620