### PR TITLE
patch: banner image height with blur bg

### DIFF
--- a/app/[locale]/developers/apps/_components/HighlightsSection.tsx
+++ b/app/[locale]/developers/apps/_components/HighlightsSection.tsx
@@ -52,7 +52,7 @@ const HighlightsSection = async ({ apps }: { apps: DeveloperApp[] }) => {
                   className="space-y-6 no-underline"
                 >
                   <div className="space-y-4">
-                    <CardBanner background="accent-a" className="relative h-40">
+                    <CardBanner background="accent-a" className="relative">
                       <Image
                         src={app.banner_url!}
                         alt=""


### PR DESCRIPTION
## Extends `page-developer-apps` branch
- #17110

## Description
https://www.figma.com/design/DsDKevuPic1J0C2TQ7RpcJ?node-id=27122-3121#1598012325

- Duplicate background image
- 1.5rem (24px) blur applied
- Top image using `object-contain`

## Preview link
https://deploy-preview-17134.ethereum.it/developers/apps