### PR TITLE
Fix broken Seoul Ethereum Meetup images

### DIFF
--- a/src/data/community-meetups.json
+++ b/src/data/community-meetups.json
@@ -290,9 +290,7 @@
   {
     "title": "Seoul Ethereum Meetup",
     "location": "Seoul, South Korea",
-    "link": "https://www.meetup.com/Seoul-Ethereum-Meetup/",
-    "logoImage": "https://secure.meetupstatic.com/photos/event/c/1/0/3/600_470509411.jpeg",
-    "bannerImage": "https://secure.meetupstatic.com/photos/event/c/1/0/3/600_470509411.jpeg"
+    "link": "https://www.meetup.com/Seoul-Ethereum-Meetup/"
   },
   {
     "title": "BCN Ethereum Dev",


### PR DESCRIPTION
## Description

Removes the broken `logoImage` and `bannerImage` entries for the `Seoul Ethereum Meetup` meetup from `src/data/community-meetups.json`.

## Related Issue

Closes #17908

## Notes

This change is intentionally scoped to the single `Seoul Ethereum Meetup` entry only.
It does not change rendering logic or attempt a broader cleanup of other meetup image sources.