### PR TITLE
Add ETHPrague 2026 event listing

### DIFF
--- a/src/data/community-events.json
+++ b/src/data/community-events.json
@@ -275,7 +275,7 @@
     "href": "https://ethprague.com/",
     "location": "Prague, CZ",
     "description": "ETHPrague is an event focused on the future of Ethereum and potential concepts or applications that don't yet exist.",
-    "imageUrl": "https://ethprague.com/hub/ethprague/og-image.png",
+    "imageUrl": "https://ethprague.com/ETHPrague_soc_share_2026.png",
     "hackathon": true
   },
   {


### PR DESCRIPTION
## Summary

Adds ETHPrague 2026 (May 8-10) to the community events list.

- **Event:** ETHPrague Conference & Hackathon
- **Dates:** May 8-10, 2026
- **Location:** Prague, CZ
- **Website:** https://ethprague.com/

Closes #16808