### PR TITLE
feat(data-layer): configurable blob store name via env var

### DIFF
--- a/src/data-layer/.env.example
+++ b/src/data-layer/.env.example
@@ -32,6 +32,7 @@
 # Required for reading/writing data to Netlify Blobs when USE_MOCK_DATA=false
 # SITE_ID=your-netlify-site-id
 # NETLIFY_BLOBS_TOKEN=your-netlify-blobs-token
+# BLOB_STORE_NAME=data-layer-dev  # Blob store name (default: "data-layer" for prod)
 
 # Google APIs (Calendar events, Apps/Dapps sheet, Community picks)
 # GOOGLE_API_KEY=your-google-api-key

--- a/src/data-layer/docs.md
+++ b/src/data-layer/docs.md
@@ -88,6 +88,7 @@ Always handle `null` returns with fallback values.
 **Production:**
 - `SITE_ID` - Netlify site ID (auto-provided)
 - `NETLIFY_BLOBS_TOKEN` - Netlify Blobs access token
+- `BLOB_STORE_NAME` - Blob store name (default: `data-layer`). Use `data-layer-dev` for dev environments.
 - `TRIGGER_PROJECT_ID` - Trigger.dev project ID
 
 **S3 Image Storage:**

--- a/src/data-layer/storage.ts
+++ b/src/data-layer/storage.ts
@@ -22,8 +22,10 @@ function getBlobs() {
     throw new Error("Missing SITE_ID or NETLIFY_BLOBS_TOKEN")
   }
 
+  const storeName = process.env.BLOB_STORE_NAME || "data-layer"
+
   blobStore = getStore({
-    name: "data-layer",
+    name: storeName,
     siteID,
     token,
   } as Parameters<typeof getStore>[0])


### PR DESCRIPTION
## Summary
- Add `BLOB_STORE_NAME` env var to `storage.ts` to allow configuring the Netlify Blobs store name
- Defaults to `data-layer` (prod); set to `data-layer-dev` for dev/preview environments
- Updated `.env.example` and `docs.md` with the new variable

## Test plan
- [ ] Verify prod builds work without `BLOB_STORE_NAME` set (defaults to `data-layer`)
- [ ] Verify dev environment uses `data-layer-dev` when `BLOB_STORE_NAME=data-layer-dev`