### PR TITLE
docs: update contributor OAT references to 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,10 +197,11 @@ Learn more about how we review pull requests [here](docs/review-process.md).
 
 > An Onchain Achievement Token (OAT) is a special badge on [Galxe](https://app.galxe.com/quest/ethereumorg). It's a proof of your contribution to the ecosystem. [More on OATs](https://medium.com/galxe-news/introducing-galaxy-oat-on-chain-achievement-token-7e89779242b4).
 
-### ethereum.org 2025 Contributor OATs
+### ethereum.org 2026 Contributor OATs
 
-- If you have committed any changes in 2025 so far that were merged into our repo or if you have translated a certain amount of words, you can claim your OATs!
-- There are OATs for GitHub, content, design and translation contributions.
+If you have committed any changes in 2026 so far that were merged into our repo or if you have translated a certain amount of words, you can claim your OATs!
+
+There are OATs for GitHub, content, design and translation contributions.
 
   [![Discord](https://img.shields.io/discord/714888181740339261?color=1C1CE1&label=Claim%20Your%20POAP!%20%7C%20Discord%20%F0%9F%91%8B%20&style=flat)](https://discord.gg/ethereum-org)
 


### PR DESCRIPTION
"I noticed the README was still referencing the 2025 OAT cycle. I have updated the headings and text to 2026 to ensure the documentation stays current for new contributors entering the ecosystem this year."
