### PR TITLE
🫡

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-*       @wackerow @corwintines @pettinarip @minimalsm
+*       @wackerow @pettinarip @minimalsm
 
 # Owners of specific files
 /src/data/consensus-bounty-hunters.json @asanso @fredriksvantes


### PR DESCRIPTION
Removed @corwintines as a default owner for the repository.