### PR TITLE
perf: replace dynamic imports with fs.readFile for i18n and md content

### DIFF
--- a/src/lib/md/import.ts
+++ b/src/lib/md/import.ts
@@ -1,32 +1,32 @@
+import { readFile } from "fs/promises"
+import path from "path"
+
 import { DEFAULT_LOCALE } from "../constants"
 
 export const importMd = async (locale: string, slug: string) => {
-  let markdown = ""
+  const contentPath = path.join(process.cwd(), "public/content")
 
   if (locale === DEFAULT_LOCALE) {
-    markdown = (await import(`../../../public/content/${slug}/index.md`))
-      .default
-  } else {
-    try {
-      markdown = (
-        await import(
-          `../../../public/content/translations/${locale}/${slug}/index.md`
-        )
-      ).default
-    } catch (error) {
-      const markdown = (
-        await import(`../../../public/content/${slug}/index.md`)
-      ).default
-
-      return {
-        markdown,
-        isTranslated: false,
-      }
-    }
+    const filePath = path.join(contentPath, slug, "index.md")
+    const markdown = await readFile(filePath, "utf-8")
+    return { markdown, isTranslated: true }
   }
 
-  return {
-    markdown,
-    isTranslated: true,
+  // Try translated version first
+  const translatedPath = path.join(
+    contentPath,
+    "translations",
+    locale,
+    slug,
+    "index.md"
+  )
+  try {
+    const markdown = await readFile(translatedPath, "utf-8")
+    return { markdown, isTranslated: true }
+  } catch {
+    // Fall back to English
+    const defaultPath = path.join(contentPath, slug, "index.md")
+    const markdown = await readFile(defaultPath, "utf-8")
+    return { markdown, isTranslated: false }
   }
 }


### PR DESCRIPTION
## Summary

- Replace dynamic `import()` with `fs/promises.readFile()` for loading translation JSON files and markdown content
- Reduces webpack memory consumption during build by avoiding chunk creation for thousands of potential import paths

## Motivation

The build was exceeding memory limits on Netlify after recent i18n imports added translations for Bengali, Polish, Urdu, Ukrainian, German, Marathi, and Turkish.

**Root cause**: Dynamic imports like `await import(.../${locale}/${ns}.json)` force webpack to analyze and create chunks for all possible paths at build time:
- 60+ locales × 50 namespaces = ~3,000 JSON import possibilities
- 4,255 MD files with locale variants = thousands more

**Solution**: Use `fs.readFile()` which is a runtime operation, bypassing webpack's module resolution entirely.

## Test plan

- [x] Verify build completes without memory errors on Netlify
- [x] Verify translations load correctly on dev and production
- [x] Verify markdown content renders correctly