### PR TITLE
fix: handle missing videos directory in getVideoSlugs (auto)

### DIFF
--- a/src/lib/utils/videos.ts
+++ b/src/lib/utils/videos.ts
@@ -121,9 +121,23 @@ export async function getVideoSlugs(): Promise<string[]> {
   if (slugsCache) return slugsCache
 
   const videosDir = join(process.cwd(), CONTENT_DIR, "videos")
-  const entries = await readdir(videosDir, { withFileTypes: true })
-  slugsCache = entries.filter((e) => e.isDirectory()).map((e) => e.name)
-  return slugsCache
+  try {
+    const entries = await readdir(videosDir, { withFileTypes: true })
+    slugsCache = entries.filter((e) => e.isDirectory()).map((e) => e.name)
+    return slugsCache
+  } catch (error) {
+    // Serverless runtimes (e.g. Netlify Functions) don't bundle public/
+    // content, so readdir throws ENOENT when this is called outside the
+    // build. Degrade gracefully to match getPostSlugs().
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      console.warn(
+        `Videos directory ${videosDir} not found, returning empty slug list`
+      )
+      slugsCache = []
+      return slugsCache
+    }
+    throw error
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- `app/sitemap.ts` throws ENOENT at runtime on Netlify because `getVideoSlugs()` does a raw `readdir` on `public/content/videos`, and that directory isn't bundled into serverless functions.
- `getPostSlugs` already guards the same failure mode in `src/lib/utils/md.ts`; this PR applies the same ENOENT handling to `getVideoSlugs` so the sitemap degrades gracefully instead of 500ing.
- Build-time behaviour is unchanged: when the directory exists (as it does during `pnpm build`), all video slugs are still returned.

## Error Context

- **Source:** grafana-logs
- **Item ID:** grafana-fn-error-enoent-no-such-file-or-directory-scandir-x-at-async-o-next-se
- **Path/URL:** `/sitemap.xml` (Netlify Function `.next/server/app/sitemap.xml/route.js`)
- **Status:** 500 (ENOENT thrown from route handler)
- **Hit count:** 100
- **Request ID (sample):** 01KPTG6Z7AXST53NM89RZFZAYE
- **First seen:** 2026-04-22 (recently; introduced by videos-refactor re-merge on 2026-04-13)

## Changes

- `src/lib/utils/videos.ts`: wrap the `readdir(videosDir, ...)` call in `getVideoSlugs()` with a try/catch that maps ENOENT to an empty slug list (with a `console.warn`), mirroring the graceful fallback already implemented in `getPostSlugs` (`src/lib/utils/md.ts:64-74`).

## Analysis

Stack trace points at `/var/task/.next/server/app/sitemap.xml/route.js` and a scandir on `/var/task/public/content/videos`. That's the Netlify Functions sandbox path — `public/content/*` is only bundled into functions when explicitly listed in `netlify.toml`'s `included_files`, which today lists `i18n.config.json`, `src/intl/**/*`, and `src/data-layer/mocks/**/*`, but not `public/content/videos`.

`app/sitemap.ts` was updated on 2026-04-13 (videos-refactor PR #17870 reapply) to call `getVideoSlugs()` so the sitemap picks up `/videos/<slug>/` URLs. The individual video pages are statically generated at build time (`app/[locale]/videos/[slug]/page.tsx` uses `generateStaticParams`), so they don't hit this path — but `app/sitemap.ts` does.

`getPostSlugs` in `src/lib/utils/md.ts` handles this same environmental mismatch by catching ENOENT and returning `[]` with a warning. `getVideoSlugs` didn't — so any time Netlify invokes the sitemap route at runtime (regardless of why), we throw. 100 hits in the Grafana logs confirms it's firing consistently.

Matching the existing pattern keeps the fix small and consistent with the codebase's accepted trade-off: at build time we emit a complete sitemap with video URLs; if the sitemap route is re-executed at runtime without the content bundle, we still return a valid (video-less) sitemap instead of 500ing.

Related issue: #18014 tracks the broader WARN-level variant of this same root cause from `getPostSlugs`.

## Test Plan

- [ ] Verify the draft PR triggers a clean Netlify deploy preview.
- [ ] Load `/sitemap.xml` on the preview — expect 200, with `/videos/<slug>/` entries present (built once at build time).
- [ ] Confirm Grafana error rate for this signature drops to zero after the PR lands on `dev`.
- [ ] Optionally consider forcing the sitemap to `export const dynamic = 'force-static'` in a follow-up so runtime re-invocation never drops video URLs; out of scope here.

---
*Opened automatically by the Recovery Agent.*