### PR TITLE
fix(breadcrumbs): update homepage text and add missing root breadcrumb

### DIFF
--- a/app/[locale]/apps/[application]/page.tsx
+++ b/app/[locale]/apps/[application]/page.tsx
@@ -147,6 +147,12 @@ const Page = async ({
             <Breadcrumb>
               <BreadcrumbList>
                 <BreadcrumbItem>
+                  <BreadcrumbLink href="/">Ethereum.org</BreadcrumbLink>
+                </BreadcrumbItem>
+                <BreadcrumbSeparator className="me-[0.625rem] ms-[0.625rem] text-gray-400">
+                  /
+                </BreadcrumbSeparator>
+                <BreadcrumbItem>
                   <BreadcrumbLink href="/apps">ALL APPS</BreadcrumbLink>
                 </BreadcrumbItem>
                 <BreadcrumbSeparator className="me-[0.625rem] ms-[0.625rem] text-gray-400">

--- a/app/[locale]/apps/categories/[catetgoryName]/page.tsx
+++ b/app/[locale]/apps/categories/[catetgoryName]/page.tsx
@@ -127,6 +127,12 @@ const Page = async ({
               <Breadcrumb>
                 <BreadcrumbList>
                   <BreadcrumbItem>
+                    <BreadcrumbLink href="/">Ethereum.org</BreadcrumbLink>
+                  </BreadcrumbItem>
+                  <BreadcrumbSeparator className="me-[0.625rem] ms-[0.625rem] text-gray-400">
+                    /
+                  </BreadcrumbSeparator>
+                  <BreadcrumbItem>
                     <BreadcrumbLink href="/apps" className="uppercase">
                       {t("page-apps-all-apps")}
                     </BreadcrumbLink>

--- a/src/components/Breadcrumbs/index.tsx
+++ b/src/components/Breadcrumbs/index.tsx
@@ -59,7 +59,7 @@ const Breadcrumbs = ({ slug, startDepth = 0, ...props }: BreadcrumbsProps) => {
       ? [
           {
             fullPath: "/",
-            text: t("page-index-meta-title"),
+            text: "Ethereum.org",
           },
         ]
       : []),


### PR DESCRIPTION
## Summary
- Breadcrumbs component now shows "Ethereum.org" instead of "Home" for the homepage link
- App detail pages now have: Ethereum.org > ALL APPS > App Name
- App category pages now have: Ethereum.org > ALL APPS > Category

## Context
"Ethereum.org" is a brand name (hardcoded, not translated). The apps pages previously had no homepage breadcrumb at all, breaking the navigation trail.

## Test plan
- [ ] Breadcrumbs show "Ethereum.org" instead of "Home"
- [ ] Apps detail pages have full breadcrumb trail
- [ ] Apps category pages have full breadcrumb trail
- [ ] Homepage `<title>` tag is NOT affected