### PR TITLE
fix(content): repair broken markdown table in restaking page

### DIFF
--- a/public/content/restaking/index.md
+++ b/public/content/restaking/index.md
@@ -79,17 +79,13 @@ In this world with restaking, both the AVS and staker benefit from being able to
 
 There are several entities involved in restaking — each one of them plays an important part.
 
-| **Term**                | **Description**                                                                                                                                                                                                                    |
-| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Restaking platforms** | A restaking platform is a service that connects AVSs, ETH stakers, and operators. They build decentralized applications for stakers to restake their ETH, and marketplaces where stakers, AVSs, and operators can find each other. |
-| **Native restakers**    | People who stake their ETH by running their own Ethereum validators can connect their staked ETH to a restaking platform, including EigenLayer and others, to earn restaking rewards on top of ETH validator rewards.              |
-
-|
-| **Liquid restakers** | People who stake their ETH via a third-party liquid staking provider, like Lido or Rocket Pool, get Liquid Staking Tokens (LSTs) that represent their staked ETH. They can restake these LSTs to earn restaking rewards while keeping their original ETH staked.  
-|
-| **Operators** | Operators run the AVSs' restaking software, performing the validation tasks each AVS requires. Operators are usually professional service providers that guarantee things like uptime and performance. Like non-operator restakers, operators use staked ETH to secure AVSs, but operators also receive extra rewards in exchange for their work.  
-|
-| **AVSs** | These are the decentralized services — like price oracles, token bridges, and data systems — that receive security from restakers and offer token rewards in return. |
+| **Term**                | **Description**                                                                                                                                                                                                                                                                                                                                   |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Restaking platforms** | A restaking platform is a service that connects AVSs, ETH stakers, and operators. They build decentralized applications for stakers to restake their ETH, and marketplaces where stakers, AVSs, and operators can find each other.                                                                                                                |
+| **Native restakers**    | People who stake their ETH by running their own Ethereum validators can connect their staked ETH to a restaking platform, including EigenLayer and others, to earn restaking rewards on top of ETH validator rewards.                                                                                                                             |
+| **Liquid restakers**    | People who stake their ETH via a third-party liquid staking provider, like Lido or Rocket Pool, get Liquid Staking Tokens (LSTs) that represent their staked ETH. They can restake these LSTs to earn restaking rewards while keeping their original ETH staked.                                                                                  |
+| **Operators**           | Operators run the AVSs' restaking software, performing the validation tasks each AVS requires. Operators are usually professional service providers that guarantee things like uptime and performance. Like non-operator restakers, operators use staked ETH to secure AVSs, but operators also receive extra rewards in exchange for their work. |
+| **AVSs**                | These are the decentralized services — like price oracles, token bridges, and data systems — that receive security from restakers and offer token rewards in return.                                                                                                                                                                              |
 
 <br/>
 


### PR DESCRIPTION
## Description

Fix "How does restaking work?" table where missing closing pipes, orphan pipe lines, and a blank line mid-table broke the table into fragments instead of rendering as a single contiguous table.


## Related Issue
Fixes issues related to i18n translations of the restaking/index.md file