### PR TITLE
Fix malformed x.com link causing 404

### DIFF
--- a/public/content/social-networks/index.md
+++ b/public/content/social-networks/index.md
@@ -112,7 +112,7 @@ Users use the platform's native [ERC-20](/glossary/#erc-20) token $MIND to pay f
 
 ### Twitter/X (Crypto Tipping) {#twitter}
 
-**[Twitter](x.com)** (now X) has incorporated blockchain technology in multiple ways to enhance creator monetization and digital identity verification:
+**[Twitter](https://x.com)** (now X) has incorporated blockchain technology in multiple ways to enhance creator monetization and digital identity verification:
 
 - **Crypto Tipping**: The platform has integrated **[Ethereum tipping](https://help.x.com/en/using-x/tips)**, enabling users to send payments via Ethereum-based wallets like Strike.
 


### PR DESCRIPTION
## Summary

Fixes missing `https://` protocol on x.com link in the social-networks page.

## The Problem

```markdown
**[Twitter](x.com)** (now X)
```

Without the protocol, this was treated as a relative link, creating a 404 at `/content/social-networks/x.com`.

## Fix

```markdown
**[Twitter](https://x.com)** (now X)
```