### PR TITLE
chore(deps): update @netlify/plugin-nextjs to 5.15.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
   "devDependencies": {
     "@chromatic-com/playwright": "^0.12.4",
     "@chromatic-com/storybook": "1.5.0",
-    "@netlify/plugin-nextjs": "^5.12.0",
+    "@netlify/plugin-nextjs": "^5.15.5",
     "@playwright/test": "^1.52.0",
     "@storybook/addon-essentials": "8.6.14",
     "@storybook/addon-interactions": "8.6.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,8 +240,8 @@ importers:
         specifier: 1.5.0
         version: 1.5.0(@chromatic-com/playwright@0.12.5(@playwright/test@1.53.1)(@types/react@18.2.57)(bufferutil@4.0.9)(esbuild@0.25.12)(prettier@3.5.3)(typescript@5.8.3)(utf-8-validate@5.0.10))(react@18.3.1)
       '@netlify/plugin-nextjs':
-        specifier: ^5.12.0
-        version: 5.12.0
+        specifier: ^5.15.5
+        version: 5.15.5
       '@playwright/test':
         specifier: ^1.52.0
         version: 1.53.1
@@ -2055,8 +2055,8 @@ packages:
     resolution: {integrity: sha512-7EWbS+puDub800IQ9MUVcLrWwCNPyK/u1Rs08f0Y+O4dBGVkuTm/RyaLoU58PPLuNCfPHXebfIYFZxN+/CtZeA==}
     engines: {node: ^18.14.0 || >=20.6.1}
 
-  '@netlify/plugin-nextjs@5.12.0':
-    resolution: {integrity: sha512-SXQY/nCiSOSAZWNls/DQxrICldUR7PHSMUw2J2/ZejH1dk12Vwd3+SzSihHrRW9PNcErZkC2g3seM7bWZlvBRg==}
+  '@netlify/plugin-nextjs@5.15.5':
+    resolution: {integrity: sha512-Lvix59vHCEfvopILvdfIK2EPe/CrLH5qrIdwYnJbxpp/SSVgklsHpBrfNM9ADTr310r+WJRDz11NcDyHu3iT9w==}
     engines: {node: '>=18.0.0'}
 
   '@netlify/runtime-utils@2.2.1':
@@ -11878,7 +11878,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@netlify/plugin-nextjs@5.12.0': {}
+  '@netlify/plugin-nextjs@5.15.5': {}
 
   '@netlify/runtime-utils@2.2.1': {}
 


### PR DESCRIPTION
## Summary

- Updates `@netlify/plugin-nextjs` from 5.12.0 to 5.15.5

This addresses the build output recommendation:
```
Outdated plugins
   - @netlify/plugin-nextjs@5.12.0: latest version is 5.15.5
     To upgrade this plugin, please update its version in "package.json"
```

## Test plan

- [ ] Verify Netlify deploy preview builds successfully
- [ ] No regressions in site functionality