### PR TITLE
fix(i18n): set correct robots meta for untranslated locale pages

### DIFF
--- a/src/lib/utils/metadata.ts
+++ b/src/lib/utils/metadata.ts
@@ -141,7 +141,7 @@ export const getMetadata = async ({
   }
 
   if (!isCurrentPageTranslated) {
-    return { ...base, robots: { index: true, follow: true } }
+    return { ...base, robots: { index: false, follow: true } }
   }
 
   return base


### PR DESCRIPTION
## Summary
- Flips `index: true` to `index: false` for untranslated locale pages
- Canonical tag pointing to the English version is preserved
- `follow: true` is kept so crawlers still follow links

## Context
Untranslated locale pages (e.g., `/fr/some-page/` showing English content) were explicitly being indexed, creating massive duplicate content across 60+ locale prefixes. This will reduce indexed page count significantly (expected and correct).

## Test plan
- [x] Visit an untranslated locale page — should have `<meta name="robots" content="noindex, follow">`
- [x] Translated pages are unaffected (still indexed)
- [x] Canonical tag to English version is still present