### PR TITLE
fix: include meetup groups in events search results

### DIFF
--- a/app/[locale]/community/events/search/page.tsx
+++ b/app/[locale]/community/events/search/page.tsx
@@ -14,7 +14,7 @@ import { getMetadata } from "@/lib/utils/metadata"
 
 import EventCard from "../_components/EventCard"
 import OrganizerCTA from "../_components/OrganizerCTA"
-import { mapEventTranslations, sanitize } from "../utils"
+import { getMeetupGroups, mapEventTranslations, sanitize } from "../utils"
 
 import { getEventsData } from "@/lib/data"
 
@@ -36,7 +36,9 @@ const Page = async ({
   })
   const tCommon = await getTranslations({ locale, namespace: "common" })
 
-  const events = mapEventTranslations(_events, t)
+  const apiEvents = mapEventTranslations(_events, t)
+  const meetupGroups = getMeetupGroups()
+  const events = [...apiEvents, ...meetupGroups]
 
   const filteredEvents = ((): EventItem[] => {
     if (!q) return []


### PR DESCRIPTION
## Summary
- Fixed count mismatch between "See all (X)" button and actual search results
- Search page now includes meetup groups from `community-meetups.json`, matching the preview component

## Problem
When searching for events by location (e.g., "Italy"):
- Preview showed 6 events with "See all (8)" button
- Clicking showed only 4 results

The preview component received combined data (API events + meetup groups), but the search page only fetched API events.

## Test plan
- [ ] Go to `/community/events`
- [ ] Search for "Italy" in "Find events near you"
- [ ] Verify count in "See all" button matches results on search page
- [ ] Verify Italian meetup groups (Milan, Venice, Naples, Udine) appear in search results