### PR TITLE
Remove invalid reviewedBy property from JSON-LD schema

### DIFF
--- a/app/[locale]/10years/page-jsonld.tsx
+++ b/app/[locale]/10years/page-jsonld.tsx
@@ -69,15 +69,6 @@ export default async function TenYearJsonLD({
         height: "417",
       },
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
     mainEntity: {
       "@type": "Event",
       "@id": `${url}#ethereum-10-year-anniversary`,
@@ -97,15 +88,6 @@ export default async function TenYearJsonLD({
       "@type": "Organization",
       name: "Ethereum Foundation",
       url: "https://ethereum.org",
-    },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
     },
   }
 

--- a/app/[locale]/[...slug]/page-jsonld.tsx
+++ b/app/[locale]/[...slug]/page-jsonld.tsx
@@ -79,15 +79,6 @@ export default async function SlugJsonLD({
       name: "ethereum.org",
       url: "https://ethereum.org",
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   // JSON-LD for the article content
@@ -111,15 +102,6 @@ export default async function SlugJsonLD({
       "@type": "Organization",
       name: "ethereum.org",
       url: "https://ethereum.org",
-    },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
     },
     dateModified: frontmatter.published,
     mainEntityOfPage: url,

--- a/app/[locale]/apps/[application]/page-jsonld.tsx
+++ b/app/[locale]/apps/[application]/page-jsonld.tsx
@@ -70,15 +70,6 @@ export default async function AppsAppJsonLD({
         url: "https://ethereum.org/images/eth-home-icon.png",
       },
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   const softwareApplicationJsonLd = {

--- a/app/[locale]/apps/categories/[catetgoryName]/page-jsonld.tsx
+++ b/app/[locale]/apps/categories/[catetgoryName]/page-jsonld.tsx
@@ -80,15 +80,6 @@ export default async function AppsCategoryJsonLD({
         url: "https://ethereum.org/images/eth-home-icon.png",
       },
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   const categoryAppsJsonLd = {

--- a/app/[locale]/apps/page-jsonld.tsx
+++ b/app/[locale]/apps/page-jsonld.tsx
@@ -68,15 +68,6 @@ export default async function AppsJsonLD({
         url: "https://ethereum.org/images/eth-home-icon.png",
       },
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   const appCategoriesJsonLd = {

--- a/app/[locale]/assets/page-jsonld.tsx
+++ b/app/[locale]/assets/page-jsonld.tsx
@@ -66,15 +66,6 @@ export default async function AssetsJsonLD({
         url: "https://ethereum.org/images/eth-home-icon.png",
       },
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   const creativeWorkJsonLd = {
@@ -112,15 +103,6 @@ export default async function AssetsJsonLD({
       "@type": "Organization",
       name: "ethereum.org",
       url: "https://ethereum.org",
-    },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
     },
   }
 

--- a/app/[locale]/bug-bounty/page-jsonld.tsx
+++ b/app/[locale]/bug-bounty/page-jsonld.tsx
@@ -66,15 +66,6 @@ export default async function BugBountyJsonLD({
         url: "https://ethereum.org/images/eth-home-icon.png",
       },
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   return <PageJsonLD structuredData={[webPageJsonLd]} />

--- a/app/[locale]/collectibles/page-jsonld.tsx
+++ b/app/[locale]/collectibles/page-jsonld.tsx
@@ -73,15 +73,6 @@ export default async function CollectiblesJsonLD({
         url: "https://ethereum.org/images/eth-home-icon.png",
       },
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   const collectiblesCollectionJsonLd = {
@@ -103,15 +94,6 @@ export default async function CollectiblesJsonLD({
       "@type": "Organization",
       name: "ethereum.org",
       url: "https://ethereum.org",
-    },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
     },
     additionalProperty: [
       {

--- a/app/[locale]/community/page-jsonld.tsx
+++ b/app/[locale]/community/page-jsonld.tsx
@@ -66,15 +66,6 @@ export default async function CommunityJsonLD({
         url: "https://ethereum.org/images/eth-home-icon.png",
       },
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   const communityResourcesJsonLd = {
@@ -118,15 +109,6 @@ export default async function CommunityJsonLD({
       "@type": "Organization",
       name: "ethereum.org",
       url: "https://ethereum.org",
-    },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
     },
   }
 

--- a/app/[locale]/contributing/translation-program/acknowledgements/page-jsonld.tsx
+++ b/app/[locale]/contributing/translation-program/acknowledgements/page-jsonld.tsx
@@ -92,15 +92,6 @@ export default async function AcknowledgementsJsonLD({
         url: "https://ethereum.org/images/eth-home-icon.png",
       },
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   return <PageJsonLD structuredData={[webPageJsonLd]} />

--- a/app/[locale]/contributing/translation-program/contributors/page-jsonld.tsx
+++ b/app/[locale]/contributing/translation-program/contributors/page-jsonld.tsx
@@ -90,15 +90,6 @@ export default async function ContributorsJsonLD({
         url: "https://ethereum.org/images/eth-home-icon.png",
       },
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   return <PageJsonLD structuredData={[webPageJsonLd]} />

--- a/app/[locale]/contributing/translation-program/translatathon/leaderboard/page-jsonld.tsx
+++ b/app/[locale]/contributing/translation-program/translatathon/leaderboard/page-jsonld.tsx
@@ -90,15 +90,6 @@ export default async function TranslatathonLeaderboardJsonLD({
         url: "https://ethereum.org/images/eth-home-icon.png",
       },
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   return <PageJsonLD structuredData={[webPageJsonLd]} />

--- a/app/[locale]/developers/learning-tools/page-jsonld.tsx
+++ b/app/[locale]/developers/learning-tools/page-jsonld.tsx
@@ -74,15 +74,6 @@ export default async function LearningToolsJsonLD({
         url: "https://ethereum.org/images/eth-home-icon.png",
       },
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   return <PageJsonLD structuredData={[webPageJsonLd]} />

--- a/app/[locale]/developers/local-environment/page-jsonld.tsx
+++ b/app/[locale]/developers/local-environment/page-jsonld.tsx
@@ -77,15 +77,6 @@ export default async function LocalEnvironmentJsonLD({
         url: "https://ethereum.org/images/eth-home-icon.png",
       },
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   const developmentFrameworksJsonLd = {
@@ -117,15 +108,6 @@ export default async function LocalEnvironmentJsonLD({
       "@type": "Organization",
       name: "ethereum.org",
       url: "https://ethereum.org",
-    },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
     },
   }
 

--- a/app/[locale]/developers/page-jsonld.tsx
+++ b/app/[locale]/developers/page-jsonld.tsx
@@ -74,15 +74,6 @@ export default async function DevelopersPageJsonLD({
         url: "https://ethereum.org/images/eth-home-icon.png",
       },
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   const learningResourcesJsonLd = {
@@ -120,15 +111,6 @@ export default async function DevelopersPageJsonLD({
       "@type": "Organization",
       name: "ethereum.org",
       url: "https://ethereum.org",
-    },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
     },
   }
 

--- a/app/[locale]/developers/tutorials/page-jsonld.tsx
+++ b/app/[locale]/developers/tutorials/page-jsonld.tsx
@@ -74,15 +74,6 @@ export default async function TutorialsPageJsonLD({
         url: "https://ethereum.org/images/eth-home-icon.png",
       },
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   const tutorialCollectionJsonLd = {
@@ -103,15 +94,6 @@ export default async function TutorialsPageJsonLD({
       "@type": "Organization",
       name: "ethereum.org",
       url: "https://ethereum.org",
-    },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
     },
   }
 
@@ -148,15 +130,6 @@ export default async function TutorialsPageJsonLD({
       "@type": "Organization",
       name: "ethereum.org",
       url: "https://ethereum.org",
-    },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
     },
   }
 

--- a/app/[locale]/ethereum-history-founder-and-ownership/page-jsonld.tsx
+++ b/app/[locale]/ethereum-history-founder-and-ownership/page-jsonld.tsx
@@ -71,15 +71,6 @@ export default async function EthereumHistoryFounderAndOwnershipPageJsonLD({
       name: "ethereum.org",
       url: "https://ethereum.org",
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   // JSON-LD for the history and founder article content
@@ -105,15 +96,6 @@ export default async function EthereumHistoryFounderAndOwnershipPageJsonLD({
       url: "https://ethereum.org",
     },
     contributor: contributorList,
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
     about: [
       {
         "@type": "Thing",

--- a/app/[locale]/ethereum-vs-bitcoin/page-jsonld.tsx
+++ b/app/[locale]/ethereum-vs-bitcoin/page-jsonld.tsx
@@ -66,15 +66,6 @@ export default async function EthereumVsBitcoinPageJsonLD({
       name: "ethereum.org",
       url: "https://ethereum.org",
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   // JSON-LD for the comparison article content
@@ -98,15 +89,6 @@ export default async function EthereumVsBitcoinPageJsonLD({
       url: "https://ethereum.org",
     },
     contributor: contributorList,
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
     about: [
       {
         "@type": "Thing",

--- a/app/[locale]/founders/page-jsonld.tsx
+++ b/app/[locale]/founders/page-jsonld.tsx
@@ -68,15 +68,6 @@ export default async function FoundersPageJsonLD({
         url: "https://ethereum.org/images/eth-home-icon.png",
       },
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   return <PageJsonLD structuredData={[webPageJsonLd]} />

--- a/app/[locale]/gas/page-jsonld.tsx
+++ b/app/[locale]/gas/page-jsonld.tsx
@@ -66,15 +66,6 @@ export default async function GasPageJsonLD({
       name: "ethereum.org",
       url: "https://ethereum.org",
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   // JSON-LD for the article content about gas
@@ -95,15 +86,6 @@ export default async function GasPageJsonLD({
       "@type": "Organization",
       name: "ethereum.org",
       url: "https://ethereum.org",
-    },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
     },
     dateModified: lastEditLocaleTimestamp,
     mainEntityOfPage: {

--- a/app/[locale]/get-eth/page-jsonld.tsx
+++ b/app/[locale]/get-eth/page-jsonld.tsx
@@ -66,15 +66,6 @@ export default async function GetEthPageJsonLD({
       name: "ethereum.org",
       url: "https://ethereum.org",
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   // JSON-LD for the article content about getting ETH
@@ -96,15 +87,6 @@ export default async function GetEthPageJsonLD({
       "@type": "Organization",
       name: "ethereum.org",
       url: "https://ethereum.org",
-    },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
     },
     dateModified: lastEditLocaleTimestamp,
   }

--- a/app/[locale]/layer-2/learn/page-jsonld.tsx
+++ b/app/[locale]/layer-2/learn/page-jsonld.tsx
@@ -72,15 +72,6 @@ export default async function Layer2LearnPageJsonLD({
       name: "ethereum.org",
       url: "https://ethereum.org",
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   // JSON-LD for the article content about learning Layer 2
@@ -103,15 +94,6 @@ export default async function Layer2LearnPageJsonLD({
       url: "https://ethereum.org",
     },
     contributor: contributorList,
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
     dateModified: lastEditLocaleTimestamp,
   }
 

--- a/app/[locale]/layer-2/networks/page-jsonld.tsx
+++ b/app/[locale]/layer-2/networks/page-jsonld.tsx
@@ -70,15 +70,6 @@ export default async function Layer2NetworksPageJsonLD({
         url: "https://ethereum.org/images/eth-home-icon.png",
       },
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   // JSON-LD for Layer 2 Networks listing

--- a/app/[locale]/layer-2/page-jsonld.tsx
+++ b/app/[locale]/layer-2/page-jsonld.tsx
@@ -64,15 +64,6 @@ export default async function Layer2PageJsonLD({
       name: "ethereum.org",
       url: "https://ethereum.org",
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   // JSON-LD for the article content about Layer 2
@@ -94,15 +85,6 @@ export default async function Layer2PageJsonLD({
       "@type": "Organization",
       name: "ethereum.org",
       url: "https://ethereum.org",
-    },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
     },
   }
 

--- a/app/[locale]/learn/page-jsonld.tsx
+++ b/app/[locale]/learn/page-jsonld.tsx
@@ -60,15 +60,6 @@ export default async function LearnPageJsonLD({ locale, contributors }) {
         url: "https://ethereum.org/images/eth-home-icon.png",
       },
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   return <PageJsonLD structuredData={[webPageJsonLd]} />

--- a/app/[locale]/page-jsonld.tsx
+++ b/app/[locale]/page-jsonld.tsx
@@ -54,15 +54,6 @@ export default async function IndexPageJsonLD({
       name: "ethereum.org",
       url: "https://ethereum.org",
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
   // JSON-LD for ethereum.org as an organization
   const organizationJsonLd = {

--- a/app/[locale]/quizzes/page-jsonld.tsx
+++ b/app/[locale]/quizzes/page-jsonld.tsx
@@ -64,15 +64,6 @@ export default async function QuizzesPageJsonLD({
       name: "ethereum.org",
       url: "https://ethereum.org",
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   return <PageJsonLD structuredData={[webPageJsonLd]} />

--- a/app/[locale]/resources/page-jsonld.tsx
+++ b/app/[locale]/resources/page-jsonld.tsx
@@ -64,15 +64,6 @@ export default async function ResourcesPageJsonLD({
       name: "ethereum.org",
       url: "https://ethereum.org",
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   return <PageJsonLD structuredData={[webPageJsonLd]} />

--- a/app/[locale]/roadmap/_vision/page-jsonld.tsx
+++ b/app/[locale]/roadmap/_vision/page-jsonld.tsx
@@ -72,15 +72,6 @@ export default async function RoadmapVisionPageJsonLD({
       name: "ethereum.org",
       url: "https://ethereum.org",
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   // JSON-LD for the vision article content
@@ -103,15 +94,6 @@ export default async function RoadmapVisionPageJsonLD({
       url: "https://ethereum.org",
     },
     contributor: contributorList,
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
     about: {
       "@type": "Thing",
       name: "Ethereum Vision",

--- a/app/[locale]/roadmap/page-jsonld.tsx
+++ b/app/[locale]/roadmap/page-jsonld.tsx
@@ -64,15 +64,6 @@ export default async function RoadmapPageJsonLD({
       name: "ethereum.org",
       url: "https://ethereum.org",
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   // JSON-LD for the roadmap article content
@@ -95,15 +86,6 @@ export default async function RoadmapPageJsonLD({
       url: "https://ethereum.org",
     },
     contributor: contributorList,
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
     about: {
       "@type": "Thing",
       name: "Ethereum Roadmap",

--- a/app/[locale]/run-a-node/page-jsonld.tsx
+++ b/app/[locale]/run-a-node/page-jsonld.tsx
@@ -66,15 +66,6 @@ export default async function RunANodePageJsonLD({
       name: "ethereum.org",
       url: "https://ethereum.org",
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   // JSON-LD for the run a node article content
@@ -96,15 +87,6 @@ export default async function RunANodePageJsonLD({
       "@type": "Organization",
       name: "ethereum.org",
       url: "https://ethereum.org",
-    },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
     },
     about: {
       "@type": "Thing",

--- a/app/[locale]/stablecoins/page-jsonld.tsx
+++ b/app/[locale]/stablecoins/page-jsonld.tsx
@@ -56,15 +56,6 @@ export default async function StablecoinsPageJsonLD({ locale, contributors }) {
       name: "ethereum.org",
       url: "https://ethereum.org",
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   // JSON-LD for the stablecoins article content
@@ -86,15 +77,6 @@ export default async function StablecoinsPageJsonLD({ locale, contributors }) {
       "@type": "Organization",
       name: "ethereum.org",
       url: "https://ethereum.org",
-    },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
     },
     about: {
       "@type": "Thing",

--- a/app/[locale]/staking/page-jsonld.tsx
+++ b/app/[locale]/staking/page-jsonld.tsx
@@ -66,15 +66,6 @@ export default async function StakingPageJsonLD({
       name: "ethereum.org",
       url: "https://ethereum.org",
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   // JSON-LD for the staking article content
@@ -96,15 +87,6 @@ export default async function StakingPageJsonLD({
       "@type": "Organization",
       name: "ethereum.org",
       url: "https://ethereum.org",
-    },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
     },
     about: {
       "@type": "Thing",

--- a/app/[locale]/start/page-jsonld.tsx
+++ b/app/[locale]/start/page-jsonld.tsx
@@ -64,15 +64,6 @@ export default async function StartPageJsonLD({
       name: "ethereum.org",
       url: "https://ethereum.org",
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   // JSON-LD for the start guide article content
@@ -95,15 +86,6 @@ export default async function StartPageJsonLD({
       url: "https://ethereum.org",
     },
     contributor: contributorList,
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
     about: {
       "@type": "Thing",
       name: "Getting Started with Ethereum",

--- a/app/[locale]/trillion-dollar-security/page-jsonld.tsx
+++ b/app/[locale]/trillion-dollar-security/page-jsonld.tsx
@@ -64,15 +64,6 @@ export default async function TrillionDollarSecurityPageJsonLD({
       name: "ethereum.org",
       url: "https://ethereum.org",
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   // JSON-LD for the security report article content
@@ -94,15 +85,6 @@ export default async function TrillionDollarSecurityPageJsonLD({
       "@type": "Organization",
       name: "ethereum.org",
       url: "https://ethereum.org",
-    },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
     },
     about: {
       "@type": "Thing",

--- a/app/[locale]/wallets/find-wallet/page-jsonld.tsx
+++ b/app/[locale]/wallets/find-wallet/page-jsonld.tsx
@@ -70,15 +70,6 @@ export default async function FindWalletPageJsonLD({
       name: "ethereum.org",
       url: "https://ethereum.org",
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   // JSON-LD for the wallet finder article content
@@ -101,15 +92,6 @@ export default async function FindWalletPageJsonLD({
       url: "https://ethereum.org",
     },
     contributor: contributorList,
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
     about: {
       "@type": "Thing",
       name: "Ethereum Wallet Finder",

--- a/app/[locale]/wallets/page-jsonld.tsx
+++ b/app/[locale]/wallets/page-jsonld.tsx
@@ -60,15 +60,6 @@ export default async function WalletsPageJsonLD({
       name: "ethereum.org",
       url: "https://ethereum.org",
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   // JSON-LD for the wallets guide article content
@@ -90,15 +81,6 @@ export default async function WalletsPageJsonLD({
       "@type": "Organization",
       name: "ethereum.org",
       url: "https://ethereum.org",
-    },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
     },
     about: {
       "@type": "Thing",

--- a/app/[locale]/what-is-ether/page-jsonld.tsx
+++ b/app/[locale]/what-is-ether/page-jsonld.tsx
@@ -66,15 +66,6 @@ export default async function WhatIsEtherPageJsonLD({
       name: "ethereum.org",
       url: "https://ethereum.org",
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   // JSON-LD for the article content
@@ -97,15 +88,6 @@ export default async function WhatIsEtherPageJsonLD({
       url: "https://ethereum.org",
     },
     contributor: contributorList,
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
     about: [
       {
         "@type": "Thing",

--- a/app/[locale]/what-is-ethereum/page-jsonld.tsx
+++ b/app/[locale]/what-is-ethereum/page-jsonld.tsx
@@ -72,15 +72,6 @@ export default async function WhatIsEthereumPageJsonLD({
       name: "ethereum.org",
       url: "https://ethereum.org",
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   // JSON-LD for the what is ethereum article content
@@ -103,15 +94,6 @@ export default async function WhatIsEthereumPageJsonLD({
       url: "https://ethereum.org",
     },
     contributor: contributorList,
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
     about: {
       "@type": "Thing",
       name: "Ethereum",

--- a/app/[locale]/what-is-the-ethereum-network/page-jsonld.tsx
+++ b/app/[locale]/what-is-the-ethereum-network/page-jsonld.tsx
@@ -72,15 +72,6 @@ export default async function WhatIsTheEthereumNetworkPageJsonLD({
       name: "ethereum.org",
       url: "https://ethereum.org",
     },
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
   }
 
   // JSON-LD for the ethereum network article content
@@ -103,15 +94,6 @@ export default async function WhatIsTheEthereumNetworkPageJsonLD({
       url: "https://ethereum.org",
     },
     contributor: contributorList,
-    reviewedBy: {
-      "@type": "Organization",
-      name: "ethereum.org",
-      url: "https://ethereum.org",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://ethereum.org/images/eth-home-icon.png",
-      },
-    },
     about: {
       "@type": "Thing",
       name: "Ethereum Network",


### PR DESCRIPTION
## Summary
- Remove `reviewedBy` property from all JSON-LD structured data
- Fixes AHREFS warning: "reviewedBy - Unexpected property for Article"

The `reviewedBy` property is not valid for `Article` or `WebPage` schema types according to [schema.org](https://schema.org/Article). This was causing structured data validation warnings.

**Files changed:** 40 page-jsonld.tsx files across the app

## Test plan
- [ ] Verify pages still render correctly
- [ ] Test structured data with [Google Rich Results Test](https://search.google.com/test/rich-results)
- [ ] Confirm no new schema warnings in AHREFS