### PR TITLE
fix: add missing setRequestLocale to resources page (auto)

### DIFF
--- a/app/[locale]/resources/page.tsx
+++ b/app/[locale]/resources/page.tsx
@@ -1,4 +1,4 @@
-import { getTranslations } from "next-intl/server"
+import { getTranslations, setRequestLocale } from "next-intl/server"
 
 import type { Lang, PageParams } from "@/lib/types"
 
@@ -31,6 +31,7 @@ const EVENT_CATEGORY = "dashboard"
 
 const Page = async ({ params }: { params: PageParams }) => {
   const { locale } = params
+  setRequestLocale(locale)
 
   const t = await getTranslations({ locale, namespace: "page-resources" })
 
@@ -62,6 +63,7 @@ const Page = async ({ params }: { params: PageParams }) => {
   }
 
   const resourceSections = await getResources({
+    locale,
     txCostsMedianUsd,
     ...blobStats,
   })

--- a/app/[locale]/resources/utils.tsx
+++ b/app/[locale]/resources/utils.tsx
@@ -1,5 +1,5 @@
 import dynamic from "next/dynamic"
-import { getLocale, getTranslations } from "next-intl/server"
+import { getTranslations } from "next-intl/server"
 
 import { Lang } from "@/lib/types"
 
@@ -80,11 +80,16 @@ const UpgradeCountdownFigure = dynamic(
 )
 
 export const getResources = async ({
+  locale,
   txCostsMedianUsd,
   totalBlobs,
   avgBlobFee,
+}: {
+  locale: string
+  txCostsMedianUsd: { value: number } | { error: string }
+  totalBlobs: string
+  avgBlobFee: number
 }): Promise<DashboardSection[]> => {
-  const locale = await getLocale()
   const t = await getTranslations({ locale, namespace: "page-resources" })
   const localeForNumberFormat = getLocaleForNumberFormat(locale as Lang)
 


### PR DESCRIPTION
## Summary

- The `/[locale]/resources` page was missing the `setRequestLocale()` call that all other locale pages have
- This caused `getLocale()` in `getResources()` to trigger dynamic rendering, throwing a next-intl error
- Added `setRequestLocale(locale)` to the page and refactored `getResources` to accept `locale` as an explicit parameter

## Error Context

- **Source:** sentry
- **Item ID:** ETHORG-15H
- **Path/URL:** /[locale]/resources
- **Status:** Error (dynamic rendering opt-in)
- **Hit count:** 1
- **First seen:** 2026-03-18T05:45:01.029Z
- **Last seen:** 2026-03-18T05:45:01.029Z

## Changes

- `app/[locale]/resources/page.tsx`: Added `setRequestLocale(locale)` call, pass `locale` to `getResources`
- `app/[locale]/resources/utils.tsx`: Accept `locale` parameter instead of calling `getLocale()`, added explicit type annotation

## Analysis

The next-intl library requires `setRequestLocale()` to be called in Server Components to enable static rendering. Without it, calling any next-intl API (like `getLocale()`) forces dynamic rendering and throws an error. Every other page in the app already calls `setRequestLocale(locale)` — the resources page was the only one missing it.

## Test Plan

- [ ] Visit `/en/resources/` and verify the page renders without errors
- [ ] Check Sentry for no new ETHORG-15H occurrences after deployment

---
*Opened automatically by the Recovery Agent.*