### PR TITLE
fix(data-layer): add CoinGecko demo API key to prevent rate limiting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,9 @@
 # Dune Analytics API key (required for total eth staked)
 # DUNE_API_KEY=
 
+# CoinGecko API
+# COINGECKO_API_KEY=
+
 # Matomo environment (URL and site ID required for analytics)
 NEXT_PUBLIC_MATOMO_URL=
 NEXT_PUBLIC_MATOMO_SITE_ID=

--- a/src/data-layer/fetchers/fetchEthPrice.ts
+++ b/src/data-layer/fetchers/fetchEthPrice.ts
@@ -7,8 +7,8 @@ export const FETCH_ETH_PRICE_TASK_ID = "fetch-eth-price"
  * Returns the latest USD price data.
  */
 export async function fetchEthPrice(): Promise<MetricReturnData> {
-  const url =
-    "https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd"
+  const apiKey = process.env.COINGECKO_API_KEY
+  const url = `https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd&x_cg_demo_api_key=${apiKey}`
 
   console.log("Starting Ethereum price data fetch")
 

--- a/src/data-layer/fetchers/fetchEthereumMarketcap.ts
+++ b/src/data-layer/fetchers/fetchEthereumMarketcap.ts
@@ -7,8 +7,8 @@ export const FETCH_ETHEREUM_MARKETCAP_TASK_ID = "fetch-ethereum-marketcap"
  * Returns the latest USD market cap data.
  */
 export async function fetchEthereumMarketcap(): Promise<MetricReturnData> {
-  const url =
-    "https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd&include_market_cap=true"
+  const apiKey = process.env.COINGECKO_API_KEY
+  const url = `https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd&include_market_cap=true&x_cg_demo_api_key=${apiKey}`
 
   console.log("Starting Ethereum market cap data fetch")
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -43,8 +43,7 @@ export const GITHUB_COMMITS_URL = GITHUB_BASE_API + "/commits"
 export const GITHUB_URL = `https://github.com/`
 export const COINGECKO_API_BASE_URL =
   "https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&category="
-export const COINGECKO_API_URL_PARAMS =
-  "&order=market_cap_desc&per_page=250&page=1&sparkline=false"
+export const COINGECKO_API_URL_PARAMS = `&order=market_cap_desc&per_page=250&page=1&sparkline=false&x_cg_demo_api_key=${process.env.COINGECKO_API_KEY}`
 export const COLOR_MODE_STORAGE_KEY = "theme"
 
 // API timing


### PR DESCRIPTION
## Summary
- Added `x_cg_demo_api_key` parameter to all CoinGecko API calls to prevent 429 rate limiting errors
- Updated ETH price, ETH market cap, and stablecoins fetchers to use `COINGECKO_API_KEY` environment variable
- Added `COINGECKO_API_KEY` to `.env.example`

## Test plan
- [x] Verify `COINGECKO_API_KEY` is set in production environment
- [x] Confirm ETH price fetcher task runs successfully without 429 errors
- [x] Confirm ETH market cap fetcher task runs successfully
- [x] Confirm stablecoins fetcher runs successfully