### PR TITLE
docs: fix brand capitalization for zkSync Era

### DIFF
--- a/src/data/networks/networks.ts
+++ b/src/data/networks/networks.ts
@@ -95,7 +95,7 @@ export const layer2Data: Rollups = [
   {
     l2beatID: "zksync2",
     growthepieID: "zksync_era",
-    name: "ZKSync Era",
+    name: "zkSync Era",
     chainName: "zkSync Mainnet",
     logo: ZkSyncEraLogo,
     networkType: "zk",


### PR DESCRIPTION
## Description

corrected a branding typo by updating the name to **zkSync Era** (lowercase “k”).
