### PR TITLE
feat(ui): add SectionSubheader, SectionBody, and CardGrid atomic components

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,37 @@ This is the official Ethereum.org website - a Next.js application that serves as
 - **Custom properties**: CSS variables in `:root` for theme values
 - **Responsive design**: Mobile-first approach
 
+### Section Components
+
+The `src/components/ui/section.tsx` compound component provides consistent page section structure:
+
+- **`Section`** — Root `<section>` wrapper with scroll margin. Supports `variant="responsiveFlex"` for side-by-side layouts.
+- **`SectionTag`** — Category label (rounded pill, uppercase, primary color).
+- **`SectionHeader`** — Primary heading (`<h2>`, `text-5xl lg:text-6xl`).
+- **`SectionSubheader`** — Secondary heading (`text-4xl lg:text-5xl`). Supports `as` prop for semantic heading level (`h2`–`h6`), default `h3`.
+- **`SectionBody`** — Spacing wrapper for content below a heading (`mt-4 md:mt-16`). Not to be confused with `SectionContent`.
+- **`SectionContent`** — Text column in `responsiveFlex` layout (`space-y-2`).
+- **`SectionBanner`** — Image area in `responsiveFlex` layout.
+
+### Grid Utilities
+
+For standard card grids, use `<CardGrid>` from `src/components/ui/card-grid.tsx`:
+
+```tsx
+<CardGrid columns="fill-4" gap="lg">
+  {cards}
+</CardGrid>
+```
+
+| Utility              | Min card width | ~Cols (desktop) | Use for                    |
+|----------------------|---------------|-----------------|----------------------------|
+| `grid-cols-fill-3`   | 22rem (352px) | 3               | Large feature cards         |
+| `grid-cols-fill-4`   | 18rem (288px) | 4               | Standard cards              |
+| `grid-cols-fill-8`   | 11.25rem      | 8               | Small items, logos          |
+| `grid-cols-fill-10`  | 7.5rem        | 10              | Icons, avatars              |
+
+For non-standard grids (bento layout, manual breakpoints), use inline Tailwind classes.
+
 ## Development Workflows
 
 ### Available Scripts

--- a/app/[locale]/learn/page.tsx
+++ b/app/[locale]/learn/page.tsx
@@ -17,6 +17,7 @@ import MainArticle from "@/components/MainArticle"
 import { ContentContainer } from "@/components/MdComponents"
 import TableOfContents from "@/components/TableOfContents"
 import { ButtonLink } from "@/components/ui/buttons/Button"
+import { CardGrid } from "@/components/ui/card-grid"
 import { Center, Flex, Stack } from "@/components/ui/flex"
 import InlineLink from "@/components/ui/Link"
 import { ListItem, UnorderedList } from "@/components/ui/list"
