### PR TITLE
fix(data-layer): temporarily disable Blobscan fetch task

### DIFF
--- a/src/data-layer/tasks.ts
+++ b/src/data-layer/tasks.ts
@@ -9,7 +9,6 @@ import { schedules, task, tasks } from "@trigger.dev/sdk/v3"
 
 import { fetchApps } from "./fetchers/fetchApps"
 import { fetchBeaconChain } from "./fetchers/fetchBeaconChain"
-import { fetchBlobscanStats } from "./fetchers/fetchBlobscanStats"
 import { fetchCalendarEvents } from "./fetchers/fetchCalendarEvents"
 import { fetchCommunityPicks } from "./fetchers/fetchCommunityPicks"
 import { fetchEthereumMarketcap } from "./fetchers/fetchEthereumMarketcap"
@@ -75,7 +74,7 @@ const DAILY: TaskDef[] = [
 
 const HOURLY: TaskDef[] = [
   [KEYS.BEACONCHAIN, fetchBeaconChain],
-  [KEYS.BLOBSCAN_STATS, fetchBlobscanStats],
+  // [KEYS.BLOBSCAN_STATS, fetchBlobscanStats], // Temporarily disabled - Blobscan API is down
   [KEYS.ETHEREUM_MARKETCAP, fetchEthereumMarketcap],
   [KEYS.ETHEREUM_STABLECOINS_MCAP, fetchEthereumStablecoinsMcap],
   [KEYS.ETH_PRICE, fetchEthPrice],


### PR DESCRIPTION
## Summary
- Temporarily disables the Blobscan stats fetch task from the hourly schedule
- Blobscan API is currently down, causing task failures

## Test plan
- [x] Verify hourly data fetch continues without the Blobscan task
- [x] Confirm existing cached Blobscan data is still displayed on the resources page