### PR TITLE
fix: pin @docsearch/css to 3.9.0 to match @docsearch/react v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.982.0",
     "@aws-sdk/client-ses": "^3.859.0",
-    "@docsearch/css": "^4.6.0",
+    "@docsearch/css": "3.9.0",
     "@docsearch/react": "^3.5.2",
     "@hookform/resolvers": "^3.8.0",
     "@netlify/blobs": "^10.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         specifier: ^3.859.0
         version: 3.859.0
       '@docsearch/css':
-        specifier: ^4.6.0
-        version: 4.6.0
+        specifier: 3.9.0
+        version: 3.9.0
       '@docsearch/react':
         specifier: ^3.5.2
         version: 3.9.0(@algolia/client-search@5.25.0)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(search-insights@2.17.3)
@@ -1349,9 +1349,6 @@ packages:
 
   '@docsearch/css@3.9.0':
     resolution: {integrity: sha512-cQbnVbq0rrBwNAKegIac/t6a8nWoUAn8frnkLFW6YARaRmAQr5/Eoe6Ln2fqkUCZ40KpdrKbpSAmgrkviOxuWA==}
-
-  '@docsearch/css@4.6.0':
-    resolution: {integrity: sha512-YlcAimkXclvqta47g47efzCM5CFxDwv2ClkDfEs/fC/Ak0OxPH2b3czwa4o8O1TRBf+ujFF2RiUwszz2fPVNJQ==}
 
   '@docsearch/react@3.9.0':
     resolution: {integrity: sha512-mb5FOZYZIkRQ6s/NWnM98k879vu5pscWqTLubLFBO87igYYT4VzVazh4h5o/zCvTIZgEt3PvsCOMOswOUo9yHQ==}
@@ -11985,8 +11982,6 @@ snapshots:
   '@discoveryjs/json-ext@0.5.7': {}
 
   '@docsearch/css@3.9.0': {}
-
-  '@docsearch/css@4.6.0': {}
 
   '@docsearch/react@3.9.0(@algolia/client-search@5.25.0)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(search-insights@2.17.3)':
     dependencies:


### PR DESCRIPTION
## Summary

- Pins `@docsearch/css` to `3.9.0` to match the version expected by `@docsearch/react@3.9.0`
- PR #17818 introduced `@docsearch/css@^4.6.0` which resolved to v4, but the React component is v3 — the v4 CSS caused style regressions

## What was broken

1. **Search icon in primary/purple color** — v4 CSS doesn't override the button's inherited `text-primary`, while v3 sets body color on `.DocSearch-Search-Icon`
2. **Constant spinner in search modal** — v4 CSS shows `.DocSearch-LoadingIndicator` by default (`display: flex`), while v3 hides it unless `.DocSearch-Container--Stalled` is present
3. **Hover/highlight style issues** — v4 CSS variables and selectors don't align with the v3 React component's DOM structure

Reported in #17874 (comment): https://github.com/ethereum/ethereum-org-website/pull/17874#issuecomment-4141205224

## Test plan

- [x] Search icon in nav should be body color (dark), not purple
- [x] Opening search modal should show no spinner when idle
- [x] Search results should have correct hover and highlight colors