### PR TITLE
Fix Netlify functions mock storage path

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -39,4 +39,4 @@
     path = "en/developers/tutorials/creating-a-wagmi-ui-for-your-contract/"
 
 [functions]
-  included_files = ["i18n.config.json", "src/intl/**/*", "src/data/mocks/**/*"]
+  included_files = ["i18n.config.json", "src/intl/**/*", "src/data/mocks/**/*", "src/data-layer/mocks/**/*"]


### PR DESCRIPTION
## Summary
- Add `src/data-layer/mocks/**/*` to Netlify functions included_files
- Fixes error: `[Mock Storage] Directory not found: /var/task/src/data-layer/mocks`

The mock storage files were not being bundled with Netlify functions because the path in `netlify.toml` was incorrect (`src/data/mocks` instead of `src/data-layer/mocks`).

## Test plan
- [ ] Verify Netlify deploy preview builds successfully
- [ ] Check that functions using mock storage work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)