### PR TITLE
chore: remove unused releasesData export and CoinGecko logs

### DIFF
--- a/app/[locale]/stablecoins/page.tsx
+++ b/app/[locale]/stablecoins/page.tsx
@@ -105,7 +105,7 @@ async function Page({ params }: { params: PageParams }) {
       .map(({ id, ...rest }) => {
         const coinMarketData = stablecoinsData.find((coin) => coin.id === id)
         if (!coinMarketData) {
-          console.warn("CoinGecko stablecoin data not found:", id)
+          // CoinGecko data may not include all configured stablecoins
           return null
         }
         return { ...coinMarketData, ...rest }

--- a/src/data/roadmap/releases.tsx
+++ b/src/data/roadmap/releases.tsx
@@ -190,11 +190,3 @@ export const getReleasesData = (t: TranslationFunction): Release[] => [
     forkcast_href: "https://forkcast.org/upgrade/glamsterdam",
   },
 ]
-
-// Legacy export for backward compatibility - uses hardcoded English strings
-export const releasesData: Release[] = getReleasesData((key: string) => {
-  // This is a fallback that returns the key itself if translations aren't available
-  // In practice, this should not be used in the actual app
-  console.warn(`Translation key ${key} used without translation function`)
-  return key
-})


### PR DESCRIPTION
## Summary
- Remove the unused legacy `releasesData` named export from `releases.tsx` — all consumers use `getReleasesData(t)` directly, making this dead code that logged warnings for every translation key
- Replace the noisy `console.warn` for missing CoinGecko stablecoin data with a silent comment, since missing coins are expected behavior

## Preview link
https://deploy-preview-17680.ethereum.it/roadmap
https://deploy-preview-17680.ethereum.it/stablecoins

## Test plan
- [x] Verify `pnpm build` succeeds with no regressions
- [x] Confirm roadmap page renders release data correctly via `getReleasesData(t)`
- [x] Confirm stablecoins page renders without console warnings for missing coins