### PR TITLE
fix(sentry): filter wallet extension JSON-RPC errors

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -58,6 +58,8 @@ Sentry.init({
     /Event `Event` \(type=error\) captured as promise rejection/,
     // WebView circular reference serialization failures - wallet app injections (ETHORG-72)
     /JSON\.stringify cannot serialize cyclic structures/,
+    // Wallet extension JSON-RPC errors - extensions make their own RPC calls that fail (ETHORG-7Q)
+    /Internal JSON-RPC error/,
   ],
 
   beforeSend(event) {


### PR DESCRIPTION
## Summary
- Add ignore pattern for "Internal JSON-RPC error" messages (ETHORG-7Q)
- These errors come from wallet extensions making their own RPC calls that fail, not from our app code
- The errors have no stacktrace so they slip through the existing `beforeSend` filter

## Context
Investigated Sentry issues and found ETHORG-7Q (1,478 occurrences) was appearing across many pages (`/`, `/staking/`, `/defi/`, `/dao/`, etc.) even though WalletProviders is only used on specific pages. The error `{ code: -32603, message: "Internal JSON-RPC error." }` is a standard JSON-RPC internal error from wallet extensions.

## Test plan
- [ ] Verify the regex pattern matches the error message format
- [ ] Deploy and monitor Sentry for reduced noise from wallet extension errors