### PR TITLE
feat(ui): update tutorials layout

### DIFF
--- a/src/layouts/Tutorial.tsx
+++ b/src/layouts/Tutorial.tsx
@@ -107,9 +107,9 @@ export const TutorialLayout = ({
   const absoluteEditPath = getEditPath(slug)
 
   return (
-    <div className="flex w-full gap-8 border-b bg-background p-8 lg:mx-auto lg:bg-background-highlight lg:shadow">
+    <div className="flex w-full gap-8">
       <MainArticle
-        className="min-w-0 max-w-[1000px] rounded bg-background p-0 lg:p-16 lg:shadow"
+        className="min-w-0 max-w-screen-lg px-8 lg:py-8"
         dir={contentNotTranslated ? "ltr" : "unset"}
       >
         <Heading1>{frontmatter.title}</Heading1>
@@ -131,7 +131,7 @@ export const TutorialLayout = ({
       </MainArticle>
       {tocItems && (
         <TableOfContents
-          className="pt-8"
+          className="pt-16"
           items={tocItems}
           maxDepth={frontmatter.sidebarDepth!}
           editPath={absoluteEditPath}


### PR DESCRIPTION
## Description
- Remove padded "page" appearance and background
- Adjust margins and standardize width

## Preview link
https://deploy-preview-17703.ethereum.it/developers/tutorials/all-you-can-cache

## Screenshots

<img width="1292" height="1086" alt="image" src="https://github.com/user-attachments/assets/af0ebbbe-bf37-4429-89c5-d52dec7ae1a7" />

<img width="374" height="664" alt="image" src="https://github.com/user-attachments/assets/e4c643c0-e72c-4b3d-8539-a27b9977b682" />

cc: @konopkja 