### PR TITLE
chore(storybook): replace fa locale with ar for RTL testing

### DIFF
--- a/.storybook/modes.ts
+++ b/.storybook/modes.ts
@@ -14,7 +14,7 @@ export const viewportModes = breakpointSet.reduce<{
   }
 }, {})
 
-const localesToTest = ["en", "fa"]
+const localesToTest = ["en", "ar"]
 const locales = pickBy(baseLocales, (_, key) => localesToTest.includes(key))
 export const langModes = Object.keys(locales).reduce<{
   [locale: string]: { locale: string }

--- a/.storybook/next-intl.ts
+++ b/.storybook/next-intl.ts
@@ -3,7 +3,7 @@ export const baseLocales = {
   zh: { title: "中国人", left: "Zh" },
   ru: { title: "Русский", left: "Ru" },
   uk: { title: "українська", left: "Uk" },
-  fa: { title: "فارسی", left: "Fa" },
+  ar: { title: "العربية", left: "Ar" },
 }
 
 // Only i18n files named in this array are being exposed to Storybook. Add filenames as necessary.


### PR DESCRIPTION
## Summary
- Replace the removed `fa` (Farsi) locale with `ar` (Arabic) in Storybook configuration
- Arabic is still actively supported and maintains RTL layout testing capabilities

## Test plan
- [x] Verify Storybook builds successfully
- [x] Confirm RTL stories render correctly with Arabic locale