### PR TITLE
fix(i18n): use intl string for category tag

### DIFF
--- a/app/[locale]/developers/tools/_components/ToolModalContents.tsx
+++ b/app/[locale]/developers/tools/_components/ToolModalContents.tsx
@@ -63,7 +63,7 @@ const ToolModalContents = async ({ tool }: { tool: DeveloperTool }) => {
             status={getCategoryTagStyle(categorySlug)}
             className="px-1 py-0"
           >
-            {tool.category}
+            {t(`page-developers-tools-category-${categorySlug}-title`)}
           </Tag>
           <h2 className="text-3xl">{tool.name}</h2>
           <TagsInlineText


### PR DESCRIPTION
## Description
Fixes English category being displayed inside tool details modal on /developers/tools/* pages

## Related Issue
<img width="711" height="492" alt="image" src="https://github.com/user-attachments/assets/1d255540-acb8-44ea-addf-bbcdd490117b" />
