### PR TITLE
fix: deduplicate block explorer lists

### DIFF
--- a/public/content/developers/docs/data-and-analytics/block-explorers/index.md
+++ b/public/content/developers/docs/data-and-analytics/block-explorers/index.md
@@ -13,19 +13,19 @@ You should understand the basic concepts of Ethereum so you can make sense of th
 
 ## Services {#services}
 
-- [Blockchair](https://blockchair.com/ethereum) -_Private Ethereum explorer. Also for sorting and filtering (mempool) data. Available in Spanish, French, Italian, Dutch, Portuguese, Russian, Chinese, and Farsi_
+- [Blockchair](https://blockchair.com/ethereum) - Private Ethereum explorer. Also for sorting and filtering (mempool) data. Available in Spanish, French, Italian, Dutch, Portuguese, Russian, Chinese, and Farsi
 - [Chainlens](https://www.chainlens.com/)
 - [DexGuru Block Explorer](https://ethereum.dex.guru/)
 - [Etherchain](https://www.etherchain.org/)
-- [Etherscan](https://etherscan.io/) -_Also available in Chinese, Korean, Russian, and Japanese_
-- [Ethplorer](https://ethplorer.io/) -_A block explorer with a focus on tokens. Also available in Chinese, Spanish, French, Turkish, Russian, Korean and Vietnamese_
+- [Etherscan](https://etherscan.io/) - Also available in Chinese, Korean, Russian, and Japanese
+- [Ethplorer](https://ethplorer.io/) - A block explorer with a focus on tokens. Also available in Chinese, Spanish, French, Turkish, Russian, Korean and Vietnamese
 - [Ethseer](https://ethseer.io)
 - [EthVM](https://www.ethvm.com/)
 - [OKLink](https://www.oklink.com/eth)
 
 ## Open source tools {#open-source-tools}
 
-- [3xpl](https://3xpl.com/ethereum) -_An ad-free Ethereum explorer that allows downloading its datasets (open-core: core modules are open source)_
+- [3xpl](https://3xpl.com/ethereum) - An ad-free Ethereum explorer that allows downloading its datasets (open-core: core modules are open source)
 - [Beaconcha.in](https://beaconcha.in/)
 - [Blockscout](https://eth.blockscout.com/)
 - [lazy-etherscan](https://github.com/woxjro/lazy-etherscan)


### PR DESCRIPTION
## Summary

- Remove duplicate "Block explorers" section that repeated entries already listed under "Services"
- Merge useful descriptions from removed section into the top listings
- Recategorize open-source explorers into the "Open source tools" section
- Drop deprecated Kovan testnet reference from Ethplorer
- Alphabetize both lists

## Open-source recategorization

Moved three explorers from "Services" to "Open source tools" based on publicly available source code:

| Explorer | License | Source |
|---|---|---|
| **Blockscout** | GPL-3.0 | [blockscout/blockscout](https://github.com/blockscout/blockscout), [blockscout/frontend](https://github.com/blockscout/frontend) |
| **Beaconcha.in** | GPL-3.0 | [gobitfly/eth2-beaconchain-explorer](https://github.com/gobitfly/eth2-beaconchain-explorer), [gobitfly/beaconchain](https://github.com/gobitfly/beaconchain) |
| **3xpl** | MIT (open-core) | [3xplcom/Core](https://github.com/3xplcom/Core) — core data modules are open source; frontend is not published |
