### PR TITLE
Fix import path for fetchApps in revalidate-apps task

### DIFF
--- a/src/data-layer/trigger/old-tasks/revalidate-apps.ts
+++ b/src/data-layer/trigger/old-tasks/revalidate-apps.ts
@@ -2,9 +2,9 @@ import { schedules } from "@trigger.dev/sdk/v3"
 
 import { slugify } from "@/lib/utils/url"
 
-import { revalidatePaths } from "./utils"
+import { fetchApps } from "@/data-layer/api/fetchApps"
 
-import { fetchApps } from "@/lib/api/fetchApps"
+import { revalidatePaths } from "./utils"
 
 const categoriesSlugs = [
   "defi",


### PR DESCRIPTION
## Summary
- Fix broken import path in `src/data-layer/trigger/old-tasks/revalidate-apps.ts`
- Update import from `@/lib/api/fetchApps` to `@/data-layer/api/fetchApps`

## Problem
The Netlify build was failing with:
```
Type error: Cannot find module '@/lib/api/fetchApps' or its corresponding type declarations.
```

## Solution
The `fetchApps` function was moved during the data-layer refactor but this import wasn't updated. Fixed by pointing to the correct location.

## Test plan
- [x] TypeScript compilation passes