### PR TITLE
Add NFT Standards wiki link to resources

### DIFF
--- a/public/content/nft/index.md
+++ b/public/content/nft/index.md
@@ -109,6 +109,7 @@ Security issues relating to NFTs are most often related to phishing scams, smart
 - [ERC-721 token standard](/developers/docs/standards/tokens/erc-721/)
 - [ERC-1155 token standard](/developers/docs/standards/tokens/erc-1155/)
 - [Popular NFT Apps and Tools](https://www.ethereum-ecosystem.com/blockchains/ethereum/nfts)
+- [NFT Standards wiki](https://nft-standards.gitbook.io/nft-standards-wiki)
 
 ## Other resources {#other-resources}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added NFT Standards wiki to the resources of this page about Non-fungible tokens

## Description

Added link to NFT Standards wiki
NFT Standards wiki is a resource supported by the EthMagicians. It is a collection of over 15 NFT related EIPs and ERCs, infrastructure, vulnerabilities, security, metadata, and everything else related to NFT and standards including community contributions

## Related Issue
n/a 
