### PR TITLE
feat: Lost Pixel visual regression testing (Phase 1)

### DIFF
--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -1,0 +1,289 @@
+name: Visual Regression Tests
+
+on:
+  pull_request:
+    branches: [dev, main]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number for re-validation after approval"
+        required: false
+        type: string
+      validation_only:
+        description: "Skip screenshot capture, just check approval status"
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: visual-${{ github.event.inputs.pr_number || github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+env:
+  VISUAL_TEST_BUCKET: eth-org-visual-baselines
+  # S3-compatible endpoint (self-hosted). Leave empty for AWS S3.
+  S3_ENDPOINT: ${{ secrets.S3_ENDPOINT || '' }}
+
+jobs:
+  visual-test:
+    name: Visual Regression
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      # --- Checkout ---
+      - name: Checkout (PR)
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v4
+
+      - name: Checkout (re-validation)
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number != ''
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.inputs.pr_number }}/head
+
+      # --- Configure S3 access ---
+      # Works with both AWS S3 and S3-compatible stores (MinIO, Ceph, etc.)
+      - name: Configure S3 credentials
+        run: |
+          aws configure set aws_access_key_id "${{ secrets.VISUAL_TEST_AWS_ACCESS_KEY_ID }}"
+          aws configure set aws_secret_access_key "${{ secrets.VISUAL_TEST_AWS_SECRET_ACCESS_KEY }}"
+          aws configure set default.region "${{ secrets.VISUAL_TEST_AWS_REGION || 'us-east-1' }}"
+
+      # --- Validation-only mode ---
+      - name: Validation-only check
+        if: github.event.inputs.validation_only == 'true'
+        run: |
+          PR=${{ github.event.inputs.pr_number }}
+          ENDPOINT_FLAG=""
+          if [ -n "$S3_ENDPOINT" ]; then
+            ENDPOINT_FLAG="--endpoint-url $S3_ENDPOINT"
+          fi
+
+          aws s3 cp "s3://${{ env.VISUAL_TEST_BUCKET }}/metadata/${PR}.json" /tmp/metadata.json $ENDPOINT_FLAG
+
+          PENDING=$(node -e "
+            const m = require('/tmp/metadata.json');
+            console.log(m.summary.pending || 0);
+          ")
+
+          if [ "$PENDING" -eq 0 ]; then
+            echo "All visual changes approved."
+            exit 0
+          else
+            echo "::error::${PENDING} visual changes still pending approval."
+            exit 1
+          fi
+
+      # --- Full capture mode ---
+      - name: Setup pnpm
+        if: github.event.inputs.validation_only != 'true'
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        if: github.event.inputs.validation_only != 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+
+      - name: Install dependencies
+        if: github.event.inputs.validation_only != 'true'
+        run: pnpm install --frozen-lockfile
+
+      # --- Build Storybook ---
+      - name: Build Storybook
+        if: github.event.inputs.validation_only != 'true'
+        run: pnpm build-storybook
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
+
+      # --- Download baselines ---
+      - name: Download baselines from S3
+        if: github.event.inputs.validation_only != 'true'
+        run: |
+          ENDPOINT_FLAG=""
+          if [ -n "$S3_ENDPOINT" ]; then
+            ENDPOINT_FLAG="--endpoint-url $S3_ENDPOINT"
+          fi
+
+          mkdir -p ".lostpixel/baseline"
+          aws s3 sync \
+            "s3://${{ env.VISUAL_TEST_BUCKET }}/baselines/" \
+            ".lostpixel/baseline/" \
+            $ENDPOINT_FLAG --quiet --no-progress || echo "No baselines yet"
+
+      # --- Run Lost Pixel ---
+      - name: Run Lost Pixel
+        if: github.event.inputs.validation_only != 'true'
+        id: lostpixel
+        uses: lost-pixel/lost-pixel@v3.22.0
+        continue-on-error: true
+
+      # Guard: distinguish "diffs found" from "Lost Pixel crashed"
+      - name: Check Lost Pixel health
+        if: steps.lostpixel.outcome == 'failure' && github.event.inputs.validation_only != 'true'
+        run: |
+          dir=".lostpixel/current"
+          if [ ! -d "$dir" ] || [ -z "$(ls -A "$dir" 2>/dev/null)" ]; then
+            echo "::error::Lost Pixel crashed — no screenshots captured."
+            exit 1
+          fi
+          echo "Lost Pixel completed (diffs may exist)."
+
+      # --- Set HAS_DIFFS flag ---
+      - name: Check for diffs
+        if: github.event.inputs.validation_only != 'true'
+        id: diffs
+        run: |
+          if [ "${{ steps.lostpixel.outcome }}" == "failure" ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # --- On diff: generate metadata, upload, comment ---
+      - name: Resolve PR number
+        if: steps.diffs.outputs.found == 'true'
+        id: pr
+        run: |
+          if [ -n "${{ github.event.inputs.pr_number }}" ]; then
+            echo "number=${{ github.event.inputs.pr_number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate metadata
+        if: steps.diffs.outputs.found == 'true'
+        run: npx tsx scripts/visual-test/generate-metadata.ts
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          BRANCH: ${{ github.head_ref }}
+          COMMIT: ${{ github.sha }}
+          AUTHOR: ${{ github.event.pull_request.user.login || 'unknown' }}
+          S3_BUCKET: ${{ env.VISUAL_TEST_BUCKET }}
+          S3_ENDPOINT: ${{ env.S3_ENDPOINT }}
+
+      - name: Generate thumbnails
+        if: steps.diffs.outputs.found == 'true'
+        run: npx tsx scripts/visual-test/generate-thumbnails.ts
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+
+      - name: Upload to S3
+        if: steps.diffs.outputs.found == 'true'
+        run: |
+          PR=${{ steps.pr.outputs.number }}
+          ENDPOINT_FLAG=""
+          if [ -n "$S3_ENDPOINT" ]; then
+            ENDPOINT_FLAG="--endpoint-url $S3_ENDPOINT"
+          fi
+
+          # Retry wrapper for S3 operations
+          s3_retry() {
+            local max_attempts=3
+            local attempt=1
+            while [ $attempt -le $max_attempts ]; do
+              if "$@"; then return 0; fi
+              echo "Attempt $attempt/$max_attempts failed. Retrying in 5s..."
+              sleep 5
+              attempt=$((attempt + 1))
+            done
+            echo "::error::S3 operation failed after $max_attempts attempts: $*"
+            return 1
+          }
+
+          s3_retry aws s3 sync ".lostpixel/current/" \
+            "s3://${{ env.VISUAL_TEST_BUCKET }}/pending/${PR}/" $ENDPOINT_FLAG --quiet
+
+          s3_retry aws s3 sync ".lostpixel/difference/" \
+            "s3://${{ env.VISUAL_TEST_BUCKET }}/diffs/${PR}/" $ENDPOINT_FLAG --quiet
+
+          s3_retry aws s3 sync .lostpixel/thumbnails/ \
+            "s3://${{ env.VISUAL_TEST_BUCKET }}/thumbnails/${PR}/" $ENDPOINT_FLAG --quiet
+
+          s3_retry aws s3 cp .lostpixel/metadata.json \
+            "s3://${{ env.VISUAL_TEST_BUCKET }}/metadata/${PR}.json" $ENDPOINT_FLAG
+
+      - name: Update dashboard index
+        if: steps.diffs.outputs.found == 'true'
+        run: npx tsx scripts/visual-test/update-index.ts
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          S3_BUCKET: ${{ env.VISUAL_TEST_BUCKET }}
+          S3_ENDPOINT: ${{ env.S3_ENDPOINT }}
+
+      - name: Post PR comment
+        if: steps.diffs.outputs.found == 'true' && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const metadata = JSON.parse(
+              fs.readFileSync('.lostpixel/metadata.json', 'utf8')
+            );
+            const { summary } = metadata;
+            const pr = context.issue.number;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+            });
+
+            const existing = comments.find(
+              (c) => c.user.type === 'Bot' && c.body.includes('visual change')
+            );
+
+            const body = [
+              `### ${summary.total} visual change${summary.total !== 1 ? 's' : ''} detected`,
+              '',
+              `| Added | Changed | Removed | Pending | Approved |`,
+              `|-------|---------|---------|---------|----------|`,
+              `| ${summary.added} | ${summary.changed} | ${summary.removed} | ${summary.pending} | ${summary.approved} |`,
+              '',
+              `<details>`,
+              `<summary>Changed stories</summary>`,
+              '',
+              ...metadata.changes.map(c => {
+                const pct = c.diffPercent != null ? ` (${c.diffPercent.toFixed(1)}%)` : '';
+                return `- \`${c.story}\` [${c.type}]${pct}`;
+              }),
+              '',
+              `</details>`,
+              '',
+              `Commit: \`${metadata.snapshotCommit.slice(0, 8)}\``,
+              '',
+              `Approve with: \`pnpm visual:approve\``,
+            ].join('\n');
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr,
+                body,
+              });
+            }
+
+      - name: Upload artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-test-results
+          path: |
+            .lostpixel/current/
+            .lostpixel/difference/
+            .lostpixel/metadata.json
+          retention-days: 14
+
+      - name: Fail if visual changes detected
+        if: steps.diffs.outputs.found == 'true'
+        run: exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,9 @@ build-storybook.log
 build-archive.log
 storybook-static
 
