### PR TITLE
docs(revoke-access): correct wrong Blockscout URL

### DIFF
--- a/public/content/guides/how-to-revoke-token-access/index.md
+++ b/public/content/guides/how-to-revoke-token-access/index.md
@@ -19,7 +19,7 @@ The only protections are to refrain from using untested new projects, only appro
 Several websites let you view and revoke smart contracts connected to your address. Visit the website and connect your wallet:
 
 - [Etherscan](https://etherscan.io/tokenapprovalchecker) (Ethereum)
-- [Blockscout](https://eth.blockscout.com/apps/revokescout) (Ethereum)
+- [Blockscout](https://eth.blockscout.com/essential-dapps/revoke) (Ethereum)
 - [Revoke](https://revoke.cash/) (multiple networks)
 - [Unrekt](https://app.unrekt.net/) (multiple networks)
 - [EverRevoke](https://everrise.com/everrevoke/) (multiple networks)

--- a/public/content/translations/es/guides/how-to-revoke-token-access/index.md
+++ b/public/content/translations/es/guides/how-to-revoke-token-access/index.md
@@ -19,7 +19,7 @@ Las únicas protecciones son abstenerse de utilizar nuevos proyectos no probados
 Existen varios sitios web que le permiten ver y revocar contratos inteligentes conectados a su dirección. Visite el sitio web y conecte su cartera:
 
 - [Etherscan](https://etherscan.io/tokenapprovalchecker) (Ethereum)
-- [Blockscout](https://eth.blockscout.com/apps/revokescout) (Ethereum)
+- [Blockscout](https://eth.blockscout.com/essential-dapps/revoke) (Ethereum)
 - [Revoke](https://revoke.cash/) (múltiples redes)
 - [Unrekt](https://app.unrekt.net/) (múltiples redes)
 - [EverRevoke](https://everrise.com/everrevoke/) (múltiples redes)

--- a/public/content/translations/te/guides/how-to-revoke-token-access/index.md
+++ b/public/content/translations/te/guides/how-to-revoke-token-access/index.md
@@ -19,7 +19,7 @@ lang: te
 అనేక వెబ్‌సైట్‌లు మీ చిరునామాకు కనెక్ట్ చేయబడిన స్మార్ట్ కాంట్రాక్ట్‌లను వీక్షించడానికి మరియు రద్దు చేయడానికి మిమ్మల్ని అనుమతిస్తాయి. వెబ్‌సైట్‌ను సందర్శించి, మీ వాలెట్‌ను కనెక్ట్ చేయండి:
 
 - [Etherscan](https://etherscan.io/tokenapprovalchecker) (ఇతీరియము)
-- [Blockscout](https://eth.blockscout.com/apps/revokescout) (ఇతీరియము)
+- [Blockscout](https://eth.blockscout.com/essential-dapps/revoke) (ఇతీరియము)
 - [Revoke](https://revoke.cash/) (బహుళ నెట్‌వర్క్‌లు)
 - [Unrekt](https://app.unrekt.net/) (బహుళ నెట్‌వర్క్‌లు)
 - [EverRevoke](https://everrise.com/everrevoke/) (బహుళ నెట్‌వర్క్‌లు)

--- a/public/content/translations/tr/guides/how-to-revoke-token-access/index.md
+++ b/public/content/translations/tr/guides/how-to-revoke-token-access/index.md
@@ -19,7 +19,7 @@ Buna karşı biricik korunma yolları test edilmemiş yeni projeleri kullanmakta
 Bazı web siteleri adresinize bağlı akıllı sözleşmeleri görmenize ve kaldırmanıza olanak sağlar. Web sitesini ziyaret edin ve cüzdanınızı bağlayın:
 
 - [Etherscan](https://etherscan.io/tokenapprovalchecker) (Ethereum)
-- [Blockscout](https://eth.blockscout.com/apps/revokescout) (Ethereum)
+- [Blockscout](https://eth.blockscout.com/essential-dapps/revoke) (Ethereum)
 - [Revoke](https://revoke.cash/) (birden çok ağ)
 - [Unrekt](https://app.unrekt.net/) (birden çok ağ)
 - [EverRevoke](https://everrise.com/everrevoke/) (birden çok ağ)

--- a/public/content/translations/zh/guides/how-to-revoke-token-access/index.md
+++ b/public/content/translations/zh/guides/how-to-revoke-token-access/index.md
@@ -19,7 +19,7 @@ lang: zh
 有几个网站允许你查看与你钱包地址关联的智能合约，并进行撤销。 访问以下网站并连接到你的钱包：
 
 - [Etherscan](https://etherscan.io/tokenapprovalchecker) (以太坊)
-- [Blockscout](https://eth.blockscout.com/apps/revokescout) (以太坊)
+- [Blockscout](https://eth.blockscout.com/essential-dapps/revoke) (以太坊)
 - [Revoke](https://revoke.cash/) (多个网络)
 - [Unrekt](https://app.unrekt.net/) (多个网络)
 - [EverRevoke](https://everrise.com/everrevoke/) (多个网络)


### PR DESCRIPTION
The [how to revoke smart contract access article](https://ethereum.org/guides/how-to-revoke-token-access/) provides a Blockscout URL that returns 404. This PR provides the right URL instead.