### PR TITLE
Fix: lowercase ethereum.org in breadcrumb and footer

### DIFF
--- a/src/components/Breadcrumbs/index.tsx
+++ b/src/components/Breadcrumbs/index.tsx
@@ -59,7 +59,7 @@ const Breadcrumbs = ({ slug, startDepth = 0, ...props }: BreadcrumbsProps) => {
       ? [
           {
             fullPath: "/",
-            text: "Ethereum.org",
+            text: "ethereum.org",
           },
         ]
       : []),

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -327,7 +327,7 @@ const Footer = async ({ lastDeployLocaleTimestamp }: FooterProps) => {
           href="/"
           className="text-lg font-bold no-underline hover:text-primary"
         >
-          Ethereum.org
+          ethereum.org
         </BaseLink>
       </div>
 


### PR DESCRIPTION
## Summary
- Lowercased "Ethereum.org" to "ethereum.org" in the breadcrumb home link and footer site name to match the project's branding conventions

## Test plan
- ~~[ ] Verify breadcrumb displays "ethereum.org" on any subpage~~
- [x] Verify footer displays "ethereum.org"

🤖 Generated with [Claude Code](https://claude.com/claude-code)