### PR TITLE
refactor: Update Chains workflow to use gh CLI

### DIFF
--- a/.github/workflows/update-chains.yml
+++ b/.github/workflows/update-chains.yml
@@ -61,4 +61,4 @@ jobs:
       - name: Create Pull Request
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
-          gh pr create --base dev --head "automated-update-${{ env.TIMESTAMP }}" --title "Update chains data - ${{ env.READABLE_DATE }}" --body-file pr_body.txt
+          gh pr create --base dev --head "automated-update-${{ env.TIMESTAMP }}" --title "Update chains data - ${{ env.READABLE_DATE }}" --body-file pr_body.txt --label "update 🔄"


### PR DESCRIPTION
## Description

Replace peter-evans/create-pull-request action with the gh CLI pattern used by other automated workflows in this repo. This provides:

- Consistency with other automation workflows
- No third-party action dependency
- More explicit control over the process

## Related Issue

Fixes failing "Update Chains" workflow
Example: https://github.com/ethereum/ethereum-org-website/actions/runs/20662027772/job/59326490919