### PR TITLE
add server-rendered hidden nav for search engine crawlability

### DIFF
--- a/src/components/Nav/CrawlableNav.tsx
+++ b/src/components/Nav/CrawlableNav.tsx
@@ -1,0 +1,52 @@
+import { getTranslations } from "next-intl/server"
+
+import type { NavItem } from "./types"
+
+import { Link } from "@/i18n/navigation"
+import { buildNavigation } from "@/lib/nav/buildNavigation"
+
+function collectLinks(items: NavItem[]): { label: string; href: string }[] {
+  const links: { label: string; href: string }[] = []
+  for (const item of items) {
+    if ("href" in item && item.href) {
+      links.push({ label: item.label, href: item.href })
+    }
+    if ("items" in item && item.items) {
+      links.push(...collectLinks(item.items))
+    }
+  }
+  return links
+}
+
+/**
+ * Server-rendered hidden nav for search engine crawlability.
+ *
+ * The interactive desktop nav uses Radix NavigationMenu which unmounts
+ * dropdown content when inactive, and the mobile nav is lazy-loaded on
+ * interaction. Neither makes nav links available in the initial HTML.
+ *
+ * This component renders all nav links as plain <a> tags in the server
+ * response so crawlers can discover and follow them.
+ */
+const CrawlableNav = async () => {
+  const t = await getTranslations("common")
+  const sections = buildNavigation(t)
+
+  const allLinks = Object.values(sections).flatMap((section) =>
+    collectLinks(section.items)
+  )
+
+  return (
+    <nav aria-label="Site navigation links" className="sr-only">
+      <ul>
+        {allLinks.map(({ label, href }) => (
+          <li key={href}>
+            <Link href={href}>{label}</Link>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  )
+}
+
+export default CrawlableNav

--- a/src/components/Nav/CrawlableNav.tsx
+++ b/src/components/Nav/CrawlableNav.tsx
@@ -8,10 +8,10 @@ import { buildNavigation } from "@/lib/nav/buildNavigation"
 function collectLinks(items: NavItem[]): { label: string; href: string }[] {
   const links: { label: string; href: string }[] = []
   for (const item of items) {
-    if ("href" in item && item.href) {
+    if (item.href) {
       links.push({ label: item.label, href: item.href })
     }
-    if ("items" in item && item.items) {
+    if (item.items) {
       links.push(...collectLinks(item.items))
     }
   }
@@ -37,10 +37,10 @@ const CrawlableNav = async () => {
   )
 
   return (
-    <nav aria-label="Site navigation links" className="sr-only">
+    <nav aria-hidden="true" className="sr-only" tabIndex={-1}>
       <ul>
-        {allLinks.map(({ label, href }) => (
-          <li key={href}>
+        {allLinks.map(({ label, href }, index) => (
+          <li key={`${href}-${index}`}>
             <Link href={href}>{label}</Link>
           </li>
         ))}

--- a/src/components/Nav/CrawlableNav.tsx
+++ b/src/components/Nav/CrawlableNav.tsx
@@ -37,7 +37,7 @@ const CrawlableNav = async () => {
   )
 
   return (
-    <nav aria-hidden="true" className="sr-only" tabIndex={-1}>
+    <nav inert className="sr-only">
       <ul>
         {allLinks.map(({ label, href }, index) => (
           <li key={`${href}-${index}`}>

--- a/src/components/Nav/index.tsx
+++ b/src/components/Nav/index.tsx
@@ -8,6 +8,7 @@ import ClientOnly from "../ClientOnly"
 import MediaQuery from "../MediaQuery"
 import { BaseLink } from "../ui/Link"
 
+import CrawlableNav from "./CrawlableNav"
 import DesktopNav from "./DesktopNav"
 import { DesktopNavLoading, MobileNavLoading } from "./loading"
 import MobileNav from "./MobileNav"
@@ -16,32 +17,38 @@ const Nav = async () => {
   const t = await getTranslations("common")
 
   return (
-    <nav
-      className="sticky top-0 z-sticky flex h-19 w-full max-w-screen-2xl items-center justify-between border-b bg-background p-4 md:items-stretch md:justify-normal xl:px-8"
-      aria-label={t("nav-primary")}
-    >
-      <BaseLink
-        href="/"
-        aria-label={t("home")}
-        className="inline-flex items-center no-underline"
-        data-testid="nav-logo"
+    <>
+      <nav
+        className="sticky top-0 z-sticky flex h-19 w-full max-w-screen-2xl items-center justify-between border-b bg-background p-4 md:items-stretch md:justify-normal xl:px-8"
+        aria-label={t("nav-primary")}
       >
-        <EthHomeIcon className="text-[35px] opacity-85 hover:opacity-100" />
-      </BaseLink>
+        <BaseLink
+          href="/"
+          aria-label={t("home")}
+          className="inline-flex items-center no-underline"
+          data-testid="nav-logo"
+        >
+          <EthHomeIcon className="text-[35px] opacity-85 hover:opacity-100" />
+        </BaseLink>
 
-      <div className="ms-3 flex w-full justify-end md:justify-between xl:ms-8">
-        <ClientOnly fallback={<DesktopNavLoading />}>
-          <MediaQuery queries={[`(min-width: ${breakpointAsNumber.md}px)`]}>
-            <DesktopNav />
-          </MediaQuery>
-        </ClientOnly>
-        <ClientOnly fallback={<MobileNavLoading />}>
-          <MediaQuery queries={[`(max-width: ${breakpointAsNumber.md - 1}px)`]}>
-            <MobileNav />
-          </MediaQuery>
-        </ClientOnly>
-      </div>
-    </nav>
+        <div className="ms-3 flex w-full justify-end md:justify-between xl:ms-8">
+          <ClientOnly fallback={<DesktopNavLoading />}>
+            <MediaQuery queries={[`(min-width: ${breakpointAsNumber.md}px)`]}>
+              <DesktopNav />
+            </MediaQuery>
+          </ClientOnly>
+          <ClientOnly fallback={<MobileNavLoading />}>
+            <MediaQuery
+              queries={[`(max-width: ${breakpointAsNumber.md - 1}px)`]}
+            >
+              <MobileNav />
+            </MediaQuery>
+          </ClientOnly>
+        </div>
+      </nav>
+
+      <CrawlableNav />
+    </>
   )
 }
 


### PR DESCRIPTION
## Summary

- Adds a `CrawlableNav` server component that renders all navigation links as plain `<a>` tags in the initial HTML
- The interactive desktop nav (Radix NavigationMenu) unmounts dropdown content when inactive, and the mobile nav is lazy-loaded on click — neither exposes links to crawlers
- `CrawlableNav` uses the same `buildNavigation()` data source so links stay in sync automatically
- Rendered as a sibling `<nav>` with `sr-only` (visually hidden, present in DOM)
- Zero client-side JS — fully server-rendered

## Test plan

- [x] Verify nav links appear in the page source HTML (View Source or `curl`)
- [x] Confirm the hidden nav is not visually visible on any viewport
- [x] Check that interactive desktop and mobile menus still work as before
- [x] Validate no duplicate `key` warnings in console