### PR TITLE
Add Ethereal news to community blogs

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -230,6 +230,10 @@ export const COMMUNITY_BLOGS: CommunityBlog[] = [
     href: "https://geodework.com/blog",
     feed: "https://geodework.com/feed.xml",
   },
+  {
+    href: "https://etherealnews.substack.com/",
+    feed: "https://etherealnews.substack.com/feed",
+  },
 ]
 
 export const BLOG_FEEDS = COMMUNITY_BLOGS.map(({ feed }) => feed).filter(


### PR DESCRIPTION
## Summary
- Adds Ethereal news to the `COMMUNITY_BLOGS` array in `src/lib/constants.ts`
- Newsletter URL: https://etherealnews.substack.com/
- RSS feed: https://etherealnews.substack.com/feed

## About Ethereal news
Weekly Ethereum developer newsletter edited by Andrew B Coathup (former editor of Week in Ethereum News).

Closes #16999