### PR TITLE
fix: cache translation lookups to ensure hreflang reciprocity

### DIFF
--- a/src/lib/i18n/translationRegistry.ts
+++ b/src/lib/i18n/translationRegistry.ts
@@ -50,9 +50,16 @@ function getPageType(slug: string): "md" | "intl" {
   return primaryNamespace ? "intl" : "md"
 }
 
+// Cache of translated locales per slug, ensuring consistent results across
+// all pages rendered during a single build. Without this cache, filesystem
+// checks via existsSync() could return different results for the same slug
+// at different points in the build, breaking hreflang reciprocity.
+const translatedLocalesCache = new Map<string, string[]>()
+
 /**
  * Get all translated locales for a given page slug.
  * Works for both MD pages and intl pages.
+ * Results are cached per slug for build-time consistency.
  *
  * @param slug - Page slug/path (e.g., "about" for MD or "/wallets/" for intl)
  * @returns Promise resolving to array of locale codes that have translations
@@ -61,6 +68,9 @@ function getPageType(slug: string): "md" | "intl" {
  *   await getTranslatedLocales("/wallets/") // => ["en", "es"]
  */
 export async function getTranslatedLocales(slug: string): Promise<string[]> {
+  const cached = translatedLocalesCache.get(slug)
+  if (cached) return cached
+
   const pageType = getPageType(slug)
   const translatedLocales: string[] = []
 
@@ -80,6 +90,7 @@ export async function getTranslatedLocales(slug: string): Promise<string[]> {
     }
   }
 
+  translatedLocalesCache.set(slug, translatedLocales)
   return translatedLocales
 }
 

--- a/src/lib/i18n/translationStatus.ts
+++ b/src/lib/i18n/translationStatus.ts
@@ -3,9 +3,14 @@ import { join } from "path"
 
 import { DEFAULT_LOCALE } from "@/lib/constants"
 
+// Cache namespace existence checks so filesystem reads are consistent
+// across all pages rendered during a single build.
+const namespaceExistsCache = new Map<string, boolean>()
+
 /**
  * Determine whether all required i18n namespaces exist for a given locale.
  * Default locale is always considered translated.
+ * Results are cached per locale+namespace for build-time consistency.
  */
 export async function areNamespacesTranslated(
   locale: string,
@@ -15,7 +20,13 @@ export async function areNamespacesTranslated(
 
   const intlPath = join(process.cwd(), "src/intl")
 
-  return namespaces.every((ns) =>
-    existsSync(join(intlPath, locale, `${ns}.json`))
-  )
+  return namespaces.every((ns) => {
+    const cacheKey = `${locale}/${ns}`
+    const cached = namespaceExistsCache.get(cacheKey)
+    if (cached !== undefined) return cached
+
+    const exists = existsSync(join(intlPath, locale, `${ns}.json`))
+    namespaceExistsCache.set(cacheKey, exists)
+    return exists
+  })
 }


### PR DESCRIPTION
## Summary

- Cache `getTranslatedLocales()` results per slug in `translationRegistry.ts`
- Cache `areNamespacesTranslated()` filesystem checks per locale+namespace in `translationStatus.ts`

## Context

The March 2026 SEO audit flagged 97 pages with broken hreflang reciprocity (943 flagged rows). Google requires that if Page A declares Page B as an alternate-language version, Page B must declare Page A back.

**Root cause:** `getTranslatedLocales()` and `areNamespacesTranslated()` use uncached `existsSync()` calls. During a Next.js build, different pages render at different times. If translation files shift mid-build (e.g., concurrent Crowdin sync), different pages can see different filesystem states for the same slug — producing inconsistent locale lists that break hreflang reciprocity.

**Why it's intermittent:** We checked all 10 flagged route+locale combinations against the current production deploy and found all hreflang sets consistent. The issue only manifests when the filesystem changes during a build.

**Fix:** Module-level `Map` caches (same pattern as the existing `cachedStaticPages` in `staticPages.ts`) ensure that once a slug's translated locales are computed, every subsequent caller gets the same result for the lifetime of the build process.

**Side benefit:** Eliminates redundant `existsSync()` calls (25 locales × ~5,000 pages = up to 125K filesystem reads reduced to ~5K).

## Test plan

- [x] TypeScript passes (`npx tsc --noEmit`)
- [x] Build completes successfully (`pnpm build`)
- [x] Verify hreflang tags are consistent across locales for a sample page