### PR TITLE
fix: remove broken DeFi Pulse links

### DIFF
--- a/public/content/defi/index.md
+++ b/public/content/defi/index.md
@@ -239,7 +239,7 @@ When you use a centralized exchange you have to deposit your assets before the t
 
 There are fund management products on Ethereum that will try to grow your portfolio based on a strategy of your choice. This is automatic, open to everyone, and doesn't need a human manager taking a cut of your profits.
 
-A good example is the [DeFi Pulse Index fund (DPI)](https://defipulse.com/blog/defi-pulse-index/). This is a fund that rebalances automatically to ensure your portfolio always includes the top DeFi tokens by market capitalization. You never have to manage any of the details and you can withdraw from the fund whenever you like.
+For example, there are tokenized index funds that rebalance automatically to ensure your portfolio always includes the top DeFi tokens by market capitalization. You never have to manage any of the details and you can withdraw from the fund whenever you like.
 
 <ButtonLink href="/apps/categories/defi">
   See investment dapps
@@ -359,7 +359,6 @@ DeFi is an open-source movement. The DeFi protocols and applications are all ope
 ### Communities {#communities}
 
 - [DeFi Llama Discord server](https://discord.defillama.com/)
-- [DeFi Pulse Discord server](https://discord.gg/Gx4TCTk)
 
 <Divider />
 

--- a/public/content/developers/docs/scaling/validium/index.md
+++ b/public/content/developers/docs/scaling/validium/index.md
@@ -162,5 +162,4 @@ Multiple projects provide implementations of Validium and volitions that you can
 - [Validium And The Layer 2 Two-By-Two — Issue No. 99](https://www.buildblockchain.tech/newsletter/issues/no-99-validium-and-the-layer-2-two-by-two)
 - [ZK-rollups vs Validium](https://blog.matter-labs.io/zkrollup-vs-validium-starkex-5614e38bc263)
 - [Volition and the Emerging Data Availability spectrum](https://medium.com/starkware/volition-and-the-emerging-data-availability-spectrum-87e8bfa09bb)
-- [Rollups, Validiums, and Volitions: Learn About the Hottest Ethereum Scaling Solutions](https://www.defipulse.com/blog/rollups-validiums-and-volitions-learn-about-the-hottest-ethereum-scaling-solutions)
 - [The Practical Guide to Ethereum Rollups](https://web.archive.org/web/20241108192208/https://research.2077.xyz/the-practical-guide-to-ethereum-rollups)


### PR DESCRIPTION
## Summary

Closes #17193

DeFi Pulse Index (DPI) has been [sunset by Index Coop](https://docs.indexcoop.com/index-coop-community-handbook/products/legacy-products/defi-pulse-index-dpi) and `defipulse.com` returns 404 on all blog URLs.

Three broken references fixed:

- **`/defi/#investing`**: Rewrote the DPI paragraph to describe tokenized index funds generically instead of linking to a dead product. The concept is still valid — the specific product is not.
- **`/defi/#communities`**: Removed "DeFi Pulse Discord server" link (dead server for a dead product).
- **`/developers/docs/scaling/validium/`**: Removed broken DeFi Pulse blog link from "Further reading" section.

Note: 22 translation files still contain the old DPI link and will need Crowdin sync after this merges.

## Test plan

- [ ] Verify `/defi/#investing` paragraph reads naturally without product-specific reference
- [ ] Verify `/defi/#communities` section renders with single Discord link
- [ ] Verify `/developers/docs/scaling/validium/#further-reading` renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)