### PR TITLE
feat(ui): Heading atomic component

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,24 @@ pnpm events-import         # Import community events
 5. Export from appropriate index file
 6. Update documentation if adding new patterns
 
+### Heading Component (`src/components/ui/heading.tsx`)
+
+The `Heading` component is the single source of truth for the heading typography scale. Its size variants mirror `global.css` exactly — replacing `<h2>` with `<Heading as="h2">` is zero visual diff.
+
+**When to use `<Heading>`:**
+- Pages/components where you want explicit control over heading typography
+- Decoupling visual size from semantic level (e.g., `<Heading as="h3" size="xl">`)
+- Applying the `font-black` weight variant (SectionSubheader pattern)
+
+**When NOT to use `<Heading>`:**
+- MDX content pages — use `Heading1`–`Heading4` from `MdComponents` (different concerns: ID anchors, content spacing)
+- `SectionSubheader` / `SectionHeader` — already abstracted with layout concerns
+- Raw `<h2>` in MDX — global.css handles these
+
+**Ownership boundary:** `Heading` is for typography styling only. It has no margins, no anchors, no layout. Layout components that couple typography with spacing remain separate.
+
+**Scale note:** `SectionHeader` uses `text-5xl lg:text-6xl` — one step above the `xl` variant. A future `2xl` variant is reserved for this if SectionHeader is migrated.
+
 ### Content Updates
 
 1. Markdown files go in `public/content/`

--- a/app/[locale]/10years/_components/AdoptionSwiper/index.tsx
+++ b/app/[locale]/10years/_components/AdoptionSwiper/index.tsx
@@ -3,6 +3,7 @@
 import { Image } from "@/components/Image"
 import Translation from "@/components/Translation"
 import { ButtonLink } from "@/components/ui/buttons/Button"
