### PR TITLE
Fix canonical URL mismatch for what-is-the-ethereum-network page

### DIFF
--- a/app/[locale]/what-is-the-ethereum-network/page.tsx
+++ b/app/[locale]/what-is-the-ethereum-network/page.tsx
@@ -717,7 +717,7 @@ export async function generateMetadata({
 
   return await getMetadata({
     locale,
-    slug: ["what-is-ethereum-network"],
+    slug: ["what-is-the-ethereum-network"],
     title: t("page-what-is-ethereum-network-meta-title"),
     description: t("page-what-is-ethereum-network-meta-description"),
     twitterDescription: t(


### PR DESCRIPTION
## Summary
- Fix slug from `what-is-ethereum-network` to `what-is-the-ethereum-network`
- The canonical URL was pointing to a URL that doesn't exist

**Before:** `<link rel="canonical" href="https://ethereum.org/what-is-ethereum-network/">`
**After:** `<link rel="canonical" href="https://ethereum.org/what-is-the-ethereum-network/">`

This was flagged by AHREFS as a non-canonical URL issue.

## Test plan
- [ ] Verify canonical URL matches the actual page URL
- [ ] Check page source for correct canonical tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)