### PR TITLE
feat: add geodelabs ethstars attribution

### DIFF
--- a/app/[locale]/community/events/conferences/page.tsx
+++ b/app/[locale]/community/events/conferences/page.tsx
@@ -10,6 +10,7 @@ import {
   EdgeScrollContainer,
   EdgeScrollItem,
 } from "@/components/ui/edge-scroll-container"
+import Link from "@/components/ui/Link"
 import { Section } from "@/components/ui/section"
 
 import { getLocaleYear } from "@/lib/utils/date"
@@ -123,6 +124,11 @@ const Page = async (props: { params: Promise<PageParams> }) => {
               eventCategory: "Events_conferences",
             }}
           />
+          <p className="mt-8 text-body-medium">
+            {t.rich("page-events-data-source-callout", {
+              a: (chunks) => <Link href="https://ethstars.xyz/">{chunks}</Link>,
+            })}
+          </p>
         </Section>
 
         {/* Footer CTA */}

--- a/app/[locale]/community/events/page.tsx
+++ b/app/[locale]/community/events/page.tsx
@@ -364,6 +364,13 @@ const Page = async (props: { params: Promise<PageParams> }) => {
                 eventName: "regular_conf",
               }}
             />
+            <p className="!mt-8 text-body-medium">
+              {t.rich("page-events-data-source-callout", {
+                a: (chunks) => (
+                  <Link href="https://ethstars.xyz/">{chunks}</Link>
+                ),
+              })}
+            </p>
             <div className="flex justify-center">
               <ButtonLink
                 href="/community/events/conferences/"

--- a/src/intl/en/page-community-events.json
+++ b/src/intl/en/page-community-events.json
@@ -75,6 +75,7 @@
   "page-events-view-all-conferences": "View all conferences",
   "page-events-view-all-meetups": "View all meetups",
   "page-events-no-upcoming": "No upcoming events at this time",
+  "page-events-data-source-callout": "Ethereum event listings curated by GeodeLabs. <a>View comprehensive list of events at ETHStars</a>",
   "page-events-tag-online": "Online",
   "page-events-tag-conference": "Conference",
   "page-events-tag-hackathon": "Hackathon",

--- a/src/intl/en/page-community-events.json
+++ b/src/intl/en/page-community-events.json
@@ -75,7 +75,7 @@
   "page-events-view-all-conferences": "View all conferences",
   "page-events-view-all-meetups": "View all meetups",
   "page-events-no-upcoming": "No upcoming events at this time",
-  "page-events-data-source-callout": "Ethereum event listings curated by GeodeLabs. <a>View comprehensive list of events at ETHStars</a>",
+  "page-events-data-source-callout": "Ethereum event listings curated by <a>ETHStars</a>",
   "page-events-tag-online": "Online",
   "page-events-tag-conference": "Conference",
   "page-events-tag-hackathon": "Hackathon",


### PR DESCRIPTION
## Description
- Add GeodeLabs / ETHStars attribution to conference lists

## Preview Links
https://deploy-preview-18003.ethereum.it/community/events
https://deploy-preview-18003.ethereum.it/community/events/conferences