### PR TITLE
patch: wallet networks spacing [Fixes #16909]

### DIFF
--- a/src/components/FindWalletProductTable/WalletInfo.tsx
+++ b/src/components/FindWalletProductTable/WalletInfo.tsx
@@ -110,7 +110,7 @@ const WalletInfo = ({ wallet }: WalletInfoProps) => {
               </div>
               <ChainImages
                 chains={wallet.supported_chains as ChainName[]}
-                className={`ms-2 ${walletPersonas.length === 0 ? "mb-4" : ""}`}
+                className={walletPersonas.length === 0 ? "mb-4" : ""}
               />
             </div>
           </MediaQuery>


### PR DESCRIPTION
## Description
Removes spacing before network icons

## Related Issue
- Fixes #16909