### PR TITLE
fix: enable dynamic rendering for homepage A/B testing

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,6 +1,6 @@
 import { Fragment } from "react"
 import { Info } from "lucide-react"
-import dynamic from "next/dynamic"
+import nextDynamic from "next/dynamic"
 import { notFound } from "next/navigation"
 import { getTranslations, setRequestLocale } from "next-intl/server"
 
@@ -92,7 +92,10 @@ import {
 } from "@/lib/data"
 import EventFallback from "@/public/images/events/event-placeholder.png"
 
-const BentoCardSwiper = dynamic(
+// Force dynamic rendering to enable A/B testing (requires headers())
+export const dynamic = "force-dynamic"
+
+const BentoCardSwiper = nextDynamic(
   () => import("@/components/Homepage/BentoCardSwiper"),
   {
     ssr: false,
@@ -105,7 +108,7 @@ const BentoCardSwiper = dynamic(
   }
 )
 
-const RecentPostsSwiper = dynamic(
+const RecentPostsSwiper = nextDynamic(
   () => import("@/components/Homepage/RecentPostsSwiper"),
   {
     ssr: false,
@@ -118,7 +121,7 @@ const RecentPostsSwiper = dynamic(
   }
 )
 
-const ValuesMarquee = dynamic(
+const ValuesMarquee = nextDynamic(
   () => import("@/components/Homepage/ValuesMarquee"),
   {
     ssr: false,


### PR DESCRIPTION
## Summary
- Fixed A/B testing always showing variant 0 in production
- Added `export const dynamic = "force-dynamic"` to homepage to allow `headers()` call at runtime
- Renamed `dynamic` import to `nextDynamic` to avoid naming conflict with route segment config

## Problem
The homepage was statically generated at build time, but `getABTestAssignment()` calls `headers()` at runtime. This caused Next.js to throw "app-static-to-dynamic-error", which was caught by the error handler and fell back to variant 0.

## Test plan
- [x] Deploy to preview environment
- [x] Verify A/B test variants are correctly assigned based on user fingerprint
- [x] Confirm no "app-static-to-dynamic-error" in logs