### PR TITLE
[MUST MERGE BEFORE DEPLOY] fix(build): remove blocking rate limit retry that kills all builds

### DIFF
--- a/src/lib/utils/gh.ts
+++ b/src/lib/utils/gh.ts
@@ -122,33 +122,29 @@ async function fetchWithRateLimit(filepath: string): Promise<Commit[]> {
   // If no token available, return empty array
   if (!gitHubToken) return []
 
-  /* eslint-disable no-constant-condition --
-   * eslint does not like while(true)
-   **/
-  while (true) {
-    const response = await fetch(url.href, {
-      headers: { Authorization: `token ${gitHubToken}` },
-    })
+  const response = await fetch(url.href, {
+    headers: { Authorization: `token ${gitHubToken}` },
+  })
 
-    if (
-      response.status === 403 &&
-      response.headers.get("X-RateLimit-Remaining") === "0"
-    ) {
-      const resetTime = response.headers.get("X-RateLimit-Reset") as string
-      const waitTime = +resetTime - Math.floor(Date.now() / 1000)
-      console.log(`Rate limit exceeded, waiting for ${waitTime} seconds`)
-      await new Promise((resolve) => setTimeout(resolve, waitTime * 1000))
-      continue
-    }
-
-    if (!response.ok) throw new Error(response.statusText)
-    const json = await response.json()
-    if (!Array.isArray(json)) {
-      console.warn("Unexpected response from GitHub API", json)
-      return []
-    }
-    return json
+  if (
+    response.status === 403 &&
+    response.headers.get("X-RateLimit-Remaining") === "0"
+  ) {
+    console.warn(`GitHub API rate limit exceeded for ${filepath}. Skipping.`)
+    return []
   }
+
+  if (!response.ok) {
+    console.warn(`GitHub API error for ${filepath}: ${response.statusText}`)
+    return []
+  }
+
+  const json = await response.json()
+  if (!Array.isArray(json)) {
+    console.warn("Unexpected response from GitHub API", json)
+    return []
+  }
+  return json
 }
 
 // Fetch commit history and save it to a JSON file


### PR DESCRIPTION
## Summary

- Removes the `while(true)` rate limit retry loop in `fetchWithRateLimit()` (`src/lib/utils/gh.ts`) that blocks the entire build when GitHub API rate limits are hit
- Rate limit/error now returns empty results instead of waiting 22+ minutes for reset

## What was happening

The `fetchWithRateLimit` function retries infinitely when GitHub's API rate limit is exceeded. During static page generation:

- **39 pages** use `getAppPageContributorInfo`, each making up to 12 GitHub API calls
- **25 locales** each build independently with no shared cache
- That's **~11,700 API calls** vs GitHub's 5,000/hour rate limit
- The rate limit is hit almost immediately, and every build worker blocks in the `while(true)` loop waiting ~1,300 seconds (22 min) for reset
- Next.js kills workers after 60 seconds, restarting page generation in an infinite loop

Build log showing the issue:
```
8:23:20 PM: Rate limit exceeded, waiting for 1331 seconds
8:23:20 PM: Rate limit exceeded, waiting for 1331 seconds
(×24 more times)
8:24:20 PM: ⚠ Sending SIGTERM signal to Next.js build worker due to timeout of 60 seconds
8:24:20 PM: ⚠ Restarted static page generation for /en/10years because it took more than 60 seconds
8:24:20 PM: ⚠ Restarted static page generation for /ar/10years because it took more than 60 seconds
(every locale, every page using contributors)
```

## What this changes

`fetchWithRateLimit` now returns `[]` on rate limit or any API error instead of blocking. Pages render without contributor info, which is already handled gracefully (the error throw for missing contributors was previously commented out).

## Test plan

- [ ] Verify build completes on Netlify without timeout
- [ ] Spot check that pages still render (contributor section will be empty if rate-limited, which is acceptable)