### PR TITLE
feat(data-layer): isolate env vars into dedicated .env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,8 @@
 # warning: variables prefixed with NEXT_PUBLIC_ will be made available to client-side code
 # be careful not to expose sensitive data (e.g., your Algolia admin key)
 
-# Algolia environment (app ID, search key and base search index name required for search)
+# ─── Algolia Search ─────────────────────────────────────────────────────────────
+# App ID, search key and base search index name required for search
 # You can use the following test keys provided by DocSearch for local development/testing:
 # NEXT_PUBLIC_ALGOLIA_APP_ID=R2IYF7ETH7
 # NEXT_PUBLIC_ALGOLIA_SEARCH_KEY=599cec31baffa4868cae4e79f180729b
@@ -13,29 +14,27 @@
 # NEXT_PUBLIC_ALGOLIA_SEARCH_KEY=insertValue
 # NEXT_PUBLIC_ALGOLIA_BASE_SEARCH_INDEX_NAME=insertValue
 
+# ─── API Keys (Main App) ────────────────────────────────────────────────────────
+
 # Github token for read-only use with api functions
+# Also used by data-layer - see src/data-layer/.env.example
 # GITHUB_TOKEN_READ_ONLY=insertValue
 
-# Etherscan API key (required for Etherscan API fetches)
+# Etherscan API key (required for gas price table)
 # ETHERSCAN_API_KEY=insertValue
 
-# Google API key and Calendar ID (required to fetch Calendar events)
-# GOOGLE_API_KEY=
-# GOOGLE_CALENDAR_ID=
-# GOOGLE_SHEET_ID_DAPPS=
-
-# Dune Analytics API key (required for total eth staked)
-# DUNE_API_KEY=
-
-# CoinGecko API
-# COINGECKO_API_KEY=
-
-# Matomo environment (URL and site ID required for analytics)
+# ─── Matomo Analytics ───────────────────────────────────────────────────────────
+# URL and site ID required for analytics and A/B testing
 NEXT_PUBLIC_MATOMO_URL=
 NEXT_PUBLIC_MATOMO_SITE_ID=
 
+# API token for A/B testing experiments
+# MATOMO_API_TOKEN=your-matomo-api-token
+
 # Used to avoid loading Matomo in our preview deploys
 NEXT_PUBLIC_IS_PREVIEW_DEPLOY=false
+
+# ─── Build Configuration ────────────────────────────────────────────────────────
 
 # Build pages only for the specified langs. Leave it empty to build all the langs
 # e.g., `en,fr` will only build English and French pages
@@ -49,35 +48,19 @@ LIMIT_CPUS=
 # Enables the bundle analyzer
 ANALYZE=false
 
+# ─── Development ────────────────────────────────────────────────────────────────
+
 # Use mock data for development. Set to "false" to use live data but you must have the
 # environment variables set to make api requests
 USE_MOCK_DATA=true
 
-# AWS SES Configuration for Enterprise Contact Form
+# ─── AWS SES (Enterprise Contact Form) ──────────────────────────────────────────
 # SES_ACCESS_KEY_ID=your_iam_access_key_id
 # SES_SECRET_ACCESS_KEY=your_iam_secret_access_key
 # SES_REGION=us-east-2
 
-# Supabase Events API (Geode Labs)
-# SUPABASE_EVENTS_KEY=your-supabase-publishable-key
-
-# Netlify Blobs (data-layer storage)
-# Required when USE_MOCK_DATA=false to read/write data from Netlify Blobs
-# SITE_ID=your-netlify-site-id
-# NETLIFY_BLOBS_TOKEN=your-netlify-blobs-token
-
-# Trigger.dev (scheduled tasks)
-# TRIGGER_PROJECT_REF=your-trigger-project-ref
-
-# Sentry (error tracking)
-# Used by trigger.dev tasks and Next.js app for error monitoring
+# ─── Sentry (Error Tracking) ────────────────────────────────────────────────────
+# Used by Next.js app for error monitoring
+# Also used by data-layer/Trigger.dev - see src/data-layer/.env.example
 # NEXT_PUBLIC_SENTRY_DSN=your-sentry-dsn
 # NEXT_PUBLIC_CONTEXT=development
-
-# S3 Image Storage (data-layer image uploads)
-# Used to upload external images to S3 during data sync
-# S3_REGION=us-east-1
-# S3_ENDPOINT=https://your-s3-endpoint.com
-# S3_ACCESS_KEY_ID=your-s3-access-key-id
-# S3_SECRET_ACCESS_KEY=your-s3-secret-access-key
-# S3_IMAGE_BUCKET=your-image-bucket-name

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "test:e2e:ui": "playwright test --project=e2e --ui",
     "test:e2e:debug": "playwright test --project=e2e --debug",
     "test:e2e:report": "playwright show-report tests/__report__",
-    "trigger:dev": "npx trigger.dev@latest dev --env-file .env.local",
-    "trigger:deploy": "npx trigger.dev@latest deploy --env-file .env.local"
+    "trigger:dev": "npx trigger.dev@latest dev --env-file src/data-layer/.env",
+    "trigger:deploy": "npx trigger.dev@latest deploy --env-file src/data-layer/.env"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.982.0",

