### PR TITLE
seo(jsonld): VideoGallery + WebPage for video pages

### DIFF
--- a/app/[locale]/videos/[slug]/page-jsonld.tsx
+++ b/app/[locale]/videos/[slug]/page-jsonld.tsx
@@ -1,3 +1,5 @@
+import { getTranslations } from "next-intl/server"
+
 import type { VideoFrontmatter } from "@/lib/interfaces"
 
 import PageJsonLD from "@/components/PageJsonLD"
@@ -6,9 +8,10 @@ import { stripMarkdown } from "@/lib/utils/md"
 import { toIsoDuration } from "@/lib/utils/time"
 import { normalizeUrlForJsonLd } from "@/lib/utils/url"
 import { getDefaultThumbnailUrl } from "@/lib/utils/videos"
-import { ORGANIZATION } from "@/lib/jsonld/constants"
 
-export default function VideoPageJsonLD({
+import { BASE_GRAPH_NODES, REFERENCE } from "@/lib/jsonld/constants"
+
+export default async function VideoPageJsonLD({
   locale,
   slug,
   frontmatter,
@@ -20,37 +23,85 @@ export default function VideoPageJsonLD({
   transcript: string | null
 }) {
   const url = normalizeUrlForJsonLd(locale, `/videos/${slug}/`)
+  const videoGalleryUrl = normalizeUrlForJsonLd(locale, "/videos/")
 
-  const jsonLd: Record<string, unknown> = {
+  const t = await getTranslations("page-videos")
+
+  const mainEntityId = { "@id": `${url}#video` }
+
+  const jsonLd = {
     "@context": "https://schema.org",
-    "@type": "VideoObject",
-    "@id": `${url}#video`,
-    name: frontmatter.title,
-    description: frontmatter.description,
-    uploadDate: `${frontmatter.uploadDate}T00:00:00+00:00`,
-    duration: toIsoDuration(frontmatter.duration),
-    thumbnailUrl:
-      frontmatter.customThumbnailUrl ||
-      getDefaultThumbnailUrl(frontmatter.youtubeId),
-    embedUrl: `https://www.youtube.com/embed/${frontmatter.youtubeId}`,
-    contentUrl: `https://www.youtube.com/watch?v=${frontmatter.youtubeId}`,
-    educationalLevel: frontmatter.educationLevel,
-    inLanguage: frontmatter.lang,
-    creator: {
-      "@type": "Person",
-      name: frontmatter.author,
-    },
-    publisher: ORGANIZATION.ETHEREUM_FOUNDATION,
-    isAccessibleForFree: true,
-    isFamilyFriendly: true,
-  }
-
-  // Add transcript as plain text if available
-  if (transcript) {
-    // Escape < and / to prevent script injection (XSS protection)
-    jsonLd.transcript = stripMarkdown(transcript, true)
-      .replace(/</g, "\\u003c")
-      .replace(/\//g, "\\u002f")
+    "@graph": [
+      ...BASE_GRAPH_NODES,
+      // Type-assertion node for "isPartOf" references
+      { "@type": "VideoGallery", "@id": videoGalleryUrl },
+      {
+        "@type": "WebPage",
+        "@id": url,
+        name: frontmatter.title,
+        description: frontmatter.description,
+        url: url,
+        inLanguage: locale,
+        author: [REFERENCE.ETHEREUM_COMMUNITY],
+        isPartOf: REFERENCE.ETHEREUM_ORG_WEBSITE,
+        breadcrumb: {
+          "@type": "BreadcrumbList",
+          itemListElement: [
+            {
+              "@type": "ListItem",
+              position: 1,
+              name: "Home",
+              item: normalizeUrlForJsonLd(locale, "/"),
+            },
+            {
+              "@type": "ListItem",
+              position: 2,
+              name: t("page-videos-hero-title"),
+              item: videoGalleryUrl,
+            },
+            {
+              "@type": "ListItem",
+              position: 3,
+              name: frontmatter.breadcrumb || frontmatter.title,
+              item: url,
+            },
+          ],
+        },
+        publisher: REFERENCE.ETHEREUM_FOUNDATION,
+        reviewedBy: REFERENCE.ETHEREUM_FOUNDATION,
+        mainEntity: mainEntityId,
+      },
+      {
+        "@type": "VideoObject",
+        ...mainEntityId,
+        name: frontmatter.title,
+        description: frontmatter.description,
+        uploadDate: `${frontmatter.uploadDate}T00:00:00+00:00`,
+        duration: toIsoDuration(frontmatter.duration),
+        isPartOf: { "@id": videoGalleryUrl },
+        thumbnailUrl:
+          frontmatter.customThumbnailUrl ||
+          getDefaultThumbnailUrl(frontmatter.youtubeId),
+        embedUrl: `https://www.youtube.com/embed/${frontmatter.youtubeId}`,
+        contentUrl: `https://www.youtube.com/watch?v=${frontmatter.youtubeId}`,
+        educationalLevel: frontmatter.educationLevel,
+        inLanguage: frontmatter.lang,
+        creator: {
+          "@type": "Person",
+          name: frontmatter.author,
+        },
+        publisher: REFERENCE.ETHEREUM_FOUNDATION,
+        isAccessibleForFree: true,
+        isFamilyFriendly: true,
+        // Add transcript as plain text if available
+        transcript: transcript
+          ? stripMarkdown(transcript, true)
+              // Escape < and / to prevent script injection (XSS protection)
+              .replace(/</g, "\\u003c")
+              .replace(/\//g, "\\u002f")
+          : undefined,
+      },
+    ],
   }
 
   return <PageJsonLD structuredData={jsonLd} />

--- a/app/[locale]/videos/[slug]/page-jsonld.tsx
+++ b/app/[locale]/videos/[slug]/page-jsonld.tsx
@@ -27,7 +27,7 @@ export default async function VideoPageJsonLD({
 
   const t = await getTranslations("page-videos")
 
-  const mainEntityId = { "@id": `${url}#video` }
+  const videoObjectId = { "@id": `${url}#video` }
 
   const jsonLd = {
     "@context": "https://schema.org",
@@ -69,11 +69,11 @@ export default async function VideoPageJsonLD({
         },
         publisher: REFERENCE.ETHEREUM_FOUNDATION,
         reviewedBy: REFERENCE.ETHEREUM_FOUNDATION,
-        mainEntity: mainEntityId,
+        mainEntity: videoObjectId,
       },
       {
         "@type": "VideoObject",
-        ...mainEntityId,
+        ...videoObjectId,
         name: frontmatter.title,
         description: frontmatter.description,
         uploadDate: `${frontmatter.uploadDate}T00:00:00+00:00`,

--- a/app/[locale]/videos/page-jsonld.tsx
+++ b/app/[locale]/videos/page-jsonld.tsx
@@ -4,8 +4,9 @@ import type { VideoCardData } from "@/lib/types"
 
 import PageJsonLD from "@/components/PageJsonLD"
 
-import { BASE_GRAPH_NODES, REFERENCE } from "@/lib/jsonld/constants"
 import { normalizeUrlForJsonLd } from "@/lib/utils/url"
+
+import { BASE_GRAPH_NODES, REFERENCE } from "@/lib/jsonld/constants"
 
 export default async function VideosPageJsonLD({
   locale,
@@ -23,7 +24,7 @@ export default async function VideosPageJsonLD({
     "@graph": [
       ...BASE_GRAPH_NODES,
       {
-        "@type": "CollectionPage",
+        "@type": "VideoGallery",
         "@id": url,
         name: t("page-videos-meta-title"),
         description: t("page-videos-meta-description"),
@@ -66,7 +67,6 @@ export default async function VideosPageJsonLD({
                 ? -1
                 : 0
           )
-          .slice(0, 10)
           .map((video, index) => ({
             "@type": "ListItem",
             position: index + 1,


### PR DESCRIPTION
## Summary
- `/videos/`: promoted `CollectionPage` to `VideoGallery` (more specific subclass per Schema.org's `CollectionPage > MediaGallery > VideoGallery` hierarchy). `ItemList` retained as `mainEntity` for carousel rich-result eligibility, and the 10-item slice was dropped so the full catalog is exposed to crawlers.
- `/videos/[slug]/`: wrapped the previously orphaned `VideoObject` in a proper `@graph`. Spreads `BASE_GRAPH_NODES`, adds a `WebPage` node that owns the 3-item breadcrumb and points `mainEntity` at the `VideoObject`, and adds `VideoObject.isPartOf` → the gallery. `VideoObject.publisher` switched from the full `ORGANIZATION.ETHEREUM_FOUNDATION` object to `REFERENCE.ETHEREUM_FOUNDATION` (the full object is already declared in `BASE_GRAPH_NODES`).
- Added a minimal `{"@type": "VideoGallery", "@id": videoGalleryUrl}` stub on the viewing page so `VideoObject.isPartOf`'s cross-page `@id` resolves to a typed entity instead of the generic `CreativeWork` fallback strict validators infer from an unresolved reference.

## Key decisions
- **`VideoGallery` over `CollectionPage`** — more specific, and the subclass chain (`VideoGallery is-a CollectionPage is-a WebPage`) keeps it backward-compatible with anything that only understood the parent.
- **`WebPage` wrapper on video pages** — matches the pattern used by every other page on the site. The previously bare `VideoObject` worked for Google's video rich result but was semantically orphaned from the site graph.
- **`VideoObject.isPartOf` points to the `VideoGallery`**, not the `WebPage` or `WebSite`. A video is naturally a part of the gallery collection; pointing at the page or the site is technically valid but semantically weak.
- **Minimal type-assertion stub for `VideoGallery`** on the viewing page — `@id` references work across documents, but not every parser reconciles cross-document graphs. A `{@type, @id}` stub keeps the viewing page's graph self-contained without duplicating the canonical definition from `/videos/page-jsonld.tsx`.

## Test plan
- [x] Render `/videos/` locally, paste the `application/ld+json` from the DOM into validator.schema.org — expect `VideoGallery` with `ItemList` nested via `mainEntity`, no dangling references.
- [x] Render `/videos/[slug]/` for at least one slug, paste into validator.schema.org — expect `WebPage` with `VideoObject` nested via `mainEntity`, `VideoGallery` stub nested under `VideoObject.isPartOf`, and no generic `CreativeWork` fallback.
- [x] Browser smoke-test the gallery and at least one video page.
- [x] Verify breadcrumb renders correctly on the video page UI.

_Message generated by Claude (Opus 4.7)_
