### PR TITLE
Upload developer tool images to S3 during data sync

### DIFF
--- a/src/data-layer/fetchers/developer-tools/index.ts
+++ b/src/data-layer/fetchers/developer-tools/index.ts
@@ -1,3 +1,5 @@
+import { uploadToS3 } from "../../s3"
+
 import { fetchBuidlGuidl } from "./fetchBuidlGuidl"
 import { fetchGitHub } from "./fetchGitHub"
 import { fetchNpmJs } from "./fetchNpmJs"
@@ -44,18 +46,22 @@ export async function fetchDeveloperTools(): Promise<DeveloperToolsDataEnvelope>
   const enrichedData = await fetchNpmJs(withGitHub)
   console.log("Enriched with npm data")
 
-  // Step 4: Build lookup map
+  // Step 4: Upload external images to S3
+  const withImages = await uploadToolImages(enrichedData)
+  console.log("Uploaded developer tool images to S3")
+
+  // Step 5: Build lookup map
   const toolsById: Record<string, DeveloperTool> = Object.fromEntries(
-    enrichedData.map((tool) => [tool.id, tool])
+    withImages.map((tool) => [tool.id, tool])
   )
   console.log(
     `Built toolsById lookup with ${Object.keys(toolsById).length} tools`
   )
 
-  // Step 5: Compute randomized selections
-  const highlightsByCategory = getHighlightsByCategory(enrichedData)
+  // Step 6: Compute randomized selections
+  const highlightsByCategory = getHighlightsByCategory(withImages)
   const mainPageHighlights = getMainPageHighlights(highlightsByCategory)
-  const dataByCategory = transformDeveloperToolsData(enrichedData)
+  const dataByCategory = transformDeveloperToolsData(withImages)
   const categoryPreviews = getRandomPreviewsByCategory(dataByCategory)
 
   const selections: DeveloperToolsComputedSelections = {
@@ -81,4 +87,23 @@ export async function fetchDeveloperTools(): Promise<DeveloperToolsDataEnvelope>
 
   console.log("Developer tools data enrichment complete")
   return { toolsById: toolsById, selections }
+}
+
+async function uploadToolImages(
+  tools: DeveloperTool[]
+): Promise<DeveloperTool[]> {
+  return Promise.all(
+    tools.map(async (tool) => {
+      const thumbnail_url = tool.thumbnail_url
+        ? ((await uploadToS3(tool.thumbnail_url, "devtools/thumbnails")) ??
+          tool.thumbnail_url)
+        : tool.thumbnail_url
+      const banner_url = tool.banner_url
+        ? ((await uploadToS3(tool.banner_url, "devtools/banners")) ??
+          tool.banner_url)
+        : tool.banner_url
+
+      return { ...tool, thumbnail_url, banner_url }
+    })
+  )
 }


### PR DESCRIPTION
## Summary
- Adds S3 image upload step to the developer tools data enrichment pipeline
- Uploads `thumbnail_url` and `banner_url` images to S3 under `devtools/thumbnails/` and `devtools/banners/` prefixes
- Falls back to original URL if S3 upload fails, preserving highlight filtering behavior
- Mirrors the existing pattern used in `fetchEvents.ts` for event images

## Test plan
- [ ] Verify developer tools data sync completes successfully with S3 uploads
- [ ] Confirm tool images render correctly from S3 URLs on `/developers/tools`
- [ ] Verify fallback to original URL works when S3 upload fails