### PR TITLE
chore: run prettier format across codebase

### DIFF
--- a/app/[locale]/_components/HomepageLazy.tsx
+++ b/app/[locale]/_components/HomepageLazy.tsx
@@ -13,7 +13,7 @@ const Skeleton = ({
 }) => (
   <Section className={className}>
     <div
-      className={`w-full animate-pulse rounded-2xl bg-background-highlight ${heightClass}`}
+      className={`bg-background-highlight w-full animate-pulse rounded-2xl ${heightClass}`}
     />
   </Section>
 )

--- a/app/[locale]/community/events/_components/EventCard.tsx
+++ b/app/[locale]/community/events/_components/EventCard.tsx
@@ -49,7 +49,7 @@ function EventCardGrid({
         matomoEvent={customEventOptions}
       >
         <div className="flex gap-3">
-          <div className="from-body/5 to-body/10 dark:from-body/10 dark:to-body/20 bg-linear-to-b flex size-16 shrink-0 items-center justify-center overflow-hidden rounded-xl text-2xl">
+          <div className="from-body/5 to-body/10 dark:from-body/10 dark:to-body/20 flex size-16 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-linear-to-b text-2xl">
             {event.logoImage && !logoError ? (
               <Image
                 src={event.logoImage}
@@ -74,7 +74,7 @@ function EventCardGrid({
                 {event.eventTypesLabels?.[0] || primaryType}
               </Tag>
             )}
-            <p className="text-body group-hover:text-primary text-lg font-bold leading-tight">
+            <p className="text-body group-hover:text-primary text-lg leading-tight font-bold">
               {event.title}
             </p>
             {formattedDate && <p className="text-body">{formattedDate}</p>}
@@ -104,7 +104,7 @@ function EventCardHighlight({
         hideArrow
         matomoEvent={customEventOptions}
       >
-        <div className="from-body/5 to-body/10 dark:from-body/10 dark:to-body/20 bg-linear-to-b relative h-[200px] w-full overflow-hidden rounded-xl">
+        <div className="from-body/5 to-body/10 dark:from-body/10 dark:to-body/20 relative h-[200px] w-full overflow-hidden rounded-xl bg-linear-to-b">
           {bannerSrc && !bannerError ? (
             <Image
               src={bannerSrc}

--- a/app/[locale]/community/events/page.tsx
+++ b/app/[locale]/community/events/page.tsx
@@ -202,7 +202,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
                     key={id}
                     className={cn(
                       "ms-6 w-[calc(100%-4rem)] max-w-96 md:w-96 lg:max-w-[30%] xl:max-w-[22%]",
-                      "rounded-4xl flex flex-col justify-between gap-4 border p-8 shadow-lg",
+                      "flex flex-col justify-between gap-4 rounded-4xl border p-8 shadow-lg",
                       logoBgColor
                     )}
                   >
@@ -259,7 +259,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
               <ButtonLink
                 href="https://esp.ethereum.foundation/applicants/rfp/community-hubs"
                 variant="outline"
-                className="border-body-light rounded-4xl group w-full gap-2 p-5"
+                className="border-body-light group w-full gap-2 rounded-4xl p-5"
                 customEventOptions={{
                   eventCategory: "Events",
                   eventAction: "hubs",
@@ -435,7 +435,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
             </div>
             <div className="grid gap-8 md:grid-cols-2">
               {/* Ethereum Everywhere Card */}
-              <div className="from-accent-a/5 to-accent-a/15 dark:from-accent-a/10 dark:to-accent-a/20 rounded-4xl bg-linear-to-b flex flex-col gap-y-8 px-4 py-6 md:p-12">
+              <div className="from-accent-a/5 to-accent-a/15 dark:from-accent-a/10 dark:to-accent-a/20 flex flex-col gap-y-8 rounded-4xl bg-linear-to-b px-4 py-6 md:p-12">
                 <div className="flex items-center gap-3">
                   <div className="size-16 overflow-hidden rounded-full">
                     <Image src={ethereumEverywhereLogo} alt="" sizes="4rem" />
@@ -499,7 +499,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
               </div>
 
               {/* Geode Labs Card */}
-              <div className="from-accent-c/5 to-accent-c/15 dark:from-accent-c/10 dark:to-accent-c/20 rounded-4xl bg-linear-to-b flex flex-col gap-y-8 px-4 py-6 md:p-12">
+              <div className="from-accent-c/5 to-accent-c/15 dark:from-accent-c/10 dark:to-accent-c/20 flex flex-col gap-y-8 rounded-4xl bg-linear-to-b px-4 py-6 md:p-12">
                 <div className="flex items-center gap-3">
                   <div className="size-16 overflow-hidden rounded-full">
                     <Image src={geodeLabsLogo} alt="" sizes="4rem" />

--- a/app/[locale]/learn/page.tsx
+++ b/app/[locale]/learn/page.tsx
@@ -145,77 +145,77 @@ export default async function Page(props: { params: Promise<PageParams> }) {
       description: string
     }[]
   }[] = [
-      {
-        heading: t("books-about-ethereum"),
-        items: [
-          {
-            label: t("cryptopians-title"),
-            href: "https://www.goodreads.com/book/show/57356067-the-cryptopians",
-            description: t("cryptopians-description"),
-          },
-          {
-            label: t("out-of-the-ether-title"),
-            href: "https://www.goodreads.com/book/show/55360267-out-of-the-ether",
-            description: t("out-of-the-ether-description"),
-          },
-          {
-            label: t("the-infinite-machine-title"),
-            href: "https://www.goodreads.com/en/book/show/50175330-the-infinite-machine",
-            description: t("the-infinite-machine-description"),
-          },
-          {
-            label: t("mastering-ethereum-title"),
-            href: "https://github.com/ethereumbook/ethereumbook",
-            description: t("mastering-ethereum-description"),
-          },
-          {
-            label: t("proof-of-stake-title"),
-            href: "https://www.goodreads.com/en/book/show/59892281-proof-of-stake",
-            description: t("proof-of-stake-description"),
-          },
-        ],
-      },
-      {
-        heading: t("podcasts-about-ethereum"),
-        items: [
-          {
-            label: t("green-pill-title"),
-            href: "https://www.youtube.com/@Green_Pill_Podcast",
-            description: t("green-pill-description"),
-          },
-          {
-            label: t("zeroknowledge-title"),
-            href: "https://www.zeroknowledge.fm/",
-            description: t("zeroknowledge-description"),
-          },
-          {
-            label: t("unchained-title"),
-            href: "https://unchainedpodcast.com/",
-            description: t("unchained-description"),
-          },
-          {
-            label: t("the-daily-gwei-title"),
-            href: "https://www.youtube.com/@TheDailyGwei/",
-            description: t("the-daily-gwei-description"),
-          },
-          {
-            label: t("bankless-title"),
-            href: "https://podcast.banklesshq.com/",
-            description: t("bankless-description"),
-          },
-        ],
-      },
-      {
-        heading: t("about-ethereum-video-series"),
-        items: [
-          {
-            label: t("ethereum-basics-title"),
-            href: "https://www.youtube.com/playlist?list=PLqgutSGloqiJyyoL0zvLVFPS-GMD2wKa5",
-            description: t("ethereum-basics-description"),
-          },
-        ],
-      },
-    ]
+    {
+      heading: t("books-about-ethereum"),
+      items: [
+        {
+          label: t("cryptopians-title"),
+          href: "https://www.goodreads.com/book/show/57356067-the-cryptopians",
+          description: t("cryptopians-description"),
+        },
+        {
+          label: t("out-of-the-ether-title"),
+          href: "https://www.goodreads.com/book/show/55360267-out-of-the-ether",
+          description: t("out-of-the-ether-description"),
+        },
+        {
+          label: t("the-infinite-machine-title"),
+          href: "https://www.goodreads.com/en/book/show/50175330-the-infinite-machine",
+          description: t("the-infinite-machine-description"),
+        },
+        {
+          label: t("mastering-ethereum-title"),
+          href: "https://github.com/ethereumbook/ethereumbook",
+          description: t("mastering-ethereum-description"),
+        },
+        {
+          label: t("proof-of-stake-title"),
+          href: "https://www.goodreads.com/en/book/show/59892281-proof-of-stake",
+          description: t("proof-of-stake-description"),
+        },
+      ],
+    },
+    {
+      heading: t("podcasts-about-ethereum"),
+      items: [
+        {
+          label: t("green-pill-title"),
+          href: "https://www.youtube.com/@Green_Pill_Podcast",
+          description: t("green-pill-description"),
+        },
+        {
+          label: t("zeroknowledge-title"),
+          href: "https://www.zeroknowledge.fm/",
+          description: t("zeroknowledge-description"),
+        },
+        {
+          label: t("unchained-title"),
+          href: "https://unchainedpodcast.com/",
+          description: t("unchained-description"),
+        },
+        {
+          label: t("the-daily-gwei-title"),
+          href: "https://www.youtube.com/@TheDailyGwei/",
+          description: t("the-daily-gwei-description"),
+        },
+        {
+          label: t("bankless-title"),
+          href: "https://podcast.banklesshq.com/",
+          description: t("bankless-description"),
+        },
+      ],
+    },
+    {
+      heading: t("about-ethereum-video-series"),
+      items: [
+        {
+          label: t("ethereum-basics-title"),
+          href: "https://www.youtube.com/playlist?list=PLqgutSGloqiJyyoL0zvLVFPS-GMD2wKa5",
+          description: t("ethereum-basics-description"),
+        },
+      ],
+    },
+  ]
 
   return (
     <>

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -111,10 +111,10 @@ const Page = async (props: { params: Promise<PageParams> }) => {
                     <SectionTag variant="plain">
                       {t("page-index-simulator-tag")}
                     </SectionTag>
-                    <SectionHeader className="mb-0 mt-0 leading-tight lg:text-6xl">
+                    <SectionHeader className="mt-0 mb-0 leading-tight lg:text-6xl">
                       {t("page-index-simulator-title")}
                     </SectionHeader>
-                    <p className="text-lg text-body-medium md:text-xl">
+                    <p className="text-body-medium text-lg md:text-xl">
                       {t("page-index-simulator-subtitle")}
                     </p>
                   </div>

--- a/app/[locale]/staking/deposit-contract/page-jsonld.tsx
+++ b/app/[locale]/staking/deposit-contract/page-jsonld.tsx
@@ -2,8 +2,9 @@ import { getTranslations } from "next-intl/server"
 
 import PageJsonLD from "@/components/PageJsonLD"
 
-import { BASE_GRAPH_NODES, REFERENCE } from "@/lib/jsonld/constants"
 import { normalizeUrlForJsonLd } from "@/lib/utils/url"
+
+import { BASE_GRAPH_NODES, REFERENCE } from "@/lib/jsonld/constants"
 
 export default async function DepositContractJsonLD({
   locale,

--- a/app/[locale]/videos/[slug]/page.tsx
+++ b/app/[locale]/videos/[slug]/page.tsx
@@ -80,7 +80,7 @@ const VideoLandingPage = async (props: {
         <div className="space-y-4">
           <h1>{frontmatter.title}</h1>
 
-          <p className="text-lg text-body-medium">{frontmatter.description}</p>
+          <p className="text-body-medium text-lg">{frontmatter.description}</p>
 
           <p className="text-body-medium">
             {t("page-videos-date-published")}:{" "}

--- a/app/[locale]/videos/_components/VideoGalleryFilter.tsx
+++ b/app/[locale]/videos/_components/VideoGalleryFilter.tsx
@@ -158,7 +158,7 @@ const VideoGalleryFilter = ({
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
           {/* Search input */}
           <div className="relative w-full sm:max-w-xs">
-            <Search className="pointer-events-none absolute start-3 top-1/2 size-4 -translate-y-1/2 text-body-medium" />
+            <Search className="text-body-medium pointer-events-none absolute start-3 top-1/2 size-4 -translate-y-1/2" />
             <Input
               type="text"
               placeholder={t("page-videos-search-placeholder")}
@@ -170,7 +170,7 @@ const VideoGalleryFilter = ({
             {searchQuery && (
               <button
                 onClick={() => setSearchQuery("")}
-                className="absolute end-3 top-1/2 -translate-y-1/2 text-body-medium hover:text-body"
+                className="text-body-medium hover:text-body absolute end-3 top-1/2 -translate-y-1/2"
               >
                 <X className="size-4" />
               </button>
@@ -200,8 +200,8 @@ const VideoGalleryFilter = ({
 
       {/* Active filter strip */}
       {hasActiveFilters && (
-        <div className="flex flex-wrap items-center gap-2 border-t border-border pt-4">
-          <span className="text-xs text-body-medium">
+        <div className="border-border flex flex-wrap items-center gap-2 border-t pt-4">
+          <span className="text-body-medium text-xs">
             {t("page-videos-filtering-by")}
           </span>
 
@@ -244,7 +244,7 @@ const VideoGalleryFilter = ({
           )}
 
           <Button
-            className="cursor-pointer p-0 text-xs text-primary underline"
+            className="text-primary cursor-pointer p-0 text-xs underline"
             variant="ghost"
             size="sm"
             onClick={handleClearAll}

--- a/src/components/CalloutBannerSSR.tsx
+++ b/src/components/CalloutBannerSSR.tsx
@@ -63,7 +63,7 @@ const CalloutBannerSSR = ({
           src={image}
           alt={alt}
           width={imageWidth}
-          className="-my-24 mx-auto object-contain max-lg:mb-0"
+          className="mx-auto -my-24 object-contain max-lg:mb-0"
         />
       </div>
     )}

--- a/src/components/Hero/HomeHero/index.tsx
+++ b/src/components/Hero/HomeHero/index.tsx
@@ -92,7 +92,7 @@ const HomeHero = async ({
           <LanguageMorpher />
 
           <div className="flex flex-col items-center gap-8">
-            <h1 className="max-w-[893px] text-balance text-5xl font-black leading-[1.1] md:text-6xl lg:text-7xl lg:leading-[0.9]">
+            <h1 className="max-w-[893px] text-5xl leading-[1.1] font-black text-balance md:text-6xl lg:text-7xl lg:leading-[0.9]">
               {t("page-index-hero-title")}
             </h1>
 

--- a/src/components/Homepage/FeatureCards.tsx
+++ b/src/components/Homepage/FeatureCards.tsx
@@ -32,19 +32,19 @@ const FeatureCards = async ({
   return (
     <Section
       className={cn(
-        "rounded-none bg-background-highlight py-20 lg:py-24",
+        "bg-background-highlight rounded-none py-20 lg:py-24",
         className
       )}
     >
       <div className="mx-auto max-w-7xl px-4">
         <div className="mb-16 flex flex-col items-center gap-4 text-center">
-          <SectionHeader className="mb-0 mt-0">
+          <SectionHeader className="mt-0 mb-0">
             {t("page-index-features-title")}{" "}
             <span className="text-body">
               {t("page-index-features-title-highlight")}
             </span>
           </SectionHeader>
-          <p className="max-w-xl text-lg text-body-medium">
+          <p className="text-body-medium max-w-xl text-lg">
             {t("page-index-features-subtitle")}
           </p>
         </div>
@@ -56,7 +56,7 @@ const FeatureCards = async ({
                 src={ownershipImage}
                 alt=""
                 sizes="(max-width: 1024px) 50vw, 600px"
-                className="absolute -bottom-16 -end-16 h-2/3 w-auto object-contain opacity-25"
+                className="absolute -end-16 -bottom-16 h-2/3 w-auto object-contain opacity-25"
               />
 
               <div className="relative z-10 flex flex-col gap-6">
@@ -91,19 +91,19 @@ const FeatureCards = async ({
               </div>
             </div>
 
-            <div className="relative overflow-hidden rounded-3xl border bg-background p-8 lg:col-span-5">
+            <div className="bg-background relative overflow-hidden rounded-3xl border p-8 lg:col-span-5">
               <Image
                 src={publicRulesImage}
                 alt=""
                 sizes="(max-width: 1024px) 50vw, 450px"
-                className="absolute -bottom-12 -end-24 h-2/3 w-auto object-contain"
+                className="absolute -end-24 -bottom-12 h-2/3 w-auto object-contain"
               />
 
               <div className="relative z-10">
                 <h3 className="mb-4 text-4xl font-black lg:text-5xl">
                   {t("page-index-features-public-rules-title")}
                 </h3>
-                <p className="max-w-xs text-body">
+                <p className="text-body max-w-xs">
                   {t("page-index-features-public-rules-description")}
                 </p>
               </div>
@@ -111,12 +111,12 @@ const FeatureCards = async ({
           </div>
 
           <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
-            <div className="relative overflow-hidden rounded-3xl border bg-background p-8">
+            <div className="bg-background relative overflow-hidden rounded-3xl border p-8">
               <Image
                 src={globalImage}
                 alt=""
                 sizes="(max-width: 768px) 50vw, (max-width: 1024px) 33vw, 300px"
-                className="absolute -bottom-6 -end-8 h-2/3 w-auto object-contain"
+                className="absolute -end-8 -bottom-6 h-2/3 w-auto object-contain"
               />
 
               <div className="relative z-10">
@@ -129,12 +129,12 @@ const FeatureCards = async ({
               </div>
             </div>
 
-            <div className="relative overflow-hidden rounded-3xl border bg-background p-8">
+            <div className="bg-background relative overflow-hidden rounded-3xl border p-8">
               <Image
                 src={freeAccessImage}
                 alt=""
                 sizes="(max-width: 768px) 50vw, (max-width: 1024px) 33vw, 300px"
-                className="absolute -bottom-6 -end-8 h-2/3 w-auto object-contain"
+                className="absolute -end-8 -bottom-6 h-2/3 w-auto object-contain"
               />
 
               <div className="relative z-10">
@@ -147,7 +147,7 @@ const FeatureCards = async ({
               </div>
             </div>
 
-            <div className="rounded-3xl border border-body p-8 md:col-span-2 lg:col-span-1">
+            <div className="border-body rounded-3xl border p-8 md:col-span-2 lg:col-span-1">
               <h3 className="mb-3 text-3xl font-black">
                 {t("page-index-features-nobody-owns-title")}
               </h3>

--- a/src/components/Homepage/GetStartedGrid.tsx
+++ b/src/components/Homepage/GetStartedGrid.tsx
@@ -87,12 +87,12 @@ const GetStartedGrid = async ({
 
   return (
     <Section id="get-started" className={cn("relative", className)}>
-      <div className="flex flex-col gap-12 rounded-t-4xl bg-radial-a px-4 pb-8 pt-20 md:px-8">
+      <div className="bg-radial-a flex flex-col gap-12 rounded-t-4xl px-4 pt-20 pb-8 md:px-8">
         <div className="flex flex-col items-center gap-2 text-center">
-          <SectionHeader className="mb-0 mt-0">
+          <SectionHeader className="mt-0 mb-0">
             {t("page-index-get-started-title")}
           </SectionHeader>
-          <p className="max-w-[42rem] text-lg text-body-medium lg:text-2xl">
+          <p className="text-body-medium max-w-[42rem] text-lg lg:text-2xl">
             {t("page-index-get-started-subtitle", { minutes })}
           </p>
         </div>
@@ -100,7 +100,7 @@ const GetStartedGrid = async ({
         <div className="mx-auto grid w-full max-w-[76rem] gap-8 md:grid-cols-2 lg:grid-cols-3">
           {cards.map((card) => (
             <LinkBox key={card.title} className="h-full">
-              <Card className="flex h-full flex-col overflow-hidden rounded-4xl border bg-background p-8 transition-colors hover:border-primary-hover">
+              <Card className="bg-background hover:border-primary-hover flex h-full flex-col overflow-hidden rounded-4xl border p-8 transition-colors">
                 <div className="mb-7 h-48 overflow-hidden rounded-[10px]">
                   <Image
                     src={card.image}
@@ -121,7 +121,7 @@ const GetStartedGrid = async ({
                       >
                         <card.icon className={cn("size-6", card.iconColor)} />
                       </div>
-                      <h3 className="text-2xl font-bold leading-8">
+                      <h3 className="text-2xl leading-8 font-bold">
                         {card.title}
                       </h3>
                     </div>
@@ -140,7 +140,7 @@ const GetStartedGrid = async ({
                               card.bulletColor
                             )}
                           />
-                          <span className="text-sm leading-5 text-body-medium">
+                          <span className="text-body-medium text-sm leading-5">
                             {bullet}
                           </span>
                         </li>

--- a/src/components/Homepage/KPISection.tsx
+++ b/src/components/Homepage/KPISection.tsx
@@ -163,32 +163,32 @@ const KPISection = ({
         <div className="flex flex-col gap-2">
           <SectionTag variant="plain">{t("page-index-kpi-tag")}</SectionTag>
 
-          <SectionHeader className="!mb-0 !mt-0">
+          <SectionHeader className="!mt-0 !mb-0">
             {t("page-index-kpi-title")}
           </SectionHeader>
         </div>
 
-        <p className="text-lg leading-relaxed text-body-medium lg:text-2xl lg:leading-[39px]">
+        <p className="text-body-medium text-lg leading-relaxed lg:text-2xl lg:leading-[39px]">
           {t("page-index-kpi-description")}
         </p>
       </div>
 
       <div className="flex flex-col gap-8 lg:flex-row lg:items-center lg:gap-20">
-        <div className="hidden h-[267px] w-px bg-border lg:block" />
+        <div className="bg-border hidden h-[267px] w-px lg:block" />
 
         <div className="flex w-[300px] flex-col gap-8">
           <div className="flex items-start gap-3">
             <User
-              className="mt-[5.5px] size-8 text-body-medium"
+              className="text-body-medium mt-[5.5px] size-8"
               strokeWidth={1.5}
             />
             <div className="flex flex-col gap-1">
-              <p className="text-4xl font-bold leading-[1.2]">
+              <p className="text-4xl leading-[1.2] font-bold">
                 {accountHolders !== null
                   ? formatCompactNumber(accountHolders, locale)
                   : "—"}
               </p>
-              <p className="text-base leading-[1.6] text-body-medium">
+              <p className="text-body-medium text-base leading-[1.6]">
                 {t("page-index-kpi-holders")}
               </p>
             </div>
@@ -196,7 +196,7 @@ const KPISection = ({
 
           <div className="flex items-start gap-3">
             <ArrowLeftRight
-              className="mt-[5.5px] size-8 text-body-medium"
+              className="text-body-medium mt-[5.5px] size-8"
               strokeWidth={1.5}
             />
             <div className="flex flex-col gap-1">
@@ -204,12 +204,12 @@ const KPISection = ({
                 <AnimatedNumber
                   value={liveTransactions}
                   formatter={formatTransactions}
-                  className="text-4xl font-bold leading-[1.2]"
+                  className="text-4xl leading-[1.2] font-bold"
                 />
               ) : (
-                <p className="text-4xl font-bold leading-[1.2]">—</p>
+                <p className="text-4xl leading-[1.2] font-bold">—</p>
               )}
-              <p className="text-base leading-[1.6] text-body-medium">
+              <p className="text-body-medium text-base leading-[1.6]">
                 {t("page-index-kpi-transactions")}
               </p>
             </div>

--- a/src/components/Homepage/PersonaModalCTA.tsx
+++ b/src/components/Homepage/PersonaModalCTA.tsx
@@ -125,7 +125,7 @@ const CategoryCard = ({
       >
         <Icon className={cn("size-4 md:size-8", iconColorClass)} />
       </div>
-      <p className="text-sm font-bold uppercase tracking-wider">{label}</p>
+      <p className="text-sm font-bold tracking-wider uppercase">{label}</p>
     </div>
 
     <div className="mt-auto flex flex-col gap-2 md:gap-4">
@@ -136,10 +136,10 @@ const CategoryCard = ({
             href={href}
             onClick={() => onLinkClick(eventName)}
             hideArrow
-            className="group flex items-center justify-between text-xl font-bold text-primary no-underline transition-colors hover:text-primary-hover md:text-3xl"
+            className="group text-primary hover:text-primary-hover flex items-center justify-between text-xl font-bold no-underline transition-colors md:text-3xl"
           >
             {linkLabel}
-            <ChevronNext className="size-5 text-primary transition-transform group-hover:translate-x-1" />
+            <ChevronNext className="text-primary size-5 transition-transform group-hover:translate-x-1" />
           </BaseLink>
         </div>
       ))}

--- a/src/components/Homepage/SavingsCarousel.tsx
+++ b/src/components/Homepage/SavingsCarousel.tsx
@@ -193,7 +193,7 @@ const ComparisonCard = ({
       <FloatingCard variant={variant}>
         <p
           className={cn(
-            "text-sm font-semibold uppercase tracking-wider",
+            "text-sm font-semibold tracking-wider uppercase",
             !isPrimary && "text-body-medium"
           )}
         >
@@ -250,12 +250,12 @@ const SlideContent = ({
       <SectionContent className="order-2 flex flex-col gap-6 md:order-1 md:max-w-[660px] md:gap-10">
         <div className="flex flex-col gap-2">
           <SectionTag variant="plain">{slide.tag}</SectionTag>
-          <SectionHeader className="!mb-0 !mt-0 md:text-6xl">
+          <SectionHeader className="!mt-0 !mb-0 md:text-6xl">
             {slide.title}
           </SectionHeader>
         </div>
 
-        <div className="flex flex-col gap-4 text-lg leading-relaxed text-body-medium md:gap-6 lg:text-2xl lg:leading-relaxed">
+        <div className="text-body-medium flex flex-col gap-4 text-lg leading-relaxed md:gap-6 lg:text-2xl lg:leading-relaxed">
           <p>{slide.subtitle}</p>
           <p>{slide.description}</p>
         </div>

--- a/src/components/Homepage/TrustLogos.tsx
+++ b/src/components/Homepage/TrustLogos.tsx
@@ -49,23 +49,23 @@ const TrustLogos = async ({
             />
           </div>
 
-          <FloatingCard className="absolute -left-4 top-8 z-10 shadow-lg md:top-12 lg:-left-8">
-            <p className="text-lg font-bold text-body md:text-xl lg:text-2xl">
+          <FloatingCard className="absolute top-8 -left-4 z-10 shadow-lg md:top-12 lg:-left-8">
+            <p className="text-body text-lg font-bold md:text-xl lg:text-2xl">
               {t("page-index-trust-never-offline")}
             </p>
             <div className="mt-1 flex items-center gap-1 md:mt-2">
-              <Check className="size-3 text-success md:size-4" />
-              <span className="text-xs font-semibold text-success md:text-sm">
+              <Check className="text-success size-3 md:size-4" />
+              <span className="text-success text-xs font-semibold md:text-sm">
                 {t("page-index-trust-uptime", { uptime })}
               </span>
             </div>
           </FloatingCard>
 
           <FloatingCard className="absolute -right-4 bottom-12 z-10 shadow-lg md:-right-6 lg:-right-12">
-            <p className="text-lg font-bold text-body md:text-xl lg:text-2xl">
+            <p className="text-body text-lg font-bold md:text-xl lg:text-2xl">
               {t("page-index-trust-years", { count })}
             </p>
-            <p className="mt-1 text-xs text-body-medium md:text-sm">
+            <p className="text-body-medium mt-1 text-xs md:text-sm">
               {t("page-index-trust-since")}
             </p>
           </FloatingCard>
@@ -75,12 +75,12 @@ const TrustLogos = async ({
       <SectionContent className="flex max-w-[660px] flex-1 flex-col gap-6 pt-8 md:gap-8 md:pt-0 lg:gap-10">
         <div className="flex flex-col gap-2">
           <SectionTag variant="plain">{t("page-index-trust-tag")}</SectionTag>
-          <SectionHeader className="!mb-0 !mt-0">
+          <SectionHeader className="!mt-0 !mb-0">
             {t("page-index-trust-title")}
           </SectionHeader>
         </div>
 
-        <div className="flex flex-col gap-6 text-lg leading-relaxed text-body-medium lg:text-2xl lg:leading-relaxed">
+        <div className="text-body-medium flex flex-col gap-6 text-lg leading-relaxed lg:text-2xl lg:leading-relaxed">
           <p>{t("page-index-trust-description-1")}</p>
           <p>{t("page-index-trust-description-2")}</p>
         </div>

--- a/src/components/Layer2NetworksTable/loading.tsx
+++ b/src/components/Layer2NetworksTable/loading.tsx
@@ -19,7 +19,7 @@ const NetworkRow = ({ idx }: { idx: number }) => (
 
 const Loading = () => (
   <div className="px-4">
-    <div className="flex flex-col gap-4 pb-6 pt-4 lg:flex-row lg:gap-6 2xl:px-0">
+    <div className="flex flex-col gap-4 pt-4 pb-6 lg:flex-row lg:gap-6 2xl:px-0">
       <div className="hidden w-80 flex-col gap-2 lg:flex">
         <div className="flex items-center justify-between border-b px-2 py-1.5">
           <Skeleton className="h-5 w-24" />

--- a/src/components/Nav/index.tsx
+++ b/src/components/Nav/index.tsx
@@ -19,7 +19,7 @@ const Nav = async () => {
   return (
     <>
       <nav
-        className="z-sticky bg-background h-19 sticky top-0 flex w-full max-w-screen-2xl items-center justify-between border-b p-4 md:items-stretch md:justify-normal xl:px-8"
+        className="z-sticky bg-background sticky top-0 flex h-19 w-full max-w-screen-2xl items-center justify-between border-b p-4 md:items-stretch md:justify-normal xl:px-8"
         aria-label={t("nav-primary")}
       >
         <BaseLink

--- a/src/components/Simulator/MoreInfoPopover.tsx
+++ b/src/components/Simulator/MoreInfoPopover.tsx
@@ -27,7 +27,7 @@ export const MoreInfoPopover = ({ isFirstStep, children }: MoreInfoPopover) => {
       <PopoverTrigger asChild>
         <MotionButton
           variant="ghost"
-          className="relative min-h-0 p-0 text-sm text-body-medium"
+          className="text-body-medium relative min-h-0 p-0 text-sm"
           onClick={() => setClicked(true)}
           data-testid="more-info-popover-trigger"
         >
@@ -37,7 +37,7 @@ export const MoreInfoPopover = ({ isFirstStep, children }: MoreInfoPopover) => {
         </MotionButton>
       </PopoverTrigger>
       <PopoverContent
-        className="relative start-4 w-[calc(100vw-3rem)] max-w-xs bg-background-highlight px-4 py-6 text-sm shadow-none sm:start-8 sm:w-[calc(100vw-5rem)]"
+        className="bg-background-highlight relative start-4 w-[calc(100vw-3rem)] max-w-xs px-4 py-6 text-sm shadow-none sm:start-8 sm:w-[calc(100vw-5rem)]"
         data-testid="more-info-popover-content"
       >
         <PopoverClose className="absolute end-2 top-1 ms-auto flex size-6 items-center justify-center text-xl leading-none">

--- a/src/components/Simulator/NotificationPopover.tsx
+++ b/src/components/Simulator/NotificationPopover.tsx
@@ -32,7 +32,7 @@ export const NotificationPopover = ({
         {...restProps}
       >
         <Flex className="gap-2">
-          <header className="mb-2 mt-0.5 flex-1 p-0 font-bold">
+          <header className="mt-0.5 mb-2 flex-1 p-0 font-bold">
             {title || ""}
           </header>
           <PopoverClose className="absolute end-2 top-1 ms-auto flex size-6 items-center justify-center text-xl leading-none">

--- a/src/components/Simulator/WalletHome/AddressPill.tsx
+++ b/src/components/Simulator/WalletHome/AddressPill.tsx
@@ -16,7 +16,7 @@ export const AddressPill = ({ ...btnProps }: AddressPillProps) => {
       content={t("sim-address-tooltip")}
     >
       <Flex
-        className="gap-2 self-center rounded-full border border-border bg-background-highlight px-2 py-1 text-center text-xs text-disabled"
+        className="border-border bg-background-highlight text-disabled gap-2 self-center rounded-full border px-2 py-1 text-center text-xs"
         {...btnProps}
       >
         <p>{FAKE_DEMO_ADDRESS}</p>

--- a/src/components/Simulator/WalletHome/SendReceiveButton.tsx
+++ b/src/components/Simulator/WalletHome/SendReceiveButton.tsx
@@ -37,19 +37,19 @@ export const SendReceiveButton = ({
     >
       <div
         className={cn(
-          "relative grid aspect-square w-10 place-items-center rounded-full bg-primary group-hover:bg-primary-hover md:w-16",
+          "bg-primary group-hover:bg-primary-hover relative grid aspect-square w-10 place-items-center rounded-full md:w-16",
           isHighlighted
             ? "group-disabled:bg-primary"
             : "group-disabled:bg-body-light"
         )}
       >
         {!isDisabled && isAnimated && <PulseAnimation type="circle" />}
-        <Icon className="size-4 text-background md:size-6" />
+        <Icon className="text-background size-4 md:size-6" />
       </div>
       <div className="relative">
         <p
           className={cn(
-            "relative text-center font-bold text-primary group-hover:text-primary-hover",
+            "text-primary group-hover:text-primary-hover relative text-center font-bold",
             isHighlighted
               ? "group-disabled:text-primary"
               : "group-disabled:text-body-medium"

--- a/src/components/Simulator/WalletHome/WalletBalance.tsx
+++ b/src/components/Simulator/WalletHome/WalletBalance.tsx
@@ -15,10 +15,10 @@ export const WalletBalance = ({ usdAmount = 0 }: WalletBalanceProps) => {
   const t = useTranslations("component-wallet-simulator")
   return (
     <div className="z-[1]">
-      <p className="mb-2 text-center text-body-medium md:mb-4">
+      <p className="text-body-medium mb-2 text-center md:mb-4">
         {t("sim-your-total")}
       </p>
-      <p className="text-center text-3xl font-bold !leading-base md:text-5xl">
+      <p className="!leading-base text-center text-3xl font-bold md:text-5xl">
         {formatWalletUsd(usdAmount)}
       </p>
       <Flex className="mb-4 justify-center">

--- a/src/components/Simulator/screens/ConnectWeb3/index.tsx
+++ b/src/components/Simulator/screens/ConnectWeb3/index.tsx
@@ -134,7 +134,7 @@ export const ConnectWeb3 = ({ nav, ctaLabel }: PhoneScreenProps) => {
                   side="top"
                 >
                   <Flex className="flex-col items-start gap-1 text-start text-xs sm:text-sm">
-                    <p className="mb-auto ms-2 text-md font-bold">
+                    <p className="text-md ms-2 mb-auto font-bold">
                       {t("sim-cw-nft-title")}
                     </p>
                     <Button variant="link" disabled>
@@ -157,7 +157,7 @@ export const ConnectWeb3 = ({ nav, ctaLabel }: PhoneScreenProps) => {
                 content={t("sim-try-real-app")}
                 side="top"
               >
-                <div className="text-sm md:text-md">
+                <div className="md:text-md text-sm">
                   <Button className="block" variant="link" disabled>
                     {t("sim-cw-browse-artwork")}
                   </Button>

--- a/src/components/Simulator/screens/CreateAccount/InitialWordDisplay.tsx
+++ b/src/components/Simulator/screens/CreateAccount/InitialWordDisplay.tsx
@@ -11,7 +11,7 @@ export const InitialWordDisplay = ({ words }: InitialWordDisplayProps) => {
   return (
     <div className="bg-background-highlight">
       <div className="py-8">
-        <p className="px-4 text-xl font-bold leading-8 md:mb-6 md:px-8 md:text-2xl">
+        <p className="px-4 text-xl leading-8 font-bold md:mb-6 md:px-8 md:text-2xl">
           {t("sim-ca-recovery-example")}
         </p>
       </div>

--- a/src/components/Simulator/screens/CreateAccount/InteractiveWordSelector.tsx
+++ b/src/components/Simulator/screens/CreateAccount/InteractiveWordSelector.tsx
@@ -22,7 +22,7 @@ export const InteractiveWordSelector = ({
   const [wordsSelected, setWordsSelected] = useState(0)
   return (
     <div className="mt-8">
-      <p className="mb-4 px-4 text-2xl font-bold leading-8 max-md:hidden md:px-8">
+      <p className="mb-4 px-4 text-2xl leading-8 font-bold max-md:hidden md:px-8">
         {t("sim-ca-repeat-words")}
       </p>
       <WordList words={words} wordsSelected={wordsSelected} />

--- a/src/components/Simulator/screens/CreateAccount/RecoveryPhraseNotice.tsx
+++ b/src/components/Simulator/screens/CreateAccount/RecoveryPhraseNotice.tsx
@@ -6,12 +6,12 @@ export const RecoveryPhraseNotice = () => {
 
   return (
     <motion.div
-      className="h-full bg-background-highlight px-4 py-8 text-sm md:px-8 md:text-md [&_p]:mb-4 [&_p]:md:mb-6"
+      className="bg-background-highlight md:text-md h-full px-4 py-8 text-sm md:px-8 [&_p]:mb-4 [&_p]:md:mb-6"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.25 }}
     >
-      <p className="text-xl font-bold leading-8 md:text-2xl">
+      <p className="text-xl leading-8 font-bold md:text-2xl">
         {t("sim-ca-recovery-title")}
       </p>
       <p>

--- a/src/components/Simulator/screens/CreateAccount/WelcomeScreen.tsx
+++ b/src/components/Simulator/screens/CreateAccount/WelcomeScreen.tsx
@@ -12,12 +12,12 @@ export const WelcomeScreen = () => {
 
   return (
     <MotionFlex
-      className="h-full flex-col items-center bg-background-highlight pt-16"
+      className="bg-background-highlight h-full flex-col items-center pt-16"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.8 }}
     >
-      <EthGlyphIcon className="my-4 h-[110px] w-auto text-body md:h-[190px]" />
+      <EthGlyphIcon className="text-body my-4 h-[110px] w-auto md:h-[190px]" />
       <p className="px-4 text-center text-2xl leading-8 md:px-8">
         {t("sim-ca-welcome-to")}
         <span className="block font-bold">{t("sim-ca-wallet-simulator")}</span>

--- a/src/components/Simulator/screens/SendReceive/ReceiveEther.tsx
+++ b/src/components/Simulator/screens/SendReceive/ReceiveEther.tsx
@@ -19,7 +19,7 @@ export const ReceiveEther = () => {
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
       transition={{ duration: 0.25 }}
-      className="h-full bg-background-highlight px-4 py-6 text-sm md:px-6 md:py-8 md:text-md"
+      className="bg-background-highlight md:text-md h-full px-4 py-6 text-sm md:px-6 md:py-8"
     >
       <p className="mb-3 text-xl font-bold md:mb-6 md:text-2xl">
         {t("sim-receive-title")}
@@ -31,19 +31,19 @@ export const ReceiveEther = () => {
         content={t("sim-receive-qr-share")}
         side="top"
       >
-        <div className="relative mx-auto mb-3 w-fit bg-background p-3 md:mb-5">
+        <div className="bg-background relative mx-auto mb-3 w-fit p-3 md:mb-5">
           <Image
             alt=""
             src={QrImage}
             className="size-[6rem] rounded p-1 md:size-[7.5rem] dark:invert"
           />
-          <div className="absolute left-1/2 top-1/2 size-10 -translate-x-1/2 -translate-y-1/2 transform rounded-full bg-primary-action" />
-          <EthGlyph className="absolute left-1/2 top-1/2 size-6 -translate-x-1/2 -translate-y-1/2 transform text-white" />
+          <div className="bg-primary-action absolute top-1/2 left-1/2 size-10 -translate-x-1/2 -translate-y-1/2 transform rounded-full" />
+          <EthGlyph className="absolute top-1/2 left-1/2 size-6 -translate-x-1/2 -translate-y-1/2 transform text-white" />
         </div>
       </NotificationPopover>
       <Flex className="relative mb-3 w-full items-center justify-between gap-2 rounded border px-3 py-2 md:mb-5">
         <div>
-          <p className="m-0 text-xs text-body-medium">
+          <p className="text-body-medium m-0 text-xs">
             {t("sim-receive-your-address")}
           </p>
           <p className="m-0 text-sm">{FAKE_DEMO_ADDRESS}</p>
@@ -54,7 +54,7 @@ export const ReceiveEther = () => {
           side="top"
           align="end"
         >
-          <Button className="h-fit rounded-lg bg-body-light px-2 py-1.5 text-xs font-bold text-body">
+          <Button className="bg-body-light text-body h-fit rounded-lg px-2 py-1.5 text-xs font-bold">
             {t("sim-receive-copy")}
           </Button>
         </NotificationPopover>

--- a/src/components/Simulator/screens/SendReceive/SendEther.tsx
+++ b/src/components/Simulator/screens/SendReceive/SendEther.tsx
@@ -56,7 +56,7 @@ export const SendEther = ({
         </p>
         <p className="md:mb-6">{t("sim-send-how-much")}</p>
       </div>
-      <Flex className="justify-between gap-4 border-y border-background-highlight px-6 py-4 text-xs text-body-medium md:py-6">
+      <Flex className="border-background-highlight text-body-medium justify-between gap-4 border-y px-6 py-4 text-xs md:py-6">
         {/* Left side: Displayed send amount */}
         <NotificationPopover
           title={t("sim-example-walkthrough")}
@@ -82,21 +82,21 @@ export const SendEther = ({
             content={t("sim-send-eth-only-note")}
           >
             {/* Token selector pill */}
-            <HStack className="mb-4 gap-0 rounded-full bg-body-light px-2 py-1">
+            <HStack className="bg-body-light mb-4 gap-0 rounded-full px-2 py-1">
               {/* TODO: remove flags and `size` class when icon is migrated */}
               <EthTokenIcon className="!me-1.5 !size-[1em] !text-xl" />
-              <p className="m-0 font-bold text-body">ETH</p>
+              <p className="text-body m-0 font-bold">ETH</p>
             </HStack>
           </NotificationPopover>
           {/* Balances */}
-          <p className="font-bold leading-none">
+          <p className="leading-none font-bold">
             {t("sim-send-balance", { amount: usdAmount })}
           </p>
           <p dir="ltr">{ethAmount} ETH</p>
         </Flex>
       </Flex>
-      <div className="h-full bg-background-highlight">
-        <Flex className="relative flex-nowrap justify-between bg-background-highlight p-6 font-bold">
+      <div className="bg-background-highlight h-full">
+        <Flex className="bg-background-highlight relative flex-nowrap justify-between p-6 font-bold">
           {/* Amount buttons */}
           {AMOUNTS.map((amount, i) => (
             <Button

--- a/src/components/Simulator/screens/SendReceive/SendFromContacts.tsx
+++ b/src/components/Simulator/screens/SendReceive/SendFromContacts.tsx
@@ -36,7 +36,7 @@ export const SendFromContacts = ({
         >
           <Button
             variant="outline"
-            className="w-full cursor-auto border-disabled py-4 text-disabled hover:!text-disabled hover:shadow-none"
+            className="border-disabled text-disabled hover:!text-disabled w-full cursor-auto py-4 hover:shadow-none"
           >
             <Search />
             <span className="me-auto">{t("sim-contacts-search")}</span>
@@ -44,7 +44,7 @@ export const SendFromContacts = ({
           </Button>
         </NotificationPopover>
       </div>
-      <div className="h-full bg-background-highlight px-6 py-8">
+      <div className="bg-background-highlight h-full px-6 py-8">
         <CategoryTabs
           categories={[t("sim-contacts-my-contacts"), t("sim-contacts-recent")]}
           activeIndex={1}
@@ -55,13 +55,13 @@ export const SendFromContacts = ({
             <Button
               key={name + i}
               disabled={i > 0}
-              className="group gap-2 disabled:bg-background disabled:text-body hover:[&_path]:fill-primary-hover"
+              className="group disabled:bg-background disabled:text-body hover:[&_path]:fill-primary-hover gap-2"
               onClick={() => handleSelection(name)}
             >
-              <EthTokenIcon className="[&_circle]:fill-white [&_path]:fill-primary-action" />
+              <EthTokenIcon className="[&_path]:fill-primary-action [&_circle]:fill-white" />
               <span className="flex-1">
                 <span className="block text-start font-bold">{name}</span>
-                <span className="block text-start text-sm text-white group-disabled:text-body-medium">
+                <span className="group-disabled:text-body-medium block text-start text-sm text-white">
                   {t("sim-contact-last-action")}
                 </span>
               </span>

--- a/src/components/Simulator/screens/SendReceive/SendSummary.tsx
+++ b/src/components/Simulator/screens/SendReceive/SendSummary.tsx
@@ -43,12 +43,12 @@ export const SendSummary = ({
             {formatChosenAmount}
           </p>
         </Flex>
-        <p dir="ltr" className="text-xs text-body-medium">
+        <p dir="ltr" className="text-body-medium text-xs">
           {formatWalletToken(chosenAmount / ethPrice, locale)} ETH
         </p>
       </div>
       {/* Bottom section */}
-      <Flex className="h-full flex-col gap-3 bg-background-highlight px-6 py-4 text-sm md:gap-6 md:py-8 md:text-md">
+      <Flex className="bg-background-highlight md:text-md h-full flex-col gap-3 px-6 py-4 text-sm md:gap-6 md:py-8">
         <div>
           <p>{t("sim-summary-to")}</p>
           <p className="font-bold">{recipient}</p>
@@ -61,7 +61,7 @@ export const SendSummary = ({
           <p>{t("sim-summary-fees")}</p>
           <p className="font-bold">
             {formatWalletUsd(usdFee)}
-            <span className="ms-2 text-xs font-normal text-body-medium">
+            <span className="text-body-medium ms-2 text-xs font-normal">
               (
               {formatWalletToken(ethTransferFee, locale, {
                 maximumFractionDigits: 6,

--- a/src/components/Staking/StakingProductsCardGrid/StakingProductCard.tsx
+++ b/src/components/Staking/StakingProductsCardGrid/StakingProductCard.tsx
@@ -160,13 +160,13 @@ export const StakingProductCard = ({
   ].filter(({ status }) => !!status)
 
   return (
-    <div className="rounded-base hover:scale-101 flex flex-col bg-background-highlight transition-transform">
+    <div className="rounded-base bg-background-highlight flex flex-col transition-transform hover:scale-101">
       <div className="flex max-h-24 space-x-3 p-6">
         {!!Svg && <Svg className="size-12" />}
         <div className="flex flex-col justify-center">
           <h4 className="text-xl">{name}</h4>
           {typeof minEth !== "undefined" && (
-            <p className="text-sm font-normal text-body-medium">
+            <p className="text-body-medium text-sm font-normal">
               {minEth > 0 ? (
                 <>
                   {t("common:from")} <span dir="ltr">{minEth} ETH</span>
@@ -178,7 +178,7 @@ export const StakingProductCard = ({
           )}
         </div>
       </div>
-      <div className="min-h-75 flex flex-wrap items-start gap-1 p-6 pt-0">
+      <div className="flex min-h-75 flex-wrap items-start gap-1 p-6 pt-0">
         {platforms.map((platform, idx) => (
           <StakingBadge type="platform" key={idx}>
             {platform}
@@ -195,7 +195,7 @@ export const StakingProductCard = ({
           {data.map(({ label, status }, idx) => (
             <li
               key={idx}
-              className={`my-4 me-0 ms-auto flex items-center gap-1 text-base/none ${status === "false" && "text-body-medium"}`}
+              className={`my-4 ms-auto me-0 flex items-center gap-1 text-base/none ${status === "false" && "text-body-medium"}`}
             >
               <Status status={status} />
               {label}
@@ -215,7 +215,7 @@ export const StakingProductCard = ({
         </ButtonLink>
         <div className="flex h-7.5 items-center justify-center">
           {validSocials.length > 0 && (
-            <p className="me-2 text-body-medium">
+            <p className="text-body-medium me-2">
               {t("page-staking-products-follow")}
             </p>
           )}
@@ -223,7 +223,7 @@ export const StakingProductCard = ({
           {validSocials.map(([platform, url], idx) => (
             <Link key={idx} href={url} hideArrow>
               <SocialListItem
-                className="size-8 text-body [&>svg]:text-body"
+                className="text-body [&>svg]:text-body size-8"
                 socialIcon={
                   platform as
                     | "twitter"

--- a/src/components/Videos/VideoWatch/index.tsx
+++ b/src/components/Videos/VideoWatch/index.tsx
@@ -43,7 +43,7 @@ const VideoWatch = async ({ slug, startTime, className }: VideoWatchProps) => {
   return (
     <Card
       className={cn(
-        "my-8 max-w-xl space-y-4 border bg-background-highlight p-4 md:p-6",
+        "bg-background-highlight my-8 max-w-xl space-y-4 border p-4 md:p-6",
         className
       )}
     >

--- a/src/data/WalletSimulatorData.tsx
+++ b/src/data/WalletSimulatorData.tsx
@@ -82,7 +82,7 @@ export function useWalletOnboardingSimData(): SimulatorData {
             <>
               <Stack>
                 <p className="font-bold">{t("sim-ca-desc-6-small-title")}</p>
-                <UnorderedList className="leading-1 ms-0 list-none">
+                <UnorderedList className="ms-0 list-none leading-1">
                   <ListItem>
                     <Emoji text="✅" className="me-2" />{" "}
                     {t("sim-ca-desc-6-small-1")}
@@ -93,7 +93,7 @@ export function useWalletOnboardingSimData(): SimulatorData {
                 <p className="font-bold">
                   {t("sim-ca-desc-6-significant-title")}
                 </p>
-                <UnorderedList className="leading-1 ms-0 list-none">
+                <UnorderedList className="ms-0 list-none leading-1">
                   <ListItem>
                     <Emoji text="✅" className="me-2" />{" "}
                     {t("sim-ca-desc-6-significant-1")}
@@ -106,7 +106,7 @@ export function useWalletOnboardingSimData(): SimulatorData {
               </Stack>
               <Stack>
                 <p className="font-bold">{t("sim-ca-desc-6-unsafe-title")}</p>
-                <UnorderedList className="leading-1 ms-0 list-none">
+                <UnorderedList className="ms-0 list-none leading-1">
                   <ListItem>
                     <Emoji text="❌" className="me-2" />
                     {t("sim-ca-desc-6-unsafe-1")}


### PR DESCRIPTION
## Summary
- Ran `pnpm format` across the codebase to apply Prettier formatting
- Changes are purely Tailwind class reordering from `prettier-plugin-tailwindcss`
- No behavioral or logic changes

## Test plan
- [x] CI passes (lint, typecheck, build)
- [x] Visual spot-check of affected components (homepage, events, simulator, videos)