### PR TITLE
refactor: add semantic gap variants to Section atom

### DIFF
--- a/app/[locale]/get-eth/GetEth.stories.tsx
+++ b/app/[locale]/get-eth/GetEth.stories.tsx
@@ -5,6 +5,7 @@ import { Divider } from "@/components/atoms/divider"
 import { Stack } from "@/components/atoms/flex"
 import { Heading } from "@/components/atoms/heading"
 import InlineLink from "@/components/atoms/Link"
+import { Section } from "@/components/atoms/section"
 import EmojiCard from "@/components/molecules/Card"
 import { Alert, AlertContent, AlertDescription } from "@/components/ui/alert"
 import { ButtonLink } from "@/components/ui/buttons/Button"
@@ -36,7 +37,7 @@ export const CardGrid: StoryObj = {
 
     return (
       <div className="p-8">
-        <div className="my-4 grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
+        <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
           <EmojiCard
             className="bg-background [&_h3]:font-bold"
             emoji=":office_building:"
@@ -104,113 +105,118 @@ export const CardGrid: StoryObj = {
 }
 
 /**
- * The DEX two-column section with headings, alerts, and links.
+ * The DEX two-column section using Section gap="block".
+ * Demonstrates semantic spacing between heading and grid content.
  */
 export const DexSection: StoryObj = {
   render: () => {
     const t = useTranslations("page-get-eth")
 
     return (
-      <Stack className="gap-12 p-8">
-        <Heading as="h2" size="md" id="dex">
-          {t("page-get-eth-dexs")}
-        </Heading>
-        <div className="grid grid-cols-1 gap-16 lg:grid-cols-2">
-          <Stack className="gap-4">
-            <Heading as="h3" size="sm">
-              {t("page-get-eth-what-are-DEX's")}
-            </Heading>
-            <p>{t("page-get-eth-dexs-desc")}</p>
-            <p>{t("page-get-eth-need-wallet")}</p>
-            <ButtonLink href="/wallets/find-wallet/" className="w-fit">
-              {t("page-get-eth-get-wallet-btn")}
-            </ButtonLink>
-            <Alert variant="warning">
-              <AlertContent>
-                <AlertDescription>
-                  <Translation id="page-get-eth:page-get-eth-dexs-desc-4" />
-                </AlertDescription>
-              </AlertContent>
-            </Alert>
-          </Stack>
+      <div className="p-8">
+        <Section id="dex" gap="block">
+          <Heading as="h2" size="md">
+            {t("page-get-eth-dexs")}
+          </Heading>
+          <div className="grid grid-cols-1 gap-16 lg:grid-cols-2">
+            <Stack className="gap-4">
+              <Heading as="h3" size="sm">
+                {t("page-get-eth-what-are-DEX's")}
+              </Heading>
+              <p>{t("page-get-eth-dexs-desc")}</p>
+              <p>{t("page-get-eth-need-wallet")}</p>
+              <ButtonLink href="/wallets/find-wallet/" className="w-fit">
+                {t("page-get-eth-get-wallet-btn")}
+              </ButtonLink>
+              <Alert variant="warning">
+                <AlertContent>
+                  <AlertDescription>
+                    <Translation id="page-get-eth:page-get-eth-dexs-desc-4" />
+                  </AlertDescription>
+                </AlertContent>
+              </Alert>
+            </Stack>
 
-          <Stack className="gap-4">
-            <Heading as="h3" size="sm">
-              {t("page-get-eth-other-cryptos")}
-            </Heading>
-            <p>{t("page-get-eth-swapping")}</p>
-            <Alert variant="warning">
-              <AlertContent>
-                <AlertDescription>
-                  <Translation id="page-get-eth:page-get-eth-warning" />
-                </AlertDescription>
-              </AlertContent>
-            </Alert>
-          </Stack>
-        </div>
-      </Stack>
+            <Stack className="gap-4">
+              <Heading as="h3" size="sm">
+                {t("page-get-eth-other-cryptos")}
+              </Heading>
+              <p>{t("page-get-eth-swapping")}</p>
+              <Alert variant="warning">
+                <AlertContent>
+                  <AlertDescription>
+                    <Translation id="page-get-eth:page-get-eth-warning" />
+                  </AlertDescription>
+                </AlertContent>
+              </Alert>
+            </Stack>
+          </div>
+        </Section>
+      </div>
     )
   },
 }
 
 /**
- * The "Keep it safe" two-column section with headings.
+ * The "Keep it safe" two-column section using Section gap="block".
  */
 export const SafetySection: StoryObj = {
   render: () => {
     const t = useTranslations("page-get-eth")
 
     return (
-      <Stack className="gap-12 p-8">
-        <Heading as="h2" size="md">
-          {t("page-get-eth-keep-it-safe")}
-        </Heading>
-        <div className="grid grid-cols-1 gap-16 lg:grid-cols-2">
-          <Stack className="gap-4">
-            <Heading as="h3" size="sm">
-              {t("page-get-eth-community-safety")}
-            </Heading>
-          </Stack>
+      <div className="p-8">
+        <Section gap="block">
+          <Heading as="h2" size="md">
+            {t("page-get-eth-keep-it-safe")}
+          </Heading>
+          <div className="grid grid-cols-1 gap-16 lg:grid-cols-2">
+            <Stack className="gap-4">
+              <Heading as="h3" size="sm">
+                {t("page-get-eth-community-safety")}
+              </Heading>
+            </Stack>
 
-          <Stack className="gap-8">
-            <Stack className="gap-4">
-              <p>{t("page-get-eth-description")}</p>
-              <p>{t("page-get-eth-security")}</p>
+            <Stack className="gap-8">
+              <Stack className="gap-4">
+                <p>{t("page-get-eth-description")}</p>
+                <p>{t("page-get-eth-security")}</p>
+              </Stack>
+              <Stack className="gap-4">
+                <Heading as="h3" size="sm">
+                  {t("page-get-eth-protect-eth-in-wallet")}
+                </Heading>
+                <p>{t("page-get-eth-protect-eth-desc")}</p>
+                <InlineLink href="/wallets/">
+                  {t("page-get-eth-your-address-wallet-link")}
+                </InlineLink>
+              </Stack>
+              <Stack className="gap-4">
+                <Heading as="h3" size="sm">
+                  {t("page-get-eth-your-address")}
+                </Heading>
+                <p>{t("page-get-eth-your-address-desc")}</p>
+                <div className="mb-6 flex select-none flex-col-reverse justify-between rounded bg-[#191919] p-2 lg:flex-row">
+                  <p className="mb-0 font-monospace text-xs text-white">
+                    0x0125e2478d69eXaMpLe81766fef5c120d30fb53f
+                  </p>
+                  <p className="mx-4 mb-0 text-sm uppercase text-error">
+                    {t("page-get-eth-do-not-copy")}
+                  </p>
+                </div>
+              </Stack>
+              <Stack className="gap-4">
+                <Heading as="h3" size="sm">
+                  {t("page-get-eth-wallet-instructions")}
+                </Heading>
+                <p>{t("page-get-eth-wallet-instructions-lost")}</p>
+              </Stack>
             </Stack>
-            <Stack className="gap-4">
-              <Heading as="h3" size="sm">
-                {t("page-get-eth-protect-eth-in-wallet")}
-              </Heading>
-              <p>{t("page-get-eth-protect-eth-desc")}</p>
-              <InlineLink href="/wallets/">
-                {t("page-get-eth-your-address-wallet-link")}
-              </InlineLink>
-            </Stack>
-            <Stack className="gap-4">
-              <Heading as="h3" size="sm">
-                {t("page-get-eth-your-address")}
-              </Heading>
-              <p>{t("page-get-eth-your-address-desc")}</p>
-              <div className="mb-6 flex select-none flex-col-reverse justify-between rounded bg-[#191919] p-2 lg:flex-row">
-                <p className="mb-0 font-monospace text-xs text-white">
-                  0x0125e2478d69eXaMpLe81766fef5c120d30fb53f
-                </p>
-                <p className="mx-4 mb-0 text-sm uppercase text-error">
-                  {t("page-get-eth-do-not-copy")}
-                </p>
-              </div>
-            </Stack>
-            <Stack className="gap-4">
-              <Heading as="h3" size="sm">
-                {t("page-get-eth-wallet-instructions")}
-              </Heading>
-              <p>{t("page-get-eth-wallet-instructions-lost")}</p>
-            </Stack>
-          </Stack>
-        </div>
+          </div>
 
-        <Divider className="mx-auto my-16 md:my-32" />
-      </Stack>
+          <Divider />
+        </Section>
+      </div>
     )
   },
 }

--- a/app/[locale]/get-eth/page.tsx
+++ b/app/[locale]/get-eth/page.tsx
@@ -12,6 +12,7 @@ import { Divider } from "@/components/atoms/divider"
 import { Stack } from "@/components/atoms/flex"
 import { Heading } from "@/components/atoms/heading"
 import InlineLink from "@/components/atoms/Link"
+import { Section } from "@/components/atoms/section"
 import CalloutBanner from "@/components/molecules/CalloutBanner"
 import EmojiCard from "@/components/molecules/Card"
 import CardList, {
@@ -128,7 +129,7 @@ export default async function Page({ params }: { params: PageParams }) {
       />
 
       <MainArticle>
-        <Stack className="gap-16 p-8">
+        <div className="flex flex-col gap-12 p-8 lg:gap-16">
           <div className="relative flex w-full flex-col-reverse justify-center lg:mx-auto lg:mb-8 lg:flex-col">
             <Image
               src={hero}
@@ -159,7 +160,7 @@ export default async function Page({ params }: { params: PageParams }) {
             </div>
           </div>
 
-          <div className="my-4 grid grid-cols-1 gap-8 md:grid-cols-2 lg:my-0 lg:grid-cols-3">
+          <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
             <EmojiCard
               className="bg-background [&_h3]:font-bold"
               emoji=":office_building:"
@@ -247,7 +248,7 @@ export default async function Page({ params }: { params: PageParams }) {
           <div
             id="country-picker"
             className={cn(
-              "-mx-8 my-0 flex flex-col items-center px-8 py-16 sm:p-16 md:my-16 lg:mx-0",
+              "-mx-8 flex flex-col items-center px-8 py-16 sm:p-16 lg:mx-0",
               "bg-gradient-to-r from-accent-a/10 to-accent-c/10 dark:from-accent-a/20 dark:to-accent-c-hover/20"
             )}
           >
@@ -266,8 +267,8 @@ export default async function Page({ params }: { params: PageParams }) {
             </div>
           </div>
 
-          <Stack className="gap-12">
-            <Heading as="h2" size="md" id="dex">
+          <Section id="dex" gap="block">
+            <Heading as="h2" size="md">
               {t("page-get-eth-dexs")}
             </Heading>
             <div className="grid grid-cols-1 gap-16 lg:grid-cols-2">
@@ -311,11 +312,11 @@ export default async function Page({ params }: { params: PageParams }) {
                 </Alert>
               </Stack>
             </div>
-          </Stack>
+          </Section>
 
-          <Divider className="mx-auto my-16 md:my-32" />
+          <Divider />
 
-          <Stack className="gap-12">
+          <Section gap="block">
             <Heading as="h2" size="md">
               {t("page-get-eth-keep-it-safe")}
             </Heading>
@@ -370,9 +371,9 @@ export default async function Page({ params }: { params: PageParams }) {
                 </Stack>
               </Stack>
             </div>
-          </Stack>
+          </Section>
 
-          <Divider className="mx-auto my-16 md:my-32" />
+          <Divider />
 
           <CalloutBanner
             className="mx-4 mb-40 mt-24"
@@ -396,7 +397,7 @@ export default async function Page({ params }: { params: PageParams }) {
           />
 
           <FeedbackCard />
-        </Stack>
+        </div>
       </MainArticle>
     </>
   )

--- a/src/components/atoms/__stories__/Section.stories.tsx
+++ b/src/components/atoms/__stories__/Section.stories.tsx
@@ -1,0 +1,159 @@
+import type { Meta, StoryObj } from "@storybook/react"
+
+import { Heading } from "../heading"
+import { Section } from "../section"
+
+const meta = {
+  title: "Atoms / Layout / Section",
+  component: Section,
+  parameters: {
+    layout: null,
+    chromatic: {
+      modes: {
+        "en-base": { viewport: "base", locale: "en" },
+        "en-md": { viewport: "md", locale: "en" },
+        "en-lg": { viewport: "lg", locale: "en" },
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="p-8">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof Section>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+/**
+ * Default Section — no gap, no flex. Just scroll-margin and semantic `<section>`.
+ */
+export const Default: Story = {
+  render: () => (
+    <Section className="border border-dashed border-body-light p-4">
+      <Heading as="h2" size="md">
+        Default Section
+      </Heading>
+      <p>No gap prop — just scroll-margin and semantic markup.</p>
+    </Section>
+  ),
+}
+
+/**
+ * gap="section" — largest gap (48px mobile, 64px desktop).
+ * Used between major page sections in a page wrapper.
+ */
+export const GapSection: Story = {
+  render: () => (
+    <Section gap="section" className="border border-dashed border-body-light">
+      <div className="rounded bg-background-highlight p-6">
+        <Heading as="h2" size="md">
+          First content block
+        </Heading>
+        <p>This is a major page section.</p>
+      </div>
+      <div className="rounded bg-background-highlight p-6">
+        <Heading as="h2" size="md">
+          Second content block
+        </Heading>
+        <p>Another major page section.</p>
+      </div>
+      <div className="rounded bg-background-highlight p-6">
+        <Heading as="h2" size="md">
+          Third content block
+        </Heading>
+        <p>One more major page section.</p>
+      </div>
+    </Section>
+  ),
+}
+
+/**
+ * gap="block" — medium gap (24px mobile, 32px desktop).
+ * Used between content groups within a section (e.g., heading + grid).
+ */
+export const GapBlock: Story = {
+  render: () => (
+    <Section gap="block" className="border border-dashed border-body-light">
+      <Heading as="h2" size="md">
+        Section heading
+      </Heading>
+      <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
+        <div className="rounded bg-background-highlight p-6">
+          <p>Left column content with some descriptive text.</p>
+        </div>
+        <div className="rounded bg-background-highlight p-6">
+          <p>Right column content with some descriptive text.</p>
+        </div>
+      </div>
+      <p>
+        Footer text after the grid — spaced at block level from the grid above.
+      </p>
+    </Section>
+  ),
+}
+
+/**
+ * Demonstrates that className overrides the gap via tailwind-merge.
+ */
+export const GapOverride: Story = {
+  render: () => (
+    <Section
+      gap="block"
+      className="gap-1 border border-dashed border-body-light"
+    >
+      <Heading as="h2" size="md">
+        Overridden gap
+      </Heading>
+      <p>gap=&quot;block&quot; overridden with className=&quot;gap-1&quot;</p>
+      <p>These paragraphs should be tightly spaced.</p>
+    </Section>
+  ),
+}
+
+/**
+ * Side-by-side comparison of both gap levels.
+ */
+export const GapComparison: Story = {
+  render: () => (
+    <div className="flex flex-col gap-12">
+      <div>
+        <p className="mb-2 text-sm font-bold uppercase text-body-medium">
+          gap=&quot;section&quot; (48px / 64px)
+        </p>
+        <Section
+          gap="section"
+          className="border border-dashed border-body-light"
+        >
+          <div className="rounded bg-background-highlight p-4">Block A</div>
+          <div className="rounded bg-background-highlight p-4">Block B</div>
+          <div className="rounded bg-background-highlight p-4">Block C</div>
+        </Section>
+      </div>
+      <div>
+        <p className="mb-2 text-sm font-bold uppercase text-body-medium">
+          gap=&quot;block&quot; (24px / 32px)
+        </p>
+        <Section gap="block" className="border border-dashed border-body-light">
+          <div className="rounded bg-background-highlight p-4">Block A</div>
+          <div className="rounded bg-background-highlight p-4">Block B</div>
+          <div className="rounded bg-background-highlight p-4">Block C</div>
+        </Section>
+      </div>
+      <div>
+        <p className="mb-2 text-sm font-bold uppercase text-body-medium">
+          No gap (default — no flex layout)
+        </p>
+        <Section className="border border-dashed border-body-light">
+          <div className="rounded bg-background-highlight p-4">Block A</div>
+          <div className="rounded bg-background-highlight p-4">Block B</div>
+          <div className="rounded bg-background-highlight p-4">Block C</div>
+        </Section>
+      </div>
+    </div>
+  ),
+}

--- a/src/components/atoms/section.tsx
+++ b/src/components/atoms/section.tsx
@@ -3,11 +3,14 @@ import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils/cn"
 
-// TODO: Add to design system
 const variants = cva("w-full scroll-mt-24 lg:scroll-mt-28", {
   variants: {
     variant: {
       responsiveFlex: "flex flex-col gap-8 md:flex-row lg:gap-16",
+    },
+    gap: {
+      section: "flex flex-col gap-12 lg:gap-16",
+      block: "flex flex-col gap-6 lg:gap-8",
     },
     scrollMargin: {
       tabNav: "!scroll-mt-36 lg:!scroll-mt-40",
@@ -18,10 +21,10 @@ const variants = cva("w-full scroll-mt-24 lg:scroll-mt-28", {
 const Section = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof variants>
->(({ className, variant, scrollMargin, ...props }, ref) => (
+>(({ className, variant, gap, scrollMargin, ...props }, ref) => (
   <section
     ref={ref}
-    className={cn(variants({ variant, scrollMargin, className }))}
+    className={cn(variants({ variant, gap, scrollMargin, className }))}
     {...props}
   />
 ))


### PR DESCRIPTION
## Summary

Adds a `gap` prop to the Section atom with two semantic levels for consistent page composition spacing:

- **`gap="section"`** — 48px mobile / 64px desktop (between major page sections)
- **`gap="block"`** — 24px mobile / 32px desktop (between content groups within a section)

When `gap` is provided, Section renders as `flex flex-col` with the responsive gap. When omitted, existing behavior is completely unchanged.

This replaces the ad-hoc spacing patterns found across 20+ pages (`gap-16`, `gap-12`, `space-y-8`, etc.) with a constrained, semantic vocabulary on the right component — Section is the page composition atom, not Stack (which stays as a layout primitive).

## Changes

- **`src/components/atoms/section.tsx`** — Added `gap` CVA variant with `section` and `block` levels
- **`app/[locale]/get-eth/page.tsx`** — Refactored to use `Section gap="block"` for DEX and Safety sections; page wrapper uses raw `gap-12 lg:gap-16`; element-level spacing stays as Stack
- **`app/[locale]/get-eth/GetEth.stories.tsx`** — Updated stories to use Section gap
- **`src/components/atoms/__stories__/Section.stories.tsx`** — New stories: Default, GapSection, GapBlock, GapOverride, GapComparison

## Design decisions

- **Only 2 gap levels** (not 3) — reviewers agreed `gap="element"` doesn't belong on Section since `<section>` is a semantic HTML landmark; element-level spacing (`gap-4`) stays as Stack/className
- **No Tailwind plugin** — page wrappers use standard Tailwind classes (`gap-12 lg:gap-16`); a plugin can be added later if 5+ pages prove it necessary
- **Section highlight/size deferred** — only 2 pages use the background breakout pattern; will add after 3+ pages prove the need

## Testing

- [x] TypeScript passes (`npx tsc --noEmit`)
- [x] ESLint passes (including pre-commit hooks)
- [x] Storybook builds (`pnpm build-storybook`)
- [ ] Chromatic visual snapshots (will run on PR)

## Plan

See `plans/semantic-spacing-system.md` for full design rationale, alternative approaches considered, and incremental migration strategy.