### PR TITLE
Content update: Adding x402 to Payments content

### DIFF
--- a/public/content/payments/index.md
+++ b/public/content/payments/index.md
@@ -109,10 +109,10 @@ These cards link directly to non-custodial wallets or smart contract accounts, a
 When a client requests a resource, the server sends a `402 Payment Required` error code along with payment instructions (price, account, and what tokens and chains are supported).
 
 - Your [wallet](/wallets/) detects the request and handles the payment (often with a single click to approve, or automatically using a pre-approved allowance)
-- AI agents with access to pre-approved wallet balances can automatically detect the price and pay instantly to access data or services
+- [AI agents](/ai-agents/) with access to pre-approved wallet balances can automatically detect the price and pay instantly to access data or services
 - The client needs to have one of the supported stablecoins in their wallet, but does not need to have any ETH for [gas expenses](/gas/)
 
-This unlocks a new "Machine-to-Machine" economy where AI agents can buy resources on their own, and where API services can be accessed more efficiently.
+This unlocks a new "machine to machine" economy where AI agents can buy resources on their own, and where API services can be accessed more efficiently.
 
 The signed message is then delivered to the server. Servers typically use an [x402 facilitator](https://x402.gitbook.io/x402/core-concepts/facilitator) to handle the blockchain complexity (sending the transaction, obtaining the payment, facilitating gas fees, etc.), which means that developers can easily accept crypto micropayments without managing payment infrastructure.
 


### PR DESCRIPTION
## Description

URL: https://ethereum.org/payments

Update existing content

Current content: Current payments content touches on Ethereum’s internet-native potential for payment infrastructure. The page covers benefits like programmability, speed, and accessibility, alongside payment use cases, like stablecoins and remittances.

Proposed change: Add a short, beginner-friendly section about the x402 payment protocol as an example of Ethereum for internet payment infrastructure. Alongside general educational information, include how x402 can be used for agentic payments, as well as how per-use payments via stablecoins have the potential to eliminate accounts/subscriptions/authentications (e.g., not providing personal information to access a paid news article), while also allowing developers to more efficiently monetize APIs.

Motivation: Build awareness and adoption of x402 payments and monetization models on Ethereum. Display x402 as an innovation in internet-based payment functionality while noting that it was launched on Ethereum L2. Most x402 content online is either very technical, or highly promotional. The ‘Payments’ page is an opportunity to lead in providing an understandable, beginner-friendly explanation of x402, through the lens of its innovation and potential.

References:
- https://www.x402.org/
- https://x.com/ethereum/status/1955673875800621158?s=20

## Related Issue

