### PR TITLE
fix(docs): correct PoA concurrent blocks example

### DIFF
--- a/public/content/developers/docs/consensus-mechanisms/poa/index.md
+++ b/public/content/developers/docs/consensus-mechanisms/poa/index.md
@@ -46,7 +46,7 @@ Another small attack vector is malicious signers injecting new vote proposals in
 
 In a PoA network, When there are N authorized signers, each signer is allowed to mint 1 block out of K, which means that N-K+1 validators are allowed to mint at any given point in time. To prevent these validators from racing for blocks, each signer should add a small random "offset" to the time it releases a new block. Although this process ensures that small forks are rare, occasional forks can still happen, just like mainnet. If a signer is found to be abusing its power and causing chaos, the other signers can vote them out.
 
-If for example there are 10 authorized signers and each signer is allowed to create 1 block out of 20, then at any given time, 11 validators can create blocks. To prevent them from racing to create blocks, each signer adds a small random "offset" to the time they release a new block. This reduces the occurrence of small forks but still allows occasional forks, as seen on the Ethereum Mainnet. If a signer misuses their authority and causes disruptions, they can be voted out of the network.
+If for example there are 10 authorized signers and each signer is allowed to create 1 block out of 6, then at any given time, 5 validators can create blocks. To prevent them from racing to create blocks, each signer adds a small random "offset" to the time they release a new block. This reduces the occurrence of small forks but still allows occasional forks, as seen on the Ethereum Mainnet. If a signer misuses their authority and causes disruptions, they can be voted out of the network.
 
 ## Pros and cons {#pros-and-cons}
 


### PR DESCRIPTION
## Description

Corrects the numerical example in the `Concurrent blocks` section of the PoA docs so it matches the stated `N-K+1` formula and the signer limit described in EIP-225.

## Related Issue

Closes #15163

## Notes

This change is intentionally scoped to the single example sentence in:
`public/content/developers/docs/consensus-mechanisms/poa/index.md`

It does not modify surrounding PoA logic, other docs pages, or translations.