### PR TITLE
docs: Adding Canonical Txn Index to Portal Networks [Fixes #13361]

### DIFF
--- a/public/content/developers/docs/networking-layer/portal-network/index.md
+++ b/public/content/developers/docs/networking-layer/portal-network/index.md
@@ -61,11 +61,11 @@ The table below shows the functions of existing clients that can be delivered by
 
 ### The Portal Networks
 
-| Beacon light client | State network                | Transaction gossip  | History network |
-| ------------------- | ---------------------------- | ------------------- | --------------- |
-| Beacon chain light  | Account and contract storage | Lightweight mempool | Headers         |
-| Protocol data       |                              |                     | Block bodies    |
-|                     |                              |                     | Receipts        |
+| Beacon light client | State network                | Transaction gossip  | History network | Canonical Txn Index  |
+| ------------------- | ---------------------------- | ------------------- | --------------- | -------------------  |
+| Beacon chain light  | Account and contract storage | Lightweight mempool | Headers         | TxHash > Hash, Index |
+| Protocol data       |                              |                     | Block bodies    |                      |
+|                     |                              |                     | Receipts        |                      |
 
 ## Client diversity by default {#client-diversity-as-default}
 


### PR DESCRIPTION
## Description

Adds the missing column to the table [en & pt-br which uses the English table] in this page:

https://ethereum.org/developers/docs/networking-layer/portal-network/#how-does-portal-network-work

## Related Issue

https://github.com/ethereum/ethereum-org-website/issues/13361
