### PR TITLE
fix: remove horizontal line from expanded wallet accordion

### DIFF
--- a/src/components/ProductTable/List.tsx
+++ b/src/components/ProductTable/List.tsx
@@ -114,7 +114,7 @@ const List = <T extends { id: string }>({
                 <WalletInfo wallet={item as unknown as Wallet} />
               </div>
             </CollapsibleTrigger>
-            <CollapsibleContent className="border-t p-4">
+            <CollapsibleContent className="p-4">
               {subComponent?.(item as T, filters, virtualItem.index)}
             </CollapsibleContent>
           </Collapsible>


### PR DESCRIPTION
## Description
- Removes inappropriate `border-t` from accordion content when wallet accordion expanded

## Preview
https://deploy-preview-16953--ethereumorg.netlify.app/wallets/find-wallet

<img width="1180" height="717" alt="image" src="https://github.com/user-attachments/assets/2cd51bac-8707-435c-afed-7d04530dba60" />

## Related Issue
Fixes inappropriate horizontal line when wallet accordion expanded

<img width="1171" height="713" alt="image" src="https://github.com/user-attachments/assets/af3ed131-4e4e-4114-a4ef-e158b2f353bf" />
