### PR TITLE
Fix broken consensus specs link

### DIFF
--- a/public/content/developers/docs/consensus-mechanisms/pos/rewards-and-penalties/index.md
+++ b/public/content/developers/docs/consensus-mechanisms/pos/rewards-and-penalties/index.md
@@ -60,7 +60,7 @@ So far we have considered perfectly well-behaved validators, but what about vali
 
 The penalties for missing the target and source votes are equal to the rewards the attestor would have received had they submitted them. This means that instead of having the reward added to their balance, they have an equal value removed from their balance. There is no penalty for missing the head vote (i.e., head votes are only rewarded, never penalized). There is no penalty associated with the `inclusion_delay` - the reward will simply not be added to the validator's balance. There is also no penalty for failing to propose a block.
 
-Read more about rewards and penalties in the [consensus specs](https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/beacon-chain.md). Rewards and penalties were adjusted in the Bellatrix upgrade - watch Danny Ryan and Vitalik discuss this in this [Peep an EIP video](https://www.youtube.com/watch?v=iaAEGs1DMgQ).
+Read more about rewards and penalties in the [consensus specs](https://github.com/ethereum/consensus-specs/blob/master/specs/altair/beacon-chain.md). Rewards and penalties were adjusted in the Bellatrix upgrade - watch Danny Ryan and Vitalik discuss this in this [Peep an EIP video](https://www.youtube.com/watch?v=iaAEGs1DMgQ).
 
 ## Slashing {#slashing}
 


### PR DESCRIPTION
Fixes broken link for Altair consensus specs on the rewards and penalties page

## Description

Replaces the non-existing `dev` blob with the `master` blob in the link

## Related Issue

#17202