### PR TITLE
Increase Netlify cleanup pagination limit

### DIFF
--- a/.github/workflows/cleanup-netlify-previews.yml
+++ b/.github/workflows/cleanup-netlify-previews.yml
@@ -33,7 +33,7 @@ jobs:
 
           # 1. Fetch deploys with safety pagination
           ALL_DEPLOYS="[]"
-          for PAGE in {1..20}; do
+          for PAGE in {1..100}; do
             RESPONSE=$(curl -s -H "Authorization: Bearer $NETLIFY_TOKEN" \
               "https://api.netlify.com/api/v1/sites/$NETLIFY_SITE_ID/deploys?per_page=100&page=$PAGE")
 


### PR DESCRIPTION
## Summary

Bumps pagination from 20 pages to 100 pages (2,000 → 10,000 deploys max).

Previous run hit the 2,000 cap exactly - there are more stale deploys to clean up.

## Test plan

- [ ] Run workflow manually
- [ ] Verify it processes beyond 2,000 deploys