### PR TITLE
fix(pl): remove typo/garbage text in defi page

### DIFF
--- a/public/content/translations/pl/defi/index.md
+++ b/public/content/translations/pl/defi/index.md
@@ -18,7 +18,7 @@ DeFi jest otwartym globalnym systemem finansowym stworzonym dla ery Internetu �
 
 DeFi to określenie zestawu finansowych produktów i usług, które są otwarte dla każdego, kto ma dostęp do Ethereum — wystarczy połączenie z Internetem. Dzięki DeFi rynki są zawsze otwarte i nie ma scentralizowanych władz, które mogłyby zablokować płatności lub odmówić dostępu do czegokolwiek. Usługi, które wcześniej były powolne i narażone na ryzyko błędu ludzkiego, teraz są automatyczne i bezpieczniejsze, ponieważ są obsługiwane przez kod, który każdy może sprawdzić i przeanalizować.
 
-Jest tam kwitnąca gospodarka kryptowalutowa oSearch TMut, gdzie można pożyczać, kredytować, stosować długo- i krótkoterminowo, zarabiać na odsetkach i nie tylko. Argentyńczycy posługujący się kryptowalutami wykorzystali DeFi, aby uciec przed paraliżującą inflacją. Firmy zaczęły płacić swoim pracownikom wynagrodzenie, obliczając je w czasie rzeczywistym. Niektórzy ludzie biorą oraz spłacają pożyczki warte nawet miliony dolarów bez konieczności osobistej identyfikacji.
+Jest tam kwitnąca gospodarka kryptowalutowa, gdzie można pożyczać, kredytować, stosować długo- i krótkoterminowo, zarabiać na odsetkach i nie tylko. Argentyńczycy posługujący się kryptowalutami wykorzystali DeFi, aby uciec przed paraliżującą inflacją. Firmy zaczęły płacić swoim pracownikom wynagrodzenie, obliczając je w czasie rzeczywistym. Niektórzy ludzie biorą oraz spłacają pożyczki warte nawet miliony dolarów bez konieczności osobistej identyfikacji.
 
 <YouTube id="H-O3r2YMWJ4" />
 


### PR DESCRIPTION
Removed "oSearch TMut" from the "What is DeFi?" section in the Polish translation. It appears to be corrupted text or a copy-paste error.