### PR TITLE
Fix broken German staking link

### DIFF
--- a/public/content/translations/de/developers/docs/nodes-and-clients/node-architecture/index.md
+++ b/public/content/translations/de/developers/docs/nodes-and-clients/node-architecture/index.md
@@ -37,7 +37,7 @@ Der Konsensclient nimmt nicht an Attestierungen oder dem Vorschlagen von Blöcke
 
 Knotenbetreiber können Validatoren zu ihren Konsensclients hinzufügen, indem sie 32 ETH in den Einzahlungsvertrag einzahlen. Der Validatorclient kommt gebündelt mit dem Konsensclient und kann zu jeder Zeit einem Knoten hinzugefügt werden. Der Validator bearbeitet Attestierungen und Blockvorschläge. Sie ermöglichen einem Knoten, Prämien zu sammeln oder ETH über Strafen oder Slashing zu verlieren. Durch das Betreiben der Validatorensoftware kann ein Knoten ausgewählt werden, um einen neuen Block vorzuschlagen.
 
-[Mehr über Staking](/abstecken/).
+[Mehr über Staking](/staking/).
 
 ## Vergleich der Knotenkomponenten {#node-comparison}
 


### PR DESCRIPTION
## Summary
Fix broken link in German node-architecture translation that used `/abstecken/` (German translation of "staking") instead of the correct English URL path `/staking/`.

## Details
URLs should use English paths regardless of the content language. The German translation incorrectly used a translated URL path.

## Test plan
- [ ] Verify `/de/developers/docs/nodes-and-clients/node-architecture/` links to `/staking/` correctly