### PR TITLE
fix(meta): add noindex for non-production environments

### DIFF
--- a/src/lib/utils/metadata.ts
+++ b/src/lib/utils/metadata.ts
@@ -136,6 +136,10 @@ export const getMetadata = async ({
     },
   }
 
+  if (SITE_URL !== "https://ethereum.org") {
+    return { ...base, robots: { index: false, follow: false } }
+  }
+
   if (noIndex) {
     return { ...base, robots: { index: false } }
   }


### PR DESCRIPTION
## Summary
- Adds `<meta name="robots" content="noindex, nofollow">` on non-production environments
- Belt-and-suspenders safeguard alongside existing `robots.txt` disallow
- Uses `SITE_URL` constant (from `NEXT_PUBLIC_SITE_URL` env var)
- Production (`https://ethereum.org`) is unaffected

## Test plan
- [ ] Non-production pages have `<meta name="robots" content="noindex, nofollow">`
- [ ] Production pages unaffected (no noindex meta)
- [x] Verify `NEXT_PUBLIC_SITE_URL` is set correctly in Netlify staging config