### PR TITLE
fix: remove unnecessary forwardRef from AlertEmoji

### DIFF
--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -94,18 +94,15 @@ const AlertCloseButton = React.forwardRef<
 ))
 AlertCloseButton.displayName = "AlertCloseButton"
 
-const AlertEmoji = React.forwardRef<SVGElement, EmojiProps>(
-  ({ className, ...props }) => (
-    <Emoji
-      className={cn(
-        "flex-shrink-0 flex-grow-0 self-start text-4xl sm:self-auto",
-        className
-      )}
-      {...props}
-    />
-  )
+const AlertEmoji = ({ className, ...props }: EmojiProps) => (
+  <Emoji
+    className={cn(
+      "flex-shrink-0 flex-grow-0 self-start text-4xl sm:self-auto",
+      className
+    )}
+    {...props}
+  />
 )
-AlertEmoji.displayName = "AlertEmoji"
 
 export {
   Alert,


### PR DESCRIPTION
## Summary
- Remove forwardRef wrapper from AlertEmoji component
- The underlying Emoji component doesn't accept a ref, so wrapping in forwardRef was causing React warnings about unused ref parameters

## Test plan
- [x] Verify React warning no longer appears in console when AlertEmoji is rendered
- [x] Ensure passing build and other instances of AlertEmoji are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Related issue
Fixes:
```
Warning: forwardRef render functions accept exactly two parameters: props and ref. Did you forget to use the ref parameter?
```