### PR TITLE
patch: enterprise use cases 302 redirect

### DIFF
--- a/redirects.config.js
+++ b/redirects.config.js
@@ -97,6 +97,7 @@ module.exports = [
   ["/deprecated-software", "/apps/"],
   ["/enterprise", "https://institutions.ethereum.org/"],
   ["/enterprise/private-ethereum", "https://institutions.ethereum.org/"],
+  ["/enterprise/use-cases", "https://institutions.ethereum.org/", false],
   ["/dashboards", "/resources"],
   ["/tds", "/trillion-dollar-security"],
   ["/10-years", "/10years"],


### PR DESCRIPTION
## Description
- Adds 302 redirect from /enterprise/use-cases path to institutions subdomain

## Related Issue
Page temporarily deprecated without redirect


cc: @mnelsonBT 