### PR TITLE
fix: replace dead media.consensys.net links in English docs

### DIFF
--- a/public/content/developers/docs/programming-languages/golang/index.md
+++ b/public/content/developers/docs/programming-languages/golang/index.md
@@ -81,4 +81,4 @@ Looking for more resources? Check out [ethereum.org/developers](/developers/)
 ## Other aggregated lists {#other-aggregated-lists}
 
 - [Awesome Ethereum](https://github.com/btomashvili/awesome-ethereum)
-- [Consensys: A Definitive List of Ethereum Developer Tools](https://media.consensys.net/an-definitive-list-of-ethereum-developer-tools-2159ce865974) | [GitHub source](https://github.com/ConsenSys/ethereum-developer-tools-list)
+- [Consensys: A Definitive List of Ethereum Developer Tools](https://web.archive.org/web/2023/https://media.consensys.net/an-definitive-list-of-ethereum-developer-tools-2159ce865974) | [GitHub source](https://github.com/ConsenSys/ethereum-developer-tools-list)

--- a/public/content/developers/docs/smart-contracts/formal-verification/index.md
+++ b/public/content/developers/docs/smart-contracts/formal-verification/index.md
@@ -277,7 +277,7 @@ Also, it is not always possible for program verifiers to determine if a property
 ## Further reading {#further-reading}
 
 - [How Formal Verification of Smart Contracts Works](https://runtimeverification.com/blog/how-formal-verification-of-smart-contracts-works/)
-- [How Formal Verification Can Ensure Flawless Smart Contracts](https://media.consensys.net/how-formal-verification-can-ensure-flawless-smart-contracts-cbda8ad99bd1)
+- [How Formal Verification Can Ensure Flawless Smart Contracts](https://web.archive.org/web/2023/https://media.consensys.net/how-formal-verification-can-ensure-flawless-smart-contracts-cbda8ad99bd1)
 - [An Overview of Formal Verification Projects in the Ethereum Ecosystem](https://github.com/leonardoalt/ethereum_formal_verification_overview)
 - [End-to-End Formal Verification of Ethereum 2.0 Deposit Smart Contract](https://runtimeverification.com/blog/end-to-end-formal-verification-of-ethereum-2-0-deposit-smart-contract/)
 - [Formally Verifying The World's Most Popular Smart Contract](https://www.zellic.io/blog/formal-verification-weth)

--- a/public/content/developers/docs/smart-contracts/formal-verification/index.md
+++ b/public/content/developers/docs/smart-contracts/formal-verification/index.md
@@ -277,7 +277,6 @@ Also, it is not always possible for program verifiers to determine if a property
 ## Further reading {#further-reading}
 
 - [How Formal Verification of Smart Contracts Works](https://runtimeverification.com/blog/how-formal-verification-of-smart-contracts-works/)
-- [How Formal Verification Can Ensure Flawless Smart Contracts](https://web.archive.org/web/2023/https://media.consensys.net/how-formal-verification-can-ensure-flawless-smart-contracts-cbda8ad99bd1)
 - [An Overview of Formal Verification Projects in the Ethereum Ecosystem](https://github.com/leonardoalt/ethereum_formal_verification_overview)
 - [End-to-End Formal Verification of Ethereum 2.0 Deposit Smart Contract](https://runtimeverification.com/blog/end-to-end-formal-verification-of-ethereum-2-0-deposit-smart-contract/)
 - [Formally Verifying The World's Most Popular Smart Contract](https://www.zellic.io/blog/formal-verification-weth)

--- a/public/content/developers/tutorials/erc-721-vyper-annotated-code/index.md
+++ b/public/content/developers/tutorials/erc-721-vyper-annotated-code/index.md
@@ -97,7 +97,7 @@ This function is a `view`, which means it can read the state of the blockchain, 
 
 ### Events {#events}
 
-[Events](https://ethereum.org/en/developers/docs/smart-contracts/anatomy/#events-and-logs)
+[Events](/developers/docs/smart-contracts/anatomy/#events-and-logs)
 are emitted to inform users and servers outside of the blockchain of events. Note that the content of events
 is not available to contracts on the blockchain.
 

--- a/public/content/developers/tutorials/erc-721-vyper-annotated-code/index.md
+++ b/public/content/developers/tutorials/erc-721-vyper-annotated-code/index.md
@@ -97,7 +97,7 @@ This function is a `view`, which means it can read the state of the blockchain, 
 
 ### Events {#events}
 
-[Events](https://media.consensys.net/technical-introduction-to-events-and-logs-in-ethereum-a074d65dd61e)
+[Events](https://ethereum.org/en/developers/docs/smart-contracts/anatomy/#events-and-logs)
 are emitted to inform users and servers outside of the blockchain of events. Note that the content of events
 is not available to contracts on the blockchain.
 


### PR DESCRIPTION
## Description

The media.consensys.net domain no longer resolves (DNS lookup fails), causing 3 broken links in the English documentation.

## Changes

- developers/tutorials/erc-721-vyper-annotated-code/index.md` — Replaced dead events/logs link with ethereum.org equivalent
- `developers/docs/smart-contracts/formal-verification/index.md` — Replaced dead article link with Wayback Machine archived version
- `developers/docs/programming-languages/golang/index.md` — Replaced dead developer tools link with Wayback Machine archived version

Only English files are updated. Translation files are not modified.
