### PR TITLE
Developer docs: add goal-based wayfinding on the hub and intro pages

### DIFF
--- a/public/content/developers/docs/index.md
+++ b/public/content/developers/docs/index.md
@@ -6,7 +6,16 @@ lang: en
 
 This documentation is designed to help you build with [Ethereum](/). It covers Ethereum as a concept, explains the Ethereum tech stack, and documents advanced topics for more complex applications and use cases.
 
-This is an open-source community effort, so feel free to suggest new topics, add new content, and provide examples wherever you think it might be helpful. All documentation can be edited via GitHub – if you're unsure how, [follow these instructions](https://github.com/ethereum/ethereum-org-website/blob/dev/docs/editing-markdown.md).
+Everything here is open-source and community-maintained, so if a page is out of date or missing something useful, open an issue or a pull request. The [editing guide](https://github.com/ethereum/ethereum-org-website/blob/dev/docs/editing-markdown.md) walks through how.
+
+## Pick a starting point {#pick-a-starting-point}
+
+Readers arrive with different goals, and the fastest path through these docs depends on what you want to build. A few common entry points:
+
+- **Building a dapp that talks to Ethereum.** Start with the [technical intro](/developers/docs/intro-to-ethereum/), then work through [accounts](/developers/docs/accounts/) and [transactions](/developers/docs/transactions/). Pick a [framework](/developers/docs/frameworks/) when you're ready to write code.
+- **Writing a smart contract.** Skim the [intro](/developers/docs/intro-to-ethereum/) if EVM concepts are new, then jump to [smart contracts](/developers/docs/smart-contracts/) and a [programming language](/developers/docs/programming-languages/).
+- **Running a node or staking.** Go to [nodes and clients](/developers/docs/nodes-and-clients/), then [networking](/developers/docs/networking-layer/) and [consensus mechanisms](/developers/docs/consensus-mechanisms/).
+- **Understanding the protocol from the bottom up.** The modules below are ordered for this. Read them in sequence.
 
 ## Development modules {#development-modules}
 

--- a/public/content/developers/docs/intro-to-ethereum/index.md
+++ b/public/content/developers/docs/intro-to-ethereum/index.md
@@ -104,6 +104,14 @@ A reusable snippet of code (a program) which a developer publishes into EVM stat
 
 [More on smart contracts](/developers/docs/smart-contracts/)
 
+## Where to go next {#where-to-go-next}
+
+Most readers follow the docs in order, but the shortest path depends on what you're trying to build:
+
+- **Dapps that interact with Ethereum:** [accounts](/developers/docs/accounts/) and [transactions](/developers/docs/transactions/), then pick a [framework](/developers/docs/frameworks/).
+- **Smart contract development:** [smart contracts](/developers/docs/smart-contracts/) and [programming languages](/developers/docs/programming-languages/).
+- **Nodes and staking:** [nodes and clients](/developers/docs/nodes-and-clients/), then [consensus mechanisms](/developers/docs/consensus-mechanisms/).
+
 ## Further reading {#further-reading}
 
 - [Ethereum Whitepaper](/whitepaper/)


### PR DESCRIPTION
## Description

Two small, additive edits that help developers self-route through the docs based on what they are actually trying to build, rather than reading the modules top-to-bottom.

### `public/content/developers/docs/index.md`

- New section `Pick a starting point` above the Development modules, with four goal-based entry points (dapp, smart contract, node / staking, reading the protocol in order).
- Tightened the wording of the existing "edit on GitHub" paragraph so it reads as a note rather than front-and-centre lead copy.

### `public/content/developers/docs/intro-to-ethereum/index.md`

- New section `Where to go next` directly before `Further reading`, mirroring three of the paths from the hub page. Readers finishing the intro don't get dropped back into the generic module list.

## Motivation

The hub page currently opens with a generic intro and then three `<DeveloperDocsLinks>` blocks. Readers who know what they're trying to build (dapp vs. smart contract vs. running a node) still have to guess which of the three lists starts them off in the right place. Adding a goal-based block above the modules fixes that without touching the existing module ordering.

The mirrored block at the end of intro-to-ethereum gives readers an obvious next step based on the same goals, so they don't have to go back to the hub to re-orient.

## Scope

- Two files changed, 18 lines added, 1 line modified.
- All new headings use the `{#kebab-case-id}` convention from `docs/header-ids.md`.
- All linked target pages already exist. Verified by listing `public/content/developers/docs/`.
- No component, route, sidebar, or i18n key changes required.

## Issue

Not tied to a specific issue. Happy to open one first if that is the preferred process for wayfinding-style additions.