### PR TITLE
fix: growthepie endpoint breaking changes

### DIFF
--- a/src/lib/api/fetchGrowThePieBlockspace.ts
+++ b/src/lib/api/fetchGrowThePieBlockspace.ts
@@ -13,8 +13,8 @@ export const fetchGrowThePieBlockspace = async () => {
       const data = await response.json()
 
       blockspaceData[network.growthepieID] = {
-        nft: data.overview["30d"].nft.data[4],
-        defi: data.overview["30d"].defi.data[4],
+        nft: data.overview["30d"].collectibles.data[4],
+        defi: data.overview["30d"].finance.data[4],
         social: data.overview["30d"].social.data?.[4] || 0,
         token_transfers: data.overview["30d"].token_transfers.data[4],
         unlabeled: data.overview["30d"].unlabeled.data[4],


### PR DESCRIPTION
## Description
Fixes growthepie API updates which introduced a few breaking changes
- `nft` -> `collectibles`
- `defi` -> `finance`

## Preview link
https://deploy-preview-16861--ethereumorg.netlify.app/layer-2/networks

## Related Issue
Missing block space data
<img width="1192" height="954" alt="image" src="https://github.com/user-attachments/assets/1cbdc565-5f18-4a1a-aa5e-8c70d0bc9c23" />
