### PR TITLE
Use right link for "Introduction to Gasper"

### DIFF
--- a/public/content/developers/docs/consensus-mechanisms/pos/block-proposal/index.md
+++ b/public/content/developers/docs/consensus-mechanisms/pos/block-proposal/index.md
@@ -65,5 +65,5 @@ The block proposer receives payment for their work. There is a `base_reward` cal
 - [Introduction to blocks](/developers/docs/blocks/)
 - [Introduction to proof-of-stake](/developers/docs/consensus-mechanisms/pos/)
 - [Ethereum consensus specs](https://github.com/ethereum/consensus-specs)
-- [Introduction to Gasper](/developers/docs/consensus-mechanisms/pos/)
+- [Introduction to Gasper](/developers/docs/consensus-mechanisms/pos/gasper/)
 - [Upgrading Ethereum](https://eth2book.info/)


### PR DESCRIPTION
## Description

"Introduction to proof-of-stake" and "Introduction to Gasper" links from further reading links of Block Proposal documentation were the same. I fixed the "Introduction to Gasper" link, so that it points to the "Gasper" docs page.