### PR TITLE
fix(sitemap): include root URL in sitemap generation

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -9,7 +9,14 @@ import { getAllPagesWithTranslations } from "@/lib/i18n/translationRegistry"
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const pages = await getAllPagesWithTranslations()
 
-  const entries: MetadataRoute.Sitemap = []
+  const entries: MetadataRoute.Sitemap = [
+    {
+      url: "https://ethereum.org/",
+      changeFrequency: "daily",
+      priority: 1.0,
+      lastModified: new Date(),
+    },
+  ]
 
   for (const { slug, translatedLocales } of pages) {
     const normalizedSlug = slug.startsWith("/") ? slug : `/${slug}`


### PR DESCRIPTION
## Summary
- Adds `https://ethereum.org/` to the sitemap with `priority: 1.0`
- The existing skip logic that prevents a `/en/` duplicate is preserved
- No other sitemap entries affected

## Test plan
- [ ] `https://ethereum.org/` appears in `/sitemap.xml`
- [ ] No duplicate `/en/` entry created
- [ ] Other sitemap entries unaffected