### PR TITLE
fix: browser back navigation fails with hash URLs

### DIFF
--- a/src/components/ui/Link.tsx
+++ b/src/components/ui/Link.tsx
@@ -159,8 +159,12 @@ export const BaseLink = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
   }
 
   if (isHash) {
+    // Use I18nLink for hash links to ensure proper browser history management
+    // This prevents issues where back navigation from a subpage to a page with
+    // a hash URL fails to re-render the page (the browser would interpret it
+    // as a same-page scroll rather than a route change)
     return (
-      <a
+      <I18nLink
         onClick={(e) => {
           e.stopPropagation()
           trackCustomEvent(
@@ -175,7 +179,7 @@ export const BaseLink = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
         {...commonProps}
       >
         {children}
-      </a>
+      </I18nLink>
     )
   }
 


### PR DESCRIPTION
## Summary

Fixes browser back button navigation failing when returning to a page with a hash URL fragment. The issue occurred because hash links were rendered as plain `<a>` tags, causing the browser to interpret back navigation as a same-page scroll rather than a proper route change.

- Changed hash links in `BaseLink` component to use `I18nLink` (Next.js router) instead of native `<a>` tags
- Ensures browser history is properly managed by Next.js router
- Back navigation now correctly triggers full route changes when the target URL contains a hash

**Fixes #17080**

## Test plan

- [ ] Navigate to `/community/events`
- [ ] Click a TabNav anchor link (e.g., "Conferences") to scroll to that section
- [ ] Click the "See all" button for meetups to navigate to `/community/events/meetups/`
- [ ] Click the browser back button
- [ ] Verify the page returns to `/community/events` and displays the main events page content