### PR TITLE
feat: hide contributors if edit button hidden

### DIFF
--- a/src/layouts/Docs.tsx
+++ b/src/layouts/Docs.tsx
@@ -136,10 +136,12 @@ export const DocsLayout = ({
         <SideNav path={addSlashes(slug)} />
         <MainArticle className="min-w-0 flex-1 px-8 pb-8 pt-8 md:px-16 md:pb-16 md:pt-12">
           <H1 id="top">{frontmatter.title}</H1>
-          <FileContributors
-            contributors={contributors}
-            lastEditLocaleTimestamp={lastEditLocaleTimestamp}
-          />
+          {!frontmatter.hideEditButton && (
+            <FileContributors
+              contributors={contributors}
+              lastEditLocaleTimestamp={lastEditLocaleTimestamp}
+            />
+          )}
           <TableOfContents
             editPath={absoluteEditPath}
             items={tocItems}

--- a/src/layouts/Static.tsx
+++ b/src/layouts/Static.tsx
@@ -138,11 +138,13 @@ export const StaticLayout = ({
             />
             {children}
 
-            <FileContributors
-              className="my-10 border-t"
-              contributors={contributors}
-              lastEditLocaleTimestamp={lastEditLocaleTimestamp}
-            />
+            {!frontmatter.hideEditButton && (
+              <FileContributors
+                className="my-10 border-t"
+                contributors={contributors}
+                lastEditLocaleTimestamp={lastEditLocaleTimestamp}
+              />
+            )}
             <FeedbackCard isArticle />
           </MainArticle>
         </div>

--- a/src/layouts/Tutorial.tsx
+++ b/src/layouts/Tutorial.tsx
@@ -125,11 +125,13 @@ export const TutorialLayout = ({
           isMobile
         />
         {children}
-        <FileContributors
-          className="my-10 border-t"
-          contributors={contributors}
-          lastEditLocaleTimestamp={lastEditLocaleTimestamp}
-        />
+        {!frontmatter.hideEditButton && (
+          <FileContributors
+            className="my-10 border-t"
+            contributors={contributors}
+            lastEditLocaleTimestamp={lastEditLocaleTimestamp}
+          />
+        )}
         <FeedbackCard />
       </MainArticle>
       {tocItems && (


### PR DESCRIPTION
## Description
- Hides `FileContributors` component on pages marked with `hideEditButton`

Used on only a few pages, the `hideEditButton` flag is available for certain more-protected pages which intentionally limit community contributions for editing. In these cases, showing the file contributors component feels less appropriate.

### Current affected pages
- /community/events/organizing/
- /cookie-policy/
- /foundation/
- /privacy-policy/
- /terms-of-use/
- /whitepaper/

cc: @konopkja 