### PR TITLE
perf: dynamically import Contributors to reduce bundle size

### DIFF
--- a/src/components/MdComponents/index.tsx
+++ b/src/components/MdComponents/index.tsx
@@ -1,4 +1,5 @@
 import { type ComponentProps, type HTMLAttributes } from "react"
+import dynamic from "next/dynamic"
 
 import type { ChildOnlyProp } from "@/lib/types"
 
@@ -6,7 +7,8 @@ import Card from "@/components/Card"
 import { RestakingList } from "@/components/Content/restaking/RestakingList"
 import BrowseApps from "@/components/Content/what-are-apps/BrowseApps"
 import WhatAreAppsStories from "@/components/Content/what-are-apps/WhatAreAppsStories"
-import Contributors from "@/components/Contributors"
+
+const Contributors = dynamic(() => import("@/components/Contributors"))
 import DocLink from "@/components/DocLink"
 import Emoji from "@/components/Emoji"
 import ExpandableCard from "@/components/ExpandableCard"


### PR DESCRIPTION
## Summary

Use `next/dynamic` to lazy-load the Contributors component, avoiding bundling 420KB of contributor data for all MDX pages.

### Before
- Contributors imports `.all-contributorsrc` (377KB, 1,225 avatars) via raw-loader
- Compiled to 420KB client chunk
- Chunk was in **initial load** for ALL `[...slug]` MDX pages
- Only `/contributing` page actually uses the component

### After
- Contributors is dynamically imported
- 420KB chunk only loads when `/contributing` page is visited
- All other MDX pages (~6,500) no longer download this data

Closes #17156