### PR TITLE
[hot-fix] patch(intl): sim component namespace to /wallets

### DIFF
--- a/src/lib/utils/translations.ts
+++ b/src/lib/utils/translations.ts
@@ -69,6 +69,7 @@ export const PREFIX_PATH_NAMESPACE_MAP: Array<[string, string]> = [
 
 const EXACT_PATH_ADDITIONAL_NAMESPACES: Record<string, string[]> = {
   "/": ["page-10-year-anniversary", "page-app-descriptions"],
+  "/wallets/": ["component-wallet-simulator"],
 }
 
 const PREFIX_PATH_ADDITIONAL_NAMESPACES: Array<[string, string[]]> = [


### PR DESCRIPTION
## Description

Fixes broken translation keys (`sim-ca-title`, `sim-sr-title`, `sim-cw-title`, etc.) rendering on the `/wallets/` page where the Wallet Simulator is embedded.

## Root cause

`app/[locale]/wallets/page.tsx` uses `getRequiredNamespacesForPage("/wallets")` to pick the messages passed into `I18nProvider`. That helper returned `page-wallets` (plus `common`, glossary, quizzes) but not `component-wallet-simulator`, so the simulator's strings were missing from the client bundle and fell back to raw keys.

The homepage was unaffected because `app/[locale]/page.tsx` explicitly picks `component-wallet-simulator` alongside page-index.

## Fix

Added `"/wallets/": ["component-wallet-simulator"]` to `EXACT_PATH_ADDITIONAL_NAMESPACES` in `src/lib/utils/translations.ts` so the namespace is included wherever getRequiredNamespacesForPage is called for that route.

## Testing

- [x] Visit `/wallets/` (English) and confirm the simulator renders translated strings rather than raw keys.