### PR TITLE
docs: add Stork to oracles page

### DIFF
--- a/public/content/developers/docs/oracles/index.md
+++ b/public/content/developers/docs/oracles/index.md
@@ -408,7 +408,7 @@ There are multiple oracle applications you can integrate into your Ethereum dapp
 
 **[Gas Network](https://gas.network/)** - A distributed oracle platform providing real-time gas price data across blockchain. By bringing data from leading gas price data providers onchain, Gas Network is helping to drive interoperability. Gas Network supports data for over 35 chains, including Ethereum Mainnet and many leading L2s.
 
-**[Stork](https://stork.network)** - *Stork delivers price data at ultra-low latency, supporting a wide range of use cases including perpetuals markets, lending protocols, and DeFi ecosystems, with new assets supported rapidly on listing.*
+**[Stork](https://stork.network)** - Stork delivers price data at ultra-low latency, supporting a wide range of use cases including perpetuals markets, lending protocols, and DeFi ecosystems, with new assets supported rapidly on listing.
 
 ## Further reading {#further-reading}
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

Added Stork as an oracle provider that supports Ethereum projects, with details on its features and use cases.

## Description

<!--- Describe your changes in detail -->

Adding Stork as an oracle provider to the oracles documentation page. This is a straightforward addition following the existing format of other oracle entries (Chainlink, Pyth, etc.).

Stork provides ultra-low latency price feeds for DeFi applications.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
