### PR TITLE
Fix broken Web3 Family meetup images

### DIFF
--- a/src/data/community-meetups.json
+++ b/src/data/community-meetups.json
@@ -7,9 +7,7 @@
   {
     "title": "Web3 Family",
     "location": "Barcelona, Spain",
-    "link": "https://www.meetup.com/web3family/",
-    "logoImage": "https://secure.meetupstatic.com/photos/event/9/d/5/c/600_523840284.jpeg",
-    "bannerImage": "https://secure.meetupstatic.com/photos/event/9/d/5/c/600_523840284.jpeg"
+    "link": "https://www.meetup.com/web3family/"
   },
   {
     "title": "CryptoCanal",


### PR DESCRIPTION
Description

Removes the broken logoImage and bannerImage entries for the Web3 Family meetup from src/data/community-meetups.json.

Related Issue

Closes #17909

Notes

This change is intentionally scoped to the single Web3 Family meetup entry only.
It does not change rendering logic or attempt a broader cleanup of other meetup image sources.