### PR TITLE
Bug report: horizontal overflow on /community/events page

### DIFF
--- a/app/[locale]/community/events/page.tsx
+++ b/app/[locale]/community/events/page.tsx
@@ -148,7 +148,7 @@ const Page = async ({ params }: { params: PageParams }) => {
           />
         </StickyContainer>
 
-        <MainArticle className="space-y-20 px-4 py-10 md:px-8">
+        <MainArticle className="space-y-20 overflow-x-clip px-4 py-10 md:px-8">
           {/* Major blockchain conferences */}
           <Section id="highlights">
             <h2 className="mb-6 font-bold">


### PR DESCRIPTION
## Description

- Added 'overflow-x-clip' to the '/community/events' MainArticle to prevent horizontal overflow from EdgeScrollContainer sections.
- Keeps the internal horizontal scrolling behavior while removing page-level horizontal scroll.

## Related Issue

- Fixes https://github.com/ethereum/ethereum-org-website/issues/17777
