### PR TITLE
fix: docsearch/css dependency issue, initial env

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ pnpm install
 
 > Note: On Ubuntu or Debian you may need to run `sudo apt update && sudo apt install nodejs npm` before running `corepack enable` or `pnpm install`.
 
+4. Set up environment variables
+
+```sh
+cp .env.example .env.local
+```
+
 #### Migrating from yarn to pnpm
 
 If you previously used `yarn` to install dependencies, you can safely migrate to `pnpm` by running the following commands:

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.982.0",
     "@aws-sdk/client-ses": "^3.859.0",
+    "@docsearch/css": "^4.6.0",
     "@docsearch/react": "^3.5.2",
     "@hookform/resolvers": "^3.8.0",
     "@netlify/blobs": "^10.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
       '@aws-sdk/client-ses':
         specifier: ^3.859.0
         version: 3.859.0
+      '@docsearch/css':
+        specifier: ^4.6.0
+        version: 4.6.0
       '@docsearch/react':
         specifier: ^3.5.2
         version: 3.9.0(@algolia/client-search@5.25.0)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(search-insights@2.17.3)
@@ -1346,6 +1349,9 @@ packages:
 
   '@docsearch/css@3.9.0':
     resolution: {integrity: sha512-cQbnVbq0rrBwNAKegIac/t6a8nWoUAn8frnkLFW6YARaRmAQr5/Eoe6Ln2fqkUCZ40KpdrKbpSAmgrkviOxuWA==}
+
+  '@docsearch/css@4.6.0':
+    resolution: {integrity: sha512-YlcAimkXclvqta47g47efzCM5CFxDwv2ClkDfEs/fC/Ak0OxPH2b3czwa4o8O1TRBf+ujFF2RiUwszz2fPVNJQ==}
 
   '@docsearch/react@3.9.0':
     resolution: {integrity: sha512-mb5FOZYZIkRQ6s/NWnM98k879vu5pscWqTLubLFBO87igYYT4VzVazh4h5o/zCvTIZgEt3PvsCOMOswOUo9yHQ==}
@@ -11974,6 +11980,8 @@ snapshots:
 
   '@docsearch/css@3.9.0': {}
 
+  '@docsearch/css@4.6.0': {}
+
   '@docsearch/react@3.9.0(@algolia/client-search@5.25.0)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(search-insights@2.17.3)':
     dependencies:
       '@algolia/autocomplete-core': 1.17.9(@algolia/client-search@5.25.0)(algoliasearch@5.25.0)(search-insights@2.17.3)
@@ -17420,7 +17428,7 @@ snapshots:
 
   browserify-rsa@4.1.1:
     dependencies:
-      bn.js: 5.2.2
+      bn.js: 5.2.3
       randombytes: 2.1.0
       safe-buffer: 5.2.1
 
@@ -20358,7 +20366,7 @@ snapshots:
 
   miller-rabin@4.0.1:
     dependencies:
-      bn.js: 4.12.2
+      bn.js: 4.12.3
       brorand: 1.1.0
 
   mime-db@1.52.0: {}


### PR DESCRIPTION
## Description

- Add `@docsearch/css` as a direct dependency -- the Next 15/React 19 upgrade changed how `@docsearch/react` resolves this transitive dep, breaking fresh `pnpm install` for new contributors
- Add `cp .env.example .env.local` step to README setup instructions

## Related issue
Fixes:

```
./src/styles/global.css
Module not found: Can't resolve '@docsearch/css'
```