### PR TITLE
patch: added `sizes` for stablecoin thumbnails

### DIFF
--- a/src/components/StablecoinsTable.tsx
+++ b/src/components/StablecoinsTable.tsx
@@ -335,6 +335,7 @@ const StablecoinsTable = ({ content, hasError }: StablecoinsTableProps) => {
                           src={image}
                           alt=""
                           className="me-4 h-6 w-6"
+                          sizes="24px"
                           width={24}
                           height={24}
                         />


### PR DESCRIPTION
## Description
Adds missing `sizes` prop for next Image on stablecoins table