### PR TITLE
fix: use correct label in sync workflow

### DIFF
--- a/.github/workflows/i18n-sync-external-descriptions.yml
+++ b/.github/workflows/i18n-sync-external-descriptions.yml
@@ -77,4 +77,4 @@ jobs:
           Once merged, these strings will be picked up by the translation pipeline and translated into all 24 supported locales.
 
           This PR was created automatically by the \`i18n-sync-external-descriptions\` workflow." \
-            --label "i18n :globe_with_meridians:"
+            --label "translation 🌍"


### PR DESCRIPTION
Fix the `i18n-sync-external-descriptions` workflow using a non-existent label. Changed to the existing `translation 🌍` label.

Reviewed by Claude Opus 4.6

## Related issue
- Fixes: https://github.com/ethereum/ethereum-org-website/actions/runs/24110787874