### PR TITLE
Fix duplicate data-layer calls during build

### DIFF
--- a/src/lib/data/index.ts
+++ b/src/lib/data/index.ts
@@ -1,3 +1,4 @@
+import { cache } from "react"
 import { unstable_cache } from "next/cache"
 
 import * as dataLayer from "@/data-layer"
@@ -7,128 +8,137 @@ import { BASE_TIME_UNIT } from "@/lib/constants"
 const CACHE_REVALIDATE_HOUR = BASE_TIME_UNIT
 const CACHE_REVALIDATE_DAY = BASE_TIME_UNIT * 24
 
-export const getEthPrice = unstable_cache(
-  async () => await dataLayer.getEthPrice(),
+function createCachedGetter<T>(
+  fetcher: () => Promise<T>,
+  cacheKey: string[],
+  revalidate: number
+) {
+  const persistentCache = unstable_cache(fetcher, cacheKey, { revalidate })
+  return cache(persistentCache)
+}
+
+export const getEthPrice = createCachedGetter(
+  dataLayer.getEthPrice,
   ["eth-price"],
-  { revalidate: CACHE_REVALIDATE_HOUR }
+  CACHE_REVALIDATE_HOUR
 )
 
-export const getL2beatData = unstable_cache(
-  async () => await dataLayer.getL2beatData(),
+export const getL2beatData = createCachedGetter(
+  dataLayer.getL2beatData,
   ["l2beat-data"],
-  { revalidate: CACHE_REVALIDATE_HOUR }
+  CACHE_REVALIDATE_HOUR
 )
 
-export const getAppsData = unstable_cache(
-  async () => await dataLayer.getAppsData(),
+export const getAppsData = createCachedGetter(
+  dataLayer.getAppsData,
   ["apps-data"],
-  { revalidate: CACHE_REVALIDATE_DAY }
+  CACHE_REVALIDATE_DAY
 )
 
-export const getGrowThePieData = unstable_cache(
-  async () => await dataLayer.getGrowThePieData(),
+export const getGrowThePieData = createCachedGetter(
+  dataLayer.getGrowThePieData,
   ["grow-the-pie-data"],
-  { revalidate: CACHE_REVALIDATE_HOUR }
+  CACHE_REVALIDATE_HOUR
 )
 
-export const getGrowThePieBlockspaceData = unstable_cache(
-  async () => await dataLayer.getGrowThePieBlockspaceData(),
+export const getGrowThePieBlockspaceData = createCachedGetter(
+  dataLayer.getGrowThePieBlockspaceData,
   ["grow-the-pie-blockspace-data"],
-  { revalidate: CACHE_REVALIDATE_HOUR }
+  CACHE_REVALIDATE_HOUR
 )
 
-export const getGrowThePieMasterData = unstable_cache(
-  async () => await dataLayer.getGrowThePieMasterData(),
+export const getGrowThePieMasterData = createCachedGetter(
+  dataLayer.getGrowThePieMasterData,
   ["grow-the-pie-master-data"],
-  { revalidate: CACHE_REVALIDATE_DAY }
+  CACHE_REVALIDATE_DAY
 )
 
-export const getCommunityPicks = unstable_cache(
-  async () => await dataLayer.getCommunityPicks(),
+export const getCommunityPicks = createCachedGetter(
+  dataLayer.getCommunityPicks,
   ["community-picks"],
-  { revalidate: CACHE_REVALIDATE_DAY }
+  CACHE_REVALIDATE_DAY
 )
 
-export const getCalendarEvents = unstable_cache(
-  async () => await dataLayer.getCalendarEvents(),
+export const getCalendarEvents = createCachedGetter(
+  dataLayer.getCalendarEvents,
   ["calendar-events"],
-  { revalidate: CACHE_REVALIDATE_HOUR }
+  CACHE_REVALIDATE_HOUR
 )
 
-export const getRSSData = unstable_cache(
-  async () => await dataLayer.getRSSData(),
+export const getRSSData = createCachedGetter(
+  dataLayer.getRSSData,
   ["rss-data"],
-  { revalidate: CACHE_REVALIDATE_HOUR }
+  CACHE_REVALIDATE_HOUR
 )
 
-export const getAttestantPosts = unstable_cache(
-  async () => await dataLayer.getAttestantPosts(),
+export const getAttestantPosts = createCachedGetter(
+  dataLayer.getAttestantPosts,
   ["attestant-posts"],
-  { revalidate: CACHE_REVALIDATE_HOUR }
+  CACHE_REVALIDATE_HOUR
 )
 
-export const getBeaconchainEpochData = unstable_cache(
-  async () => await dataLayer.getBeaconchainEpochData(),
+export const getBeaconchainEpochData = createCachedGetter(
+  dataLayer.getBeaconchainEpochData,
   ["beaconchain-epoch-data"],
-  { revalidate: CACHE_REVALIDATE_HOUR }
+  CACHE_REVALIDATE_HOUR
 )
 
-export const getBeaconchainEthstoreData = unstable_cache(
-  async () => await dataLayer.getBeaconchainEthstoreData(),
+export const getBeaconchainEthstoreData = createCachedGetter(
+  dataLayer.getBeaconchainEthstoreData,
   ["beaconchain-ethstore-data"],
-  { revalidate: CACHE_REVALIDATE_HOUR }
+  CACHE_REVALIDATE_HOUR
 )
 
-export const getBlobscanStats = unstable_cache(
-  async () => await dataLayer.getBlobscanStats(),
+export const getBlobscanStats = createCachedGetter(
+  dataLayer.getBlobscanStats,
   ["blobscan-stats"],
-  { revalidate: CACHE_REVALIDATE_HOUR }
+  CACHE_REVALIDATE_HOUR
 )
 
-export const getEthereumMarketcapData = unstable_cache(
-  async () => await dataLayer.getEthereumMarketcapData(),
+export const getEthereumMarketcapData = createCachedGetter(
+  dataLayer.getEthereumMarketcapData,
   ["ethereum-marketcap-data"],
-  { revalidate: CACHE_REVALIDATE_HOUR }
+  CACHE_REVALIDATE_HOUR
 )
 
-export const getEthereumStablecoinsMcapData = unstable_cache(
-  async () => await dataLayer.getEthereumStablecoinsMcapData(),
+export const getEthereumStablecoinsMcapData = createCachedGetter(
+  dataLayer.getEthereumStablecoinsMcapData,
   ["ethereum-stablecoins-mcap-data"],
-  { revalidate: CACHE_REVALIDATE_HOUR }
+  CACHE_REVALIDATE_HOUR
 )
 
-export const getGFIs = unstable_cache(
-  async () => await dataLayer.getGFIs(),
+export const getGFIs = createCachedGetter(
+  dataLayer.getGFIs,
   ["gfis"],
-  { revalidate: CACHE_REVALIDATE_HOUR }
+  CACHE_REVALIDATE_HOUR
 )
 
-export const getGitHistory = unstable_cache(
-  async () => await dataLayer.getGitHistory(),
+export const getGitHistory = createCachedGetter(
+  dataLayer.getGitHistory,
   ["git-history"],
-  { revalidate: CACHE_REVALIDATE_HOUR }
+  CACHE_REVALIDATE_HOUR
 )
 
-export const getGithubRepoData = unstable_cache(
-  async () => await dataLayer.getGithubRepoData(),
+export const getGithubRepoData = createCachedGetter(
+  dataLayer.getGithubRepoData,
   ["github-repo-data"],
-  { revalidate: CACHE_REVALIDATE_DAY }
+  CACHE_REVALIDATE_DAY
 )
 
-export const getStablecoinsData = unstable_cache(
-  async () => await dataLayer.getStablecoinsData(),
+export const getStablecoinsData = createCachedGetter(
+  dataLayer.getStablecoinsData,
   ["stablecoins-data"],
-  { revalidate: CACHE_REVALIDATE_HOUR }
+  CACHE_REVALIDATE_HOUR
 )
 
-export const getTotalEthStakedData = unstable_cache(
-  async () => await dataLayer.getTotalEthStakedData(),
+export const getTotalEthStakedData = createCachedGetter(
+  dataLayer.getTotalEthStakedData,
   ["total-eth-staked-data"],
-  { revalidate: CACHE_REVALIDATE_HOUR }
+  CACHE_REVALIDATE_HOUR
 )
 
-export const getTotalValueLockedData = unstable_cache(
-  async () => await dataLayer.getTotalValueLockedData(),
+export const getTotalValueLockedData = createCachedGetter(
+  dataLayer.getTotalValueLockedData,
   ["total-value-locked-data"],
-  { revalidate: CACHE_REVALIDATE_HOUR }
+  CACHE_REVALIDATE_HOUR
 )


### PR DESCRIPTION
I noticed we were hitting Netlify Blobs multiple times for the same data during static generation. For example, `getGrowThePieData` was being called 6 times instead of once when building the layer-2 pages.

**The issue:** Next.js renders each page twice during build (data collection + HTML generation), and `unstable_cache` alone doesn't deduplicate within the same render cycle.

**The fix:** Wrap our cached getters with React's `cache()` function, which memoizes calls within the same request/render. Now we get:
- `cache()` → deduplication within same render
- `unstable_cache` → persistence across requests with time-based revalidation

Before: ~6 calls per data source during build  
After: ~2 calls (one per worker process)