### PR TITLE
fix: handle malformed URI in events search query param (auto)

### DIFF
--- a/app/[locale]/community/events/search/page.tsx
+++ b/app/[locale]/community/events/search/page.tsx
@@ -18,6 +18,14 @@ import { mapEventTranslations, sanitize } from "../utils"
 
 import { getEventsData } from "@/lib/data"
 
+const safeDecodeURIComponent = (str: string) => {
+  try {
+    return decodeURIComponent(str)
+  } catch {
+    return str
+  }
+}
+
 const Page = async ({
   params,
   searchParams,
@@ -56,7 +64,7 @@ const Page = async ({
   })()
 
   const title = q
-    ? t("page-events-search-hero-title-q", { q: decodeURIComponent(q) })
+    ? t("page-events-search-hero-title-q", { q: safeDecodeURIComponent(q) })
     : t("page-events-search-hero-title")
 
   const Results = () => {
@@ -117,7 +125,7 @@ const Page = async ({
             <Input
               type="search"
               name="q"
-              defaultValue={q ? decodeURIComponent(q) : ""}
+              defaultValue={q ? safeDecodeURIComponent(q) : ""}
               placeholder={t("page-events-search-placeholder")}
               aria-describedby="input-instruction"
               className="w-full"


### PR DESCRIPTION
## Summary

- `decodeURIComponent(q)` in the events search page threw `URIError: URI malformed` when the `q` query parameter contained malformed percent-encoded sequences (e.g., from bots or copy-paste errors)
- Two unprotected calls crashed server-side rendering with a 500 error
- Added a `safeDecodeURIComponent` wrapper with try-catch that falls back to the raw string

## Error Context

- **Source:** netlify-function-logs
- **Item ID:** netlify-fn-urierror-uri-malformed
- **Path/URL:** /community/events/search
- **Status:** 500 (SSR crash)
- **Hit count:** 12
- **First seen:** Mar 15, 05:28:20 AM
- **Last seen:** Mar 15, 05:28:20 AM

## Changes

- `app/[locale]/community/events/search/page.tsx`: Added `safeDecodeURIComponent()` helper, replaced both bare `decodeURIComponent(q)` calls (page title on line 59, input default value on line 120)

## Analysis

The stack trace shows `decodeURIComponent` throwing at the built page. When bots or users send URLs with malformed percent-encoded sequences in the `?q=` parameter, the unprotected decode crashes SSR. The fix wraps the decode in try-catch, falling back to the raw query string.

## Test Plan

- [x] Visit `/community/events/search?q=hello%20world` — should work normally
- [x] Visit `/community/events/search?q=%E0%A4%A` (malformed) — should render page with raw query string instead of 500

---
*Opened automatically by the Recovery Agent.*