### PR TITLE
Fix critical form-data vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
   "packageManager": "pnpm@10.12.4",
   "pnpm": {
     "overrides": {
+      "form-data": ">=4.0.4",
       "sha.js": ">=2.4.12"
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  form-data: '>=4.0.4'
   sha.js: '>=2.4.12'
 
 importers:
@@ -6472,8 +6473,8 @@ packages:
       typescript: '>3.6.0'
       webpack: ^5.11.0
 
-  form-data@4.0.2:
-    resolution: {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
   forwarded-parse@2.1.2:
@@ -16330,7 +16331,7 @@ snapshots:
   axios@1.9.0:
     dependencies:
       follow-redirects: 1.15.9
-      form-data: 4.0.2
+      form-data: 4.0.5
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
@@ -18040,11 +18041,12 @@ snapshots:
       typescript: 5.8.3
       webpack: 5.99.9(esbuild@0.25.12)
 
-  form-data@4.0.2:
+  form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
       mime-types: 2.1.35
 
   forwarded-parse@2.1.2: {}


### PR DESCRIPTION
## Summary
- Adds pnpm override to force form-data >= 4.0.4
- Fixes critical vulnerability: form-data uses unsafe random function for choosing boundary

## Security Advisory
https://github.com/advisories/GHSA-g625-hm26-33c3

## Test plan
- [x] Verified form-data upgraded to 4.0.5 via `pnpm why form-data`
- [ ] CI passes