### PR TITLE
fix(i18n): disable automatic locale prefix redirect

### DIFF
--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -8,6 +8,7 @@ export const routing = defineRouting({
   defaultLocale: DEFAULT_LOCALE,
   localePrefix: "as-needed",
   alternateLinks: false,
+  localeDetection: false,
 })
 
 // Lightweight wrappers around Next.js' navigation APIs


### PR DESCRIPTION
## Summary
- Adds `localeDetection: false` to the next-intl routing config
- Stops automatic redirect based on browser `Accept-Language` header
- Users can still switch languages via the language selector

## Test plan
- [x] Visit `ethereum.org` with a non-English browser — should stay on `/`, not redirect to `/ja/` etc.
- [x] Language selector still works
- [x] RTL languages still render correctly