### PR TITLE
Fix Trigger.dev CI deploy authentication

### DIFF
--- a/.github/workflows/deploy-data-layer.yml
+++ b/.github/workflows/deploy-data-layer.yml
@@ -32,4 +32,4 @@ jobs:
       - name: Deploy to Trigger.dev
         run: pnpm exec trigger deploy
         env:
-          TRIGGER_SECRET_KEY: ${{ secrets.TRIGGER_SECRET_KEY }}
+          TRIGGER_ACCESS_TOKEN: ${{ secrets.TRIGGER_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary

- Replace `TRIGGER_SECRET_KEY` with `TRIGGER_ACCESS_TOKEN` in the deploy-data-layer workflow
- The Trigger.dev CLI requires a Personal Access Token (`TRIGGER_ACCESS_TOKEN`) for CI authentication

## Action required

Add the `TRIGGER_ACCESS_TOKEN` secret to the repo (Settings → Secrets → Actions) with a Trigger.dev Personal Access Token.

## Test plan

- [x] Verify `TRIGGER_ACCESS_TOKEN` secret is set in repo settings
- [ ] Trigger a deploy by pushing a change to `src/data-layer/` on master and confirm the workflow passes