### PR TITLE
fix(ab-test): extract client IP from x-forwarded-for header

### DIFF
--- a/src/lib/ab-testing/server.ts
+++ b/src/lib/ab-testing/server.ts
@@ -28,8 +28,11 @@ export const getABTestAssignment = async (
   const headers = await import("next/headers").then((m) => m.headers())
 
   // Get IP and user agent (primary identifier)
+  // x-forwarded-for contains: "client_ip, proxy1, proxy2, ..." - extract only client IP
   const forwardedFor =
-    headers.get("x-forwarded-for") || headers.get("x-real-ip") || "unknown"
+    headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+    headers.get("x-real-ip") ||
+    "unknown"
   const userAgent = headers.get("user-agent") || ""
 
   // Add privacy-preserving entropy sources


### PR DESCRIPTION
## Summary

Fixes non-deterministic A/B test variant assignment caused by the Cloudflare proxy layer.

**Problem:** The `x-forwarded-for` header contains a comma-separated list of IPs: `"client_ip, proxy1, proxy2, cdn_edge"`. With Cloudflare in front, the proxy IPs change between requests (different edge nodes handle different requests), causing different fingerprints and non-deterministic variant assignment for the same user.

**Fix:** Extract only the first IP (the actual client IP) for stable fingerprinting.

## Test plan

- [x] Verified in production with debug logging that client IP is now stable across requests
- [x] Confirmed variant assignment is deterministic after the fix