### PR TITLE
feat: improve FileContributors display

### DIFF
--- a/.claude/commands/prepare-release.md
+++ b/.claude/commands/prepare-release.md
@@ -101,6 +101,7 @@ These accounts should be filtered from the contributors list:
 - `github-actions`
 - `github-actions[bot]`
 - `actions-user`
+- `myelinated-wackerow`
 
 **Keep the structure intact**:
 - Keep section headers (⚡️ Changes, 🌐 Translations, 🐛 Bug Fix, etc.)

--- a/src/data-layer/fetchers/fetchGitHubContributors.ts
+++ b/src/data-layer/fetchers/fetchGitHubContributors.ts
@@ -66,6 +66,7 @@ const EXCLUDED_LOGINS = [
   "eth-bot",
   "ethereumoptimism-bot",
   "coderabbitai[bot]",
+  "myelinated-wackerow",
 ]
 
 /** Name patterns (case-insensitive substring match) for AI agent co-authors */

--- a/src/data/team.ts
+++ b/src/data/team.ts
@@ -1,0 +1,14 @@
+/**
+ * GitHub logins of ethereum.org team members.
+ * Used by FileContributors to sort team members to the end of the list,
+ * so external community contributions are highlighted first.
+ */
+export const TEAM_LOGINS: Set<string> = new Set([
+  "minimalsm",
+  "pettinarip",
+  "wackerow",
+  "nloureiro",
+  "konopkja",
+  "mnelsonBT",
+  "lukassim",
+])

--- a/src/lib/utils/contributors.ts
+++ b/src/lib/utils/contributors.ts
@@ -2,6 +2,8 @@ import { join } from "path"
 
 import type { FileContributor, Lang } from "@/lib/types"
 
+import { TEAM_LOGINS } from "@/data/team"
+
 import { CONTENT_PATH, DEFAULT_LOCALE } from "@/lib/constants"
 
 import {
@@ -12,6 +14,12 @@ import { getAppPageLastCommitDate } from "./gh"
 import { getLocaleTimestamp } from "./time"
 
 import { getGitHubContributors, getStaticGitHubContributors } from "@/lib/data"
+
+/** Sort team members to the end, preserving relative order within each group. */
+const sortTeamToEnd = (contributors: FileContributor[]): FileContributor[] =>
+  contributors.toSorted((a, b) =>
+    Number(TEAM_LOGINS.has(a.login)) - Number(TEAM_LOGINS.has(b.login))
+  )
 
 export const getMarkdownFileContributorInfo = async (
   slug: string,
@@ -33,8 +41,8 @@ export const getMarkdownFileContributorInfo = async (
     fileLang === DEFAULT_LOCALE || crowdinContributors.length === 0
 
   const contributors: FileContributor[] = englishOnly
-    ? gitHubContributors
-    : [...crowdinContributors, ...gitHubContributors]
+    ? sortTeamToEnd(gitHubContributors)
+    : [...crowdinContributors, ...sortTeamToEnd(gitHubContributors)]
 
   return { contributors, lastUpdatedDate }
 }
@@ -65,5 +73,8 @@ export const getAppPageContributorInfo = async (
   //   )
   // }
 
-  return { contributors: uniqueGitHubContributors, lastEditLocaleTimestamp }
+  return {
+    contributors: sortTeamToEnd(uniqueGitHubContributors),
+    lastEditLocaleTimestamp,
+  }
 }


### PR DESCRIPTION
## Summary

- Filter `myelinated-wackerow` (secondary team account) from page contributor lists and release note thank-yous
- Sort team members to end of contributor lists so external community contributions are highlighted first
- New `src/data/team.ts` canonical list of team GitHub logins

## Details

**Filtering:** Added `myelinated-wackerow` to `EXCLUDED_LOGINS` in the GitHub contributors fetcher and to the prepare-release contributor filter. PRs from this account still appear in release note changes -- only the thank-you mention is removed.

**Sorting:** External contributors now appear first in the FileContributors component (both markdown content pages and app pages). Team members are sorted to the end, preserving relative order within each group.

## Test plan

- [ ] Verify `myelinated-wackerow` no longer appears in FileContributors after next data refresh
- [ ] Verify team members (minimalsm, pettinarip, wackerow, etc.) appear after external contributors
- [ ] Run next `/prepare-release` and confirm `myelinated-wackerow` is removed from thank-you line but PRs remain in changes

Generated with Claude Code (Claude Opus 4.6)