### PR TITLE
fix: TruncatedText line-clamp class not applying

### DIFF
--- a/app/[locale]/apps/_components/AppCard.tsx
+++ b/app/[locale]/apps/_components/AppCard.tsx
@@ -85,7 +85,6 @@ const AppCard = ({
         {showDescription && (
           <TruncatedText
             text={app.description}
-            maxLines={2}
             className="text-body group-hover:text-body"
             matomoEvent={{
               eventCategory: matomoCategory,

--- a/app/[locale]/apps/_components/AppsHighlight.tsx
+++ b/app/[locale]/apps/_components/AppsHighlight.tsx
@@ -40,7 +40,6 @@ const AppsHighlight = ({ apps, matomoCategory }: AppsHighlightProps) => {
         <div className="mb-4">
           <TruncatedText
             text={app.description}
-            maxLines={2}
             matomoEvent={{
               eventCategory: matomoCategory,
               eventAction: "highlights_show_more",

--- a/src/components/ui/TruncatedText.tsx
+++ b/src/components/ui/TruncatedText.tsx
@@ -27,11 +27,18 @@ const TruncatedText = ({
 }: TruncatedTextProps) => {
   const [isExpanded, setIsExpanded] = useState(false)
 
+  const lineClampClass = {
+    1: "line-clamp-1",
+    2: "line-clamp-2",
+    3: "line-clamp-3",
+    4: "line-clamp-4",
+  }
+
   return (
     <div className={className}>
       <p
         className={`text-body ${
-          !isExpanded ? `line-clamp-${maxLines} overflow-hidden` : ""
+          !isExpanded ? `${lineClampClass[maxLines]} overflow-hidden` : ""
         }`}
         style={
           !isExpanded


### PR DESCRIPTION
## Summary
- Fix line-clamp not working in TruncatedText component
- Tailwind cannot use string-interpolated classes because they are not included in the compiled CSS
- Replace with explicit class mapping object
- Remove redundant maxLines={2} props (2 is already the default)

## Test plan
- [ ] Verify text truncation works on /apps page cards
- [ ] Verify Show more expansion still works

Generated with Claude Code