### PR TITLE
fix: use documented DefiLlama endpoint for DeFi TVL

### DIFF
--- a/src/data-layer/fetchers/fetchTotalValueLocked.ts
+++ b/src/data-layer/fetchers/fetchTotalValueLocked.ts
@@ -7,7 +7,7 @@ export const FETCH_TOTAL_VALUE_LOCKED_TASK_ID = "fetch-total-value-locked"
  * Returns the latest total liquidity USD value for Ethereum.
  */
 export async function fetchTotalValueLocked(): Promise<MetricReturnData> {
-  const url = "https://api.llama.fi/charts/Ethereum"
+  const url = "https://api.llama.fi/v2/historicalChainTvl/Ethereum"
 
   console.log("Starting total value locked data fetch from DefiLlama")
 
@@ -26,7 +26,7 @@ export async function fetchTotalValueLocked(): Promise<MetricReturnData> {
   }
 
   // Today's value at end of array
-  const value = json[json.length - 1].totalLiquidityUSD
+  const value = json[json.length - 1].tvl
   const timestamp = Date.now()
 
   console.log("Successfully fetched total value locked data", {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -588,8 +588,8 @@ export type EtherscanTxCountResponse = {
 }
 
 export type DefiLlamaTVLResponse = {
-  date: string
-  totalLiquidityUSD: number
+  date: number
+  tvl: number
 }[]
 
 export type MetricReturnData = ValueOrError<number>


### PR DESCRIPTION
## Summary

- Switch from undocumented `/charts/Ethereum` endpoint to documented `/v2/historicalChainTvl/Ethereum`
- The old endpoint was returning 403 errors and showed ~$99B (unclear methodology)
- The new documented endpoint returns verified DeFi-only TVL (~$51B), which correctly matches the "Value locked in DeFi" label in the home page

## Context

The previous undocumented endpoint returned a mystery number (~$99B) that didn't add up:
- DeFi TVL: ~$51B
- Staked ETH: ~$68B
- Neither sum explains $99B

Now using the documented endpoint that returns accurate, verifiable DeFi TVL.

## Test plan

- [x] Verify the TVL stat loads correctly on the homepage
- [x] Confirm the displayed value (~$51B) matches DefiLlama's chain page