### PR TITLE
fix(ab-test): add custom dimension for segment queries

### DIFF
--- a/src/components/AB/TestTracker.tsx
+++ b/src/components/AB/TestTracker.tsx
@@ -35,6 +35,8 @@ export function ABTestTracker({ assignment }: ABTestTrackerProps) {
         variation: assignment.variant,
       },
     ] as [string, Record<string, string>])
+    // Set custom dimension for segment queries (e.g., dimension1==Original)
+    push(["setCustomDimension", 1, assignment.variant])
   }, [assignment])
 
   return null // This component doesn't render anything


### PR DESCRIPTION
## Summary
- Adds `setCustomDimension` call to track A/B test variant in Matomo's custom dimension 1
- Enables querying variants via segment queries (e.g., `dimension1==Original`)
- Fixes issue where Original variation returned empty for segment queries

## Test plan
- [ ] Verify Matomo receives custom dimension data after deploy
- [ ] Confirm segment query `dimension1==Original` returns results