### PR TITLE
Fix nested button hydration error in Tooltip components

### DIFF
--- a/src/components/ListenToPlayer/PlayerWidget/index.tsx
+++ b/src/components/ListenToPlayer/PlayerWidget/index.tsx
@@ -26,7 +26,9 @@ const PlayerButton = ({
   return isMobile() ? (
     children
   ) : (
-    <Tooltip content={tooltipContent}>{children}</Tooltip>
+    <Tooltip content={tooltipContent} asChild>
+      {children}
+    </Tooltip>
   )
 }
 
@@ -147,7 +149,7 @@ const PlayerWidget = ({
       >
         <div className="flex justify-between">
           <p className="text-sm font-bold leading-base">{title}</p>
-          <Tooltip content={"Collapse"}>
+          <Tooltip content={"Collapse"} asChild>
             <button
               className="cursor-pointer text-body-medium hover:text-body"
               aria-label={"Collapse"}

--- a/src/components/Stat/index.tsx
+++ b/src/components/Stat/index.tsx
@@ -43,7 +43,7 @@ const Stat = ({ tooltipProps, value, label, isError }: StatProps) => {
       <div className="flex items-center space-x-2 leading-none text-body-medium">
         <span>{label}</span>
         {!!tooltipProps && (
-          <Tooltip {...tooltipProps}>
+          <Tooltip {...tooltipProps} asChild>
             <button className="flex text-inherit">
               <content.tooltipIcon className="h-4 w-4" />
             </button>

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -21,6 +21,7 @@ export type TooltipProps = ComponentProps<typeof Popover> & {
   children?: ReactNode
   onBeforeOpen?: () => void
   container?: HTMLElement | null
+  asChild?: boolean
   customMatomoEvent?: {
     eventCategory: string
     eventAction: string
@@ -33,6 +34,7 @@ const Tooltip = ({
   children,
   onBeforeOpen,
   container,
+  asChild,
   customMatomoEvent,
   ...props
 }: TooltipProps) => {
@@ -100,7 +102,10 @@ const Tooltip = ({
       delayDuration={200}
       {...props}
     >
-      <Trigger className="focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-hover">
+      <Trigger
+        asChild={asChild}
+        className="focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-hover"
+      >
         {children}
       </Trigger>
       <Portal container={container}>


### PR DESCRIPTION
## Summary
- Added `asChild` prop to the custom `Tooltip` component, forwarded to Radix's `TooltipTrigger`
- Applied `asChild` to `PlayerButton` and standalone `Tooltip` usages in `PlayerWidget` and `Stat` that wrap `<button>` children, so the child button *becomes* the trigger instead of being nested inside one
- Fixes `<button> cannot be a descendant of <button>` hydration error on `/what-is-ethereum` and anywhere else these components are used

## Test plan
- [ ] Verify no hydration errors in console on `/what-is-ethereum`
- [ ] Verify player widget tooltips still appear on hover (desktop) and tap (mobile)
- [ ] Verify Stat tooltip icon buttons still work
- [ ] Check no visual regression in Chromatic