### PR TITLE
testing: restore e2e visual snapshots for all browser/device projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
     "crowdin-needs-review": "ts-node -O '{ \"module\": \"commonjs\" }' src/scripts/crowdin/reports/generateReviewReport.ts",
     "update-tutorials": "ts-node -O '{ \"module\": \"commonjs\" }' src/scripts/update-tutorials-list.ts",
     "prepare": "husky",
-    "test": "USE_MOCK_DATA=true playwright test --project=unit --project=e2e",
-    "test:e2e": "playwright test --project=e2e",
+    "test": "pnpm test:unit && pnpm test:e2e",
+    "test:unit": "USE_MOCK_DATA=true playwright test --project=unit",
+    "test:e2e": "playwright test --project=e2e --project=e2e-webkit --project=e2e-mobile-chrome --project=e2e-mobile-safari",
     "test:e2e:ui": "playwright test --project=e2e --ui",
     "test:e2e:debug": "playwright test --project=e2e --debug",
     "test:e2e:report": "playwright show-report tests/__report__",
-    "test:unit": "USE_MOCK_DATA=true playwright test --project=unit",
     "trigger:dev": "dotenv -e .env -- npx trigger.dev@latest dev"
   },
   "dependencies": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -38,8 +38,11 @@ export default defineConfig<ChromaticConfig>({
   expect: {
     timeout: 10000,
   },
+
   projects: [
-    /* E2E tests - require browser */
+    // ─────────────────────────────────────────────────────────────────────────
+    // E2E tests - Visual regression + functional tests across browsers/devices
+    // ─────────────────────────────────────────────────────────────────────────
     {
       name: "e2e",
       testDir: "./tests/e2e",
@@ -60,7 +63,10 @@ export default defineConfig<ChromaticConfig>({
       testDir: "./tests/e2e",
       use: { ...devices["iPhone 12"] },
     },
-    /* Unit tests - no browser needed */
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Unit tests
+    // ─────────────────────────────────────────────────────────────────────────
     {
       name: "unit",
       testDir: "./tests/unit",


### PR DESCRIPTION
Restores Chromatic visual regression coverage to include all browser and device viewports.

## Description
- Updates `test:e2e` script to run all 4 e2e projects (desktop Chrome/Safari, mobile Chrome/Safari) instead of just desktop Chrome
- Refactors `test` script to properly separate unit tests (with mock data) from e2e tests (with live data)
- Adds section comments to `playwright.config.ts` for clarity

This fixes the regression where Chromatic went from 7 visual snapshots to only 3, by ensuring mobile viewport tests run again.