### PR TITLE
chore: add `tailwindStylesheet` pointer, deprecate `.eslintignore`

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,0 @@
-.next
-dist
-node_modules/
-
-!.storybook

--- a/.prettierrc
+++ b/.prettierrc
@@ -5,6 +5,7 @@
   "tabWidth": 2,
   "trailingComma": "es5",
   "plugins": ["prettier-plugin-tailwindcss"],
+  "tailwindStylesheet": "./src/styles/global.css",
   "overrides": [
     {
       "files": "src/data-layer/index.ts",


### PR DESCRIPTION
## Description

- Adds `tailwindStylesheet` pointer to `.prettierrc` -- Fixes canonical prettier formatting with known Tailwind configuration/theming
- Deprecates `.eslintignore`; already replaced by `ignorePatterns` in `.eslintrc`

## Related Issue

Repo `.prettierrc` is missing the `tailwindStylesheet` option, which the plugin's own README calls out as **required** for Tailwind v4:

> "When using Tailwind CSS v4 you **must** specify your CSS file entry point, which includes your theme, custom utilities, and other Tailwind configuration options."

In v3 the plugin auto-discovered `tailwind.config.js`. In v4's CSS-first world there's no JS config — so without the pointer, the plugin doesn't know about:

- repo `@theme` tokens (`src/styles/theme.css`)
- repos many `@utility` declarations (`bg-gradient-main`, `grid-cols-bento`, the whole `z-*` set, etc. in `src/styles/utilities.css`)
- repos `@custom-variant dark` in `src/styles/global.css`

Unknown utilities get sorted to the end in a less stable way, and everything else around them can shift.