### PR TITLE
Update Ethereal news to canonical website

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -231,8 +231,8 @@ export const COMMUNITY_BLOGS: CommunityBlog[] = [
     feed: "https://geodework.com/feed.xml",
   },
   {
-    href: "https://etherealnews.substack.com/",
-    feed: "https://etherealnews.substack.com/feed",
+    href: "https://ethereal.news",
+    feed: "https://ethereal.news/rss.xml",
   },
 ]
 


### PR DESCRIPTION
## Ethereal news
website: https://ethereal.news/
feed: https://ethereal.news/rss.xml

<!--- Provide a general summary of your changes in the Title above -->

## Description

Update Ethereal news to canonical website rather than Substack.

## Related Issue

#16999
