### PR TITLE
Add internal infrastructure section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,3 +280,10 @@ Required for Matomo integration:
 - **Platform**: Netlify (config in `netlify.toml`)
 - **Next.js Integration**: Uses `@netlify/plugin-nextjs` for seamless Netlify and Next.js compatibility
 - **Monitoring**: Matomo analytics integration
+
+## Internal Infrastructure
+
+The following external-looking services are managed by the ethereum.org team:
+
+- **`s3-dcl1.ethquokkaops.io`** — S3-compatible object storage for app screenshots and media. Used by the data layer to serve images for the `/dapps` and app listing pages. Downtime here means broken images on the live site.
+- **Netlify Blobs** (`@netlify/blobs`) — Key-value store used by the data layer to cache API responses. Accessed via `src/data-layer/storage.ts`.


### PR DESCRIPTION
## Summary
- Add Internal Infrastructure section to AGENTS.md documenting team-managed services
- Documents `s3-dcl1.ethquokkaops.io` (S3 storage for app screenshots/media) and Netlify Blobs (KV cache for data layer)
- Keeps AGENTS.md in sync with CLAUDE.md

## Test plan
- [ ] Verify AGENTS.md renders correctly on GitHub
- [ ] Confirm section matches CLAUDE.md