### PR TITLE
fix(links): update stale internal links and add missing redirects

### DIFF
--- a/redirects.config.js
+++ b/redirects.config.js
@@ -104,4 +104,12 @@ module.exports = [
   ["/tds", "/trillion-dollar-security"],
   ["/10-years", "/10years"],
   ["/history", "/ethereum-forks"],
+  ["/developers/docs/scaling/rollups", "/developers/docs/scaling/"],
+  [
+    "/eth2/get-involved/staking-community-grants",
+    "/staking/",
+  ],
+  ["/developers/docs/zk", "/zero-knowledge-proofs/"],
+  ["/developers/docs/security", "/developers/docs/smart-contracts/security/"],
+  ["/wallet", "/wallets/"],
 ]

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -62,7 +62,7 @@ const Footer = ({ lastDeployLocaleTimestamp }: FooterProps) => {
           text: t("what-is-ethereum"),
         },
         {
-          href: "/eth/",
+          href: "/what-is-ether/",
           text: t("what-is-ether"),
         },
         {
@@ -185,7 +185,7 @@ const Footer = ({ lastDeployLocaleTimestamp }: FooterProps) => {
           text: t("nav-docs-design-label"),
         },
         {
-          href: "/enterprise/",
+          href: "https://institutions.ethereum.org/",
           text: t("enterprise-mainnet"),
         },
         {


### PR DESCRIPTION
## Summary
- Updates footer links pointing to URLs that redirect (`/eth/` -> `/what-is-ether/`, `/enterprise/` -> external URL)
- Adds 5 permanent redirects for broken URLs that still receive external traffic

## Added redirects
| Broken URL | Redirect To | Referring Domains |
|-----------|-------------|-------------------|
| `/developers/docs/scaling/rollups` | `/developers/docs/scaling/` | 303 |
| `/eth2/get-involved/staking-community-grants` | `/staking/` | 159 |
| `/developers/docs/zk` | `/zero-knowledge-proofs/` | 69 |
| `/developers/docs/security` | `/developers/docs/smart-contracts/security/` | 65 |
| `/wallet` | `/wallets/` | 47 |

## Test plan
- [x] Footer links go directly to final destination (no redirect chain)
- [x] New redirects resolve correctly (`curl -IL`)
- [x] No redirect loops