### PR TITLE
content: add contextual internal links on key pages

### DIFF
--- a/public/content/dao/index.md
+++ b/public/content/dao/index.md
@@ -49,7 +49,7 @@ To help this make more sense, here's a few examples of how you could use a DAO:
 
 ## How do DAOs work? {#how-daos-work}
 
-The backbone of a DAO is its [smart contract](/glossary/#smart-contract), which defines the rules of the organization and holds the group's treasury. Once the contract is live on Ethereum, no one can change the rules except by a vote. If anyone tries to do something that's not covered by the rules and logic in the code, it will fail. And because the treasury is defined by the smart contract too that means no one can spend the money without the group's approval either. This means that DAOs don't need a central authority. Instead, the group makes decisions collectively, and payments are automatically authorized when votes pass.
+The backbone of a DAO is its [smart contract](/glossary/#smart-contract), which defines the rules of the organization and holds the group's treasury. Once the contract is live on [Ethereum](/), no one can change the rules except by a vote. If anyone tries to do something that's not covered by the rules and logic in the code, it will fail. And because the treasury is defined by the smart contract too that means no one can spend the money without the group's approval either. This means that DAOs don't need a central authority. Instead, the group makes decisions collectively, and payments are automatically authorized when votes pass.
 
 This is possible because smart contracts are tamper-proof once they go live on Ethereum. You can't just edit the code (the DAOs rules) without people noticing because everything is public.
 

--- a/public/content/defi/index.md
+++ b/public/content/defi/index.md
@@ -17,7 +17,7 @@ DeFi is an open and global financial system built for the internet age – an al
 
 ## What's DeFi? {#what-is-defi}
 
-DeFi is a collective term for financial products and services that are accessible to anyone who can use Ethereum – anyone with an internet connection. With DeFi, the markets are always open and there are no centralized authorities who can block payments or deny you access to anything. Services that were previously slow and at risk of human error are automatic and safer now that they're handled by code that anyone can inspect and scrutinize.
+DeFi is a collective term for financial products and services that are accessible to anyone who can use [Ethereum](/) – anyone with an internet connection. With DeFi, the markets are always open and there are no centralized authorities who can block payments or deny you access to anything. Services that were previously slow and at risk of human error are automatic and safer now that they're handled by code that anyone can inspect and scrutinize.
 
 There's a booming crypto economy out there, where you can lend, borrow, long/short, earn interest, and more. Crypto-savvy Argentinians have used DeFi to escape crippling inflation. Companies have started streaming their employees their wages in real time. Some folks have even taken out and paid off loans worth millions of dollars without the need for any personal identification.
 

--- a/public/content/developers/docs/consensus-mechanisms/pos/index.md
+++ b/public/content/developers/docs/consensus-mechanisms/pos/index.md
@@ -12,7 +12,7 @@ To better understand this page, we recommend you first read up on [consensus mec
 
 ## What is proof-of-stake (PoS)? {#what-is-pos}
 
-Proof-of-stake is a way to prove that validators have put something of value into the network that can be destroyed if they act dishonestly. In Ethereum's proof-of-stake, validators explicitly stake capital in the form of ETH into a smart contract on Ethereum. The validator is then responsible for checking that new blocks propagated over the network are valid and occasionally creating and propagating new blocks themselves. If they try to defraud the network (for example by proposing multiple blocks when they ought to send one or sending conflicting attestations), some or all of their staked ETH can be destroyed.
+Proof-of-stake is a way to prove that validators have put something of value into the network that can be destroyed if they act dishonestly. In [Ethereum's](/) proof-of-stake, validators explicitly stake capital in the form of ETH into a smart contract on Ethereum. The validator is then responsible for checking that new blocks propagated over the network are valid and occasionally creating and propagating new blocks themselves. If they try to defraud the network (for example by proposing multiple blocks when they ought to send one or sending conflicting attestations), some or all of their staked ETH can be destroyed.
 
 ## Validators {#validators}
 

--- a/public/content/developers/docs/evm/index.md
+++ b/public/content/developers/docs/evm/index.md
@@ -4,7 +4,7 @@ description: An introduction to the Ethereum virtual machine and how it relates 
 lang: en
 ---
 
-The Ethereum Virtual Machine (EVM) is a decentralized virtual environment that executes code consistently and securely across all Ethereum nodes. Nodes run the EVM to execute smart contracts, using "[gas](/developers/docs/gas/)" to measure the computational effort required for [operations](/developers/docs/evm/opcodes/), ensuring efficient resource allocation and network security.
+The [Ethereum](/) Virtual Machine (EVM) is a decentralized virtual environment that executes code consistently and securely across all Ethereum nodes. Nodes run the EVM to execute smart contracts, using "[gas](/developers/docs/gas/)" to measure the computational effort required for [operations](/developers/docs/evm/opcodes/), ensuring efficient resource allocation and network security.
 
 ## Prerequisites {#prerequisites}
 

--- a/public/content/developers/docs/standards/tokens/erc-20/index.md
+++ b/public/content/developers/docs/standards/tokens/erc-20/index.md
@@ -8,7 +8,7 @@ lang: en
 
 **What is a Token?**
 
-Tokens can represent virtually anything in Ethereum:
+Tokens can represent virtually anything in [Ethereum](/):
 
 - reputation points in an online platform
 - skills of a character in a game

--- a/public/content/governance/index.md
+++ b/public/content/governance/index.md
@@ -6,7 +6,7 @@ lang: en
 
 # Introduction to Ethereum governance {#introduction}
 
-_If no one owns Ethereum, how are decisions about past and future changes to Ethereum made? Ethereum governance refers to the process that allows such decisions to be made._
+_If no one owns [Ethereum](/), how are decisions about past and future changes to Ethereum made? Ethereum governance refers to the process that allows such decisions to be made._
 
 <Divider />
 

--- a/public/content/nft/index.md
+++ b/public/content/nft/index.md
@@ -15,7 +15,7 @@ summaryPoint3: Powered by smart contracts on the Ethereum blockchain.
 
 ## What are NFTs? {#what-are-nfts}
 
-NFTs are tokens that are **individually unique**. Each NFT has different properties (non-fungible) and is provably scarce. This is different from tokens such as [ETH](/glossary/#ether) or other Ethereum based tokens like USDC where every token is identical and has the same properties ('fungible'). You don't care which specific dollar bill (or ETH) you have in your wallet, because they are all identical and worth the same. However, you _do_ care which specific NFT you own, because they all have individual properties that distinguish them from others ('non-fungible').
+NFTs are tokens that are **individually unique**. Each NFT has different properties (non-fungible) and is provably scarce. This is different from tokens such as [ETH](/glossary/#ether) or other [Ethereum](/) based tokens like USDC where every token is identical and has the same properties ('fungible'). You don't care which specific dollar bill (or ETH) you have in your wallet, because they are all identical and worth the same. However, you _do_ care which specific NFT you own, because they all have individual properties that distinguish them from others ('non-fungible').
 
 The uniqueness of each NFT enables tokenization of things like art, collectibles, or even real estate, where one specific unique NFT represents some specific unique real world or digital item. Ownership of an asset is publicly verifiable on Ethereum [blockchain](/glossary/#blockchain).
 

--- a/public/content/roadmap/merge/index.md
+++ b/public/content/roadmap/merge/index.md
@@ -12,7 +12,7 @@ summaryPoint4: The Merge reduced Ethereum's energy consumption by ~99.95%.
 ---
 
 <UpgradeStatus isShipped dateKey="page-upgrades:page-upgrades-beacon-date">
-  The Merge was executed on September 15, 2022. This completed Ethereum's transition to proof-of-stake consensus, officially deprecating proof-of-work and reducing energy consumption by ~99.95%.
+  The Merge was executed on September 15, 2022. This completed [Ethereum's](/) transition to proof-of-stake consensus, officially deprecating proof-of-work and reducing energy consumption by ~99.95%.
 </UpgradeStatus>
 
 ## What was The Merge? {#what-is-the-merge}

--- a/public/content/smart-contracts/index.md
+++ b/public/content/smart-contracts/index.md
@@ -11,7 +11,7 @@ lang: en
 <ListenToPlayer slug="/smart-contracts/" />
 </div>
 
-Smart contracts are the fundamental building blocks of Ethereum's application layer. They are computer programs stored on the [blockchain](/glossary/#blockchain) that follow "if this then that" logic, and are guaranteed to execute according to the rules defined by its code, which cannot be changed once created.
+Smart contracts are the fundamental building blocks of [Ethereum's](/) application layer. They are computer programs stored on the [blockchain](/glossary/#blockchain) that follow "if this then that" logic, and are guaranteed to execute according to the rules defined by its code, which cannot be changed once created.
 
 Nick Szabo coined the term "smart contract". In 1994, he wrote [an introduction to the concept](https://www.fon.hum.uva.nl/rob/Courses/InformationInSpeech/CDROM/Literature/LOTwinterschool2006/szabo.best.vwh.net/smart.contracts.html), and in 1996 he wrote [an exploration of what smart contracts could do](https://www.fon.hum.uva.nl/rob/Courses/InformationInSpeech/CDROM/Literature/LOTwinterschool2006/szabo.best.vwh.net/smart_contracts_2.html).
 

--- a/public/content/whitepaper/index.md
+++ b/public/content/whitepaper/index.md
@@ -8,7 +8,7 @@ hideEditButton: true
 
 <WhitepaperBridge />
 
-_While several years old, we maintain the original paper below because it continues to serve as a useful reference and an accurate representation of Ethereum and its vision._
+_While several years old, we maintain the original paper below because it continues to serve as a useful reference and an accurate representation of [Ethereum](/) and its vision._
 
 # Ethereum Whitepaper {#ethereum-whitepaper}
 


### PR DESCRIPTION
## Summary
- Adds `[Ethereum](/)` link on the first contextual mention of "Ethereum" in body content across 10 high-traffic pages
- Only the first occurrence is linked on each page

## Pages updated
| Page | Referring Domains |
|------|-------------------|
| `/roadmap/merge/` | 3,133 |
| `/whitepaper/` | 2,784 |
| `/developers/docs/consensus-mechanisms/pos/` | 1,967 |
| `/developers/docs/evm/` | 1,837 |
| `/developers/docs/standards/tokens/erc-20/` | 1,730 |
| `/nft/` | 1,695 |
| `/defi/` | — |
| `/smart-contracts/` | — |
| `/governance/` | — |
| `/dao/` | — |

## Test plan
- [ ] Links render correctly in MDX
- [ ] No broken links introduced
- [ ] Only first mention linked on each page