### PR TITLE
fix: remove broken image URLs for Web3 Family meetup

### DIFF
--- a/src/data/community-meetups.json
+++ b/src/data/community-meetups.json
@@ -7,9 +7,7 @@
   {
     "title": "Web3 Family",
     "location": "Barcelona, Spain",
-    "link": "https://www.meetup.com/web3family/",
-    "logoImage": "https://secure.meetupstatic.com/photos/event/9/d/5/c/600_523840284.jpeg",
-    "bannerImage": "https://secure.meetupstatic.com/photos/event/9/d/5/c/600_523840284.jpeg"
+    "link": "https://www.meetup.com/web3family/"
   },
   {
     "title": "CryptoCanal",


### PR DESCRIPTION
## Summary

- Remove broken `logoImage` and `bannerImage` URLs from the Web3 Family meetup entry in `community-meetups.json`
- The Meetup.com CDN image (`secure.meetupstatic.com/photos/event/9/d/5/c/600_523840284.jpeg`) returns HTTP 403 Forbidden
- Without these fields, the UI displays a default fallback instead of a broken image

## Details

The external image hosted on Meetup.com's CDN is no longer accessible. Other meetup entries in the same file (e.g. "DC Onchain") already omit image fields when no stable image is available, so this follows existing conventions.

Closes #17909

## Test plan

- [ ] Verify `/community/events/meetups/` page renders without broken images for Web3 Family
- [ ] Confirm default fallback is displayed for entries without image fields