+# Lost Pixel (visual regression testing)
+.lostpixel
+
 # Trigger
 .trigger
 

--- a/.storybook/decorators/visualTest.tsx
+++ b/.storybook/decorators/visualTest.tsx
@@ -1,0 +1,17 @@
+import { useEffect } from "react"
+import type { Decorator } from "@storybook/react"
+
+function VisualTestWrapper({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    document.body.classList.add("visual-test-mode")
+    return () => document.body.classList.remove("visual-test-mode")
+  }, [])
+
+  return <>{children}</>
+}
+
+export const withVisualTest: Decorator = (Story) => (
+  <VisualTestWrapper>
+    <Story />
+  </VisualTestWrapper>
+)

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -6,6 +6,7 @@ import type { Preview } from "@storybook/react"
 import ThemeProvider from "@/components/ThemeProvider"
 import { TooltipProvider } from "@/components/ui/tooltip"
 
+import { withVisualTest } from "./decorators/visualTest"
 import nextIntl, { baseLocales } from "./next-intl"
 import { withNextThemes } from "./withNextThemes"
 
@@ -45,6 +46,7 @@ const preview: Preview = {
     locales: baseLocales,
   },
   decorators: [
+    withVisualTest,
     withNextThemes({
       themes: {
         light: "light",

--- a/lostpixel.config.ts
+++ b/lostpixel.config.ts
@@ -1,0 +1,29 @@
+import type { CustomProjectConfig } from "lost-pixel"
+
+export const config: CustomProjectConfig = {
+  storybookShots: {
+    storybookUrl: "./storybook-static",
+    breakpoints: [375, 1280],
+  },
+
+  // Percentage-of-image threshold (0–1 scale). 0.1 = fail if >0.1% of pixels differ.
+  threshold: 0.1,
+
+  compareEngine: "odiff",
+
+  generateOnly: false,
+  failOnDifference: true,
+
+  browser: "chromium",
+
+  // Fonts are bundled in the static Storybook build (next/font/google with preload: true),
+  // so no async font loading to wait for. Animations are disabled via visual-test-mode CSS.
+  // Tune upward if flaky screenshots appear during parallel run.
+  waitBeforeScreenshot: 500,
+  waitForFirstRequest: 1000,
+  waitForLastRequest: 1000,
+
+  imagePathBaseline: ".lostpixel/baseline",
+  imagePathCurrent: ".lostpixel/current",
+  imagePathDifference: ".lostpixel/difference",
+}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "test:e2e:debug": "playwright test --project=e2e --debug",
     "test:e2e:report": "playwright show-report tests/__report__",
     "trigger:dev": "npx trigger.dev@latest dev --env-file .env.local",
-    "trigger:deploy": "npx trigger.dev@latest deploy --env-file .env.local"
+    "trigger:deploy": "npx trigger.dev@latest deploy --env-file .env.local",
+    "visual:approve": "bash scripts/visual-test/approve.sh"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.982.0",
@@ -156,11 +157,13 @@
     "raw-loader": "^4.0.2",
     "rehype-slug": "^6.0.0",
     "remark-heading-id": "^1.0.1",
+    "lost-pixel": "^3.22.0",
     "storybook": "8.6.15",
     "storybook-next-intl": "^1.2.5",
     "tailwindcss": "^3.4.4",
     "ts-node": "^10.9.1",
     "tsconfig-paths-webpack-plugin": "4.1.0",
+    "tsx": "^4.19.0",
     "typescript": "^5.5.2",
     "unified": "^10.0.0",
     "unist-util-visit": "^5.0.0",

--- a/scripts/visual-test/approve.sh
+++ b/scripts/visual-test/approve.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -e
+
+BUCKET="${VISUAL_TEST_BUCKET:-eth-org-visual-baselines}"
+ENDPOINT="${S3_ENDPOINT:-}"
+ENDPOINT_FLAG=""
+if [ -n "$ENDPOINT" ]; then
+  ENDPOINT_FLAG="--endpoint-url $ENDPOINT"
+fi
+
+# Get current PR number from git branch
+BRANCH=$(git branch --show-current)
+PR=$(gh pr view "$BRANCH" --json number --jq '.number' 2>/dev/null || echo "")
+
+if [ -z "$PR" ]; then
+  echo "No PR found for branch $BRANCH"
+  echo "Usage: Provide PR number as argument"
+  PR=$1
+fi
+
+if [ -z "$PR" ]; then
+  echo "Error: Could not determine PR number"
+  exit 1
+fi
+
+echo "Promoting pending screenshots for PR #$PR to baselines..."
+
+# Copy pending to baselines
+aws s3 sync \
+  "s3://${BUCKET}/pending/${PR}/" \
+  "s3://${BUCKET}/baselines/" \
+  $ENDPOINT_FLAG
+
+# Update metadata
+aws s3 cp "s3://${BUCKET}/metadata/${PR}.json" /tmp/metadata.json $ENDPOINT_FLAG
+GIT_USER_NAME="$(git config user.name)" node -e "
+  const m = require('/tmp/metadata.json');
+  const approver = process.env.GIT_USER_NAME;
+  m.changes.forEach(c => {
+    if (c.status === 'pending') {
+      c.status = 'approved';
+      c.approvedBy = approver;
+      c.approvedAt = new Date().toISOString();
+    }
+  });
+  m.summary.approved = m.changes.filter(c => c.status === 'approved').length;
+  m.summary.pending = m.changes.filter(c => c.status === 'pending').length;
+  m.updatedAt = new Date().toISOString();
+  require('fs').writeFileSync('/tmp/metadata.json', JSON.stringify(m, null, 2));
+"
+aws s3 cp /tmp/metadata.json "s3://${BUCKET}/metadata/${PR}.json" $ENDPOINT_FLAG
+
+echo "Done. Baselines updated. Push or re-run CI to validate."

--- a/scripts/visual-test/generate-metadata.ts
+++ b/scripts/visual-test/generate-metadata.ts
@@ -1,0 +1,190 @@
+import { execSync } from "child_process"
+import * as crypto from "crypto"
+import * as fs from "fs"
+import * as path from "path"
+
+const BASELINE_DIR = ".lostpixel/baseline"
+const CURRENT_DIR = ".lostpixel/current"
+const DIFF_DIR = ".lostpixel/difference"
+const OUTPUT = ".lostpixel/metadata.json"
+
+interface Change {
+  id: string
+  story: string
+  type: "added" | "changed" | "removed"
+  status: "pending" | "approved"
+  diffPercent: number | null
+  screenshotHash: string | null
+  baseline: string | null
+  current: string | null
+  diff: string | null
+  approvedBy?: string
+  approvedAt?: string
+}
+
+interface Metadata {
+  pr: number
+  branch: string
+  snapshotCommit: string
+  author: string
+  createdAt: string
+  updatedAt: string
+  status: string
+  summary: {
+    total: number
+    added: number
+    changed: number
+    removed: number
+    pending: number
+    approved: number
+  }
+  changes: Change[]
+}
+
+function listPngs(dir: string): Set<string> {
+  if (!fs.existsSync(dir)) return new Set()
+  return new Set(
+    fs
+      .readdirSync(dir, { recursive: true })
+      .filter((f) => String(f).endsWith(".png"))
+      .map((f) => String(f))
+  )
+}
+
+function hashFile(filePath: string): string {
+  const content = fs.readFileSync(filePath)
+  return crypto.createHash("sha256").update(content).digest("hex")
+}
+
+function fetchExistingMetadata(pr: number): Metadata | null {
+  const bucket = process.env.S3_BUCKET
+  if (!bucket) return null
+
+  const endpoint = process.env.S3_ENDPOINT
+  const endpointFlag = endpoint ? `--endpoint-url ${endpoint}` : ""
+
+  try {
+    execSync(
+      `aws s3 cp s3://${bucket}/metadata/${pr}.json /tmp/existing-metadata.json ${endpointFlag} --quiet`,
+      { stdio: "pipe" }
+    )
+    return JSON.parse(fs.readFileSync("/tmp/existing-metadata.json", "utf8"))
+  } catch {
+    return null
+  }
+}
+
+function generate(): void {
+  const pr = parseInt(process.env.PR_NUMBER!, 10)
+  const branch = process.env.BRANCH || ""
+  const commit = process.env.COMMIT || ""
+  const author = process.env.AUTHOR || ""
+
+  const baselineFiles = listPngs(BASELINE_DIR)
+  const currentFiles = listPngs(CURRENT_DIR)
+  const diffFiles = listPngs(DIFF_DIR)
+
+  // Fetch existing metadata to preserve approvals
+  const existing = fetchExistingMetadata(pr)
+  const existingApprovals = new Map<string, Change>()
+  if (existing) {
+    for (const c of existing.changes) {
+      if (c.status === "approved") {
+        existingApprovals.set(c.id, c)
+      }
+    }
+  }
+
+  const changes: Change[] = []
+
+  // Changed: in both baseline and diff
+  for (const file of diffFiles) {
+    const id = file.replace(/\.png$/, "")
+    const prev = existingApprovals.get(id)
+    const currentHash = hashFile(path.join(CURRENT_DIR, file))
+
+    // Carry forward approval if the screenshot content is identical to
+    // what was previously approved (uses hash, not commit SHA)
+    const carryForward = prev?.screenshotHash === currentHash
+
+    changes.push({
+      id,
+      story: id,
+      type: "changed",
+      status: carryForward ? "approved" : "pending",
+      diffPercent: null,
+      screenshotHash: currentHash,
+      baseline: `baselines/${file}`,
+      current: `pending/${pr}/${file}`,
+      diff: `diffs/${pr}/${file}`,
+      ...(carryForward
+        ? { approvedBy: prev.approvedBy, approvedAt: prev.approvedAt }
+        : {}),
+    })
+  }
+
+  // Added: in current but not baseline, and not in diff (purely new)
+  for (const file of currentFiles) {
+    if (!baselineFiles.has(file) && !diffFiles.has(file)) {
+      const id = file.replace(/\.png$/, "")
+      changes.push({
+        id,
+        story: id,
+        type: "added",
+        status: "pending",
+        diffPercent: null,
+        screenshotHash: hashFile(path.join(CURRENT_DIR, file)),
+        baseline: null,
+        current: `pending/${pr}/${file}`,
+        diff: null,
+      })
+    }
+  }
+
+  // Removed: in baseline but not current
+  for (const file of baselineFiles) {
+    if (!currentFiles.has(file)) {
+      const id = file.replace(/\.png$/, "")
+      changes.push({
+        id,
+        story: id,
+        type: "removed",
+        status: "pending",
+        diffPercent: null,
+        screenshotHash: null,
+        baseline: `baselines/${file}`,
+        current: null,
+        diff: null,
+      })
+    }
+  }
+
+  const approved = changes.filter((c) => c.status === "approved").length
+
+  const metadata: Metadata = {
+    pr,
+    branch,
+    snapshotCommit: commit,
+    author,
+    createdAt: existing?.createdAt || new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    status: "pending_review",
+    summary: {
+      total: changes.length,
+      added: changes.filter((c) => c.type === "added").length,
+      changed: changes.filter((c) => c.type === "changed").length,
+      removed: changes.filter((c) => c.type === "removed").length,
+      pending: changes.length - approved,
+      approved,
+    },
+    changes,
+  }
+
+  fs.mkdirSync(path.dirname(OUTPUT), { recursive: true })
+  fs.writeFileSync(OUTPUT, JSON.stringify(metadata, null, 2))
+  console.log(
+    `Generated metadata: ${changes.length} changes (${metadata.summary.added} added, ${metadata.summary.changed} changed, ${metadata.summary.removed} removed)`
+  )
+}
+
+generate()

--- a/scripts/visual-test/generate-thumbnails.ts
+++ b/scripts/visual-test/generate-thumbnails.ts
@@ -1,0 +1,97 @@
+import * as fs from "fs"
+import * as path from "path"
+
+import sharp from "sharp"
+
+const CURRENT_DIR = ".lostpixel/current"
+const BASELINE_DIR = ".lostpixel/baseline"
+const DIFF_DIR = ".lostpixel/difference"
+const THUMBNAIL_DIR = ".lostpixel/thumbnails"
+const THUMBNAIL_WIDTH = 300
+
+const PR_NUMBER = process.env.PR_NUMBER
+
+if (!PR_NUMBER) {
+  console.error("PR_NUMBER environment variable is required")
+  process.exit(1)
+}
+
+async function generateThumbnail(
+  srcPath: string,
+  destPath: string
+): Promise<void> {
+  if (!fs.existsSync(srcPath)) return
+
+  fs.mkdirSync(path.dirname(destPath), { recursive: true })
+  await sharp(srcPath).resize(THUMBNAIL_WIDTH).png().toFile(destPath)
+}
+
+function listPngs(dir: string): string[] {
+  if (!fs.existsSync(dir)) return []
+  return fs
+    .readdirSync(dir, { recursive: true })
+    .filter((f) => String(f).endsWith(".png"))
+    .map((f) => String(f))
+}
+
+async function main(): Promise<void> {
+  const currentFiles = listPngs(CURRENT_DIR)
+  const diffFiles = listPngs(DIFF_DIR)
+  const baselineFiles = listPngs(BASELINE_DIR)
+
+  // All files that have diffs or are new
+  const relevantFiles = new Set([...diffFiles, ...currentFiles])
+
+  let count = 0
+  for (const file of relevantFiles) {
+    const promises: Promise<void>[] = []
+
+    // Current thumbnail
+    const currentSrc = path.join(CURRENT_DIR, file)
+    if (fs.existsSync(currentSrc)) {
+      promises.push(
+        generateThumbnail(currentSrc, path.join(THUMBNAIL_DIR, "current", file))
+      )
+    }
+
+    // Baseline thumbnail
+    const baselineSrc = path.join(BASELINE_DIR, file)
+    if (fs.existsSync(baselineSrc)) {
+      promises.push(
+        generateThumbnail(
+          baselineSrc,
+          path.join(THUMBNAIL_DIR, "baseline", file)
+        )
+      )
+    }
+
+    // Diff thumbnail
+    const diffSrc = path.join(DIFF_DIR, file)
+    if (fs.existsSync(diffSrc)) {
+      promises.push(
+        generateThumbnail(diffSrc, path.join(THUMBNAIL_DIR, "diff", file))
+      )
+    }
+
+    await Promise.all(promises)
+    count++
+  }
+
+  // Also generate thumbnails for removed files (in baseline but not current)
+  for (const file of baselineFiles) {
+    if (!currentFiles.includes(file)) {
+      await generateThumbnail(
+        path.join(BASELINE_DIR, file),
+        path.join(THUMBNAIL_DIR, "baseline", file)
+      )
+      count++
+    }
+  }
+
+  console.log(`Generated thumbnails for ${count} screenshots`)
+}
+
+main().catch((err) => {
+  console.error("Thumbnail generation failed:", err)
+  process.exit(1)
+})

--- a/scripts/visual-test/update-index.ts
+++ b/scripts/visual-test/update-index.ts
@@ -1,0 +1,71 @@
+import { execSync } from "child_process"
+import * as fs from "fs"
+
+const BUCKET = process.env.S3_BUCKET
+const PR_NUMBER = process.env.PR_NUMBER
+const ENDPOINT = process.env.S3_ENDPOINT
+const endpointFlag = ENDPOINT ? `--endpoint-url ${ENDPOINT}` : ""
+
+if (!BUCKET || !PR_NUMBER) {
+  console.error("S3_BUCKET and PR_NUMBER environment variables are required")
+  process.exit(1)
+}
+
+interface IndexEntry {
+  pr: number
+  branch: string
+  author: string
+  updatedAt: string
+  summary: { total: number; pending: number; approved: number }
+}
+
+function fetchIndex(): IndexEntry[] {
+  try {
+    execSync(
+      `aws s3 cp s3://${BUCKET}/metadata/index.json /tmp/visual-index.json ${endpointFlag} --quiet`,
+      { stdio: "pipe" }
+    )
+    return JSON.parse(fs.readFileSync("/tmp/visual-index.json", "utf8"))
+  } catch {
+    return []
+  }
+}
+
+function main(): void {
+  const metadata = JSON.parse(
+    fs.readFileSync(".lostpixel/metadata.json", "utf8")
+  )
+
+  const index = fetchIndex()
+  const pr = parseInt(PR_NUMBER!, 10)
+
+  // Update or add entry for this PR
+  const existingIdx = index.findIndex((e) => e.pr === pr)
+  const entry: IndexEntry = {
+    pr,
+    branch: metadata.branch,
+    author: metadata.author,
+    updatedAt: metadata.updatedAt,
+    summary: {
+      total: metadata.summary.total,
+      pending: metadata.summary.pending,
+      approved: metadata.summary.approved,
+    },
+  }
+
+  if (existingIdx >= 0) {
+    index[existingIdx] = entry
+  } else {
+    index.unshift(entry)
+  }
+
+  fs.writeFileSync("/tmp/visual-index.json", JSON.stringify(index, null, 2))
+  execSync(
+    `aws s3 cp /tmp/visual-index.json s3://${BUCKET}/metadata/index.json ${endpointFlag}`,
+    { stdio: "inherit" }
+  )
+
+  console.log(`Updated dashboard index for PR #${pr}`)
+}
+
+main()

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -224,3 +224,22 @@
     animation-play-state: paused;
   }
 }
+
+/* Visual regression testing: disable animations and hide dynamic content */
+.visual-test-mode *,
+.visual-test-mode *::before,
+.visual-test-mode *::after {
+  animation-duration: 0s !important;
+  animation-delay: 0s !important;
+  transition-duration: 0s !important;
+  transition-delay: 0s !important;
+}
+
+.visual-test-mode [data-visual-test-hide] {
+  visibility: hidden !important;
+}
+
+.visual-test-mode [data-testid="skeleton"] {
+  background: #e5e5e5 !important;
+  animation: none !important;
+}


### PR DESCRIPTION
## Summary

- Adds self-hosted Lost Pixel visual regression testing infrastructure to replace Chromatic
- Runs on every PR with unlimited snapshots (~$5/month S3 storage vs Chromatic's 35K cap)
- S3 endpoint parameterized for self-hosted S3-compatible storage (`s3-dcl1.ethquokkaops.io`)
- CLI approval workflow (`pnpm visual:approve`) for promoting screenshots to baselines

## What's included

| File | Purpose |
|------|---------|
| `.github/workflows/visual-tests.yml` | CI pipeline: build Storybook, run Lost Pixel, upload diffs, post PR comment |
| `lostpixel.config.ts` | Lost Pixel config: odiff engine, 375px + 1280px breakpoints, 0.1% threshold |
| `scripts/visual-test/generate-metadata.ts` | Classifies changes (added/changed/removed), merges with existing approvals |
| `scripts/visual-test/generate-thumbnails.ts` | Generates 300px-wide thumbnails for PR comments |
| `scripts/visual-test/update-index.ts` | Updates dashboard index.json in S3 |
| `scripts/visual-test/approve.sh` | CLI script to promote pending screenshots to baselines |
| `.storybook/decorators/visualTest.tsx` | Adds `visual-test-mode` class to disable animations |
| `src/styles/global.css` | Flake prevention: disables animations/transitions in visual test mode |

## Before this works

- [ ] DevOps: provision S3 bucket (`eth-org-visual-baselines`) on `s3-dcl1.ethquokkaops.io`
- [ ] Add GitHub Secrets: `VISUAL_TEST_AWS_ACCESS_KEY_ID`, `VISUAL_TEST_AWS_SECRET_ACCESS_KEY`, `S3_ENDPOINT`
- [ ] Confirm S3-compatible store supports: versioning, lifecycle policies (needed for Phase 2)
- [ ] Run `pnpm install` to install `lost-pixel` and `tsx` devDependencies

## Test plan

- [ ] `pnpm build-storybook` succeeds with visual-test-mode decorator
- [ ] Lost Pixel runs locally: `npx lost-pixel` against `storybook-static/`
- [ ] CI workflow triggers on PR to dev
- [ ] PR comment posts with change summary
- [ ] `pnpm visual:approve` promotes pending screenshots

## References

- [Proposal: docs/proposals/visual-regression-testing.md](https://github.com/ethereum/ethereum-org-website/blob/feat/visual-regression-testing/docs/proposals/visual-regression-testing.md)
- Phase 2 (Review UI) is a separate repo, not included here