### PR TITLE
content: update future-proofing page + add post-quantum cryptography subpage

### DIFF
--- a/public/content/roadmap/future-proofing/index.md
+++ b/public/content/roadmap/future-proofing/index.md
@@ -63,10 +63,10 @@ Complexity creates opportunities for bugs and vulnerabilities. Part of the roadm
 
 Several recent upgrades have made Ethereum simpler and more efficient:
 
-- **[Pectra (7-May-2025)](/roadmap/pectra/)**: Introduced EIP-7702, which lets externally owned accounts temporarily delegate to smart contract code, a stepping stone toward full [account abstraction](/roadmap/account-abstraction/). Also added the BLS12-381 precompile (EIP-2537), onchain deposit handling (EIP-6110), historical block hash access in the EVM (EIP-2935), and increased the maximum effective balance for validators (EIP-7251).
-- **[Fusaka (3-Dec-2025)](/roadmap/fusaka/)**: Deployed PeerDAS (EIP-7594), a peer-to-peer data availability sampling system that distributes the data availability workload across the network. Also increased blob parameters, expanding data throughput for [rollups](/glossary/#rollups).
+- **[Pectra (May 2025)](/roadmap/pectra/)**: Introduced EIP-7702, which lets externally owned accounts temporarily delegate to smart contract code, a stepping stone toward full [account abstraction](/roadmap/account-abstraction/). Also added the BLS12-381 precompile (EIP-2537), onchain deposit handling (EIP-6110), historical block hash access in the EVM (EIP-2935), and increased the maximum effective balance for validators (EIP-7251).
+- **[Fusaka (December 2025)](/roadmap/fusaka/)**: Deployed PeerDAS (EIP-7594), a peer-to-peer data availability sampling system that distributes the data availability workload across the network. Also increased blob parameters, expanding data throughput for [rollups](/glossary/#rollups).
 - **[Dencun (March 2024)](/roadmap/dencun/)**: Introduced blob transactions (EIP-4844) for cheaper rollup data and restricted `SELFDESTRUCT` (EIP-6780) to remove a long-standing source of complexity.
-- **[London (2021)](/ethereum-forks/#london)**: Overhauled [gas](/glossary/#gas) pricing with EIP-1559, introducing a base fee and burn mechanism for more predictable transaction costs.
+- **[London (August 2021)](/ethereum-forks/#london)**: Overhauled [gas](/glossary/#gas) pricing with EIP-1559, introducing a base fee and burn mechanism for more predictable transaction costs.
 
 ### What is in progress {#what-is-in-progress}
 

--- a/public/content/roadmap/future-proofing/index.md
+++ b/public/content/roadmap/future-proofing/index.md
@@ -6,8 +6,8 @@ image: /images/roadmap/roadmap-future.png
 alt: "Ethereum roadmap"
 template: roadmap
 summaryPoints:
-  - Post-quantum cryptography protects Ethereum from future quantum computer threats
-  - Protocol simplification makes Ethereum easier to maintain and more secure
+  - Post-quantum cryptography ensures Ethereum can survive advanced hardware threats as quantum computing advances
+  - Protocol simplification makes Ethereum easier to maintain, audit, and secure
   - Recent upgrades have already delivered meaningful efficiency improvements
 ---
 
@@ -15,19 +15,19 @@ Some parts of the roadmap are not about scaling or securing Ethereum right now. 
 
 ## Quantum resistance {#quantum-resistance}
 
-Ethereum uses [cryptography](/glossary/#cryptography) to keep the network secure and protect user funds. Some of these cryptographic methods will eventually be **vulnerable to quantum computers**, a new type of computer that solves certain mathematical problems much faster than today's machines.
+Ethereum uses [cryptography](/glossary/#cryptography) to keep the network secure and protect user funds. Eventually, some of these cryptographic methods will be **vulnerable to quantum computers**, which can solve specific mathematical problems exponentially faster than classical machines.
 
-**No quantum computer can break Ethereum's cryptography today.** Current quantum hardware is far from powerful enough. But recent research suggests the gap is closing faster than previously expected. In March 2026, Google Quantum AI published a paper estimating that breaking 256-bit elliptic curve cryptography (the type Ethereum uses for account signatures) could require roughly 1,200 logical qubits, about 20 times fewer than earlier estimates. Google has set a 2029 internal deadline for migrating its own systems to quantum-safe cryptography.
+**No quantum computer can break Ethereum's cryptography today.** The hardware required does not yet exist at scale. But recent research suggests the gap is closing faster than previously expected. In March 2026, Google Quantum AI published a paper estimating that breaking 256-bit elliptic curve cryptography (the type Ethereum uses for account signatures) could require roughly 1,200 logical qubits, about 20 times fewer than earlier estimates. Google has set a 2029 internal deadline for migrating its own systems to quantum-safe cryptography.
 
-Cryptographic transitions take years to plan and execute. Ethereum's security model is designed to last decades. That is why preparation is happening now, not as a reaction to an emergency.
+Cryptographic transitions take years to plan and execute safely. Because Ethereum's security model is designed to last decades, post-quantum preparation was in Ethereum's roadmap before it was in mainstream headlines. Network preparation is happening now to ensure a seamless transition, not as a reaction to an emergency.
 
 ### What is at risk? {#what-is-at-risk}
 
-Vitalik Buterin has identified **four areas** of Ethereum's cryptography that need post-quantum upgrades:
+Four primary areas of Ethereum's cryptography have been identified as requiring post-quantum upgrades:
 
-1. **Consensus signatures (BLS)**: [Validators](/glossary/#validator) use BLS signatures to vote on valid [blocks](/glossary/#block). Quantum computers could break these.
-2. **Data availability (KZG commitments)**: The [commitment schemes](/roadmap/danksharding/#what-is-kzg) that help Ethereum scale rely on math that quantum computers can attack.
-3. **Account signatures (ECDSA)**: The signature scheme that protects individual Ethereum accounts. A quantum computer could derive a private key from a public key, potentially allowing theft of funds.
+1. **Consensus signatures (BLS)**: [Validators](/glossary/#validator) use BLS signatures to vote on valid [blocks](/glossary/#block). A quantum computer could forge these signatures.
+2. **Data availability (KZG commitments)**: The [commitment schemes](/roadmap/danksharding/#what-is-kzg) that help Ethereum scale rely on math (specifically, elliptic curve pairing) that is vulnerable to quantum attacks.
+3. **Account signatures (ECDSA)**: The signature scheme that protects individual Ethereum accounts. When an account sends a transaction, its public key is exposed onchain. A quantum computer could derive the private key from this exposed public key, potentially allowing theft of funds.
 4. **Application-layer ZK-proofs**: Zero-knowledge proof systems used by rollups and other applications rely on cryptographic assumptions that quantum computers could undermine.
 
 <ExpandableCard title="Can quantum computers steal my ETH today?" eventCategory="/roadmap/future-proofing" eventName="clicked can quantum computers steal my ETH today?">
@@ -38,17 +38,17 @@ No. No quantum computer today can break Ethereum's cryptography. The work descri
 
 ### What is being done? {#what-is-being-done}
 
-The Ethereum Foundation formed a dedicated **Post-Quantum Security team** in January 2026. The team's work is tracked publicly at [pq.ethereum.org](https://pq.ethereum.org).
+Ethereum is currently the most proactive defender against quantum threats in the blockchain ecosystem. The Ethereum Foundation formed a dedicated **Post-Quantum Security team** in January 2026, and active work spans across multiple client teams and research groups. The EF Post-Quantum team's work is tracked publicly at [pq.ethereum.org](https://pq.ethereum.org).
 
 Active work includes:
 
 - **Hash-based signatures (leanXMSS)**: A quantum-safe replacement for validator signatures, built on hash functions that quantum computers cannot efficiently break.
-- **Minimal zkVM (leanVM)**: A tool for aggregating quantum-safe signatures efficiently, so the network does not slow down after the transition.
+- **Minimal zkVM (leanVM)**: Because quantum-safe signatures are larger than the signatures currently used, leanXMSS is paired with a minimal zkVM (leanVM). This engine aggregates quantum-safe signatures efficiently, compressing the data by 250x, so the network remains fast after the transition.
 - **Weekly interop testing**: More than 10 client teams participate in regular post-quantum devnets.
 - **Poseidon Prize**: A $1 million research prize targeting improvements in hash-based cryptographic primitives.
 - **NIST standards**: The U.S. National Institute of Standards and Technology finalized three post-quantum cryptography standards in August 2024 (ML-KEM, ML-DSA, SLH-DSA). Ethereum's work builds on these foundations.
 
-A key part of the transition strategy is **EIP-8141**, which introduces native [account abstraction](/roadmap/account-abstraction/). This allows individual accounts to choose their own signature verification, meaning users could switch to quantum-safe signatures **without waiting for a single protocol-wide migration**. EIP-8141 is being considered for the Hegota hard fork (planned for H2 2026).
+A key part of the transition strategy is **EIP-8141**, which introduces native [account abstraction](/roadmap/account-abstraction/). This allows individual accounts to choose their own signature verification, meaning users could switch to quantum-safe signatures **without waiting for a single protocol-wide migration**. EIP-8141 is being considered for the Hegotá hard fork (planned for second half of 2026).
 
 The Ethereum Foundation has outlined structured fork milestones targeting completion of core post-quantum infrastructure by approximately 2029. These are planning targets, not guaranteed commitments.
 
@@ -69,19 +69,19 @@ Several recent upgrades have made Ethereum simpler and more efficient:
 
 ### What is in progress {#what-is-in-progress}
 
-- **Glamsterdam (planned H1 2026)**: Expected to include enshrined proposer-builder separation (EIP-7732), block-level access lists (EIP-7928), and gas repricing to better align costs with actual resource usage.
-- **Hegota (planned H2 2026)**: Expected to include [Verkle Trees](/roadmap/verkle-trees/), replacing the current data structure with a more efficient one that enables stateless clients. Also targeted for EIP-8141 (native account abstraction).
+- **Glamsterdam (planned first half of 2026)**: Being considered for inclusion: enshrined proposer-builder separation (EIP-7732), block-level access lists (EIP-7928), and gas repricing to better align costs with actual resource usage.
+- **Hegotá (planned second half of 2026)**: Being considered for inclusion: [Verkle Trees](/roadmap/verkle-trees/), replacing the current data structure with a more efficient one that enables stateless clients. Also targeted for EIP-8141 (native account abstraction).
 - **Ongoing**: Efforts to simplify the [EVM](/developers/docs/evm/), harmonize client implementations, and phase out deprecated features continue across the Ethereum development community.
 
 ## Current progress {#current-progress}
 
 As of early 2026:
 
-**Simplification and efficiency**: Significant progress. Pectra and Fusaka delivered real improvements in account flexibility, data availability, and validator operations. Glamsterdam and Hegota are in active development with clear EIP targets.
+**Simplification and efficiency**: Significant progress. Pectra and Fusaka delivered real improvements in account flexibility, data availability, and validator operations. Glamsterdam and Hegotá are in active development with clear EIP targets.
 
 **Post-quantum cryptography**: Active research and early implementation. The Ethereum Foundation has a dedicated team, funded research prizes, and weekly interop devnets running across multiple clients. However, **no post-quantum code is in production on Ethereum Mainnet yet**. The structured fork milestones target 2029 for completion.
 
-**Account abstraction and signature agility**: EIP-7702 shipped in Pectra. EIP-8141, being considered for Hegota, will allow accounts to use any signature scheme, giving users a path to adopt quantum-safe signatures before the full protocol transition is complete.
+**Account abstraction and signature agility**: EIP-7702 shipped in Pectra. EIP-8141, being considered for Hegotá, will allow accounts to use any signature scheme, giving users a path to adopt quantum-safe signatures before the full protocol transition is complete.
 
 No part of this work is finished. Timelines are targets, not guarantees. But the scope and pace of active development represent a clear commitment to keeping Ethereum secure and efficient for the long term.
 

--- a/public/content/roadmap/future-proofing/index.md
+++ b/public/content/roadmap/future-proofing/index.md
@@ -89,8 +89,7 @@ No part of this work is finished. Timelines are targets, not guarantees. But the
 **Further reading**
 
 - [Post-quantum cryptography on Ethereum](/roadmap/future-proofing/quantum-resistance/)
-- [Privacy Stewards of Ethereum: Post-Quantum Cryptography and Ethereum](https://pse.dev/projects/post-quantum-cryptography)
-- [lean week: leanVM + PQ workshops, Cambridge 2025](https://github.com/leanEthereum/pm/blob/main/workshops-and-interops/2025/lean-week-cambridge/index.md)
+- [strawmap.org](https://strawmap.org/) - _EF Architecture_
 - [pq.ethereum.org](https://pq.ethereum.org)
 - [Gas](/developers/docs/gas/)
 - [EVM](/developers/docs/evm/)

--- a/public/content/roadmap/future-proofing/index.md
+++ b/public/content/roadmap/future-proofing/index.md
@@ -5,49 +5,90 @@ lang: en
 image: /images/roadmap/roadmap-future.png
 alt: "Ethereum roadmap"
 template: roadmap
+summaryPoints:
+  - Post-quantum cryptography protects Ethereum from future quantum computer threats
+  - Protocol simplification makes Ethereum easier to maintain and more secure
+  - Recent upgrades have already delivered meaningful efficiency improvements
 ---
 
-Some parts of the roadmap are not necessarily required for scaling or securing Ethereum in the near-term, but set Ethereum up for stability and reliability far into the future.
+Some parts of the roadmap are not about scaling or securing Ethereum right now. They are about making Ethereum **stable and reliable far into the future**. This means preparing for new kinds of threats and removing unnecessary complexity from the protocol.
 
 ## Quantum resistance {#quantum-resistance}
 
-Some of the [cryptography](/glossary/#cryptography) securing present-day Ethereum will be compromised when quantum computing becomes a reality. Although quantum computers are probably decades away from being a genuine threat to modern cryptography, Ethereum is being built to be secure for centuries to come. This means making [Ethereum quantum resistant](https://consensys.net/blog/developers/how-will-quantum-supremacy-affect-blockchain/) as soon as possible.
+Ethereum uses [cryptography](/glossary/#cryptography) to keep the network secure and protect user funds. Some of these cryptographic methods will eventually be **vulnerable to quantum computers**, a new type of computer that solves certain mathematical problems much faster than today's machines.
 
-The challenge facing Ethereum developers is that the current [proof-of-stake](/glossary/#pos) protocol relies upon a very efficient signature scheme known as BLS to aggregate votes on valid [blocks](/glossary/#block). This signature scheme is broken by quantum computers, but the quantum resistant alternatives are not as efficient.
+**No quantum computer can break Ethereum's cryptography today.** Current quantum hardware is far from powerful enough. But recent research suggests the gap is closing faster than previously expected. In March 2026, Google Quantum AI published a paper estimating that breaking 256-bit elliptic curve cryptography (the type Ethereum uses for account signatures) could require roughly 1,200 logical qubits, about 20 times fewer than earlier estimates. Google has set a 2029 internal deadline for migrating its own systems to quantum-safe cryptography.
 
-The [“KZG” commitment schemes](/roadmap/danksharding/#what-is-kzg) used in several places across Ethereum to generate cryptographic secrets are known to be quantum-vulnerable. Currently, this is circumvented using “trusted setups” (for which the main setup ceremony completed successfully in 2023), where many users generated randomness that cannot be reverse-engineered by a quantum computer. However, the ideal long-term solution would be to incorporate quantum safe cryptography instead. There are two leading approaches that could become efficient replacements for the BLS scheme: [STARK-based](https://hackmd.io/@vbuterin/stark_aggregation) and [lattice-based](https://medium.com/asecuritysite-when-bob-met-alice/so-what-is-lattice-encryption-326ac66e3175) signing. **These are still being actively researched and prototyped**.
+Cryptographic transitions take years to plan and execute. Ethereum's security model is designed to last decades. That is why preparation is happening now, not as a reaction to an emergency.
 
-[Read about KZG and trusted setups](/roadmap/danksharding#what-is-kzg)
+### What is at risk? {#what-is-at-risk}
+
+Vitalik Buterin has identified **four areas** of Ethereum's cryptography that need post-quantum upgrades:
+
+1. **Consensus signatures (BLS)**: [Validators](/glossary/#validator) use BLS signatures to vote on valid [blocks](/glossary/#block). Quantum computers could break these.
+2. **Data availability (KZG commitments)**: The [commitment schemes](/roadmap/danksharding/#what-is-kzg) that help Ethereum scale rely on math that quantum computers can attack.
+3. **Account signatures (ECDSA)**: The signature scheme that protects individual Ethereum accounts. A quantum computer could derive a private key from a public key, potentially allowing theft of funds.
+4. **Application-layer ZK-proofs**: Zero-knowledge proof systems used by rollups and other applications rely on cryptographic assumptions that quantum computers could undermine.
+
+<ExpandableCard title="Can quantum computers steal my ETH today?" eventCategory="/roadmap/future-proofing" eventName="clicked can quantum computers steal my ETH today?">
+
+No. No quantum computer today can break Ethereum's cryptography. The work described on this page is preparation for the future, not a response to an active threat. When post-quantum wallets become available, wallet software will guide you through the migration. For now, there is nothing you need to do.
+
+</ExpandableCard>
+
+### What is being done? {#what-is-being-done}
+
+The Ethereum Foundation formed a dedicated **Post-Quantum Security team** in January 2026. The team's work is tracked publicly at [pq.ethereum.org](https://pq.ethereum.org).
+
+Active work includes:
+
+- **Hash-based signatures (leanXMSS)**: A quantum-safe replacement for validator signatures, built on hash functions that quantum computers cannot efficiently break.
+- **Minimal zkVM (leanVM)**: A tool for aggregating quantum-safe signatures efficiently, so the network does not slow down after the transition.
+- **Weekly interop testing**: More than 10 client teams participate in regular post-quantum devnets.
+- **Poseidon Prize**: A $1 million research prize targeting improvements in hash-based cryptographic primitives.
+- **NIST standards**: The U.S. National Institute of Standards and Technology finalized three post-quantum cryptography standards in August 2024 (ML-KEM, ML-DSA, SLH-DSA). Ethereum's work builds on these foundations.
+
+A key part of the transition strategy is **EIP-8141**, which introduces native [account abstraction](/roadmap/account-abstraction/). This allows individual accounts to choose their own signature verification, meaning users could switch to quantum-safe signatures **without waiting for a single protocol-wide migration**. EIP-8141 is being considered for the Hegota hard fork (planned for H2 2026).
+
+The Ethereum Foundation has outlined structured fork milestones targeting completion of core post-quantum infrastructure by approximately 2029. These are planning targets, not guaranteed commitments.
+
+[Read our detailed guide to post-quantum cryptography on Ethereum](/roadmap/future-proofing/quantum-resistance/)
 
 ## Simpler and more efficient Ethereum {#simpler-more-efficient-ethereum}
 
-Complexity creates opportunities for bugs or vulnerabilities that can be exploited by attackers. Therefore, part of the roadmap is simplifying Ethereum and removing or modifying code that has hung around through various upgrades but is no longer needed or can now be improved upon. A leaner, simpler codebase is easier for developers to maintain and reason about.
+Complexity creates opportunities for bugs and vulnerabilities. Part of the roadmap focuses on **simplifying Ethereum and removing technical debt** so the protocol is easier to maintain, audit, and reason about.
 
-To make the [Ethereum Virtual Machine (EVM)](/developers/docs/evm) simpler and more efficient, improvements are continuously researched and implemented. This involves both addressing legacy components and introducing optimizations.
+### What has been delivered {#what-has-been-delivered}
 
-**Recent Changes Implemented:**
+Several recent upgrades have made Ethereum simpler and more efficient:
 
-- **Gas Calculation Overhaul:** The way [gas](/glossary/#gas) is calculated was significantly improved with **EIP-1559 (implemented in the London upgrade, 2021)**, introducing a base fee and burn mechanism for more predictable transaction pricing.
-- **`SELFDESTRUCT` Restriction:** The `SELFDESTRUCT` opcode, while rarely used, posed potential risks. Its functionality was heavily **restricted in the Dencun upgrade (March 2024) via EIP-6780** to mitigate dangers, especially concerning state management.
-- **Modernized Transaction Types:** New transaction formats have been introduced (e.g., via **EIP-2718** and **EIP-4844** for blobs in the Dencun upgrade) to support new features and improve efficiency over legacy types.
+- **Pectra (7-May-2025)**: Introduced EIP-7702, which lets externally owned accounts temporarily delegate to smart contract code, a stepping stone toward full [account abstraction](/roadmap/account-abstraction/). Also added the BLS12-381 precompile (EIP-2537), onchain deposit handling (EIP-6110), historical block hash access in the EVM (EIP-2935), and increased the maximum effective balance for validators (EIP-7251).
+- **Fusaka (3-Dec-2025)**: Deployed PeerDAS (EIP-7594), a peer-to-peer data availability sampling system that distributes the data availability workload across the network. Also increased blob parameters, expanding data throughput for [rollups](/glossary/#rollups).
+- **Dencun (March 2024)**: Introduced blob transactions (EIP-4844) for cheaper rollup data and restricted `SELFDESTRUCT` (EIP-6780) to remove a long-standing source of complexity.
+- **London (2021)**: Overhauled [gas](/glossary/#gas) pricing with EIP-1559, introducing a base fee and burn mechanism for more predictable transaction costs.
 
-**Ongoing and future goals:**
+### What is in progress {#what-is-in-progress}
 
-- **Further `SELFDESTRUCT` Handling:** While restricted, the **potential complete removal** of the `SELFDESTRUCT` opcode is still considered for future upgrades to further simplify the EVM state. ([More context on SELFDESTRUCT issues](https://hackmd.io/@vbuterin/selfdestruct)).
-- **Phasing Out Legacy Transactions:** Although [Ethereum clients](/glossary/#consensus-client) still support older transaction types for backward compatibility, the goal is to encourage migration to newer types and **potentially deprecate or fully remove support for the oldest formats** in the future.
-- **Continued Gas Efficiency Research:** Exploration continues into **further refinements for gas calculation**, potentially including concepts like multi-dimensional gas to better reflect resource usage.
-- **Optimized Cryptographic Operations:** Efforts are ongoing to **bring in more efficient methods for the arithmetic** underpinning cryptographic operations used within the EVM.
-
-Similarly, there are updates that can be made to other parts of present-day Ethereum clients. One example is that current execution and consensus clients use a different type of data compression. It will be much easier and more intuitive to share data between clients when the compression scheme is unified across the whole network. This remains an area of exploration.
+- **Glamsterdam (planned H1 2026)**: Expected to include enshrined proposer-builder separation (EIP-7732), block-level access lists (EIP-7928), and gas repricing to better align costs with actual resource usage.
+- **Hegota (planned H2 2026)**: Expected to include [Verkle Trees](/roadmap/verkle-trees/), replacing the current data structure with a more efficient one that enables stateless clients. Also targeted for EIP-8141 (native account abstraction).
+- **Ongoing**: Efforts to simplify the [EVM](/developers/docs/evm/), harmonize client implementations, and phase out deprecated features continue across the Ethereum development community.
 
 ## Current progress {#current-progress}
 
-Many of the long-term future-proofing upgrades, particularly **full quantum resistance for core protocols, are still in the research phase and may be several years away** from being implemented.
+As of early 2026:
 
-However, **significant progress has already been made on simplification efforts.** For example, key changes like the **restriction of `SELFDESTRUCT` (EIP-6780)** and the introduction of **blob-carrying transactions (EIP-4844)** were implemented in the **Dencun upgrade (March 2024)**. Work on harmonizing client compression schemes and other efficiency improvements also continues.
+**Simplification and efficiency**: Significant progress. Pectra and Fusaka delivered real improvements in account flexibility, data availability, and validator operations. Glamsterdam and Hegota are in active development with clear EIP targets.
+
+**Post-quantum cryptography**: Active research and early implementation. The Ethereum Foundation has a dedicated team, funded research prizes, and weekly interop devnets running across multiple clients. However, **no post-quantum code is in production on Ethereum Mainnet yet**. The structured fork milestones target 2029 for completion.
+
+**Account abstraction and signature agility**: EIP-7702 shipped in Pectra. EIP-8141, being considered for Hegota, will allow accounts to use any signature scheme, giving users a path to adopt quantum-safe signatures before the full protocol transition is complete.
+
+No part of this work is finished. Timelines are targets, not guarantees. But the scope and pace of active development represent a clear commitment to keeping Ethereum secure and efficient for the long term.
 
 **Further reading**
 
-- [Gas](/developers/docs/gas)
-- [EVM](/developers/docs/evm)
-- [Data structures](/developers/docs/data-structures-and-encoding)
+- [pq.ethereum.org](https://pq.ethereum.org)
+- [Post-quantum cryptography on Ethereum](/roadmap/future-proofing/quantum-resistance/)
+- [Gas](/developers/docs/gas/)
+- [EVM](/developers/docs/evm/)
+- [Data structures](/developers/docs/data-structures-and-encoding/)

--- a/public/content/roadmap/future-proofing/index.md
+++ b/public/content/roadmap/future-proofing/index.md
@@ -63,14 +63,14 @@ Complexity creates opportunities for bugs and vulnerabilities. Part of the roadm
 
 Several recent upgrades have made Ethereum simpler and more efficient:
 
-- **Pectra (7-May-2025)**: Introduced EIP-7702, which lets externally owned accounts temporarily delegate to smart contract code, a stepping stone toward full [account abstraction](/roadmap/account-abstraction/). Also added the BLS12-381 precompile (EIP-2537), onchain deposit handling (EIP-6110), historical block hash access in the EVM (EIP-2935), and increased the maximum effective balance for validators (EIP-7251).
-- **Fusaka (3-Dec-2025)**: Deployed PeerDAS (EIP-7594), a peer-to-peer data availability sampling system that distributes the data availability workload across the network. Also increased blob parameters, expanding data throughput for [rollups](/glossary/#rollups).
-- **Dencun (March 2024)**: Introduced blob transactions (EIP-4844) for cheaper rollup data and restricted `SELFDESTRUCT` (EIP-6780) to remove a long-standing source of complexity.
-- **London (2021)**: Overhauled [gas](/glossary/#gas) pricing with EIP-1559, introducing a base fee and burn mechanism for more predictable transaction costs.
+- **[Pectra (7-May-2025)](/roadmap/pectra/)**: Introduced EIP-7702, which lets externally owned accounts temporarily delegate to smart contract code, a stepping stone toward full [account abstraction](/roadmap/account-abstraction/). Also added the BLS12-381 precompile (EIP-2537), onchain deposit handling (EIP-6110), historical block hash access in the EVM (EIP-2935), and increased the maximum effective balance for validators (EIP-7251).
+- **[Fusaka (3-Dec-2025)](/roadmap/fusaka/)**: Deployed PeerDAS (EIP-7594), a peer-to-peer data availability sampling system that distributes the data availability workload across the network. Also increased blob parameters, expanding data throughput for [rollups](/glossary/#rollups).
+- **[Dencun (March 2024)](/roadmap/dencun/)**: Introduced blob transactions (EIP-4844) for cheaper rollup data and restricted `SELFDESTRUCT` (EIP-6780) to remove a long-standing source of complexity.
+- **[London (2021)](/ethereum-forks/#london)**: Overhauled [gas](/glossary/#gas) pricing with EIP-1559, introducing a base fee and burn mechanism for more predictable transaction costs.
 
 ### What is in progress {#what-is-in-progress}
 
-- **Glamsterdam (planned first half of 2026)**: Being considered for inclusion: enshrined proposer-builder separation (EIP-7732), block-level access lists (EIP-7928), and gas repricing to better align costs with actual resource usage.
+- **[Glamsterdam (planned first half of 2026)](/roadmap/glamsterdam/)**: Being considered for inclusion: enshrined proposer-builder separation (EIP-7732), block-level access lists (EIP-7928), and gas repricing to better align costs with actual resource usage.
 - **Hegotá (planned second half of 2026)**: Being considered for inclusion: [Verkle Trees](/roadmap/verkle-trees/), replacing the current data structure with a more efficient one that enables stateless clients. Also targeted for EIP-8141 (native account abstraction).
 - **Ongoing**: Efforts to simplify the [EVM](/developers/docs/evm/), harmonize client implementations, and phase out deprecated features continue across the Ethereum development community.
 
@@ -78,9 +78,9 @@ Several recent upgrades have made Ethereum simpler and more efficient:
 
 As of early 2026:
 
-**Simplification and efficiency**: Significant progress. Pectra and Fusaka delivered real improvements in account flexibility, data availability, and validator operations. Glamsterdam and Hegotá are in active development with clear EIP targets.
+**Simplification and efficiency**: Pectra and Fusaka delivered real improvements in account flexibility, data availability, and validator operations. Glamsterdam and Hegotá are in active development with clear targets to make the network more resilient and efficient, while removing external dependencies.
 
-**Post-quantum cryptography**: Active research and early implementation. The Ethereum Foundation has a dedicated team, funded research prizes, and weekly interop devnets running across multiple clients. However, **no post-quantum code is in production on Ethereum Mainnet yet**. The structured fork milestones target 2029 for completion.
+**Post-quantum cryptography**: Active research and early implementation are underway. The ecosystem has funded research prizes and runs weekly interop devnets across multiple clients, in addition to the research done by the Ethereum Foundation's dedicated Post-Quantum team. While the structured fork milestones target approximately 2029 for completion, early research is producing tangible proof points demonstrating that post-quantum execution is viable today.
 
 **Account abstraction and signature agility**: EIP-7702 shipped in Pectra. EIP-8141, being considered for Hegotá, will allow accounts to use any signature scheme, giving users a path to adopt quantum-safe signatures before the full protocol transition is complete.
 
@@ -88,8 +88,10 @@ No part of this work is finished. Timelines are targets, not guarantees. But the
 
 **Further reading**
 
-- [pq.ethereum.org](https://pq.ethereum.org)
 - [Post-quantum cryptography on Ethereum](/roadmap/future-proofing/quantum-resistance/)
+- [Privacy Stewards of Ethereum: Post-Quantum Cryptography and Ethereum](https://pse.dev/projects/post-quantum-cryptography)
+- [lean week: leanVM + PQ workshops, Cambridge 2025](https://github.com/leanEthereum/pm/blob/main/workshops-and-interops/2025/lean-week-cambridge/index.md)
+- [pq.ethereum.org](https://pq.ethereum.org)
 - [Gas](/developers/docs/gas/)
 - [EVM](/developers/docs/evm/)
 - [Data structures](/developers/docs/data-structures-and-encoding/)

--- a/public/content/roadmap/future-proofing/index.md
+++ b/public/content/roadmap/future-proofing/index.md
@@ -45,6 +45,7 @@ Active work includes:
 - **Hash-based signatures (leanXMSS)**: A quantum-safe replacement for validator signatures, built on hash functions that quantum computers cannot efficiently break.
 - **Minimal zkVM (leanVM)**: Because quantum-safe signatures are larger than the signatures currently used, leanXMSS is paired with a minimal zkVM (leanVM). This engine aggregates quantum-safe signatures efficiently, compressing the data by 250x, so the network remains fast after the transition.
 - **Weekly interop testing**: More than 10 client teams participate in regular post-quantum devnets.
+- **Data availability:** Upgrading the underlying cryptography used to handle large amounts of network data will ensure Ethereum stays fast and affordable to use without risking future quantum vulnerabilities.
 - **Poseidon Prize**: A $1 million research prize targeting improvements in hash-based cryptographic primitives.
 - **NIST standards**: The U.S. National Institute of Standards and Technology finalized three post-quantum cryptography standards in August 2024 (ML-KEM, ML-DSA, SLH-DSA). Ethereum's work builds on these foundations.
 

--- a/public/content/roadmap/future-proofing/quantum-resistance/index.md
+++ b/public/content/roadmap/future-proofing/quantum-resistance/index.md
@@ -32,9 +32,9 @@ Current quantum hardware is far from this scale, operating with a few thousand n
 
 This is not an imminent threat. But cryptographic transitions take years, and Ethereum's security model is designed to last centuries. Ethereum's response is the **Lean Ethereum** roadmap, a deliberate, multi-year mission to rebuild Ethereum around primitives that will survive any cryptographic threat.
 
-## The four vulnerable areas {#four-vulnerable-areas}
+## Four areas vulnerable to quantum attack {#four-vulnerable-areas}
 
-In February 2026, Vitalik Buterin published a roadmap identifying four distinct areas of Ethereum's cryptography that need post-quantum upgrades. Each has different challenges and different solution paths.
+In February 2026, Vitalik Buterin [published a roadmap](https://x.com/VitalikButerin/status/2027075026378543132) identifying four distinct areas of Ethereum's cryptography that need post-quantum upgrades. Each has different challenges and different solution paths.
 
 ### 1. Consensus-layer BLS signatures {#consensus-bls}
 
@@ -42,9 +42,9 @@ In February 2026, Vitalik Buterin published a roadmap identifying four distinct 
 
 **Why it is vulnerable**: BLS signatures rely on elliptic curve pairings, which a quantum computer could break.
 
-**The approach**: The Ethereum Foundation is developing two complementary tools:
-- **leanXMSS**: A hash-based signature scheme for validators. Hash-based signatures are considered quantum-safe because they rely only on the security of hash functions, which quantum computers weaken but do not break.
-- **leanVM**: A minimal zkVM (zero-knowledge virtual machine) for SNARK-based signature aggregation. This preserves the efficiency benefits of combining many signatures into one, even after switching to quantum-safe schemes.
+**The approach**: The Lean Consensus roadmap includes developing two complementary tools:
+- **leanXMSS**: Ethereum will replace BLS signatures with leanXMSS, a hash-based signature scheme for validators. Hash-based signatures are considered quantum-safe because they rely only on the security of hash functions, which quantum computers weaken but do not break.
+- **leanVM**: A minimal zkVM (zero-knowledge virtual machine) for SNARK-based signature aggregation. Because hash-based signatures are significantly larger (roughly 3,000 bytes compared to 96 bytes for BLS), switching to leanXMSS would produce significantly more data per slot. To solve this, leanVM acts as an aggregation engine, compressing the data by 250x. This preserves the efficiency benefits of combining many signatures into one, even after switching to quantum-safe schemes.
 
 <ExpandableCard title="Why can't Ethereum just replace BLS with a quantum-safe scheme?" eventCategory="/roadmap/future-proofing/quantum-resistance" eventName="clicked why cant ethereum just replace BLS?">
 
@@ -70,7 +70,7 @@ Both approaches are still being researched for efficiency and practicality at Et
 
 **What it does**: Every standard Ethereum account (externally owned account, or [EOA](/glossary/#eoa)) uses ECDSA on the secp256k1 curve to sign transactions. This is what protects your funds.
 
-**Why it is vulnerable**: A quantum computer could derive a private key from a public key. For accounts that have sent at least one transaction, the public key is exposed onchain, making them a potential target.
+**Why it is vulnerable**: For any account that has sent a transaction, the public key is exposed onchain. A quantum computer could derive the private key from this exposed public key data.
 
 **Important nuance**: Accounts that have only received ether and never sent a transaction have not exposed their public key. Only the address (a hash of the public key) is visible, which provides some additional protection.
 
@@ -84,11 +84,11 @@ This is a pragmatic approach. Users and wallets that want post-quantum protectio
 
 **Why it is vulnerable**: Many popular ZK-proof systems (SNARKs using elliptic curve pairings) rely on quantum-vulnerable assumptions.
 
-**The approach**: STARKs, which rely on hash functions rather than elliptic curves, are already quantum-resistant and are used by several rollups. The transition for this layer is partly happening already through natural ecosystem adoption of STARK-based systems.
+**The approach**: STARKs, which rely on hash functions rather than elliptic curves, are already quantum-resistant and are used by several rollups. Natural ecosystem adoption of STARK-based systems is already providing post-quantum security at the application layer.
 
 ## NIST standards {#nist-standards}
 
-In August 2024, the U.S. National Institute of Standards and Technology (NIST) finalized three post-quantum cryptography standards. These matter because they give the entire technology industry, including Ethereum, a shared set of vetted algorithms to build on rather than each project inventing its own.
+In August 2024, the U.S. National Institute of Standards and Technology (NIST) [finalized three post-quantum cryptography standards](https://www.nist.gov/news-events/news/2024/08/nist-releases-first-3-finalized-post-quantum-encryption-standards). These matter because they give the entire technology industry, including Ethereum, a shared set of vetted algorithms to build on rather than each project inventing its own.
 
 | Standard | Name | Type | Use case |
 |----------|------|------|----------|
@@ -106,8 +106,9 @@ The Ethereum Foundation formed a dedicated Post-Quantum Security team in January
 
 - **Weekly interop devnets**: More than 10 client teams participate in regular post-quantum interoperability testing, including Lighthouse, Grandine, Zeam, Ream Labs, and PierTwo.
 - **Poseidon Prize**: A $1 million research prize targeting improvements in hash-based cryptographic primitives.
-- **Open-source implementations**: leanXMSS, leanVM, leanSpec (Python), leanSig (Rust), and leanMultisig are all available under the leanEthereum GitHub organization.
+- **Open-source implementations**: leanXMSS, leanVM, leanSpec (Python), leanSig (Rust), and leanMultisig are all available under the [leanEthereum GitHub organization](https://github.com/leanEthereum).
 - **2nd Annual PQ Research Retreat**: Planned for 9-Oct-2026 to 12-Oct-2026 in Cambridge, UK.
+- **NIST Alignment**: Ethereum's work builds upon the post-quantum cryptography standards finalized by NIST in August 2024 (such as ML-KEM, ML-DSA, and SLH-DSA).
 
 ### Migration milestones {#migration-milestones}
 
@@ -120,13 +121,13 @@ The team has outlined a series of protocol upgrades to incrementally introduce p
 | L* | PQ attestations and real-time consensus-layer proofs via leanVM. Validators begin using PQ signatures for consensus. |
 | M* | Full PQ signature aggregation and PQ-safe blob commitments. |
 
-**Target**: Core post-quantum infrastructure in place by approximately 2029. Full execution-layer and ecosystem migration extends beyond that.
+**Target**: The structured fork milestones target the completion of core post-quantum infrastructure by approximately 2029. Full execution-layer and ecosystem migration extends beyond that.
 
 ## What do users need to do? {#what-users-need-to-do}
 
 **Right now: nothing.** Your funds are safe. No quantum computer today can threaten Ethereum's cryptography.
 
-**In the future**: Once post-quantum signature schemes are available on Ethereum (expected to begin with EIP-8141), you will want to migrate your account to quantum-safe signatures. Wallet software will guide you through this transition.
+**In the future**: Once post-quantum signature schemes are widely supported on Ethereum (expected following the Hegotá hard fork and implementation of EIP-8141), you will want to migrate your account to quantum-safe signatures. Wallet software will guide you through this transition.
 
 If your account has never sent a transaction (meaning your public key has not been exposed onchain), it has an additional layer of protection. But all accounts should eventually migrate.
 
@@ -160,7 +161,7 @@ Assets on Ethereum are controlled by account signatures. Once your account is mi
 
 <ExpandableCard title="Is Ethereum behind other blockchains on this?" eventCategory="/roadmap/future-proofing/quantum-resistance" eventName="clicked is Ethereum behind?">
 
-Ethereum has one of the most structured post-quantum programs of any blockchain: a dedicated team, funded research, weekly devnets, and a published migration roadmap. No blockchain has completed a full post-quantum transition yet. According to Ethereum Foundation estimates, Ethereum's quantum-vulnerable dormant fund exposure is approximately 0.1%.
+No. Ethereum has one of the most structured post-quantum programs of any blockchain: a dedicated team, funded research, weekly devnets, and a published migration roadmap, treating quantum computing as a first-class design constraint. No blockchain has completed a full post-quantum transition yet. According to Ethereum Foundation estimates, Ethereum's quantum-vulnerable dormant fund exposure is approximately 0.1%, drastically lower than other major blockchain networks.
 
 </ExpandableCard>
 
@@ -173,9 +174,16 @@ Ethereum has one of the most structured post-quantum programs of any blockchain:
 ## Further reading {#further-reading}
 
 - [pq.ethereum.org](https://pq.ethereum.org) - _Ethereum Foundation_
+- [Post-Quantum Cryptography Project](https://pse.dev/projects/post-quantum-cryptography) - _Privacy Stewards of Ethereum (PSE)_
 - [NIST Post-Quantum Cryptography standards](https://csrc.nist.gov/projects/post-quantum-cryptography) - _NIST_
 - [Safeguarding cryptocurrency by disclosing quantum vulnerabilities responsibly](https://research.google/blog/safeguarding-cryptocurrency-by-disclosing-quantum-vulnerabilities-responsibly/) - _Google Quantum AI_
 - [Quantum frontiers may be closer than they appear](https://blog.google/innovation-and-ai/technology/safety-security/cryptography-migration-timeline/) - _Google_
 - [KZG and trusted setups](/roadmap/danksharding/#what-is-kzg)
+- [Lean Week Cambridge (2025) leanVM + PQ workshop resources](https://github.com/leanEthereum/pm/blob/main/workshops-and-interops/2025/lean-week-cambridge/index.md) - _Lean Ethereum_
+- [PQ Transaction Signatures ACD Breakout Calls](https://youtube.com/playlist?list=PLJqWcTqh_zKEOum3uR0odkH59fmGUYuZB) - _Ethereum Foundation_
+- [PQ Interop ACD Breakout Calls](https://youtube.com/playlist?list=PLJqWcTqh_zKF_Q9HNXBLW_AtktsjToTIu) - _Ethereum Foundation_
+- [Lean Ethereum & Post-Quantum Security YouTube Playlist](https://youtube.com/playlist?list=PLJqWcTqh_zKGGuO_q1dgYLsfUoX1sNhWM) - _Ethereum Foundation_
+- [Panel interview post-quantum resistance](https://youtu.be/5DRDjeMmOPw) - _Bankless Podcast_
 - [Account abstraction on Ethereum](/roadmap/account-abstraction/)
 - [strawmap.org](https://strawmap.org/) - _EF Architecture_
+- [Superpositioned: Analysis of the Quantum Computing Industry](https://www.superpositioned.co/) - _Saneel Sreeni_

--- a/public/content/roadmap/future-proofing/quantum-resistance/index.md
+++ b/public/content/roadmap/future-proofing/quantum-resistance/index.md
@@ -1,0 +1,183 @@
+---
+title: Post-quantum cryptography on Ethereum
+description: How Ethereum is preparing for the post-quantum era, what is vulnerable, and what is being built to protect it.
+lang: en
+image: /images/roadmap/roadmap-future.png
+alt: "Ethereum roadmap"
+template: roadmap
+summaryPoints:
+  - Quantum computers will eventually threaten the cryptography Ethereum uses today
+  - The Ethereum Foundation has a dedicated team and a structured plan targeting 2029
+  - Your funds are safe today and wallet software will guide you through future migration
+---
+
+# Post-quantum cryptography on Ethereum {#post-quantum-cryptography}
+
+Quantum computers will eventually be able to break the cryptographic methods that secure Ethereum and most other digital systems today. This page explains what that means, what is being done about it, and what you need to know.
+
+## Why this matters {#why-this-matters}
+
+Ethereum relies on several forms of [cryptography](/glossary/#cryptography) to keep the network secure and protect user funds. The most important are:
+
+- **Elliptic curve cryptography (ECDSA)**: Used to sign transactions. Your Ethereum account's security depends on this.
+- **BLS signatures**: Used by [validators](/glossary/#validator) to reach [consensus](/glossary/#consensus) on the state of the network.
+- **KZG polynomial commitments**: Used for [data availability](/glossary/#data-availability) in Ethereum's scaling roadmap.
+- **ZK-proof systems**: Used by rollups and other applications to verify computations offchain.
+
+All of these rely on mathematical problems that are hard for classical computers but could be solved efficiently by a sufficiently powerful quantum computer.
+
+### How close are quantum computers? {#how-close}
+
+In March 2026, Google Quantum AI published research estimating that breaking 256-bit elliptic curve cryptography (the type Ethereum uses for account signatures) could require roughly 1,200 logical qubits. Previous estimates put this number much higher. Google has set a 2029 internal deadline for migrating its own systems to post-quantum cryptography.
+
+Current quantum hardware operates with a few thousand noisy physical qubits. Logical qubits (which correct for errors and perform reliable computation) require many physical qubits each. **The gap between current hardware and what is needed to break Ethereum's cryptography remains significant, but it is narrowing faster than many expected.**
+
+This is not an imminent threat. But cryptographic transitions take years, and Ethereum's security model is designed to last decades. Preparing now is prudent.
+
+## The four vulnerable areas {#four-vulnerable-areas}
+
+In February 2026, Vitalik Buterin published a roadmap identifying four distinct areas of Ethereum's cryptography that need post-quantum upgrades. Each has different challenges and different solution paths.
+
+### 1. Consensus-layer BLS signatures {#consensus-bls}
+
+**What it does**: Ethereum's [proof-of-stake](/glossary/#pos) protocol uses BLS signatures to aggregate votes from hundreds of thousands of validators. BLS allows many signatures to be combined into one, keeping the network efficient.
+
+**Why it is vulnerable**: BLS signatures rely on elliptic curve pairings, which a quantum computer could break.
+
+**The approach**: The Ethereum Foundation is developing two complementary tools:
+- **leanXMSS**: A hash-based signature scheme for validators. Hash-based signatures are considered quantum-safe because they rely only on the security of hash functions, which quantum computers weaken but do not break.
+- **leanVM**: A minimal zkVM (zero-knowledge virtual machine) for SNARK-based signature aggregation. This preserves the efficiency benefits of combining many signatures into one, even after switching to quantum-safe schemes.
+
+<ExpandableCard title="Why can't Ethereum just replace BLS with a quantum-safe scheme?" eventCategory="/roadmap/future-proofing/quantum-resistance" eventName="clicked why cant ethereum just replace BLS?">
+
+The aggregation property that makes BLS efficient (combining hundreds of thousands of signatures into one) does not have an obvious quantum-safe equivalent. Post-quantum signatures are also much larger than BLS signatures. Simply swapping one for the other would make Ethereum's consensus layer significantly slower and more expensive. That is why the team is building leanVM, a tool that uses zero-knowledge proofs to aggregate quantum-safe signatures efficiently.
+
+</ExpandableCard>
+
+### 2. Data availability: KZG commitments {#data-availability-kzg}
+
+**What it does**: KZG polynomial commitments ensure that data (particularly [blob](/glossary/#blob) data from rollups) is available on the network without requiring every node to download all of it.
+
+**Why it is vulnerable**: KZG commitments rely on elliptic curve pairings, the same mathematical structure that quantum computers can attack.
+
+**Current mitigation**: KZG commitments use a "trusted setup" where many participants contributed randomness. As long as at least one participant was honest and discarded their secret, the setup is secure, even against quantum computers attempting to reverse-engineer it after the fact.
+
+**Long-term solution**: Replace KZG with a quantum-safe commitment scheme. The two leading candidates are:
+- **STARK-based commitments**: Rely on hash functions rather than elliptic curves. Already used in some ZK-rollups.
+- **Lattice-based commitments**: Rely on the hardness of lattice problems, which are believed to be quantum-resistant.
+
+Both approaches are still being researched for efficiency and practicality at Ethereum's scale.
+
+### 3. Account signatures: ECDSA {#eoa-signatures}
+
+**What it does**: Every standard Ethereum account (externally owned account, or [EOA](/glossary/#eoa)) uses ECDSA on the secp256k1 curve to sign transactions. This is what protects your funds.
+
+**Why it is vulnerable**: A quantum computer could derive a private key from a public key. For accounts that have sent at least one transaction, the public key is exposed onchain, making them a potential target.
+
+**Important nuance**: Accounts that have only received ether and never sent a transaction have not exposed their public key. Only the address (a hash of the public key) is visible, which provides some additional protection.
+
+**The approach**: Rather than a single protocol-wide migration, Ethereum plans to use [account abstraction](/roadmap/account-abstraction/) (specifically EIP-8141, being considered for Hegota in H2 2026) to give users **signature agility**. Individual accounts could switch to a post-quantum signature scheme without waiting for the entire protocol to change.
+
+This is a pragmatic approach. Users and wallets that want post-quantum protection early can adopt it voluntarily, while the broader migration happens over time.
+
+### 4. Application-layer ZK-proofs {#zk-proofs}
+
+**What it does**: Zero-knowledge proof systems are used by L2 rollups and other applications to verify computations without revealing underlying data.
+
+**Why it is vulnerable**: Many popular ZK-proof systems (SNARKs using elliptic curve pairings) rely on quantum-vulnerable assumptions.
+
+**The approach**: STARKs, which rely on hash functions rather than elliptic curves, are already quantum-resistant and are used by several rollups. The transition for this layer is partly happening already through natural ecosystem adoption of STARK-based systems.
+
+## NIST standards {#nist-standards}
+
+In August 2024, the U.S. National Institute of Standards and Technology (NIST) finalized three post-quantum cryptography standards:
+
+| Standard | Name | Type | Use case |
+|----------|------|------|----------|
+| FIPS 203 | ML-KEM | Lattice-based | Key encapsulation (key exchange) |
+| FIPS 204 | ML-DSA (Dilithium) | Lattice-based | Digital signatures |
+| FIPS 205 | SLH-DSA (SPHINCS+) | Hash-based | Digital signatures |
+
+These standards provide a foundation for the broader industry's post-quantum transition. Ethereum's work builds on and extends these, with particular focus on the unique challenges of a decentralized network where efficiency and aggregation matter.
+
+## The Ethereum Foundation's approach {#ef-approach}
+
+The Ethereum Foundation formed a dedicated Post-Quantum Security team in January 2026, led by Thomas Coratger. The team's work is tracked publicly at [pq.ethereum.org](https://pq.ethereum.org).
+
+### Current activity (as of April 2026) {#current-activity}
+
+- **Weekly interop devnets**: More than 10 client teams participate in regular post-quantum interoperability testing, including Lighthouse, Grandine, Zeam, Ream Labs, and PierTwo.
+- **Poseidon Prize**: A $1 million research prize targeting improvements in hash-based cryptographic primitives.
+- **Open-source implementations**: leanXMSS, leanVM, leanSpec (Python), leanSig (Rust), and leanMultisig are all available under the leanEthereum GitHub organization.
+- **2nd Annual PQ Research Retreat**: Planned for 9-Oct-2026 to 12-Oct-2026 in Cambridge, UK.
+
+### Migration milestones {#migration-milestones}
+
+The team has outlined a series of protocol upgrades to incrementally introduce post-quantum cryptography into Ethereum. These are planning milestones, not guaranteed commitments. Names and ordering may change.
+
+| Milestone | What it introduces |
+|-----------|--------------------|
+| I* | PQ key registry. Validators can register post-quantum public keys alongside existing BLS keys. |
+| J* | PQ signature verification precompiles. Smart contracts and wallets can verify PQ signatures natively. |
+| L* | PQ attestations and real-time consensus-layer proofs via leanVM. Validators begin using PQ signatures for consensus. |
+| M* | Full PQ signature aggregation and PQ-safe blob commitments. |
+
+**Target**: Core post-quantum infrastructure in place by approximately 2029. Full execution-layer and ecosystem migration extends beyond that.
+
+## What do users need to do? {#what-users-need-to-do}
+
+**Right now: nothing.** Your funds are safe. No quantum computer today can threaten Ethereum's cryptography.
+
+**In the future**: Once post-quantum signature schemes are available on Ethereum (expected to begin with EIP-8141), you will want to migrate your account to quantum-safe signatures. Wallet software will guide you through this transition.
+
+If your account has never sent a transaction (meaning your public key has not been exposed onchain), it has an additional layer of protection. But all accounts should eventually migrate.
+
+The question of how to handle dormant wallets (accounts whose owners may not be aware of the need to migrate) is an open governance topic. The Ethereum community has not yet reached consensus on this.
+
+## Frequently asked questions {#faq}
+
+<ExpandableCard title="Can quantum computers steal my ETH today?" eventCategory="/roadmap/future-proofing/quantum-resistance" eventName="clicked can quantum computers steal my ETH today?">
+
+**No.** No quantum computer today can break Ethereum's cryptography. Current quantum hardware is far from the scale needed. The work described on this page is preparation for the future, not a response to an active threat.
+
+</ExpandableCard>
+
+<ExpandableCard title="When could quantum computers become a threat?" eventCategory="/roadmap/future-proofing/quantum-resistance" eventName="clicked when could quantum computers become a threat?">
+
+Estimates vary. Google's March 2026 research suggests the hardware needed to break 256-bit elliptic curve cryptography could arrive sometime around the end of this decade at the earliest, but significant engineering challenges remain. Most researchers consider a realistic threat to be several years away at minimum. The honest answer is that no one knows the exact timeline, which is precisely why preparing now is important.
+
+</ExpandableCard>
+
+<ExpandableCard title="Will I need to do anything to protect my wallet?" eventCategory="/roadmap/future-proofing/quantum-resistance" eventName="clicked will I need to do anything?">
+
+Eventually, yes. Once post-quantum signature schemes are available on Ethereum, users will want to migrate their accounts. Wallet software will likely handle this transition for you. For now, there is nothing you need to do. When action is needed, the Ethereum community and wallet developers will provide clear guidance and tools.
+
+</ExpandableCard>
+
+<ExpandableCard title="What about my tokens, NFTs, and DeFi positions?" eventCategory="/roadmap/future-proofing/quantum-resistance" eventName="clicked what about tokens NFTs DeFi?">
+
+Assets on Ethereum are controlled by account signatures. Once your account is migrated to a quantum-safe signature scheme, everything in that account is protected. You do not need to migrate each asset individually. Smart contracts that hold funds (like DeFi protocols) may need their own upgrades depending on what cryptographic primitives they use internally.
+
+</ExpandableCard>
+
+<ExpandableCard title="Is Ethereum behind other blockchains on this?" eventCategory="/roadmap/future-proofing/quantum-resistance" eventName="clicked is Ethereum behind?">
+
+Ethereum has one of the most structured post-quantum programs of any blockchain: a dedicated team, funded research, weekly devnets, and a published migration roadmap. No blockchain has completed a full post-quantum transition yet. Ethereum's quantum-vulnerable dormant fund exposure is estimated at approximately 0.1%, compared to approximately 5% for Bitcoin.
+
+</ExpandableCard>
+
+<ExpandableCard title="What is 'harvest now, decrypt later'?" eventCategory="/roadmap/future-proofing/quantum-resistance" eventName="clicked what is harvest now decrypt later?">
+
+"Harvest now, decrypt later" is an attack where someone records encrypted data or exposed public keys today, then breaks the encryption later once a powerful enough quantum computer exists. For Ethereum, this is most relevant to accounts whose public keys are already exposed onchain (any account that has sent a transaction). This is one reason the community treats post-quantum migration as time-sensitive even though the quantum threat is not yet immediate.
+
+</ExpandableCard>
+
+## Further reading {#further-reading}
+
+- [pq.ethereum.org](https://pq.ethereum.org) - _Ethereum Foundation_
+- [NIST Post-Quantum Cryptography standards](https://csrc.nist.gov/projects/post-quantum-cryptography) - _NIST_
+- [Safeguarding cryptocurrency by disclosing quantum vulnerabilities responsibly](https://research.google/blog/safeguarding-cryptocurrency-by-disclosing-quantum-vulnerabilities-responsibly/) - _Google Quantum AI_
+- [Quantum frontiers may be closer than they appear](https://blog.google/innovation-and-ai/technology/safety-security/cryptography-migration-timeline/) - _Google_
+- [KZG and trusted setups](/roadmap/danksharding/#what-is-kzg)
+- [Account abstraction on Ethereum](/roadmap/account-abstraction/)
+- [strawmap.org](https://strawmap.org/) - _EF Architecture_

--- a/public/content/roadmap/future-proofing/quantum-resistance/index.md
+++ b/public/content/roadmap/future-proofing/quantum-resistance/index.md
@@ -7,30 +7,30 @@ alt: "Ethereum roadmap"
 template: roadmap
 summaryPoints:
   - Quantum computers will eventually threaten the cryptography Ethereum uses today
-  - The Ethereum Foundation has a dedicated team and a structured plan targeting 2029
+  - The Ethereum Foundation has a dedicated post-quantum research team, and a structured "Lean Ethereum" roadmap targeting 2029 for full post-quantum protection
   - Your funds are safe today and wallet software will guide you through future migration
 ---
 
-Quantum computers will eventually be able to break the cryptographic methods that secure Ethereum and most other digital systems today. This page explains what that means, what is being done about it, and what you need to know.
+Quantum computers will eventually be able to break the cryptographic methods that secure Ethereum and most other digital systems today. This page explains what that means, how the network is proactively developing improvements to mitigate this risk, and what you need to know.
 
-## Why this matters {#why-this-matters}
+## Why post-quantum cryptography matters {#why-post-quantum-matters}
 
 Ethereum relies on several forms of [cryptography](/glossary/#cryptography) to keep the network secure and protect user funds. The most important are:
 
-- **Elliptic curve digital signature algorithm (ECDSA)**: Used to sign transactions. Your Ethereum account's security depends on this.
+- **Elliptic curve digital signature algorithm (ECDSA)**: The cryptography used to sign transactions. Your Ethereum account's security depends on this.
 - **BLS signatures**: Used by [validators](/glossary/#validator) to reach [consensus](/glossary/#consensus) on the state of the network.
 - **KZG polynomial commitments**: Used for [data availability](/glossary/#data-availability) in Ethereum's scaling roadmap.
 - **ZK-proof systems**: Used by rollups and other applications to verify computations offchain.
 
-All of these rely on mathematical problems that are hard for classical computers but could be solved efficiently by a sufficiently powerful quantum computer.
+All of these rely on mathematical structures, such as Abelian groups, that are hard for classical computers but can be solved efficiently by a quantum computer using [Shor's algorithm](https://en.wikipedia.org/wiki/Shor%27s_algorithm).
 
-### How close are quantum computers? {#how-close}
+### When will quantum computers threaten Ethereum? {#when-will-quantum-computers-threaten-ethereum}
 
 In March 2026, Google Quantum AI published research estimating that breaking 256-bit elliptic curve cryptography (the type Ethereum uses for account signatures) could require roughly 1,200 logical qubits. Previous estimates put this number much higher. Google has set a 2029 internal deadline for migrating its own systems to post-quantum cryptography.
 
-Current quantum hardware operates with a few thousand noisy physical qubits. Logical qubits (which correct for errors and perform reliable computation) require many physical qubits each. **The gap between current hardware and what is needed to break Ethereum's cryptography remains significant, but it is narrowing faster than many expected.**
+Current quantum hardware is far from this scale, operating with a few thousand noisy physical qubits. Logical qubits (which correct for errors and perform reliable computation) require many physical qubits each. **The gap between current hardware and what is needed to break Ethereum's cryptography remains significant, but it is narrowing faster than many expected.** Notably, the U.S. National Institute of Standards and Technology (NIST) anticipates deprecating ECDSA by 2030 and disallowing it by 2035.
 
-This is not an imminent threat. But cryptographic transitions take years, and Ethereum's security model is designed to last centuries. Preparing now is prudent.
+This is not an imminent threat. But cryptographic transitions take years, and Ethereum's security model is designed to last centuries. Ethereum's response is the **Lean Ethereum** roadmap, a deliberate, multi-year mission to rebuild Ethereum around primitives that will survive any cryptographic threat.
 
 ## The four vulnerable areas {#four-vulnerable-areas}
 

--- a/public/content/roadmap/future-proofing/quantum-resistance/index.md
+++ b/public/content/roadmap/future-proofing/quantum-resistance/index.md
@@ -11,15 +11,13 @@ summaryPoints:
   - Your funds are safe today and wallet software will guide you through future migration
 ---
 
-# Post-quantum cryptography on Ethereum {#post-quantum-cryptography}
-
 Quantum computers will eventually be able to break the cryptographic methods that secure Ethereum and most other digital systems today. This page explains what that means, what is being done about it, and what you need to know.
 
 ## Why this matters {#why-this-matters}
 
 Ethereum relies on several forms of [cryptography](/glossary/#cryptography) to keep the network secure and protect user funds. The most important are:
 
-- **Elliptic curve cryptography (ECDSA)**: Used to sign transactions. Your Ethereum account's security depends on this.
+- **Elliptic curve digital signature algorithm (ECDSA)**: Used to sign transactions. Your Ethereum account's security depends on this.
 - **BLS signatures**: Used by [validators](/glossary/#validator) to reach [consensus](/glossary/#consensus) on the state of the network.
 - **KZG polynomial commitments**: Used for [data availability](/glossary/#data-availability) in Ethereum's scaling roadmap.
 - **ZK-proof systems**: Used by rollups and other applications to verify computations offchain.
@@ -32,7 +30,7 @@ In March 2026, Google Quantum AI published research estimating that breaking 256
 
 Current quantum hardware operates with a few thousand noisy physical qubits. Logical qubits (which correct for errors and perform reliable computation) require many physical qubits each. **The gap between current hardware and what is needed to break Ethereum's cryptography remains significant, but it is narrowing faster than many expected.**
 
-This is not an imminent threat. But cryptographic transitions take years, and Ethereum's security model is designed to last decades. Preparing now is prudent.
+This is not an imminent threat. But cryptographic transitions take years, and Ethereum's security model is designed to last centuries. Preparing now is prudent.
 
 ## The four vulnerable areas {#four-vulnerable-areas}
 
@@ -76,7 +74,7 @@ Both approaches are still being researched for efficiency and practicality at Et
 
 **Important nuance**: Accounts that have only received ether and never sent a transaction have not exposed their public key. Only the address (a hash of the public key) is visible, which provides some additional protection.
 
-**The approach**: Rather than a single protocol-wide migration, Ethereum plans to use [account abstraction](/roadmap/account-abstraction/) (specifically EIP-8141, being considered for Hegota in H2 2026) to give users **signature agility**. Individual accounts could switch to a post-quantum signature scheme without waiting for the entire protocol to change.
+**The approach**: Rather than a single protocol-wide migration, Ethereum plans to use [account abstraction](/roadmap/account-abstraction/) (specifically EIP-8141, being considered for Hegotá in second half of 2026) to give users **signature agility**. Individual accounts could switch to a post-quantum signature scheme without waiting for the entire protocol to change.
 
 This is a pragmatic approach. Users and wallets that want post-quantum protection early can adopt it voluntarily, while the broader migration happens over time.
 
@@ -90,7 +88,7 @@ This is a pragmatic approach. Users and wallets that want post-quantum protectio
 
 ## NIST standards {#nist-standards}
 
-In August 2024, the U.S. National Institute of Standards and Technology (NIST) finalized three post-quantum cryptography standards:
+In August 2024, the U.S. National Institute of Standards and Technology (NIST) finalized three post-quantum cryptography standards. These matter because they give the entire technology industry, including Ethereum, a shared set of vetted algorithms to build on rather than each project inventing its own.
 
 | Standard | Name | Type | Use case |
 |----------|------|------|----------|
@@ -162,7 +160,7 @@ Assets on Ethereum are controlled by account signatures. Once your account is mi
 
 <ExpandableCard title="Is Ethereum behind other blockchains on this?" eventCategory="/roadmap/future-proofing/quantum-resistance" eventName="clicked is Ethereum behind?">
 
-Ethereum has one of the most structured post-quantum programs of any blockchain: a dedicated team, funded research, weekly devnets, and a published migration roadmap. No blockchain has completed a full post-quantum transition yet. Ethereum's quantum-vulnerable dormant fund exposure is estimated at approximately 0.1%, compared to approximately 5% for Bitcoin.
+Ethereum has one of the most structured post-quantum programs of any blockchain: a dedicated team, funded research, weekly devnets, and a published migration roadmap. No blockchain has completed a full post-quantum transition yet. According to Ethereum Foundation estimates, Ethereum's quantum-vulnerable dormant fund exposure is approximately 0.1%.
 
 </ExpandableCard>
 

--- a/redirects.config.js
+++ b/redirects.config.js
@@ -135,8 +135,6 @@ module.exports = [
     false, // Selectively applying temporary for possible future route usage
   ],
   ["/developers/docs/rollups", "/developers/docs/scaling/#rollups"],
-  // Removed: ["/roadmap/future-proofing/:path+", "/roadmap/future-proofing/"],
-  // This blanket redirect prevented subpages (e.g. /quantum-resistance/) from rendering
   ["/eth2/what-is-eth2", "/roadmap/"],
   [
     "/developers/docs/accounts/account-abstraction",

--- a/redirects.config.js
+++ b/redirects.config.js
@@ -135,7 +135,8 @@ module.exports = [
     false, // Selectively applying temporary for possible future route usage
   ],
   ["/developers/docs/rollups", "/developers/docs/scaling/#rollups"],
-  ["/roadmap/future-proofing/:path+", "/roadmap/future-proofing/"],
+  // Removed: ["/roadmap/future-proofing/:path+", "/roadmap/future-proofing/"],
+  // This blanket redirect prevented subpages (e.g. /quantum-resistance/) from rendering
   ["/eth2/what-is-eth2", "/roadmap/"],
   [
     "/developers/docs/accounts/account-abstraction",


### PR DESCRIPTION
## Summary

- Rewrites `/roadmap/future-proofing/` with current information (2026 state), beginner-friendly tone matching the ethereum.org style guide
- Creates new `/roadmap/future-proofing/quantum-resistance/` subpage with deeper post-quantum cryptography coverage, following the established pattern of dedicated subpages for complex topics (like account-abstraction, verkle-trees, danksharding)

### What changed in the parent page

- **Quantum resistance section**: Replaces outdated "probably decades away" framing with honest, attributed assessment of current timelines. Adds EF Post-Quantum Security team, pq.ethereum.org, Vitalik's four-pronged vulnerability framework, EIP-8141 signature agility, and structured fork milestones
- **Simpler and more efficient Ethereum section**: Reorganized into "delivered" (London, Dencun, Pectra, Fusaka) and "in progress" (Glamsterdam, Hegota). Each fork lists specific EIPs
- **Current progress section**: Updated from Dencun (March 2024) to early 2026 state with honest assessment of what is and isn't in production
- Added `summaryPoints` frontmatter to match other roadmap pages

### New quantum-resistance subpage

Covers: why PQ matters, the four vulnerable areas (BLS, KZG, ECDSA, ZK-proofs), NIST standards table, EF approach and milestones (I*/J*/L*/M*), what users need to do, and 6 FAQ items using ExpandableCard components.

### Editorial approach

- All claims attributed to primary sources (Google Quantum AI paper, pq.ethereum.org, NIST, CoinDesk)
- No fear-mongering: leads with "your funds are safe today" framing
- Does not overplay Ethereum's readiness: "actively preparing, not quantum-safe"
- Acknowledges open questions (dormant wallets, governance)
- Date-stamps progress claims ("as of April 2026")
- EIP-8141 described as "being considered for" Hegota, not confirmed

### Sources verified

| Claim | Source |
|-------|--------|
| ~1,200 logical qubits | [Google Research Blog](https://research.google/blog/safeguarding-cryptocurrency-by-disclosing-quantum-vulnerabilities-responsibly/) (March 2026) |
| PQ milestones I*/J*/L*/M* | [pq.ethereum.org](https://pq.ethereum.org) |
| PQ as strawmap north star | [strawmap.org](https://strawmap.org/) |
| NIST FIPS 203/204/205 | [NIST](https://www.nist.gov/news-events/news/2024/08/nist-releases-first-3-finalized-post-quantum-encryption-standards) |
| EF PQ team formation | [CoinDesk](https://www.coindesk.com/tech/2026/01/24/ethereum-foundation-makes-post-quantum-security-a-top-priority-as-new-team-forms) |

Closes #17943

## Test plan

- [ ] Verify both pages render correctly in local dev server
- [ ] Check all internal links resolve (glossary terms, roadmap pages, developer docs)
- [ ] Verify ExpandableCard components expand/collapse properly
- [ ] Review on mobile viewport for readability
- [ ] EF Post-Quantum Security team should review PQ subpage for technical accuracy
- [ ] Re-verify EIP-8141 CFI status and Glamsterdam/Hegota timelines at merge time

🤖 Generated with [Claude Code](https://claude.com/claude-code)