### PR TITLE
refactor(data-layer): convert fetchers to individual trigger.dev tasks

### DIFF
--- a/src/data-layer/tasks.ts
+++ b/src/data-layer/tasks.ts
@@ -5,7 +5,7 @@
  * Hourly tasks run every hour.
  */
 
-import { retry, schedules } from "@trigger.dev/sdk/v3"
+import { schedules, task } from "@trigger.dev/sdk/v3"
 
 import { fetchApps } from "./fetchers/fetchApps"
 import { fetchBeaconChain } from "./fetchers/fetchBeaconChain"
@@ -55,9 +55,9 @@ export const KEYS = {
 } as const
 
 // Task definition: storage key + fetch function
-type Task = [string, () => Promise<unknown>]
+type TaskDef = [string, () => Promise<unknown>]
 
-const DAILY: Task[] = [
+const DAILY: TaskDef[] = [
   [KEYS.APPS, fetchApps],
   [KEYS.CALENDAR_EVENTS, fetchCalendarEvents],
   [KEYS.COMMUNITY_PICKS, fetchCommunityPicks],
@@ -73,7 +73,7 @@ const DAILY: Task[] = [
   [KEYS.EVENTS, fetchEvents],
 ]
 
-const HOURLY: Task[] = [
+const HOURLY: TaskDef[] = [
   [KEYS.BEACONCHAIN, fetchBeaconChain],
   [KEYS.BLOBSCAN_STATS, fetchBlobscanStats],
   [KEYS.ETHEREUM_MARKETCAP, fetchEthereumMarketcap],
@@ -84,42 +84,41 @@ const HOURLY: Task[] = [
   [KEYS.STABLECOINS_DATA, fetchStablecoinsData],
 ]
 
-async function runTasks(tasks: Task[]) {
-  const results = await Promise.allSettled(
-    tasks.map(async ([key, fetchFn]) => {
-      const data = await retry.onThrow(fetchFn, {
-        maxAttempts: 3,
-        minTimeoutInMs: 2000,
-        maxTimeoutInMs: 30000,
-        factor: 2,
-        randomize: true,
-      })
+// ─── Dynamic task creation ───
+function createDataTask([key, fetchFn]: TaskDef) {
+  return task({
+    id: key,
+    retry: {
+      maxAttempts: 3,
+      factor: 2,
+      minTimeoutInMs: 2000,
+      maxTimeoutInMs: 30000,
+      randomize: true,
+    },
+    run: async () => {
+      const data = await fetchFn()
       await set(key, data)
       console.log(`✓ ${key}`)
-      return key
-    })
-  )
-
-  const summary = results.map((r, i) => ({
-    key: tasks[i][0],
-    ok: r.status === "fulfilled",
-    error: r.status === "rejected" ? String(r.reason) : undefined,
-  }))
-
-  const failed = summary.filter((s) => !s.ok)
-  failed.forEach((f) => console.error(`✗ ${f.key}: ${f.error}`))
-
-  return summary
+      return { key }
+    },
+  })
 }
 
+const dailyFetchTasks = DAILY.map(createDataTask)
+const hourlyFetchTasks = HOURLY.map(createDataTask)
+
+// Must export for trigger.dev to discover
+export const allFetchTasks = [...dailyFetchTasks, ...hourlyFetchTasks]
+
+// ─── Scheduled orchestrators ───
 export const dailyTask = schedules.task({
   id: "daily-data-fetch",
   cron: "0 0 * * *",
-  run: () => runTasks(DAILY),
+  run: () => Promise.all(dailyFetchTasks.map((t) => t.trigger())),
 })
 
 export const hourlyTask = schedules.task({
   id: "hourly-data-fetch",
   cron: "0 * * * *",
-  run: () => runTasks(HOURLY),
+  run: () => Promise.all(hourlyFetchTasks.map((t) => t.trigger())),
 })


### PR DESCRIPTION
## Summary
- Each data fetcher is now a separate trigger.dev task with its own retry policy
- Enables per-task visibility in the trigger.dev dashboard
- Independent failure tracking and retries for each fetcher
- Scheduled orchestrators (`dailyTask`, `hourlyTask`) trigger all tasks in parallel

## Test plan
- [x] Deploy to trigger.dev and verify all tasks appear individually in the dashboard
- [x] Trigger a manual run to confirm tasks execute correctly
- [x] Verify failure alerts work via the dashboard alert configuration