### PR TITLE
fix: use trigger.dev catchError and logger for task error visibility

### DIFF
--- a/src/data-layer/tasks.ts
+++ b/src/data-layer/tasks.ts
@@ -7,7 +7,7 @@
  */
 
 import * as Sentry from "@sentry/nextjs"
-import { schedules, task, tasks } from "@trigger.dev/sdk/v3"
+import { logger, schedules, task, tasks } from "@trigger.dev/sdk/v3"
 
 import { fetchDeveloperTools } from "./fetchers/developer-tools"
 import { fetchAccountHolders } from "./fetchers/fetchAccountHolders"
@@ -110,10 +110,13 @@ function createDataTask([key, fetchFn]: TaskDef) {
       maxTimeoutInMs: 30000,
       randomize: true,
     },
+    catchError: async ({ error }) => {
+      logger.error(`[${key}] failed`, { error })
+    },
     run: async () => {
       const data = await fetchFn()
       await set(key, data)
-      console.log(`✓ ${key}`)
+      logger.info(`✓ ${key}`)
       return { key }
     },
   })


### PR DESCRIPTION
## Summary

- Use Trigger.dev's built-in `catchError` hook and `logger` to surface full error details (including `.cause` chains) in the dashboard
- Replace `console.log` with `logger.info` for consistent task output
- Fixes opaque `TypeError: fetch failed` errors that gave no actionable information

## Test plan

- [ ] Verify errors in Trigger.dev dashboard now show full error details including cause chain
- [ ] Confirm retry behavior is unchanged (catchError returns nothing → normal retry continues)
- [ ] Confirm `onFailure` global handler still fires after retries exhausted