### PR TITLE
perf: move PieChart to docs-specific components

### DIFF
--- a/src/components/MdComponents/index.tsx
+++ b/src/components/MdComponents/index.tsx
@@ -17,7 +17,6 @@ import MarkdownImage from "@/components/Image/MarkdownImage"
 import IssuesList from "@/components/IssuesList"
 import LocaleDateTime from "@/components/LocaleDateTime"
 import MainArticle from "@/components/MainArticle"
-import { PieChart } from "@/components/PieChart"
 import { StandaloneQuizWidget } from "@/components/Quiz/QuizWidget"
 import TooltipLink from "@/components/TooltipLink"
 import { ButtonLink } from "@/components/ui/buttons/Button"
@@ -177,7 +176,6 @@ export const reactComponents = {
   FeaturedText,
   GlossaryTooltip,
   Page,
-  PieChart,
   QuizWidget: StandaloneQuizWidget,
   IssuesList,
   RestakingList,

--- a/src/layouts/Docs.tsx
+++ b/src/layouts/Docs.tsx
@@ -21,6 +21,7 @@ import {
   Heading3 as MdHeading3,
   Heading4 as MdHeading4,
 } from "@/components/MdComponents"
+import { PieChart } from "@/components/PieChart"
 import SideNav from "@/components/SideNav"
 import SideNavMobile from "@/components/SideNavMobile"
 import TableOfContents from "@/components/TableOfContents"
@@ -92,6 +93,7 @@ export const docsComponents = {
   Divider,
   Emoji,
   GlossaryTooltip,
+  PieChart,
   YouTube,
 } as MDXRemoteProps["components"]
 


### PR DESCRIPTION
## Summary

Move PieChart from base MdComponents to docs-specific components to reduce bundle size for most pages.

### Problem
- PieChart imports Recharts (~75KB parsed)
- Was bundled for ALL 6,500+ MDX pages via the base MdComponents
- Only actually used on 2 pages (both in `/developers/docs/` using the docs layout)

### Solution
- Remove PieChart from `src/components/MdComponents/index.tsx` (base components)
- Add PieChart to `src/layouts/Docs.tsx` (docs-specific components)

### Impact
- Non-docs pages no longer bundle Recharts
- Pages using the docs layout still have access to PieChart
- No functionality change for end users

Closes #17152