### PR TITLE
feat: add empty action for branch tasks

### DIFF
--- a/.github/workflows/branch-task.yml
+++ b/.github/workflows/branch-task.yml
@@ -1,0 +1,10 @@
+name: Branch Task
+
+on:
+  workflow_dispatch:
+
+jobs:
+  stub:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "ok"


### PR DESCRIPTION
## Description
- Branch-only GitHub actions cannot be executed until at least a base workflow under its name are found on `dev` branch
- Adds empty GitHub action workflow for development use/testing of actions via branches