### PR TITLE
fix(search): use JSON clone for browser compatibility

### DIFF
--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -63,7 +63,8 @@ const Search = ({ asChild = false, children }: SearchProps) => {
     },
     transformItems: (items: DocSearchHit[]) =>
       items.map((item: DocSearchHit) => {
-        const newItem: DocSearchHit = structuredClone(item)
+        // Use JSON clone for browser compatibility (structuredClone not available in Chrome < 98)
+        const newItem: DocSearchHit = JSON.parse(JSON.stringify(item))
         newItem.url = sanitizeHitUrl(item.url)
         const newTitle = sanitizeHitTitle(item.hierarchy.lvl0 || "")
         newItem.hierarchy.lvl0 = newTitle


### PR DESCRIPTION
## Summary
- Replace `structuredClone()` with `JSON.parse(JSON.stringify())` in Search component
- Fixes crashes for users on older browsers (Chrome < 98, older Android devices)

## Problem
`structuredClone` was introduced in Chrome 98 (Feb 2022). Users on older browsers experience crashes when using the search feature.

**Sentry Issue**: [ETHORG-B7](https://ethereumorg-ow.sentry.io/issues/ETHORG-B7) - 628 events
- Affected: Chrome Mobile 91 on Android 9, and similar older browser/OS combinations

## Solution
Use JSON-based cloning which has universal browser support. Since `DocSearchHit` is a plain object without special types (Date, Map, etc.), JSON cloning works identically to `structuredClone` for this use case.

## Test plan
- [ ] Verify search works on modern browsers
- [ ] Test search functionality in browser compatibility mode (Chrome DevTools can simulate older versions)

Fixes ETHORG-B7