### PR TITLE
patch(ui): use 14px font-size on breadcrumbs

### DIFF
--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -21,7 +21,7 @@ const BreadcrumbList = React.forwardRef<
   <ol
     ref={ref}
     className={cn(
-      "m-0 flex list-none flex-wrap items-center tracking-wider",
+      "m-0 flex list-none flex-wrap items-center text-sm tracking-wider",
       className
     )}
     {...props}


### PR DESCRIPTION
## Description
- Decrease ui/breadcrumb font-size to 14px from 16px

## Preview links
https://deploy-preview-17697.ethereum.it/staking/solo
https://deploy-preview-17697.ethereum.it/community/events

cc: @konopkja 