### PR TITLE
fix: Remove stray backtick in Russian table translation

### DIFF
--- a/src/intl/ru/table.json
+++ b/src/intl/ru/table.json
@@ -1,5 +1,5 @@
 {
-  "table-active": "активные`",
+  "table-active": "активные",
   "table-filters": "Фильтры",
   "table-showing": "Показаны ",
   "table-reset-filters": "Сбросить",


### PR DESCRIPTION
## Description

This PR fixes a typo in the Russian translation for table component.

### Changes:
- Fixed typo: "активные`" → "активные" (removed stray backtick character)

## Type of change
- [x] Translation/content update

