### PR TITLE
Fix Accessibility Violations: Social Media Link Labels

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -360,10 +360,13 @@ const Footer = ({ lastDeployLocaleTimestamp }: FooterProps) => {
               key={href}
               href={href}
               hideArrow
-              aria-label={ariaLabel}
               className="text-body hover:text-primary"
             >
-              <Icon className="h-9 w-9 hover:transform hover:transition-colors" />
+              <Icon
+                aria-hidden="true"
+                className="h-9 w-9 hover:transform hover:transition-colors"
+              />
+              <span className="sr-only">{ariaLabel}</span>
             </BaseLink>
           ))}
         </div>


### PR DESCRIPTION
This PR fixes accessibility violations in the footer where social media links lacked proper accessible names for screen reader users.

## Description

### Issue Description

The IBM Equal Access Accessibility Checker identified multiple violations:

- Issue: Accessible name does not match or contain the visible label text
- Elements: Social media icon links (GitHub, LinkedIn, X/Twitter, Discord) in the footer
- Impact: Screen reader users cannot properly identify the purpose of these links because the aria-label attribute on the <a> element conflicts with the decorative icon inside

**Root Cause**
The previous implementation applied aria-label directly to the link element while the icon inside was not marked as decorative. This creates confusion for assistive technologies about which label to announce.

### Fix Description

Refactored the social media links to follow accessibility best practices:

- Removed aria-label from the <BaseLink> component
- Added aria-hidden="true" to the <Icon> component to mark it as decorative
- Added a visually hidden <span className="sr-only"> containing the descriptive text

This approach ensures:

- The icon is hidden from screen readers (decorative only)
- The accessible name comes from visible/semantic content
- Screen readers announce the clear, descriptive label

**Changes**
```tsx
- aria-label={ariaLabel}
  className="text-body hover:text-primary"
>
- <Icon className="h-9 w-9 hover:transform hover:transition-colors" />
+ <Icon
+   aria-hidden="true"
+   className="h-9 w-9 hover:transform hover:transition-colors"
+ />
+ <span className="sr-only">{ariaLabel}</span>
</BaseLink>
```

## Related Issue

- Fixes #17138

