### PR TITLE
perf: static generate only English video detail pages

### DIFF
--- a/app/[locale]/videos/[slug]/page.tsx
+++ b/app/[locale]/videos/[slug]/page.tsx
@@ -27,6 +27,8 @@ import { getMetadata } from "@/lib/utils/metadata"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 import { getVideoData, getVideoSlugs } from "@/lib/utils/videos"
 
+import { DEFAULT_LOCALE } from "@/lib/constants"
+
 import VideoPageJsonLD from "./page-jsonld"
 
 import { renderSimpleMarkdown } from "@/lib/md/renderSimple"
@@ -115,7 +117,7 @@ const VideoLandingPage = async (props: {
 
 export async function generateStaticParams() {
   const slugs = await getVideoSlugs()
-  return slugs.map((slug) => ({ slug }))
+  return slugs.map((slug) => ({ locale: DEFAULT_LOCALE, slug }))
 }
 
 export async function generateMetadata(props: {


### PR DESCRIPTION
## Summary

- Limits `generateStaticParams` in `app/[locale]/videos/[slug]/page.tsx` to English locale only
- Reduces static video detail pages from ~1,050 (42 slugs * 25 locales) to 42 (English only)
- Non-English video detail pages render on-demand via ISR, then get cached

## Context

Netlify builds are hitting `ENOSPC` (no space left on device) after the videos PR (#17870) merged into staging. The 1,050 new statically generated pages pushed the build past the disk limit.

This is a targeted fix for the video detail pages only -- the video gallery listing page (`/videos/`) remains fully static for all locales. Non-English video detail pages still work identically for users; they just render on first request rather than at build time.

## What this means for users

- English video pages: no change (pre-rendered, fast)
- Non-English video pages: slightly slower first load (server render), then cached
- All pages remain fully functional, crawlable, and in the sitemap

## Test plan

- [x] Netlify deploy preview builds successfully
- [ ] English video detail page loads correctly
- [ ] Non-English video detail page loads correctly (on-demand render)
- [ ] Video gallery page unaffected (all locales still static)