### PR TITLE
fix(seo): wrap remaining generateMetadata notFound() calls in try/catch

### DIFF
--- a/app/[locale]/apps/categories/[catetgoryName]/page.tsx
+++ b/app/[locale]/apps/categories/[catetgoryName]/page.tsx
@@ -36,8 +36,6 @@ import { slugify } from "@/lib/utils/url"
 
 import { appsCategories } from "@/data/apps/categories"
 
-import { DEFAULT_LOCALE } from "@/lib/constants"
-
 import AppsHighlight from "../../_components/AppsHighlight"
 import AppsTable from "../../_components/AppsTable"
 import SuggestAnApp from "../../_components/SuggestAnApp"
@@ -151,7 +149,7 @@ const Page = async (props: {
                   <BreadcrumbItem>
                     <BreadcrumbLink href="/">Ethereum.org</BreadcrumbLink>
                   </BreadcrumbItem>
-                  <BreadcrumbSeparator className="me-[0.625rem] ms-[0.625rem] text-gray-400">
+                  <BreadcrumbSeparator className="ms-[0.625rem] me-[0.625rem] text-gray-400">
                     /
                   </BreadcrumbSeparator>
                   <BreadcrumbItem>
@@ -159,7 +157,7 @@ const Page = async (props: {
                       {t("page-apps-all-apps")}
                     </BreadcrumbLink>
                   </BreadcrumbItem>
-                  <BreadcrumbSeparator className="me-[0.625rem] ms-[0.625rem] text-gray-400">
+                  <BreadcrumbSeparator className="ms-[0.625rem] me-[0.625rem] text-gray-400">
                     /
                   </BreadcrumbSeparator>
                   <BreadcrumbItem>
@@ -257,10 +255,7 @@ export async function generateMetadata(props: {
       description,
     })
   } catch {
-    const t = await getTranslations({
-      locale: DEFAULT_LOCALE,
-      namespace: "common",
-    })
+    const t = await getTranslations("common")
 
     return {
       title: t("page-not-found"),

--- a/app/[locale]/apps/categories/[catetgoryName]/page.tsx
+++ b/app/[locale]/apps/categories/[catetgoryName]/page.tsx
@@ -36,6 +36,8 @@ import { slugify } from "@/lib/utils/url"
 
 import { appsCategories } from "@/data/apps/categories"
 
+import { DEFAULT_LOCALE } from "@/lib/constants"
+
 import AppsHighlight from "../../_components/AppsHighlight"
 import AppsTable from "../../_components/AppsTable"
 import SuggestAnApp from "../../_components/SuggestAnApp"
@@ -223,35 +225,48 @@ export async function generateMetadata(props: {
 }) {
   const params = await props.params
   const { locale, catetgoryName } = params
-  const t = await getTranslations("page-apps")
 
-  // Normalize slug to lowercase
-  const normalizedSlug = catetgoryName.toLowerCase()
+  try {
+    const t = await getTranslations("page-apps")
 
-  // Find category by matching the slug
-  const categoryEntry = Object.entries(appsCategories).find(
-    ([, categoryData]) => categoryData.slug === normalizedSlug
-  )
+    // Normalize slug to lowercase
+    const normalizedSlug = catetgoryName.toLowerCase()
 
-  if (!categoryEntry) {
-    notFound()
+    // Find category by matching the slug
+    const categoryEntry = Object.entries(appsCategories).find(
+      ([, categoryData]) => categoryData.slug === normalizedSlug
+    )
+
+    if (!categoryEntry) {
+      throw new Error(`App category not found: ${catetgoryName}`)
+    }
+
+    const [categoryEnum, category] = categoryEntry
+
+    if (!isValidCategory(categoryEnum)) {
+      throw new Error(`Invalid app category enum: ${categoryEnum}`)
+    }
+
+    const title = t(category.metaTitle)
+    const description = t(category.metaDescription)
+
+    return await getMetadata({
+      locale,
+      slug: ["apps", "categories", normalizedSlug],
+      title,
+      description,
+    })
+  } catch {
+    const t = await getTranslations({
+      locale: DEFAULT_LOCALE,
+      namespace: "common",
+    })
+
+    return {
+      title: t("page-not-found"),
+      description: t("page-not-found-description"),
+    }
   }
-
-  const [categoryEnum, category] = categoryEntry
-
-  if (!isValidCategory(categoryEnum)) {
-    notFound()
-  }
-
-  const title = t(category.metaTitle)
-  const description = t(category.metaDescription)
-
-  return await getMetadata({
-    locale,
-    slug: ["apps", "categories", normalizedSlug],
-    title,
-    description,
-  })
 }
 
 export default Page

--- a/app/[locale]/developers/tools/[category]/page.tsx
+++ b/app/[locale]/developers/tools/[category]/page.tsx
@@ -11,6 +11,8 @@ import { Section } from "@/components/ui/section"
 import { getAppPageContributorInfo } from "@/lib/utils/contributors"
 import { getMetadata } from "@/lib/utils/metadata"
 
+import { DEFAULT_LOCALE } from "@/lib/constants"
+
 import CategoryToolsGrid from "../_components/CategoryToolsGrid"
 import HighlightsSection from "../_components/HighlightsSection"
 import ToolModalContents from "../_components/ToolModalContents"
@@ -152,20 +154,32 @@ export async function generateMetadata(props: {
   const params = await props.params
   const { locale, category } = params
 
-  if (!VALID_CATEGORY_SLUGS.has(category as DeveloperToolCategorySlug)) {
-    notFound()
+  try {
+    if (!VALID_CATEGORY_SLUGS.has(category as DeveloperToolCategorySlug)) {
+      throw new Error(`Invalid developer tools category: ${category}`)
+    }
+
+    const t = await getTranslations("page-developers-tools")
+
+    return await getMetadata({
+      locale,
+      slug: ["developers", "tools", category],
+      title: t(`page-developers-tools-category-${category}-title`),
+      description: t(
+        `page-developers-tools-category-${category}-meta-description`
+      ),
+    })
+  } catch {
+    const t = await getTranslations({
+      locale: DEFAULT_LOCALE,
+      namespace: "common",
+    })
+
+    return {
+      title: t("page-not-found"),
+      description: t("page-not-found-description"),
+    }
   }
-
-  const t = await getTranslations("page-developers-tools")
-
-  return await getMetadata({
-    locale,
-    slug: ["developers", "tools", category],
-    title: t(`page-developers-tools-category-${category}-title`),
-    description: t(
-      `page-developers-tools-category-${category}-meta-description`
-    ),
-  })
 }
 
 export default Page

--- a/app/[locale]/developers/tools/[category]/page.tsx
+++ b/app/[locale]/developers/tools/[category]/page.tsx
@@ -11,8 +11,6 @@ import { Section } from "@/components/ui/section"
 import { getAppPageContributorInfo } from "@/lib/utils/contributors"
 import { getMetadata } from "@/lib/utils/metadata"
 
-import { DEFAULT_LOCALE } from "@/lib/constants"
-
 import CategoryToolsGrid from "../_components/CategoryToolsGrid"
 import HighlightsSection from "../_components/HighlightsSection"
 import ToolModalContents from "../_components/ToolModalContents"
@@ -119,7 +117,7 @@ const Page = async (props: {
 
         <Section id="categories" className="space-y-4">
           <h2>{t("page-developers-tools-categories-title-other")}</h2>
-          <div className="grid grid-cols-fill-4 gap-8">
+          <div className="grid-cols-fill-4 grid gap-8">
             {DEV_TOOL_CATEGORIES.filter(({ slug }) => slug !== category).map(
               ({ slug, Icon }) => (
                 <SubpageCard
@@ -170,10 +168,7 @@ export async function generateMetadata(props: {
       ),
     })
   } catch {
-    const t = await getTranslations({
-      locale: DEFAULT_LOCALE,
-      namespace: "common",
-    })
+    const t = await getTranslations("common")
 
     return {
       title: t("page-not-found"),


### PR DESCRIPTION
## Summary

Two remaining `generateMetadata` functions on `dev` still call `notFound()` directly, which in Netlify's serverless runtime surfaces as a **502** instead of a 404 — poisoning hreflang reports (see Ahrefs export from 2026-04-17, 335 pages flagged with "Some pages are not returning 200 status code"). This patches both:

- `app/[locale]/developers/tools/[category]/page.tsx` — wraps the category-slug validation in try/catch, falls back to basic "page not found" metadata. Directly explains the 3 `/developers/tools/.../?toolId=…` 502s in the Ahrefs export.
- `app/[locale]/apps/categories/[catetgoryName]/page.tsx` — same pattern applied to the two `notFound()` calls (invalid slug + invalid enum). Not in the current Ahrefs export (category slugs come from `generateStaticParams`, so misses are rare), but the bug class is identical and worth closing while we're here.

The main `Page()` functions keep their existing `notFound()` calls untouched — they handle the actual 404 HTTP status correctly. Only `generateMetadata` needs the fallback.

## Companion to #17978

PR #17978 (`trailingSEO`) applied the same pattern to `app/[locale]/apps/[application]/page.tsx`, which accounts for the bulk of the 502 cascade (all `/apps/[slug]/` URLs). This PR closes the remaining gaps I found while sweeping the codebase for `generateMetadata` + `notFound()` combinations. After both land, a repeat Ahrefs crawl should show the hreflang-to-5xx counts collapse.

## Test plan

- [ ] CI green (typecheck + lint pass locally)
- [ ] Hit an invalid dev-tools category slug in a preview deploy — confirm 404, not 502
- [ ] Hit an invalid apps category slug in a preview deploy — confirm 404, not 502
- [ ] After merge + deploy, re-run Ahrefs crawl and confirm hreflang-to-5xx count drops