### PR TITLE
fix: add missing setRequestLocale in developers page (auto)

### DIFF
--- a/app/[locale]/developers/page.tsx
+++ b/app/[locale]/developers/page.tsx
@@ -1,4 +1,4 @@
-import { getTranslations } from "next-intl/server"
+import { getTranslations, setRequestLocale } from "next-intl/server"
 
 import type { Lang, PageParams } from "@/lib/types"
 import { ChildOnlyProp } from "@/lib/types"
@@ -122,6 +122,7 @@ const WhyGrid = () => {
 }
 const DevelopersPage = async ({ params }: { params: PageParams }) => {
   const { locale } = params
+  setRequestLocale(locale)
   const t = await getTranslations({
     locale,
     namespace: "page-developers-index",


### PR DESCRIPTION
## Summary

- The `/[locale]/developers` page was missing the `setRequestLocale(locale)` call required by next-intl for static rendering
- Without it, next-intl falls back to dynamic rendering via `headers()`, which throws during static generation (ISR/SSG)
- Added the call at the top of the component, matching the pattern used by all other page components

## Error Context

- **Source:** sentry
- **Item ID:** ETHORG-15G
- **Path/URL:** /[locale]/developers (observed on /sk/developers/)
- **Status:** Error (escalating)
- **Hit count:** 38
- **First seen:** 2026-03-18T03:16:06Z
- **Last seen:** 2026-03-18T07:56:14Z

## Changes

- `app/[locale]/developers/page.tsx`: Added `setRequestLocale` import and call at the top of the `DevelopersPage` component

## Analysis

The `next-intl` library requires `setRequestLocale(locale)` to be called in every Server Component page/layout to enable static rendering. The developers page was the only top-level page missing this call. When Next.js attempted static generation (ISR), `next-intl` tried to read the locale from `headers()`, which triggered a `DYNAMIC_SERVER_USAGE` error since the route was expected to be statically rendered.

## Test Plan

- [ ] Verify `/en/developers/` loads correctly in development
- [ ] Verify `/sk/developers/` (the locale from the error) loads correctly
- [ ] Confirm no `setRequestLocale` errors in server logs

---
*Opened automatically by the Recovery Agent.*