@@ -98,10 +99,6 @@ const Section = ({
       {children}
     </section>
   </Stack>
-)
-
-const CardGrid = ({ children }: ChildOnlyProp) => (
-  <div className="grid grid-cols-fill-4 gap-8">{children}</div>
 )
 
 const H3 = ({ children, ...props }: HTMLAttributes<HTMLHeadingElement>) => (

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -54,8 +54,10 @@ import Link from "@/components/ui/Link"
 import {
   Section,
   SectionBanner,
+  SectionBody,
   SectionContent,
   SectionHeader,
+  SectionSubheader,
   SectionTag,
 } from "@/components/ui/section"
 import { Skeleton, SkeletonCardGrid } from "@/components/ui/skeleton"
@@ -817,9 +819,7 @@ const Page = async ({ params }: { params: PageParams }) => {
 
           {/* Recent posts */}
           <Section id="recent">
-            <h3 className="mb-4 mt-2 text-4xl font-black lg:text-5xl">
-              {t("page-index-posts-header")}
-            </h3>
+            <SectionSubheader>{t("page-index-posts-header")}</SectionSubheader>
             <p>{t("page-index-posts-subtitle")}</p>
 
             {/* dynamic / lazy loaded */}
@@ -851,11 +851,9 @@ const Page = async ({ params }: { params: PageParams }) => {
 
           {/* Events */}
           <Section id="events">
-            <h3 className="mb-4 mt-2 text-4xl font-black lg:text-5xl">
-              {t("page-index-events-header")}
-            </h3>
+            <SectionSubheader>{t("page-index-events-header")}</SectionSubheader>
             <p>{t("page-index-events-subtitle")}</p>
-            <div className="mt-4 md:mt-16">
+            <SectionBody>
               <div className="grid grid-cols-1 gap-8 self-stretch sm:grid-cols-2 md:grid-cols-3">
                 {upcomingEvents.map(
                   (
@@ -908,7 +906,7 @@ const Page = async ({ params }: { params: PageParams }) => {
                   )
                 )}
               </div>
-            </div>
+            </SectionBody>
             <div className="flex py-8 sm:justify-center">
               <ButtonLink
                 href="/community/events/"

--- a/src/components/Homepage/__stories__/HomepageSections.stories.tsx
+++ b/src/components/Homepage/__stories__/HomepageSections.stories.tsx
@@ -1,0 +1,196 @@
+/**
+ * Page-section stories for Chromatic visual regression testing.
+ * These render representative homepage section markup with mocked data
+ * so that component migrations show up as Chromatic diffs.
+ */
+import { Meta, StoryObj } from "@storybook/react"
+
+import { ButtonLink } from "@/components/ui/buttons/Button"
+import {
+  Card,
+  CardBanner,
+  CardContent,
+  CardParagraph,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  Section,
+  SectionBody,
+  SectionContent,
+  SectionHeader,
+  SectionSubheader,
+  SectionTag,
+} from "@/components/ui/section"
+
+const meta = {
+  title: "Pages / Homepage / Sections",
+  parameters: {
+    layout: "none",
+    chromatic: {
+      modes: {
+        "en-base": { viewport: "base", locale: "en" },
+        "en-md": { viewport: "md", locale: "en" },
+        "en-lg": { viewport: "lg", locale: "en" },
+        "ar-base": { viewport: "base", locale: "ar" },
+        "ar-md": { viewport: "md", locale: "ar" },
+        "ar-lg": { viewport: "lg", locale: "ar" },
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-full space-y-32 px-4 md:mx-6">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+const mockEvents = [
+  {
+    id: "1",
+    title: "Devconnect 2025",
+    dateRange: "Nov 12 – 19, 2025",
+    location: "Istanbul, Turkey",
+  },
+  {
+    id: "2",
+    title: "ETHGlobal Bangkok",
+    dateRange: "Dec 1 – 3, 2025",
+    location: "Bangkok, Thailand",
+  },
+  {
+    id: "3",
+    title: "EthCC 2025",
+    dateRange: "Jul 8 – 10, 2025",
+    location: "Cannes, France",
+  },
+]
+
+const mockBlogPosts = [
+  { name: "Ethereum Foundation Blog", href: "https://blog.ethereum.org" },
+  { name: "Attestant", href: "https://www.attestant.io/posts/" },
+  { name: "Bankless", href: "https://www.bankless.com/" },
+  { name: "Week in Ethereum News", href: "https://weekinethereumnews.com/" },
+]
+
+/**
+ * Recent Posts section — uses SectionSubheader + inline spacing on swiper.
+ * The h3 and paragraph below it are what we're migrating.
+ */
+export const RecentPosts: Story = {
+  render: () => (
+    <Section id="recent">
+      <SectionSubheader>Recent posts</SectionSubheader>
+      <p>What the Ethereum community is saying</p>
+
+      {/* RecentPostsSwiper placeholder — mt-4 md:mt-16 is on the component */}
+      <SectionBody>
+        <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-4">
+          {Array.from({ length: 4 }, (_, i) => (
+            <Card key={i}>
+              <CardBanner background="accent-a">
+                <div className="flex h-32 items-center justify-center text-2xl">
+                  Blog {i + 1}
+                </div>
+              </CardBanner>
+              <CardContent>
+                <CardTitle>Blog Post Title {i + 1}</CardTitle>
+                <CardParagraph variant="light" size="sm">
+                  Jan {i + 1}, 2025
+                </CardParagraph>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </SectionBody>
+
+      <div className="mt-8 flex flex-col gap-4 rounded-2xl border p-8">
+        <p className="text-lg">Read more from the community</p>
+        <div className="flex flex-wrap gap-x-6 gap-y-4">
+          {mockBlogPosts.map(({ name, href }) => (
+            <a key={name} href={href} className="text-primary underline">
+              {name}
+            </a>
+          ))}
+        </div>
+      </div>
+    </Section>
+  ),
+}
+
+/**
+ * Events section — uses SectionSubheader + SectionBody wrapping a card grid.
+ * The h3, paragraph, spacing div, and grid are what we're migrating.
+ */
+export const Events: Story = {
+  render: () => (
+    <Section id="events">
+      <SectionSubheader>Upcoming events</SectionSubheader>
+      <p>Come to an Ethereum event</p>
+      <SectionBody>
+        <div className="grid grid-cols-1 gap-8 self-stretch sm:grid-cols-2 md:grid-cols-3">
+          {mockEvents.map((event) => (
+            <Card key={event.id} href="#">
+              <CardBanner background="accent-b">
+                <div className="flex h-40 items-center justify-center text-body-medium">
+                  Event image
+                </div>
+              </CardBanner>
+              <CardContent>
+                <CardTitle>{event.title}</CardTitle>
+                <CardParagraph variant="subtitle" size="sm">
+                  {event.dateRange}
+                </CardParagraph>
+                <CardParagraph variant="uppercase">
+                  {event.location}
+                </CardParagraph>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </SectionBody>
+      <div className="flex py-8 sm:justify-center">
+        <ButtonLink href="/community/events/" size="lg">
+          See all events
+        </ButtonLink>
+      </div>
+    </Section>
+  ),
+}
+
+/**
+ * What is Ethereum section — uses Section compound pattern with
+ * SectionTag, SectionHeader, SectionContent, and SectionBanner.
+ * This pattern is already migrated; here for regression coverage.
+ */
+export const WhatIsEthereum: Story = {
+  render: () => (
+    <Section id="what-is-ethereum" variant="responsiveFlex">
+      <SectionContent>
+        <SectionTag>The network</SectionTag>
+        <SectionHeader>What is Ethereum?</SectionHeader>
+        <div className="space-y-6 py-8 text-lg text-body">
+          <p>
+            Ethereum is a technology for building apps and organizations,
+            holding assets, transacting and communicating without being
+            controlled by a central authority.
+          </p>
+          <p>
+            You don&apos;t need to hand over all your personal details to use
+            Ethereum — you keep control of your own data.
+          </p>
+        </div>
+        <div className="flex">
+          <ButtonLink href="/what-is-ethereum/" size="lg">
+            Learn about Ethereum
+          </ButtonLink>
+        </div>
+      </SectionContent>
+    </Section>
+  ),
+}

--- a/src/components/LearningToolsCardGrid.tsx
+++ b/src/components/LearningToolsCardGrid.tsx
@@ -1,9 +1,11 @@
 import { LearningToolsCardGridProps } from "@/lib/types"
 
+import { CardGrid } from "@/components/ui/card-grid"
+
 import ProductCard from "./ProductCard"
 
 const LearningToolsCardGrid = ({ products }: LearningToolsCardGridProps) => (
-  <div className="mb-8 grid grid-cols-fill-4 gap-8">
+  <CardGrid className="mb-8">
     {products
       .sort(({ locales }) => (locales?.length ? -1 : 0))
       .map(({ description, ...product }) => (
@@ -11,7 +13,7 @@ const LearningToolsCardGrid = ({ products }: LearningToolsCardGridProps) => (
           {description}
         </ProductCard>
       ))}
-  </div>
+  </CardGrid>
 )
 
 export default LearningToolsCardGrid

--- a/src/components/ui/__stories__/CardGrid.stories.tsx
+++ b/src/components/ui/__stories__/CardGrid.stories.tsx
@@ -1,0 +1,85 @@
+import { Meta, StoryObj } from "@storybook/react"
+
+import { CardGrid } from "../card-grid"
+
+const meta = {
+  title: "Atoms / Layout / CardGrid",
+  component: CardGrid,
+  parameters: {
+    layout: "none",
+    chromatic: {
+      modes: {
+        "en-base": { viewport: "base", locale: "en" },
+        "en-md": { viewport: "md", locale: "en" },
+        "en-lg": { viewport: "lg", locale: "en" },
+        "ar-base": { viewport: "base", locale: "ar" },
+        "ar-md": { viewport: "md", locale: "ar" },
+        "ar-lg": { viewport: "lg", locale: "ar" },
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="p-8">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof CardGrid>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+const PlaceholderCard = ({ label }: { label: string }) => (
+  <div className="rounded-lg border bg-background p-6">
+    <p className="font-bold">{label}</p>
+    <p className="text-sm text-body-medium">Placeholder card content</p>
+  </div>
+)
+
+const cards = Array.from({ length: 8 }, (_, i) => (
+  <PlaceholderCard key={i} label={`Card ${i + 1}`} />
+))
+
+export const Default: Story = {
+  render: () => <CardGrid>{cards}</CardGrid>,
+}
+
+export const ThreeColumns: Story = {
+  render: () => <CardGrid columns="fill-3">{cards.slice(0, 6)}</CardGrid>,
+}
+
+export const SmallItems: Story = {
+  render: () => (
+    <CardGrid columns="fill-8" gap="sm">
+      {Array.from({ length: 16 }, (_, i) => (
+        <div
+          key={i}
+          className="flex aspect-square items-center justify-center rounded-lg border bg-background"
+        >
+          {i + 1}
+        </div>
+      ))}
+    </CardGrid>
+  ),
+}
+
+export const GapVariants: Story = {
+  render: () => (
+    <div className="space-y-12">
+      <div>
+        <h3 className="mb-2 text-lg font-bold">gap=&quot;sm&quot; (gap-4)</h3>
+        <CardGrid gap="sm">{cards.slice(0, 4)}</CardGrid>
+      </div>
+      <div>
+        <h3 className="mb-2 text-lg font-bold">gap=&quot;md&quot; (gap-6)</h3>
+        <CardGrid gap="md">{cards.slice(0, 4)}</CardGrid>
+      </div>
+      <div>
+        <h3 className="mb-2 text-lg font-bold">gap=&quot;lg&quot; (gap-8)</h3>
+        <CardGrid gap="lg">{cards.slice(0, 4)}</CardGrid>
+      </div>
+    </div>
+  ),
+}

--- a/src/components/ui/__stories__/Section.stories.tsx
+++ b/src/components/ui/__stories__/Section.stories.tsx
@@ -1,0 +1,138 @@
+import { Meta, StoryObj } from "@storybook/react"
+
+import {
+  Section,
+  SectionBanner,
+  SectionBody,
+  SectionContent,
+  SectionHeader,
+  SectionSubheader,
+  SectionTag,
+} from "../section"
+
+const meta = {
+  title: "Atoms / Layout / Section",
+  component: Section,
+  parameters: {
+    layout: "none",
+    chromatic: {
+      modes: {
+        "en-base": { viewport: "base", locale: "en" },
+        "en-md": { viewport: "md", locale: "en" },
+        "en-lg": { viewport: "lg", locale: "en" },
+        "ar-base": { viewport: "base", locale: "ar" },
+        "ar-md": { viewport: "md", locale: "ar" },
+        "ar-lg": { viewport: "lg", locale: "ar" },
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="p-8">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof Section>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: () => (
+    <Section>
+      <SectionTag>Tag label</SectionTag>
+      <SectionHeader>Section Header</SectionHeader>
+      <SectionContent>
+        <p>
+          This is the default Section layout with SectionTag, SectionHeader, and
+          SectionContent.
+        </p>
+        <p>SectionContent uses a vertical stack with consistent spacing.</p>
+      </SectionContent>
+    </Section>
+  ),
+}
+
+export const WithSubheader: Story = {
+  render: () => (
+    <Section>
+      <SectionTag>Tag label</SectionTag>
+      <SectionHeader>Section Header</SectionHeader>
+      <SectionSubheader>Subsection Heading</SectionSubheader>
+      <SectionBody>
+        <p>
+          SectionSubheader renders as an h3 by default, one level below
+          SectionHeader&apos;s h2.
+        </p>
+        <p>
+          SectionBody provides consistent vertical spacing (mt-4 md:mt-16)
+          between the heading and content below.
+        </p>
+      </SectionBody>
+    </Section>
+  ),
+}
+
+export const SubheaderHeadingLevels: Story = {
+  render: () => (
+    <Section>
+      <SectionHeader>Heading Levels Demo</SectionHeader>
+      <div className="space-y-4">
+        <SectionSubheader as="h2">as h2</SectionSubheader>
+        <SectionSubheader as="h3">as h3 (default)</SectionSubheader>
+        <SectionSubheader as="h4">as h4</SectionSubheader>
+        <SectionSubheader as="h5">as h5</SectionSubheader>
+        <SectionSubheader as="h6">as h6</SectionSubheader>
+      </div>
+    </Section>
+  ),
+}
+
+export const WithBanner: Story = {
+  render: () => (
+    <Section variant="responsiveFlex">
+      <SectionBanner>
+        <div className="flex h-64 items-center justify-center bg-primary-low-contrast text-body-medium">
+          Banner image area
+        </div>
+      </SectionBanner>
+      <SectionContent>
+        <SectionTag>Tag label</SectionTag>
+        <SectionHeader>Section with Banner</SectionHeader>
+        <p>
+          The responsiveFlex variant creates a side-by-side layout at md
+          breakpoint, with SectionBanner and SectionContent as children.
+        </p>
+      </SectionContent>
+    </Section>
+  ),
+}
+
+export const CompositionExample: Story = {
+  render: () => (
+    <div className="space-y-16">
+      <Section>
+        <SectionTag>Explore</SectionTag>
+        <SectionHeader>What is Ethereum?</SectionHeader>
+        <SectionContent>
+          <p>
+            Ethereum is a technology for building apps and organizations,
+            holding assets, transacting and communicating without being
+            controlled by a central authority.
+          </p>
+        </SectionContent>
+        <SectionSubheader>Get started</SectionSubheader>
+        <SectionBody>
+          <div className="grid grid-cols-fill-4 gap-8">
+            <div className="rounded-lg border p-4">Card 1</div>
+            <div className="rounded-lg border p-4">Card 2</div>
+            <div className="rounded-lg border p-4">Card 3</div>
+            <div className="rounded-lg border p-4">Card 4</div>
+          </div>
+        </SectionBody>
+      </Section>
+    </div>
+  ),
+}

--- a/src/components/ui/card-grid.tsx
+++ b/src/components/ui/card-grid.tsx
@@ -1,0 +1,38 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils/cn"
+
+const cardGridVariants = cva("grid", {
+  variants: {
+    columns: {
+      "fill-3": "grid-cols-fill-3",
+      "fill-4": "grid-cols-fill-4",
+      "fill-8": "grid-cols-fill-8",
+      "fill-10": "grid-cols-fill-10",
+    },
+    gap: {
+      sm: "gap-4",
+      md: "gap-6",
+      lg: "gap-8",
+    },
+  },
+  defaultVariants: {
+    columns: "fill-4",
+    gap: "lg",
+  },
+})
+
+const CardGrid = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof cardGridVariants>
+>(({ className, columns, gap, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(cardGridVariants({ columns, gap }), className)}
+    {...props}
+  />
+))
+CardGrid.displayName = "CardGrid"
+
+export { CardGrid, cardGridVariants }

--- a/src/components/ui/section.tsx
+++ b/src/components/ui/section.tsx
@@ -3,7 +3,6 @@ import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils/cn"
 
-// TODO: Add to design system
 const variants = cva("w-full scroll-mt-24 lg:scroll-mt-28", {
   variants: {
     variant: {
@@ -82,4 +81,44 @@ const SectionContent = React.forwardRef<
 ))
 SectionContent.displayName = "SectionContent"
 
-export { Section, SectionBanner, SectionContent, SectionHeader, SectionTag }
+type HeadingLevel = "h2" | "h3" | "h4" | "h5" | "h6"
+
+interface SectionSubheaderProps
+  extends React.HTMLAttributes<HTMLHeadingElement> {
+  as?: HeadingLevel
+}
+
+const SectionSubheader = React.forwardRef<
+  HTMLHeadingElement,
+  SectionSubheaderProps
+>(({ className, as: Tag = "h3", ...props }, ref) => (
+  <Tag
+    ref={ref}
+    className={cn("mb-4 mt-2 text-4xl font-black lg:text-5xl", className)}
+    {...props}
+  />
+))
+SectionSubheader.displayName = "SectionSubheader"
+
+/**
+ * Vertical spacing wrapper for content below a SectionHeader or SectionSubheader.
+ * Not to be confused with SectionContent, which is the text column in a
+ * responsiveFlex Section layout.
+ */
+const SectionBody = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("mt-4 md:mt-16", className)} {...props} />
+))
+SectionBody.displayName = "SectionBody"
+
+export {
+  Section,
+  SectionBanner,
+  SectionBody,
+  SectionContent,
+  SectionHeader,
+  SectionSubheader,
+  SectionTag,
+}

--- a/src/layouts/md/Staking.tsx
+++ b/src/layouts/md/Staking.tsx
@@ -20,6 +20,7 @@ import StakingLaunchpadWidget from "@/components/Staking/StakingLaunchpadWidget"
 import StakingProductsCardGrid from "@/components/Staking/StakingProductsCardGrid"
 import WithdrawalCredentials from "@/components/Staking/WithdrawalCredentials"
 import WithdrawalsTabComparison from "@/components/Staking/WithdrawalsTabComparison"
+import { CardGrid as InfoGridComponent } from "@/components/ui/card-grid"
 import { List, ListItem } from "@/components/ui/list"
 import UpgradeStatus from "@/components/UpgradeStatus"
 
@@ -36,7 +37,7 @@ const Heading4 = (props: HTMLAttributes<HTMLHeadingElement>) => (
 )
 
 export const InfoGrid = (props: ChildOnlyProp) => (
-  <div className="grid grid-cols-fill-3 gap-8" {...props} />
+  <InfoGridComponent columns="fill-3" {...props} />
 )
 
 const CardGrid = (props: ChildOnlyProp) => (

--- a/src/layouts/md/UseCases.tsx
+++ b/src/layouts/md/UseCases.tsx
@@ -11,6 +11,7 @@ import { RestakingList } from "@/components/Content/restaking/RestakingList"
 import TabbedSection from "@/components/Content/restaking/RestakingTab"
 import Emoji from "@/components/Emoji"
 import { ContentHero } from "@/components/Hero"
+import { CardGrid } from "@/components/ui/card-grid"
 import InlineLink from "@/components/ui/Link"
 import { List, ListItem } from "@/components/ui/list"
 
@@ -20,10 +21,6 @@ import { getSummaryPoints } from "@/lib/utils/getSummaryPoints"
 import { ContentLayout } from "../ContentLayout"
 
 import { useTranslation } from "@/hooks/useTranslation"
-
-const CardGrid = (props: ChildOnlyProp) => (
-  <div className="grid grid-cols-fill-4 gap-8" {...props} />
-)
 
 // UseCases layout components
 export const useCasesComponents = {

--- a/src/layouts/stories/LearnPageSections.stories.tsx
+++ b/src/layouts/stories/LearnPageSections.stories.tsx
@@ -1,0 +1,125 @@
+/**
+ * Page-section stories for Chromatic visual regression testing.
+ * These render representative learn page patterns with mocked data
+ * so that CardGrid migrations show up as Chromatic diffs.
+ */
+import { Meta, StoryObj } from "@storybook/react"
+
+import { ButtonLink } from "@/components/ui/buttons/Button"
+import { CardGrid } from "@/components/ui/card-grid"
+
+const meta = {
+  title: "Pages / Learn / Sections",
+  parameters: {
+    layout: "none",
+    chromatic: {
+      modes: {
+        "en-base": { viewport: "base", locale: "en" },
+        "en-md": { viewport: "md", locale: "en" },
+        "en-lg": { viewport: "lg", locale: "en" },
+        "ar-base": { viewport: "base", locale: "ar" },
+        "ar-md": { viewport: "md", locale: "ar" },
+        "ar-lg": { viewport: "lg", locale: "ar" },
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-screen-lg p-8">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+const MockCard = ({
+  title,
+  description,
+}: {
+  title: string
+  description: string
+}) => (
+  <div className="flex flex-col justify-between rounded-sm border bg-background p-6 [&_h3]:mt-0">
+    <div>
+      <div className="mb-4 flex justify-center">
+        <div className="flex h-[200px] w-auto items-center justify-center rounded bg-background-highlight px-8 text-body-medium">
+          Image
+        </div>
+      </div>
+      <h3 className="text-xl font-bold">{title}</h3>
+      <p className="text-body-medium">{description}</p>
+    </div>
+    <ButtonLink href="#" className="mt-4">
+      {title}
+    </ButtonLink>
+  </div>
+)
+
+const mockCards = [
+  {
+    title: "What is Ethereum?",
+    description: "Learn about the technology behind Ethereum.",
+  },
+  {
+    title: "What is ETH?",
+    description: "Learn about ETH, the native currency of Ethereum.",
+  },
+  {
+    title: "What is Web3?",
+    description: "Explore how Web3 differs from Web2.",
+  },
+  { title: "DeFi", description: "Decentralized finance built on Ethereum." },
+  {
+    title: "Stablecoins",
+    description: "Crypto tokens pegged to stable assets.",
+  },
+  { title: "NFTs", description: "Non-fungible tokens on Ethereum." },
+]
+
+/**
+ * Learn page CardGrid — the local CardGrid definition is being replaced
+ * with the atomic <CardGrid> component. Both render grid-cols-fill-4 gap-8.
+ */
+export const CardGridSection: Story = {
+  render: () => (
+    <section className="mt-24">
+      <h2 className="text-2xl leading-[1.4] md:text-[2rem]">
+        What is crypto and Ethereum?
+      </h2>
+      <p className="mt-8">
+        Ethereum is a technology that lets you send cryptocurrency to anyone for
+        a small fee.
+      </p>
+      <CardGrid className="mt-8">
+        {mockCards.slice(0, 3).map((card) => (
+          <MockCard key={card.title} {...card} />
+        ))}
+      </CardGrid>
+    </section>
+  ),
+}
+
+/**
+ * Learn page with 6 cards — tests the fill-4 grid wrapping behavior.
+ */
+export const CardGridSixCards: Story = {
+  render: () => (
+    <section className="mt-24">
+      <h2 className="text-2xl leading-[1.4] md:text-[2rem]">
+        What is Ethereum used for?
+      </h2>
+      <p className="mt-8">
+        Ethereum has led to the creation of new products and services.
+      </p>
+      <CardGrid className="mt-8">
+        {mockCards.map((card) => (
+          <MockCard key={card.title} {...card} />
+        ))}
+      </CardGrid>
+    </section>
+  ),
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -328,6 +328,16 @@ const config = {
       borderRadius: {
         "4xl": "2rem" /* 32px */,
       },
+      // Auto-fill grid templates for responsive card layouts.
+      // Use <CardGrid> from ui/card-grid.tsx for standard grids.
+      // Use inline classes for non-standard grids (bento, manual breakpoints).
+      //
+      // | Utility        | Min card width | ~Cols (desktop) | Use for              |
+      // |----------------|---------------|-----------------|----------------------|
+      // | grid-cols-fill-3  | 22rem (352px) | 3               | Large feature cards  |
+      // | grid-cols-fill-4  | 18rem (288px) | 4               | Standard cards       |
+      // | grid-cols-fill-8  | 11.25rem      | 8               | Small items, logos   |
+      // | grid-cols-fill-10 | 7.5rem        | 10              | Icons, avatars       |
       gridTemplateColumns: {
         bento: "repeat(12, 1fr)",
         "fill-3": "repeat(auto-fill, minmax(min(100%, 22rem), 1fr))",


### PR DESCRIPTION
## Summary

- Adds `SectionSubheader` (polymorphic h2–h6, default h3) and `SectionBody` (vertical spacing wrapper) to `src/components/ui/section.tsx`
- Adds `CardGrid` component (`src/components/ui/card-grid.tsx`) with CVA column/gap variants wrapping the existing `grid-cols-fill-*` utilities
- Migrates 5 pages/layouts from inline patterns to the new components: homepage, learn page, use-cases layout, staking layout, and `LearningToolsCardGrid`

## What changed

| Component | Classes extracted | Used by |
|-----------|------------------|---------|
| `SectionSubheader` | `mb-4 mt-2 text-4xl font-black lg:text-5xl` | homepage (×2) |
| `SectionBody` | `mt-4 md:mt-16` | homepage (×1) |
| `CardGrid` | `grid grid-cols-fill-{3,4,8,10} gap-{4,6,8}` | learn, use-cases, staking, learning-tools |

## Visual regression

Chromatic confirms zero visual diff:
- **Build 4981**: baseline set with old inline patterns in page-section stories
- **Build 4982**: stories updated to new atomic components — **0 changes detected** across 347 snapshots

## What's NOT migrated (intentional)

- Homepage bento section (custom `xl:text-7xl` sizing)
- Events grid (manual `sm:grid-cols-2 md:grid-cols-3` breakpoints, not auto-fill)
- Staking client `CardGrid` (manual breakpoints + `[&_h3]:mt-0`)
- Learn page local `Section` (different API with `headingId`/`headingTitle` props)

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `pnpm lint` passes (only pre-existing errors)
- [x] Storybook builds
- [x] Chromatic build 4982 — zero visual changes
- [ ] Manual spot-check homepage, learn, staking pages in dev