### PR TITLE
Fix canonical URL for translatathon leaderboard page

### DIFF
--- a/app/[locale]/contributing/translation-program/translatathon/leaderboard/page.tsx
+++ b/app/[locale]/contributing/translation-program/translatathon/leaderboard/page.tsx
@@ -164,7 +164,7 @@ export async function generateMetadata({
 
   return await getMetadata({
     locale,
-    slug: ["translatathon"],
+    slug: ["contributing", "translation-program", "translatathon", "leaderboard"],
     title: "2025 Ethereum.org Translatathon",
     description: "2025 Ethereum.org Translatathon",
   })


### PR DESCRIPTION
## Summary
- Fix canonical URL from `/translatathon/` (404s) to `/contributing/translation-program/translatathon/leaderboard/`

**Before:** `<link rel="canonical" href="https://ethereum.org/translatathon/">` (404)
**After:** `<link rel="canonical" href="https://ethereum.org/contributing/translation-program/translatathon/leaderboard/">`

Flagged by AHREFS non-canonical URL audit.

## Test plan
- [ ] Verify canonical URL matches actual page URL
- [ ] Check page source for correct canonical tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)