### PR TITLE
fix(scripts): route prepare-release logs to stderr

### DIFF
--- a/src/scripts/prepare-release.sh
+++ b/src/scripts/prepare-release.sh
@@ -35,10 +35,10 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
-log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
-log_dry() { echo -e "${BLUE}[DRY-RUN]${NC} Would run: $1"; }
+log_info() { echo -e "${GREEN}[INFO]${NC} $1" >&2; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1" >&2; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1" >&2; }
+log_dry() { echo -e "${BLUE}[DRY-RUN]${NC} Would run: $1" >&2; }
 
 # Run a command, or just log it if in dry-run mode
 run_or_dry() {
@@ -245,13 +245,13 @@ cmd_version() {
     log_dry "git push origin dev --follow-tags"
   else
     log_info "Bumping $VERSION_TYPE version..."
-    run_in_workdir pnpm version "$VERSION_TYPE"
+    run_in_workdir pnpm version "$VERSION_TYPE" >&2
 
     NEW_VERSION=$(run_in_workdir node -p "require('./package.json').version")
     log_info "New version: v$NEW_VERSION"
 
     log_info "Pushing to origin with tags..."
-    run_in_workdir git push origin dev --follow-tags
+    run_in_workdir git push origin dev --follow-tags >&2
   fi
 
   echo "$NEW_VERSION"

--- a/src/scripts/prepare-release.sh
+++ b/src/scripts/prepare-release.sh
@@ -227,7 +227,7 @@ cmd_version() {
   fi
 
   # Ensure we're working in the right directory
-  setup_worktree
+  setup_worktree >&2
 
   if [[ "$DRY_RUN" == "true" ]]; then
     # In dry-run, calculate what the new version would be without changing anything


### PR DESCRIPTION
## Summary

- All `log_*` functions in `src/scripts/prepare-release.sh` now write to stderr
- `cmd_version` redirects `pnpm version` and `git push` output to stderr too
- End result: `VERSION=$(./src/scripts/prepare-release.sh version minor)` cleanly captures just `11.4.0` — no log noise contaminating the value

## Why

During the v11.4.0 release today, `VERSION` in the `/prepare-release` flow captured log output alongside the bare version. When passed to `publish "$VERSION"`, the script prepended `v` and produced the tag `vv11.4.0`. The release had to be deleted and recreated manually via `gh release create v11.4.0`.

With this fix, only `echo "$NEW_VERSION"` hits stdout from `cmd_version`, so command substitution captures the value the downstream commands expect.

## Test plan

- [x] Run `./src/scripts/prepare-release.sh --dry-run version patch` and confirm stdout contains only the bare version string (`X.Y.Z`)
- [x] Run `./src/scripts/prepare-release.sh --dry-run preflight` and confirm logs still render with colors in the terminal
- [ ] Verify on next real release that the `publish` step produces a single-`v` tag