### PR TITLE
Fix mobile menu scrolling in Safari

### DIFF
--- a/src/components/LanguagePicker/index.tsx
+++ b/src/components/LanguagePicker/index.tsx
@@ -94,7 +94,7 @@ const LanguagePicker = ({
   return (
     <div className={cn("flex flex-col", className)}>
       <LanguagePickerMenu
-        className="flex-1 gap-2 overflow-y-auto p-4"
+        className="min-h-0 flex-1 gap-2 overflow-y-auto p-4"
         languages={sortedLanguages}
         onSelect={handleMenuItemSelect}
         onClose={handleNoResultsClose}

--- a/src/components/Nav/MobileMenu/index.tsx
+++ b/src/components/Nav/MobileMenu/index.tsx
@@ -57,7 +57,7 @@ export default async function MobileMenu({
           value="navigation"
           className="mt-0 hidden min-h-0 flex-1 flex-col border-none p-0 data-[state=active]:flex"
         >
-          <NavigationContent className="flex-1 overflow-y-auto" />
+          <NavigationContent className="min-h-0 flex-1 overflow-y-auto" />
         </TabsPrimitive.Content>
         <TabsPrimitive.Content
           value="languages"


### PR DESCRIPTION
## Summary
- Fixes hamburger menu scrolling issue on Safari where users couldn't scroll through menu items
- Adds `min-h-0` to flex containers with `overflow-y-auto` to fix a known Safari flexbox bug
- Affects both the navigation menu and language picker in the mobile menu

## Background
Users reported that when using the hamburger menu on Safari, the menus don't scroll and they have to resize the page to see all menu items.

This is caused by a known Safari flexbox bug where nested flex containers with `overflow-y: auto` require `min-height: 0` on each flex item in the chain to enable scrolling.

## Test plan
- [x] Open the site on Safari mobile (or responsive mode)
- [x] Click the hamburger menu
- [x] Expand "Learn" → "Basics" to see many menu items
- [x] Verify the menu can be scrolled
- [x] Switch to "Languages" tab
- [x] Verify the language list can be scrolled