### PR TITLE
fix(ci): fetch all open PRs in Netlify cleanup workflow

### DIFF
--- a/.github/workflows/cleanup-netlify-previews.yml
+++ b/.github/workflows/cleanup-netlify-previews.yml
@@ -49,7 +49,7 @@ jobs:
           PREVIEW_COUNT=$(echo "$PREVIEW_DEPLOYS" | jq 'length')
           echo "Found $PREVIEW_COUNT preview/branch deploys"
 
-          OPEN_PRS=$(gh pr list --state open --json number --jq '.[].number')
+          OPEN_PRS=$(gh pr list --state open --limit 1000 --json number --jq '.[].number')
           REMOTE_BRANCHES=$(git branch -r | sed 's/origin\///' | tr -d ' ')
 
           echo ""


### PR DESCRIPTION
## Summary
- Fix pagination bug in Netlify preview cleanup workflow
- `gh pr list` defaults to 30 results, but we have 61+ open PRs
- This caused preview deploys for PRs beyond the first 30 to be incorrectly deleted

## Test plan
- [ ] Verify workflow runs successfully on schedule
- [ ] Confirm no preview deploys are incorrectly deleted for open PRs