### PR TITLE
fix: add setRequestLocale to developers page (auto)

### DIFF
--- a/app/[locale]/developers/page.tsx
+++ b/app/[locale]/developers/page.tsx
@@ -1,4 +1,4 @@
-import { getTranslations } from "next-intl/server"
+import { getTranslations, setRequestLocale } from "next-intl/server"
 
 import type { Lang, PageParams } from "@/lib/types"
 import { ChildOnlyProp } from "@/lib/types"
@@ -122,6 +122,8 @@ const WhyGrid = () => {
 }
 const DevelopersPage = async ({ params }: { params: PageParams }) => {
   const { locale } = params
+  setRequestLocale(locale)
+
   const t = await getTranslations({
     locale,
     namespace: "page-developers-index",


### PR DESCRIPTION
## Summary

- The `/developers` page was missing the `setRequestLocale(locale)` call that all other pages have
- Without it, `getLocale()` in `utils.tsx` triggers dynamic rendering via `headers()`, throwing on statically rendered routes
- Added the call matching the established pattern (e.g., staking, stablecoins, wallets pages)

## Error Context

- **Source:** sentry
- **Item ID:** ETHORG-15F
- **Path/URL:** /[locale]/developers (e.g., /tw/developers/)
- **Status:** 500 (SSR crash)
- **Hit count:** 36
- **First seen:** 2026-03-18T03:16:05.935Z
- **Last seen:** 2026-03-18T07:36:45.518Z

## Changes

- `app/[locale]/developers/page.tsx`: Import `setRequestLocale` from `next-intl/server` and call it at the top of `DevelopersPage` before any other next-intl API usage

## Analysis

The `getBuilderPaths()` and `getVideoCourses()` utility functions call `getLocale()` from next-intl, which internally reads from `headers()`. In static rendering mode, `headers()` is unavailable, so next-intl throws an error advising to use `setRequestLocale`. The page component receives `locale` from route params but wasn't calling `setRequestLocale(locale)` to populate the cache. All other pages in the codebase (staking, stablecoins, wallets, roadmap, etc.) already have this call.

## Test Plan

- [ ] Visit `/en/developers/` and verify the page renders without errors
- [ ] Visit `/tw/developers/` (the locale from the Sentry event) and verify it renders
- [ ] Confirm no new Sentry errors for ETHORG-15F after deployment

---
*Opened automatically by the Recovery Agent.*