### PR TITLE
Improve mobile Lighthouse performance (LCP, JS bundle)

### DIFF
--- a/app/[locale]/_components/HomepageLazyImports.tsx
+++ b/app/[locale]/_components/HomepageLazyImports.tsx
@@ -38,3 +38,30 @@ export const ValuesMarquee = dynamic(
     loading: () => <ValuesMarqueeFallback />,
   }
 )
+
+export const CodeExamples = dynamic(
+  () => import("@/components/Homepage/CodeExamples"),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex flex-col gap-4">
+        <Skeleton className="h-10 w-64 rounded-lg" />
+        <Skeleton className="h-[400px] w-full rounded-2xl" />
+      </div>
+    ),
+  }
+)
+
+export const AppsHighlight = dynamic(
+  () => import("../apps/_components/AppsHighlight"),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="hidden gap-6 md:grid md:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Skeleton key={i} className="h-64 w-full rounded-xl" />
+        ))}
+      </div>
+    ),
+  }
+)

--- a/app/[locale]/_components/HomepageLazyImports.tsx
+++ b/app/[locale]/_components/HomepageLazyImports.tsx
@@ -44,9 +44,8 @@ export const CodeExamples = dynamic(
   {
     ssr: false,
     loading: () => (
-      <div className="flex flex-col gap-4">
-        <Skeleton className="h-10 w-64 rounded-lg" />
-        <Skeleton className="h-[400px] w-full rounded-2xl" />
+      <div className="py-8 md:pb-16 md:pt-8 lg:pb-32 lg:pt-16">
+        <Skeleton className="h-[400px] w-full max-w-screen-md rounded-2xl" />
       </div>
     ),
   }

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -15,7 +15,6 @@ import ActivityStats from "@/components/ActivityStats"
 import { ChevronNext } from "@/components/Chevron"
 import HomeHero from "@/components/Hero/HomeHero"
 import BentoCard from "@/components/Homepage/BentoCard"
-import CodeExamples from "@/components/Homepage/CodeExamples"
 import HomepageSectionImage from "@/components/Homepage/HomepageSectionImage"
 import { getBentoBoxItems } from "@/components/Homepage/utils"
 import BlockHeap from "@/components/icons/block-heap.svg"
@@ -74,11 +73,12 @@ import {
 } from "@/lib/constants"
 
 import {
+  AppsHighlight,
   BentoCardSwiper,
+  CodeExamples,
   RecentPostsSwiper,
   ValuesMarquee,
 } from "./_components/HomepageLazyImports"
-import AppsHighlight from "./apps/_components/AppsHighlight"
 import IndexPageJsonLD from "./page-jsonld"
 import { getActivity } from "./utils"
 

--- a/src/components/Hero/HomeHero/index.tsx
+++ b/src/components/Hero/HomeHero/index.tsx
@@ -68,7 +68,12 @@ const HomeHero = async ({
             media={`(max-width: ${breakpointAsNumber["md"] - 1}px)`}
             srcSet={srcSetBase}
           />
-          <img {...rest} alt={alt} className="h-full w-full object-cover" />
+          <img
+            {...rest}
+            alt={alt}
+            fetchPriority="high"
+            className="h-full w-full object-cover"
+          />
         </picture>
       </div>
       <div className="flex flex-col items-center border-t-[3px] border-primary-low-contrast px-4 py-10 text-center">


### PR DESCRIPTION
## Summary

Addresses three high-impact findings from the [April 2026 mobile Lighthouse audit](https://pagespeed.web.dev/analysis/https-ethereum-org/trmu2ptdnw?form_factor=mobile) (score: 60, LCP 7.8s lab, 344 KiB unused JS).

- **Add `fetchPriority="high"` to hero image** — The LCP element uses `getImageProps()` with a manual `<picture>`, which doesn't automatically set the HTML attribute despite `priority: true`. Lighthouse explicitly flags this as missing.
- **Lazy-load `CodeExamples`** via `next/dynamic` (`ssr: false`) — Defers `prism-react-renderer`, Solidity syntax support, and `CodeModal` from the initial bundle (~40-60 KiB). Rendered in the Builders section, well below the fold.
- **Lazy-load `AppsHighlight`** via `next/dynamic` (`ssr: false`) — Defers the Swiper library (~20-30 KiB). Only rendered for the default locale, below the fold.

Both lazy-loaded components follow the existing pattern in `HomepageLazyImports.tsx` (same as `BentoCardSwiper`, `RecentPostsSwiper`, `ValuesMarquee`).

## Test plan

- [x] Homepage renders correctly on mobile and desktop
- [x] Hero image loads with high priority (check `fetchpriority="high"` in DevTools → Elements)
- [x] CodeExamples section loads when scrolled into view (Builders section)
- [x] AppsHighlight section loads when scrolled into view (Apps of the week)
- [x] Skeleton placeholders display while components load
- [x] Run Lighthouse mobile audit and compare LCP / JS bundle size