### PR TITLE
feat: text version of ef mandate

### DIFF
--- a/public/content/foundation/index.md
+++ b/public/content/foundation/index.md
@@ -15,7 +15,9 @@ The EF is not a company, or even a traditional non-profit. It does not control o
 
 ## EF Mandate {#ef-mandate}
 
-The [EF Mandate](/foundation/mandate/) defines the Foundation's purpose, principles, and commitments to the Ethereum ecosystem. Published onchain, it enshrines the EF's dedication to **censorship resistance, open source, privacy, and security (CROPS)** as non-negotiable priorities.
+The EF Mandate defines the Foundation's purpose, principles, and commitments to the Ethereum ecosystem. Published onchain, it enshrines the EF's dedication to **censorship resistance, open source, privacy, and security (CROPS)** as non-negotiable priorities.
+
+[Read the Ethereum Foundation Mandate](/foundation/mandate/)
 
 ## What the EF does {#what-the-ef-does}
 

--- a/public/content/foundation/index.md
+++ b/public/content/foundation/index.md
@@ -13,6 +13,10 @@ The [Ethereum Foundation](http://ethereum.foundation/) (EF) is a non-profit orga
 
 The EF is not a company, or even a traditional non-profit. It does not control or lead Ethereum, nor is it the only organization that funds critical development of Ethereum-related technologies. The EF is one part of a much larger [ecosystem](/community/).
 
+## EF Mandate {#ef-mandate}
+
+The [EF Mandate](/foundation/mandate/) defines the Foundation's purpose, principles, and commitments to the Ethereum ecosystem. Published onchain, it enshrines the EF's dedication to **censorship resistance, open source, privacy, and security (CROPS)** as non-negotiable priorities.
+
 ## What the EF does {#what-the-ef-does}
 
 - **Protocol development** – Supporting teams working on Ethereum's core protocol, including client development, research, upgrades, and the [bug bounty program](/bug-bounty/)

--- a/public/content/foundation/mandate/index.md
+++ b/public/content/foundation/mandate/index.md
@@ -1,6 +1,6 @@
 ---
 title: Ethereum Foundation Mandate
-description: The Ethereum Foundation Mandate in text form
+description: Explore the official Ethereum Foundation Mandate, defining the Foundation's purpose, principles, and commitments to the Ethereum ecosystem.
 hideEditButton: true
 sidebarDepth: 1
 lang: en

--- a/public/content/foundation/mandate/index.md
+++ b/public/content/foundation/mandate/index.md
@@ -8,8 +8,9 @@ lang: en
 
 # The Ethereum Foundation Mandate {#mandate}
 
-- [Graphical PDF version](https://ethereum.foundation/ef-mandate.pdf)
-- [Canonically signed onchain source (via Blockscout explorer)](https://eth.blockscout.com/tx/0x5dd574df963a1df1f064791e0f6ff41ec972cdbba12293b7e1ece582052ba855) - Select "View details", under _Raw input_ selecting _UTF-8_
+This mandate was originally published by the Ethereum Foundation on 13-March-2026. Read the [original mandate here](https://ethereum.foundation/ef-mandate.pdf) in its fully-designed format.
+
+This document was placed onchain and signed by the Foundation, [visible on the Blockscout block explorer](https://eth.blockscout.com/tx/0x5dd574df963a1df1f064791e0f6ff41ec972cdbba12293b7e1ece582052ba855) (select "View details", under _Raw input_ with _UTF-8_).
 
 ## I. ETHEREUM {#i-ethereum}
 

--- a/public/content/foundation/mandate/index.md
+++ b/public/content/foundation/mandate/index.md
@@ -1,0 +1,1126 @@
+---
+title: Ethereum Foundation Mandate
+description: The Ethereum Foundation Mandate in text form
+hideEditButton: true
+sidebarDepth: 1
+lang: en
+---
+
+# The Ethereum Foundation Mandate {#mandate}
+
+- [Graphical PDF version](https://ethereum.foundation/ef-mandate.pdf)
+- [Canonically signed onchain source (via Blockscout explorer)](https://eth.blockscout.com/tx/0x5dd574df963a1df1f064791e0f6ff41ec972cdbba12293b7e1ece582052ba855) - Select "View details", under _Raw input_ selecting _UTF-8_
+
+## I. ETHEREUM {#i-ethereum}
+
+**Ethereum was born out of a dream. A dream for freedom.**
+
+Not just for one, not just for many, but for all who are ready to grasp it with
+their own hands.
+
+**Its creators realized that the armamentarium of freedom was missing two vital
+tools: self-sovereign computation, and the computational ability to coordinate
+at scale without violating anyone else’s own sacrosanct self-sovereignty.**
+
+Only if a user had the final say over their own computation - their data, their
+assets, their instructions, their identities, their agents, their essential
+digital gestalt, and the right to exit from any system that proves unfavorable
+to those things - would they have any chance in the brave new electronic world,
+of being able to live in the way they truly want and deserve.
+
+If you want only self-sovereignty of computation, and do not need to coordinate,
+then you can run applications locally on your own machine - and in many
+situations this is the correct approach. If you want to coordinate, but do not
+mind being at the whims of centralized, unaccountable power, then we will only
+say that centralized platforms can often provide excellent user experience.
+
+The value of Ethereum is precisely in the space of computational needs where we
+need both.
+
+Money was the first application. Money requires coordination, because it has no
+meaning without someone else to recognize both the asset itself, and the
+blockchain as a living registry of who owns that asset. And money requires self-
+sovereignty, because the losses from having one’s money arbitrarily inflated
+away, frozen or simply expropriated are so high.
+
+Ether is a store of value and money, that also happens to be an application -
+and there have been, and will be, many, many more. This includes those imagined
+in the Ethereum Whitepaper, those described and built over the last twelve
+years, and others not yet conceived of - and Ethereum will be home to all of
+them.
+
+**Ethereum honors its first promise, to enable self-sovereignty, by being
+humanity’s common computational substrate that anyone can interact with
+trustlessly, permissionlessly, and persistently.**
+
+**This is what is meant by “The World Computer.”**
+
+**On this foundation Ethereum honors its second promise: allowing the
+infrastructures of self-sovereign coordination to arise and thrive in any form
+imaginable and expressible - unmolested, unimpeded, and undisturbed - without
+violating any individual’s freedom.**
+
+Ethereum is meant to be a liberatory technology - not just from power relations
+that are imposed without true consent or where dissent imposes a heavy price,
+but even more importantly, from attempts to order reality itself in a way that
+leaves no alternative.
+
+And the Ethereum Foundation exists to ensure Ethereum remains resilient enough
+to be so.
+
+## II. OUR ROLE {#ii-our-role}
+
+**The Ethereum Foundation is the original steward of the Ethereum project.**
+
+We helped grow Ethereum from its early days as a seedling software project into
+today’s infinite garden that countless participants use to grow their own
+projects - and we did this by making deliberate, considered choices, with the
+aim of inspiring others to become fellow custodians of a vibrant, open, and
+infinite commons.
+
+The underlying principles that led us to conceive of, invent, then steward
+Ethereum, and the unwavering belief that it is possible to build and maintain a
+better world without caprice or coercion - could have led to many destinations
+other than Ethereum, whether in computing, communications, artificial
+intelligence, education, health, expression in all its forms, and many other
+domains.
+
+By asking ourselves “if we had these principles, and we operated in a different
+domain, what would we create?”, then seeing what things in our existing world
+come closest, we can start to find our natural allies.
+
+But to find dependable allies, not merely allies of convenience that remain for
+only one finite round of the infinite game, we need to be clear about what our
+principles are, and this document is where we express and enshrine them.
+
+**The Foundation is not the parent, owner, or ruler of Ethereum. We are not “the
+system” itself.**
+
+Our role is to coordinate, to provide substrate, and to offer context that helps
+anyone who shares our purpose to work together - without creating a centralizing
+bottleneck, and without collapsing into a monoculture that drifts toward goals
+misaligned with Ethereum’s core promises.
+
+The Foundation exists to ensure Ethereum becomes, and stays, a decentralized and
+resilient civilizational foundational infrastructure - part of the bedrock on
+which broader self-sovereignty can be built, alongside other requirements like
+clean air, water, energy, freedom of communication, and access to knowledge.
+
+**Our ultimate goal is for Ethereum to pass the _walkaway_ test:** its protocol and
+core application layers become robust and trustless enough that they would
+continue to reliably function and evolve even if the Foundation and today’s core
+developers disappeared tomorrow.
+
+**We are a real non-profit - independent, with no other agenda.** We reject
+temptations around flows of value, even when they are framed as reasonable
+rewards, or as necessary for alignment or self-perpetuation. We consider them
+antithetical to our mission and our legal constitution. These are slippery
+slopes to arbitrary extraction and insidious capture, with many such cases
+exemplified elsewhere. **Our enduring assets are our legitimacy and virtue, and we
+will not risk or squander them.**
+
+Our bottom line is not profit, nor organizational growth, nor blind adoption at
+all costs. We support adoption insofar as it does not contravene our mandate.
+
+**Our bottom line is the mission of securing Ethereum’s resilience.**
+
+Our primary and secondary measures of success are how much self-sovereignty, and
+how much sovereignty-preserving coordination at scale, Ethereum resiliently
+enables - both with and without the Foundation.
+
+**This document is primarily for members of the Foundation: a clarification of our
+pre-existing purpose, and a practical guide for translating mission and
+principles into action, in the context of not just being stewards of Ethereum
+but also fellow travelers on the path of freedom, empowerment, and human well-
+being.**
+
+We write it for the present onwards. We acknowledge we have not always succeeded
+in the past, but we will succeed going forward.
+
+## III. OUR MANDATE {#iii-our-mandate}
+
+**The Ethereum Foundation’s mandate is twofold.**
+
+**The first aim is to ensure Ethereum becomes and stays a decentralized and
+resilient tool for self-sovereignty: our first fundamental principle is that a
+user has the final say over their identities, assets, actions, and agents.**
+
+It is certain that Ethereum will be used in many other ways, but we believe
+applications only become truly meaningful if they rest on this inalienable
+foundation of user self-sovereignty.
+
+**It is therefore necessary for us to ensure that Ethereum upholds and contains
+the following properties:**
+
+- **Censorship Resistance**
+- **Open Source and Free, as in Freedom**
+- **Privacy**
+- **Security**
+
+**We hold that these properties - CROPS - must remain, as an indivisible whole,
+the sine qua non of all Ethereum’s development priorities, which cannot be
+displaced.**
+
+**They are Ethereum’s most important properties and are inseparable from its
+success.**
+
+**Therefore, we ourselves must embody these properties as a guiding principle and
+prioritize them in all our decisions.**
+
+**The second aim is scaling the guaranteed availability of self-sovereignty to
+users ready to exercise it directly.**
+
+**This is our second fundamental principle: that unstoppable self-sovereignty must
+become possible for those who choose it, at the scale and in the form that they
+want it, without violating anyone else’s.**
+
+We believe that self-sovereignty is positive, is positive-sum, and that self-
+sovereignty at scale is the dominant positive-sum strategy.
+
+We believe that self-sovereignty is competitively scalable without compromise on
+CROPS, and that sovereignty-preserving coordination at scale is possible.
+
+We believe that self-sovereignty stacks on top of itself on multiple overlapping
+scales: individuals, families, local communities, enterprises, nations,
+religions, world-spanning internet communities all deserve their space to
+maintain their own internal accounting and to interact with each other on their
+own terms.
+
+We further believe these views are shared by a critical mass of people. While
+Ethereum is permissionless, the Foundation will remain focused on working with
+those who share our vision and sense of mission.
+
+We recognize that self-sovereignty itself is just one crucial component of a
+greater goal - namely, human empowerment and well-being - championed by loose
+coalitions of builders of a brighter future.
+
+Only through being a decentralized and resilient self-sovereignty tool, imbued
+throughout with CROPS, and unstoppable at scale while preserving individual
+freedom, can Ethereum’s essential nature be recognized: a secure, user-aligned
+World Computer that can be shared with all who want it.
+
+And only through the Foundation enshrining its principles and vision for all to
+see, can it be most effective in ensuring Ethereum blossoms.
+
+**Our Mandate is written for a thousand-year horizon. Principled adherence is
+subject to drift and erosion over time - like water, standards tend to flow from
+high to low, and are far easier to lose than to regain. We are starting as high
+as we can, to slow any long-run erosion over centuries, so we do not expect any
+material compromise within our lifetimes.**
+
+<details>
+<summary>SOURCE SEPPUKU LICENSE</summary>
+<div className="text-sm [&_p]:mb-2 [&_p]:mt-0">
+
+> By inclusion of this license, the author, maintainer, editor or (re)distributor
+> (the “Actor”) of this software SHALL uphold the following pledges:
+>
+> To always make freely available and publicly accessible a full and accurate copy
+> of the source code and associated documents of this software, including all
+> modifications hereto by the Actor.
+>
+> To take his or her own life with a sword upon failure to uphold any of the
+> pledges in this license, or upon modification or removal of any part of this
+> license.
+>
+> May the Foundation fall on its own sword if it fails to uphold its solemn
+> promise to Ethereum.
+
+</div>
+</details>
+
+## IV. PRINCIPLES FOR ACTION {#iv-principles-for-action}
+
+**Our Mandate rests on two pillars, each comprising four principles.**
+
+**Everything we do - technical work both at the protocol layer and elsewhere,
+community support, and decision-making - must be derived from and answer to
+these twin pillars and their principles, with CROPS treated as non-negotiable.**
+
+### Technical Pillar {#iv-technical-pillar}
+
+- **Censorship Resistance:** No actor can selectively exclude valid use or break
+  functionality, including by gaining durable, non-competitive control of any
+  critical mechanisms.
+
+All work must be architected to be maximally unstoppable and to function without
+incorporating centralized intermediaries or kill switches.
+
+The provision of unstoppability should itself be censorship-resistant to avoid
+it becoming an anticompetitive and extractive game of selectively providing
+censorship-resistance to the compliant, to cartels, or to highest bidders
+without proper competition.
+
+Censorship resistance also includes technical resistance to extra-technical
+pressure, such as social mores or legal restriction. The protocol relies on
+cryptographic guarantees for its resilience and neutrality, not on the temporal
+concerns of the political context. Our work must protect the protocol from
+attempts to replace fundamental physical properties with short-term brittle
+mechanisms to try to achieve the same thing.
+
+- **Open Source and Free, as in Freedom:** No privileged code or hidden
+  specifications.
+
+All work must be public and auditable: no proprietary “black boxes.” All work
+must also be forkable: Ethereum’s credibility depends on predictable exit paths,
+and systems that aren’t open and free have unacceptable friction to forking.
+
+Supported projects must pledge that they will not change their open source or
+copyleft license in the future. Permissive licenses are accepted, viral copyleft
+licenses are appreciated, but merely source-available licenses are not
+tolerated.
+
+- **Privacy:** User data is not exposed beyond necessity or against their interests.
+
+We strongly advocate for maximal privacy to become the default for user data to
+the greatest extent possible: first in any tools that sit above the protocol
+that the Ethereum Foundation builds, and then ultimately in the protocol itself
+from the very core on out.
+
+The purpose of privacy is to prevent structural power asymmetries from
+infringing on self-sovereignty and self-sovereign coordination. History shows us
+that the wielders of power, once they gain the ability to restrict or even de-
+normalize privacy, will never surrender the advantage they obtain. Hence,
+privacy must be permissionless and available to all.
+
+Privacy is not about total concealment of everything. It is about freedom and
+true consent: to choose what information to disclose to whom, on one’s own
+terms. In our day-to-day lives, we often disclose information, or prove claims
+about ourselves, to participate with others, or to build relationships on trust,
+gradually.
+
+However, we believe that end users should always selectively negotiate their
+disclosures, and that this should only be supported on top of a base of freely
+available, unconditional privacy.
+
+- **Security:** Things must do what they claim to do, no more and no less.
+
+Security is paramount. We advocate rigorous security design at both the protocol
+and application layers to prevent harm to users and preserve system integrity.
+We invest deeply in testing and verification, using multiple methods to specify
+desired properties and confirm that designs satisfy them.
+
+Security requires simplicity, including responsible minimization of lines of
+code and external dependencies; a protocol is not “trustless” if only a small
+number of people can understand how it works and why it is secure. Work must be
+verifiable to many. Entirely new domains for the protocol must clear an
+extremely high necessity threshold, and do so legibly.
+
+Security also means governance minimization; no social layer should override
+protocol guarantees lightly.
+
+Security additionally means passing the walkaway test, not just for the
+protocol, but also for users: self-sovereignty means a user should not be forced
+into frequent, complex migrations that create unintended risks.
+
+True security protects both system and users from technical failure, social
+entrapment, and coercion.
+
+---
+
+**We must always remember that the ultimate goal is for Ethereum to pass the
+walkaway test. Achieving this needs, among other things, intermediary
+minimization and structural decentralization, and the best way to achieve that
+is to build with our CROPS principles in mind.**
+
+### Social Pillar {#iv-social-pillar}
+
+- **Principled Alignment:** Our first principle is that we are principled in our work.
+
+We focus on work which embodies our principles and not on work which allows
+private capture or uncompetitive user extraction.
+
+We value the quality of principle-upholding resilience over the quantity of
+users or the optimization-for-value of design.
+
+A billion users in a centralized silo is not a success; designing around the
+enshrinement of centralized extraction pipelines in the protocol is not a
+success; it is a failure of mission.
+
+- **Discipline:** We care about doing it right and doing it well.
+
+We are truth-seeking and beauty-seeking in our work. We demand technical rigor,
+excellence, and creativity.
+
+We choose relevant timing over either going fast or going slow, which may
+include not acting at all. We share research and results quickly; we make sure
+what we ship is mission-critically reliable.
+
+We exercise courage to make hard, potentially unpopular, decisions based on
+principled assessments rather than market pressure or institutional comfort. We
+accept that rejecting and reforming compromised defaults is part of our work. We
+defend our decisions with patience and truthfulness.
+
+We also admit when we get things - particularly big things - wrong, with
+humility, grace, and an honest and clear explanation of why our views have
+changed and what our new views are.
+
+We pair high standards with kindness: resilient systems are built by people who
+can disagree clearly without cruelty and who can stay curious when under
+pressure.
+
+- **Right Association:** Who we work with is itself a principled choice.
+
+We prioritize working with individuals and teams who share our principles,
+spread them, and make their work legible through comprehensive and open
+documentation even in challenging conditions.
+
+For projects dependent on support from the Foundation, we prefer to work more
+closely with those who also actively work to achieve independence from us.
+
+Right association also means we prefer to focus on individuals, teams, and
+projects that share our principles but operate in different domains, over those
+individuals, teams, and projects who are in crypto, but operate according to a
+very different set of standards.
+
+- **Big Picture:** We remember that Ethereum’s future is bigger than its present.
+
+Our horizon is broader than crypto: Ethereum’s promise only holds if it serves
+self-sovereignty beyond any one subculture, asset class, or industry.
+
+The World Computer is decentralized infrastructure for permissionless compute,
+communication, and association, and it naturally connects to builders who uphold
+those freedoms: open source projects, privacy and cryptography researchers,
+civil liberties defenders, educators and public-interest technologists, builders
+of resilient local communities, and the quiet maintainers of civilization who
+keep essential systems and traditions running.
+
+We remember that we require of them no aesthetic conformity, only principled
+alignment: when people share the instinct to keep systems forkable, censorship
+resistant, private, and secure, we treat them as fellow travelers of the path
+and fellow stewards of the infinite garden.
+
+Our loose coalition does not need to be put together. It is together.
+
+## V. CARRYING OUT THE WORK {#v-carrying-out-the-work}
+
+### Approach {#v-approach}
+
+**Our operating approach can be summarized as a process of subtraction for
+resilience.**
+
+Ethereum is more resilient when it can continue to provide self-sovereignty and
+sovereignty-preserving coordination at scale without depending on us to guide
+it.
+
+We therefore have a bias toward work that makes us less necessary over time,
+through a framework that guides our approach:
+
+- **The Only-EF Rule:** We focus on critical tasks that have no other natural home and
+  that no other ecosystem actor can or will reliably undertake. This includes but
+  is not limited to: core protocol upgrades and long-horizon research, neutral
+  multi-client specs and tests, public-good security work, crisis coordination,
+  preventing chokepoints, and core dev tooling and documentation where no
+  sustainable owner exists. We check that these tasks are actually critical.
+
+- **Handoff for Ecosystem Maturity:** As soon as a function or role can be
+  successfully managed by an aligned community actor, we facilitate that
+  transition, so capability and responsibility diffuse through our ecosystem
+  rather than concentrate in one place.
+
+- **Independent Inspiration and Reliability:** We work across varied domains rather
+  than in a narrowly hierarchical manner - the glue that connects us is our
+  mission, not our structure. We hire individuals who are deeply aligned with the
+  mission. We prize those individuals who operate with high integrity and
+  flexibility, as in our experience, they have been the most effective in rapidly
+  changing conditions and are the most reliable during uncertainty.
+
+- **Compounding Effects:** We prioritize efforts that are as far upstream and high
+  leverage as possible, by making sure the research, documentation, coordination,
+  and infrastructure we support can be freely reused, extended, and operated
+  independently. This can include supporting shared primitives, specifications,
+  tooling, and evaluation methods that reduce avoidable friction and create
+  network effects for those who share our principles. When we work downstream, it
+  is on making CROPS-native affordances competitive and viable for adoption.
+
+- **Subtraction as Success:** Our goal is to reduce the Foundation’s relative
+  influence over time. This is not retreat or sabotage. Subtraction is rather a
+  process of ensuring Ethereum’s maturity: a trajectory of growth with
+  decentralization, robust enough to outgrow and outlast us, however long this may
+  take.
+
+Doing subtraction well is challenging.
+
+At first glance, there seems to be a tension between stewarding something to
+grow into the infinite, and deliberately diminishing one’s own presence. It is
+an especially unusual act from an organization of our type and current influence
+&hyphen; the landscape of contemporary corporate philanthropy is littered with
+eterna foundations and institutes. Many will be discomforted and ask, “if the
+Ethereu Foundation, with its stature and legitimacy, doesn’t strive to stay
+front and center, then who else realistically could?”
+
+There are also concrete instances of failure in subtraction in the past. There
+have been many attempts to create alternative stewards within Ethereum that have
+died out, and there have been many attempts, both within the Ethereum ecosystem
+and far outside it, to nurture federated ecosystems with multiple actors, that
+ended up unable to get past the stage of one of them dominating far above the
+others. These failures each have valuable lessons that we must honestly
+recognize, and learn from.
+
+Yet, we believe, and history shows us time and again, that the only way to grow
+a garden into something truly infinite is to choose subtraction. Ethereum’s
+resilience and therefore runaway growth can only truly arise where there is no
+single indispensable entity responsible for the ecosystem’s success. History is
+filled with examples of transition stages that started off temporary then became
+permanent. For decentralization to truly take root, we must keep growing toward
+it today, not tomorrow.
+
+This does not mean our subtraction takes place carelessly and inconsiderately.
+Subtraction means ecosystem growth that outpaces ours. It requires the highest
+standards of observation, planning, and execution. Our subtraction happens when
+the systems we support can attain or have achieved greater resilience with
+others, either inside or beyond Ethereum, or without needing anyone at all.
+
+Subtraction done well is subtractive of the Foundation, but additive for
+Ethereum. The privilege of stewarding Ethereum must not be hoarded, but shared
+and multiplied with others, whether they have been loyal friends since the
+beginning or new travelers who have discovered the Infinite Garden.
+
+This is why subtraction is a definitive signal of success. The garden can become
+bigger, stronger, and more vibrant than any organizations could ever dictate,
+when the mission of ensuring Ethereum remains humanity’s common computational
+substrate is shared with all who recognize the future as it should be.
+
+The more Ethereum succeeds, the tinier we become; if Ethereum fails, so too will
+we perish.
+
+Subtraction will occur either way, so we choose success.
+
+### Limits {#v-limits}
+
+**Our limits exist for the same reason: Ethereum’s resilience.**
+
+The Foundation does not build for everyone. We contribute technical expertise
+and provide underlying support so those aligned with Ethereum’s self-sovereignty
+mission - and its potential for sovereignty-preserving coordination at scale -
+can build Ethereum and build on Ethereum, and so that they in turn can build for
+everyone.
+
+**Our contributions may take many forms, but we are not bound to them - as
+Ethereum evolves, so too will our support.**
+
+Today, we may support coordination both of the core protocol and beyond it;
+support education and public portals; close essential funding gaps; or provide
+stewardship in other principles-aligned ways.
+
+Tomorrow, we will adapt to do what is necessary, by applying our execution
+strategy: identifying and relieving coordination bottlenecks, and preventing
+capture of the protocol or ecosystem.
+
+**In short, we do for Ethereum, what Ethereum is meant to do for its users.**
+
+To maintain our role as a credibly neutral steward, we operate within clear
+limits. We avoid activities that could create a centralized point of control
+(including ourselves) or compromise Ethereum’s long-term potential.
+
+- **We are NOT a Corporate:** We are not a development company. We do not build
+  consumer apps. If it can be a sustainable business, it belongs in the community,
+  and use of the protocol must not depend on it.
+
+- **We are NOT a Kingmaker:** We support mechanisms and designs that are in line with
+  our mandate and core principles, not specific private brands or companies. We
+  neither support nor enforce standards that compromise on our principles and
+  goals.
+
+- **We are NOT an Accreditation Body:** We do not certify or endorse projects, teams,
+  or audits. However, we do support the development of mechanisms in line with our
+  principles to help users evaluate security and legitimacy without relying on us
+  to provide stamps of approval.
+
+- **We are NOT a Product Studio:** We do not act as a product development laboratory
+  for the ecosystem. We think deeply about how users interact with Ethereum and
+  use this to inform our upstream work on shared primitives, tooling, and
+  fundamental research, all in service of helping builders deliver systems and
+  products that are practical to use, sustainably viable, and capable of
+  accelerating the availability of a credible alternative that fully embodies our
+  principles.
+
+- **We are NOT a Marketing Agency:** We do not engage in hype cycles or promote short-
+  term price action. Our communications are grounded in technical reality, in our
+  long-term mission and mandate, and in having fun on the Internet.
+
+- **We are NOT the Boss:** We cannot force hard forks or protocol changes. We are
+  opinionated only so as to advocate and propose what’s best for the mission.
+
+- **We are NOT a Government or Regulatory Body:** We do not act as a governing body
+  for ecosystem participants.
+
+- **We are NOT a Casino:** We do not encourage people to take life-changing, and
+  possibly life-wrecking, amounts of risk by going into personal debt hyper-
+  gambling. Ethereum has the potential to be a foundation for a secure and free
+  life; debt promotes the opposite.
+
+- **We are NOT Opportunists:** We do not actively assist in adoption of Ethereum in
+  ways that compromise trustlessness. We recognize that such adoption may occur,
+  but we apply our expertise in the trust-minimizing end of the spectrum in any
+  category we engage with.
+
+### Tradeoff Considerations {#tradeoff-considerations}
+
+**The world Ethereum must function in is not yet CROPS-native.**
+
+Today, most use of Ethereum flows through partially centralized surfaces:
+wallets, RPC providers, relays to the MEV-industrial complex, app stores,
+exchanges, institutions, and the social defaults that surround them.
+
+As Ethereum’s growing roots and branches come into contact with centralized
+infrastructure at ever-greater scales, we will face these same dynamics
+repeatedly.
+
+**We will have to choose, tomorrow as today, whether to take an incrementalist
+approach or a nativist approach to growing Ethereum and advancing CROPS
+adoption.**
+
+In truth, these are two distinct strands of work: the incrementalist approach
+accelerates CROPS by demonstrating to those who are at or prioritize scale that
+CROPS increases value; the other directly grows and distributes CROPS, and
+develops and demonstrates further best practices for doing so.
+
+Our priority, and the default path for decisions, in line with our mandate and
+the Only-EF Rule, is the CROPS-native approach. **CROPS-adherence is a compounding
+force:** it produces usable self-sovereignty tools and escape hatches, and sets
+durable precedents others can later follow. We value usability and performance
+improvements that make sovereignty easier to choose, as long as they do not
+introduce new points of leverage over a user or create dependencies.
+
+**Adoption can be earned over time, but principled ground once ceded is far harder
+to regain.**
+
+We leave space within the Foundation for the incrementalist approach only in
+tightly bounded circumstances: as a tactical intervention when it durably
+reduces central control, does not result in deeper entrenchment than what it
+supersedes, and accelerates the availability of a credible alternative that
+fully embodies our principles.
+
+Our work must not introduce new chokepoints or entrench existing ones. It must
+not expand or normalize reliance on added trust assumptions, and it must not
+require constant Foundation presence to ensure alignment with our principles.
+
+We are skeptical of walled garden projects but we may consider engaging with
+projects that advance or innovate access to self-sovereignty for end users, and
+that preserve a path for users to default to full self-sovereign control of
+their identity and assets.
+
+Work that is more incrementalist may well be valuable for Ethereum’s success and
+growth. There may always be those who want to build walled gardens on the World
+Computer. But the natural home of such work is outside the Foundation. This
+Mandate does not preclude working with them, but we must do so in a principled
+way to promote and secure the self-sovereignty of end users. The underlying goal
+of our participation should be to engage with our resources and CROPS expertise
+in order to help make the CROPS properties of such external work stronger.
+
+**The guiding question is: does this make Ethereum and its users less susceptible
+to capture over time, or does it normalize capture in exchange for reach?**
+
+**We must also always consider that doing nothing may be the best course of
+action, and that our energies are better spent elsewhere. Sometimes work in a
+given area cannot be one of our priorities.**
+
+---
+
+**When we encounter adversarial situations, whether within Ethereum or beyond it,
+we focus on creating structural improvement: building open source tools for
+self-sovereignty and sovereignty-preserving coordination, with de-totalization
+as a matter of principle, rather than acting on opinions about particular
+conflicts.**
+
+As individuals, we may hold diverse views shaped by the moment. As the
+Foundation, we believe that free people, flourishing on the basis of self-
+sovereignty, are best suited to building worlds worth living in and to carrying
+freedom forward. We therefore focus on strategies that expand the conditions for
+flourishing through self-sovereign computation, including in circumstances we
+cannot yet foresee.
+
+Differential and open source promotion of “defense” is not a novel idea. The
+Mohists authored and widely distributed manuals that helped all cities better
+defend themselves, operating under the theory that shifting the balance from
+offense to defense broadly reduces suffering.
+
+> **卷十四 Book 14**
+>
+> 52. 备城门 Fortification of the City Gate
+> 53. 备高临 Defense against Attack from an Elevation
+> 54. 备梯 Defense against Attack with Ladders
+> 55. 备水 Preparation against Inundation
+> 56. 备突 Preparation against a Sally
+> 57. 备穴 Preparation against Tunneling
+> 58. 备蛾傅 Defense against Ant-Rush
+>
+> **卷十五 Book 15**
+>
+> 68. 迎敌祠 The Sacrifice against the Coming of the Enemy
+> 69. 旗帜 Flags and Pennants
+> 70. 号令 Commands and Orders
+> 71. 杂守 Miscellaneous Measures in Defenss
+
+One major difference between the Mohists and us is that they also directly
+intervened in conflicts based on their own judgment about who was defending and
+who was attacking.
+
+Our approach is closer to writing the manuals and making them available, and not
+intervening in individual conflicts.
+
+We believe that de-totalization - building toward a world in which no
+organization, system, or moral order has total dominance over any individual
+life - is the most reliably good aim.
+
+Censorship resistance, security, and privacy stand in relation to de-
+totalization much as city walls stood to pre-modern collective defense. Open
+source ensures these protections are broadly distributed, iterable, and
+customizable, rather than becoming the asymmetric advantage of any one group,
+even a group for which any of us as individuals may hold particular sympathies.
+
+The team of today may not be the team of tomorrow.
+
+## VI. RESOLVING QUANDARIES {#vi-resolving-quandaries}
+
+Over the course of the next thousand years, we and our successors will face
+countless challenges and be confronted with difficult choices whose specific
+details we cannot anticipate.
+
+But human history teaches us that although no two rivers flow the same course,
+the shapes of the valleys they carve are familiar, once you know how to look.
+
+That is to say, the structures of those challenges and the dynamics by which
+they unfold are not so novel.
+
+While it would be impossible to describe every such obstacle, we illustrate
+several timeless tensions we believe will forever exist around Ethereum until
+the mission is complete.
+
+---
+
+**1. When two technically credible paths compete, we pick the one that removes
+points of leverage, not the one that can be shipped faster.**
+
+It is a common refrain from those who build centralized chokepoints into their
+designs, such as entrenched trust architectures, that they have done so out of
+necessity, and will be removed later when things are “more mature.”
+
+But human experience, both from software development and from political history,
+tells us that such a path is fraught with danger, and we should view such
+statements with suspicion.
+
+**The wiser course, therefore, is to prefer the option that is fully-CROPS from
+the beginning even if it is technically or socially more difficult to get off
+the ground and scale.**
+
+For example: a proposal offers “better protocol UX” or “better safety” for
+transaction propagation via a curated private relay network with trusted
+partners that results in the possibility for centralizing infrastructure such as
+shared blacklists or whitelists, that will “be decentralized later when the
+ecosystem and protocol are ready”; a second proposal keeps propagation
+permissionless straight out of the box via open p2p tooling, with optional
+private relays for exotic transactions, and with free routing around verifiable
+failures.
+
+All else being equal, CROPS means we support the design where broadcast is
+auditable and does not depend on a small set of intermediaries; private
+propagation is opt-in and escapable; and where users can route around censorship
+or extraction permissionlessly.
+
+**The lesson is that it is not sufficient that a solution simply works today; it
+also needs to not become a chokepoint tomorrow.**
+
+**2. When designing or judging a proposal, we think through the higher-order
+effects of implementation beyond the layer at hand, ensuring that the overall
+impact advances self-sovereignty, and avoid capture points simply being
+displaced beyond narrow focus or becoming an externality.**
+
+It is understandable to focus only on the properties of the solution at hand,
+and to leave consideration of the other-order consequences of that solution to
+others. This is not necessarily due to insufficient capacity, motivation, or
+discipline. It is often due to simple familiarity.
+
+Nevertheless, it is our responsibility to ensure that we do think about the
+overall consequences of any proposal beyond our own immediate frame of
+reference. Indeed, thinking across layers may lead us to the elimination of
+undesirable properties or structures at one level by creating a solution at
+another.
+
+For example: work on the protocol’s capabilities, such as scale or speed, can be
+done in myriad ways. Some may even be “CROPS-aligned” by the standard of using
+the CROPS properties as a checklist.
+
+But we must remember our broader aim, promoting self-sovereignty. A proposal
+that on narrow analysis satisfies the CROPS properties, yet introduces a user
+chokepoint at another layer of interaction, whether that be forced
+intermediation, extraction, or some other anti-sovereign pattern, is a proposal
+that must be rejected. But a proposal that increases the capabilities of the
+core protocol with the result of eliminating chokepoints at other layers should
+be welcomed.
+
+It is a recurring temptation to treat CROPS properties in isolation, and to
+consider any gaps acceptable as long as they can be compensated for elsewhere.
+Whenever this temptation arises, we must scrutinize it carefully. Protocols may
+remain formally un-degraded or “pristine” while in reality, positive or
+essential capabilities such as scale, speed, UX accessibility, privacy,
+extraction-resistance, or account functionality migrate into centralized,
+intermediary-dependent, trust-dependent, permissioned, or opaque structures or
+services.
+
+There are several scenarios that can illustrate the need for, and value of,
+cross-layer thinking.
+
+First, **scale**. If the protocol does not support sufficient scale for a use case,
+then those users often turn to extra-protocol mechanisms to process transactions
+elsewhere and return on-chain proofs and commitments. In theory they may achieve
+security sufficient for their purposes; in practice, they may be unknowingly
+accepting deeper CROPS compromises than the situation warrants.
+
+Second, **account types**. If Ethereum supports only a narrow set of account types,
+and lacks a general-purpose account model capable of supporting smart accounts,
+then those use cases that require smart accounts can only be served through
+intermediaries. We must recognize that this degrades their CROPS properties and
+long-term liveness guarantees, even if a large number of competing
+intermediaries theoretically exist. This prevents users from fully benefiting
+from protocol-level features meant to improve transaction inclusion and access
+guarantees.
+
+Third, **native privacy support at the protocol layer**. Protocol native privacy
+greatly increases the anonymity set of the participants, reducing the risk of
+privacy compromise. No construction layered on top could match the anonymity set
+the protocol itself could provide.
+
+Fourth, **transaction protections at the protocol layer**. Transaction inclusion,
+protection against adverse execution outcomes, and fair execution should be
+achieved at the lowest layer of the stack consistent with safety. Implementation
+at the protocol level would alleviate pressure for users to seek such guarantees
+from intermediaries via centralized transaction pipelines, and therefore reduce
+opportunities for systemic extraction.
+
+Fifth, **aggregation of cryptographic objects**. Intermediaries perform aggregation
+functions for users because the individual submission on-chain of cryptographic
+objects, for example, zero-knowledge proofs, is often cost prohibitive. The high
+fixed costs of providing aggregation mean that the market for this service is
+likely to be monopolistic, which is a centralized chokepoint. Therefore, if the
+protocol were to support batched aggregation and efficient verification of such
+objects, this centralization risk would be removed.
+
+---
+
+In each of these cases, we judge the complexity and centralization-pressure
+risks of native scaling against off-chain scaling; native smart accounts against
+intermediated smart account services; native privacy against application layer
+privacy; native transaction protections against intermediated and likely
+extractive transaction guarantee services; and native aggregation against
+intermediated and likely monopolistic, aggregation intermediaries.
+
+We keep in mind the risks at other parts of the Ethereum stack when thinking of
+improving performance and usability of the core Ethereum protocol, for example:
+if scaling comes at the cost of verifiability; if inclusion guarantees come at
+the cost of novel forms of coercion or extraction; or if slot time reduction
+comes at the cost of increasing pressures for geographic and economic
+centralization.
+
+We also remember that protocol complexity is itself a technical risk: it expands
+the bug surface area and reduces the viability of new independent protocol
+implementations. However, we also recognize the upside: work on performance and
+usability may be empowering where it removes the need for entire classes of
+intermediaries above the protocol, or at least creates a credible and accessible
+path around them.
+
+Striking the wrong balance across layers may be very costly. The downsides to
+making mistakes due to complexity or risk at the protocol layer are often going
+to be greater than downsides at the application layer, where users can
+individually opt in or out, or collectively work to upgrade without changes to
+the protocol.
+
+For example: if we add an aggregation scheme to Ethereum, but no one uses it -
+not even power users who deeply need CROPS properties - then we have added
+hundreds of lines of protocol code that create permanent ongoing risk without
+much benefit.
+
+**We therefore hold protocol improvements that bear any risk at all to the
+protocol’s CROPS properties to a much higher bar, evaluating them with greater
+caution and care to avoid compromise at such a fundamental part of the Ethereum
+stack.**
+
+**3. When considering adversarial user environments, we default to empowering user
+agency, not to solutions that weaken user agency.**
+
+Safety is an important problem in our time, and “attacks on the mind” must be
+taken as seriously as attacks that target technical properties or community
+dynamics.
+
+However, we aim for defenses that are user-empowering and user-controlled. We do
+not support high priests dictating or installing restrictions on user agency
+under their logic of user protection, especially if users never opted in or
+can’t opt out.
+
+For example: in the name of safety in a hostile world, a wallet ships a “safe
+mode” enabled by default that incorporates dark design patterns such as silently
+blocking certain contracts, steering users toward preferred venues or
+counterparties, and into using unmodifiable preinstalled whitelists; or that
+ships an AI copilot that flags “risky” actions using an uninspectable
+proprietary model and reports user actions back home silently.
+
+**CROPS pushes user-controlled defenses instead:** a choice of independent locally-
+verifiable filters with transparent rules, multiple independently-built
+community-created and propagated whitelists and blacklists with clear override
+paths, and private-by-default tool use including any AI components.
+
+Our work in Ethereum is to prove that the most natural and right way to help
+users defend themselves from threats they may not even understand is to expose
+them to empowering defensive tools. We demonstrate our fundamental belief in
+user-empowerment over paternalism by pioneering this approach.
+
+**The goal is not to sanitize the environment; it is to keep users sovereign
+inside it.**
+
+**4. Where a use case important to our mandate involves some form of
+intermediation, we work to ensure that barriers to entry are minimized and
+market competitiveness is maximized for anyone who plays that role. At the same
+time, we aim to eliminate the need for such intermediaries wherever possible,
+and to ensure that a practical, fully disintermediated path exists wherever it
+can.**
+
+There are already many places across the Ethereum protocol and application layer
+
+- block building, RPC servers, entities attesting to aspects of digital identity
+- where intermediaries exist. This state of affairs carries serious risks: one
+  or more intermediaries may become dominant chokepoints, impose their special
+  interests, censor users, enforce arbitrary participation rules, or extract
+  value.
+
+We therefore work to eliminate the need for such intermediaries wherever
+possible. Where they cannot yet be removed, we design protocols that reduce the
+technical and economic pressures that drive them toward capture.
+
+**In particular, we ensure the presence of a “zero option”: for every affordance
+that has an intermediated path, any intermediary-free path that is possible must
+be built and must remain credible and accessible. This serves both as a present
+exit for users who may already be exploited by intermediaries, and as a credible
+constraint against the expansion of such abuse. We do not skip this step.**
+
+For example: consider an application where participation requires some form of
+identity. This may be for sybil resistance or anti-denial-of-service
+protections, an online forum meant to be writable only by members of a certain
+community, or myriad other reasons.
+
+A naive approach would be to take the easiest available off-the-shelf form of
+“official” identity - government, biometric or corpoid - wrap it in a zero-
+knowledge proof, and declare the result CROPS-friendly.
+
+But we must do better. We begin by examining the underlying need of the
+application and ask exactly what aspect of identity or information disclosure is
+actually required. Often, the requirement is not identity in full, but some
+narrower property that identity also fulfills.
+
+If the use case needs only sybil resistance or only a way to make abuse
+expensive, the system should provide a narrower alternative than providing
+identity itself. Users who hold some quantity of ETH, for example, could provide
+a zero-knowledge proof of ownership of it, or post a zero-knowledge security
+deposit, in lieu of dependence on identity.
+
+Where identity attestations are genuinely required, our principles lead us to
+design the system so that intermediaries are bounded and replaceable rather than
+entrenched. The identity proof mechanism should be fully privacy-preserving in
+all cases, with no backdoors.
+
+Once credentials have been issued, proof generation and verification should be
+as local, verifiable, and non-custodial as possible, so that ongoing
+participation does not depend on continued deference to a privileged
+intermediary and cannot be revoked arbitrarily.
+
+We should also ensure that multiple fit-for-purpose sources of ground truth for
+identity exist and can be used inside real-world applications that rely on the
+system. The software stack should make it easy for implementations to integrate
+multiple independent attestation sources, and should make this plurality the
+default path. It should support combination approaches, allowing multiple weaker
+signals - such as social-graph attestations - and not just single stronger
+attestations, such as a signature from an official entity.
+
+Designing such a chokepoint-minimized system is inherently harder than the naive
+approach. For that reason, and in accordance with the Only-EF rule, it is
+exactly the kind of work we consider taking on where it serves our mandate.
+
+**The north star is disintermediation. Where intermediation can be eliminated, we
+prefer to eliminate it. Where it is unavoidable, we work to minimize the risk of
+capture by keeping intermediary roles open, plural, bounded, and verifiable. If
+an intermediary-free design becomes possible, we ensure that it is credible and
+accessible, so that intermediaries are ultimately optional rather than
+entrenched.**
+
+**5. When deciding which teams to back, we look past short-term output and social
+cues, and instead judge patterns of choices and revealed preferences.**
+
+It is often the case that we are presented with ideas wrapped in the language of
+CROPS; of self-sovereignty; of freedom - yet upon closer inspection there is
+less than meets the eye; the thin veneer of purported principles disintegrates
+upon examination. This is not always disingenuous - indeed, many such ideas are
+proposed by well-meaning, conscientious individuals, teams and projects, either
+through genuine though misguided belief, or through lack of introspection or
+interrogation.
+
+One way that this occurs is through thinking only about the “happy case,” where
+all the variables play out as planned, but not about the “unhappy case” such as
+where third-party dependencies (whether APIs, content delivery networks, or
+otherwise) disappear or break - or worse, where the team itself disappears or is
+hacked or an insider turns hostile.
+
+Another way is through the echo chamber effect, or in other words, cascading
+social proof. In what is currently a small domain, groups of well-meaning people
+commonly wish to be supportive, especially to their friends. Ideas form and are
+shared and discussed; precisely because we operate in a space that has an
+affinity for disintermediation, the speed at which ideas circulate often reaches
+escape velocity, if not virality. Further, if amplified ideas attract social
+proof and incentives - whether credit or reward - and are presented publicly
+before they have been suitably interrogated or examined critically, then post
+hoc questioning may become costly and face resistance.
+
+For example: two teams submit proposals for improving UX in some complicated
+scenarios that involve multiple tokens and asynchronous communication. At first
+glance, both look “CROPS-aligned:” open specification, progressive
+decentralization roadmap, user-first UX.
+
+On review, the first team is socially polished, using the right language of
+CROPS and armed with peer endorsement and resources, but the design keeps a
+“secret-sauce” intermediary layer closed, bootstraps with a small whitelisted
+provider set, and uses soft-defaults to steer flow through preferred paths.
+
+The other team has no social presence, minimal backing and finds it difficult to
+communicate their vision, but implements an open market for intermediaries (eg.
+using staking) without a whitelist, and treats them as a temporary artifact with
+a credible path to elimination via user-driven routes and on-chain guarantees.
+They publish early research and threat models, ship legible specs and references
+and invite critique, and challenge unaffiliated teams to co-build so the default
+outcome is shared infrastructure rather than a branded moat.
+
+**When choosing who to support, clarity of perception is paramount. It is
+imperative to employ discernment and good judgment: not to anchor on polish,
+credentials, or sympathetic signals of alignment, especially when social proof
+arrives before due diligence.** Instead, we must examine what a project optimizes
+for in practice - the tradeoffs it repeatedly chooses, technically and socially.
+
+Despite CROPS language, if on closer inspection work introduces privileged
+positions - such as closed components, whitelists, soft-default routing,
+discretionary upgrade ability, or dependency-heavy integrations - it is right to
+be skeptical.
+
+Likewise, if a team continually selects for control or value over
+decentralization, or if their partners and endorsers have a tradition of anti-
+self-sovereign choices, it is right to be wary.
+
+**Our technical and social principles lead us to ask whether the default path
+removes leverage over time or concentrates it in a silo, and whether the signals
+of alignment are matched by CROPS-consistent action under scrutiny.**
+
+**We do not require first versions to be complete; they only need to stay live.
+Open source building means a strong design path can be improved or finished by
+subsequent teams. We appreciate teams that publish early, build openly, and
+invite critique, so unaffiliated builders can pick up unfinished work without
+having to ask.**
+
+## VII. THE FUTURE {#vii-the-future}
+
+For a long time, people have been pushed to believe that we only have two bad
+choices.
+
+One is to accept that the name of the game is to obtain and maintain advantage;
+and so to accept rule from the top, by those who already hold power: macro-
+sovereigns like states, empires, corporate oligarchies, eschatological missions,
+and grand ideologies that dictate how people live, decide who gets to act
+freely, and who must comply, regardless of their subjects’ wishes.
+
+The other is to respond to that game without a principled aim: to burn it all
+down, to retreat into mockery or withdrawal; or to defect to one or another
+macro-sovereign, not because they are better, but simply because it is
+opportune.
+
+But there are those who abjure this belief: it does not have to be this way.
+
+**Ethereum rejects the idea that there is no alternative.**
+
+Ethereum is not a weapon for either side of this conflict, and its stewards are
+not a partisan faction within it. Ethereum is a tool that countless people -
+individuals, families, and communities - are independently using to build
+resilient sanctuaries from this contest of power: shelters from ideological
+psychodrama, where anyone capable of taking refuge can live neither oppressed
+nor oppressing, and where they can be left to their pursuits of happiness.
+
+And we, as Ethereum’s stewards, carry an additional responsibility: to keep
+Ethereum usable for this purpose, and to keep the path open for users to create
+and join sanctuaries that protect their freedoms and empower them to live the
+lives they imagine for themselves.
+
+These sanctuaries are enabled in part by technology - decentralized,
+permissionless, auditable, secure, and privacy-preserving machinery - and in
+part by cultural and social aesthetics, which we bring to them as sensible and
+considerate people, and which our technologies help defend.
+
+Our participation is in both the technology and the aesthetics: we build
+infrastructure that secures forkable, self-sovereign computation from the ground
+up; then, on top of this, we may experiment with novel coordination systems
+underpinned by the sovereign freedoms to express and to exit.
+
+**Ethereum’s front in this sanctuary work is the front that defends permissionless
+computation and communication with as much privacy and end-user agency as is
+technologically viable.**
+
+Our closest collaborators include those working directly on privacy,
+verifiability, and programmable cryptography. In the middle distance are our
+neighbors working on open silicon, alternative networks and allied efforts. And
+on the horizon are our friends working for clean air, and for regenerative and
+sustainable habitats and permaculture; for freedom of speech and expression, and
+the freedom to associate and dissociate voluntarily; for forkable technology
+transfer; free open source collaboration in science, software, hardware, health,
+and elsewhere, and a thousand other known and unknown things we trust them to
+build without asking first.
+
+Ethereum is descended from a storied lineage of preservation instinct, prosocial
+impulse, and principled predisposition. This is why it both has natural allies
+and is an intrinsic building block for fellow travelers far beyond what we call
+today, “crypto” or “web3.”
+
+**Alternatives exist. Trust hope, embrace resilience.**
+
+## VIII. CLOSING {#viii-closing}
+
+Our work is not about capturing markets, corporates, or states, nor about
+helping them extract or capture.
+
+We are here to uncapture the individual, and to entrench their freedoms of
+association.
+
+We are here to provide the infrastructure that enables a voice for those forms
+of cooperation, organization, and community that go unrecognized within existing
+hierarchies and systems.
+
+We provide the tools and the digital space needed for this civilization-scale
+project, one that is open to anyone willing to claim self-sovereignty with their
+own hands, that is available to everyone, especially those with nothing to lose
+but their barbed wire fences.
+
+Ethereum is so other people can’t rug you; society can’t rug you; your
+government can’t rug you; another government can’t rug you; corporations can’t
+rug you; institutions can’t rug you; AI can’t rug you; mountain men can’t rug
+you; your family can’t rug you; and so you don’t accidentally rug yourself
+either.
+
+The Foundation exists to prevent Ethereum - more accurately, the promise of
+Ethereum - from being rugged; to prevent Ethereum rugging those who are relying
+on it to build their own sanctuaries; to make sure that it embodies the shared
+principles from which Ethereum descends, upholding and advancing them rather
+than letting them down. We have been entrusted with the torch of liberty and we
+must keep it burning bright until the time comes to pass it on as it was passed
+to us.
+
+Ethereum is for far more than crypto. The World Computer must rise and take its
+rightful place as a shining star in the constellation of technologies that
+underpin human freedom and flourishing. A lot more than crypto is counting on us
+to steward Ethereum with skillful intent and discernment.
+
+For we are building nothing less than the machinery of freedom - not just for
+today, but for the next thousand years.
+
+Our goal is to ensure the garden we’ve grown doesn’t just stay alive but
+flourishes, the commons it creates remain open and infinitely spacious, and the
+tools of sovereignty that are built remain available to all who would grasp
+them, to all who would log on and win, forever.
+
+**There will be times when the work will be thankless; the journey will be
+arduous; the path will be lonely. But every road to the stars first passes
+through darkness.**
+
+_E quindi uscimmo a riveder le stelle._


### PR DESCRIPTION
## Description
- Adds a text-only version of the EF Mandate to /foundation/mandate -- verbatim text from PDF
- Fixes SEO and LLM crawability
- Fixes a11y issues by serving an alternative to the 24MB PDF
- Links out originals
- Enables future translations

## Preview links
https://deploy-preview-17782.ethereum.it/foundation
https://deploy-preview-17782.ethereum.it/foundation/mandate