### PR TITLE
docs: add ERC-7540 page

### DIFF
--- a/public/content/developers/docs/standards/tokens/erc-20/index.md
+++ b/public/content/developers/docs/standards/tokens/erc-20/index.md
@@ -188,6 +188,7 @@ Some alternative standards have come out of this issue such as [ERC-223](/develo
 - [ERC-1363](/developers/docs/standards/tokens/erc-1363)
 - [ERC-777](/developers/docs/standards/tokens/erc-777)
 - [ERC-4626 - Tokenized vaults](/developers/docs/standards/tokens/erc-4626)
+- [ERC-7540 - Asynchronous tokenized vaults](/developers/docs/standards/tokens/erc-7540)
 
 ## Tutorials: Build with ERC-20 on Ethereum {#tutorials}
 

--- a/public/content/developers/docs/standards/tokens/erc-4626/index.md
+++ b/public/content/developers/docs/standards/tokens/erc-4626/index.md
@@ -22,7 +22,7 @@ ERC-4626 is optimized for atomic deposits and redemptions up to a limit. If the 
 
 ERC-7540 expands the utility of ERC-4626 Vaults for asynchronous use cases. The existing Vault interface (`deposit`/`withdraw`/`mint`/`redeem`) is fully utilized to claim asynchronous Requests.
 
-The ERC-7540 extension is described fully in [ERC-7540](https://eips.ethereum.org/EIPS/eip-7540).
+Learn more about [ERC-7540 Asynchronous Tokenized Vaults](/developers/docs/standards/tokens/erc-7540/).
 
 **Multi-asset vault extension (ERC-7575)**
 

--- a/public/content/developers/docs/standards/tokens/erc-7540/erc-4626-sync-flow.svg
+++ b/public/content/developers/docs/standards/tokens/erc-7540/erc-4626-sync-flow.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 200" font-family="monospace" font-size="14">
+  <style>
+    text { fill: #222; }
+    .label { font-weight: bold; font-size: 13px; }
+    .note { font-size: 12px; fill: #666; }
+    line, path { stroke: #444; stroke-width: 1.5; }
+  </style>
+
+  <!-- Title -->
+  <text x="260" y="24" text-anchor="middle" font-weight="bold" font-size="15">ERC-4626 (synchronous)</text>
+
+  <!-- Lifelines -->
+  <text x="80" y="60" text-anchor="middle" class="label">Investor</text>
+  <line x1="80" y1="70" x2="80" y2="180" stroke-dasharray="4,4"/>
+
+  <text x="400" y="60" text-anchor="middle" class="label">Vault</text>
+  <line x1="400" y1="70" x2="400" y2="180" stroke-dasharray="4,4"/>
+
+  <!-- deposit arrow -->
+  <line x1="80" y1="95" x2="390" y2="95" marker-end="url(#arrow)"/>
+  <text x="235" y="88" text-anchor="middle" font-size="12">deposit(assets)</text>
+
+  <!-- shares arrow -->
+  <line x1="400" y1="125" x2="90" y2="125" marker-end="url(#arrow)" stroke-dasharray="6,3"/>
+  <text x="235" y="118" text-anchor="middle" font-size="12">shares (instant)</text>
+
+  <!-- Note -->
+  <text x="260" y="165" text-anchor="middle" class="note">Done in one transaction</text>
+
+  <defs>
+    <marker id="arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#444"/>
+    </marker>
+  </defs>
+</svg>

--- a/public/content/developers/docs/standards/tokens/erc-7540/erc-4626-sync-flow.svg
+++ b/public/content/developers/docs/standards/tokens/erc-7540/erc-4626-sync-flow.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 200" font-family="monospace" font-size="14">
   <style>
-    text { fill: #222; }
+    text { fill: currentColor; }
     .label { font-weight: bold; font-size: 13px; }
-    .note { font-size: 12px; fill: #666; }
-    line, path { stroke: #444; stroke-width: 1.5; }
+    .note { font-size: 12px; opacity: 0.6; }
+    line, path { stroke: currentColor; stroke-width: 1.5; }
   </style>
 
   <!-- Title -->
@@ -29,7 +29,7 @@
 
   <defs>
     <marker id="arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6" fill="#444"/>
+      <path d="M0,0 L8,3 L0,6" fill="currentColor"/>
     </marker>
   </defs>
 </svg>

--- a/public/content/developers/docs/standards/tokens/erc-7540/erc-4626-sync-flow.svg
+++ b/public/content/developers/docs/standards/tokens/erc-7540/erc-4626-sync-flow.svg
@@ -1,10 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 200" font-family="monospace" font-size="14">
   <style>
-    text { fill: currentColor; }
+    text { fill: #1a1a2e; }
     .label { font-weight: bold; font-size: 13px; }
-    .note { font-size: 12px; opacity: 0.6; }
-    line, path { stroke: currentColor; stroke-width: 1.5; }
+    .note { font-size: 12px; fill: #6b6b7b; }
+    line, path { stroke: #1a1a2e; stroke-width: 1.5; }
   </style>
+
+  <!-- Opaque background so the diagram is legible in both light and dark mode -->
+  <rect x="0" y="0" width="520" height="200" rx="8" fill="#ffffff"/>
 
   <!-- Title -->
   <text x="260" y="24" text-anchor="middle" font-weight="bold" font-size="15">ERC-4626 (synchronous)</text>
@@ -29,7 +32,7 @@
 
   <defs>
     <marker id="arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6" fill="currentColor"/>
+      <path d="M0,0 L8,3 L0,6" fill="#1a1a2e"/>
     </marker>
   </defs>
 </svg>

--- a/public/content/developers/docs/standards/tokens/erc-7540/erc-7540-async-flow.svg
+++ b/public/content/developers/docs/standards/tokens/erc-7540/erc-7540-async-flow.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 440" font-family="monospace" font-size="13">
   <style>
-    text { fill: #222; }
+    text { fill: currentColor; }
     .label { font-weight: bold; font-size: 13px; }
-    .note { font-size: 11px; fill: #666; }
-    .step { font-size: 11px; fill: #555; }
-    line { stroke: #444; stroke-width: 1.5; }
+    .note { font-size: 11px; opacity: 0.6; }
+    .step { font-size: 11px; opacity: 0.7; }
+    line { stroke: currentColor; stroke-width: 1.5; }
     rect.box { fill: #f5f0ff; stroke: #7c5cbf; stroke-width: 1.5; rx: 4; }
   </style>
 
@@ -17,9 +17,9 @@
   <text x="560" y="58" text-anchor="middle" class="label">Manager</text>
 
   <!-- Lifelines -->
-  <line x1="90" y1="68" x2="90" y2="420" stroke-dasharray="4,4" stroke="#aaa"/>
-  <line x1="320" y1="68" x2="320" y2="420" stroke-dasharray="4,4" stroke="#aaa"/>
-  <line x1="560" y1="68" x2="560" y2="420" stroke-dasharray="4,4" stroke="#aaa"/>
+  <line x1="90" y1="68" x2="90" y2="420" stroke-dasharray="4,4" stroke="currentColor" opacity="0.4"/>
+  <line x1="320" y1="68" x2="320" y2="420" stroke-dasharray="4,4" stroke="currentColor" opacity="0.4"/>
+  <line x1="560" y1="68" x2="560" y2="420" stroke-dasharray="4,4" stroke="currentColor" opacity="0.4"/>
 
   <!-- requestDeposit -->
   <line x1="90" y1="95" x2="310" y2="95" marker-end="url(#arr)"/>
@@ -55,7 +55,7 @@
 
   <defs>
     <marker id="arr" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6" fill="#444"/>
+      <path d="M0,0 L8,3 L0,6" fill="currentColor"/>
     </marker>
   </defs>
 </svg>

--- a/public/content/developers/docs/standards/tokens/erc-7540/erc-7540-async-flow.svg
+++ b/public/content/developers/docs/standards/tokens/erc-7540/erc-7540-async-flow.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 440" font-family="monospace" font-size="13">
+  <style>
+    text { fill: #222; }
+    .label { font-weight: bold; font-size: 13px; }
+    .note { font-size: 11px; fill: #666; }
+    .step { font-size: 11px; fill: #555; }
+    line { stroke: #444; stroke-width: 1.5; }
+    rect.box { fill: #f5f0ff; stroke: #7c5cbf; stroke-width: 1.5; rx: 4; }
+  </style>
+
+  <!-- Title -->
+  <text x="340" y="24" text-anchor="middle" font-weight="bold" font-size="15">ERC-7540 (asynchronous)</text>
+
+  <!-- Lifeline labels -->
+  <text x="90" y="58" text-anchor="middle" class="label">Investor</text>
+  <text x="320" y="58" text-anchor="middle" class="label">Vault</text>
+  <text x="560" y="58" text-anchor="middle" class="label">Manager</text>
+
+  <!-- Lifelines -->
+  <line x1="90" y1="68" x2="90" y2="420" stroke-dasharray="4,4" stroke="#aaa"/>
+  <line x1="320" y1="68" x2="320" y2="420" stroke-dasharray="4,4" stroke="#aaa"/>
+  <line x1="560" y1="68" x2="560" y2="420" stroke-dasharray="4,4" stroke="#aaa"/>
+
+  <!-- requestDeposit -->
+  <line x1="90" y1="95" x2="310" y2="95" marker-end="url(#arr)"/>
+  <text x="200" y="88" text-anchor="middle" font-size="12">requestDeposit()</text>
+  <text x="200" y="115" text-anchor="middle" class="note">assets locked</text>
+
+  <!-- batch to manager -->
+  <line x1="320" y1="130" x2="550" y2="130" marker-end="url(#arr)"/>
+  <text x="435" y="123" text-anchor="middle" font-size="12">batch to manager</text>
+
+  <!-- Manager processing box -->
+  <rect class="box" x="460" y="150" width="200" height="150"/>
+  <text x="560" y="172" text-anchor="middle" class="step" font-weight="bold">Step 1: Approve</text>
+  <text x="560" y="188" text-anchor="middle" class="step">set asset price,</text>
+  <text x="560" y="204" text-anchor="middle" class="step">release assets for investment</text>
+  <text x="560" y="230" text-anchor="middle" class="step">... manager invests ...</text>
+  <text x="560" y="258" text-anchor="middle" class="step" font-weight="bold">Step 2: Issue</text>
+  <text x="560" y="274" text-anchor="middle" class="step">set share price,</text>
+  <text x="560" y="290" text-anchor="middle" class="step">mint shares</text>
+
+  <!-- fulfillment arrow -->
+  <line x1="560" y1="320" x2="330" y2="320" marker-end="url(#arr)" stroke-dasharray="6,3"/>
+  <text x="445" y="340" text-anchor="middle" font-size="12">fulfillment</text>
+
+  <!-- deposit (claim) -->
+  <line x1="90" y1="370" x2="310" y2="370" marker-end="url(#arr)"/>
+  <text x="200" y="363" text-anchor="middle" font-size="12">deposit()</text>
+
+  <!-- shares back -->
+  <line x1="320" y1="395" x2="100" y2="395" marker-end="url(#arr)" stroke-dasharray="6,3"/>
+  <text x="200" y="388" text-anchor="middle" font-size="12">shares</text>
+  <text x="200" y="415" text-anchor="middle" class="note">(claim)</text>
+
+  <defs>
+    <marker id="arr" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#444"/>
+    </marker>
+  </defs>
+</svg>

--- a/public/content/developers/docs/standards/tokens/erc-7540/erc-7540-async-flow.svg
+++ b/public/content/developers/docs/standards/tokens/erc-7540/erc-7540-async-flow.svg
@@ -1,12 +1,16 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 440" font-family="monospace" font-size="13">
   <style>
-    text { fill: currentColor; }
+    text { fill: #1a1a2e; }
     .label { font-weight: bold; font-size: 13px; }
-    .note { font-size: 11px; opacity: 0.6; }
-    .step { font-size: 11px; opacity: 0.7; }
-    line { stroke: currentColor; stroke-width: 1.5; }
+    .note { font-size: 11px; fill: #6b6b7b; }
+    .step { font-size: 11px; fill: #4a3a6b; }
+    line { stroke: #1a1a2e; stroke-width: 1.5; }
+    line.lifeline { stroke: #b8b8c4; }
     rect.box { fill: #f5f0ff; stroke: #7c5cbf; stroke-width: 1.5; rx: 4; }
   </style>
+
+  <!-- Opaque background so the diagram is legible in both light and dark mode -->
+  <rect x="0" y="0" width="680" height="440" rx="8" fill="#ffffff"/>
 
   <!-- Title -->
   <text x="340" y="24" text-anchor="middle" font-weight="bold" font-size="15">ERC-7540 (asynchronous)</text>
@@ -17,9 +21,9 @@
   <text x="560" y="58" text-anchor="middle" class="label">Manager</text>
 
   <!-- Lifelines -->
-  <line x1="90" y1="68" x2="90" y2="420" stroke-dasharray="4,4" stroke="currentColor" opacity="0.4"/>
-  <line x1="320" y1="68" x2="320" y2="420" stroke-dasharray="4,4" stroke="currentColor" opacity="0.4"/>
-  <line x1="560" y1="68" x2="560" y2="420" stroke-dasharray="4,4" stroke="currentColor" opacity="0.4"/>
+  <line class="lifeline" x1="90" y1="68" x2="90" y2="420" stroke-dasharray="4,4"/>
+  <line class="lifeline" x1="320" y1="68" x2="320" y2="420" stroke-dasharray="4,4"/>
+  <line class="lifeline" x1="560" y1="68" x2="560" y2="420" stroke-dasharray="4,4"/>
 
   <!-- requestDeposit -->
   <line x1="90" y1="95" x2="310" y2="95" marker-end="url(#arr)"/>
@@ -55,7 +59,7 @@
 
   <defs>
     <marker id="arr" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6" fill="currentColor"/>
+      <path d="M0,0 L8,3 L0,6" fill="#1a1a2e"/>
     </marker>
   </defs>
 </svg>

--- a/public/content/developers/docs/standards/tokens/erc-7540/index.md
+++ b/public/content/developers/docs/standards/tokens/erc-7540/index.md
@@ -177,4 +177,4 @@ In asynchronous vaults, `previewDeposit`, `previewMint`, `previewRedeem`, and `p
 
 - [EIP-7540: Asynchronous ERC-4626 Tokenized Vaults](https://eips.ethereum.org/EIPS/eip-7540)
 - [EIP-4626: Tokenized Vault Standard](https://eips.ethereum.org/EIPS/eip-4626)
-- [ERC-7540 Reference Implementation](https://github.com/ERC4626-Alliance/ERC-7540-Reference)
+- [OpenZeppelin ERC-7540 Implementation](https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/token/ERC20/extensions/ERC7540.sol)

--- a/public/content/developers/docs/standards/tokens/erc-7540/index.md
+++ b/public/content/developers/docs/standards/tokens/erc-7540/index.md
@@ -6,18 +6,16 @@ lang: en
 
 ## Introduction {#introduction}
 
-ERC-7540 extends the [ERC-4626 Tokenized Vault Standard](/developers/docs/standards/tokens/erc-4626/) by adding support for **asynchronous deposit and redemption flows**. It introduces a **request-then-claim pattern**: users first submit a request (locking their assets or shares), then claim the result after the vault has processed it.
+ERC-7540 extends the [ERC-4626 Tokenized Vault Standard](/developers/docs/standards/tokens/erc-4626/) by adding support for asynchronous deposit and redemption flows. It introduces a request-then-claim pattern: users first submit a request (locking their assets or shares), then claim the result after the vault has processed it.
 
 This is needed when a vault cannot settle instantly in one transaction, for example:
 
-- **Real-world asset (RWA) protocols** like tokenized treasuries, private credit, and other assets with T+1 or T+2 settlement cycles
-- **Undercollateralized lending** where credit assessments happen off-chain
-- **Cross-chain vault strategies** where bridging introduces delays
-- **Liquid staking tokens** with unbonding periods
+- Real-world asset (RWA) protocols like tokenized treasuries, private credit, and other assets with T+1 or T+2 settlement cycles
+- Undercollateralized lending where credit assessments happen off-chain
+- Cross-chain vault strategies where bridging introduces delays
+- Liquid staking tokens with unbonding periods
 
 Vaults can choose to be asynchronous on deposits only, redemptions only, or both. This flexibility lets vault developers add async flows only where the underlying strategy requires it, while keeping the other side synchronous.
-
-The key concept is **forward pricing**: unlike ERC-4626's immediate pricing, exchange rates in ERC-7540 are determined at fulfillment time, not request time. This mirrors traditional fund subscriptions where allocations occur at NAV strikes rather than submission time.
 
 ## Prerequisites {#prerequisites}
 
@@ -25,21 +23,21 @@ To better understand this page, we recommend you first read about [token standar
 
 ## ERC-4626 vs ERC-7540 {#comparison}
 
-**ERC-4626 (synchronous)**
+In ERC-4626, a deposit settles atomically: the investor sends assets and receives shares back in a single transaction.
 
 ![ERC-4626 synchronous deposit flow](./erc-4626-sync-flow.svg)
 
-**ERC-7540 (asynchronous)**
+ERC-7540 splits this into two steps. The investor first calls `requestDeposit()` to lock assets, then waits for the vault manager to process the request. Once fulfilled, the investor calls `deposit()` to claim their shares. Exchange rates are determined at fulfillment time, not request time.
 
 ![ERC-7540 asynchronous deposit flow](./erc-7540-async-flow.svg)
 
-**Request lifecycle**
+Each request moves through three states: pending (submitted, waiting for processing), claimable (fulfilled and priced), and claimed (investor has collected their shares or assets).
 
 ![Request lifecycle: Pending, Claimable, Claimed](./request-lifecycle.svg)
 
 ## ERC-7540 Functions and Features {#body}
 
-ERC-7540 inherits the full ERC-4626 interface but repurposes `deposit`/`mint`/`withdraw`/`redeem` as **claim** functions. The new `requestDeposit` and `requestRedeem` functions handle the initial request step.
+ERC-7540 inherits the full ERC-4626 interface but repurposes `deposit`/`mint`/`withdraw`/`redeem` as claim functions. The new `requestDeposit` and `requestRedeem` functions handle the initial request step.
 
 ### Deposit request flow {#deposit-request-flow}
 
@@ -131,7 +129,7 @@ When a vault returns `requestId = 0` for all requests, only the `controller` add
 
 #### DepositRequest Event {#depositrequest-event}
 
-**MUST** be emitted when a deposit request is submitted via [`requestDeposit`](#requestdeposit).
+MUST be emitted when a deposit request is submitted via [`requestDeposit`](#requestdeposit).
 
 ```solidity
 event DepositRequest(
@@ -145,7 +143,7 @@ event DepositRequest(
 
 #### RedeemRequest Event {#redeemrequest-event}
 
-**MUST** be emitted when a redemption request is submitted via [`requestRedeem`](#requestredeem).
+MUST be emitted when a redemption request is submitted via [`requestRedeem`](#requestredeem).
 
 ```solidity
 event RedeemRequest(
@@ -159,7 +157,7 @@ event RedeemRequest(
 
 #### OperatorSet Event {#operatorset-event}
 
-**MUST** be emitted when an operator is approved or revoked via [`setOperator`](#setoperator).
+MUST be emitted when an operator is approved or revoked via [`setOperator`](#setoperator).
 
 ```solidity
 event OperatorSet(
@@ -171,7 +169,7 @@ event OperatorSet(
 
 ### Preview functions {#preview-functions}
 
-In asynchronous vaults, `previewDeposit`, `previewMint`, `previewRedeem`, and `previewWithdraw` **MUST** revert because the exchange rate is not known until the request is fulfilled. This is a key behavioral difference from ERC-4626.
+In asynchronous vaults, `previewDeposit`, `previewMint`, `previewRedeem`, and `previewWithdraw` MUST revert because the exchange rate is not known until the request is fulfilled. This is a key behavioral difference from ERC-4626.
 
 ## Further reading {#further-reading}
 

--- a/public/content/developers/docs/standards/tokens/erc-7540/index.md
+++ b/public/content/developers/docs/standards/tokens/erc-7540/index.md
@@ -177,4 +177,4 @@ In asynchronous vaults, `previewDeposit`, `previewMint`, `previewRedeem`, and `p
 
 - [EIP-7540: Asynchronous ERC-4626 Tokenized Vaults](https://eips.ethereum.org/EIPS/eip-7540)
 - [EIP-4626: Tokenized Vault Standard](https://eips.ethereum.org/EIPS/eip-4626)
-- [Centrifuge: ERC-7540 Reference Implementation](https://github.com/centrifuge/liquidity-pools)
+- [ERC-7540 Reference Implementation](https://github.com/ERC4626-Alliance/ERC-7540-Reference)

--- a/public/content/developers/docs/standards/tokens/erc-7540/index.md
+++ b/public/content/developers/docs/standards/tokens/erc-7540/index.md
@@ -6,24 +6,24 @@ lang: en
 
 ## Introduction {#introduction}
 
-ERC-7540 extends the [ERC-4626 Tokenized Vault Standard](/developers/docs/standards/tokens/erc-4626/) by adding support for **asynchronous deposit and redemption flows**. While ERC-4626 requires deposits and redemptions to complete atomically in a single transaction, many real-world use cases need a delay between a user's request and the actual settlement.
+ERC-7540 extends the [ERC-4626 Tokenized Vault Standard](/developers/docs/standards/tokens/erc-4626/) by adding support for **asynchronous deposit and redemption flows**. It introduces a **request-then-claim pattern**: users first submit a request (locking their assets or shares), then claim the result after the vault has processed it.
 
-ERC-7540 introduces a **request-then-claim pattern**: users first submit a request (locking their assets or shares), then claim the result after the vault has processed it. This two-step approach enables vaults to handle scenarios that require off-chain processing, delayed settlement, or compliance checks.
-
-The standard is described fully in [EIP-7540](https://eips.ethereum.org/EIPS/eip-7540).
-
-### Why asynchronous vaults? {#why-async}
-
-ERC-4626 works well when a vault can instantly determine the exchange rate and settle in one transaction. But this breaks down for:
+This is needed when a vault cannot settle instantly in one transaction, for example:
 
 - **Real-world asset (RWA) protocols** like tokenized treasuries, private credit, and other assets with T+1 or T+2 settlement cycles
 - **Undercollateralized lending** where credit assessments happen off-chain
 - **Cross-chain vault strategies** where bridging introduces delays
 - **Liquid staking tokens** with unbonding periods
 
-In all these cases, the vault cannot provide an instant exchange rate at request time. ERC-7540 solves this by separating the request from the claim.
+Vaults can choose to be asynchronous on deposits only, redemptions only, or both. This flexibility lets vault developers add async flows only where the underlying strategy requires it, while keeping the other side synchronous.
 
-### ERC-4626 vs ERC-7540 {#comparison}
+The key concept is **forward pricing**: unlike ERC-4626's immediate pricing, exchange rates in ERC-7540 are determined at fulfillment time, not request time. This mirrors traditional fund subscriptions where allocations occur at NAV strikes rather than submission time.
+
+## Prerequisites {#prerequisites}
+
+To better understand this page, we recommend you first read about [token standards](/developers/docs/standards/tokens/), [ERC-20](/developers/docs/standards/tokens/erc-20/), and [ERC-4626](/developers/docs/standards/tokens/erc-4626/).
+
+## ERC-4626 vs ERC-7540 {#comparison}
 
 **ERC-4626 (synchronous)**
 
@@ -36,12 +36,6 @@ In all these cases, the vault cannot provide an instant exchange rate at request
 **Request lifecycle**
 
 ![Request lifecycle: Pending, Claimable, Claimed](./request-lifecycle.svg)
-
-The key difference is **forward pricing**: unlike ERC-4626's immediate pricing, exchange rates in ERC-7540 are determined at fulfillment time, not request time. This mirrors traditional fund subscriptions where allocations occur at NAV strikes rather than submission time.
-
-## Prerequisites {#prerequisites}
-
-To better understand this page, we recommend you first read about [token standards](/developers/docs/standards/tokens/), [ERC-20](/developers/docs/standards/tokens/erc-20/), and [ERC-4626](/developers/docs/standards/tokens/erc-4626/).
 
 ## ERC-7540 Functions and Features {#body}
 
@@ -129,9 +123,9 @@ Returns whether `operator` is approved to act on behalf of `controller`.
 
 ### Request IDs {#request-ids}
 
-Request IDs discriminate between different batches of requests. All requests sharing the same `requestId` are fungible: they transition between states together and receive the same exchange rate.
+Request IDs differentiate between different batches of requests. All requests sharing the same `requestId` are fungible: they transition between states together and receive the same exchange rate.
 
-When a vault returns `requestId = 0` for all requests, only the `controller` address discriminates request state. Multiple requests from the same controller are aggregated.
+When a vault returns `requestId = 0` for all requests, only the `controller` address differentiates request state. Multiple requests from the same controller are aggregated.
 
 ### Events {#events}
 
@@ -178,16 +172,6 @@ event OperatorSet(
 ### Preview functions {#preview-functions}
 
 In asynchronous vaults, `previewDeposit`, `previewMint`, `previewRedeem`, and `previewWithdraw` **MUST** revert because the exchange rate is not known until the request is fulfilled. This is a key behavioral difference from ERC-4626.
-
-### Implementation flexibility {#implementation-flexibility}
-
-Vaults may implement:
-
-- Asynchronous deposits only
-- Asynchronous redemptions only
-- Both (fully asynchronous)
-- Variable or fixed exchange rates between request and claim
-- Different underlying accounting mechanisms (global, per-user, or batched)
 
 ## Further reading {#further-reading}
 

--- a/public/content/developers/docs/standards/tokens/erc-7540/index.md
+++ b/public/content/developers/docs/standards/tokens/erc-7540/index.md
@@ -27,54 +27,15 @@ In all these cases, the vault cannot provide an instant exchange rate at request
 
 **ERC-4626 (synchronous)**
 
-```text
-  Investor                          Vault
-     │                                │
-     │──── deposit(assets) ──────────>│
-     │<─── shares (instant) ─────────│
-     │                                │
-     done in one transaction
-```
+![ERC-4626 synchronous deposit flow](./erc-4626-sync-flow.svg)
 
 **ERC-7540 (asynchronous)**
 
-```text
-  Investor              Vault                   Manager
-     │                    │                        │
-     │── requestDeposit()─>│                        │
-     │   assets locked     │── batch to manager ───>│
-     │                     │                        │
-     │                     │       ┌────────────────┤
-     │                     │       │ Step 1: Approve │
-     │                     │       │ (set asset price,│
-     │                     │       │  release assets  │
-     │                     │       │  for investment) │
-     │                     │       │                  │
-     │                     │       │ ... manager      │
-     │                     │       │ invests ...      │
-     │                     │       │                  │
-     │                     │       │ Step 2: Issue    │
-     │                     │       │ (set share price,│
-     │                     │       │  mint shares)    │
-     │                     │       └────────────────┤
-     │                     │                        │
-     │                     │<── fulfillment ────────│
-     │                     │                        │
-     │── deposit() ───────>│                        │
-     │<── shares ──────────│                        │
-     │   (claim)           │                        │
-```
+![ERC-7540 asynchronous deposit flow](./erc-7540-async-flow.svg)
 
 **Request lifecycle**
 
-```text
-  ┌──────────┐    ┌──────────┐    ┌──────────┐
-  │ PENDING  │───>│CLAIMABLE │───>│ CLAIMED  │
-  │          │    │          │    │          │
-  │ request  │    │ approved │    │ investor │
-  │ submitted│    │ + priced │    │ claims   │
-  └──────────┘    └──────────┘    └──────────┘
-```
+![Request lifecycle: Pending, Claimable, Claimed](./request-lifecycle.svg)
 
 The key difference is **forward pricing**: unlike ERC-4626's immediate pricing, exchange rates in ERC-7540 are determined at fulfillment time, not request time. This mirrors traditional fund subscriptions where allocations occur at NAV strikes rather than submission time.
 

--- a/public/content/developers/docs/standards/tokens/erc-7540/index.md
+++ b/public/content/developers/docs/standards/tokens/erc-7540/index.md
@@ -1,0 +1,235 @@
+---
+title: ERC-7540 Asynchronous Tokenized Vault Standard
+description: An extension of ERC-4626 that adds asynchronous deposit and redemption flows for tokenized vaults.
+lang: en
+---
+
+## Introduction {#introduction}
+
+ERC-7540 extends the [ERC-4626 Tokenized Vault Standard](/developers/docs/standards/tokens/erc-4626/) by adding support for **asynchronous deposit and redemption flows**. While ERC-4626 requires deposits and redemptions to complete atomically in a single transaction, many real-world use cases need a delay between a user's request and the actual settlement.
+
+ERC-7540 introduces a **request-then-claim pattern**: users first submit a request (locking their assets or shares), then claim the result after the vault has processed it. This two-step approach enables vaults to handle scenarios that require off-chain processing, delayed settlement, or compliance checks.
+
+The standard is described fully in [EIP-7540](https://eips.ethereum.org/EIPS/eip-7540).
+
+### Why asynchronous vaults? {#why-async}
+
+ERC-4626 works well when a vault can instantly determine the exchange rate and settle in one transaction. But this breaks down for:
+
+- **Real-world asset (RWA) protocols** like tokenized treasuries, private credit, and other assets with T+1 or T+2 settlement cycles
+- **Undercollateralized lending** where credit assessments happen off-chain
+- **Cross-chain vault strategies** where bridging introduces delays
+- **Liquid staking tokens** with unbonding periods
+
+In all these cases, the vault cannot provide an instant exchange rate at request time. ERC-7540 solves this by separating the request from the claim.
+
+### ERC-4626 vs ERC-7540 {#comparison}
+
+**ERC-4626 (synchronous)**
+
+```text
+  Investor                          Vault
+     │                                │
+     │──── deposit(assets) ──────────>│
+     │<─── shares (instant) ─────────│
+     │                                │
+     done in one transaction
+```
+
+**ERC-7540 (asynchronous)**
+
+```text
+  Investor              Vault                   Manager
+     │                    │                        │
+     │── requestDeposit()─>│                        │
+     │   assets locked     │── batch to manager ───>│
+     │                     │                        │
+     │                     │       ┌────────────────┤
+     │                     │       │ Step 1: Approve │
+     │                     │       │ (set asset price,│
+     │                     │       │  release assets  │
+     │                     │       │  for investment) │
+     │                     │       │                  │
+     │                     │       │ ... manager      │
+     │                     │       │ invests ...      │
+     │                     │       │                  │
+     │                     │       │ Step 2: Issue    │
+     │                     │       │ (set share price,│
+     │                     │       │  mint shares)    │
+     │                     │       └────────────────┤
+     │                     │                        │
+     │                     │<── fulfillment ────────│
+     │                     │                        │
+     │── deposit() ───────>│                        │
+     │<── shares ──────────│                        │
+     │   (claim)           │                        │
+```
+
+**Request lifecycle**
+
+```text
+  ┌──────────┐    ┌──────────┐    ┌──────────┐
+  │ PENDING  │───>│CLAIMABLE │───>│ CLAIMED  │
+  │          │    │          │    │          │
+  │ request  │    │ approved │    │ investor │
+  │ submitted│    │ + priced │    │ claims   │
+  └──────────┘    └──────────┘    └──────────┘
+```
+
+The key difference is **forward pricing**: unlike ERC-4626's immediate pricing, exchange rates in ERC-7540 are determined at fulfillment time, not request time. This mirrors traditional fund subscriptions where allocations occur at NAV strikes rather than submission time.
+
+## Prerequisites {#prerequisites}
+
+To better understand this page, we recommend you first read about [token standards](/developers/docs/standards/tokens/), [ERC-20](/developers/docs/standards/tokens/erc-20/), and [ERC-4626](/developers/docs/standards/tokens/erc-4626/).
+
+## ERC-7540 Functions and Features {#body}
+
+ERC-7540 inherits the full ERC-4626 interface but repurposes `deposit`/`mint`/`withdraw`/`redeem` as **claim** functions. The new `requestDeposit` and `requestRedeem` functions handle the initial request step.
+
+### Deposit request flow {#deposit-request-flow}
+
+#### requestDeposit {#requestdeposit}
+
+```solidity
+function requestDeposit(uint256 assets, address controller, address owner) external returns (uint256 requestId)
+```
+
+Transfers `assets` from `owner` into the vault and submits a request to deposit. The `controller` address receives control of the request. Returns a `requestId` identifying the request batch.
+
+#### pendingDepositRequest {#pendingdepositrequest}
+
+```solidity
+function pendingDepositRequest(uint256 requestId, address controller) external view returns (uint256 assets)
+```
+
+Returns the amount of `assets` in a pending (not yet claimable) deposit request for the given `controller` and `requestId`.
+
+#### claimableDepositRequest {#claimabledepositrequest}
+
+```solidity
+function claimableDepositRequest(uint256 requestId, address controller) external view returns (uint256 assets)
+```
+
+Returns the amount of `assets` in a claimable (fulfilled but not yet claimed) deposit request for the given `controller` and `requestId`.
+
+#### Claiming deposits {#claiming-deposits}
+
+Once a deposit request becomes claimable, the user calls the standard ERC-4626 [`deposit`](/developers/docs/standards/tokens/erc-4626/#deposit) or [`mint`](/developers/docs/standards/tokens/erc-4626/#mint) function to claim their shares. In ERC-7540, these functions no longer transfer assets (that already happened at request time). They only mint shares to the receiver.
+
+### Redemption request flow {#redemption-request-flow}
+
+#### requestRedeem {#requestredeem}
+
+```solidity
+function requestRedeem(uint256 shares, address controller, address owner) external returns (uint256 requestId)
+```
+
+Locks `shares` from `owner` and submits a request to redeem. The `controller` address receives control of the request.
+
+#### pendingRedeemRequest {#pendingredeemrequest}
+
+```solidity
+function pendingRedeemRequest(uint256 requestId, address controller) external view returns (uint256 shares)
+```
+
+Returns the amount of `shares` in a pending redemption request for the given `controller` and `requestId`.
+
+#### claimableRedeemRequest {#claimableredeemrequest}
+
+```solidity
+function claimableRedeemRequest(uint256 requestId, address controller) external view returns (uint256 shares)
+```
+
+Returns the amount of `shares` in a claimable redemption request for the given `controller` and `requestId`.
+
+#### Claiming redemptions {#claiming-redemptions}
+
+Once a redemption request becomes claimable, the user calls the standard ERC-4626 [`redeem`](/developers/docs/standards/tokens/erc-4626/#redeem) or [`withdraw`](/developers/docs/standards/tokens/erc-4626/#withdraw) function to claim their assets.
+
+### Operator management {#operator-management}
+
+ERC-7540 includes an operator pattern (from [ERC-6909](https://eips.ethereum.org/EIPS/eip-6909)) that allows third parties to manage requests on behalf of a user.
+
+#### setOperator {#setoperator}
+
+```solidity
+function setOperator(address operator, bool approved) external returns (bool)
+```
+
+Approves or revokes `operator` to act on behalf of `msg.sender` for deposit/redeem requests and claims.
+
+#### isOperator {#isoperator}
+
+```solidity
+function isOperator(address controller, address operator) external view returns (bool)
+```
+
+Returns whether `operator` is approved to act on behalf of `controller`.
+
+### Request IDs {#request-ids}
+
+Request IDs discriminate between different batches of requests. All requests sharing the same `requestId` are fungible: they transition between states together and receive the same exchange rate.
+
+When a vault returns `requestId = 0` for all requests, only the `controller` address discriminates request state. Multiple requests from the same controller are aggregated.
+
+### Events {#events}
+
+#### DepositRequest Event {#depositrequest-event}
+
+**MUST** be emitted when a deposit request is submitted via [`requestDeposit`](#requestdeposit).
+
+```solidity
+event DepositRequest(
+    address indexed controller,
+    address indexed owner,
+    uint256 indexed requestId,
+    address sender,
+    uint256 assets
+)
+```
+
+#### RedeemRequest Event {#redeemrequest-event}
+
+**MUST** be emitted when a redemption request is submitted via [`requestRedeem`](#requestredeem).
+
+```solidity
+event RedeemRequest(
+    address indexed controller,
+    address indexed owner,
+    uint256 indexed requestId,
+    address sender,
+    uint256 shares
+)
+```
+
+#### OperatorSet Event {#operatorset-event}
+
+**MUST** be emitted when an operator is approved or revoked via [`setOperator`](#setoperator).
+
+```solidity
+event OperatorSet(
+    address indexed controller,
+    address indexed operator,
+    bool approved
+)
+```
+
+### Preview functions {#preview-functions}
+
+In asynchronous vaults, `previewDeposit`, `previewMint`, `previewRedeem`, and `previewWithdraw` **MUST** revert because the exchange rate is not known until the request is fulfilled. This is a key behavioral difference from ERC-4626.
+
+### Implementation flexibility {#implementation-flexibility}
+
+Vaults may implement:
+
+- Asynchronous deposits only
+- Asynchronous redemptions only
+- Both (fully asynchronous)
+- Variable or fixed exchange rates between request and claim
+- Different underlying accounting mechanisms (global, per-user, or batched)
+
+## Further reading {#further-reading}
+
+- [EIP-7540: Asynchronous ERC-4626 Tokenized Vaults](https://eips.ethereum.org/EIPS/eip-7540)
+- [EIP-4626: Tokenized Vault Standard](https://eips.ethereum.org/EIPS/eip-4626)
+- [Centrifuge: ERC-7540 Reference Implementation](https://github.com/centrifuge/liquidity-pools)

--- a/public/content/developers/docs/standards/tokens/erc-7540/index.md
+++ b/public/content/developers/docs/standards/tokens/erc-7540/index.md
@@ -31,13 +31,15 @@ ERC-7540 splits this into two steps. The investor first calls `requestDeposit()`
 
 ![ERC-7540 asynchronous deposit flow](./erc-7540-async-flow.svg)
 
-Each request moves through three states: pending (submitted, waiting for processing), claimable (fulfilled and priced), and claimed (investor has collected their shares or assets).
-
-![Request lifecycle: Pending, Claimable, Claimed](./request-lifecycle.svg)
+The redemption flow works the same way: `requestRedeem()` locks shares, and once fulfilled the investor calls `redeem()` to claim assets.
 
 ## ERC-7540 Functions and Features {#body}
 
 ERC-7540 inherits the full ERC-4626 interface but repurposes `deposit`/`mint`/`withdraw`/`redeem` as claim functions. The new `requestDeposit` and `requestRedeem` functions handle the initial request step.
+
+Each request moves through three states: pending (submitted, waiting for processing), claimable (fulfilled and priced), and claimed (investor has collected their shares or assets).
+
+![Request lifecycle: Pending, Claimable, Claimed](./request-lifecycle.svg)
 
 ### Deposit request flow {#deposit-request-flow}
 

--- a/public/content/developers/docs/standards/tokens/erc-7540/index.md
+++ b/public/content/developers/docs/standards/tokens/erc-7540/index.md
@@ -171,7 +171,7 @@ event OperatorSet(
 
 ### Preview functions {#preview-functions}
 
-In asynchronous vaults, `previewDeposit`, `previewMint`, `previewRedeem`, and `previewWithdraw` MUST revert because the exchange rate is not known until the request is fulfilled. This is a key behavioral difference from ERC-4626.
+The preview functions must revert only for the flows that are asynchronous, because the exchange rate is not known until the request is fulfilled. In an async-deposit vault, `previewDeposit` and `previewMint` MUST revert, while `previewRedeem` and `previewWithdraw` keep working as in ERC-4626 (and vice versa for an async-redeem vault). This is a key behavioral difference from ERC-4626.
 
 ## Further reading {#further-reading}
 

--- a/public/content/developers/docs/standards/tokens/erc-7540/request-lifecycle.svg
+++ b/public/content/developers/docs/standards/tokens/erc-7540/request-lifecycle.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 560 140" font-family="monospace" font-size="13">
+  <style>
+    text { fill: #222; }
+    .state-label { font-weight: bold; font-size: 14px; }
+    .desc { font-size: 11px; fill: #666; }
+    rect { rx: 8; ry: 8; }
+  </style>
+
+  <!-- Title -->
+  <text x="280" y="20" text-anchor="middle" font-weight="bold" font-size="15">Request lifecycle</text>
+
+  <!-- PENDING box -->
+  <rect x="20" y="40" width="140" height="80" fill="#fef3c7" stroke="#d97706" stroke-width="1.5"/>
+  <text x="90" y="68" text-anchor="middle" class="state-label">PENDING</text>
+  <text x="90" y="88" text-anchor="middle" class="desc">request</text>
+  <text x="90" y="103" text-anchor="middle" class="desc">submitted</text>
+
+  <!-- Arrow 1 -->
+  <line x1="160" y1="80" x2="200" y2="80" stroke="#444" stroke-width="2" marker-end="url(#arw)"/>
+
+  <!-- CLAIMABLE box -->
+  <rect x="200" y="40" width="140" height="80" fill="#d1fae5" stroke="#059669" stroke-width="1.5"/>
+  <text x="270" y="68" text-anchor="middle" class="state-label">CLAIMABLE</text>
+  <text x="270" y="88" text-anchor="middle" class="desc">approved</text>
+  <text x="270" y="103" text-anchor="middle" class="desc">+ priced</text>
+
+  <!-- Arrow 2 -->
+  <line x1="340" y1="80" x2="380" y2="80" stroke="#444" stroke-width="2" marker-end="url(#arw)"/>
+
+  <!-- CLAIMED box -->
+  <rect x="380" y="40" width="140" height="80" fill="#dbeafe" stroke="#2563eb" stroke-width="1.5"/>
+  <text x="450" y="68" text-anchor="middle" class="state-label">CLAIMED</text>
+  <text x="450" y="88" text-anchor="middle" class="desc">investor</text>
+  <text x="450" y="103" text-anchor="middle" class="desc">claims</text>
+
+  <defs>
+    <marker id="arw" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#444"/>
+    </marker>
+  </defs>
+</svg>

--- a/public/content/developers/docs/standards/tokens/erc-7540/request-lifecycle.svg
+++ b/public/content/developers/docs/standards/tokens/erc-7540/request-lifecycle.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 560 140" font-family="monospace" font-size="13">
   <style>
-    text { fill: #222; }
+    text { fill: currentColor; }
     .state-label { font-weight: bold; font-size: 14px; }
-    .desc { font-size: 11px; fill: #666; }
+    .desc { font-size: 11px; opacity: 0.6; }
     rect { rx: 8; ry: 8; }
   </style>
 
@@ -16,7 +16,7 @@
   <text x="90" y="103" text-anchor="middle" class="desc">submitted</text>
 
   <!-- Arrow 1 -->
-  <line x1="160" y1="80" x2="200" y2="80" stroke="#444" stroke-width="2" marker-end="url(#arw)"/>
+  <line x1="160" y1="80" x2="200" y2="80" stroke="currentColor" stroke-width="2" marker-end="url(#arw)"/>
 
   <!-- CLAIMABLE box -->
   <rect x="200" y="40" width="140" height="80" fill="#d1fae5" stroke="#059669" stroke-width="1.5"/>
@@ -25,7 +25,7 @@
   <text x="270" y="103" text-anchor="middle" class="desc">+ priced</text>
 
   <!-- Arrow 2 -->
-  <line x1="340" y1="80" x2="380" y2="80" stroke="#444" stroke-width="2" marker-end="url(#arw)"/>
+  <line x1="340" y1="80" x2="380" y2="80" stroke="currentColor" stroke-width="2" marker-end="url(#arw)"/>
 
   <!-- CLAIMED box -->
   <rect x="380" y="40" width="140" height="80" fill="#dbeafe" stroke="#2563eb" stroke-width="1.5"/>
@@ -35,7 +35,7 @@
 
   <defs>
     <marker id="arw" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6" fill="#444"/>
+      <path d="M0,0 L8,3 L0,6" fill="currentColor"/>
     </marker>
   </defs>
 </svg>

--- a/public/content/developers/docs/standards/tokens/erc-7540/request-lifecycle.svg
+++ b/public/content/developers/docs/standards/tokens/erc-7540/request-lifecycle.svg
@@ -1,41 +1,45 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 560 140" font-family="monospace" font-size="13">
   <style>
-    text { fill: currentColor; }
+    text { fill: #1a1a2e; }
     .state-label { font-weight: bold; font-size: 14px; }
-    .desc { font-size: 11px; opacity: 0.6; }
-    rect { rx: 8; ry: 8; }
+    .desc { font-size: 11px; fill: #4a4a5a; }
+    rect.state { rx: 8; ry: 8; }
+    line, path { stroke: #1a1a2e; }
   </style>
+
+  <!-- Opaque background so the diagram is legible in both light and dark mode -->
+  <rect x="0" y="0" width="560" height="140" rx="8" fill="#ffffff"/>
 
   <!-- Title -->
   <text x="280" y="20" text-anchor="middle" font-weight="bold" font-size="15">Request lifecycle</text>
 
   <!-- PENDING box -->
-  <rect x="20" y="40" width="140" height="80" fill="#fef3c7" stroke="#d97706" stroke-width="1.5"/>
+  <rect class="state" x="20" y="40" width="140" height="80" fill="#fef3c7" stroke="#d97706" stroke-width="1.5"/>
   <text x="90" y="68" text-anchor="middle" class="state-label">PENDING</text>
   <text x="90" y="88" text-anchor="middle" class="desc">request</text>
   <text x="90" y="103" text-anchor="middle" class="desc">submitted</text>
 
   <!-- Arrow 1 -->
-  <line x1="160" y1="80" x2="200" y2="80" stroke="currentColor" stroke-width="2" marker-end="url(#arw)"/>
+  <line x1="160" y1="80" x2="200" y2="80" stroke-width="2" marker-end="url(#arw)"/>
 
   <!-- CLAIMABLE box -->
-  <rect x="200" y="40" width="140" height="80" fill="#d1fae5" stroke="#059669" stroke-width="1.5"/>
+  <rect class="state" x="200" y="40" width="140" height="80" fill="#d1fae5" stroke="#059669" stroke-width="1.5"/>
   <text x="270" y="68" text-anchor="middle" class="state-label">CLAIMABLE</text>
   <text x="270" y="88" text-anchor="middle" class="desc">approved</text>
   <text x="270" y="103" text-anchor="middle" class="desc">+ priced</text>
 
   <!-- Arrow 2 -->
-  <line x1="340" y1="80" x2="380" y2="80" stroke="currentColor" stroke-width="2" marker-end="url(#arw)"/>
+  <line x1="340" y1="80" x2="380" y2="80" stroke-width="2" marker-end="url(#arw)"/>
 
   <!-- CLAIMED box -->
-  <rect x="380" y="40" width="140" height="80" fill="#dbeafe" stroke="#2563eb" stroke-width="1.5"/>
+  <rect class="state" x="380" y="40" width="140" height="80" fill="#dbeafe" stroke="#2563eb" stroke-width="1.5"/>
   <text x="450" y="68" text-anchor="middle" class="state-label">CLAIMED</text>
   <text x="450" y="88" text-anchor="middle" class="desc">investor</text>
   <text x="450" y="103" text-anchor="middle" class="desc">claims</text>
 
   <defs>
     <marker id="arw" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6" fill="currentColor"/>
+      <path d="M0,0 L8,3 L0,6" fill="#1a1a2e"/>
     </marker>
   </defs>
 </svg>


### PR DESCRIPTION
Adds page describing ERC-7540 in detail (fixes https://github.com/ethereum/ethereum-org-website/issues/17911)

## Description

ERC-7540 has grown significantly in adoption, but is a complex standard. While it is already briefly explained on the ERC-4626 page, a more detailed guide specifically for asynchronous vaults can be very useful to a wider audience.