### PR TITLE
fix: update env vars and trigger.dev config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,3 +57,16 @@ USE_MOCK_DATA=true
 
 # Supabase Events API (Geode Labs)
 # SUPABASE_EVENTS_KEY=your-supabase-publishable-key
+
+# Netlify Blobs (data-layer storage)
+# Required when USE_MOCK_DATA=false to read/write data from Netlify Blobs
+# SITE_ID=your-netlify-site-id
+# NETLIFY_BLOBS_TOKEN=your-netlify-blobs-token
+
+# Trigger.dev (scheduled tasks)
+# TRIGGER_PROJECT_REF=your-trigger-project-ref
+
+# Sentry (error tracking)
+# Used by trigger.dev tasks and Next.js app for error monitoring
+# NEXT_PUBLIC_SENTRY_DSN=your-sentry-dsn
+# NEXT_PUBLIC_CONTEXT=development

--- a/src/data-layer/storage.ts
+++ b/src/data-layer/storage.ts
@@ -15,7 +15,7 @@ let blobStore: ReturnType<typeof getStore> | null = null
 function getBlobs() {
   if (blobStore) return blobStore
 
-  const siteID = process.env.SITE_ID
+  const siteID = process.env.NETLIFY_SITE_ID || process.env.SITE_ID
   const token = process.env.NETLIFY_BLOBS_TOKEN
 
   if (!siteID || !token) {

--- a/trigger.config.ts
+++ b/trigger.config.ts
@@ -6,7 +6,7 @@ import { defineConfig } from "@trigger.dev/sdk/v3"
  * See https://trigger.dev/docs for documentation.
  */
 export default defineConfig({
-  project: process.env.TRIGGER_PROJECT_ID || "",
+  project: process.env.TRIGGER_PROJECT_REF!,
   runtime: "node",
   logLevel: "log",
   // Maximum duration for all tasks (5 minutes)


### PR DESCRIPTION
## Summary
- Add missing env vars to `.env.example` (Netlify Blobs, Trigger.dev, Sentry)
- Support `NETLIFY_SITE_ID` as primary env var for storage (falls back to `SITE_ID`)
- Use `TRIGGER_PROJECT_REF` for trigger.dev config (matches Trigger.dev docs naming convention)

## Test plan
- [x] Verify local dev works with `NETLIFY_SITE_ID` env var
- [x] Verify trigger.dev tasks run with `TRIGGER_PROJECT_REF`