+import { Heading } from "@/components/ui/heading"
 import {
   Swiper,
   SwiperContainer,
@@ -37,7 +38,9 @@ const AdoptionSwiper = ({
                   alt={title}
                   className="mx-auto mb-4 h-36 object-contain"
                 />
-                <h3 className="mb-4 text-2xl font-bold">{title}</h3>
+                <Heading as="h3" className="mb-4 lg:text-2xl">
+                  {title}
+                </Heading>
                 <p className="mb-8">
                   <Translation
                     id={`page-10-year-adoption-card-${index + 1}-description`}

--- a/app/[locale]/10years/page.tsx
+++ b/app/[locale]/10years/page.tsx
@@ -13,6 +13,7 @@ import { Image } from "@/components/Image"
 import MainArticle from "@/components/MainArticle"
 import Translation from "@/components/Translation"
 import { ButtonLink } from "@/components/ui/buttons/Button"
+import { Heading } from "@/components/ui/heading"
 import InlineLink from "@/components/ui/Link"
 import { LinkBox, LinkOverlay } from "@/components/ui/link-box"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
@@ -85,9 +86,9 @@ const Page = async ({ params }: { params: PageParams }) => {
         >
           <div className="flex flex-1 flex-col gap-5">
             <div>
-              <h1 className="text-2xl font-bold">
+              <Heading size="md" className="lg:text-2xl">
                 {t("page-10-year-hero-title")}
-              </h1>
+              </Heading>
             </div>
 
             <div className="flex flex-1 flex-col gap-4">
@@ -162,7 +163,10 @@ const Page = async ({ params }: { params: PageParams }) => {
                             key={country}
                             className={cn("flex flex-col border-b px-4 py-6")}
                           >
-                            <h3 className="mb-2 flex items-center gap-2 text-2xl font-bold text-body-medium">
+                            <Heading
+                              as="h3"
+                              className="mb-2 flex items-center gap-2 text-body-medium lg:text-2xl"
+                            >
                               <span className="flex min-h-6 min-w-6 items-center justify-center overflow-hidden rounded-full bg-primary-low-contrast">
                                 <Emoji
                                   text={countryEvents[0].countryFlag}
@@ -170,7 +174,7 @@ const Page = async ({ params }: { params: PageParams }) => {
                                 />
                               </span>
                               {country}
-                            </h3>
+                            </Heading>
                             <div className="flex flex-col py-4">
                               {countryEvents.map((event, index) => (
                                 <LinkBox
@@ -257,16 +261,16 @@ const Page = async ({ params }: { params: PageParams }) => {
             </div>
             <div className="flex flex-1 flex-col gap-8">
               <div>
-                <h3 className="text-lg font-bold">
+                <Heading as="h3" className="text-lg lg:text-lg">
                   {t("page-10-year-torch-one-of-kind-title")}
-                </h3>
+                </Heading>
                 <p>{t("page-10-year-torch-one-of-kind-description")}</p>
               </div>
 
               <div>
-                <h3 className="text-lg font-bold">
+                <Heading as="h3" className="text-lg lg:text-lg">
                   {t("page-10-year-torch-time-limited-title")}
-                </h3>
+                </Heading>
                 <p>{t("page-10-year-torch-time-limited-description")}</p>
               </div>
             </div>
@@ -332,9 +336,9 @@ const Page = async ({ params }: { params: PageParams }) => {
                   alt={t(`page-10-year-adoption-card-${index + 1}-title`)}
                   className="mx-auto mb-4 max-h-[300px] object-contain"
                 />
-                <h3 className="mb-4 text-2xl font-bold">
+                <Heading as="h3" className="mb-4 lg:text-2xl">
                   {t(`page-10-year-adoption-card-${index + 1}-title`)}
-                </h3>
+                </Heading>
                 <p className="mb-8">
                   <Translation
                     id={`page-10-year-adoption-card-${index + 1}-description`}

--- a/app/[locale]/bug-bounty/page.tsx
+++ b/app/[locale]/bug-bounty/page.tsx
@@ -20,6 +20,7 @@ import MainArticle from "@/components/MainArticle"
 import { ButtonLink } from "@/components/ui/buttons/Button"
 import { Divider } from "@/components/ui/divider"
 import { Center, Flex, VStack } from "@/components/ui/flex"
+import { Heading } from "@/components/ui/heading"
 import InlineLink from "@/components/ui/Link"
 import Link from "@/components/ui/Link"
 import { ListItem, UnorderedList } from "@/components/ui/list"
@@ -275,10 +276,10 @@ export default async function Page({ params }: { params: Promise<Params> }) {
                   WebkitTextFillColor: "transparent",
                 }}
               >
-                <h1 className="mb-6 text-4xl font-bold lg:text-5xl">
+                <Heading className="mb-6">
                   {t("page-upgrades-bug-bounty-slogan")}&nbsp;
                   <Emoji text=":bug:" />
-                </h1>
+                </Heading>
               </div>
               <Text className="mt-4 max-w-[480px] leading-xs text-body-medium">
                 {t("page-upgrades-bug-bounty-subtitle")}

--- a/app/[locale]/collectibles/_components/CollectiblesCurrentYear.tsx
+++ b/app/[locale]/collectibles/_components/CollectiblesCurrentYear.tsx
@@ -20,6 +20,7 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion"
 import { Card } from "@/components/ui/card"
+import { Heading } from "@/components/ui/heading"
 import Link, { ExternalLinkIcon, LinkProps } from "@/components/ui/Link"
 import {
   ListItem,
@@ -283,9 +284,9 @@ const CollectiblesCurrentYear = ({
                 alt="Developer badge" // TODO: extract intl
                 href={developerBadge.link}
               >
-                <h4 className="text-lg font-bold">
+                <Heading as="h4" className="text-lg lg:text-lg">
                   {t("page-collectibles-code-content-developer-title")}
-                </h4>
+                </Heading>
                 <p>{t("page-collectibles-code-content-developer-desc")}</p>
                 <CheckList>
                   <CheckItem owned={developerBadge.owned}>
@@ -319,9 +320,9 @@ const CollectiblesCurrentYear = ({
                 alt="Writer badge" // TODO: extract intl
                 href={writingBadge.link}
               >
-                <h4 className="text-lg font-bold">
+                <Heading as="h4" className="text-lg lg:text-lg">
                   {t("page-collectibles-code-content-writing-title")}
-                </h4>
+                </Heading>
                 <p>{t("page-collectibles-code-content-writing-desc")}</p>
                 <CheckList>
                   <CheckItem owned={writingBadge.owned}>
@@ -348,9 +349,9 @@ const CollectiblesCurrentYear = ({
                 alt="Design / user testing badge" // TODO: extract intl
                 href={designBadge.link}
               >
-                <h4 className="text-lg font-bold">
+                <Heading as="h4" className="text-lg lg:text-lg">
                   {t("page-collectibles-code-content-design-title")}
-                </h4>
+                </Heading>
                 <p>{t("page-collectibles-code-content-design-desc")}</p>
                 <CheckList>
                   <CheckItem owned={designBadge.owned}>
@@ -377,9 +378,9 @@ const CollectiblesCurrentYear = ({
                 alt="GitPOAP badge" // TODO: extract intl
                 href={gitpoapBadge.link}
               >
-                <h4 className="text-lg font-bold">
+                <Heading as="h4" className="text-lg lg:text-lg">
                   {t("page-collectibles-code-content-gitpoap-title")}
-                </h4>
+                </Heading>
                 <p>{t("page-collectibles-code-content-gitpoap-desc")}</p>
                 <CheckList>
                   <CheckItem owned={gitpoapBadge.owned}>
@@ -441,9 +442,9 @@ const CollectiblesCurrentYear = ({
                   address && !translationBadge.owned && "[&_img]:grayscale"
                 )}
               >
-                <h4 className="text-lg font-bold">
+                <Heading as="h4" className="text-lg lg:text-lg">
                   {t("page-collectibles-translations-title")}
-                </h4>
+                </Heading>
                 <p>{t("page-collectibles-translations-badge-desc")}</p>
                 <CheckList>
                   <CheckItem owned={translationBadge.owned}>

--- a/app/[locale]/community/events/page.tsx
+++ b/app/[locale]/community/events/page.tsx
@@ -24,6 +24,7 @@ import {
   EdgeScrollContainer,
   EdgeScrollItem,
 } from "@/components/ui/edge-scroll-container"
+import { Heading } from "@/components/ui/heading"
 import Link from "@/components/ui/Link"
 import { Section } from "@/components/ui/section"
 import TabNav, { StickyContainer } from "@/components/ui/TabNav"
@@ -158,9 +159,9 @@ const Page = async ({ params }: { params: PageParams }) => {
         <MainArticle className="space-y-20 px-4 py-10 md:px-8">
           {/* Major blockchain conferences */}
           <Section id="highlights">
-            <h2 className="mb-6 font-bold">
+            <Heading as="h2" className="mb-6">
               {t("page-events-section-major-conferences")}
-            </h2>
+            </Heading>
             <EdgeScrollContainer>
               {highlightedConferences.map((event) => (
                 <EdgeScrollItem
@@ -224,7 +225,9 @@ const Page = async ({ params }: { params: PageParams }) => {
                           sizes="6rem"
                         />
                       </div>
-                      <h3 className="text-2xl font-bold">{location}</h3>
+                      <Heading as="h3" className="lg:text-2xl">
+                        {location}
+                      </Heading>
                       <div className="space-y-[1lh]">
                         <p>{t(descriptionKey)}</p>
                         <p>{t(ctaKey)}</p>
@@ -400,9 +403,9 @@ const Page = async ({ params }: { params: PageParams }) => {
                 />
               </div>
               <div>
-                <h3 className="mb-2 text-xl font-bold">
+                <Heading as="h3" size="sm" className="mb-2 lg:text-xl">
                   {t("page-events-section-organizers-planning")}
-                </h3>
+                </Heading>
                 <p className="mb-4 max-w-4xl">
                   {t("page-events-section-organizers-planning-description")}
                 </p>
@@ -440,9 +443,9 @@ const Page = async ({ params }: { params: PageParams }) => {
                       sizes="4rem"
                     />
                   </div>
-                  <h3 className="text-xl font-bold">
+                  <Heading as="h3" size="sm" className="lg:text-xl">
                     {t("page-events-support-ethereum-everywhere")}
-                  </h3>
+                  </Heading>
                 </div>
 
                 <div className="space-y-[1lh]">
@@ -508,9 +511,9 @@ const Page = async ({ params }: { params: PageParams }) => {
                       sizes="4rem"
                     />
                   </div>
-                  <h3 className="text-xl font-bold">
+                  <Heading as="h3" size="sm" className="lg:text-xl">
                     {t("page-events-support-geode-labs")}
-                  </h3>
+                  </Heading>
                 </div>
                 <div className="space-y-[1lh] [&_a]:no-underline">
                   <p>{t("page-events-support-geode-labs-description")}</p>

--- a/app/[locale]/developers/_components/BuilderCard.tsx
+++ b/app/[locale]/developers/_components/BuilderCard.tsx
@@ -1,6 +1,7 @@
 import { Image } from "@/components/Image"
 import { ButtonLink } from "@/components/ui/buttons/Button"
 import { Card } from "@/components/ui/card"
+import { Heading } from "@/components/ui/heading"
 import { Tag } from "@/components/ui/tag"
 
 import { cn } from "@/lib/utils/cn"
@@ -30,7 +31,9 @@ const BuilderCard = ({ path, className }: BuildCardProps) => (
           {path.tag}
         </Tag>
       )}
-      <h3 className="text-lg font-bold">{path.title}</h3>
+      <Heading as="h3" className="text-lg lg:text-lg">
+        {path.title}
+      </Heading>
       <p className="mb-4 text-sm text-body-medium">{path.description}</p>
     </div>
     <ButtonLink

--- a/app/[locale]/developers/_components/VideoCourseCard.tsx
+++ b/app/[locale]/developers/_components/VideoCourseCard.tsx
@@ -1,5 +1,6 @@
 import { Image } from "@/components/Image"
 import { Card } from "@/components/ui/card"
+import { Heading } from "@/components/ui/heading"
 import { Tag } from "@/components/ui/tag"
 
 import { cn } from "@/lib/utils/cn"
@@ -37,9 +38,12 @@ const VideoCourseCard = ({ course, className }: VideoCourseCardProps) => (
       >
         {course.hours}
       </Tag>
-      <h3 className="text-lg font-bold text-body group-hover:underline">
+      <Heading
+        as="h3"
+        className="text-lg text-body group-hover:underline lg:text-lg"
+      >
         {course.title}
-      </h3>
+      </Heading>
       <p className="mb-4 text-sm text-body-medium">{course.description}</p>
     </div>
   </Card>

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -49,6 +49,7 @@ import {
   CardParagraph,
   CardTitle,
 } from "@/components/ui/card"
+import { Heading } from "@/components/ui/heading"
 import InlineLink from "@/components/ui/Link"
 import Link from "@/components/ui/Link"
 import {
@@ -817,9 +818,9 @@ const Page = async ({ params }: { params: PageParams }) => {
 
           {/* Recent posts */}
           <Section id="recent">
-            <h3 className="mb-4 mt-2 text-4xl font-black lg:text-5xl">
+            <Heading as="h3" size="xl" weight="black" className="mb-4 mt-2">
               {t("page-index-posts-header")}
-            </h3>
+            </Heading>
             <p>{t("page-index-posts-subtitle")}</p>
 
             {/* dynamic / lazy loaded */}
@@ -851,9 +852,9 @@ const Page = async ({ params }: { params: PageParams }) => {
 
           {/* Events */}
           <Section id="events">
-            <h3 className="mb-4 mt-2 text-4xl font-black lg:text-5xl">
+            <Heading as="h3" size="xl" weight="black" className="mb-4 mt-2">
               {t("page-index-events-header")}
-            </h3>
+            </Heading>
             <p>{t("page-index-events-subtitle")}</p>
             <div className="mt-4 md:mt-16">
               <div className="grid grid-cols-1 gap-8 self-stretch sm:grid-cols-2 md:grid-cols-3">

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -546,9 +546,9 @@ const Page = async ({ params }: { params: PageParams }) => {
 
               {/* Popular topics */}
               <div className="flex flex-col gap-y-8 pt-8">
-                <h3 className="text-xl font-bold">
+                <Heading as="h3" size="sm" className="lg:text-xl">
                   {t("page-index-popular-topics-header")}
-                </h3>
+                </Heading>
                 <div className="grid grid-cols-1 gap-8 sm:grid-cols-2">
                   {popularTopics
                     .filter((topic) => topic.href !== "/what-is-ethereum/")

--- a/app/[locale]/stablecoins/page.tsx
+++ b/app/[locale]/stablecoins/page.tsx
@@ -27,6 +27,7 @@ import Translation from "@/components/Translation"
 import { ButtonLink } from "@/components/ui/buttons/Button"
 import { Divider } from "@/components/ui/divider"
 import { Flex } from "@/components/ui/flex"
+import { Heading } from "@/components/ui/heading"
 import InlineLink from "@/components/ui/Link"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 
@@ -671,9 +672,9 @@ async function Page({ params }: { params: PageParams }) {
                       <Emoji text={feature.emoji} />
                     </div>
                     <div className="flex-1">
-                      <h3 className="mb-4 text-3xl font-bold">
+                      <Heading as="h3" className="mb-4 text-3xl lg:text-3xl">
                         {feature.title}
-                      </h3>
+                      </Heading>
                       <div className="mb-6 text-lg">{feature.description}</div>
                       <div className="my-6 grid grid-cols-1 gap-6 md:grid-cols-2">
                         {feature.pros && (

--- a/src/components/FeedbackCard.tsx
+++ b/src/components/FeedbackCard.tsx
@@ -11,6 +11,7 @@ import { trackCustomEvent } from "@/lib/utils/matomo"
 import { isLangRightToLeft } from "@/lib/utils/translations"
 
 import { Button } from "./ui/buttons/Button"
+import { Heading } from "./ui/heading"
 import Translation from "./Translation"
 
 import { useSurvey } from "@/hooks/useSurvey"
@@ -69,9 +70,9 @@ const FeedbackCard = ({ prompt, isArticle, ...props }: FeedbackCardProps) => {
       dir={dir}
     >
       <div className="flex flex-col gap-4">
-        <h2 className="mb-2 text-xl lg:text-2xl">
+        <Heading as="h2" size="sm" className="mb-2">
           {getTitle(feedbackSubmitted)}
-        </h2>
+        </Heading>
         {feedbackSubmitted && (
           <p>
             {t("feedback-widget-thank-you-subtitle")}{" "}

--- a/src/components/FindWalletProductTable/WalletSubComponent.tsx
+++ b/src/components/FindWalletProductTable/WalletSubComponent.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/icons/staking"
 import Twitter from "@/components/icons/twitter.svg"
 import Tooltip from "@/components/Tooltip"
+import { Heading } from "@/components/ui/heading"
 import InlineLink from "@/components/ui/Link"
 
 import { cn } from "@/lib/utils/cn"
@@ -79,7 +80,9 @@ const WalletSubComponent = ({
             )!
             return (
               <div key={idx} className="mx-2">
-                <h4 className="mb-2 text-md font-bold">{filterItem.title}</h4>
+                <Heading as="h4" size="xs" className="mb-2 lg:text-md">
+                  {filterItem.title}
+                </Heading>
                 <ul className="m-0 list-none">
                   {filterItem.items
                     .sort((a, b) =>
@@ -131,9 +134,9 @@ const WalletSubComponent = ({
           })}
         </div>
         <div className="ml-3">
-          <h4 className="mb-2 text-md font-bold">
+          <Heading as="h4" size="xs" className="mb-2 lg:text-md">
             {t("page-find-wallet-social-links")}
-          </h4>
+          </Heading>
           <div className="flex flex-row gap-4">
             <SocialLink
               href={wallet.url}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -14,6 +14,7 @@ import { cn } from "@/lib/utils/cn"
 import { scrollIntoView } from "@/lib/utils/scrollIntoView"
 
 import { Button } from "./ui/buttons/Button"
+import { Heading } from "./ui/heading"
 import { BaseLink } from "./ui/Link"
 import { List, ListItem } from "./ui/list"
 
@@ -336,7 +337,9 @@ const Footer = ({ lastDeployLocaleTimestamp }: FooterProps) => {
       <div className="grid auto-cols-auto justify-between gap-4 px-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-5">
         {linkSections.map((section: FooterLinkSection, idx) => (
           <div key={idx}>
-            <h3 className="my-5 text-sm font-bold">{section.title}</h3>
+            <Heading as="h3" size="2xs" className="my-5 lg:text-sm">
+              {section.title}
+            </Heading>
             <List className="m-0 mb-4 list-none text-sm">
               {section.links.map((link, linkIdx) => (
                 <ListItem key={linkIdx} className="mb-4">

--- a/src/components/Hero/HubHero/index.tsx
+++ b/src/components/Hero/HubHero/index.tsx
@@ -5,6 +5,7 @@ import type { CommonHeroProps } from "@/lib/types"
 import { CallToAction } from "@/components/Hero/CallToAction"
 import { Image } from "@/components/Image"
 import { Stack } from "@/components/ui/flex"
+import { Heading } from "@/components/ui/heading"
 
 import { cn } from "@/lib/utils/cn"
 
@@ -61,9 +62,11 @@ const HubHero = ({
         ) : null}
         <Stack className="max-w-screen-md gap-2 self-center md:gap-1">
           {title ? (
-            <h2 className="text-4xl lg:text-5xl">{header}</h2>
+            <Heading as="h2" size="xl">
+              {header}
+            </Heading>
           ) : (
-            <h1 className="text-4xl lg:text-5xl">{header}</h1>
+            <Heading>{header}</Heading>
           )}
 
           <p className="text-lg">{description}</p>

--- a/src/components/StablecoinAccordion/index.tsx
+++ b/src/components/StablecoinAccordion/index.tsx
@@ -13,6 +13,7 @@ import CardList from "../CardList"
 import Translation from "../Translation"
 import { Accordion } from "../ui/accordion"
 import { Alert, AlertContent, AlertEmoji } from "../ui/alert"
+import { Heading } from "../ui/heading"
 
 import {
   AccordionCustomItem,
@@ -24,7 +25,7 @@ import { useStablecoinAccordion } from "./useStablecoinAccordion"
 import { useTranslation } from "@/hooks/useTranslation"
 
 const SectionTitle = (props: ChildOnlyProp) => (
-  <h4 className="mb-8 mt-0 text-start text-xl font-bold" {...props} />
+  <Heading as="h4" className="mb-8 mt-0 text-start lg:text-xl" {...props} />
 )
 
 const StepBoxContainer = (props: ChildOnlyProp) => (
@@ -57,7 +58,7 @@ const StepBox = (
 }
 
 const H4 = (props: ChildOnlyProp) => (
-  <h4 className="mb-4 text-xl font-bold" {...props} />
+  <Heading as="h4" className="mb-4 lg:text-xl" {...props} />
 )
 
 const StablecoinAccordion = () => {

--- a/src/components/Staking/StakingConsiderations/index.tsx
+++ b/src/components/Staking/StakingConsiderations/index.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/icons/staking"
 import Translation from "@/components/Translation"
 import { Flex, VStack } from "@/components/ui/flex"
+import { Heading } from "@/components/ui/heading"
 import { List, ListItem } from "@/components/ui/list"
 
 import { cn } from "@/lib/utils/cn"
@@ -96,7 +97,9 @@ const StakingConsiderations = ({ page }: StakingConsiderationsProps) => {
       </div>
       <Flex className="min-h-[410px] flex-[2] flex-col items-center bg-background-highlight p-6">
         <StyledSvg />
-        <h3 className="mt-10 text-2xl font-bold leading-[1.4]">{title}</h3>
+        <Heading as="h3" className="mt-10 leading-[1.4] lg:text-2xl">
+          {title}
+        </Heading>
         <p>{description}</p>
         <Flex className="mt-auto justify-center gap-8">
           {!!valid && (

--- a/src/components/StartWithEthereumFlow/ConnectYourWallet/index.tsx
+++ b/src/components/StartWithEthereumFlow/ConnectYourWallet/index.tsx
@@ -6,6 +6,7 @@ import ConnectToEthereumButton from "@/components/ConnectToEthereumButton"
 import Emoji from "@/components/Emoji"
 import { Image } from "@/components/Image"
 import { Button } from "@/components/ui/buttons/Button"
+import { Heading } from "@/components/ui/heading"
 import { Tag } from "@/components/ui/tag"
 
 import { trackCustomEvent } from "@/lib/utils/matomo"
@@ -43,9 +44,9 @@ const ConnectYourWallet = ({
               {stepIndex} / {totalSteps}
             </Tag>
           </div>
-          <h2 className="text-3xl font-bold">
+          <Heading as="h2" className="lg:text-3xl">
             {t("page-start-connect-wallet-title")}
-          </h2>
+          </Heading>
           <p>{t("page-start-connect-wallet-description")}</p>
         </div>
         <div className="hidden flex-col items-center justify-center gap-4 lg:flex">

--- a/src/components/StartWithEthereumFlow/DownloadAWallet/index.tsx
+++ b/src/components/StartWithEthereumFlow/DownloadAWallet/index.tsx
@@ -6,6 +6,7 @@ import { Wallet } from "@/lib/types"
 import { Image } from "@/components/Image"
 import { Button, ButtonLink } from "@/components/ui/buttons/Button"
 import Checkbox from "@/components/ui/checkbox"
+import { Heading } from "@/components/ui/heading"
 import InlineLink from "@/components/ui/Link"
 import { LinkBox, LinkOverlay } from "@/components/ui/link-box"
 import { Tag } from "@/components/ui/tag"
@@ -35,9 +36,9 @@ const DownloadAWallet = ({
               {stepIndex} / {totalSteps}
             </Tag>
           </div>
-          <h2 className="text-3xl font-bold">
+          <Heading as="h2" className="lg:text-3xl">
             {t("page-start-download-wallet-title")}
-          </h2>
+          </Heading>
           <p>{t("page-start-download-wallet-description")}</p>
         </div>
         <div className="hidden flex-col gap-8 lg:flex">

--- a/src/components/StartWithEthereumFlow/LetUseSomeApps/index.tsx
+++ b/src/components/StartWithEthereumFlow/LetUseSomeApps/index.tsx
@@ -2,6 +2,7 @@ import { useTranslations } from "next-intl"
 
 import { Image } from "@/components/Image"
 import { ButtonLink } from "@/components/ui/buttons/Button"
+import { Heading } from "@/components/ui/heading"
 import Link from "@/components/ui/Link"
 import { LinkBox } from "@/components/ui/link-box"
 import { Tag } from "@/components/ui/tag"
@@ -94,7 +95,9 @@ const LetUseSomeApps = ({
               {stepIndex} / {totalSteps}
             </Tag>
           </div>
-          <h2 className="text-3xl font-bold">{t("page-start-apps-title")}</h2>
+          <Heading as="h2" className="lg:text-3xl">
+            {t("page-start-apps-title")}
+          </Heading>
           <p>{t("page-start-apps-description")}</p>
           <div className="hidden lg:flex">
             <Link href="/apps" className="font-bold no-underline">

--- a/src/components/Translatathon/TranslatathonCalendar.tsx
+++ b/src/components/Translatathon/TranslatathonCalendar.tsx
@@ -7,6 +7,7 @@ import type { Lang } from "@/lib/types"
 import Discord from "@/components/icons/discord.svg"
 import { ButtonLink } from "@/components/ui/buttons/Button"
 import { Flex } from "@/components/ui/flex"
+import { Heading } from "@/components/ui/heading"
 import InlineLink from "@/components/ui/Link"
 
 import { cn } from "@/lib/utils/cn"
@@ -53,7 +54,9 @@ export const TranslatathonCalendar = () => {
           "bg-gradient-to-r from-accent-a/10 to-accent-c/10 dark:from-accent-a/20 dark:to-accent-c-hover/20"
         )}
       >
-        <h3 className="text-2xl font-bold">Translatathon calls</h3>
+        <Heading as="h3" className="lg:text-2xl">
+          Translatathon calls
+        </Heading>
         <p>
           Join us on the ethereum.org Discord for a series of onboarding calls
           and workshops where we’ll cover everything you need to know about the

--- a/src/components/ui/__stories__/Heading.stories.tsx
+++ b/src/components/ui/__stories__/Heading.stories.tsx
@@ -1,50 +1,119 @@
-import * as React from "react"
-import { Meta, StoryObj } from "@storybook/react"
+import type { Meta, StoryObj } from "@storybook/react"
 
-import { Center, Stack } from "../flex"
+import { Stack } from "../flex"
+import { Heading, type HeadingLevel } from "../heading"
 
 const meta = {
   title: "Atoms / Typography / Heading",
+  component: Heading,
   parameters: {
     layout: null,
     chromatic: {
       modes: {
-        md: {
-          viewport: "md",
-        },
-        "2xl": {
-          viewport: "2xl",
-        },
+        "en-base": { viewport: "base", locale: "en" },
+        "en-md": { viewport: "md", locale: "en" },
+        "en-lg": { viewport: "lg", locale: "en" },
+        "ar-base": { viewport: "base", locale: "ar" },
+        "ar-md": { viewport: "md", locale: "ar" },
+        "ar-lg": { viewport: "lg", locale: "ar" },
       },
     },
   },
   decorators: [
     (Story) => (
-      <Center className="min-h-[100vh] flex-col">
+      <div className="p-8">
         <Story />
-      </Center>
+      </div>
     ),
   ],
-} satisfies Meta
+} satisfies Meta<typeof Heading>
 
 export default meta
 
 type Story = StoryObj<typeof meta>
 
-const headings = ["h1", "h2", "h3", "h4", "h5", "h6"] as const
+const sizes = ["xl", "lg", "md", "sm", "xs", "2xs"] as const
+const levels: HeadingLevel[] = ["h1", "h2", "h3", "h4", "h5", "h6"]
 
-export const Heading: Story = {
+/**
+ * All 6 size variants at default weight, with labels.
+ */
+export const AllSizes: Story = {
   render: () => (
-    <>
-      <div>
-        Adjust the viewport to below &quot;md&quot; to see the font size and
-        line height change
-      </div>
-      <Stack>
-        {headings.map((Heading) => (
-          <Heading key={Heading}>{`${Heading} base component`}</Heading>
-        ))}
-      </Stack>
-    </>
+    <Stack>
+      {sizes.map((size) => (
+        <Heading key={size} size={size}>
+          size=&quot;{size}&quot; — The quick brown fox
+        </Heading>
+      ))}
+    </Stack>
+  ),
+}
+
+/**
+ * Each `as` level (h1–h6) at default size — should match
+ * current global.css rendering of raw heading elements.
+ */
+export const SemanticLevels: Story = {
+  render: () => (
+    <Stack>
+      {levels.map((level) => (
+        <Heading key={level} as={level}>
+          &lt;Heading as=&quot;{level}&quot;&gt; — The quick brown fox
+        </Heading>
+      ))}
+    </Stack>
+  ),
+}
+
+/**
+ * Proves decoupling: h3 that looks like h1, h1 that looks like h4.
+ */
+export const DecoupledSizeAndLevel: Story = {
+  render: () => (
+    <Stack>
+      <Heading as="h3" size="xl">
+        h3 with size=&quot;xl&quot; (looks like h1)
+      </Heading>
+      <Heading as="h1" size="sm">
+        h1 with size=&quot;sm&quot; (looks like h4)
+      </Heading>
+      <Heading as="h4" size="lg">
+        h4 with size=&quot;lg&quot; (looks like h2)
+      </Heading>
+    </Stack>
+  ),
+}
+
+/**
+ * size="lg" in bold and black weights.
+ */
+export const WeightVariants: Story = {
+  render: () => (
+    <Stack>
+      <Heading as="h2" weight="bold">
+        weight=&quot;bold&quot; (default)
+      </Heading>
+      <Heading as="h2" weight="black">
+        weight=&quot;black&quot; (SectionSubheader pattern)
+      </Heading>
+    </Stack>
+  ),
+}
+
+/**
+ * Confirms CVA overrides @layer base correctly.
+ * Also shows className="font-normal" override for rare cases.
+ */
+export const WeightOverride: Story = {
+  render: () => (
+    <Stack>
+      <Heading as="h2" weight="bold">
+        weight=&quot;bold&quot; — CVA overrides global.css @layer base
+      </Heading>
+      <Heading as="h2" className="font-normal">
+        className=&quot;font-normal&quot; — override via className
+      </Heading>
+    </Stack>
   ),
 }

--- a/src/components/ui/heading.tsx
+++ b/src/components/ui/heading.tsx
@@ -1,0 +1,66 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils/cn"
+
+type HeadingLevel = "h1" | "h2" | "h3" | "h4" | "h5" | "h6"
+
+// Size scale mirrors global.css heading sizes exactly
+const headingVariants = cva("scroll-mt-20", {
+  variants: {
+    size: {
+      xl: "text-4xl lg:text-5xl", // h1 default
+      lg: "text-3xl lg:text-4xl", // h2 default
+      md: "text-2xl lg:text-3xl", // h3 default
+      sm: "text-xl lg:text-2xl", // h4 default
+      xs: "text-md lg:text-xl", // h5 default
+      "2xs": "text-sm lg:text-md", // h6 default
+    },
+    weight: {
+      bold: "font-bold", // default — matches global.css
+      black: "font-black", // SectionSubheader pattern
+    },
+  },
+  defaultVariants: {
+    size: "xl",
+    weight: "bold",
+  },
+})
+
+const defaultSizeMap = {
+  h1: "xl",
+  h2: "lg",
+  h3: "md",
+  h4: "sm",
+  h5: "xs",
+  h6: "2xs",
+} as const satisfies Record<
+  HeadingLevel,
+  NonNullable<VariantProps<typeof headingVariants>["size"]>
+>
+
+interface HeadingProps
+  extends React.HTMLAttributes<HTMLHeadingElement>,
+    VariantProps<typeof headingVariants> {
+  as?: HeadingLevel
+}
+
+const Heading = React.forwardRef<HTMLHeadingElement, HeadingProps>(
+  ({ as: Tag = "h1", size, weight, className, ...props }, ref) => {
+    const resolvedSize = size ?? defaultSizeMap[Tag]
+    return (
+      <Tag
+        ref={ref}
+        className={cn(
+          headingVariants({ size: resolvedSize, weight }),
+          className
+        )}
+        {...props}
+      />
+    )
+  }
+)
+Heading.displayName = "Heading"
+
+export { Heading, headingVariants }
+export type { HeadingLevel, HeadingProps }


### PR DESCRIPTION
## Summary

Introduces the `Heading` atomic component and migrates 20 files to use it. This is part of the incremental Atomic Design System effort (follows #17222 which shipped SectionSubheader, SectionBody, CardGrid).

- **New component**: `src/components/ui/heading.tsx` — CVA-based polymorphic heading with `as`, `size`, and `weight` props. Size scale mirrors `global.css` heading rules exactly.
- **Storybook stories**: 5 stories (AllSizes, SemanticLevels, DecoupledSizeAndLevel, WeightVariants, WeightOverride) with Chromatic modes for en/ar × base/md/lg viewports.
- **Migration batch 1** (4 files): Headings whose inline classes already matched the responsive scale — clean 1:1 swap.
- **Migration batch 2** (16 files): Headings with `font-bold` and a single size class (e.g. `text-2xl`). Uses `className="lg:text-2xl"` to pin the lg breakpoint and maintain zero visual difference, since inline utilities beat `@layer base` rules from global.css.

### Files migrated (20)

| File | Headings converted |
|---|---|
| `HubHero/index.tsx` | h1, h2 |
| `bug-bounty/page.tsx` | h1 |
| `FeedbackCard.tsx` | h2 |
| `page.tsx` (homepage) | 3× h3 |
| `TranslatathonCalendar.tsx` | h3 |
| `DownloadAWallet/index.tsx` | h2 |
| `LetUseSomeApps/index.tsx` | h2 |
| `ConnectYourWallet/index.tsx` | h2 |
| `StablecoinAccordion/index.tsx` | h3, h4 |
| `Footer.tsx` | h3 |
| `WalletSubComponent.tsx` | 2× h4 |
| `StakingConsiderations/index.tsx` | h3 |
| `10years/page.tsx` | h1, 5× h3 |
| `AdoptionSwiper/index.tsx` | h3 |
| `BuilderCard.tsx` | h3 |
| `VideoCourseCard.tsx` | h3 |
| `community/events/page.tsx` | h2, 5× h3 |
| `stablecoins/page.tsx` | h3 |
| `CollectiblesCurrentYear.tsx` | 5× h4 |

### Intentionally skipped

Headings with non-standard line-heights, arbitrary values, or shorthand syntax that don't map cleanly to the scale:
- `PageHero.tsx` — `text-[2.5rem]`, `!leading-xs`
- `BugBountyCards.tsx` — `text-2xl/6`
- `what-is-ethereum/page.tsx` — `text-3xl/snug lg:text-4xl/tight`
- `wallets/page.tsx` — `leading-[115%]`, `lg:text-5xl`
- `roadmap/ReleaseCarousel.tsx` — `lg:text-6xl`

## Test plan

- [ ] `npx tsc --noEmit` — passes (only pre-existing script errors)
- [ ] `pnpm build-storybook` — builds clean
- [ ] Chromatic visual regression — expect zero diffs on migrated pages
- [ ] Spot-check migrated pages in dev server at base and lg viewports