--- a/src/data-layer/.env.example
+++ b/src/data-layer/.env.example
@@ -1,0 +1,59 @@
+# Data Layer Environment Variables
+# =================================
+# This file contains environment variables used by the data-layer module and Trigger.dev tasks.
+#
+# Local Development:
+#   Copy this file to src/data-layer/.env and fill in the values.
+#   Run tasks with: pnpm trigger:dev
+#
+# Production (Trigger.dev Cloud):
+#   Configure these variables in your Trigger.dev project dashboard.
+#
+# NOTE: Some variables are shared with the main app and must also be set in the root .env file.
+
+# ─── Shared with Main App ───────────────────────────────────────────────────────
+# These variables are used by BOTH the data-layer AND the main Next.js app.
+# They should be configured in both environments.
+
+# GitHub token for read-only API access (used for fetching repo data, GFIs, git history)
+# GITHUB_TOKEN_READ_ONLY=your-github-token
+
+# Sentry (error tracking for Trigger.dev tasks)
+# NEXT_PUBLIC_SENTRY_DSN=your-sentry-dsn
+# NEXT_PUBLIC_CONTEXT=development
+
+# ─── Data Layer Only ────────────────────────────────────────────────────────────
+# These variables are ONLY used by the data-layer and Trigger.dev.
+
+# Trigger.dev project reference
+# TRIGGER_PROJECT_REF=your-trigger-project-ref
+
+# Netlify Blobs (data storage)
+# Required for reading/writing data to Netlify Blobs when USE_MOCK_DATA=false
+# SITE_ID=your-netlify-site-id
+# NETLIFY_BLOBS_TOKEN=your-netlify-blobs-token
+
+# Google APIs (Calendar events, Apps/Dapps sheet, Community picks)
+# GOOGLE_API_KEY=your-google-api-key
+# GOOGLE_CALENDAR_ID=your-google-calendar-id
+# GOOGLE_SHEET_ID_DAPPS=your-google-sheet-id
+
+# CoinGecko API (ETH price, market cap, stablecoins data)
+# COINGECKO_API_KEY=your-coingecko-api-key
+
+# Dune Analytics (total ETH staked)
+# DUNE_API_KEY=your-dune-api-key
+
+# Supabase Events API (community events from Geode Labs)
+# SUPABASE_EVENTS_KEY=your-supabase-publishable-key
+
+# S3 Image Storage (external image uploads during data sync)
+# Used to upload external images to S3 for Next.js Image optimization
+# S3_REGION=us-east-1
+# S3_ENDPOINT=https://your-s3-endpoint.com
+# S3_ACCESS_KEY_ID=your-s3-access-key-id
+# S3_SECRET_ACCESS_KEY=your-s3-secret-access-key
+# S3_IMAGE_BUCKET=your-image-bucket-name
+
+# Discord Webhook (failure notifications)
+# DISCORD_WEBHOOK_URL=your-discord-webhook-url

--- a/src/data-layer/fetchers/fetchStablecoinsData.ts
+++ b/src/data-layer/fetchers/fetchStablecoinsData.ts
@@ -1,7 +1,6 @@
-import {
-  COINGECKO_API_BASE_URL,
-  COINGECKO_API_URL_PARAMS,
-} from "@/lib/constants"
+const COINGECKO_API_BASE_URL =
+  "https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&category="
+const COINGECKO_API_URL_PARAMS = `&order=market_cap_desc&per_page=250&page=1&sparkline=false&x_cg_demo_api_key=${process.env.COINGECKO_API_KEY}`
 
 export interface CoinGeckoCoinMarket {
   id: string

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -41,9 +41,6 @@ export const GITHUB_BASE_API =
   "https://api.github.com/repos/ethereum/ethereum-org-website"
 export const GITHUB_COMMITS_URL = GITHUB_BASE_API + "/commits"
 export const GITHUB_URL = `https://github.com/`
-export const COINGECKO_API_BASE_URL =
-  "https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&category="
-export const COINGECKO_API_URL_PARAMS = `&order=market_cap_desc&per_page=250&page=1&sparkline=false&x_cg_demo_api_key=${process.env.COINGECKO_API_KEY}`
 export const COLOR_MODE_STORAGE_KEY = "theme"
 
 // API timing


### PR DESCRIPTION
## Summary
- Create `src/data-layer/.env.example` with all data-layer/Trigger.dev environment variables
- Update trigger.dev scripts to use `src/data-layer/.env` instead of `.env.local`
- Move CoinGecko constants from `src/lib/constants.ts` to `src/data-layer/fetchers/fetchStablecoinsData.ts` (only used there)
- Clean up root `.env.example` by removing data-layer only vars and adding section headers

## Test plan
- [x] Verify `pnpm trigger:dev` works with `src/data-layer/.env`
- [x] Verify main app builds without CoinGecko env var in root `.env`
- [x] Verify data-layer tasks still function correctly