### PR TITLE
fix: apply `select-none` to external link text

### DIFF
--- a/src/components/ui/Link.tsx
+++ b/src/components/ui/Link.tsx
@@ -133,8 +133,9 @@ export const BaseLink = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
         ) : (
           children
         )}
-        <span className="sr-only">
-          {isMailto ? "opens email client" : "opens in a new tab"}
+        <span className="sr-only select-none">
+          &nbsp;
+          {isMailto ? "(opens email client)" : "(opens in a new tab)"}
         </span>
         {!hideArrow && !isMailto && <ExternalLinkIcon />}
       </a>


### PR DESCRIPTION
## Description
- Prevents inclusion of "opens in a new tab" when copy/pasting text that includes links using `select-none `
- Treats this text as parenthetical (adds parentheses) to improve readability by screen readers
