### PR TITLE
fix: update metamask open source status

### DIFF
--- a/src/data/wallets/wallet-data.ts
+++ b/src/data/wallets/wallet-data.ts
@@ -426,7 +426,7 @@ export const walletsData: WalletData[] = [
     firefox: true,
     chromium: true,
     hardware: false,
-    open_source: true,
+    open_source: false,
     repo_url: "https://github.com/MetaMask",
     non_custodial: true,
     security_audit: [],


### PR DESCRIPTION
## Summary

- Update MetaMask `open_source` flag from `true` to `false` in wallet data

## Details

MetaMask was originally licensed under MIT, but in August 2020 ConsenSys switched all MetaMask repositories to a custom proprietary license. The code is publicly viewable ("source-available") but does not meet the Open Source Definition maintained by the OSI.

**Key restrictions in the current license:**

- `metamask-extension`: Non-commercial use only, with a hard cap of 10,000 monthly active users on any derivative work
- `metamask-mobile`: Even more restrictive -- grants only a license to inspect and study the code; no modification or distribution without ConsenSys consent
- `metamask-sdk`: Same restrictions as the extension

These restrictions fail multiple OSI criteria (free redistribution, derived works, non-discrimination against fields of endeavor), making the "open source" designation inaccurate.

**References:**

- [metamask-extension LICENSE](https://github.com/MetaMask/metamask-extension/blob/develop/LICENSE)
- [metamask-mobile LICENSE](https://github.com/MetaMask/metamask-mobile/blob/main/LICENSE)
- [GitHub Issue #9304 - Community discussion on relicensing](https://github.com/MetaMask/metamask-extension/issues/9304)

---
_Research assisted by Claude Opus 4.6_