### PR TITLE
Accessibility Violations - Add Accessible Labels to Swiper Navigation…

### DIFF
--- a/src/components/ui/swiper.tsx
+++ b/src/components/ui/swiper.tsx
@@ -113,13 +113,16 @@ SwiperNavContainer.displayName = "SwiperNavContainer"
 const SwiperNavigation = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
->((props, ref) => (
-  <SwiperNavContainer ref={ref} {...props}>
-    <SwiperPrevButton data-testid="swiper-prev-button" />
-    <SwiperPaginationDots data-testid="swiper-pagination-dots" />
-    <SwiperNextButton data-testid="swiper-next-button" />
-  </SwiperNavContainer>
-))
+>((props, ref) => {
+  const { t } = useTranslation("common")
+  return (
+    <SwiperNavContainer ref={ref} {...props}>
+      <SwiperPrevButton data-testid="swiper-prev-button" aria-label={t("previous")} />
+      <SwiperPaginationDots data-testid="swiper-pagination-dots" />
+      <SwiperNextButton data-testid="swiper-next-button" aria-label={t("next")} />
+    </SwiperNavContainer>
+  )
+})
 SwiperNavigation.displayName = "SwiperNavigation"
 
 const variants = cva("!flex gap-y-6", {


### PR DESCRIPTION
This PR fixes accessibility violations in the Swiper component where the previous/next navigation buttons lack accessible labels, making them unusable for screen reader users.


## Description

The swiper navigation buttons (`SwiperPrevButton` and `SwiperNextButton`) are icon-only controls without any text alternatives. While they may be visually clear through directional arrow icons, assistive technologies have no way to convey their purpose to users.

Added internationalized `aria-label` attributes to both navigation buttons:

Previous Button: Added `aria-label={t("previous")}` for localized "Previous" label
Next Button: Added `aria-label={t("next")}` for localized "Next" label
i18n Integration: Imported `useTranslation` hook to provide translated labels that match the site's current language setting

## Related Issue

- Closes #17154
