### PR TITLE
Replace beaconscan slot/epoch links with beaconcha.in on history page

### DIFF
--- a/src/components/History/NetworkUpgradeSummary.tsx
+++ b/src/components/History/NetworkUpgradeSummary.tsx
@@ -80,13 +80,13 @@ const NetworkUpgradeSummary = ({ name }: NetworkUpgradeSummaryProps) => {
       {epochNumber &&
         blockTypeTranslation(
           "page-history:page-history-epoch-number",
-          "https://beaconscan.com/epoch/",
+          "https://beaconcha.in/epoch/",
           epochNumber
         )}
       {slotNumber &&
         blockTypeTranslation(
           "page-history:page-history-slot-number",
-          "https://beaconscan.com/slot/",
+          "https://beaconcha.in/slot/",
           slotNumber
         )}
       {ethPriceInUSD && (


### PR DESCRIPTION
## Description

Updated the history page link targets for consensus-layer references:

- `Epoch number` links now point to `https://beaconcha.in/epoch/{epoch}`
- `Slot number` links now point to `https://beaconcha.in/slot/{slot}`

Reason for change: `beaconscan` is no longer maintained, so these backlinks should use an actively maintained explorer (`beaconcha.in`).

Code change was made in:
- `src/components/History/NetworkUpgradeSummary.tsx`
