### PR TITLE
Remove outdated EIP-1662 references from translations

### DIFF
--- a/public/content/translations/id/developers/tutorials/downsizing-contracts-to-fight-the-contract-size-limit/index.md
+++ b/public/content/translations/id/developers/tutorials/downsizing-contracts-to-fight-the-contract-size-limit/index.md
@@ -138,9 +138,3 @@ function doSomething() { checkStuff(); }
 ```
 
 Tips tersebut akan membantu Anda mengurangi ukuran kontrak secara signifikan. Sekali lagi, ini sangat penting, selalu fokus pada pemisahan kontrak jika memungkinkan untuk mendapatkan hasil terbaik.
-
-## Masa depan batasan ukuran kontrak {#the-future-for-the-contract-size-limits}
-
-Ada [proposal terbuka](https://eips.ethereum.org/EIPS/eip-1662) untuk menghapus batasan ukuran kontrak. Ide ini pada dasarnya untuk membuat pemanggilan kontrak lebih mahal untuk kontrak dengan ukuran sangat besar. Ini tidak akan terlalu sulit untuk diimplementasikan, memiliki kompatibilitas ke belakang yang sederhana (menempatkan semua kontrak yang telah digunakan sebelumnya dalam kategori termurah), tetapi [tidak semua orang diyakinkan oleh ide ini](https://ethereum-magicians.org/t/removing-or-increasing-the-contract-size-limit/3045/24).
-
-Hanya waktu yang akan menentukan apakah batasan itu akan berubah di masa depan, reaksinya (lihat gambar di sebelah kanan) secara pasti menunjukkan persyaratan yang jelas bagi kita para pengembang. Sayangnya, ini bukanlah sesuatu yang dapat Anda harapkan dalam waktu dekat ini.

--- a/public/content/translations/ro/developers/tutorials/downsizing-contracts-to-fight-the-contract-size-limit/index.md
+++ b/public/content/translations/ro/developers/tutorials/downsizing-contracts-to-fight-the-contract-size-limit/index.md
@@ -138,9 +138,3 @@ function doSomething() { checkStuff(); }
 ```
 
 Aceste sugestii ar trebui să vă ajute să reduceți semnificativ dimensiunea contractului. Repet cât se poate de des, axați-vă pe cât posibil pe divizarea contractelor pentru a obține cel mai bun impact.
-
-## Viitorul privind limitele dimensiunii contractelor {#the-future-for-the-contract-size-limits}
-
-Există o [propunere deschisă](https://eips.ethereum.org/EIPS/eip-1662) de eliminare a limitelor dimensiunii contractelor. Ideea de bază este de a scumpi apelurile de contract pentru contractele mari. Nu ar fi prea greu de implementat, însă are o compatibilitate retroactivă simplă (pune toate contractele implementate anterior în cea mai ieftină categorie), dar [nu toată lumea este convinsă](https://ethereum-magicians.org/t/removing-or-increasing-the-contract-size-limit/3045/24).
-
-Doar timpul va spune dacă aceste limite se vor schimba în viitor, reacțiile (priviți imaginea din dreapta) arată absolut clar această necesitate pentru noi ca dezvoltatori. Din nefericire, nu vă puteți aștepta să se întâmple prea curând.


### PR DESCRIPTION
## Summary
Remove outdated section referencing non-existent EIP-1662 from Romanian and Indonesian translations.

## Details
The "Future for contract size limits" section referencing EIP-1662 was removed from the English source of the "downsizing contracts" tutorial but remained in the Romanian and Indonesian translations. EIP-1662 does not exist and returns a 404.

## Files changed
- `public/content/translations/ro/developers/tutorials/downsizing-contracts-to-fight-the-contract-size-limit/index.md`
- `public/content/translations/id/developers/tutorials/downsizing-contracts-to-fight-the-contract-size-limit/index.md`

## Test plan
- [ ] Verify translation files no longer reference EIP-1662
- [ ] Verify build succeeds