### PR TITLE
fix: respect matomo opt-out for page view tracking

### DIFF
--- a/src/components/Matomo.tsx
+++ b/src/components/Matomo.tsx
@@ -15,7 +15,7 @@ export default function Matomo() {
   const [previousPath, setPreviousPath] = useState("")
 
   useEffect(() => {
-    if (!matomoInitialized) {
+    if (!matomoInitialized && !isOptedOut()) {
       init({
         url: process.env.NEXT_PUBLIC_MATOMO_URL!,
         siteId: process.env.NEXT_PUBLIC_MATOMO_SITE_ID!,

--- a/src/components/Matomo.tsx
+++ b/src/components/Matomo.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState } from "react"
 import { usePathname } from "next/navigation"
 import { init, push } from "@socialgouv/matomo-next"
 
+import { isOptedOut } from "@/lib/utils/matomo"
+
 // Module-level flag to prevent double initialization in React Strict Mode
 let matomoInitialized = false
 
@@ -45,6 +47,8 @@ export default function Matomo() {
     if (!previousPath) {
       return setPreviousPath(pathname)
     }
+
+    if (isOptedOut()) return setPreviousPath(pathname)
 
     push(["setReferrerUrl", previousPath])
     push(["setCustomUrl", pathname])

--- a/src/components/MatomoOptOut.tsx
+++ b/src/components/MatomoOptOut.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react"
 
-import { MATOMO_LS_KEY } from "@/lib/utils/matomo"
+import { clearMatomoOptOutCache, MATOMO_LS_KEY } from "@/lib/utils/matomo"
 
 import Checkbox from "./ui/checkbox"
 
@@ -29,6 +29,7 @@ const MatomoOptOut = () => {
     setIsOptedOut(!checked)
     // Save selection to localStorage
     localStorage.setItem(MATOMO_LS_KEY, String(!checked))
+    clearMatomoOptOutCache()
   }
   return (
     <div className="mb-4 mt-8 flex flex-col rounded border border-body-light bg-background p-6">

--- a/src/components/Select/innerComponents.tsx
+++ b/src/components/Select/innerComponents.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext } from "react"
+import { createContext, useContext, useRef } from "react"
 import { ChevronDown } from "lucide-react"
 import type {
   ContainerProps,
@@ -11,6 +11,7 @@ import type {
   OptionProps,
 } from "react-select"
 import { tv, type VariantProps } from "tailwind-variants"
+import { useVirtualizer } from "@tanstack/react-virtual"
 
 import { cn } from "@/lib/utils/cn"
 
@@ -154,6 +155,9 @@ const Menu = <
   )
 }
 
+const OPTION_HEIGHT = 36
+const VIRTUAL_THRESHOLD = 50 // Virtualize when more than 50 options
+
 const MenuList = <
   Option,
   IsMulti extends boolean,
@@ -163,14 +167,97 @@ const MenuList = <
 ) => {
   const { innerProps, innerRef, children } = props
   const { menuList } = useSelectStyles()
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  const childArray = Array.isArray(children) ? children : []
+  const shouldVirtualize = childArray.length > VIRTUAL_THRESHOLD
+
+  if (!shouldVirtualize) {
+    return (
+      <div
+        ref={innerRef}
+        {...innerProps}
+        className={menuList()}
+        id="react-select-menu-list"
+      >
+        {children}
+      </div>
+    )
+  }
+
+  return (
+    <VirtualizedMenuListInner
+      innerRef={innerRef}
+      innerProps={innerProps}
+      className={menuList()}
+      items={childArray}
+      focusedIndex={childArray.findIndex(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (child: any) => child?.props?.isFocused
+      )}
+      scrollRef={scrollRef}
+    />
+  )
+}
+
+function VirtualizedMenuListInner({
+  innerRef,
+  innerProps,
+  className,
+  items,
+  focusedIndex,
+  scrollRef,
+}: {
+  innerRef: React.Ref<HTMLDivElement>
+  innerProps: React.HTMLAttributes<HTMLDivElement>
+  className: string
+  items: React.ReactNode[]
+  focusedIndex: number
+  scrollRef: React.RefObject<HTMLDivElement | null>
+}) {
+  const virtualizer = useVirtualizer({
+    count: items.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => OPTION_HEIGHT,
+    overscan: 5,
+    initialOffset: focusedIndex > 0 ? focusedIndex * OPTION_HEIGHT : 0,
+  })
+
   return (
     <div
-      ref={innerRef}
+      ref={(el) => {
+        scrollRef.current = el
+        if (typeof innerRef === "function") innerRef(el)
+        else if (innerRef && "current" in innerRef)
+          (innerRef as React.MutableRefObject<HTMLDivElement | null>).current =
+            el
+      }}
       {...innerProps}
-      className={menuList()}
+      className={className}
       id="react-select-menu-list"
     >
-      {children}
+      <div
+        style={{
+          height: virtualizer.getTotalSize(),
+          width: "100%",
+          position: "relative",
+        }}
+      >
+        {virtualizer.getVirtualItems().map((virtualItem) => (
+          <div
+            key={virtualItem.key}
+            style={{
+              position: "absolute",
+              top: 0,
+              left: 0,
+              width: "100%",
+              transform: `translateY(${virtualItem.start}px)`,
+            }}
+          >
+            {items[virtualItem.index]}
+          </div>
+        ))}
+      </div>
     </div>
   )
 }

--- a/src/components/Select/innerComponents.tsx
+++ b/src/components/Select/innerComponents.tsx
@@ -1,4 +1,10 @@
-import { createContext, useContext, useRef } from "react"
+import {
+  createContext,
+  isValidElement,
+  useContext,
+  useEffect,
+  useRef,
+} from "react"
 import { ChevronDown } from "lucide-react"
 import type {
   ContainerProps,
@@ -156,7 +162,7 @@ const Menu = <
 }
 
 const OPTION_HEIGHT = 36
-const VIRTUAL_THRESHOLD = 50 // Virtualize when more than 50 options
+const VIRTUAL_THRESHOLD = 30
 
 const MenuList = <
   Option,
@@ -192,8 +198,9 @@ const MenuList = <
       className={menuList()}
       items={childArray}
       focusedIndex={childArray.findIndex(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (child: any) => child?.props?.isFocused
+        (child) =>
+          isValidElement<{ isFocused?: boolean }>(child) &&
+          child.props.isFocused
       )}
       scrollRef={scrollRef}
     />
@@ -222,6 +229,13 @@ function VirtualizedMenuListInner({
     overscan: 5,
     initialOffset: focusedIndex > 0 ? focusedIndex * OPTION_HEIGHT : 0,
   })
+
+  // Scroll to focused option on keyboard navigation (arrow keys, Page Up/Down, Home/End)
+  useEffect(() => {
+    if (focusedIndex >= 0) {
+      virtualizer.scrollToIndex(focusedIndex, { align: "auto" })
+    }
+  }, [focusedIndex, virtualizer])
 
   return (
     <div

--- a/src/lib/utils/matomo.ts
+++ b/src/lib/utils/matomo.ts
@@ -6,6 +6,30 @@ import { IS_PROD } from "./env"
 
 export const MATOMO_LS_KEY = "ethereum-org.matomo-opt-out"
 
+// Cache opt-out status to avoid synchronous localStorage reads on every interaction
+let cachedOptOut: boolean | null = null
+
+const isOptedOut = (): boolean => {
+  if (cachedOptOut !== null) return cachedOptOut
+  try {
+    const value = localStorage.getItem(MATOMO_LS_KEY) || "false"
+    cachedOptOut = JSON.parse(value)
+  } catch {
+    cachedOptOut = false
+  }
+  return cachedOptOut!
+}
+
+// Allow cache refresh when opt-out status changes (e.g. from cookie banner)
+export const clearMatomoOptOutCache = () => {
+  cachedOptOut = null
+}
+
+const scheduleIdleCallback =
+  typeof requestIdleCallback === "function"
+    ? requestIdleCallback
+    : (cb: () => void) => setTimeout(cb, 0)
+
 export const trackCustomEvent = ({
   eventCategory,
   eventAction,
@@ -17,13 +41,14 @@ export const trackCustomEvent = ({
   // Respect Do Not Track header
   if (navigator.doNotTrack === "1") return
 
-  const optedOutValue = localStorage.getItem(MATOMO_LS_KEY) || "false"
-  const isOptedOut = JSON.parse(optedOutValue)
-  if (isOptedOut) return
+  if (isOptedOut()) return
 
-  // Set custom URL removing any query params or hash fragments
-  if (window) {
-    push([`setCustomUrl`, window.location.href.split(/[?#]/)[0]])
-  }
-  push([`trackEvent`, eventCategory, eventAction, eventName, eventValue])
+  // Defer tracking to avoid blocking user interactions (improves INP)
+  scheduleIdleCallback(() => {
+    // Set custom URL removing any query params or hash fragments
+    if (window) {
+      push([`setCustomUrl`, window.location.href.split(/[?#]/)[0]])
+    }
+    push([`trackEvent`, eventCategory, eventAction, eventName, eventValue])
+  })
 }

--- a/src/lib/utils/matomo.ts
+++ b/src/lib/utils/matomo.ts
@@ -8,7 +8,7 @@ export const MATOMO_LS_KEY = "ethereum-org.matomo-opt-out"
 
 let cachedOptOut: boolean | null = null
 
-const isOptedOut = (): boolean => {
+export const isOptedOut = (): boolean => {
   if (cachedOptOut !== null) return cachedOptOut
   try {
     const value = localStorage.getItem(MATOMO_LS_KEY) || "false"

--- a/src/lib/utils/matomo.ts
+++ b/src/lib/utils/matomo.ts
@@ -6,7 +6,6 @@ import { IS_PROD } from "./env"
 
 export const MATOMO_LS_KEY = "ethereum-org.matomo-opt-out"
 
-// Cache opt-out status to avoid synchronous localStorage reads on every interaction
 let cachedOptOut: boolean | null = null
 
 const isOptedOut = (): boolean => {
@@ -17,10 +16,9 @@ const isOptedOut = (): boolean => {
   } catch {
     cachedOptOut = false
   }
-  return cachedOptOut!
+  return cachedOptOut as boolean
 }
 
-// Allow cache refresh when opt-out status changes (e.g. from cookie banner)
 export const clearMatomoOptOutCache = () => {
   cachedOptOut = null
 }
@@ -43,7 +41,6 @@ export const trackCustomEvent = ({
 
   if (isOptedOut()) return
 
-  // Defer tracking to avoid blocking user interactions (improves INP)
   scheduleIdleCallback(() => {
     // Set custom URL removing any query params or hash fragments
     if (window) {


### PR DESCRIPTION
## Summary

- The Matomo opt-out toggle on `/privacy-policy/` only gated custom events (`trackCustomEvent`), while page view tracking in `Matomo.tsx` continued regardless of opt-out status
- This is a gap between the privacy policy (section 3.3) which implies opting out stops all Matomo tracking, and the actual code behavior
- Exports the existing `isOptedOut()` helper from `matomo.ts` and checks it before sending page view events in `Matomo.tsx`

Depends on #17912 (branches off `perf/improve-inp-core-web-vitals`).

## Test plan

- [x] Visit `/privacy-policy/`, opt out via the Matomo checkbox
- [x] Navigate to other pages and confirm no `matomo.php` requests appear in the Network tab
- [x] Opt back in and confirm page view tracking resumes on navigation