### PR TITLE
chore: rm obsolete .well-known

### DIFF
--- a/public/.well-known/matrix/server
+++ b/public/.well-known/matrix/server
@@ -1,3 +1,0 @@
-{
-    "m.server": "matrix.ethereum.org:8448"
-}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

There is no longer a Matrix server hosted as matrix.ethereum.org so we can remove this `well-known` file. Thanks!
