### PR TITLE
fix: add ErrorBoundary to Search modal and fix MobileMenu error recovery

### DIFF
--- a/src/components/Nav/MobileMenu/MobileMenuClient.tsx
+++ b/src/components/Nav/MobileMenu/MobileMenuClient.tsx
@@ -107,15 +107,15 @@ const MobileMenuClient = ({ className, side }: MobileMenuClientProps) => {
       >
         {hasBeenOpened && (
           <ErrorBoundary
-            fallback={({ reset }) => (
+            fallback={() => (
               <div className="flex flex-1 flex-col items-center justify-center gap-4 p-8 text-center">
                 <p className="text-body-medium">{t("loading-error")}</p>
                 <div className="flex gap-3">
                   <button
                     className="rounded-md bg-primary px-4 py-2 text-sm text-white hover:bg-primary-hover"
-                    onClick={reset}
+                    onClick={() => window.location.reload()}
                   >
-                    {t("try-again")}
+                    {t("refresh")}
                   </button>
                   <button
                     className="rounded-md border border-body-light px-4 py-2 text-sm text-body hover:bg-background-highlight"

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -7,6 +7,8 @@ import { type DocSearchHit, useDocSearchKeyboardEvents } from "@docsearch/react"
 import * as Portal from "@radix-ui/react-portal"
 import { Slot } from "@radix-ui/react-slot"
 
+import { ErrorBoundary } from "@/components/ui/error-boundary"
+
 import { trackCustomEvent } from "@/lib/utils/matomo"
 import { sanitizeHitTitle } from "@/lib/utils/sanitizeHitTitle"
 import { sanitizeHitUrl } from "@/lib/utils/url"
@@ -134,7 +136,33 @@ const Search = ({ asChild = false, children }: SearchProps) => {
         </>
       )}
       <Portal.Root>
-        {isOpen && <SearchModal {...searchModalProps} />}
+        {isOpen && (
+          <ErrorBoundary
+            fallback={() => (
+              <div className="fixed inset-0 z-modal flex items-center justify-center bg-black/50">
+                <div className="mx-4 flex flex-col items-center gap-4 rounded-lg bg-background p-8 text-center shadow-lg">
+                  <p className="text-body-medium">{t("loading-error")}</p>
+                  <div className="flex gap-3">
+                    <button
+                      className="rounded-md bg-primary px-4 py-2 text-sm text-white hover:bg-primary-hover"
+                      onClick={() => window.location.reload()}
+                    >
+                      {t("refresh")}
+                    </button>
+                    <button
+                      className="rounded-md border border-body-light px-4 py-2 text-sm text-body hover:bg-background-highlight"
+                      onClick={onClose}
+                    >
+                      {t("close")}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
+          >
+            <SearchModal {...searchModalProps} />
+          </ErrorBoundary>
+        )}
       </Portal.Root>
     </>
   )


### PR DESCRIPTION
## Summary

- Wrap the dynamically-imported `SearchModal` with an `ErrorBoundary` so that a `ChunkLoadError` shows a recovery dialog ("Refresh page" / "Close") instead of crashing the entire app to a black screen
- Fix the `MobileMenu` error fallback to use `window.location.reload()` instead of `reset`, since `reset` just re-triggers the same failed dynamic import

## Context

The webpack runtime in Next.js 14 App Router uses `[chunkhash]` instead of `[contenthash]` ([vercel/next.js#78756](https://github.com/vercel/next.js/issues/78756)), so its filename can stay the same across deploys even when chunk mappings change. Browsers that cached the old runtime serve stale chunk hashes, causing 404s on lazy imports like `SearchModal`. This is fixed upstream in Next.js 15.3.4+ ([vercel/next.js#80153](https://github.com/vercel/next.js/pull/80153)).

## Test plan

- [x] Click Search button — modal opens normally
- [x] Simulate chunk load failure (e.g. block the chunk URL in DevTools) — error dialog appears with "Refresh page" and "Close" buttons instead of black screen
- [x] Click "Close" — dialog dismisses, page remains usable
- [x] Click "Refresh page" — page reloads
- [x] Open mobile menu — menu works normally
- [x] Simulate chunk failure on mobile menu — same recovery dialog behavior