### PR TITLE
feat: add S3 image host for app images

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -118,6 +118,10 @@ module.exports = (phase, { defaultConfig }) => {
         },
         {
           protocol: "https",
+          hostname: "s3-dcl1.ethquokkaops.io",
+        },
+        {
+          protocol: "https",
           hostname: "cdn.galxe.com",
         },
         {


### PR DESCRIPTION
## Summary

- Add `s3-dcl1.ethquokkaops.io` to Next.js `remotePatterns` configuration

## Context

Imgur is blocked in the UK due to the Digital Safety Act, causing app images to be broken for UK users. This PR adds our self-hosted S3 storage as an allowed image host, enabling migration of app images from imgur to infrastructure we control.

## Changes

- Added S3 hostname to `next.config.js` remotePatterns (4 lines)

## Test plan

- [ ] Verify build succeeds
- [ ] Verify images from `s3-dcl1.ethquokkaops.io` load correctly in Next.js Image component