### PR TITLE
chore: re-run prettier format with tailwindStylesheet config

### DIFF
--- a/app/[locale]/10years/_components/AdoptionSwiper/loading.tsx
+++ b/app/[locale]/10years/_components/AdoptionSwiper/loading.tsx
@@ -2,7 +2,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 
 const Loading = () => (
   <div className="flex w-full flex-col items-center gap-6 md:hidden">
-    <div className="bg-card-gradient-secondary flex w-full max-w-[550px] flex-col gap-6 rounded-2xl p-4 sm:p-6 xl:max-w-[700px]">
+    <div className="flex w-full max-w-[550px] flex-col gap-6 rounded-2xl bg-card-gradient-secondary p-4 sm:p-6 xl:max-w-[700px]">
       <Skeleton className="mx-auto size-36 rounded-4xl" />
       <Skeleton className="h-8 w-1/2" />
       <div className="space-y-1">

--- a/app/[locale]/10years/_components/InnovationSwiper/index.tsx
+++ b/app/[locale]/10years/_components/InnovationSwiper/index.tsx
@@ -24,7 +24,7 @@ const InnovationSwiper = ({ innovationCards }: InnovationSwiperProps) => (
           ({ image, title, date, description1, description2 }, index) => (
             <SwiperSlide
               key={index}
-              className="bg-card-gradient-secondary mx-auto flex w-full max-w-[550px] flex-col gap-4 rounded-lg p-4 sm:p-6 xl:max-w-[700px]"
+              className="mx-auto flex w-full max-w-[550px] flex-col gap-4 rounded-lg bg-card-gradient-secondary p-4 sm:p-6 xl:max-w-[700px]"
             >
               <Image
                 src={image}

--- a/app/[locale]/10years/_components/InnovationSwiper/loading.tsx
+++ b/app/[locale]/10years/_components/InnovationSwiper/loading.tsx
@@ -2,7 +2,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 
 const Loading = () => (
   <div className="flex w-full flex-col items-center gap-6">
-    <div className="bg-card-gradient-secondary flex w-full max-w-[550px] flex-col gap-6 rounded-lg p-4 sm:p-6 xl:max-w-[700px]">
+    <div className="flex w-full max-w-[550px] flex-col gap-6 rounded-lg bg-card-gradient-secondary p-4 sm:p-6 xl:max-w-[700px]">
       <Skeleton className="mx-auto size-48 rounded-4xl" />
       <Skeleton className="h-8 w-1/2" />
       <Skeleton className="h-5 w-1/4" />

--- a/app/[locale]/10years/_components/NFTMintCard/index.tsx
+++ b/app/[locale]/10years/_components/NFTMintCard/index.tsx
@@ -47,7 +47,7 @@ const NFTMintCard = ({ className }: NFTMintCardProps) => {
           {/* Curved text */}
           <Curved10YearsText
             viewBox="0 0 313 186"
-            className="fill-primary absolute top-0 left-1/2 h-min w-full max-w-[300px] -translate-x-1/2"
+            className="absolute top-0 left-1/2 h-min w-full max-w-[300px] -translate-x-1/2 fill-primary"
             width="100%"
             height="auto"
           />

--- a/app/[locale]/10years/_components/TenYearHero.tsx
+++ b/app/[locale]/10years/_components/TenYearHero.tsx
@@ -51,7 +51,7 @@ const TenYearHero = async () => {
           >
             {WORDS[0]}
           </span>
-          <span className="text-accent-b text-3xl font-bold md:absolute md:start-0 md:text-nowrap">
+          <span className="text-3xl font-bold text-accent-b md:absolute md:start-0 md:text-nowrap">
             {/* CLIENT SIDE, lazy loaded */}
             <Morpher words={WORDS} charSet="abcdfgijklnopqsvwxyz" />
           </span>

--- a/app/[locale]/10years/_components/TorchHistoryCard.tsx
+++ b/app/[locale]/10years/_components/TorchHistoryCard.tsx
@@ -41,7 +41,7 @@ const TorchHistoryCard: React.FC<TorchHistoryCardProps> = ({
   return (
     <Card
       className={cn(
-        "dark:text-body-inverse flex flex-col rounded-xl border border-gray-100/50 bg-linear-to-b from-white to-gray-100 px-6 py-12 shadow-lg",
+        "flex flex-col rounded-xl border border-gray-100/50 bg-linear-to-b from-white to-gray-100 px-6 py-12 shadow-lg dark:text-body-inverse",
         isCurrentHolder && "bg-linear-to-b from-[#B38DF0] to-[#DED4ED]",
         isPlaceholder && "bg-linear-to-b from-gray-100 to-gray-200 opacity-50",
         className

--- a/app/[locale]/10years/_components/UserStories/index.tsx
+++ b/app/[locale]/10years/_components/UserStories/index.tsx
@@ -52,7 +52,7 @@ const Stories = ({ stories }: StoriesProps) => {
           <div
             key={story.name}
             className={cn(
-              "bg-background relative w-full rounded-2xl border p-6 transition-all duration-500",
+              "relative w-full rounded-2xl border bg-background p-6 transition-all duration-500",
               story.storyOriginal && "cursor-pointer"
             )}
           >
@@ -69,14 +69,14 @@ const Stories = ({ stories }: StoriesProps) => {
                   <div className="flex flex-col gap-2">
                     <div className="mb-4 flex flex-row items-center justify-between">
                       <div className="flex flex-row items-center gap-2">
-                        <div className="bg-primary-hover flex h-8 w-8 items-center justify-center rounded-full">
+                        <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary-hover">
                           <p aria-hidden className="font-bold">
                             {story.name?.slice(0, 1) || "?"}
                           </p>
                         </div>
                         <div className="">
                           <p className="text-md font-bold">{story.name}</p>
-                          <p className="text-body-medium text-sm">
+                          <p className="text-sm text-body-medium">
                             {story.country}
                           </p>
                         </div>
@@ -89,7 +89,7 @@ const Stories = ({ stories }: StoriesProps) => {
                             hideArrow
                             className="text-sm"
                           >
-                            <Twitter className="text-body text-xl" />
+                            <Twitter className="text-xl text-body" />
                           </ButtonLink>
                         </div>
                       )}
@@ -122,7 +122,7 @@ const Stories = ({ stories }: StoriesProps) => {
                     </div>
                     {story.storyOriginal && (
                       <div>
-                        <p className="text-body-medium text-xs">
+                        <p className="text-xs text-body-medium">
                           {t("page-10-year-stories-english-translation")}
                         </p>
                         <Button
@@ -139,7 +139,7 @@ const Stories = ({ stories }: StoriesProps) => {
                         </Button>
                       </div>
                     )}
-                    <p className="text-body-medium mt-2 text-sm">
+                    <p className="mt-2 text-sm text-body-medium">
                       {story.date}
                     </p>
                   </div>
@@ -148,14 +148,14 @@ const Stories = ({ stories }: StoriesProps) => {
                   <div className="flex flex-col gap-2">
                     <div className="mb-4 flex flex-row items-center justify-between">
                       <div className="flex flex-row items-center gap-2">
-                        <div className="bg-primary-hover flex h-8 w-8 items-center justify-center rounded-full">
+                        <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary-hover">
                           <p aria-hidden className="font-bold">
                             {story.name?.slice(0, 1) || "?"}
                           </p>
                         </div>
                         <div className="">
                           <p className="text-md font-bold">{story.name}</p>
-                          <p className="text-body-medium text-sm">
+                          <p className="text-sm text-body-medium">
                             {story.country}
                           </p>
                         </div>
@@ -168,7 +168,7 @@ const Stories = ({ stories }: StoriesProps) => {
                             hideArrow
                             className="text-sm"
                           >
-                            <Twitter className="text-body h-5 w-5" />
+                            <Twitter className="h-5 w-5 text-body" />
                           </ButtonLink>
                         </div>
                       )}
@@ -200,7 +200,7 @@ const Stories = ({ stories }: StoriesProps) => {
                       )}
                     </div>
                     <div>
-                      <p className="text-body-medium text-xs">
+                      <p className="text-xs text-body-medium">
                         {t("page-10-year-stories-original-language")}
                       </p>
                       <Button
@@ -216,7 +216,7 @@ const Stories = ({ stories }: StoriesProps) => {
                         {t("page-10-year-stories-show-english")}
                       </Button>
                     </div>
-                    <p className="text-body-medium mt-2 text-sm">
+                    <p className="mt-2 text-sm text-body-medium">
                       {story.date}
                     </p>
                   </div>

--- a/app/[locale]/10years/_components/UserStories/loading.tsx
+++ b/app/[locale]/10years/_components/UserStories/loading.tsx
@@ -5,7 +5,7 @@ const Loading = () => (
     {Array.from({ length: 3 }).map((_, idx) => (
       <div
         key={idx}
-        className="bg-background w-full space-y-8 rounded-2xl border p-6"
+        className="w-full space-y-8 rounded-2xl border bg-background p-6"
       >
         <div className="flex items-center gap-2 py-1">
           <Skeleton className="size-8 rounded-full" />

--- a/app/[locale]/10years/page.tsx
+++ b/app/[locale]/10years/page.tsx
@@ -96,7 +96,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
         </div>
 
         <div className="w-full px-4 py-8 md:px-8">
-          <div className="bg-radial-a flex flex-col items-center gap-4 rounded-4xl px-4 pt-8 lg:px-14 lg:pt-14">
+          <div className="flex flex-col items-center gap-4 rounded-4xl bg-radial-a px-4 pt-8 lg:px-14 lg:pt-14">
             <div className="flex flex-col gap-4 text-center">
               <h2 className="text-4xl font-black">
                 {t("page-10-year-livestream-title")}
@@ -117,12 +117,12 @@ const Page = async (props: { params: Promise<PageParams> }) => {
               defaultValue={Object.keys(tenYearEventRegions)[0]}
               className="w-full"
             >
-              <TabsList className="border-b-primary w-full flex-nowrap justify-start overflow-x-auto overflow-y-hidden rounded-none border-b-2 p-0">
+              <TabsList className="w-full flex-nowrap justify-start overflow-x-auto overflow-y-hidden rounded-none border-b-2 border-b-primary p-0">
                 {Object.entries(tenYearEventRegions).map(([key, data]) => (
                   <TabsTrigger
                     key={key}
                     value={key}
-                    className="text-primary border-0 whitespace-nowrap"
+                    className="border-0 whitespace-nowrap text-primary"
                   >
                     {data.label}&nbsp;
                     <span className="text-sm">({data.events.length})</span>
@@ -157,8 +157,8 @@ const Page = async (props: { params: Promise<PageParams> }) => {
                             key={country}
                             className={cn("flex flex-col border-b px-4 py-6")}
                           >
-                            <h3 className="text-body-medium mb-2 flex items-center gap-2 text-2xl font-bold">
-                              <span className="bg-primary-low-contrast flex min-h-6 min-w-6 items-center justify-center overflow-hidden rounded-full">
+                            <h3 className="mb-2 flex items-center gap-2 text-2xl font-bold text-body-medium">
+                              <span className="flex min-h-6 min-w-6 items-center justify-center overflow-hidden rounded-full bg-primary-low-contrast">
                                 <Emoji
                                   text={countryEvents[0].countryFlag}
                                   className="scale-[1.75]"
@@ -170,7 +170,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
                               {countryEvents.map((event, index) => (
                                 <LinkBox
                                   key={index}
-                                  className="hover:bg-background-highlight flex flex-col justify-between gap-2 rounded-lg p-2 md:flex-row"
+                                  className="flex flex-col justify-between gap-2 rounded-lg p-2 hover:bg-background-highlight md:flex-row"
                                 >
                                   <div className="flex flex-col gap-2 md:flex-row md:items-center">
                                     <div>
@@ -239,7 +239,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
 
           <TorchHistorySwiper holders={torchHolders} />
 
-          <div className="text-body-inverse dark:text-body flex flex-col gap-12 px-8 pt-12 pb-24 sm:px-16 md:flex-row">
+          <div className="flex flex-col gap-12 px-8 pt-12 pb-24 text-body-inverse sm:px-16 md:flex-row dark:text-body">
             <div className="flex flex-1 flex-col gap-8">
               <p>
                 <Translation
@@ -271,10 +271,10 @@ const Page = async (props: { params: Promise<PageParams> }) => {
         <div className="flex w-full flex-col items-center gap-8 px-8 py-8 lg:flex-row">
           <div className="flex flex-1 flex-col gap-6">
             <h2 className="flex flex-col gap-2 font-black">
-              <span className="text-accent-a text-4xl">
+              <span className="text-4xl text-accent-a">
                 {t("page-10-year-innovation-title")}
               </span>
-              <span className="text-body text-5xl md:text-7xl">
+              <span className="text-5xl text-body md:text-7xl">
                 {t("page-10-year-innovation-subtitle")}
               </span>
             </h2>
@@ -292,10 +292,10 @@ const Page = async (props: { params: Promise<PageParams> }) => {
           <div className="relative flex max-w-[350px] flex-1 flex-col gap-6">
             <div className="flex flex-col gap-6 lg:sticky lg:top-64 lg:mb-24">
               <h2 className="flex flex-col gap-2 font-black">
-                <span className="text-accent-a text-4xl">
+                <span className="text-4xl text-accent-a">
                   {t("page-10-year-adoption-title")}
                 </span>
-                <span className="text-body text-5xl md:text-7xl">
+                <span className="text-5xl text-body md:text-7xl">
                   {t("page-10-year-adoption-subtitle")}
                 </span>
               </h2>
@@ -348,10 +348,10 @@ const Page = async (props: { params: Promise<PageParams> }) => {
           <div className="flex max-w-[350px] flex-1 flex-col gap-6">
             <div className="flex flex-col gap-6 lg:sticky lg:top-64 lg:mb-24">
               <h2 className="flex flex-col gap-2 font-black">
-                <span className="text-accent-a text-4xl">
+                <span className="text-4xl text-accent-a">
                   {t("page-10-year-stories-title")}
                 </span>
-                <span className="text-body text-5xl md:text-7xl">
+                <span className="text-5xl text-body md:text-7xl">
                   {t("page-10-year-stories-subtitle")}
                 </span>
               </h2>

--- a/app/[locale]/_components/HomepageLazy.tsx
+++ b/app/[locale]/_components/HomepageLazy.tsx
@@ -13,7 +13,7 @@ const Skeleton = ({
 }) => (
   <Section className={className}>
     <div
-      className={`bg-background-highlight w-full animate-pulse rounded-2xl ${heightClass}`}
+      className={`w-full animate-pulse rounded-2xl bg-background-highlight ${heightClass}`}
     />
   </Section>
 )

--- a/app/[locale]/apps/[application]/page.tsx
+++ b/app/[locale]/apps/[application]/page.tsx
@@ -189,13 +189,13 @@ const Page = async (props: {
                           chains={app.networks as ChainName[]}
                           className="mt-2"
                         />
-                        <p className="text-body-medium text-sm">
+                        <p className="text-sm text-body-medium">
                           by {app.parentCompany}
                         </p>
                       </div>
                       <div className="flex flex-row items-center">
                         <LanguagesIcon className="size-6" />
-                        <p className="text-body-medium text-sm">
+                        <p className="text-sm text-body-medium">
                           {formatStringList(
                             formatLanguageNames(app.languages),
                             5
@@ -275,7 +275,7 @@ const Page = async (props: {
                         )}
                       </div>
                       {nextApp && (
-                        <LinkBox className="group hover:bg-background-highlight flex flex-row items-center rounded-lg sm:hidden">
+                        <LinkBox className="group flex flex-row items-center rounded-lg hover:bg-background-highlight sm:hidden">
                           <div className="mr-2 flex flex-col text-right">
                             <p className="text-sm text-gray-500">
                               {t("page-apps-see-next")}
@@ -293,7 +293,7 @@ const Page = async (props: {
                             />
                           </div>
                           <div className="flex gap-2">
-                            <ChevronNext className="group-hover:text-primary h-8 w-8 text-gray-400" />
+                            <ChevronNext className="h-8 w-8 text-gray-400 group-hover:text-primary" />
                           </div>
                         </LinkBox>
                       )}
@@ -302,7 +302,7 @@ const Page = async (props: {
                 </div>
               </div>
               {nextApp && (
-                <LinkBox className="group hover:bg-background-highlight hidden flex-row items-center rounded-lg p-3 sm:flex">
+                <LinkBox className="group hidden flex-row items-center rounded-lg p-3 hover:bg-background-highlight sm:flex">
                   <div className="mr-2 flex flex-col text-right">
                     <p className="text-sm text-nowrap text-gray-500">
                       {t("page-apps-see-next")}
@@ -320,14 +320,14 @@ const Page = async (props: {
                     />
                   </div>
                   <div className="flex gap-2">
-                    <ChevronNext className="group-hover:text-primary h-8 w-8 text-gray-400" />
+                    <ChevronNext className="h-8 w-8 text-gray-400 group-hover:text-primary" />
                   </div>
                 </LinkBox>
               )}
             </div>
           </div>
 
-          <div className="bg-background-highlight grid grid-cols-1 grid-rows-[auto_1fr] gap-10 px-4 py-10 md:grid-cols-[minmax(0,1fr)_auto] md:px-8">
+          <div className="grid grid-cols-1 grid-rows-[auto_1fr] gap-10 bg-background-highlight px-4 py-10 md:grid-cols-[minmax(0,1fr)_auto] md:px-8">
             <p className="max-w-3xl">
               {getLocalizedDescription(
                 appDescriptions,
@@ -336,22 +336,22 @@ const Page = async (props: {
                 app.description
               )}
             </p>
-            <div className="bg-background flex h-fit w-full flex-col gap-4 rounded-2xl border p-8 md:row-span-2 md:w-44">
+            <div className="flex h-fit w-full flex-col gap-4 rounded-2xl border bg-background p-8 md:row-span-2 md:w-44">
               <h3 className="text-lg">{t("page-apps-info-title")}</h3>
               <div>
-                <p className="text-body-medium text-sm">
+                <p className="text-sm text-body-medium">
                   {t("page-apps-info-founded")}
                 </p>
                 <p className="text-sm">{getDisplayYear(app.dateOfLaunch)}</p>
               </div>
               <div>
-                <p className="text-body-medium text-sm">
+                <p className="text-sm text-body-medium">
                   {t("page-apps-info-creator")}
                 </p>
                 <p className="text-sm">{app.parentCompany}</p>
               </div>
               <div>
-                <p className="text-body-medium text-sm">
+                <p className="text-sm text-body-medium">
                   {t("page-apps-info-last-updated")}
                 </p>
                 <p className="text-sm">{getTimeAgo(app.lastUpdated)}</p>

--- a/app/[locale]/apps/_components/AppsHighlight.tsx
+++ b/app/[locale]/apps/_components/AppsHighlight.tsx
@@ -19,7 +19,7 @@ const AppsHighlight = ({ apps, matomoCategory }: AppsHighlightProps) => {
   const cards = apps.slice(0, 3).map((app, index) => (
     <LinkBox
       key={index}
-      className="group hover:bg-background-highlight w-full rounded-xl p-3"
+      className="group w-full rounded-xl p-3 hover:bg-background-highlight"
     >
       <LinkOverlay
         href={`/apps/${slugify(app.name)}`}

--- a/app/[locale]/apps/_components/SuggestAnApp.tsx
+++ b/app/[locale]/apps/_components/SuggestAnApp.tsx
@@ -5,7 +5,7 @@ import { ButtonLink } from "@/components/ui/buttons/Button"
 const SuggestAnApp = async () => {
   const t = await getTranslations("page-apps")
   return (
-    <div className="bg-radial-a flex flex-col items-center gap-4 rounded-2xl p-12">
+    <div className="flex flex-col items-center gap-4 rounded-2xl bg-radial-a p-12">
       <h2>{t("page-apps-suggest-an-app-title")}</h2>
       <p>{t("page-apps-suggest-an-app-description")}</p>
       <ButtonLink

--- a/app/[locale]/apps/_components/TopApps.tsx
+++ b/app/[locale]/apps/_components/TopApps.tsx
@@ -95,7 +95,7 @@ const TopApps = ({ appsData }: TopAppsProps) => {
         {Object.keys(appsData).map((category) => (
           <SwiperSlide key={category}>
             <div className="flex flex-col rounded-xl border">
-              <LinkBox className="hover:bg-background-highlight rounded-t-xl border-b p-4">
+              <LinkBox className="rounded-t-xl border-b p-4 hover:bg-background-highlight">
                 <LinkOverlay
                   href={`/apps/categories/${slugify(category)}`}
                   className="text-body no-underline"
@@ -121,7 +121,7 @@ const TopApps = ({ appsData }: TopAppsProps) => {
                           )
                         })()}
                       </div>
-                      <p className="text-body group-hover:text-primary text-lg font-bold no-underline">
+                      <p className="text-lg font-bold text-body no-underline group-hover:text-primary">
                         {t(appsCategories[category].name)}
                       </p>
                     </div>

--- a/app/[locale]/assets/_components/assets.tsx
+++ b/app/[locale]/assets/_components/assets.tsx
@@ -76,15 +76,15 @@ import wallet from "@/public/images/wallet.png"
 import whatIsEthereum from "@/public/images/what-is-ethereum.png"
 
 const Row = (props: ChildOnlyProp) => (
-  <div className="grid-cols-fit-4 -mx-4 mb-8 grid" {...props} />
+  <div className="-mx-4 mb-8 grid grid-cols-fit-4" {...props} />
 )
 
 const H2 = (props: HTMLAttributes<HTMLHeadingElement>) => (
-  <h2 className="leading-xs mt-16 mb-6 scroll-mt-24" {...props} />
+  <h2 className="mt-16 mb-6 scroll-mt-24 leading-xs" {...props} />
 )
 
 const H3 = (props: ChildOnlyProp) => (
-  <h3 className="leading-xs mt-10 mb-0" {...props} />
+  <h3 className="mt-10 mb-0 leading-xs" {...props} />
 )
 
 const AssetsPage = () => {

--- a/app/[locale]/bug-bounty/page.tsx
+++ b/app/[locale]/bug-bounty/page.tsx
@@ -55,7 +55,7 @@ const H2 = ({ className, ...props }: ComponentProps<"h2">) => (
 )
 
 const H4 = (props: ChildOnlyProp) => (
-  <h4 className="leading-xs my-8" {...props} />
+  <h4 className="my-8 leading-xs" {...props} />
 )
 
 const Text = ({ className, ...props }: ComponentProps<"p">) => (
@@ -259,13 +259,13 @@ export default async function Page(props: { params: Promise<Params> }) {
             <div className="flex-1 basis-1/2 pt-24 pr-0 pb-16 pl-0 lg:-mt-32 lg:pt-32 lg:pr-8 lg:pb-32 lg:pl-8">
               <Breadcrumbs slug="bug-bounty" className="mb-8" />
               <Row>
-                <div className="bg-success h-2 w-2 rounded-full" />{" "}
-                <Text className="text-body ms-2 mb-0 text-sm uppercase">
+                <div className="h-2 w-2 rounded-full bg-success" />{" "}
+                <Text className="ms-2 mb-0 text-sm text-body uppercase">
                   {t("page-upgrades-bug-bounty-title")}
                 </Text>
               </Row>
               <div
-                className="bg-linear-bug-bounty-title mt-4 max-w-[720px] overflow-auto bg-clip-text"
+                className="mt-4 max-w-[720px] overflow-auto bg-linear-bug-bounty-title bg-clip-text"
                 style={{
                   WebkitBackgroundClip: "text",
                   WebkitTextFillColor: "transparent",
@@ -276,7 +276,7 @@ export default async function Page(props: { params: Promise<Params> }) {
                   <Emoji text=":bug:" />
                 </h1>
               </div>
-              <Text className="leading-xs text-body-medium mt-4 max-w-[480px]">
+              <Text className="mt-4 max-w-[480px] leading-xs text-body-medium">
                 {t("page-upgrades-bug-bounty-subtitle")}
               </Text>
               <Flex className="mt-4 flex-wrap items-center gap-4">
@@ -380,7 +380,7 @@ export default async function Page(props: { params: Promise<Params> }) {
             />
           </Client>
         </ClientRow>
-        <div className="bg-background-highlight shadow-table-item-box mt-8 mb-12 w-full border-t px-0 py-16">
+        <div className="mt-8 mb-12 w-full border-t bg-background-highlight px-0 py-16 shadow-table-item-box">
           <Content>
             <div className="flex-1">
               <H2 id="in-scope">{t("page-upgrades-bug-bounty-validity")}</H2>
@@ -514,10 +514,10 @@ export default async function Page(props: { params: Promise<Params> }) {
               {/* Out of Scope */}
               <div
                 id="out-of-scope"
-                className="bg-background-highlight m-4 flex-[1_1_100%] overflow-hidden rounded-xs border border-solid p-6"
+                className="m-4 flex-[1_1_100%] overflow-hidden rounded-xs border border-solid bg-background-highlight p-6"
               >
                 <H2>{t("page-upgrades-bug-bounty-not-included")}</H2>
-                <p className="text-body-medium mb-6">
+                <p className="mb-6 text-body-medium">
                   {t.rich("page-upgrades-bug-bounty-not-included-desc", {
                     a: (chunks) => <Link href="#in-scope">{chunks}</Link>,
                   })}
@@ -564,7 +564,7 @@ export default async function Page(props: { params: Promise<Params> }) {
                     ] as const
                   ).map(({ key, footnote }) => (
                     <li key={key} className="flex items-start gap-3 text-sm">
-                      <span className="text-error mt-0.5 shrink-0">✕</span>
+                      <span className="mt-0.5 shrink-0 text-error">✕</span>
                       <span>
                         {t(key)}
                         {footnote && <sup>*</sup>}
@@ -572,14 +572,14 @@ export default async function Page(props: { params: Promise<Params> }) {
                     </li>
                   ))}
                 </ul>
-                <p className="text-body-medium mt-4 text-xs">
+                <p className="mt-4 text-xs text-body-medium">
                   <sup>*</sup>
                   {t("page-upgrades-bug-bounty-out-of-scope-footnote")}
                 </p>
               </div>
 
               {/* Bug Hunting Rules */}
-              <div className="bg-background-highlight m-4 flex-[1_1_100%] overflow-hidden rounded-xs border border-solid p-6">
+              <div className="m-4 flex-[1_1_100%] overflow-hidden rounded-xs border border-solid bg-background-highlight p-6">
                 <H2 id="rules">{t("page-upgrades-bug-bounty-hunting")}</H2>
                 <Text className="text-body-medium italic">
                   {t("page-upgrades-bug-bounty-hunting-desc")}
@@ -595,9 +595,9 @@ export default async function Page(props: { params: Promise<Params> }) {
                   ).map((key, idx) => (
                     <li
                       key={key}
-                      className="border-border bg-background flex items-start gap-4 rounded-xs border p-4"
+                      className="flex items-start gap-4 rounded-xs border border-border bg-background p-4"
                     >
-                      <span className="bg-primary/10 text-primary flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-sm font-bold">
+                      <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary/10 text-sm font-bold text-primary">
                         {idx + 1}
                       </span>
                       <span className="text-sm leading-relaxed">{t(key)}</span>
@@ -612,12 +612,12 @@ export default async function Page(props: { params: Promise<Params> }) {
               <H2 id="qualifications" className="max-w-[100ch]">
                 {t("page-upgrades-bug-bounty-severity-qualifications-title")}
               </H2>
-              <p className="text-body-medium mb-8 max-w-[100ch]">
+              <p className="mb-8 max-w-[100ch] text-body-medium">
                 {t("page-upgrades-bug-bounty-severity-qualifications-desc")}
               </p>
               <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
                 {/* Low */}
-                <div className="border-border bg-background flex flex-col rounded-xs border p-6">
+                <div className="flex flex-col rounded-xs border border-border bg-background p-6">
                   <span className="mb-4 inline-flex w-fit rounded-full bg-green-500/10 px-3 py-1 text-sm font-semibold text-green-600 dark:text-green-400">
                     {t("page-upgrades-bug-bounty-severity-low-title")}
                   </span>
@@ -640,7 +640,7 @@ export default async function Page(props: { params: Promise<Params> }) {
                   </ul>
                 </div>
                 {/* Medium */}
-                <div className="border-border bg-background flex flex-col rounded-xs border p-6">
+                <div className="flex flex-col rounded-xs border border-border bg-background p-6">
                   <span className="mb-4 inline-flex w-fit rounded-full bg-yellow-500/10 px-3 py-1 text-sm font-semibold text-yellow-600 dark:text-yellow-400">
                     {t("page-upgrades-bug-bounty-severity-medium-title")}
                   </span>
@@ -663,7 +663,7 @@ export default async function Page(props: { params: Promise<Params> }) {
                   </ul>
                 </div>
                 {/* High */}
-                <div className="border-border bg-background flex flex-col rounded-xs border p-6">
+                <div className="flex flex-col rounded-xs border border-border bg-background p-6">
                   <span className="mb-4 inline-flex w-fit rounded-full bg-orange-500/10 px-3 py-1 text-sm font-semibold text-orange-600 dark:text-orange-400">
                     {t("page-upgrades-bug-bounty-severity-high-title")}
                   </span>
@@ -686,7 +686,7 @@ export default async function Page(props: { params: Promise<Params> }) {
                   </ul>
                 </div>
                 {/* Critical */}
-                <div className="border-border bg-background flex flex-col rounded-xs border p-6">
+                <div className="flex flex-col rounded-xs border border-border bg-background p-6">
                   <span className="mb-4 inline-flex w-fit rounded-full bg-red-500/10 px-3 py-1 text-sm font-semibold text-red-600 dark:text-red-400">
                     {t("page-upgrades-bug-bounty-severity-critical-title")}
                   </span>
@@ -737,7 +737,7 @@ export default async function Page(props: { params: Promise<Params> }) {
         <BugBountyCards />
         <div
           id="leaderboard"
-          className="bg-banner-grid-gradient shadow-table-item-box mt-8 w-full border-t px-0 py-16"
+          className="mt-8 w-full border-t bg-banner-grid-gradient px-0 py-16 shadow-table-item-box"
         >
           <Flex className="flex-col items-start justify-center lg:flex-row">
             <FullLeaderboardContainer>

--- a/app/[locale]/collectibles/_components/CollectiblesContent/index.tsx
+++ b/app/[locale]/collectibles/_components/CollectiblesContent/index.tsx
@@ -83,7 +83,7 @@ const CollectiblesContent = ({ badges }: CollectiblesPageProps) => {
   return (
     <div className="flex flex-col gap-8 xl:flex-row">
       {/* Already a contributor? section */}
-      <div className="border-accent-a/5 from-accent-a/5 to-accent-a/10 dark:from-accent-a/10 dark:to-accent-a/20 flex h-fit w-full flex-col gap-y-4 rounded-2xl border bg-linear-to-b px-6 py-6 xl:sticky xl:top-28 xl:max-w-xs">
+      <div className="flex h-fit w-full flex-col gap-y-4 rounded-2xl border border-accent-a/5 bg-linear-to-b from-accent-a/5 to-accent-a/10 px-6 py-6 xl:sticky xl:top-28 xl:max-w-xs dark:from-accent-a/10 dark:to-accent-a/20">
         <Image
           src={alreadyContributorImg}
           alt={t("page-collectibles-contributor-img-alt")}

--- a/app/[locale]/collectibles/_components/CollectiblesCurrentYear.tsx
+++ b/app/[locale]/collectibles/_components/CollectiblesCurrentYear.tsx
@@ -50,7 +50,7 @@ const HighlightCard = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <Card
     className={cn(
-      "space-between border-background-highlight flex flex-col overflow-hidden border",
+      "space-between flex flex-col overflow-hidden border border-background-highlight",
       className
     )}
     {...props}
@@ -97,12 +97,12 @@ const HighlightCardFooter = ({
 }: HighlightCardFooterProps) => (
   <div
     className={cn(
-      "bg-background-highlight flex items-center gap-1 px-6 py-2",
+      "flex items-center gap-1 bg-background-highlight px-6 py-2",
       className
     )}
     {...props}
   >
-    <Zap className="fill-primary text-primary size-4" />
+    <Zap className="size-4 fill-primary text-primary" />
     <Link href={href} className="text-sm font-bold no-underline">
       {children}
     </Link>
@@ -112,7 +112,7 @@ const HighlightCardFooter = ({
 const CheckList = ({ className, ...props }: ListProps) => (
   <UnorderedList
     className={cn(
-      "text-body-medium m-0 my-2 list-none space-y-2 text-xs",
+      "m-0 my-2 list-none space-y-2 text-xs text-body-medium",
       className
     )}
     {...props}
@@ -126,7 +126,7 @@ type CheckItemProps = ChildOnlyProp & {
 const CheckItem = ({ children, owned }: CheckItemProps) => (
   <ListItem className="mb-0 flex items-center gap-2">
     <CircleCheckIcon
-      className={cn("text-body-medium size-4", owned && "text-success")}
+      className={cn("size-4 text-body-medium", owned && "text-success")}
     />
     {children}
   </ListItem>
@@ -507,7 +507,7 @@ const CollectiblesCurrentYear = ({
           </AccordionItem>
         </Accordion>
 
-        <div className="grid-cols-fill-8 mt-4 grid gap-2">
+        <div className="mt-4 grid grid-cols-fill-8 gap-2">
           {socialBadges.map((badge) => (
             <Link
               key={badge.id}

--- a/app/[locale]/collectibles/_components/CollectiblesPreviousYears.tsx
+++ b/app/[locale]/collectibles/_components/CollectiblesPreviousYears.tsx
@@ -71,7 +71,7 @@ const CollectiblesPreviousYears = ({
                   </Tag>
                 </div>
               </div>
-              <div className="grid-cols-fill-10 grid gap-4 md:gap-6">
+              <div className="grid grid-cols-fill-10 gap-4 md:gap-6">
                 {grouped[year].map((badge: Badge) => {
                   const sanitizedName = badge.name
                     .replace(/\s?ethereum.org\s?/i, " ") // Remove "ethereum.org" from label
@@ -97,7 +97,7 @@ const CollectiblesPreviousYears = ({
                         alt={badge.name}
                         className="size-16 transition-transform group-hover:scale-105 group-hover:transition-transform md:size-20"
                       />
-                      <div className="text-primary text-xs md:text-sm">
+                      <div className="text-xs text-primary md:text-sm">
                         {label}
                         <ExternalLinkIcon />
                       </div>

--- a/app/[locale]/collectibles/_components/CollectiblesProgress/index.tsx
+++ b/app/[locale]/collectibles/_components/CollectiblesProgress/index.tsx
@@ -61,7 +61,7 @@ const CollectiblesProgress = ({ badges }: CollectiblesProgressProps) => {
           value={(ownedCount / (currentYearBadges.length || 1)) * 100}
         />
       </div>
-      <p className="text-body-medium text-sm">
+      <p className="text-sm text-body-medium">
         {t("page-collectibles-index-frequency")}
       </p>
     </>

--- a/app/[locale]/collectibles/page.tsx
+++ b/app/[locale]/collectibles/page.tsx
@@ -83,7 +83,7 @@ export default async function Page(props: { params: Promise<PageParams> }) {
             id="stats"
             className="flex flex-col gap-x-6 gap-y-4 px-4 xl:flex-row xl:px-12"
           >
-            <div className="border-primary/10 from-primary/10 to-primary/5 dark:from-primary/20 dark:to-primary/10 flex-[2] space-y-4 rounded-2xl border bg-linear-to-r px-8 py-12 text-lg">
+            <div className="flex-[2] space-y-4 rounded-2xl border border-primary/10 bg-linear-to-r from-primary/10 to-primary/5 px-8 py-12 text-lg dark:from-primary/20 dark:to-primary/10">
               <h2 className="text-3xl md:text-4xl">
                 {t("page-collectibles-improve-title")}
               </h2>
@@ -110,7 +110,7 @@ export default async function Page(props: { params: Promise<PageParams> }) {
 
             <div className="grid min-w-fit grid-cols-2 place-items-center gap-4 md:grid-cols-3 md:justify-start xl:grid-cols-2">
               {/* Minted */}
-              <div className="border-accent-a/20 from-accent-a/5 to-accent-a/15 text-accent-a flex h-full w-full flex-col items-center justify-center rounded-xl border bg-linear-to-b px-4 py-8 max-md:col-span-2 xl:col-span-2 xl:p-6">
+              <div className="flex h-full w-full flex-col items-center justify-center rounded-xl border border-accent-a/20 bg-linear-to-b from-accent-a/5 to-accent-a/15 px-4 py-8 text-accent-a max-md:col-span-2 xl:col-span-2 xl:p-6">
                 <div className="text-4xl font-bold md:text-6xl">
                   {stats.collectorsCount
                     ? numberFormat(locale).format(stats.collectorsCount)
@@ -121,7 +121,7 @@ export default async function Page(props: { params: Promise<PageParams> }) {
                 </div>
               </div>
               {/* Collectors */}
-              <div className="border-accent-b/20 from-accent-b/5 to-accent-b/15 text-accent-b flex h-full w-full flex-col items-center justify-center rounded-xl border bg-linear-to-b p-6">
+              <div className="flex h-full w-full flex-col items-center justify-center rounded-xl border border-accent-b/20 bg-linear-to-b from-accent-b/5 to-accent-b/15 p-6 text-accent-b">
                 <div className="text-4xl font-bold md:text-6xl">
                   {stats.uniqueAddressesCount
                     ? numberFormat(locale).format(stats.uniqueAddressesCount)
@@ -132,7 +132,7 @@ export default async function Page(props: { params: Promise<PageParams> }) {
                 </div>
               </div>
               {/* Unique Badges */}
-              <div className="border-accent-c/20 from-accent-c/5 to-accent-c/15 text-accent-c flex h-full w-full flex-col items-center justify-center rounded-xl border bg-linear-to-b p-6">
+              <div className="flex h-full w-full flex-col items-center justify-center rounded-xl border border-accent-c/20 bg-linear-to-b from-accent-c/5 to-accent-c/15 p-6 text-accent-c">
                 <div className="text-4xl font-bold md:text-6xl">
                   {stats.collectiblesCount
                     ? numberFormat(locale).format(stats.collectiblesCount)

--- a/app/[locale]/community/_components/community.tsx
+++ b/app/[locale]/community/_components/community.tsx
@@ -75,7 +75,7 @@ const ImageContainer = ({ children }: ChildOnlyProp) => {
 }
 
 const Subtitle = ({ children }: ChildOnlyProp) => {
-  return <p className="text-md mb-8 sm:text-xl">{children}</p>
+  return <p className="mb-8 text-md sm:text-xl">{children}</p>
 }
 
 const FeatureContent = ({ children }: ChildOnlyProp) => {
@@ -161,7 +161,7 @@ const CommunityPage = () => {
     <Page>
       <HubHero {...heroContent} />
       <Divider />
-      <Flex className="border-b-border-high-contrast -mt-px w-full flex-row-reverse items-center border-b py-8 ps-0 lg:py-0 lg:ps-8">
+      <Flex className="-mt-px w-full flex-row-reverse items-center border-b border-b-border-high-contrast py-8 ps-0 lg:py-0 lg:ps-8">
         <div className="mb-12 w-full px-8 py-4">
           <Flex className="flex-col items-center">
             <H2 className="lg:text-4xl">
@@ -181,7 +181,7 @@ const CommunityPage = () => {
           </CardContainer>
         </div>
       </Flex>
-      <div className="bg-background-highlight shadow-table-item-box w-full pb-16">
+      <div className="w-full bg-background-highlight pb-16 shadow-table-item-box">
         <div className="w-full px-4 py-4 lg:px-8">
           <Flex className="mt-0 mb-0 flex-col-reverse items-center md:m-12 md:mt-4 md:flex-row">
             <div className="h-full w-full p-0 sm:p-8 lg:p-24">
@@ -216,7 +216,7 @@ const CommunityPage = () => {
           </div>
         </div>
       </div>
-      <Flex className="border-y-border-high-contrast -mt-px h-full w-full flex-col-reverse items-center border-y bg-[#ccfcff] py-8 ps-0 lg:h-[720px] lg:flex-row-reverse lg:py-0 lg:ps-8 dark:bg-[#293233]">
+      <Flex className="-mt-px h-full w-full flex-col-reverse items-center border-y border-y-border-high-contrast bg-[#ccfcff] py-8 ps-0 lg:h-[720px] lg:flex-row-reverse lg:py-0 lg:ps-8 dark:bg-[#293233]">
         <RowReverse>
           <FeatureContent>
             <H2>{t("page-community-open-source")}</H2>
@@ -243,7 +243,7 @@ const CommunityPage = () => {
           </ImageContainer>
         </RowReverse>
       </Flex>
-      <Flex className="border-y-border-high-contrast -mt-px h-full w-full flex-col-reverse items-center border-y bg-[#ffe5f9] py-8 ps-0 lg:h-[720px] lg:flex-row-reverse lg:py-0 lg:ps-8 dark:bg-[#332027]">
+      <Flex className="-mt-px h-full w-full flex-col-reverse items-center border-y border-y-border-high-contrast bg-[#ffe5f9] py-8 ps-0 lg:h-[720px] lg:flex-row-reverse lg:py-0 lg:ps-8 dark:bg-[#332027]">
         <Flex className="flex-col-reverse items-center lg:flex-row">
           <FeatureContent>
             <Flex className="flex-col justify-center">
@@ -272,7 +272,7 @@ const CommunityPage = () => {
           </ImageContainer>
         </Flex>
       </Flex>
-      <Flex className="border-y-border-high-contrast -mt-px h-full w-full flex-col-reverse items-center border-y bg-[#e8e8ff] lg:h-[720px] lg:flex-row dark:bg-[#212131]">
+      <Flex className="-mt-px h-full w-full flex-col-reverse items-center border-y border-y-border-high-contrast bg-[#e8e8ff] lg:h-[720px] lg:flex-row dark:bg-[#212131]">
         <RowReverse>
           <FeatureContent>
             <H2>{t("page-community-support")}</H2>

--- a/app/[locale]/community/events/_components/ContinentTabs.tsx
+++ b/app/[locale]/community/events/_components/ContinentTabs.tsx
@@ -127,7 +127,7 @@ export default function ContinentTabs({
       />
 
       {filteredEvents.length === 0 ? (
-        <p className="text-body-medium py-8 text-center">{noEventsMessage}</p>
+        <p className="py-8 text-center text-body-medium">{noEventsMessage}</p>
       ) : (
         <div className="grid grid-cols-1 lg:grid-cols-[auto_3fr_2fr_auto]">
           {displayedEvents.map((event) => {
@@ -149,7 +149,7 @@ export default function ContinentTabs({
                 </div>
 
                 {/* Logo + Title + Location */}
-                <LinkBox className="group hover:bg-background-highlight rounded-xl p-2 max-lg:-m-2">
+                <LinkBox className="group rounded-xl p-2 hover:bg-background-highlight max-lg:-m-2">
                   <LinkOverlay
                     href={event.link}
                     className="flex min-w-0 items-center gap-4 no-underline"
@@ -170,7 +170,7 @@ export default function ContinentTabs({
                       />
                     </div>
                     <div className="min-w-0">
-                      <p className="text-body group-hover:text-primary flex items-center gap-1 font-bold">
+                      <p className="flex items-center gap-1 font-bold text-body group-hover:text-primary">
                         {event.title}
                         <ExternalLink className="size-4 shrink-0" />
                       </p>

--- a/app/[locale]/community/events/_components/EventCard.tsx
+++ b/app/[locale]/community/events/_components/EventCard.tsx
@@ -41,7 +41,7 @@ function EventCardGrid({
     : null
 
   return (
-    <LinkBox className="hover:bg-background-highlight group rounded-xl p-2">
+    <LinkBox className="group rounded-xl p-2 hover:bg-background-highlight">
       <LinkOverlay
         href={event.link}
         className="no-underline"
@@ -49,7 +49,7 @@ function EventCardGrid({
         matomoEvent={customEventOptions}
       >
         <div className="flex gap-3">
-          <div className="from-body/5 to-body/10 dark:from-body/10 dark:to-body/20 flex size-16 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-linear-to-b text-2xl">
+          <div className="flex size-16 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-linear-to-b from-body/5 to-body/10 text-2xl dark:from-body/10 dark:to-body/20">
             {event.logoImage && !logoError ? (
               <Image
                 src={event.logoImage}
@@ -60,7 +60,7 @@ function EventCardGrid({
                 onError={() => setLogoError(true)}
               />
             ) : (
-              <MapPin className="text-body-medium size-8" />
+              <MapPin className="size-8 text-body-medium" />
             )}
           </div>
           <div className="flex flex-1 flex-col gap-1">
@@ -74,11 +74,11 @@ function EventCardGrid({
                 {event.eventTypesLabels?.[0] || primaryType}
               </Tag>
             )}
-            <p className="text-body group-hover:text-primary text-lg leading-tight font-bold">
+            <p className="text-lg leading-tight font-bold text-body group-hover:text-primary">
               {event.title}
             </p>
             {formattedDate && <p className="text-body">{formattedDate}</p>}
-            <p className="text-body-medium text-sm">{event.location}</p>
+            <p className="text-sm text-body-medium">{event.location}</p>
           </div>
         </div>
       </LinkOverlay>
@@ -97,14 +97,14 @@ function EventCardHighlight({
   const bannerSrc = event.bannerImage || event.logoImage
 
   return (
-    <LinkBox className="hover:bg-background-highlight group w-full rounded-xl p-3">
+    <LinkBox className="group w-full rounded-xl p-3 hover:bg-background-highlight">
       <LinkOverlay
         href={event.link}
-        className="text-body space-y-6 no-underline"
+        className="space-y-6 text-body no-underline"
         hideArrow
         matomoEvent={customEventOptions}
       >
-        <div className="from-body/5 to-body/10 dark:from-body/10 dark:to-body/20 relative h-[200px] w-full overflow-hidden rounded-xl bg-linear-to-b">
+        <div className="relative h-[200px] w-full overflow-hidden rounded-xl bg-linear-to-b from-body/5 to-body/10 dark:from-body/10 dark:to-body/20">
           {bannerSrc && !bannerError ? (
             <Image
               src={bannerSrc}
@@ -114,13 +114,13 @@ function EventCardHighlight({
               onError={() => setBannerError(true)}
             />
           ) : (
-            <div className="text-body-medium flex size-full items-center justify-center">
+            <div className="flex size-full items-center justify-center text-body-medium">
               <MapPin className="size-16" />
             </div>
           )}
         </div>
         <div className="flex gap-3">
-          <div className="bg-body/5 dark:bg-body/10 flex size-16 shrink-0 items-center justify-center overflow-hidden rounded-lg">
+          <div className="flex size-16 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-body/5 dark:bg-body/10">
             {event.logoImage && !logoError ? (
               <Image
                 src={event.logoImage}
@@ -131,13 +131,13 @@ function EventCardHighlight({
                 onError={() => setLogoError(true)}
               />
             ) : (
-              <MapPin className="text-body-medium size-8" />
+              <MapPin className="size-8 text-body-medium" />
             )}
           </div>
           <div className="space-y-1">
             <h3>{event.title}</h3>
-            <p className="text-body-medium text-sm">{event.location}</p>
-            <p className="text-body-medium text-sm">
+            <p className="text-sm text-body-medium">{event.location}</p>
+            <p className="text-sm text-body-medium">
               {formatDateRange(event.startTime, event.endTime, locale)}
             </p>
           </div>

--- a/app/[locale]/community/events/_components/FilterEvents.tsx
+++ b/app/[locale]/community/events/_components/FilterEvents.tsx
@@ -67,7 +67,7 @@ export default function FilterEvents({ events }: FilterProps) {
 
     return (
       <>
-        <div className="grid-cols-fill-4 grid gap-8">
+        <div className="grid grid-cols-fill-4 gap-8">
           {filteredEvents.slice(0, MAX_RESULTS).map((event) => (
             <EventCard
               key={event.id}

--- a/app/[locale]/community/events/_components/OrganizerCTA.tsx
+++ b/app/[locale]/community/events/_components/OrganizerCTA.tsx
@@ -15,7 +15,7 @@ export default async function OrganizerCTA({ className }: OrganizerCTAProps) {
   return (
     <Section
       className={cn(
-        "border-accent-a/20 from-accent-a/5 to-accent-a/10 dark:from-accent-a/10 dark:to-accent-a/20 bg-linear-to-b",
+        "border-accent-a/20 bg-linear-to-b from-accent-a/5 to-accent-a/10 dark:from-accent-a/10 dark:to-accent-a/20",
         "space-y-8 rounded-4xl px-4 py-12 text-center md:px-8 md:py-20",
         className
       )}

--- a/app/[locale]/community/events/conferences/page.tsx
+++ b/app/[locale]/community/events/conferences/page.tsx
@@ -137,7 +137,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
               eventCategory: "Events_conferences",
             }}
           />
-          <p className="text-body-medium mt-8">
+          <p className="mt-8 text-body-medium">
             {t.rich("page-events-data-source-callout", {
               a: (chunks) => <Link href="https://ethstars.xyz/">{chunks}</Link>,
             })}

--- a/app/[locale]/community/events/meetups/_components/FilterMeetups.tsx
+++ b/app/[locale]/community/events/meetups/_components/FilterMeetups.tsx
@@ -49,7 +49,7 @@ export default function FilterMeetups({ events }: FilterMeetupsProps) {
         {t("page-events-search-sr-text")}
       </span>
       {filteredEvents.length ? (
-        <div className="grid-cols-fill-4 grid gap-8">
+        <div className="grid grid-cols-fill-4 gap-8">
           {filteredEvents.map((event) => (
             <EventCard
               key={event.id}

--- a/app/[locale]/community/events/page.tsx
+++ b/app/[locale]/community/events/page.tsx
@@ -259,14 +259,14 @@ const Page = async (props: { params: Promise<PageParams> }) => {
               <ButtonLink
                 href="https://esp.ethereum.foundation/applicants/rfp/community-hubs"
                 variant="outline"
-                className="border-body-light group w-full gap-2 rounded-4xl p-5"
+                className="group w-full gap-2 rounded-4xl border-body-light p-5"
                 customEventOptions={{
                   eventCategory: "Events",
                   eventAction: "hubs",
                   eventName: "apply",
                 }}
               >
-                <div className="border-primary rounded-full border border-dashed p-3">
+                <div className="rounded-full border border-dashed border-primary p-3">
                   <Plus className="size-4 transition-transform group-hover:scale-150 group-hover:transition-transform" />
                 </div>
                 {t("page-events-hub-apply-cta")}
@@ -277,7 +277,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
           {/* Find events near you */}
           <Section
             id="search"
-            className="bg-gradient-banner dark:bg-radial-b rounded-t-[4rem] px-6 py-12 md:px-12 md:py-16"
+            className="rounded-t-[4rem] bg-gradient-banner px-6 py-12 md:px-12 md:py-16 dark:bg-radial-b"
           >
             <div className="space-y-6">
               <div className="space-y-2 text-center">
@@ -364,7 +364,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
                 eventName: "regular_conf",
               }}
             />
-            <p className="text-body-medium !mt-8">
+            <p className="!mt-8 text-body-medium">
               {t.rich("page-events-data-source-callout", {
                 a: (chunks) => (
                   <Link href="https://ethstars.xyz/">{chunks}</Link>
@@ -435,7 +435,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
             </div>
             <div className="grid gap-8 md:grid-cols-2">
               {/* Ethereum Everywhere Card */}
-              <div className="from-accent-a/5 to-accent-a/15 dark:from-accent-a/10 dark:to-accent-a/20 flex flex-col gap-y-8 rounded-4xl bg-linear-to-b px-4 py-6 md:p-12">
+              <div className="flex flex-col gap-y-8 rounded-4xl bg-linear-to-b from-accent-a/5 to-accent-a/15 px-4 py-6 md:p-12 dark:from-accent-a/10 dark:to-accent-a/20">
                 <div className="flex items-center gap-3">
                   <div className="size-16 overflow-hidden rounded-full">
                     <Image src={ethereumEverywhereLogo} alt="" sizes="4rem" />
@@ -499,7 +499,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
               </div>
 
               {/* Geode Labs Card */}
-              <div className="from-accent-c/5 to-accent-c/15 dark:from-accent-c/10 dark:to-accent-c/20 flex flex-col gap-y-8 rounded-4xl bg-linear-to-b px-4 py-6 md:p-12">
+              <div className="flex flex-col gap-y-8 rounded-4xl bg-linear-to-b from-accent-c/5 to-accent-c/15 px-4 py-6 md:p-12 dark:from-accent-c/10 dark:to-accent-c/20">
                 <div className="flex items-center gap-3">
                   <div className="size-16 overflow-hidden rounded-full">
                     <Image src={geodeLabsLogo} alt="" sizes="4rem" />

--- a/app/[locale]/community/events/search/page.tsx
+++ b/app/[locale]/community/events/search/page.tsx
@@ -82,7 +82,7 @@ const Page = async (props: {
 
     return (
       <>
-        <div className="grid-cols-fill-4 grid gap-8">
+        <div className="grid grid-cols-fill-4 gap-8">
           {filteredEvents.map((event) => (
             <EventCard
               key={event.id}

--- a/app/[locale]/community/support/page.tsx
+++ b/app/[locale]/community/support/page.tsx
@@ -49,7 +49,7 @@ export default async function Page(props: { params: Promise<PageParams> }) {
         breadcrumbs={<Breadcrumbs slug="community/support" startDepth={1} />}
         title={t("page-community-support-hero-title")}
         subtitle={
-          <div className="text-body-medium space-y-[1lh] text-base">
+          <div className="space-y-[1lh] text-base text-body-medium">
             <p className="text-lg">
               {t("page-community-support-hero-subtitle-1")}
             </p>
@@ -64,7 +64,7 @@ export default async function Page(props: { params: Promise<PageParams> }) {
 
       <MainArticle className="space-y-16 px-4 py-16 md:px-10 md:py-20">
         {/* Decentralization alert */}
-        <Alert className="text-body-medium max-w-3xl">
+        <Alert className="max-w-3xl text-body-medium">
           <AlertIcon>
             <Shield />
           </AlertIcon>
@@ -100,7 +100,7 @@ export default async function Page(props: { params: Promise<PageParams> }) {
                   className="h-fit"
                 >
                   <div className="[&>*]:px-6 [&>*]:py-4 [&>a]:block [&>a]:border-t [&>a]:no-underline">
-                    <p className="text-body-medium text-sm leading-relaxed">
+                    <p className="text-sm leading-relaxed text-body-medium">
                       {t(descriptionKey)}
                     </p>
                     {items.map(({ labelKey, href, eventName }) => (
@@ -146,7 +146,7 @@ export default async function Page(props: { params: Promise<PageParams> }) {
                   className="h-fit"
                 >
                   <div className="[&>*]:px-6 [&>*]:py-4 [&>a]:block [&>a]:border-t [&>a]:no-underline">
-                    <p className="text-body-medium text-sm leading-relaxed">
+                    <p className="text-sm leading-relaxed text-body-medium">
                       {t(descriptionKey)}
                     </p>
                     {items.map(({ labelKey, href, eventName }) => (
@@ -173,13 +173,13 @@ export default async function Page(props: { params: Promise<PageParams> }) {
         {/* Still need help? */}
         <Section
           id="still-need-help"
-          className="border-accent-a/20 from-accent-a/5 to-accent-a/10 dark:from-accent-a/10 dark:to-accent-a/20 space-y-8 rounded-4xl border bg-linear-to-b px-8 py-16 lg:px-16"
+          className="space-y-8 rounded-4xl border border-accent-a/20 bg-linear-to-b from-accent-a/5 to-accent-a/10 px-8 py-16 lg:px-16 dark:from-accent-a/10 dark:to-accent-a/20"
         >
           <div className="flex flex-col items-center gap-6 text-center">
             <h2 className="text-3xl font-bold lg:text-4xl">
               {t("page-community-support-still-need-help")}
             </h2>
-            <p className="text-body-medium max-w-lg">
+            <p className="max-w-lg text-body-medium">
               {t("page-community-support-still-need-help-description")}
             </p>
             <ButtonLink

--- a/app/[locale]/contributing/translation-program/acknowledgements/_components/acknowledgements.tsx
+++ b/app/[locale]/contributing/translation-program/acknowledgements/_components/acknowledgements.tsx
@@ -37,7 +37,7 @@ const H2 = ({
   className,
   ...props
 }: BaseHTMLAttributes<HTMLHeadingElement>) => (
-  <h2 className={cn("leading-xs mt-12 mb-8", className)} {...props} />
+  <h2 className={cn("mt-12 mb-8 leading-xs", className)} {...props} />
 )
 
 const Text = ({
@@ -62,7 +62,7 @@ const TranslatorAcknowledgements = () => {
     <Flex className="w-full flex-col items-center">
       <Content>
         <Breadcrumbs slug={pathname} className="mt-12" />
-        <h1 className="leading-xs my-8">
+        <h1 className="my-8 leading-xs">
           {t(
             "page-contributing-translation-program-acknowledgements-acknowledgement-page-title"
           )}
@@ -192,7 +192,7 @@ const TranslatorAcknowledgements = () => {
         <Text>
           {t("page-contributing-translation-program-acknowledgements-3")}
         </Text>
-        <h3 className="leading-xs mt-10 mb-8">
+        <h3 className="mt-10 mb-8 leading-xs">
           {t(
             "page-contributing-translation-program-acknowledgements-how-to-claim-title"
           )}

--- a/app/[locale]/contributing/translation-program/contributors/_components/contributors.tsx
+++ b/app/[locale]/contributing/translation-program/contributors/_components/contributors.tsx
@@ -43,10 +43,10 @@ const Contributors = () => {
     <Flex className="w-full flex-col items-center">
       <Content>
         <Breadcrumbs slug={pathname} className="mt-12" />
-        <h1 className="leading-xs my-8">
+        <h1 className="my-8 leading-xs">
           {t("page-contributing-translation-program-contributors-title")}
         </h1>
-        <h4 className="leading-xs my-8">
+        <h4 className="my-8 leading-xs">
           {t(
             "page-contributing-translation-program-contributors-number-of-contributors"
           )}{" "}
@@ -74,7 +74,7 @@ const Contributors = () => {
           </InlineLink>
           .
         </Text>
-        <h2 className="leading-xs mt-12 mb-8">
+        <h2 className="mt-12 mb-8 leading-xs">
           {t("page-contributing-translation-program-contributors-thank-you")}
         </h2>
         <List className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6">

--- a/app/[locale]/contributing/translation-program/translatathon/leaderboard/_components/Leaderboard.tsx
+++ b/app/[locale]/contributing/translation-program/translatathon/leaderboard/_components/Leaderboard.tsx
@@ -57,7 +57,7 @@ export const Leaderboard = () => {
   }
 
   return (
-    <div className="bg-background-highlight mb-8 w-full shadow-md">
+    <div className="mb-8 w-full bg-background-highlight shadow-md">
       <div className="bg-muted text-foreground mb-[1px] flex w-full items-center justify-between p-4">
         <div className="flex">
           <div className="w-10 opacity-40">#</div>
@@ -112,7 +112,7 @@ export const Leaderboard = () => {
             onClick={showMore}
             className="m-2 mx-0 flex h-full w-full items-center justify-center rounded-full px-6 py-4 lg:mx-2 lg:w-auto"
           >
-            <span className="text-md text-center leading-none font-semibold md:text-lg md:font-normal">
+            <span className="text-center text-md leading-none font-semibold md:text-lg md:font-normal">
               Show more
             </span>
           </Button>

--- a/app/[locale]/developers/_components/BuilderCard.tsx
+++ b/app/[locale]/developers/_components/BuilderCard.tsx
@@ -31,7 +31,7 @@ const BuilderCard = ({ path, className }: BuildCardProps) => (
         </Tag>
       )}
       <h3 className="text-lg font-bold">{path.title}</h3>
-      <p className="text-body-medium text-sm">{path.description}</p>
+      <p className="text-sm text-body-medium">{path.description}</p>
     </div>
     <ButtonLink
       href={path.href}

--- a/app/[locale]/developers/_components/BuilderSwiper/loading.tsx
+++ b/app/[locale]/developers/_components/BuilderSwiper/loading.tsx
@@ -2,7 +2,7 @@ import { Card } from "@/components/ui/card"
 import { Skeleton, SkeletonLines } from "@/components/ui/skeleton"
 
 const Loading = () => (
-  <Card className="bg-background relative ms-8 w-[85vw] space-y-4 rounded-4xl border px-6 py-6">
+  <Card className="relative ms-8 w-[85vw] space-y-4 rounded-4xl border bg-background px-6 py-6">
     <Skeleton data-label="banner" className="mb-6 h-44 w-full rounded-xl" />
     <Skeleton data-label="tag" className="h-5 w-19" />
     <Skeleton data-label="title" className="h-5 w-1/2" />

--- a/app/[locale]/developers/_components/VideoCourseCard.tsx
+++ b/app/[locale]/developers/_components/VideoCourseCard.tsx
@@ -37,10 +37,10 @@ const VideoCourseCard = ({ course, className }: VideoCourseCardProps) => (
       >
         {course.hours}
       </Tag>
-      <h3 className="text-body text-lg font-bold group-hover:underline">
+      <h3 className="text-lg font-bold text-body group-hover:underline">
         {course.title}
       </h3>
-      <p className="text-body-medium mb-4 text-sm">{course.description}</p>
+      <p className="mb-4 text-sm text-body-medium">{course.description}</p>
     </div>
   </Card>
 )

--- a/app/[locale]/developers/page.tsx
+++ b/app/[locale]/developers/page.tsx
@@ -103,9 +103,9 @@ const WhyGrid = () => {
   return (
     <div
       className={cn(
-        "border-accent-c/20 rounded-4xl border",
+        "rounded-4xl border border-accent-c/20",
         "grid grid-cols-1 gap-6 p-8 md:grid-cols-2 md:p-14",
-        "from-accent-c/5 to-accent-c/15 bg-linear-to-b from-[60%]"
+        "bg-linear-to-b from-accent-c/5 from-[60%] to-accent-c/15"
       )}
     >
       {items.map(({ heading, description }) => (
@@ -186,7 +186,7 @@ const DevelopersPage = async (props: { params: Promise<PageParams> }) => {
             id="why"
             className={cn(
               "grid grid-cols-1 gap-6 md:gap-10 lg:grid-cols-2",
-              "bg-background-highlight -mx-8 w-screen max-w-screen-2xl items-center px-8 py-10 md:py-20"
+              "-mx-8 w-screen max-w-screen-2xl items-center bg-background-highlight px-8 py-10 md:py-20"
             )}
           >
             <div className="space-y-4">
@@ -261,7 +261,7 @@ const DevelopersPage = async (props: { params: Promise<PageParams> }) => {
             id="resources"
             className={cn(
               "grid grid-cols-1 gap-6 md:grid-cols-2 md:gap-8",
-              "bg-background-highlight -mx-8 w-screen max-w-screen-2xl px-8 py-10 md:py-20"
+              "-mx-8 w-screen max-w-screen-2xl bg-background-highlight px-8 py-10 md:py-20"
             )}
           >
             <h2 className="sr-only">
@@ -269,7 +269,7 @@ const DevelopersPage = async (props: { params: Promise<PageParams> }) => {
             </h2>
 
             {/* Quickstart your idea */}
-            <Card className="bg-background !space-y-8 px-6 py-8 break-words md:space-y-6 lg:p-8">
+            <Card className="!space-y-8 bg-background px-6 py-8 break-words md:space-y-6 lg:p-8">
               <Image
                 src={scaffoldDebugScreenshot}
                 alt="Scaffold-ETH 2 debug screenshot"
@@ -278,7 +278,7 @@ const DevelopersPage = async (props: { params: Promise<PageParams> }) => {
               />
               <div>
                 <h3>{t("page-developers-jump-right-in-title")}</h3>
-                <p className="text-body-medium text-sm">
+                <p className="text-sm text-body-medium">
                   {t("page-developers-quickstart-scaffold-subtext")}{" "}
                   <Link
                     href="https://docs.scaffoldeth.io/"
@@ -293,7 +293,7 @@ const DevelopersPage = async (props: { params: Promise<PageParams> }) => {
                   </Link>
                 </p>
               </div>
-              <div className="bg-background flex items-center rounded-lg border px-3 py-1">
+              <div className="flex items-center rounded-lg border bg-background px-3 py-1">
                 <span className="flex-1 font-mono text-sm">
                   npx create-eth@latest
                 </span>
@@ -324,7 +324,7 @@ const DevelopersPage = async (props: { params: Promise<PageParams> }) => {
             </Card>
 
             {/* Get help */}
-            <Card className="bg-background !space-y-8 px-6 py-8 break-words md:space-y-6 lg:p-8">
+            <Card className="!space-y-8 bg-background px-6 py-8 break-words md:space-y-6 lg:p-8">
               <Image
                 src={stackExchangeScreenshot}
                 alt="Ethereum Stack Exchange screenshot"
@@ -333,7 +333,7 @@ const DevelopersPage = async (props: { params: Promise<PageParams> }) => {
               />
               <div>
                 <h3>{t("page-developers-get-help-title")}</h3>
-                <p className="text-body-medium text-sm">
+                <p className="text-sm text-body-medium">
                   {t("page-developers-get-help-desc")}
                 </p>
               </div>
@@ -362,7 +362,7 @@ const DevelopersPage = async (props: { params: Promise<PageParams> }) => {
             </Card>
 
             {/* Resources */}
-            <Card className="bg-background !space-y-8 px-6 py-8 break-words md:space-y-6 lg:p-8">
+            <Card className="!space-y-8 bg-background px-6 py-8 break-words md:space-y-6 lg:p-8">
               <Image
                 src={resourcesBanner}
                 alt="Banner showing four resource app icons"
@@ -371,7 +371,7 @@ const DevelopersPage = async (props: { params: Promise<PageParams> }) => {
               />
               <div>
                 <h3>{t("page-developers-resources-title")}</h3>
-                <p className="text-body-medium text-sm">
+                <p className="text-sm text-body-medium">
                   {t("page-developers-resources-desc")}
                 </p>
               </div>
@@ -393,7 +393,7 @@ const DevelopersPage = async (props: { params: Promise<PageParams> }) => {
             </Card>
 
             {/* Tutorials */}
-            <Card className="bg-background !space-y-8 px-6 py-8 break-words md:space-y-6 lg:p-8">
+            <Card className="!space-y-8 bg-background px-6 py-8 break-words md:space-y-6 lg:p-8">
               <Image
                 src={tutorialTagsBanner}
                 alt="Banner displaying multiple learning topics in a tag cloud"
@@ -402,7 +402,7 @@ const DevelopersPage = async (props: { params: Promise<PageParams> }) => {
               />
               <div>
                 <h3>{t("page-developers-tutorials-title")}</h3>
-                <p className="text-body-medium text-sm">
+                <p className="text-sm text-body-medium">
                   {t("page-developers-tutorials-desc")}
                 </p>
               </div>
@@ -449,7 +449,7 @@ const DevelopersPage = async (props: { params: Promise<PageParams> }) => {
             id="docs"
             className={cn(
               "shadow-table-item-box",
-              "bg-background-highlight -mx-8 w-screen max-w-screen-2xl px-8 py-10 md:py-20"
+              "-mx-8 w-screen max-w-screen-2xl bg-background-highlight px-8 py-10 md:py-20"
             )}
           >
             <div className="w-full scroll-mt-24 px-8 py-4">
@@ -642,12 +642,12 @@ const DevelopersPage = async (props: { params: Promise<PageParams> }) => {
             <div
               className={cn(
                 "mx-auto max-w-screen-lg",
-                "before:z-hide before:absolute before:-inset-px before:bottom-0 before:rounded-[calc(var(--radius-4xl)+1px)] before:content-['']", // Border/gradient positioning
-                "before:from-primary-hover/[0.24] before:to-primary-hover/[0.08] before:dark:from-primary-hover/40 before:dark:to-primary-hover/20 before:bg-linear-to-b", // Border/gradient coloring
-                "bg-background relative inset-0 rounded-4xl" // Paint background color over card portion
+                "before:absolute before:-inset-px before:bottom-0 before:z-hide before:rounded-[calc(var(--radius-4xl)+1px)] before:content-['']", // Border/gradient positioning
+                "before:bg-linear-to-b before:from-primary-hover/[0.24] before:to-primary-hover/[0.08] before:dark:from-primary-hover/40 before:dark:to-primary-hover/20", // Border/gradient coloring
+                "relative inset-0 rounded-4xl bg-background" // Paint background color over card portion
               )}
             >
-              <div className="bg-radial-a mb-12 flex flex-col items-center gap-y-8 rounded-4xl px-8 py-12 lg:mb-32 xl:mb-36">
+              <div className="mb-12 flex flex-col items-center gap-y-8 rounded-4xl bg-radial-a px-8 py-12 lg:mb-32 xl:mb-36">
                 <div className="flex flex-col gap-y-4 text-center">
                   <h2>{t("page-developers-founders-title")}</h2>
                   <p>{t("page-developers-founders-desc")}</p>

--- a/app/[locale]/developers/tools/[category]/page.tsx
+++ b/app/[locale]/developers/tools/[category]/page.tsx
@@ -117,7 +117,7 @@ const Page = async (props: {
 
         <Section id="categories" className="space-y-4">
           <h2>{t("page-developers-tools-categories-title-other")}</h2>
-          <div className="grid-cols-fill-4 grid gap-8">
+          <div className="grid grid-cols-fill-4 gap-8">
             {DEV_TOOL_CATEGORIES.filter(({ slug }) => slug !== category).map(
               ({ slug, Icon }) => (
                 <SubpageCard

--- a/app/[locale]/developers/tools/_components/CategoryToolsGrid.tsx
+++ b/app/[locale]/developers/tools/_components/CategoryToolsGrid.tsx
@@ -43,7 +43,7 @@ export default function CategoryToolsGrid({
         totalCount={tools.length}
       />
 
-      <div className="grid-cols-fill-3 grid gap-x-8">
+      <div className="grid grid-cols-fill-3 gap-x-8">
         {filteredTools.map((tool) => (
           <AppCard
             key={tool.id}

--- a/app/[locale]/developers/tools/_components/ToolModalContents.tsx
+++ b/app/[locale]/developers/tools/_components/ToolModalContents.tsx
@@ -53,7 +53,7 @@ const ToolModalContents = async ({ tool }: { tool: DeveloperTool }) => {
 
   return (
     <div className="bg-background">
-      <div className="from-accent-a/5 to-accent-a/10 dark:from-accent-a/10 dark:to-accent-a/20 h-36 w-full bg-linear-to-b">
+      <div className="h-36 w-full bg-linear-to-b from-accent-a/5 to-accent-a/10 dark:from-accent-a/10 dark:to-accent-a/20">
         {tool.banner_url && (
           <Image
             src={tool.banner_url}

--- a/app/[locale]/developers/tools/page.tsx
+++ b/app/[locale]/developers/tools/page.tsx
@@ -95,7 +95,7 @@ const Page = async (props: {
                 className="ms-6 w-[calc(100%-4rem)] max-w-md md:min-w-96 md:flex-1 lg:max-w-[33%]"
               >
                 <Card className="h-fit overflow-hidden border">
-                  <LinkBox className="hover:bg-background-highlight p-4">
+                  <LinkBox className="p-4 hover:bg-background-highlight">
                     <LinkOverlay
                       href={`/developers/tools/${slug}`}
                       className="text-body no-underline"
@@ -104,7 +104,7 @@ const Page = async (props: {
                         <div className="rounded-lg border p-2">
                           <Icon className="size-6" />
                         </div>
-                        <h3 className="text-md flex-1">
+                        <h3 className="flex-1 text-md">
                           {t(`page-developers-tools-category-${slug}-title`)}
                         </h3>
                         <Button
@@ -141,7 +141,7 @@ const Page = async (props: {
 
         <Section id="categories" className="space-y-4">
           <h2>{t("page-developers-tools-categories-title")}</h2>
-          <div className="grid-cols-fill-4 grid gap-8">
+          <div className="grid grid-cols-fill-4 gap-8">
             {DEV_TOOL_CATEGORIES.map(({ slug, Icon }) => (
               <SubpageCard
                 key={slug}

--- a/app/[locale]/developers/tutorials/_components/TutorialsLazy.tsx
+++ b/app/[locale]/developers/tutorials/_components/TutorialsLazy.tsx
@@ -8,7 +8,7 @@ const TutorialsList = dynamic(() => import("./tutorials"), {
   ssr: false,
   loading: () => (
     <div className="mt-8 w-full max-w-screen-lg">
-      <div className="border-border border-b px-8 pt-8 pb-6">
+      <div className="border-b border-border px-8 pt-8 pb-6">
         {/* Skill tabs + search skeleton */}
         <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
           <div className="flex gap-2">

--- a/app/[locale]/developers/tutorials/_components/modal.tsx
+++ b/app/[locale]/developers/tutorials/_components/modal.tsx
@@ -36,7 +36,7 @@ const TutorialSubmitModal = ({
           <Translation id="page-developers-tutorials:page-tutorial-listing-policy-intro" />
         </p>
         <Flex className="flex-col gap-2 md:flex-row">
-          <Flex className="border-border w-full flex-col justify-between rounded-xs border p-4">
+          <Flex className="w-full flex-col justify-between rounded-xs border border-border p-4">
             <b>
               <Translation id="page-developers-tutorials:page-tutorial-create-an-issue" />
             </b>
@@ -55,7 +55,7 @@ const TutorialSubmitModal = ({
       </Modal>
 
       <Button
-        className="text-body px-3 py-2"
+        className="px-3 py-2 text-body"
         variant="outline"
         onClick={() => {
           setModalOpen(true)

--- a/app/[locale]/developers/tutorials/_components/tutorials.tsx
+++ b/app/[locale]/developers/tutorials/_components/tutorials.tsx
@@ -258,7 +258,7 @@ const TutorialsList = ({ internalTutorials }: TutorialsListProps) => {
 
   return (
     <>
-      <div className="shadow-table-box my-8 w-full max-w-screen-lg">
+      <div className="my-8 w-full max-w-screen-lg shadow-table-box">
         {/* Skill level TabNav + Search */}
         <div className="flex flex-col gap-6 px-8 pt-6 md:max-lg:w-fit lg:flex-row lg:items-center">
           <TabNav
@@ -274,7 +274,7 @@ const TutorialsList = ({ internalTutorials }: TutorialsListProps) => {
             }}
           />
           <div className="relative w-full lg:ms-auto lg:w-44">
-            <Search className="text-body-medium pointer-events-none absolute start-3 top-1/2 size-4 -translate-y-1/2" />
+            <Search className="pointer-events-none absolute start-3 top-1/2 size-4 -translate-y-1/2 text-body-medium" />
             <Input
               type="text"
               placeholder={t("page-tutorial-search-placeholder")}
@@ -286,7 +286,7 @@ const TutorialsList = ({ internalTutorials }: TutorialsListProps) => {
             {searchQuery && (
               <button
                 onClick={() => setSearchQuery("")}
-                className="text-body-medium hover:text-body absolute end-3 top-1/2 -translate-y-1/2"
+                className="absolute end-3 top-1/2 -translate-y-1/2 text-body-medium hover:text-body"
               >
                 <X className="size-4" />
               </button>
@@ -295,10 +295,10 @@ const TutorialsList = ({ internalTutorials }: TutorialsListProps) => {
         </div>
 
         {/* Filter controls */}
-        <div className="border-border border-b px-8 pt-5 pb-6">
+        <div className="border-b border-border px-8 pt-5 pb-6">
           {/* Row 2: Topic tags */}
           <div className="mt-5">
-            <p className="text-body-medium mb-3 text-xs tracking-wider uppercase">
+            <p className="mb-3 text-xs tracking-wider text-body-medium uppercase">
               <Translation id="page-developers-tutorials:page-tutorial-topics" />
             </p>
             <div className="flex flex-wrap gap-2">
@@ -318,7 +318,7 @@ const TutorialsList = ({ internalTutorials }: TutorialsListProps) => {
               {nicheTags.length > 0 && (
                 <button
                   onClick={() => setShowAllTags(!showAllTags)}
-                  className="border-body-medium text-body-medium hover:border-primary hover:text-primary inline-flex items-center gap-1 rounded-full border border-dashed px-3 py-0.5 text-xs uppercase transition-colors"
+                  className="inline-flex items-center gap-1 rounded-full border border-dashed border-body-medium px-3 py-0.5 text-xs text-body-medium uppercase transition-colors hover:border-primary hover:text-primary"
                 >
                   {showAllTags ? (
                     <>
@@ -341,8 +341,8 @@ const TutorialsList = ({ internalTutorials }: TutorialsListProps) => {
 
           {/* Row 3: Active filters summary (only when filters active) */}
           {hasActiveFilters && (
-            <div className="border-border mt-4 flex flex-wrap items-center gap-2 border-t pt-4">
-              <span className="text-body-medium text-xs">
+            <div className="mt-4 flex flex-wrap items-center gap-2 border-t border-border pt-4">
+              <span className="text-xs text-body-medium">
                 <Translation id="page-developers-tutorials:page-tutorial-filtering-by" />
               </span>
 
@@ -384,7 +384,7 @@ const TutorialsList = ({ internalTutorials }: TutorialsListProps) => {
               )}
 
               <Button
-                className="text-primary cursor-pointer p-0 text-xs underline"
+                className="cursor-pointer p-0 text-xs text-primary underline"
                 variant="ghost"
                 size="sm"
                 onClick={handleClearAll}
@@ -399,7 +399,7 @@ const TutorialsList = ({ internalTutorials }: TutorialsListProps) => {
         {filteredTutorials.length === 0 ? (
           <div className="mt-0 p-12 text-center">
             <Emoji text=":crying_face:" className="my-8 text-5xl" />
-            <h2 className="leading-xs mt-12 mb-8">
+            <h2 className="mt-12 mb-8 leading-xs">
               <Translation id="page-developers-tutorials:page-tutorial-tags-error" />
             </h2>
             <Translation id="page-developers-tutorials:page-find-wallet-try-removing" />
@@ -413,11 +413,11 @@ const TutorialsList = ({ internalTutorials }: TutorialsListProps) => {
           <BaseLink
             key={tutorial.href}
             href={tutorial.href ?? undefined}
-            className="hover:bg-background-highlight block w-full space-y-6 border-b p-8 no-underline duration-100"
+            className="block w-full space-y-6 border-b p-8 no-underline duration-100 hover:bg-background-highlight"
             hideArrow
           >
             <Flex className="flex-col items-start justify-between gap-y-4 md:flex-row">
-              <h3 className="text-body relative me-0 text-2xl font-semibold md:me-24">
+              <h3 className="relative me-0 text-2xl font-semibold text-body md:me-24">
                 {tutorial.title}
                 {tutorial.isExternal && (
                   <ExternalLink className="ms-[0.25em] mb-[0.25em] inline-block size-[0.875em]" />
@@ -459,7 +459,7 @@ const TutorialsList = ({ internalTutorials }: TutorialsListProps) => {
                 <>
                   {" "}
                   •<Emoji text=":link:" className="mx-2 text-sm" />
-                  <span className="text-primary cursor-pointer">
+                  <span className="cursor-pointer text-primary">
                     <Translation id="page-developers-tutorials:page-tutorial-external-link" />
                   </span>
                 </>

--- a/app/[locale]/founders/page.tsx
+++ b/app/[locale]/founders/page.tsx
@@ -383,7 +383,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
                   value={key}
                   className="mt-12 border-0 p-0"
                 >
-                  <div className="grid-cols-fill-4 grid gap-4">
+                  <div className="grid grid-cols-fill-4 gap-4">
                     {entities.map(
                       ({
                         name,
@@ -397,10 +397,10 @@ const Page = async (props: { params: Promise<PageParams> }) => {
                       }) => (
                         <Card
                           key={name}
-                          className="bg-background-highlight row-span-3 grid grid-rows-subgrid gap-y-8 rounded-2xl p-8 max-md:px-4"
+                          className="row-span-3 grid grid-rows-subgrid gap-y-8 rounded-2xl bg-background-highlight p-8 max-md:px-4"
                         >
                           <h3 className="sr-only">{name}</h3>
-                          <Logo className="[&_*]:!fill-body my-auto max-h-9 max-w-full" />
+                          <Logo className="my-auto max-h-9 max-w-full [&_*]:!fill-body" />
                           <div className="space-y-4">
                             {!!tags.length && (
                               <div className="flex flex-wrap gap-x-1 gap-y-2">

--- a/app/[locale]/gas/_components/gas.tsx
+++ b/app/[locale]/gas/_components/gas.tsx
@@ -124,7 +124,7 @@ const GasPage = ({
 
   return (
     <Page>
-      <div className="from-accent-a/10 to-accent-c/10 dark:from-accent-a/20 dark:to-accent-c-hover/20 w-full bg-linear-to-r">
+      <div className="w-full bg-linear-to-r from-accent-a/10 to-accent-c/10 dark:from-accent-a/20 dark:to-accent-c-hover/20">
         <div className="pb-8">
           <PageHero
             content={{
@@ -284,7 +284,7 @@ const GasPage = ({
               <ListItem>
                 <Translation id="page-gas:page-gas-how-is-gas-calculated-item-3" />
                 <UnorderedList className="ms-6 list-none gap-3">
-                  <ListItem className="text-body-medium text-sm">
+                  <ListItem className="text-sm text-body-medium">
                     <Translation id="page-gas:page-gas-how-is-gas-calculated-list-item-1" />
                   </ListItem>
                 </UnorderedList>

--- a/app/[locale]/get-eth/page.tsx
+++ b/app/[locale]/get-eth/page.tsx
@@ -138,7 +138,7 @@ export default async function Page(props: { params: Promise<PageParams> }) {
                 <h1 className="my-8 text-4xl md:text-5xl">
                   {t("page-get-eth-where-to-buy-title")}
                 </h1>
-                <p className="text-body-medium mb-0 max-w-[45ch] text-center text-xl leading-snug">
+                <p className="mb-0 max-w-[45ch] text-center text-xl leading-snug text-body-medium">
                   {t("page-get-eth-where-to-buy-desc")}
                 </p>
                 <br />
@@ -239,7 +239,7 @@ export default async function Page(props: { params: Promise<PageParams> }) {
               id="country-picker"
               className={cn(
                 "-mx-8 my-0 flex flex-col items-center px-8 py-16 sm:p-16 md:my-16 lg:mx-0",
-                "from-accent-a/10 to-accent-c/10 dark:from-accent-a/20 dark:to-accent-c-hover/20 bg-linear-to-r"
+                "bg-linear-to-r from-accent-a/10 to-accent-c/10 dark:from-accent-a/20 dark:to-accent-c-hover/20"
               )}
             >
               <div className="flex flex-col items-center">
@@ -344,10 +344,10 @@ export default async function Page(props: { params: Promise<PageParams> }) {
                     </h3>
                     <p>{t("page-get-eth-your-address-desc")}</p>
                     <div className="mb-6 flex flex-col-reverse justify-between rounded bg-[#191919] p-2 select-none lg:flex-row">
-                      <p className="font-monospace mb-0 text-xs text-white">
+                      <p className="mb-0 font-monospace text-xs text-white">
                         0x0125e2478d69eXaMpLe81766fef5c120d30fb53f
                       </p>
-                      <p className="text-error mx-4 mb-0 text-sm uppercase">
+                      <p className="mx-4 mb-0 text-sm text-error uppercase">
                         {t("page-get-eth-do-not-copy")}
                       </p>
                     </div>

--- a/app/[locale]/layer-2/_components/layer-2.tsx
+++ b/app/[locale]/layer-2/_components/layer-2.tsx
@@ -123,7 +123,7 @@ const Layer2Hub = ({
 
         <div id="layer-2-stats-box" className="w-full px-8 py-9">
           <div className="m-auto max-w-[992px] py-9">
-            <div className="border-body-light flex flex-col gap-8 border p-8 md:flex-row md:gap-14">
+            <div className="flex flex-col gap-8 border border-body-light p-8 md:flex-row md:gap-14">
               <div className="flex-1">
                 <div className="max-w-[224px]">
                   <p className="text-5xl">
@@ -138,7 +138,7 @@ const Layer2Hub = ({
                   </p>
                 </div>
               </div>
-              <div className="border-body-light h-auto w-auto self-stretch border-b md:border-r" />
+              <div className="h-auto w-auto self-stretch border-b border-body-light md:border-r" />
               <div className="flex-1">
                 <div className="max-w-[224px]">
                   <p className="text-5xl">
@@ -170,10 +170,10 @@ const Layer2Hub = ({
             </p>
             <div className="relative m-auto h-[275px] w-[275px] sm:h-[375px] sm:w-[375px]">
               {/* Outer ring */}
-              <div className="border-body-medium absolute inset-0 rounded-full border border-dashed"></div>
-              <div className="animate-spin-30 absolute inset-0 rounded-full">
+              <div className="absolute inset-0 rounded-full border border-dashed border-body-medium"></div>
+              <div className="absolute inset-0 animate-spin-30 rounded-full">
                 {/* Top logo */}
-                <div className="animate-counter-spin-30 bg-primary absolute -top-[12px] left-1/2 h-6 w-6 rounded-full">
+                <div className="absolute -top-[12px] left-1/2 h-6 w-6 animate-counter-spin-30 rounded-full bg-primary">
                   <Image
                     className="rounded-full"
                     src={randomL2s[0].logo}
@@ -183,7 +183,7 @@ const Layer2Hub = ({
                   />
                 </div>
                 {/* Bottom right logo */}
-                <div className="animate-counter-spin-30 absolute right-[8%] bottom-[17%] h-6 w-6 rounded-full">
+                <div className="absolute right-[8%] bottom-[17%] h-6 w-6 animate-counter-spin-30 rounded-full">
                   <Image
                     className="rounded-full"
                     src={randomL2s[1].logo}
@@ -193,7 +193,7 @@ const Layer2Hub = ({
                   />
                 </div>
                 {/* Bottom left logo */}
-                <div className="animate-counter-spin-30 absolute bottom-[17%] left-[8%] h-6 w-6 rounded-full">
+                <div className="absolute bottom-[17%] left-[8%] h-6 w-6 animate-counter-spin-30 rounded-full">
                   <Image
                     className="rounded-full"
                     src={randomL2s[2].logo}
@@ -205,10 +205,10 @@ const Layer2Hub = ({
               </div>
 
               {/* Middle ring */}
-              <div className="border-body-medium absolute inset-[30px] rounded-full border border-dashed sm:inset-[54px]"></div>
-              <div className="animate-spin-21 absolute inset-[30px] rounded-full sm:inset-[54px]">
+              <div className="absolute inset-[30px] rounded-full border border-dashed border-body-medium sm:inset-[54px]"></div>
+              <div className="absolute inset-[30px] animate-spin-21 rounded-full sm:inset-[54px]">
                 {/* Top logo */}
-                <div className="animate-counter-spin-21 absolute -top-[12px] left-1/2 h-6 w-6 rounded-full">
+                <div className="absolute -top-[12px] left-1/2 h-6 w-6 animate-counter-spin-21 rounded-full">
                   <Image
                     className="rounded-full"
                     src={randomL2s[3].logo}
@@ -218,7 +218,7 @@ const Layer2Hub = ({
                   />
                 </div>
                 {/* Bottom right logo */}
-                <div className="animate-counter-spin-21 absolute right-[5%] bottom-[15%] h-6 w-6 rounded-full">
+                <div className="absolute right-[5%] bottom-[15%] h-6 w-6 animate-counter-spin-21 rounded-full">
                   <Image
                     className="rounded-full"
                     src={randomL2s[4].logo}
@@ -228,7 +228,7 @@ const Layer2Hub = ({
                   />
                 </div>
                 {/* Bottom left logo */}
-                <div className="animate-counter-spin-21 absolute bottom-[15%] left-[5%] h-6 w-6 rounded-full">
+                <div className="absolute bottom-[15%] left-[5%] h-6 w-6 animate-counter-spin-21 rounded-full">
                   <Image
                     className="rounded-full"
                     src={randomL2s[5].logo}
@@ -240,10 +240,10 @@ const Layer2Hub = ({
               </div>
 
               {/* Inner ring */}
-              <div className="border-body-medium absolute inset-[60px] rounded-full border border-dashed sm:inset-[108px]"></div>
-              <div className="animate-spin-9 absolute inset-[60px] rounded-full sm:inset-[108px]">
+              <div className="absolute inset-[60px] rounded-full border border-dashed border-body-medium sm:inset-[108px]"></div>
+              <div className="absolute inset-[60px] animate-spin-9 rounded-full sm:inset-[108px]">
                 {/* Top logo */}
-                <div className="animate-counter-spin-9 absolute -top-[12px] left-1/2 h-6 w-6 rounded-full">
+                <div className="absolute -top-[12px] left-1/2 h-6 w-6 animate-counter-spin-9 rounded-full">
                   <Image
                     className="rounded-full"
                     src={randomL2s[6].logo}
@@ -253,7 +253,7 @@ const Layer2Hub = ({
                   />
                 </div>
                 {/* Bottom right logo */}
-                <div className="animate-counter-spin-9 absolute right-[5%] bottom-[15%] h-6 w-6 rounded-full">
+                <div className="absolute right-[5%] bottom-[15%] h-6 w-6 animate-counter-spin-9 rounded-full">
                   <Image
                     className="rounded-full"
                     src={randomL2s[7].logo}
@@ -263,7 +263,7 @@ const Layer2Hub = ({
                   />
                 </div>
                 {/* Bottom left logo */}
-                <div className="animate-counter-spin-9 absolute bottom-[15%] left-[5%] h-6 w-6 rounded-full">
+                <div className="absolute bottom-[15%] left-[5%] h-6 w-6 animate-counter-spin-9 rounded-full">
                   <Image
                     className="rounded-full"
                     src={randomL2s[8].logo}
@@ -324,7 +324,7 @@ const Layer2Hub = ({
         </div>
 
         <div id="layer-2-cta" className="w-full px-8 py-9">
-          <div className="bg-main-gradient mx-auto flex max-w-[640px] flex-col gap-6 rounded p-8">
+          <div className="mx-auto flex max-w-[640px] flex-col gap-6 rounded bg-main-gradient p-8">
             <div className="flex flex-col gap-6">
               {userRandomL2s.map((l2, idx) => {
                 return (
@@ -332,12 +332,12 @@ const Layer2Hub = ({
                     key={idx}
                     className={`flex flex-1 flex-col items-start gap-4 p-4 md:flex-row md:items-center ${
                       idx < randomL2s.slice(0, 3).length - 1
-                        ? "border-background border-b"
+                        ? "border-b border-background"
                         : ""
                     }`}
                   >
                     <div className="flex flex-1 flex-col items-start gap-4 md:flex-row md:items-center">
-                      <div className="bg-background shadow-drop flex h-14 w-14 items-center justify-center rounded-md">
+                      <div className="flex h-14 w-14 items-center justify-center rounded-md bg-background shadow-drop">
                         <Image
                           src={l2.logo}
                           alt={l2.name}
@@ -372,7 +372,7 @@ const Layer2Hub = ({
             </div>
 
             <div className="flex justify-center">
-              <div className="bg-background mx-auto inline-flex items-center justify-center gap-2 rounded-full px-4 py-2 text-sm font-bold">
+              <div className="mx-auto inline-flex items-center justify-center gap-2 rounded-full bg-background px-4 py-2 text-sm font-bold">
                 <Image
                   src={EthereumLogo}
                   alt={t("page-layer-2-ethereum-logo-alt")}
@@ -391,7 +391,7 @@ const Layer2Hub = ({
           id="layer-2-why-do-we-need-multiple-networks"
           className="w-full px-8 py-9"
         >
-          <div className="bg-background-highlight flex flex-col gap-8 px-12 py-12 md:flex-row">
+          <div className="flex flex-col gap-8 bg-background-highlight px-12 py-12 md:flex-row">
             <div className="flex flex-1 items-center justify-center">
               <Image
                 src={WalkingImage}

--- a/app/[locale]/layer-2/learn/_components/learn.tsx
+++ b/app/[locale]/layer-2/learn/_components/learn.tsx
@@ -122,7 +122,7 @@ const Layer2Learn = ({
 
       <div
         id="what-is-layer-1"
-        className="bg-body-light flex w-full flex-col gap-4 px-8 py-9"
+        className="flex w-full flex-col gap-4 bg-body-light px-8 py-9"
       >
         <h2>{t("page-layer-2-learn-what-is-layer-1-title")}</h2>
         <div className="flex flex-col justify-between gap-16 md:flex-row">
@@ -140,25 +140,25 @@ const Layer2Learn = ({
             </p>
             <ol className="list-none space-y-2 pl-0 [counter-reset:item]">
               <li className="flex items-center space-x-3">
-                <span className="bg-body-inverse flex h-8 w-8 flex-none items-center justify-center rounded-full text-sm font-medium [counter-increment:item] before:content-[counter(item)]"></span>
+                <span className="flex h-8 w-8 flex-none items-center justify-center rounded-full bg-body-inverse text-sm font-medium [counter-increment:item] before:content-[counter(item)]"></span>
                 <span>
                   <Translation id="page-layer-2-learn:page-layer-2-learn-layer-1-list-1" />
                 </span>
               </li>
               <li className="flex items-center space-x-3">
-                <span className="bg-body-inverse flex h-8 w-8 flex-none items-center justify-center rounded-full text-sm font-medium [counter-increment:item] before:content-[counter(item)]"></span>
+                <span className="flex h-8 w-8 flex-none items-center justify-center rounded-full bg-body-inverse text-sm font-medium [counter-increment:item] before:content-[counter(item)]"></span>
                 <span>
                   <Translation id="page-layer-2-learn:page-layer-2-learn-layer-1-list-2" />
                 </span>
               </li>
               <li className="flex items-center space-x-3">
-                <span className="bg-body-inverse flex h-8 w-8 flex-none items-center justify-center rounded-full text-sm font-medium [counter-increment:item] before:content-[counter(item)]"></span>
+                <span className="flex h-8 w-8 flex-none items-center justify-center rounded-full bg-body-inverse text-sm font-medium [counter-increment:item] before:content-[counter(item)]"></span>
                 <span>
                   <Translation id="page-layer-2-learn:page-layer-2-learn-layer-1-list-3" />
                 </span>
               </li>
               <li className="flex items-center space-x-3">
-                <span className="bg-body-inverse flex h-8 w-8 flex-none items-center justify-center rounded-full text-sm font-medium [counter-increment:item] before:content-[counter(item)]"></span>
+                <span className="flex h-8 w-8 flex-none items-center justify-center rounded-full bg-body-inverse text-sm font-medium [counter-increment:item] before:content-[counter(item)]"></span>
                 <span>
                   <Translation id="page-layer-2-learn:page-layer-2-learn-layer-1-list-4" />
                 </span>
@@ -230,7 +230,7 @@ const Layer2Learn = ({
           return (
             <div
               key={idx}
-              className="border-body-light bg-background-highlight flex w-full flex-col gap-4 rounded-xs border border-solid p-6 md:w-[50%]"
+              className="flex w-full flex-col gap-4 rounded-xs border border-solid border-body-light bg-background-highlight p-6 md:w-[50%]"
             >
               <Image src={card.image} alt={""} />
               <h3>{card.title}</h3>

--- a/app/[locale]/layer-2/networks/page.tsx
+++ b/app/[locale]/layer-2/networks/page.tsx
@@ -167,7 +167,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
         <Layer2NetworksTable {...layer2NetworksProps} />
 
         <div id="more-advanced-cta" className="w-full px-8 py-9">
-          <div className="bg-main-gradient flex flex-col gap-8 px-12 py-14">
+          <div className="flex flex-col gap-8 bg-main-gradient px-12 py-14">
             <h3>{t("page-layer-2-networks-more-advanced-title")}</h3>
             <div className="flex max-w-[768px] flex-col gap-8">
               <p>

--- a/app/[locale]/learn/page.tsx
+++ b/app/[locale]/learn/page.tsx
@@ -46,7 +46,7 @@ const AdditionalDocReading = ({
   docLinks: DocLinkProps[]
 }) => (
   <div className="mt-24 space-y-8">
-    <h3 className="text-md text-center lg:text-xl">{heading}</h3>
+    <h3 className="text-center text-md lg:text-xl">{heading}</h3>
     <div className="flex flex-col gap-2 xl:mx-36">
       {docLinks.map(({ children, ...rest }) => (
         <DocLink key={rest.href} {...rest}>
@@ -70,7 +70,7 @@ const LearnCard = ({
   description: string
   ctaLabel: string
 }) => (
-  <Card className="bg-background-highlight row-span-3 grid grid-rows-subgrid gap-y-8 p-8 max-md:p-4">
+  <Card className="row-span-3 grid grid-rows-subgrid gap-y-8 bg-background-highlight p-8 max-md:p-4">
     <CardBanner background="none" fit="contain">
       <Image src={image} alt="" sizes="250px" />
     </CardBanner>
@@ -239,7 +239,7 @@ export default async function Page(props: { params: Promise<PageParams> }) {
                 {t("what-is-crypto-2-after-link")}
               </p>
 
-              <div className="grid-cols-fill-4 grid gap-4">
+              <div className="grid grid-cols-fill-4 gap-4">
                 <LearnCard
                   href="/what-is-ethereum/"
                   image={whatIsEth}
@@ -264,7 +264,7 @@ export default async function Page(props: { params: Promise<PageParams> }) {
               </div>
 
               <h3>{t("keep-learning-title")}</h3>
-              <div className="grid-cols-fill-4 grid gap-4">
+              <div className="grid grid-cols-fill-4 gap-4">
                 <LearnCard
                   href="/what-is-the-ethereum-network/"
                   image={developersEthBlocks}
@@ -315,7 +315,7 @@ export default async function Page(props: { params: Promise<PageParams> }) {
               <h2>{tocItems[1].title}</h2>
               <p>{t("how-do-i-use-ethereum-1")}</p>
 
-              <div className="grid-cols-fill-4 grid gap-4">
+              <div className="grid grid-cols-fill-4 gap-4">
                 <LearnCard
                   href="/wallets/"
                   image={wallet}
@@ -385,7 +385,7 @@ export default async function Page(props: { params: Promise<PageParams> }) {
               <p>{t("go-deeper-description")}</p>
             </div>
 
-            <div className="grid-cols-fill-4 grid gap-4">
+            <div className="grid grid-cols-fill-4 gap-4">
               <LearnCard
                 href="/roadmap/"
                 image={merge}

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -114,7 +114,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
                     <SectionHeader className="mt-0 mb-0 leading-tight lg:text-6xl">
                       {t("page-index-simulator-title")}
                     </SectionHeader>
-                    <p className="text-body-medium text-lg md:text-xl">
+                    <p className="text-lg text-body-medium md:text-xl">
                       {t("page-index-simulator-subtitle")}
                     </p>
                   </div>

--- a/app/[locale]/quizzes/_components/quizzes.tsx
+++ b/app/[locale]/quizzes/_components/quizzes.tsx
@@ -88,7 +88,7 @@ const QuizzesPage = () => {
                   {...commonQuizListProps}
                 />
               </div>
-              <Flex className="bg-background-highlight items-center justify-between p-8 max-xl:flex-col max-xl:gap-4 lg:rounded-lg">
+              <Flex className="items-center justify-between bg-background-highlight p-8 max-xl:flex-col max-xl:gap-4 lg:rounded-lg">
                 <div className="max-xl:text-center">
                   <p className="font-bold">{t("want-more-quizzes")}</p>
                   <p>{t("contribute")}</p>
@@ -100,7 +100,7 @@ const QuizzesPage = () => {
                   onClick={handleGHAdd}
                 >
                   <HStack className="gap-0">
-                    <Github className="text-body me-2 text-2xl" />
+                    <Github className="me-2 text-2xl text-body" />
                     {t("add-quiz")}
                   </HStack>
                 </ButtonLink>

--- a/app/[locale]/resources/_components/ResourcesUI.tsx
+++ b/app/[locale]/resources/_components/ResourcesUI.tsx
@@ -27,7 +27,7 @@ export const ResourceItem = ({
   <Link
     href={href}
     className={cn(
-      "text-body hover:bg-background-highlight hover:text-body flex gap-2 border-b p-3 no-underline last-of-type:border-0",
+      "flex gap-2 border-b p-3 text-body no-underline last-of-type:border-0 hover:bg-background-highlight hover:text-body",
       className
     )}
     customEventOptions={{

--- a/app/[locale]/resources/_components/UpgradeCountdown.tsx
+++ b/app/[locale]/resources/_components/UpgradeCountdown.tsx
@@ -98,15 +98,15 @@ const UpgradeCountdown = () => {
     <>
       <BaseLink
         href={`/roadmap/${upgrade}/`}
-        className="text-body hover:text-primary text-5xl font-bold no-underline"
+        className="text-5xl font-bold text-body no-underline hover:text-primary"
       >
         {upgrade.slice(0, 1).toUpperCase() + upgrade.slice(1)}
       </BaseLink>
-      <div className="text-body-medium text-xl font-bold">
+      <div className="text-xl font-bold text-body-medium">
         {scalingUpgradeCountdown ? (
           scalingUpgradeCountdown
         ) : (
-          <div className="bg-success text-success-light rounded-full px-2 py-1 text-xs font-normal uppercase">
+          <div className="rounded-full bg-success px-2 py-1 text-xs font-normal text-success-light uppercase">
             Live Since{" "}
             {dateTimeFormat(locale, { timeZone: "UTC" }).format(
               new Date(upgradeDate)

--- a/app/[locale]/resources/page.tsx
+++ b/app/[locale]/resources/page.tsx
@@ -105,7 +105,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
 
         <Stack className="gap-4 px-2 py-6 md:gap-8 md:px-4 lg:px-8 xl:gap-11">
           <StickyContainer className="top-[26px] space-y-5">
-            <div className="text-body-medium my-2 text-center">
+            <div className="my-2 text-center text-body-medium">
               {t("page-resources-whats-on-this-page")}
             </div>
             <TabNav
@@ -122,7 +122,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
               <Stack key={key} asChild>
                 <section id={key} className="!scroll-mt-40 gap-8 md:gap-6">
                   <div className="group flex w-full items-center gap-4 border-b bg-transparent px-2 py-4">
-                    <div className="border-border-low-contrast grid size-12 place-items-center rounded-lg border text-2xl [&_svg]:shrink-0">
+                    <div className="grid size-12 place-items-center rounded-lg border border-border-low-contrast text-2xl [&_svg]:shrink-0">
                       {icon || <StackIcon />}
                     </div>
                     <h2 className="flex-1 text-start font-black">{label}</h2>
@@ -139,7 +139,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
                         <div className="border-b bg-[#ffffff] px-6 py-4 font-bold dark:bg-[#171717]">
                           {title}
                         </div>
-                        <div className="bg-background to-primary/10 dark:to-primary/10 h-full bg-linear-to-br from-white px-2 py-6 dark:from-transparent">
+                        <div className="h-full bg-background bg-linear-to-br from-white to-primary/10 px-2 py-6 dark:from-transparent dark:to-primary/10">
                           {metric && metric}
                           <ResourcesContainer>
                             {items.map(({ className, ...item }) => (
@@ -178,9 +178,9 @@ const Page = async (props: { params: Promise<PageParams> }) => {
 
           <Section
             id="contribute"
-            className="border-body/5 bg-background relative rounded-4xl border"
+            className="relative rounded-4xl border border-body/5 bg-background"
           >
-            <VStack className="bg-radial-a rounded-4xl px-4 py-6 md:py-12">
+            <VStack className="rounded-4xl bg-radial-a px-4 py-6 md:py-12">
               <Stack className="max-w-xl gap-y-10 py-6 lg:max-w-[700px]">
                 <div className="flex flex-col gap-y-4 text-center">
                   <h2>{t("page-resources-contribute-title")}</h2>

--- a/app/[locale]/roadmap/_components/ReleaseCarousel.tsx
+++ b/app/[locale]/roadmap/_components/ReleaseCarousel.tsx
@@ -113,7 +113,7 @@ const ReleaseCarousel = () => {
   return (
     <div className="w-full max-w-[100vw] overflow-hidden" dir="ltr">
       <div className="mx-auto w-full max-w-screen-2xl px-4 sm:px-6">
-        <div className="bg-background-highlight w-full rounded-2xl py-6">
+        <div className="w-full rounded-2xl bg-background-highlight py-6">
           <div className="flex flex-col gap-6">
             {/* First Carousel */}
             <Carousel
@@ -141,7 +141,7 @@ const ReleaseCarousel = () => {
                           {status === "prod" && (
                             <div
                               className={cn(
-                                "bg-primary-low-contrast w-fit rounded-lg px-2 py-1",
+                                "w-fit rounded-lg bg-primary-low-contrast px-2 py-1",
                                 currentIndex !== index && "hidden"
                               )}
                             >
@@ -153,7 +153,7 @@ const ReleaseCarousel = () => {
                           {status === "soon" && (
                             <div
                               className={cn(
-                                "bg-warning-light w-fit rounded-lg px-2 py-1",
+                                "w-fit rounded-lg bg-warning-light px-2 py-1",
                                 currentIndex !== index && "hidden"
                               )}
                             >
@@ -165,7 +165,7 @@ const ReleaseCarousel = () => {
                           {status === "dev" && (
                             <div
                               className={cn(
-                                "bg-card-gradient-secondary-hover w-fit rounded-lg px-2 py-1",
+                                "w-fit rounded-lg bg-card-gradient-secondary-hover px-2 py-1",
                                 currentIndex !== index && "hidden"
                               )}
                             >
@@ -182,7 +182,7 @@ const ReleaseCarousel = () => {
                               "flex h-1 flex-1",
                               index !== 0
                                 ? status === "soon"
-                                  ? "from-primary to-primary-low-contrast bg-linear-to-r"
+                                  ? "bg-linear-to-r from-primary to-primary-low-contrast"
                                   : status === "prod"
                                     ? "bg-primary"
                                     : "bg-primary-low-contrast"
@@ -196,7 +196,7 @@ const ReleaseCarousel = () => {
                                 ? "bg-primary"
                                 : "bg-primary-low-contrast",
                               status === "soon" &&
-                                "border-primary bg-background border-2"
+                                "border-2 border-primary bg-background"
                             )}
                           />
                           <div
@@ -214,7 +214,7 @@ const ReleaseCarousel = () => {
                           <p className="text-md font-bold">
                             {release.releaseName}
                           </p>
-                          <p className="text-body-medium font-mono text-sm">
+                          <p className="font-mono text-sm text-body-medium">
                             {displayDate}
                           </p>
                         </div>

--- a/app/[locale]/roadmap/_vision/_components/vision.tsx
+++ b/app/[locale]/roadmap/_vision/_components/vision.tsx
@@ -86,7 +86,7 @@ const CentralContent = (props: ChildOnlyProp) => (
 
 const TrilemmaContent = (props: ChildOnlyProp) => (
   <div
-    className="from-accent-a/10 to-accent-c/10 my-8 w-full bg-linear-to-r p-8"
+    className="my-8 w-full bg-linear-to-r from-accent-a/10 to-accent-c/10 p-8"
     {...props}
   />
 )

--- a/app/[locale]/run-a-node/_components/run-a-node.tsx
+++ b/app/[locale]/run-a-node/_components/run-a-node.tsx
@@ -82,7 +82,7 @@ const SoftwareHighlight = ({
 }: HTMLAttributes<HTMLHeadingElement>) => (
   <Center
     className={cn(
-      "border-border-high-contrast text-body relative isolate !ml-0 w-full flex-col-reverse gap-8 rounded-xs border p-8 ps-16 pe-16 after:absolute after:inset-0 after:-z-10 after:bg-inherit after:blur-xl after:content-[''] md:mx-24 md:flex-row",
+      "relative isolate !ml-0 w-full flex-col-reverse gap-8 rounded-xs border border-border-high-contrast p-8 ps-16 pe-16 text-body after:absolute after:inset-0 after:-z-10 after:bg-inherit after:blur-xl after:content-[''] md:mx-24 md:flex-row",
       className
     )}
     {...props}
@@ -121,7 +121,7 @@ const Container = ({
 }: HTMLAttributes<HTMLHeadingElement>) => (
   <Flex
     className={cn(
-      "border-border-high-contrast bg-background-highlight text-body rounded-md border px-8 py-0",
+      "rounded-md border border-border-high-contrast bg-background-highlight px-8 py-0 text-body",
       className
     )}
     {...props}
@@ -133,7 +133,7 @@ const BuildBox = ({
   ...props
 }: HTMLAttributes<HTMLHeadingElement>) => (
   <Container
-    className={cn("bg-background-highlight flex-1 flex-col p-8", className)}
+    className={cn("flex-1 flex-col bg-background-highlight p-8", className)}
     {...props}
   />
 )
@@ -172,15 +172,15 @@ const StakingCalloutContainer = (props: ChildOnlyProp) => (
 )
 
 const H2 = (props: ChildOnlyProp) => (
-  <h2 className="leading-xs mt-12 mb-8" {...props} />
+  <h2 className="mt-12 mb-8 leading-xs" {...props} />
 )
 
 const H3 = ({ className, ...props }: HTMLAttributes<HTMLHeadingElement>) => (
-  <h3 className={cn("leading-xs mt-10 mb-8", className)} {...props} />
+  <h3 className={cn("mt-10 mb-8 leading-xs", className)} {...props} />
 )
 
 const H4 = (props: ChildOnlyProp) => (
-  <h4 className="leading-xs my-8" {...props} />
+  <h4 className="my-8 leading-xs" {...props} />
 )
 
 const Text = ({ className, ...props }: HTMLAttributes<HTMLHeadingElement>) => (
@@ -296,7 +296,7 @@ const RunANodePage = ({
   return (
     <>
       <GappedPage>
-        <div className="from-accent-b/5 via-primary/10 to-accent-b/15 dark:from-accent-b/20 dark:via-primary/15 dark:to-accent-a/20 w-full bg-linear-to-br">
+        <div className="w-full bg-linear-to-br from-accent-b/5 via-primary/10 to-accent-b/15 dark:from-accent-b/20 dark:via-primary/15 dark:to-accent-a/20">
           <div className="pb-8">
             <PageHero content={heroContent} isReverse />
           </div>
@@ -368,7 +368,7 @@ const RunANodePage = ({
           <H2>
             <Translation id="page-run-a-node:page-run-a-node-why-title" />
           </H2>
-          <div className="grid-cols-fill-3 grid gap-8">
+          <div className="grid grid-cols-fill-3 gap-8">
             {whyRunANodeCards.map(({ Svg, title, preview, body }) => (
               <ExpandableCard
                 contentPreview={preview}
@@ -402,7 +402,7 @@ const RunANodePage = ({
                 </Text>
                 <Text>
                   <code>
-                    <Emoji text=":warning:" className="text-md me-4" />
+                    <Emoji text=":warning:" className="me-4 text-md" />
                     {t(
                       "page-run-a-node-getting-started-software-section-1-alert"
                     )}

--- a/app/[locale]/stablecoins/page.tsx
+++ b/app/[locale]/stablecoins/page.tsx
@@ -462,8 +462,8 @@ async function Page(props: { params: Promise<PageParams> }) {
           <div
             className={cn(
               "my-8 w-full py-16 shadow-inner",
-              "from-accent-a/10 to-accent-c/10 bg-linear-to-r",
-              "dark:from-primary/20 dark:via-accent-a/20 dark:to-accent-c/20 dark:bg-linear-to-tr dark:from-20% dark:via-60% dark:to-95%"
+              "bg-linear-to-r from-accent-a/10 to-accent-c/10",
+              "dark:bg-linear-to-tr dark:from-primary/20 dark:from-20% dark:via-accent-a/20 dark:via-60% dark:to-accent-c/20 dark:to-95%"
             )}
           >
             <div className="-mb-8 w-full px-8 py-4">
@@ -496,7 +496,7 @@ async function Page(props: { params: Promise<PageParams> }) {
               <div className="mb-16 grid grid-cols-1 gap-16 lg:grid-cols-2">
                 {editorsChoices.map((choice, idx) => (
                   <Flex
-                    className="border-border-high-contrast bg-background text-body w-full flex-col-reverse justify-between gap-x-8 rounded-xs border p-8 sm:flex-row"
+                    className="w-full flex-col-reverse justify-between gap-x-8 rounded-xs border border-border-high-contrast bg-background p-8 text-body sm:flex-row"
                     key={idx}
                     style={{
                       boxShadow: `0.75rem 0.75rem 0 hsla(var(--${choice.shadowColor}-500), 0.25)`,
@@ -505,7 +505,7 @@ async function Page(props: { params: Promise<PageParams> }) {
                     <Flex className="flex-col">
                       <div>
                         <h4 className="mb-2 text-3xl">{choice.title}</h4>
-                        <p className="text-body-medium mb-6">{choice.body}</p>
+                        <p className="mb-6 text-body-medium">{choice.body}</p>
                       </div>
                       <div className="mt-auto">
                         <Flex className="flex-col">
@@ -547,10 +547,10 @@ async function Page(props: { params: Promise<PageParams> }) {
                               {choice.marketCap}
                             </span>
                           ) : (
-                            <span className="text-body-medium text-lg">-</span>
+                            <span className="text-lg text-body-medium">-</span>
                           )}
                         </div>
-                        <div className="text-body-medium text-center text-sm">
+                        <div className="text-center text-sm text-body-medium">
                           {t(
                             "page-stablecoins-stablecoins-table-header-column-2"
                           )}
@@ -626,7 +626,7 @@ async function Page(props: { params: Promise<PageParams> }) {
                 <p className="mb-6">{t("page-stablecoins-saving")}</p>
               </div>
             </Flex>
-            <div className="grid-cols-fill-4 mb-16 grid gap-8">
+            <div className="mb-16 grid grid-cols-fill-4 gap-8">
               {dapps.map((dapp, idx) => (
                 <DataProductCard
                   key={idx}
@@ -676,7 +676,7 @@ async function Page(props: { params: Promise<PageParams> }) {
                       <div className="my-6 grid grid-cols-1 gap-6 md:grid-cols-2">
                         {feature.pros && (
                           <div>
-                            <h4 className="bg-success/25 mb-2 rounded p-2 text-xl font-semibold">
+                            <h4 className="mb-2 rounded bg-success/25 p-2 text-xl font-semibold">
                               {t("pros")}
                             </h4>
                             <ul className="list-inside list-disc">
@@ -688,7 +688,7 @@ async function Page(props: { params: Promise<PageParams> }) {
                         )}
                         {feature.cons && (
                           <div>
-                            <h4 className="bg-error/25 mb-2 rounded p-2 text-xl font-semibold">
+                            <h4 className="mb-2 rounded bg-error/25 p-2 text-xl font-semibold">
                               {t("cons")}
                             </h4>
                             <ul className="list-inside list-disc">

--- a/app/[locale]/staking/_components/staking.tsx
+++ b/app/[locale]/staking/_components/staking.tsx
@@ -48,7 +48,7 @@ const PageContainer = (props: ChildOnlyProp) => (
 )
 
 const HeroStatsWrapper = (props: ChildOnlyProp) => (
-  <VStack className="bg-main-gradient w-full gap-0" {...props} />
+  <VStack className="w-full gap-0 bg-main-gradient" {...props} />
 )
 
 const ComparisonGrid = (props: ChildOnlyProp) => {
@@ -61,7 +61,7 @@ const ComparisonGrid = (props: ChildOnlyProp) => {
 }
 
 const H2 = (props: HTMLAttributes<HTMLHeadingElement>) => (
-  <h2 className="leading-xs mt-0 mb-8 text-2xl md:text-[2rem]" {...props} />
+  <h2 className="mt-0 mb-8 text-2xl leading-xs md:text-[2rem]" {...props} />
 )
 
 const ColorH3 = ({

--- a/app/[locale]/staking/deposit-contract/_components/deposit-contract.tsx
+++ b/app/[locale]/staking/deposit-contract/_components/deposit-contract.tsx
@@ -54,11 +54,11 @@ const RightColumn = (props: ChildOnlyProp) => (
 )
 
 const Title = (props: ChildOnlyProp) => (
-  <h1 className="leading-xs py-8" {...props} />
+  <h1 className="py-8 leading-xs" {...props} />
 )
 
 const Subtitle = (props: ChildOnlyProp) => (
-  <p className="leading-xs text-body-medium mb-14" {...props} />
+  <p className="mb-14 leading-xs text-body-medium" {...props} />
 )
 
 const ButtonRow = (props: ChildOnlyProp) => (
@@ -69,7 +69,7 @@ const ButtonRow = (props: ChildOnlyProp) => (
 )
 
 const H2 = (props: ChildOnlyProp) => (
-  <h2 className="leading-xs mt-12 mb-8" {...props} />
+  <h2 className="mt-12 mb-8 leading-xs" {...props} />
 )
 
 const StyledButton = ({
@@ -83,7 +83,7 @@ const StyledButton = ({
 
 const CardTag = (props: ChildOnlyProp) => (
   <Flex
-    className="bg-primary dark:text-background-medium items-center justify-center rounded-t-sm border-b-white p-2 text-sm text-white uppercase"
+    className="items-center justify-center rounded-t-sm border-b-white bg-primary p-2 text-sm text-white uppercase dark:text-background-medium"
     {...props}
   />
 )
@@ -91,7 +91,7 @@ const CardTag = (props: ChildOnlyProp) => (
 const AddressCard = (props: ChildOnlyProp) => {
   return (
     <div
-      className="border-border shadow-table mb-8 max-w-full rounded-xs border lg:sticky lg:top-28 lg:max-w-[560px]"
+      className="mb-8 max-w-full rounded-xs border border-border shadow-table lg:sticky lg:top-28 lg:max-w-[560px]"
       {...props}
     />
   )
@@ -99,7 +99,7 @@ const AddressCard = (props: ChildOnlyProp) => {
 
 const Address = (props: ChildOnlyProp) => (
   <div
-    className="font-monospace leading-xs mb-4 flex-wrap rounded-xs text-[2rem] uppercase"
+    className="mb-4 flex-wrap rounded-xs font-monospace text-[2rem] leading-xs uppercase"
     {...props}
   />
 )
@@ -124,7 +124,7 @@ const CardTitle = (props: ChildOnlyProp) => (
 )
 
 const Caption = (props: ChildOnlyProp) => (
-  <p className="text-body-medium mb-8 md:mb-8 lg:mb-0" {...props} />
+  <p className="mb-8 text-body-medium md:mb-8 lg:mb-0" {...props} />
 )
 
 const Blockie = (props: { src: string }) => (
@@ -139,7 +139,7 @@ const Blockie = (props: { src: string }) => (
 
 const StyledFakeLink = (props: ButtonProps) => (
   <Button
-    className="text-primary me-2 cursor-pointer px-0"
+    className="me-2 cursor-pointer px-0 text-primary"
     variant="ghost"
     {...props}
   />

--- a/app/[locale]/start/page.tsx
+++ b/app/[locale]/start/page.tsx
@@ -71,7 +71,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
               <StartWithEthereumFlow newToCryptoWallets={wallets} />
             </div>
 
-            <div className="border-accent-c/10 from-accent-c/10 to-accent-c/5 dark:from-accent-c/20 dark:to-accent-c/10 flex w-full flex-col gap-12 rounded-2xl border bg-linear-to-t from-20% to-60% px-12 py-16 md:flex-row">
+            <div className="flex w-full flex-col gap-12 rounded-2xl border border-accent-c/10 bg-linear-to-t from-accent-c/10 from-20% to-accent-c/5 to-60% px-12 py-16 md:flex-row dark:from-accent-c/20 dark:to-accent-c/10">
               <div className="flex flex-1 flex-col gap-8">
                 <h2 className="">{t("page-start-share-section-title")}</h2>
                 <p>{t("page-start-share-section-description")}</p>

--- a/app/[locale]/trillion-dollar-security/page.tsx
+++ b/app/[locale]/trillion-dollar-security/page.tsx
@@ -24,7 +24,7 @@ import TdsReport from "@/public/images/trillion-dollar-security/report.png"
 
 const ReportCard = ({ cta, altText }: { cta: string; altText: string }) => {
   return (
-    <Card className="bg-card-gradient rounded-2xl border p-8 shadow dark:bg-linear-to-br dark:from-white/0 dark:to-purple-500/10">
+    <Card className="rounded-2xl border bg-card-gradient p-8 shadow dark:bg-linear-to-br dark:from-white/0 dark:to-purple-500/10">
       <CardContent className="p-0 pb-4">
         <CardParagraph variant="light" size="sm">
           <Image
@@ -73,7 +73,7 @@ const TdsPage = async (props: { params: Promise<PageParams> }) => {
             className="max-h-[480px] w-full object-cover"
           />
           <div className="px-6 md:px-8">
-            <p className="text-body-medium mt-6 mb-2 text-center">
+            <p className="mt-6 mb-2 text-center text-body-medium">
               {t("page-trillion-dollar-security-subtitle")}
             </p>
             <h1 className="mb-20 text-center">
@@ -124,12 +124,12 @@ const TdsPage = async (props: { params: Promise<PageParams> }) => {
                 </p>
                 <p>{t("page-trillion-dollar-security-hero-paragraph-6")}</p>
 
-                <ol className="text-primary list-decimal font-bold">
+                <ol className="list-decimal font-bold text-primary">
                   <li>
                     <Link href="#ux" className="no-underline">
                       {t("page-trillion-dollar-security-user-experience-title")}
                     </Link>
-                    <p className="text-body font-normal">
+                    <p className="font-normal text-body">
                       {t(
                         "page-trillion-dollar-security-user-experience-description"
                       )}
@@ -139,7 +139,7 @@ const TdsPage = async (props: { params: Promise<PageParams> }) => {
                     <Link href="#smart-contracts" className="no-underline">
                       {t("page-trillion-dollar-security-smart-contract-title")}
                     </Link>
-                    <p className="text-body font-normal">
+                    <p className="font-normal text-body">
                       {t(
                         "page-trillion-dollar-security-smart-contract-description"
                       )}
@@ -149,7 +149,7 @@ const TdsPage = async (props: { params: Promise<PageParams> }) => {
                     <Link href="#infrastructure" className="no-underline">
                       {t("page-trillion-dollar-security-infrastructure-title")}
                     </Link>
-                    <p className="text-body font-normal">
+                    <p className="font-normal text-body">
                       {t(
                         "page-trillion-dollar-security-infrastructure-description"
                       )}
@@ -159,7 +159,7 @@ const TdsPage = async (props: { params: Promise<PageParams> }) => {
                     <Link href="#consensus" className="no-underline">
                       {t("page-trillion-dollar-security-consensus-title")}
                     </Link>
-                    <p className="text-body font-normal">
+                    <p className="font-normal text-body">
                       {t("page-trillion-dollar-security-consensus-description")}
                     </p>
                   </li>
@@ -167,7 +167,7 @@ const TdsPage = async (props: { params: Promise<PageParams> }) => {
                     <Link href="#incident" className="no-underline">
                       {t("page-trillion-dollar-security-incident-title")}
                     </Link>
-                    <p className="text-body font-normal">
+                    <p className="font-normal text-body">
                       {t("page-trillion-dollar-security-incident-description")}
                     </p>
                   </li>
@@ -175,7 +175,7 @@ const TdsPage = async (props: { params: Promise<PageParams> }) => {
                     <Link href="#social" className="no-underline">
                       {t("page-trillion-dollar-security-social-title")}
                     </Link>
-                    <p className="text-body font-normal">
+                    <p className="font-normal text-body">
                       {t("page-trillion-dollar-security-social-description")}
                     </p>
                   </li>

--- a/app/[locale]/use-cases/page.tsx
+++ b/app/[locale]/use-cases/page.tsx
@@ -54,7 +54,7 @@ const UseCaseCard = ({
   description: string
   ctaLabel: string
 }) => (
-  <Card className="bg-background-highlight row-span-3 grid grid-rows-subgrid gap-y-8 p-8 max-md:p-4">
+  <Card className="row-span-3 grid grid-rows-subgrid gap-y-8 bg-background-highlight p-8 max-md:p-4">
     <CardBanner background="none" fit="contain">
       <Image src={image} alt="" sizes="250px" />
     </CardBanner>
@@ -117,7 +117,7 @@ export default async function Page(props: { params: Promise<PageParams> }) {
         showDropdown={false}
       >
         <div className="space-y-24 max-lg:pt-10">
-          <p className="text-body-medium text-lg">
+          <p className="text-lg text-body-medium">
             {t("page-intro-before-link")}{" "}
             <InlineLink href="/what-is-ether/">
               {t("page-intro-ether-link")}
@@ -131,7 +131,7 @@ export default async function Page(props: { params: Promise<PageParams> }) {
               <h2>{tocItems[0].title}</h2>
               <p>{t("financial-tools-description")}</p>
 
-              <div className="grid-cols-fill-4 grid gap-4">
+              <div className="grid grid-cols-fill-4 gap-4">
                 <UseCaseCard
                   href="/defi/"
                   image={defi}
@@ -159,7 +159,7 @@ export default async function Page(props: { params: Promise<PageParams> }) {
             <div className="space-y-8">
               <h3>{t("novel-uses-title")}</h3>
 
-              <div className="grid-cols-fill-4 grid gap-4">
+              <div className="grid grid-cols-fill-4 gap-4">
                 <UseCaseCard
                   href="/real-world-assets/"
                   image={manAndDog}
@@ -207,7 +207,7 @@ export default async function Page(props: { params: Promise<PageParams> }) {
             <h2>{tocItems[1].title}</h2>
             <p>{t("digital-ownership-description")}</p>
 
-            <div className="grid-cols-fill-4 grid gap-4">
+            <div className="grid grid-cols-fill-4 gap-4">
               <UseCaseCard
                 href="/nft/"
                 image={infrastructureTransparent}
@@ -230,7 +230,7 @@ export default async function Page(props: { params: Promise<PageParams> }) {
             <h2>{tocItems[2].title}</h2>
             <p>{t("organizations-description")}</p>
 
-            <div className="grid-cols-fill-4 grid gap-4">
+            <div className="grid grid-cols-fill-4 gap-4">
               <UseCaseCard
                 href="/dao/"
                 image={daoImg}
@@ -260,7 +260,7 @@ export default async function Page(props: { params: Promise<PageParams> }) {
             <h2>{tocItems[3].title}</h2>
             <p>{t("science-description")}</p>
 
-            <div className="grid-cols-fill-4 grid gap-4">
+            <div className="grid grid-cols-fill-4 gap-4">
               <UseCaseCard
                 href="/desci/"
                 image={futureTransparent}

--- a/app/[locale]/videos/[slug]/page.tsx
+++ b/app/[locale]/videos/[slug]/page.tsx
@@ -80,7 +80,7 @@ const VideoLandingPage = async (props: {
         <div className="space-y-4">
           <h1>{frontmatter.title}</h1>
 
-          <p className="text-body-medium text-lg">{frontmatter.description}</p>
+          <p className="text-lg text-body-medium">{frontmatter.description}</p>
 
           <p className="text-body-medium">
             {t("page-videos-date-published")}:{" "}

--- a/app/[locale]/videos/_components/VideoGalleryFilter.tsx
+++ b/app/[locale]/videos/_components/VideoGalleryFilter.tsx
@@ -158,7 +158,7 @@ const VideoGalleryFilter = ({
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
           {/* Search input */}
           <div className="relative w-full sm:max-w-xs">
-            <Search className="text-body-medium pointer-events-none absolute start-3 top-1/2 size-4 -translate-y-1/2" />
+            <Search className="pointer-events-none absolute start-3 top-1/2 size-4 -translate-y-1/2 text-body-medium" />
             <Input
               type="text"
               placeholder={t("page-videos-search-placeholder")}
@@ -170,7 +170,7 @@ const VideoGalleryFilter = ({
             {searchQuery && (
               <button
                 onClick={() => setSearchQuery("")}
-                className="text-body-medium hover:text-body absolute end-3 top-1/2 -translate-y-1/2"
+                className="absolute end-3 top-1/2 -translate-y-1/2 text-body-medium hover:text-body"
               >
                 <X className="size-4" />
               </button>
@@ -200,8 +200,8 @@ const VideoGalleryFilter = ({
 
       {/* Active filter strip */}
       {hasActiveFilters && (
-        <div className="border-border flex flex-wrap items-center gap-2 border-t pt-4">
-          <span className="text-body-medium text-xs">
+        <div className="flex flex-wrap items-center gap-2 border-t border-border pt-4">
+          <span className="text-xs text-body-medium">
             {t("page-videos-filtering-by")}
           </span>
 
@@ -244,7 +244,7 @@ const VideoGalleryFilter = ({
           )}
 
           <Button
-            className="text-primary cursor-pointer p-0 text-xs underline"
+            className="cursor-pointer p-0 text-xs text-primary underline"
             variant="ghost"
             size="sm"
             onClick={handleClearAll}

--- a/app/[locale]/wallets/find-wallet/page.tsx
+++ b/app/[locale]/wallets/find-wallet/page.tsx
@@ -70,7 +70,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
             <h1 className="text-[2.5rem] leading-[1.4] md:text-5xl">
               {t("page-find-wallet-title")}
             </h1>
-            <p className="text-body-medium mb-6 text-xl leading-[1.4] last:mb-8">
+            <p className="mb-6 text-xl leading-[1.4] text-body-medium last:mb-8">
               {t("page-find-wallet-description")}
             </p>
           </div>

--- a/app/[locale]/wallets/page.tsx
+++ b/app/[locale]/wallets/page.tsx
@@ -39,7 +39,7 @@ import HeroImage from "@/public/images/wallets/wallet-hero.png"
 
 const StyledCard = (props: ComponentPropsWithRef<typeof Card>) => (
   <Card
-    className="bg-background m-4 max-w-full min-w-[280px] flex-1 p-6 md:max-w-[46%] lg:max-w-[31%]"
+    className="m-4 max-w-full min-w-[280px] flex-1 bg-background p-6 md:max-w-[46%] lg:max-w-[31%]"
     {...props}
   />
 )
@@ -205,7 +205,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
       <MainArticle className="mx-auto flex w-full flex-col items-center">
         <PageHero content={heroContent} isReverse />
 
-        <div className="bg-background-highlight mt-4 w-full border-t px-0 py-16 lg:mt-8">
+        <div className="mt-4 w-full border-t bg-background-highlight px-0 py-16 lg:mt-8">
           <div className="-mb-8 w-full px-8 py-4 pb-0">
             <ListenToPlayer slug="/wallets/" />
           </div>
@@ -216,19 +216,19 @@ const Page = async (props: { params: Promise<PageParams> }) => {
           </div>
           <div className="mb-0 flex flex-col justify-between p-8 lg:flex-row">
             <div className="me-0 flex-[0_1_50%] lg:me-8 lg:mt-0 lg:max-w-full">
-              <p className="text-md leading-base mb-[1.45rem]">
+              <p className="mb-[1.45rem] text-md leading-base">
                 <Translation id="page-wallets:page-wallets-description" />
               </p>
-              <p className="text-md leading-base mb-[1.45rem]">
+              <p className="mb-[1.45rem] text-md leading-base">
                 {t("page-wallets-desc-2")}
               </p>
               <CardList items={guides} className="mb-6 lg:mb-0" />
             </div>
             <div className="max-w-full flex-[0_1_50%] lg:ms-8">
-              <p className="text-md leading-base mb-[1.45rem]">
+              <p className="mb-[1.45rem] text-md leading-base">
                 {t("page-wallets-desc-3")}
               </p>
-              <p className="text-md leading-base mb-[1.45rem]">
+              <p className="mb-[1.45rem] text-md leading-base">
                 {t("page-wallets-desc-4")}
               </p>
             </div>
@@ -252,27 +252,27 @@ const Page = async (props: { params: Promise<PageParams> }) => {
             <h2 className="mt-12 mb-8 text-2xl leading-[1.4] md:text-[2rem]">
               {t("page-wallets-accounts-addresses")}
             </h2>
-            <p className="text-md leading-base mb-[1.45rem]">
+            <p className="mb-[1.45rem] text-md leading-base">
               {t("page-wallets-accounts-addresses-desc")}
             </p>
             <ul>
               <li>
-                <p className="text-md leading-base mb-[1.45rem]">
+                <p className="mb-[1.45rem] text-md leading-base">
                   <Translation id="page-wallets:page-wallets-ethereum-account" />
                 </p>
               </li>
               <li>
-                <p className="text-md leading-base mb-[1.45rem]">
+                <p className="mb-[1.45rem] text-md leading-base">
                   <Translation id="page-wallets:page-wallets-accounts-ethereum-addresses" />
                 </p>
               </li>
               <li>
-                <p className="text-md leading-base mb-[1.45rem]">
+                <p className="mb-[1.45rem] text-md leading-base">
                   <Translation id="page-wallets:page-wallets-ethereum-wallet" />
                 </p>
               </li>
             </ul>
-            <p className="text-md leading-base mb-[1.45rem]">
+            <p className="mb-[1.45rem] text-md leading-base">
               {t("page-wallets-most-wallets")}
             </p>
           </div>
@@ -280,7 +280,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
             <h2 className="mt-12 mb-8 text-2xl leading-[1.4] md:text-[2rem]">
               {t("page-wallets-types")}
             </h2>
-            <p className="text-md leading-base mb-[1.45rem]">
+            <p className="mb-[1.45rem] text-md leading-base">
               {t("page-wallets-types-desc")}
             </p>
             <div className="flex flex-col gap-2">
@@ -301,7 +301,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
           <div className="my-20 w-full px-0 py-4">
             <Suspense>
               <WalletSimulator>
-                <p className="leading-base text-body-medium mb-2 text-lg italic md:text-xl lg:text-2xl">
+                <p className="mb-2 text-lg leading-base text-body-medium italic md:text-xl lg:text-2xl">
                   Interactive tutorial
                 </p>
                 <h2 className="m-0 text-3xl leading-[115%] font-bold lg:text-5xl">
@@ -311,13 +311,13 @@ const Page = async (props: { params: Promise<PageParams> }) => {
             </Suspense>
           </div>
         ) : (
-          <div className="bg-gradient-main my-12 mt-4 w-full border-t px-0 py-16 lg:mt-8">
+          <div className="my-12 mt-4 w-full border-t bg-gradient-main px-0 py-16 lg:mt-8">
             <div className="w-full px-8 py-4">
               <div className="mb-8 flex flex-col items-center">
                 <h2 className="mt-12 mb-8 text-2xl leading-[1.4] md:text-[2rem]">
                   {t("page-wallets-features-title")}
                 </h2>
-                <div className="leading-base mb-6 text-center text-xl">
+                <div className="mb-6 text-center text-xl leading-base">
                   {t("page-wallets-features-desc")}
                 </div>
                 <ButtonLink
@@ -345,7 +345,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
             <h2 className="mt-12 mb-8 text-2xl leading-[1.4] md:text-[2rem]">
               {t("page-wallets-stay-safe")}
             </h2>
-            <p className="leading-xs mb-6">
+            <p className="mb-6 leading-xs">
               <Translation id="page-wallets:page-wallets-stay-safe-desc" />
             </p>
             <div className="flex flex-col gap-4">
@@ -367,7 +367,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
                 emojiClassName="text-2xl"
                 className="items-start"
               >
-                <p className="text-md leading-base mb-[1.45rem]">
+                <p className="mb-[1.45rem] text-md leading-base">
                   {t("page-wallets-seed-phrase-example")}
                 </p>
                 <div className="rounded-base mb-4 bg-black p-2">
@@ -375,7 +375,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
                     {t("page-wallets-seed-phrase-snippet")}
                   </p>
                 </div>
-                <p className="text-md leading-base mb-[1.45rem]">
+                <p className="mb-[1.45rem] text-md leading-base">
                   {t("page-wallets-seed-phrase-write-down")}
                 </p>
               </HorizontalCard>
@@ -401,7 +401,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
             <h2 className="mt-12 mb-8 text-2xl leading-[1.4] md:text-[2rem]">
               {t("page-wallets-tips")}
             </h2>
-            <p className="leading-xs mb-6">
+            <p className="mb-6 leading-xs">
               {t("page-wallets-tips-community")}
             </p>
             <CardList items={articles} />

--- a/app/[locale]/what-is-ethereum/_components/WhySwiper/index.tsx
+++ b/app/[locale]/what-is-ethereum/_components/WhySwiper/index.tsx
@@ -15,7 +15,7 @@ import { trackCustomEvent } from "@/lib/utils/matomo"
 import useTranslation from "@/hooks/useTranslation"
 
 const H3 = (props: ChildOnlyProp) => (
-  <h3 className="leading-xs text-xl font-semibold md:text-2xl" {...props} />
+  <h3 className="text-xl leading-xs font-semibold md:text-2xl" {...props} />
 )
 
 const WhySwiper = () => {
@@ -29,7 +29,7 @@ const WhySwiper = () => {
   ]
 
   return (
-    <SwiperContainer className="bg-background rounded border p-8">
+    <SwiperContainer className="rounded border bg-background p-8">
       <Swiper
         onSlideChange={({ activeIndex }) => {
           trackCustomEvent({

--- a/app/[locale]/what-is-ethereum/_components/WhySwiper/loading.tsx
+++ b/app/[locale]/what-is-ethereum/_components/WhySwiper/loading.tsx
@@ -1,7 +1,7 @@
 import { Skeleton, SkeletonLines } from "@/components/ui/skeleton"
 
 const Loading = () => (
-  <div className="bg-background h-fit space-y-8 rounded border p-8">
+  <div className="h-fit space-y-8 rounded border bg-background p-8">
     <SkeletonLines noOfLines={5} />
     <SkeletonLines noOfLines={5} />
     <Skeleton className="mx-auto h-5 w-40 rounded-full" />

--- a/app/[locale]/what-is-ethereum/page.tsx
+++ b/app/[locale]/what-is-ethereum/page.tsx
@@ -301,7 +301,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
 
             <Section
               id={getId(tocItems[2].url)}
-              className="border-accent-a/20 from-accent-a/5 to-accent-a/15 space-y-8 rounded-4xl border bg-linear-to-b px-4 py-6 lg:p-12"
+              className="space-y-8 rounded-4xl border border-accent-a/20 bg-linear-to-b from-accent-a/5 to-accent-a/15 px-4 py-6 lg:p-12"
             >
               <div className="flex flex-col items-center justify-center gap-4 xl:flex-row">
                 <Image
@@ -347,7 +347,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
 
             <Section
               id={getId(tocItems[3].url)}
-              className="border-accent-c/20 from-accent-c/5 to-accent-c/15 space-y-8 rounded-4xl border bg-linear-to-b px-4 py-6 lg:p-12"
+              className="space-y-8 rounded-4xl border border-accent-c/20 bg-linear-to-b from-accent-c/5 to-accent-c/15 px-4 py-6 lg:p-12"
             >
               <div className="flex flex-col items-center gap-4 xl:flex-row-reverse">
                 <Image
@@ -636,8 +636,8 @@ const Page = async (props: { params: Promise<PageParams> }) => {
               </div>
 
               <Card className="overflow-hidden rounded-2xl border">
-                <CardTitle className="bg-background-highlight flex items-center gap-4 border-b p-4">
-                  <User className="text-accent-a size-8" />
+                <CardTitle className="flex items-center gap-4 border-b bg-background-highlight p-4">
+                  <User className="size-8 text-accent-a" />
                   {t("page-what-is-ethereum-start-individuals-title")}
                 </CardTitle>
                 <CardContent className="space-y-12 p-8">
@@ -712,8 +712,8 @@ const Page = async (props: { params: Promise<PageParams> }) => {
               </Card>
 
               <Card className="overflow-hidden rounded-2xl border">
-                <CardTitle className="bg-background-highlight flex items-center gap-4 border-b p-4">
-                  <SquareCode className="text-accent-b size-8" />
+                <CardTitle className="flex items-center gap-4 border-b bg-background-highlight p-4">
+                  <SquareCode className="size-8 text-accent-b" />
                   {t("page-what-is-ethereum-start-developers-title")}
                 </CardTitle>
                 <CardContent className="space-y-12 p-8">
@@ -754,8 +754,8 @@ const Page = async (props: { params: Promise<PageParams> }) => {
               </Card>
 
               <Card className="overflow-hidden rounded-2xl border">
-                <CardTitle className="bg-background-highlight flex items-center gap-4 border-b p-4">
-                  <Landmark className="text-accent-c size-8" />
+                <CardTitle className="flex items-center gap-4 border-b bg-background-highlight p-4">
+                  <Landmark className="size-8 text-accent-c" />
                   {t("page-what-is-ethereum-start-business-title")}
                 </CardTitle>
                 <CardContent className="space-y-12 p-8">
@@ -884,19 +884,19 @@ const Page = async (props: { params: Promise<PageParams> }) => {
                     </h3>
                     <OrderedList className="m-0 list-none [&>li]:mb-0">
                       <ListItem>
-                        <span className="text-body-medium font-bold">
+                        <span className="font-bold text-body-medium">
                           2013:
                         </span>{" "}
                         {t("page-what-is-ethereum-when-who-history-2013")}
                       </ListItem>
                       <ListItem>
-                        <span className="text-body-medium font-bold">
+                        <span className="font-bold text-body-medium">
                           2014:
                         </span>{" "}
                         {t("page-what-is-ethereum-when-who-history-2014")}
                       </ListItem>
                       <ListItem>
-                        <span className="text-body-medium font-bold">
+                        <span className="font-bold text-body-medium">
                           2015:
                         </span>{" "}
                         {t.rich("page-what-is-ethereum-when-who-history-2015", {
@@ -904,19 +904,19 @@ const Page = async (props: { params: Promise<PageParams> }) => {
                         })}
                       </ListItem>
                       <ListItem>
-                        <span className="text-body-medium font-bold">
+                        <span className="font-bold text-body-medium">
                           2016:
                         </span>{" "}
                         {t("page-what-is-ethereum-when-who-history-2016")}{" "}
                       </ListItem>
                       <ListItem>
-                        <span className="text-body-medium font-bold">
+                        <span className="font-bold text-body-medium">
                           2020:
                         </span>{" "}
                         {t("page-what-is-ethereum-when-who-history-2020")}{" "}
                       </ListItem>
                       <ListItem>
-                        <span className="text-body-medium font-bold">
+                        <span className="font-bold text-body-medium">
                           2021:
                         </span>{" "}
                         {t.rich("page-what-is-ethereum-when-who-history-2021", {
@@ -924,7 +924,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
                         })}{" "}
                       </ListItem>
                       <ListItem>
-                        <span className="text-body-medium font-bold">
+                        <span className="font-bold text-body-medium">
                           2022:
                         </span>{" "}
                         {t.rich("page-what-is-ethereum-when-who-history-2022", {
@@ -932,7 +932,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
                         })}{" "}
                       </ListItem>
                       <ListItem>
-                        <span className="text-body-medium font-bold">
+                        <span className="font-bold text-body-medium">
                           2025:
                         </span>{" "}
                         {t.rich("page-what-is-ethereum-when-who-history-2025", {

--- a/src/components/AB/TestDebugPanel.tsx
+++ b/src/components/AB/TestDebugPanel.tsx
@@ -39,11 +39,11 @@ export const ABTestDebugPanel = ({
   const panelContent = (
     <div
       ref={panelRef}
-      className="z-modal bg-background-low fixed right-5 bottom-5 rounded-lg border-2 p-2.5 font-mono text-xs"
+      className="fixed right-5 bottom-5 z-modal rounded-lg border-2 bg-background-low p-2.5 font-mono text-xs"
     >
       <Button
         onClick={() => setIsOpen(!isOpen)}
-        className="bg-accent-a hover:bg-accent-a-hover w-full cursor-pointer rounded border-none px-2.5 py-1 font-semibold text-white"
+        className="w-full cursor-pointer rounded border-none bg-accent-a px-2.5 py-1 font-semibold text-white hover:bg-accent-a-hover"
       >
         🧪 AB Test Switcher
       </Button>
@@ -65,7 +65,7 @@ export const ABTestDebugPanel = ({
               className={cn(
                 "my-0.5 block w-full rounded border border-gray-300 px-2 py-1",
                 selectedVariant === index &&
-                  "bg-success hover:bg-success-dark text-white"
+                  "bg-success text-white hover:bg-success-dark"
               )}
             >
               {variant}

--- a/src/components/ActionCard.tsx
+++ b/src/components/ActionCard.tsx
@@ -41,14 +41,14 @@ const ActionCard = ({
   return (
     <LinkBox
       className={cn(
-        "shadow-table hover:bg-background-highlight hover:shadow-table-box-hover focus:shadow-table-box-hover flex flex-col hover:scale-[1.02] hover:rounded hover:duration-100 focus:scale-[1.02] focus:rounded focus:duration-100 md:flex-row",
+        "flex flex-col shadow-table hover:scale-[1.02] hover:rounded hover:bg-background-highlight hover:shadow-table-box-hover hover:duration-100 focus:scale-[1.02] focus:rounded focus:shadow-table-box-hover focus:duration-100 md:flex-row",
         className
       )}
       {...props}
     >
       <Flex
         className={cn(
-          "from-accent-a/10 to-accent-c/10 flex h-[260px] flex-row bg-linear-to-r",
+          "flex h-[260px] flex-row bg-linear-to-r from-accent-a/10 to-accent-c/10",
           isBottom ? "items-end" : "items-center",
           isRight ? "justify-end" : "justify-center"
         )}
@@ -72,7 +72,7 @@ const ActionCard = ({
             </InlineLink>
           </LinkOverlay>
         </h3>
-        <p className={"text-body/65 mb-0"}>{description}</p>
+        <p className={"mb-0 text-body/65"}>{description}</p>
         {children && <div className="mt-8">{children}</div>}
       </div>
     </LinkBox>

--- a/src/components/AppCard/AppCard.stories.tsx
+++ b/src/components/AppCard/AppCard.stories.tsx
@@ -57,11 +57,11 @@ export const LayoutComparison = {
   render: () => (
     <VStack className="items-stretch gap-8">
       <div>
-        <p className="text-body-medium mb-2 text-sm">Vertical (default)</p>
+        <p className="mb-2 text-sm text-body-medium">Vertical (default)</p>
         <AppCard {...sampleApp} layout="vertical" href="/apps/uniswap" />
       </div>
       <div>
-        <p className="text-body-medium mb-2 text-sm">Horizontal</p>
+        <p className="mb-2 text-sm text-body-medium">Horizontal</p>
         <AppCard {...sampleApp} layout="horizontal" href="/apps/uniswap" />
       </div>
     </VStack>
@@ -75,7 +75,7 @@ export const ImageSizes = {
       {(["xs", "small", "thumbnail", "medium", "large"] as const).map(
         (size) => (
           <div key={size}>
-            <p className="text-body-medium mb-2 text-sm">Size: {size}</p>
+            <p className="mb-2 text-sm text-body-medium">Size: {size}</p>
             <AppCard
               {...sampleApp}
               layout="horizontal"
@@ -209,7 +209,7 @@ export const CategoryTagStatuses = {
 export const AppsPageStyle = {
   render: () => (
     <VStack className="items-stretch gap-4">
-      <p className="text-body-medium text-sm">
+      <p className="text-sm text-body-medium">
         As used on /apps page (vertical with description)
       </p>
       <AppCard
@@ -235,7 +235,7 @@ export const AppsPageStyle = {
 export const DeveloperAppsPageStyle = {
   render: () => (
     <VStack className="items-stretch gap-4">
-      <p className="text-body-medium text-sm">
+      <p className="text-sm text-body-medium">
         As used on /developers/tools page (horizontal, no category, no tracking)
       </p>
       <AppCard
@@ -262,7 +262,7 @@ export const DeveloperAppsPageStyle = {
 export const CategoryListStyle = {
   render: () => (
     <VStack className="items-stretch gap-4">
-      <p className="text-body-medium text-sm">
+      <p className="text-sm text-body-medium">
         Apps listed by category (bordered container, no card-level hover)
       </p>
       <div className="flex flex-col rounded-xl border">
@@ -302,10 +302,10 @@ export const CategoryListStyle = {
 export const HighlightCardCover = {
   render: () => (
     <VStack className="items-stretch gap-4">
-      <p className="text-body-medium text-sm">
+      <p className="text-sm text-body-medium">
         Banner with fit=&quot;cover&quot; - image fills and may crop
       </p>
-      <LinkBox className="group hover:bg-background-highlight w-full rounded-xl p-3">
+      <LinkBox className="group w-full rounded-xl p-3 hover:bg-background-highlight">
         <LinkOverlay href="/apps/uniswap" className="no-underline">
           {/* Banner image - cover crops to fill */}
           <CardBanner fit="cover" background="accent-a" className="mb-2">
@@ -343,11 +343,11 @@ export const HighlightCardCover = {
 export const HighlightCardContain = {
   render: () => (
     <VStack className="items-stretch gap-4">
-      <p className="text-body-medium text-sm">
+      <p className="text-sm text-body-medium">
         Banner with fit=&quot;contain&quot; - image fully visible with blur
         background
       </p>
-      <LinkBox className="group hover:bg-background-highlight w-full rounded-xl p-3">
+      <LinkBox className="group w-full rounded-xl p-3 hover:bg-background-highlight">
         <LinkOverlay href="/apps/uniswap" className="no-underline">
           {/* Banner image - contain shows full image with blur bg */}
           <CardBanner fit="contain" background="accent-a" className="mb-2">

--- a/src/components/AppCard/index.tsx
+++ b/src/components/AppCard/index.tsx
@@ -150,7 +150,7 @@ const AppCard = React.forwardRef<HTMLDivElement, AppCardProps>(
           )}
 
           {/* Name - hover effect triggers when inside a group (LinkBox) */}
-          <p className="text-body group-hover/appcard:text-primary-hover text-lg leading-none font-bold">
+          <p className="text-lg leading-none font-bold text-body group-hover/appcard:text-primary-hover">
             {name}
           </p>
 

--- a/src/components/AssetDownload/index.tsx
+++ b/src/components/AssetDownload/index.tsx
@@ -49,7 +49,7 @@ const AssetDownload = ({
       className={cn("m-4 justify-between gap-0 p-0", className)}
       {...props}
     >
-      <h4 className="text-md my-8 font-medium md:text-xl">{title}</h4>
+      <h4 className="my-8 text-md font-medium md:text-xl">{title}</h4>
       <div>
         <AssetDownloadImage image={image} alt={alt} />
         {artistName && (

--- a/src/components/Banners/BannerNotification.tsx
+++ b/src/components/Banners/BannerNotification.tsx
@@ -14,7 +14,7 @@ const BannerNotification = ({
   return (
     <aside
       className={cn(
-        "bg-primary-action flex w-full items-center justify-center gap-2 px-8 py-4 text-white [&_a]:text-white [&_a]:hover:text-white/80",
+        "flex w-full items-center justify-center gap-2 bg-primary-action px-8 py-4 text-white [&_a]:text-white [&_a]:hover:text-white/80",
         className
       )}
       {...props}

--- a/src/components/Banners/EventsOrganizerBanner.tsx
+++ b/src/components/Banners/EventsOrganizerBanner.tsx
@@ -15,7 +15,7 @@ function EventsOrganizerBanner({
     <aside
       className={cn(
         "flex flex-col rounded md:flex-row",
-        "from-accent-a/10 to-accent-c/10 dark:from-accent-a/20 dark:to-accent-c-hover/20 bg-linear-to-r",
+        "bg-linear-to-r from-accent-a/10 to-accent-c/10 dark:from-accent-a/20 dark:to-accent-c-hover/20",
         className
       )}
       {...props}
@@ -41,7 +41,7 @@ function EventsOrganizerBanner({
       >
         <Stack className="px-2">
           <h2>Planning an Ethereum event?</h2>
-          <p className="text-body text-lg">
+          <p className="text-lg text-body">
             Check out the Ethereum event guide built by the community, for the
             community.
           </p>

--- a/src/components/BoxGrid.tsx
+++ b/src/components/BoxGrid.tsx
@@ -54,10 +54,10 @@ const BoxGrid = ({ items }: BoxGridProps) => {
         return (
           <Flex
             className={cn(
-              "border-body hover:shadow-table-box-hover cursor-pointer items-center justify-between border p-6 transition-transform duration-500 hover:-skew-x-6 lg:items-stretch",
+              "cursor-pointer items-center justify-between border border-body p-6 transition-transform duration-500 hover:-skew-x-6 hover:shadow-table-box-hover lg:items-stretch",
               isOpen
                 ? `flex-col text-gray-600 sm:flex-col lg:row-start-1 lg:row-end-3 lg:flex-col ${color}`
-                : "bg-background text-body hover:bg-background-highlight flex-col-reverse sm:flex-row-reverse lg:flex-col-reverse"
+                : "flex-col-reverse bg-background text-body hover:bg-background-highlight sm:flex-row-reverse lg:flex-col-reverse"
             )}
             onClick={() => {
               setOpenIndex(idx)
@@ -79,11 +79,11 @@ const BoxGrid = ({ items }: BoxGridProps) => {
               text={item.emoji}
             />
             <div>
-              <h3 className="leading-xs mt-0 mb-8 text-[2.5rem] font-normal">
+              <h3 className="mt-0 mb-8 text-[2.5rem] leading-xs font-normal">
                 {item.title}
               </h3>
               {isOpen && (
-                <p className="leading-xs mb-6 text-xl text-gray-600">
+                <p className="mb-6 text-xl leading-xs text-gray-600">
                   {item.description}
                 </p>
               )}

--- a/src/components/BugBountyCards.tsx
+++ b/src/components/BugBountyCards.tsx
@@ -102,8 +102,8 @@ const BugBountyCards = () => {
           key={`bug-bounty-card-${idx}`}
           className={cn(
             "row-span-6 m-4 grid grid-rows-subgrid",
-            "bg-background shadow-table-box overflow-hidden rounded border",
-            "hover:bg-background-highlight hover:shadow-table-box-hover hover:scale-[1.02] hover:rounded hover:transition-transform hover:duration-100"
+            "overflow-hidden rounded border bg-background shadow-table-box",
+            "hover:scale-[1.02] hover:rounded hover:bg-background-highlight hover:shadow-table-box-hover hover:transition-transform hover:duration-100"
           )}
         >
           <Banner card={card} />

--- a/src/components/CallToContribute/CallToContribute.stories.tsx
+++ b/src/components/CallToContribute/CallToContribute.stories.tsx
@@ -32,7 +32,7 @@ type Story = StoryObj<typeof meta>
 const ContentContainer = (props: ChildOnlyProp) => {
   return (
     <div
-      className="bg-background-highlight flex w-full justify-between py-0 ps-0 lg:pe-8"
+      className="flex w-full justify-between bg-background-highlight py-0 ps-0 lg:pe-8"
       {...props}
     />
   )

--- a/src/components/CallToContribute/index.tsx
+++ b/src/components/CallToContribute/index.tsx
@@ -13,20 +13,20 @@ export type CallToContributeProps = {
 
 const ContentColumn = (props: ChildOnlyProp) => (
   <Flex
-    className="text-body flex-1 basis-1/2 flex-col p-4 lg:text-start"
+    className="flex-1 basis-1/2 flex-col p-4 text-body lg:text-start"
     {...props}
   />
 )
 
 const DescriptionParagraph = ({ children }: ChildOnlyProp) => (
-  <p className="font-monospace leading-xs text-body mb-6">{children}</p>
+  <p className="mb-6 font-monospace leading-xs text-body">{children}</p>
 )
 
 const CallToContribute = ({ editPath }: CallToContributeProps) => {
   return (
-    <aside className="border-primary bg-background-highlight mt-8 items-center rounded-md border border-b-4">
+    <aside className="mt-8 items-center rounded-md border border-b-4 border-primary bg-background-highlight">
       <ContentColumn>
-        <h2 className="font-monospace leading-xs mt-0 mb-8 p-1 uppercase">
+        <h2 className="mt-0 mb-8 p-1 font-monospace leading-xs uppercase">
           <Translation id="page-developers-docs:page-calltocontribute-title" />
         </h2>
         <DescriptionParagraph>

--- a/src/components/CalloutBanner.tsx
+++ b/src/components/CalloutBanner.tsx
@@ -30,7 +30,7 @@ const CalloutBanner = ({
     <aside
       className={cn(
         "flex flex-col rounded p-8 sm:p-12 lg:flex-row-reverse",
-        "from-accent-a/10 to-accent-c/10 dark:from-accent-a/20 dark:to-accent-c-hover/20 bg-linear-to-r",
+        "bg-linear-to-r from-accent-a/10 to-accent-c/10 dark:from-accent-a/20 dark:to-accent-c-hover/20",
         className
       )}
       {...props}
@@ -45,10 +45,10 @@ const CalloutBanner = ({
       </div>
 
       <div className="flex w-full shrink-0 grow basis-1/2 flex-col justify-center sm:ps-4 lg:w-[inherit] lg:ps-8">
-        <h2 className="leading-xs mb-8 text-2xl sm:text-[2rem]">
+        <h2 className="mb-8 text-2xl leading-xs sm:text-[2rem]">
           {t(titleKey)}
         </h2>
-        <p className="text-body-medium mb-8 w-[90%] text-xl">
+        <p className="mb-8 w-[90%] text-xl text-body-medium">
           {t(descriptionKey)}
         </p>
         {children}

--- a/src/components/CalloutSSR.tsx
+++ b/src/components/CalloutSSR.tsx
@@ -58,7 +58,7 @@ const CalloutSSR = ({
             </h3>
           )}
           {description && (
-            <p className="text-body-medium mb-6 text-xl leading-[140%]">
+            <p className="mb-6 text-xl leading-[140%] text-body-medium">
               {description}
             </p>
           )}

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -23,7 +23,7 @@ const Card = ({
   <div
     className={cn(
       "flex flex-col justify-between space-y-4",
-      "bg-background-highlight rounded-xs",
+      "rounded-xs bg-background-highlight",
       "border border-solid",
       "p-6",
       className

--- a/src/components/CardList.tsx
+++ b/src/components/CardList.tsx
@@ -68,7 +68,7 @@ const Card = ({
           <div>{title}</div>
         )}
 
-        <div className="text-body-medium mb-0 text-sm">{description}</div>
+        <div className="mb-0 text-sm text-body-medium">{description}</div>
       </div>
       {caption && (
         <div className="me-4 flex flex-[1_0_25%] flex-wrap items-center">
@@ -97,7 +97,7 @@ const CardList = ({
   customEventOptions,
   className,
 }: CardListProps) => (
-  <div className={cn("bg-background w-full", className)}>
+  <div className={cn("w-full bg-background", className)}>
     {items.map((listItem, idx) => {
       const { link, id } = listItem
       const isLink = !!link

--- a/src/components/Codeblock.tsx
+++ b/src/components/Codeblock.tsx
@@ -91,7 +91,7 @@ const Codeblock = ({
     /* Context: https://github.com/ethereum/ethereum-org-website/issues/6202 */
     <div className={cn("relative", className)} dir="ltr">
       <div
-        className="bg-background-highlight text-primary overflow-auto rounded"
+        className="overflow-auto rounded bg-background-highlight text-primary"
         style={{
           maxHeight: isCollapsed
             ? `calc((1.2rem * ${LINES_BEFORE_COLLAPSABLE}) + 4.185rem)`

--- a/src/components/CommentCard/index.tsx
+++ b/src/components/CommentCard/index.tsx
@@ -18,7 +18,7 @@ const CommentCard = ({
   return (
     <Card
       className={cn(
-        "bg-background-highlight [&_[data-label='avatar']]:bg-accent-c mx-auto h-fit max-w-[400px] space-y-1 rounded-2xl border p-6",
+        "mx-auto h-fit max-w-[400px] space-y-1 rounded-2xl border bg-background-highlight p-6 [&_[data-label='avatar']]:bg-accent-c",
         className
       )}
     >
@@ -28,13 +28,13 @@ const CommentCard = ({
       <div className="flex items-center gap-x-2">
         <div
           data-label="avatar"
-          className="text-body-inverse grid size-8 place-items-center rounded-full"
+          className="grid size-8 place-items-center rounded-full text-body-inverse"
         >
           {name.charAt(0)}
         </div>
         <div>
           <p className="font-bold">{name}</p>
-          <p className="text-body-medium text-sm">{title}</p>
+          <p className="text-sm text-body-medium">{title}</p>
         </div>
       </div>
     </Card>

--- a/src/components/Content/ai-agents/BuildYourOwnAIAgent.tsx
+++ b/src/components/Content/ai-agents/BuildYourOwnAIAgent.tsx
@@ -12,7 +12,7 @@ const BuildYourOwnAIAgent = () => {
           src={ai16z}
           alt="AI16Z"
           width={128}
-          className="dark:shadow-body-light rounded-xl shadow-lg"
+          className="rounded-xl shadow-lg dark:shadow-body-light"
         />
         <p className="text-2xl font-semibold">Build your own AI agent</p>
         <p>Developer first framework</p>
@@ -31,7 +31,7 @@ const BuildYourOwnAIAgent = () => {
           src={game}
           alt="GAME"
           width={128}
-          className="dark:shadow-body-light rounded-xl shadow-lg"
+          className="rounded-xl shadow-lg dark:shadow-body-light"
         />
         <p className="text-2xl font-semibold">GAME framework</p>
         <p>No-code AI agent platform</p>

--- a/src/components/Content/apps/CategoryAppsGrid.tsx
+++ b/src/components/Content/apps/CategoryAppsGrid.tsx
@@ -91,7 +91,7 @@ const CategoryAppsGrid = async ({
 
   if (hideFilter) {
     return (
-      <div className={cn("grid-cols-fill-4 grid gap-6 md:gap-12", className)}>
+      <div className={cn("grid grid-cols-fill-4 gap-6 md:gap-12", className)}>
         {sortedApps.slice(0, +limit).map((app) => (
           <AppCard
             key={app.name}

--- a/src/components/Content/apps/FilterableCategoryAppsGrid.tsx
+++ b/src/components/Content/apps/FilterableCategoryAppsGrid.tsx
@@ -71,7 +71,7 @@ const FilterableCategoryAppsGrid = ({
           eventName: "",
         }}
       />
-      <div className="grid-cols-fill-4 grid gap-6 md:gap-12">
+      <div className="grid grid-cols-fill-4 gap-6 md:gap-12">
         {displayApps.map((app) => (
           <AppCard
             key={app.name}

--- a/src/components/Content/what-are-apps/BrowseApps.tsx
+++ b/src/components/Content/what-are-apps/BrowseApps.tsx
@@ -29,7 +29,7 @@ const apps = [
 
 const BrowseApps = () => {
   return (
-    <div className="bg-radial-b mt-16 flex flex-col items-center justify-center rounded-3xl p-8 md:p-20">
+    <div className="mt-16 flex flex-col items-center justify-center rounded-3xl bg-radial-b p-8 md:p-20">
       <div className="flex max-w-2xl flex-col items-center justify-center gap-2 text-center">
         <h2>Browse apps</h2>
         <p className="text-body-medium">
@@ -48,11 +48,11 @@ const BrowseApps = () => {
               <div
                 key={idx}
                 className={`flex flex-1 flex-col items-start gap-4 p-4 md:flex-row md:items-center ${
-                  idx < apps.length - 1 ? "border-background border-b" : ""
+                  idx < apps.length - 1 ? "border-b border-background" : ""
                 }`}
               >
                 <div className="flex flex-1 flex-col items-start gap-4 md:flex-row md:items-center">
-                  <div className="bg-background shadow-drop flex h-14 w-14 items-center justify-center rounded-md">
+                  <div className="flex h-14 w-14 items-center justify-center rounded-md bg-background shadow-drop">
                     <Image
                       src={app.logo}
                       alt={app.name}
@@ -82,7 +82,7 @@ const BrowseApps = () => {
         </div>
       </div>
       <div className="mt-6 flex justify-center">
-        <div className="bg-gradient-step-1 mx-auto inline-flex items-center justify-center gap-2 rounded-full px-4 py-2 text-sm font-bold">
+        <div className="mx-auto inline-flex items-center justify-center gap-2 rounded-full bg-gradient-step-1 px-4 py-2 text-sm font-bold">
           <Image
             src={EthereumLogo}
             alt="Ethereum"

--- a/src/components/Content/what-are-apps/WhatAreAppsStories.tsx
+++ b/src/components/Content/what-are-apps/WhatAreAppsStories.tsx
@@ -58,7 +58,7 @@ const WhatAreAppsStories = () => {
       {stories.map((story, index) => (
         <div
           key={story.name}
-          className="bg-background flex flex-col gap-4 rounded-2xl border p-6"
+          className="flex flex-col gap-4 rounded-2xl border bg-background p-6"
         >
           <div className="flex flex-row items-center justify-between gap-2">
             <div className="flex flex-row items-center gap-2">
@@ -73,7 +73,7 @@ const WhatAreAppsStories = () => {
                   />
                 )}
                 {!story.twitter && (
-                  <div className="bg-accent-c flex h-10 w-10 items-center justify-center rounded-full">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-full bg-accent-c">
                     <p className="text-lg font-bold text-white">
                       {story.name?.slice(0, 1).toUpperCase()}
                     </p>
@@ -82,7 +82,7 @@ const WhatAreAppsStories = () => {
               </div>
               <div>
                 <p className="text-md font-bold">{story.name}</p>
-                <p className="text-body-medium text-sm">
+                <p className="text-sm text-body-medium">
                   {story.twitter
                     ? `@${story.twitter.split("/").pop()}`
                     : story.country}
@@ -94,7 +94,7 @@ const WhatAreAppsStories = () => {
                 <ButtonLink
                   href={story.twitter}
                   variant="ghost"
-                  className="text-body justify-start px-0"
+                  className="justify-start px-0 text-body"
                   hideArrow
                 >
                   <Twitter />
@@ -119,7 +119,7 @@ const WhatAreAppsStories = () => {
               {expandedStories[index] ? "Read less" : "Read more"}
             </Button>
           </div>
-          <p className="text-body-medium text-sm">
+          <p className="text-sm text-body-medium">
             {dateTimeFormat("en-US", {
               year: "numeric",
               month: "long",

--- a/src/components/Contributors/index.tsx
+++ b/src/components/Contributors/index.tsx
@@ -34,7 +34,7 @@ const ContributorCard = ({ contributor }: { contributor: Contributor }) => {
         sizes="132px"
       />
       <div className="p-4">
-        <h3 className="text-md text-body mt-2 mb-4">
+        <h3 className="mt-2 mb-4 text-md text-body">
           {contributor.profile ? (
             <LinkOverlay asChild>
               <InlineLink
@@ -55,7 +55,7 @@ const ContributorCard = ({ contributor }: { contributor: Contributor }) => {
 
   if (contributor.profile) {
     return (
-      <LinkBox className="hover:bg-background-highlight m-2 max-w-[132px] transform shadow transition-transform duration-100 hover:scale-[1.02] hover:rounded focus:scale-[1.02] focus:rounded">
+      <LinkBox className="m-2 max-w-[132px] transform shadow transition-transform duration-100 hover:scale-[1.02] hover:rounded hover:bg-background-highlight focus:scale-[1.02] focus:rounded">
         {content}
       </LinkBox>
     )

--- a/src/components/DataProductCard.tsx
+++ b/src/components/DataProductCard.tsx
@@ -39,7 +39,7 @@ const DataProductCard = ({
   return (
     <LinkBox
       className={cn(
-        "shadow-table-box hover:bg-background-highlight focus:bg-background-highlight flex flex-col overflow-hidden rounded border transition-transform duration-100 ease-linear hover:scale-[1.02] focus:scale-[1.02]",
+        "flex flex-col overflow-hidden rounded border shadow-table-box transition-transform duration-100 ease-linear hover:scale-[1.02] hover:bg-background-highlight focus:scale-[1.02] focus:bg-background-highlight",
         className
       )}
     >

--- a/src/components/DataTable/index.tsx
+++ b/src/components/DataTable/index.tsx
@@ -115,7 +115,7 @@ const DataTable = <TData, TValue>({
 
   return (
     <div className="relative">
-      <div className="border-b-background-highlight bg-background sticky top-[76px] z-10 w-full lg:border-b">
+      <div className="sticky top-[76px] z-10 w-full border-b-background-highlight bg-background lg:border-b">
         <Table {...props}>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
@@ -146,7 +146,7 @@ const DataTable = <TData, TValue>({
               <Fragment key={row.id}>
                 <TableRow
                   data-state={row.getIsSelected() && "selected"}
-                  className={`${row.getIsExpanded() ? "border-b-background-highlight bg-background-highlight cursor-pointer" : "cursor-pointer"} hover:bg-background-highlight`}
+                  className={`${row.getIsExpanded() ? "cursor-pointer border-b-background-highlight bg-background-highlight" : "cursor-pointer"} hover:bg-background-highlight`}
                   onClick={(e) => {
                     // Prevent expanding the wallet more info section when clicking on the "Visit website" button
                     if (!(e.target as Element).matches("a, a svg")) {

--- a/src/components/DocLink/index.tsx
+++ b/src/components/DocLink/index.tsx
@@ -22,13 +22,13 @@ const DocLink = ({ href, children, isExternal = false }: DocLinkProps) => {
     <LinkBox
       className={cn(
         "flex rounded-xs border p-4 text-current no-underline",
-        "hover:bg-background-highlight hover:rounded hover:no-underline",
-        "group hover:shadow-primary hover:shadow-[0_0_1px]"
+        "hover:rounded hover:bg-background-highlight hover:no-underline",
+        "group hover:shadow-[0_0_1px] hover:shadow-primary"
       )}
     >
       <Flex className="flex-1 justify-between">
         <Center>
-          <Emoji className="text-md me-4" text=":page_with_curl:" />
+          <Emoji className="me-4 text-md" text=":page_with_curl:" />
         </Center>
         <Stack className="flex-1">
           <LinkOverlay asChild>
@@ -43,7 +43,7 @@ const DocLink = ({ href, children, isExternal = false }: DocLinkProps) => {
         <ArrowRight
           className={cn(
             "mx-6 h-6 w-6 self-center",
-            "group-hover:text-primary transition-transform duration-100 group-hover:scale-[1.2]",
+            "transition-transform duration-100 group-hover:scale-[1.2] group-hover:text-primary",
             isExternal ? "-rotate-45" : "rotate-0",
             isRtl && isExternal ? "-rotate-[135deg]" : "",
             isRtl && !isExternal ? "-rotate-[180deg]" : ""

--- a/src/components/DocsNav/index.tsx
+++ b/src/components/DocsNav/index.tsx
@@ -47,7 +47,7 @@ const CardLink = ({ docData, isPrev, contentNotTranslated }: CardLinkProps) => {
     <BaseLink
       href={docData.href}
       className={cn(
-        "group border-primary bg-background flex w-full items-center rounded-xs border !no-underline",
+        "group flex w-full items-center rounded-xs border border-primary bg-background !no-underline",
         isPrev ? "justify-start" : "justify-end",
         "hover:border-primary-hover"
       )}
@@ -68,13 +68,13 @@ const CardLink = ({ docData, isPrev, contentNotTranslated }: CardLinkProps) => {
         )}
       >
         {isPrev ? (
-          <ChevronLeft className="group-hover:fill-primary-hover text-xl" />
+          <ChevronLeft className="text-xl group-hover:fill-primary-hover" />
         ) : (
-          <ChevronRight className="group-hover:fill-primary-hover text-xl" />
+          <ChevronRight className="text-xl group-hover:fill-primary-hover" />
         )}
       </div>
       <TextDiv className={cn(isPrev ? "ps-0" : "pe-0 text-end")}>
-        <p className="btn-txt text-primary group-hover:text-primary-hover !m-0 text-lg">
+        <p className="btn-txt !m-0 text-lg text-primary group-hover:text-primary-hover">
           {t(isPrev ? "previous" : "next")}
         </p>
         <p className="!mb-0 text-sm no-underline">{t(docData.id)}</p>

--- a/src/components/EthPriceCard.tsx
+++ b/src/components/EthPriceCard.tsx
@@ -111,13 +111,13 @@ const EthPriceCard = ({
       className={cn(
         "max-h-48 w-full max-w-[420px] flex-col items-center justify-between rounded border p-6",
         isNegativeChange
-          ? "from-error/10 dark:border-error/50 bg-linear-to-b"
-          : "from-success/20 dark:border-success/50 bg-linear-to-t",
+          ? "bg-linear-to-b from-error/10 dark:border-error/50"
+          : "bg-linear-to-t from-success/20 dark:border-success/50",
         className
       )}
       {...props}
     >
-      <h4 className="leading-xs m-0 flex items-center text-sm font-medium tracking-wider uppercase">
+      <h4 className="m-0 flex items-center text-sm leading-xs font-medium tracking-wider uppercase">
         {t("eth-current-price")}&nbsp;
         <Tooltip content={tooltipContent}>
           <Info className="size-[0.875em] text-sm" />
@@ -126,8 +126,8 @@ const EthPriceCard = ({
 
       <div
         className={cn(
-          "leading-xs text-5xl",
-          hasError && "text-md text-error my-4"
+          "text-5xl leading-xs",
+          hasError && "my-4 text-md text-error"
         )}
       >
         {price}
@@ -137,7 +137,7 @@ const EthPriceCard = ({
       <Flex className="mt-2 min-h-[33px] w-full flex-col-reverse items-center justify-center sm:flex-row">
         <div
           className={cn(
-            "leading-xs me-4 text-2xl",
+            "me-4 text-2xl leading-xs",
             isNegativeChange ? "text-error" : "text-success"
           )}
         >
@@ -148,7 +148,7 @@ const EthPriceCard = ({
             <ArrowUpRight className={cn(twFlipForRtl, "inline-block")} />
           )}
         </div>
-        <div className="leading-xs text-body-medium text-sm tracking-wider uppercase">
+        <div className="text-sm leading-xs tracking-wider text-body-medium uppercase">
           ({t("last-24-hrs")})
         </div>
       </Flex>

--- a/src/components/ExpandableCard.tsx
+++ b/src/components/ExpandableCard.tsx
@@ -69,12 +69,12 @@ const ExpandableCard = ({
       >
         <AccordionItem
           value="item-1"
-          className="hover:bg-background-highlight rounded-xs border"
+          className="rounded-xs border hover:bg-background-highlight"
         >
           <AccordionTrigger
             hideIcon
             onClick={onClick}
-            className="hover:bg-background-highlight w-full p-6 transition-colors hover:text-black md:p-6 dark:hover:text-white [&[data-state=open]]:bg-transparent [&[data-state=open]]:text-black dark:[&[data-state=open]]:text-white"
+            className="w-full p-6 transition-colors hover:bg-background-highlight hover:text-black md:p-6 dark:hover:text-white [&[data-state=open]]:bg-transparent [&[data-state=open]]:text-black dark:[&[data-state=open]]:text-white"
           >
             <Flex className="w-full flex-col items-center text-left sm:flex-row">
               <VStack className="items-center md:items-start">
@@ -82,17 +82,17 @@ const ExpandableCard = ({
                   {Svg && <Svg className="mr-6" />}
                   <h3 className="text-xl font-semibold">{title}</h3>
                 </HStack>
-                <p className="text-body-medium w-fit text-sm">
+                <p className="w-fit text-sm text-body-medium">
                   {contentPreview}
                 </p>
               </VStack>
-              <span className="text-md text-primary my-auto sm:ml-auto">
+              <span className="my-auto text-md text-primary sm:ml-auto">
                 {t(isVisible ? "less" : "more")}
               </span>
             </Flex>
           </AccordionTrigger>
           <AccordionContent className="p-6 pt-0 md:p-6 md:pt-0">
-            <div className="text-md text-body border-t pt-6">{children}</div>
+            <div className="border-t pt-6 text-md text-body">{children}</div>
           </AccordionContent>
         </AccordionItem>
       </Accordion>

--- a/src/components/Faq/index.tsx
+++ b/src/components/Faq/index.tsx
@@ -20,8 +20,8 @@ const FaqTrigger = React.forwardRef<
       "w-full p-4 md:px-8 md:py-6",
       "text-start font-medium",
       "hover:text-body hover:[&_h2]:!text-body [&_svg]:rotate-90 [&[data-state=open]_h2]:text-current [&[data-state=open]_svg]:-rotate-90",
-      "[&_[data-label='icon-container']]:border-body [&_[data-label='icon-container']]:ms-8 [&_[data-label='icon-container']]:rounded-full [&_[data-label='icon-container']]:border [&_[data-label='icon-container']]:p-2 [&_svg]:text-lg",
-      "[&_[data-label='icon-container']:hover_svg]:text-primary-hover hover:[&_[data-label='icon-container']]:!border-primary-hover hover:[&_[data-label='icon-container']]:shadow-[4px_4px_0_hsla(var(--primary-low-contrast),1)]",
+      "[&_[data-label='icon-container']]:ms-8 [&_[data-label='icon-container']]:rounded-full [&_[data-label='icon-container']]:border [&_[data-label='icon-container']]:border-body [&_[data-label='icon-container']]:p-2 [&_svg]:text-lg",
+      "hover:[&_[data-label='icon-container']]:!border-primary-hover hover:[&_[data-label='icon-container']]:shadow-[4px_4px_0_hsla(var(--primary-low-contrast),1)] [&_[data-label='icon-container']:hover_svg]:text-primary-hover",
       "[&[data-state=open]]:text-current",
       className
     )}
@@ -43,7 +43,7 @@ const Faq = ({
       collapsible
       className={cn(
         "overflow-hidden rounded border",
-        "bg-background w-full",
+        "w-full bg-background",
         props?.className
       )}
       {...props}
@@ -60,7 +60,7 @@ const FaqItem = React.forwardRef<
   <AccordionItem
     ref={ref}
     className={cn(
-      "hover:bg-background-highlight [&[data-state=open]]:bg-background-highlight w-full border-b last:border-b-0",
+      "w-full border-b last:border-b-0 hover:bg-background-highlight [&[data-state=open]]:bg-background-highlight",
       className
     )}
     {...props}
@@ -76,11 +76,11 @@ const FaqContent = React.forwardRef<
     ref={ref}
     className={cn(
       "w-full overflow-hidden px-4 text-sm md:px-8",
-      "data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down transition-all"
+      "transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
     )}
     {...props}
   >
-    <div className={cn("border-body-light border-t py-3 md:py-6", className)}>
+    <div className={cn("border-t border-body-light py-3 md:py-6", className)}>
       {children}
     </div>
   </AccordionContent>

--- a/src/components/FeaturedText/index.tsx
+++ b/src/components/FeaturedText/index.tsx
@@ -2,7 +2,7 @@ import type { ChildOnlyProp } from "@/lib/types"
 
 function FeaturedText({ children }: ChildOnlyProp) {
   return (
-    <div className="border-primary -ms-4 border border-dashed ps-4">
+    <div className="-ms-4 border border-dashed border-primary ps-4">
       {children}
     </div>
   )

--- a/src/components/FeedbackCard.tsx
+++ b/src/components/FeedbackCard.tsx
@@ -64,7 +64,7 @@ const FeedbackCard = ({ prompt, isArticle, ...props }: FeedbackCardProps) => {
 
   return (
     <div
-      className="border-body-light bg-feedback-gradient mt-8 mb-4 flex w-full flex-col rounded border p-6"
+      className="mt-8 mb-4 flex w-full flex-col rounded border border-body-light bg-feedback-gradient p-6"
       {...props}
       dir={dir}
     >

--- a/src/components/FeedbackWidget/FixedDot.tsx
+++ b/src/components/FeedbackWidget/FixedDot.tsx
@@ -24,7 +24,7 @@ const FixedDot = forwardRef<HTMLButtonElement, FixedDotProps>(
         data-testid="feedback-widget-button"
         aria-label={t("feedback-widget")}
         className={cn(
-          "z-overlay shadow-table-item-box fixed end-4 bottom-4 flex size-12 items-center gap-0 rounded-full text-white",
+          "fixed end-4 bottom-4 z-overlay flex size-12 items-center gap-0 rounded-full text-white shadow-table-item-box",
           "transition-all duration-200 hover:shadow-none hover:transition-transform hover:duration-200",
           !suppressScale && "hover:scale-110",
           offsetBottom && "bottom-31 lg:bottom-4",

--- a/src/components/FeedbackWidget/index.tsx
+++ b/src/components/FeedbackWidget/index.tsx
@@ -50,7 +50,7 @@ const FeedbackWidget = () => {
         </PopoverTrigger>
 
         <PopoverContent
-          className="bg-background mx-2 w-80 max-w-[calc(100vw_-_1rem)] rounded p-4 sm:p-8"
+          className="mx-2 w-80 max-w-[calc(100vw_-_1rem)] rounded bg-background p-4 sm:p-8"
           data-testid="feedback-widget-modal"
         >
           <div className="flex items-start gap-2">
@@ -62,7 +62,7 @@ const FeedbackWidget = () => {
             <PopoverClose asChild>
               <Button
                 variant="ghost"
-                className="text-body w-8 py-0"
+                className="w-8 py-0 text-body"
                 size="sm"
                 ref={cancelRef}
               >
@@ -73,10 +73,10 @@ const FeedbackWidget = () => {
 
           {feedbackSubmitted && (
             <>
-              <div className="text-md text-center leading-5 font-normal">
+              <div className="text-center text-md leading-5 font-normal">
                 {t("feedback-widget-thank-you-subtitle")}
               </div>
-              <div className="text-body-medium text-center text-xs leading-4 font-bold tracking-wide">
+              <div className="text-center text-xs leading-4 font-bold tracking-wide text-body-medium">
                 {t("feedback-widget-thank-you-timing")}
               </div>
             </>

--- a/src/components/FileContributors.tsx
+++ b/src/components/FileContributors.tsx
@@ -91,7 +91,7 @@ const ContributorAvatarGroup = ({
         </div>
       ))}
       {remainingCount > 0 && (
-        <Center className="bg-primary text-body-inverse -me-2 size-10 rounded-full ps-1 text-sm">
+        <Center className="-me-2 size-10 rounded-full bg-primary ps-1 text-sm text-body-inverse">
           +{remainingCount}
         </Center>
       )}
@@ -109,7 +109,7 @@ const Contributor = ({ contributor }: ContributorProps) => {
         label={hasProfile ? "@" + contributor.login : contributor.login}
       />
       {contributor.html_url.includes("crowdin.com") && (
-        <p className="text-body-medium ms-5">
+        <p className="ms-5 text-body-medium">
           <Translation id="translator" />
         </p>
       )}
@@ -159,7 +159,7 @@ const FileContributors = ({
       >
         <Flex className="my-4 me-4 flex-1 flex-col items-start lg:mb-0">
           {lastEditLocaleTimestamp && (
-            <p className="text-body-medium mb-2">
+            <p className="mb-2 text-body-medium">
               <Translation id="page-last-update" /> {lastEditLocaleTimestamp}
             </p>
           )}

--- a/src/components/FilterBar/index.tsx
+++ b/src/components/FilterBar/index.tsx
@@ -91,7 +91,7 @@ export default function FilterBar({
               aria-expanded={open}
               aria-controls={COMBOBOX_ID}
               variant="ghost"
-              className="text-body hover:bg-background-highlight w-full items-center justify-between gap-2 p-2 transition-colors sm:w-64"
+              className="w-full items-center justify-between gap-2 p-2 text-body transition-colors hover:bg-background-highlight sm:w-64"
             >
               <span className="truncate">
                 {selectedLabel ?? t("filter-bar-placeholder")}
@@ -137,7 +137,7 @@ export default function FilterBar({
         )}
       </div>
 
-      <p className="text-body-medium p-2">
+      <p className="p-2 text-body-medium">
         {t("filter-bar-showing")}{" "}
         <span className="text-body">({countDisplay})</span>
       </p>

--- a/src/components/FindWalletProductTable/FindWalletLanguageSelectInput.tsx
+++ b/src/components/FindWalletProductTable/FindWalletLanguageSelectInput.tsx
@@ -77,7 +77,7 @@ const FindWalletLanguageSelectInput = ({
         </SelectTrigger>
         <SelectContent>
           <div
-            className="bg-background sticky -top-2 z-10 p-2"
+            className="sticky -top-2 z-10 bg-background p-2"
             onKeyDown={(e) => e.stopPropagation()}
             onClick={(e) => e.stopPropagation()}
           >
@@ -127,7 +127,7 @@ const FindWalletLanguageSelectInput = ({
           })}
         </SelectContent>
       </Select>
-      <p className="text-body-medium text-sm">
+      <p className="text-sm text-body-medium">
         {t("page-find-wallet-popular-languages")}
       </p>
       <div className="flex flex-row flex-wrap gap-2">
@@ -135,7 +135,7 @@ const FindWalletLanguageSelectInput = ({
           return (
             <span
               key={language.langCode}
-              className="text-primary cursor-pointer text-sm"
+              className="cursor-pointer text-sm text-primary"
               onClick={() => {
                 trackCustomEvent({
                   eventCategory: "WalletFilterSidebar",

--- a/src/components/FindWalletProductTable/FindWalletsNoResults.tsx
+++ b/src/components/FindWalletProductTable/FindWalletsNoResults.tsx
@@ -24,7 +24,7 @@ const FindWalletsNoResults = ({ resetFilters }) => {
   }
 
   return (
-    <div className="border-body-light border-2 border-dashed lg:m-24">
+    <div className="border-2 border-dashed border-body-light lg:m-24">
       <div className="p-12">
         <h3 className="mb-6 text-3xl font-normal">
           {t("page-find-wallet-empty-results-title")}

--- a/src/components/FindWalletProductTable/WalletSubComponent.tsx
+++ b/src/components/FindWalletProductTable/WalletSubComponent.tsx
@@ -79,7 +79,7 @@ const WalletSubComponent = ({
             )!
             return (
               <div key={idx} className="mx-2">
-                <h4 className="text-md mb-2 font-bold">{filterItem.title}</h4>
+                <h4 className="mb-2 text-md font-bold">{filterItem.title}</h4>
                 <ul className="m-0 list-none">
                   {filterItem.items
                     .sort((a, b) =>
@@ -131,7 +131,7 @@ const WalletSubComponent = ({
           })}
         </div>
         <div className="ml-3">
-          <h4 className="text-md mb-2 font-bold">
+          <h4 className="mb-2 text-md font-bold">
             {t("page-find-wallet-social-links")}
           </h4>
           <div className="flex flex-row gap-4">
@@ -145,7 +145,7 @@ const WalletSubComponent = ({
                 eventValue: JSON.stringify(filters),
               }}
             >
-              <Globe className="text-primary text-2xl" />
+              <Globe className="text-2xl text-primary" />
             </SocialLink>
             {wallet.discord && (
               <SocialLink

--- a/src/components/FindWalletProductTable/index.tsx
+++ b/src/components/FindWalletProductTable/index.tsx
@@ -35,7 +35,7 @@ const FindWalletProductTable = ({ wallets }: { wallets: WalletRow[] }) => {
     >
       {({ filteredData, filters, resetFilters }) => (
         <>
-          <div className="border-b-background-highlight bg-background sticky top-[76px] z-10 w-full lg:border-b">
+          <div className="sticky top-[76px] z-10 w-full border-b-background-highlight bg-background lg:border-b">
             <div className="flex w-full flex-row items-center justify-between border-none px-4 py-2">
               <p className="text-body-medium">
                 {t("page-find-wallet-showing-all-wallets")}{" "}

--- a/src/components/FindWalletProductTable/loading.tsx
+++ b/src/components/FindWalletProductTable/loading.tsx
@@ -32,7 +32,7 @@ const Loading = () => (
       {Array.from({ length: 5 }).map((_, idx) => (
         <Skeleton
           key={"personas" + idx}
-          className="shadow-svg-button-link h-40 min-w-48 rounded-2xl xl:h-32"
+          className="h-40 min-w-48 rounded-2xl shadow-svg-button-link xl:h-32"
         />
       ))}
     </div>

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -314,8 +314,8 @@ const Footer = async ({ lastDeployLocaleTimestamp }: FooterProps) => {
 
   return (
     <footer className="px-4 py-4">
-      <div className="border-body-light flex flex-wrap items-center justify-center gap-8 border-t px-4 py-4 md:justify-between">
-        <p className="text-body-medium text-sm italic">
+      <div className="flex flex-wrap items-center justify-center gap-8 border-t border-body-light px-4 py-4 md:justify-between">
+        <p className="text-sm text-body-medium italic">
           {t("website-last-updated")}: {lastDeployLocaleTimestamp}
         </p>
 
@@ -325,7 +325,7 @@ const Footer = async ({ lastDeployLocaleTimestamp }: FooterProps) => {
       <div className="px-4 py-4">
         <BaseLink
           href="/"
-          className="hover:text-primary text-lg font-bold no-underline"
+          className="text-lg font-bold no-underline hover:text-primary"
         >
           ethereum.org
         </BaseLink>
@@ -351,7 +351,7 @@ const Footer = async ({ lastDeployLocaleTimestamp }: FooterProps) => {
           </div>
         ))}
       </div>
-      <div className="bg-background-highlight flex flex-col items-center justify-center p-6 text-sm">
+      <div className="flex flex-col items-center justify-center bg-background-highlight p-6 text-sm">
         <div className="flex gap-4">
           {socialLinks.map(({ href, ariaLabel, icon: Icon }) => (
             <BaseLink

--- a/src/components/GhostCard.tsx
+++ b/src/components/GhostCard.tsx
@@ -15,10 +15,10 @@ const GhostCard: React.FC<GhostCardProps> = ({
 }) => {
   return (
     <div className={cn("relative self-stretch", className)}>
-      <div className="z-hide border-border-high-contrast bg-background-medium absolute bottom-2 left-2 h-full w-full rounded-xs" />
+      <div className="absolute bottom-2 left-2 z-hide h-full w-full rounded-xs border-border-high-contrast bg-background-medium" />
       <Card
         className={cn(
-          "text-card-foreground bg-background-highlight z-10 h-full w-full rounded-xs border p-6 text-left"
+          "text-card-foreground z-10 h-full w-full rounded-xs border bg-background-highlight p-6 text-left"
         )}
         {...props}
       >

--- a/src/components/GitStars.tsx
+++ b/src/components/GitStars.tsx
@@ -27,12 +27,12 @@ const GitStars = ({ gitHubRepo, hideStars, ...props }: GitStarsProps) => {
 
   return (
     <BaseLink
-      className="text-body ms-auto no-underline hover:underline"
+      className="ms-auto text-body no-underline hover:underline"
       href={gitHubRepo.url}
       hideArrow
       {...props}
     >
-      <Flex className="bg-background-medium items-stretch overflow-hidden rounded">
+      <Flex className="items-stretch overflow-hidden rounded bg-background-medium">
         {hideStars ? (
           <Github className="m-1 text-2xl" />
         ) : (
@@ -41,8 +41,8 @@ const GitStars = ({ gitHubRepo, hideStars, ...props }: GitStarsProps) => {
               <Github />
               <Emoji text=":star:" />
             </Center>
-            <Flex className="bg-background-highlight items-center px-1.5">
-              <p className="text-body my-0 text-xs">{starsString}</p>
+            <Flex className="items-center bg-background-highlight px-1.5">
+              <p className="my-0 text-xs text-body">{starsString}</p>
             </Flex>
           </>
         )}

--- a/src/components/Glossary/GlossaryTooltip/index.tsx
+++ b/src/components/Glossary/GlossaryTooltip/index.tsx
@@ -63,7 +63,7 @@ const GlossaryTooltip = ({
           })
         }}
       >
-        <u className="hover:text-primary-hover hover:decoration-primary-hover cursor-help decoration-dotted underline-offset-3">
+        <u className="cursor-help decoration-dotted underline-offset-3 hover:text-primary-hover hover:decoration-primary-hover">
           {children}
         </u>
       </Tooltip>

--- a/src/components/Hero/HomeHero/index.tsx
+++ b/src/components/Hero/HomeHero/index.tsx
@@ -96,7 +96,7 @@ const HomeHero = async ({
               {t("page-index-hero-title")}
             </h1>
 
-            <p className="text-body-medium max-w-[741px] text-lg leading-relaxed tracking-[0.07px] md:text-2xl md:leading-[1.625]">
+            <p className="max-w-[741px] text-lg leading-relaxed tracking-[0.07px] text-body-medium md:text-2xl md:leading-[1.625]">
               {t("page-index-hero-subtitle")}
             </p>
 

--- a/src/components/Hero/HubHero/index.tsx
+++ b/src/components/Hero/HubHero/index.tsx
@@ -54,7 +54,7 @@ const HubHero = ({
         {title ? (
           <h1
             data-label="breadcrumb"
-            className="text-md text-body-medium font-normal uppercase"
+            className="text-md font-normal text-body-medium uppercase"
           >
             {title}
           </h1>

--- a/src/components/Hero/SimpleHero/index.tsx
+++ b/src/components/Hero/SimpleHero/index.tsx
@@ -50,7 +50,7 @@ const SimpleHero = ({
     >
       {breadcrumbs}
       <h1 className="text-[2.5rem] leading-[1.4] md:text-5xl">{title}</h1>
-      <div className="text-body-medium text-xl leading-[1.4]">{subtitle}</div>
+      <div className="text-xl leading-[1.4] text-body-medium">{subtitle}</div>
       {buttons && buttons.length > 0 && (
         <div className="flex flex-wrap gap-4">
           {buttons.map((button, index) => (

--- a/src/components/HighlightCard/index.tsx
+++ b/src/components/HighlightCard/index.tsx
@@ -6,7 +6,7 @@ export const IconBox = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "shadow-window-box grid size-20 place-items-center rounded-2xl border p-6 [&_svg]:size-8",
+      "grid size-20 place-items-center rounded-2xl border p-6 shadow-window-box [&_svg]:size-8",
       className
     )}
     {...props}
@@ -40,5 +40,5 @@ export const HighlightCardContent = ({
   className,
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn("text-body-medium space-y-6", className)} {...props} />
+  <div className={cn("space-y-6 text-body-medium", className)} {...props} />
 )

--- a/src/components/Homepage/FeatureCards.tsx
+++ b/src/components/Homepage/FeatureCards.tsx
@@ -32,7 +32,7 @@ const FeatureCards = async ({
   return (
     <Section
       className={cn(
-        "bg-background-highlight rounded-none py-20 lg:py-24",
+        "rounded-none bg-background-highlight py-20 lg:py-24",
         className
       )}
     >
@@ -44,7 +44,7 @@ const FeatureCards = async ({
               {t("page-index-features-title-highlight")}
             </span>
           </SectionHeader>
-          <p className="text-body-medium max-w-xl text-lg">
+          <p className="max-w-xl text-lg text-body-medium">
             {t("page-index-features-subtitle")}
           </p>
         </div>
@@ -91,7 +91,7 @@ const FeatureCards = async ({
               </div>
             </div>
 
-            <div className="bg-background relative overflow-hidden rounded-3xl border p-8 lg:col-span-5">
+            <div className="relative overflow-hidden rounded-3xl border bg-background p-8 lg:col-span-5">
               <Image
                 src={publicRulesImage}
                 alt=""
@@ -103,7 +103,7 @@ const FeatureCards = async ({
                 <h3 className="mb-4 text-4xl font-black lg:text-5xl">
                   {t("page-index-features-public-rules-title")}
                 </h3>
-                <p className="text-body max-w-xs">
+                <p className="max-w-xs text-body">
                   {t("page-index-features-public-rules-description")}
                 </p>
               </div>
@@ -111,7 +111,7 @@ const FeatureCards = async ({
           </div>
 
           <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
-            <div className="bg-background relative overflow-hidden rounded-3xl border p-8">
+            <div className="relative overflow-hidden rounded-3xl border bg-background p-8">
               <Image
                 src={globalImage}
                 alt=""
@@ -129,7 +129,7 @@ const FeatureCards = async ({
               </div>
             </div>
 
-            <div className="bg-background relative overflow-hidden rounded-3xl border p-8">
+            <div className="relative overflow-hidden rounded-3xl border bg-background p-8">
               <Image
                 src={freeAccessImage}
                 alt=""
@@ -147,7 +147,7 @@ const FeatureCards = async ({
               </div>
             </div>
 
-            <div className="border-body rounded-3xl border p-8 md:col-span-2 lg:col-span-1">
+            <div className="rounded-3xl border border-body p-8 md:col-span-2 lg:col-span-1">
               <h3 className="mb-3 text-3xl font-black">
                 {t("page-index-features-nobody-owns-title")}
               </h3>

--- a/src/components/Homepage/FloatingCard.tsx
+++ b/src/components/Homepage/FloatingCard.tsx
@@ -17,7 +17,7 @@ const FloatingCard = ({
         "flex flex-col justify-center rounded-2xl px-5 py-4 md:rounded-3xl md:px-6 md:shadow-lg",
         variant === "primary"
           ? "bg-linear-to-b from-[#5c1eb4] to-[#7b3fd8] text-white"
-          : "bg-background border",
+          : "border bg-background",
         className
       )}
     >

--- a/src/components/Homepage/GetStartedGrid.tsx
+++ b/src/components/Homepage/GetStartedGrid.tsx
@@ -87,12 +87,12 @@ const GetStartedGrid = async ({
 
   return (
     <Section id="get-started" className={cn("relative", className)}>
-      <div className="bg-radial-a flex flex-col gap-12 rounded-t-4xl px-4 pt-20 pb-8 md:px-8">
+      <div className="flex flex-col gap-12 rounded-t-4xl bg-radial-a px-4 pt-20 pb-8 md:px-8">
         <div className="flex flex-col items-center gap-2 text-center">
           <SectionHeader className="mt-0 mb-0">
             {t("page-index-get-started-title")}
           </SectionHeader>
-          <p className="text-body-medium max-w-[42rem] text-lg lg:text-2xl">
+          <p className="max-w-[42rem] text-lg text-body-medium lg:text-2xl">
             {t("page-index-get-started-subtitle", { minutes })}
           </p>
         </div>
@@ -100,7 +100,7 @@ const GetStartedGrid = async ({
         <div className="mx-auto grid w-full max-w-[76rem] gap-8 md:grid-cols-2 lg:grid-cols-3">
           {cards.map((card) => (
             <LinkBox key={card.title} className="h-full">
-              <Card className="bg-background hover:border-primary-hover flex h-full flex-col overflow-hidden rounded-4xl border p-8 transition-colors">
+              <Card className="flex h-full flex-col overflow-hidden rounded-4xl border bg-background p-8 transition-colors hover:border-primary-hover">
                 <div className="mb-7 h-48 overflow-hidden rounded-[10px]">
                   <Image
                     src={card.image}
@@ -140,7 +140,7 @@ const GetStartedGrid = async ({
                               card.bulletColor
                             )}
                           />
-                          <span className="text-body-medium text-sm leading-5">
+                          <span className="text-sm leading-5 text-body-medium">
                             {bullet}
                           </span>
                         </li>

--- a/src/components/Homepage/KPISection.tsx
+++ b/src/components/Homepage/KPISection.tsx
@@ -168,18 +168,18 @@ const KPISection = ({
           </SectionHeader>
         </div>
 
-        <p className="text-body-medium text-lg leading-relaxed lg:text-2xl lg:leading-[39px]">
+        <p className="text-lg leading-relaxed text-body-medium lg:text-2xl lg:leading-[39px]">
           {t("page-index-kpi-description")}
         </p>
       </div>
 
       <div className="flex flex-col gap-8 lg:flex-row lg:items-center lg:gap-20">
-        <div className="bg-border hidden h-[267px] w-px lg:block" />
+        <div className="hidden h-[267px] w-px bg-border lg:block" />
 
         <div className="flex w-[300px] flex-col gap-8">
           <div className="flex items-start gap-3">
             <User
-              className="text-body-medium mt-[5.5px] size-8"
+              className="mt-[5.5px] size-8 text-body-medium"
               strokeWidth={1.5}
             />
             <div className="flex flex-col gap-1">
@@ -188,7 +188,7 @@ const KPISection = ({
                   ? formatCompactNumber(accountHolders, locale)
                   : "—"}
               </p>
-              <p className="text-body-medium text-base leading-[1.6]">
+              <p className="text-base leading-[1.6] text-body-medium">
                 {t("page-index-kpi-holders")}
               </p>
             </div>
@@ -196,7 +196,7 @@ const KPISection = ({
 
           <div className="flex items-start gap-3">
             <ArrowLeftRight
-              className="text-body-medium mt-[5.5px] size-8"
+              className="mt-[5.5px] size-8 text-body-medium"
               strokeWidth={1.5}
             />
             <div className="flex flex-col gap-1">
@@ -209,7 +209,7 @@ const KPISection = ({
               ) : (
                 <p className="text-4xl leading-[1.2] font-bold">—</p>
               )}
-              <p className="text-body-medium text-base leading-[1.6]">
+              <p className="text-base leading-[1.6] text-body-medium">
                 {t("page-index-kpi-transactions")}
               </p>
             </div>

--- a/src/components/Homepage/LanguageMorpher.tsx
+++ b/src/components/Homepage/LanguageMorpher.tsx
@@ -45,7 +45,7 @@ const LanguageMorpher = () => {
 
   return (
     <Button
-      className="text-md text-primary mx-auto w-fit no-underline"
+      className="mx-auto w-fit text-md text-primary no-underline"
       onClick={isLargeScreen ? handleDesktopClick : handleMobileClick}
       variant="ghost"
     >

--- a/src/components/Homepage/PersonaModalCTA.tsx
+++ b/src/components/Homepage/PersonaModalCTA.tsx
@@ -136,10 +136,10 @@ const CategoryCard = ({
             href={href}
             onClick={() => onLinkClick(eventName)}
             hideArrow
-            className="group text-primary hover:text-primary-hover flex items-center justify-between text-xl font-bold no-underline transition-colors md:text-3xl"
+            className="group flex items-center justify-between text-xl font-bold text-primary no-underline transition-colors hover:text-primary-hover md:text-3xl"
           >
             {linkLabel}
-            <ChevronNext className="text-primary size-5 transition-transform group-hover:translate-x-1" />
+            <ChevronNext className="size-5 text-primary transition-transform group-hover:translate-x-1" />
           </BaseLink>
         </div>
       ))}

--- a/src/components/Homepage/SavingsCarousel.tsx
+++ b/src/components/Homepage/SavingsCarousel.tsx
@@ -255,7 +255,7 @@ const SlideContent = ({
           </SectionHeader>
         </div>
 
-        <div className="text-body-medium flex flex-col gap-4 text-lg leading-relaxed md:gap-6 lg:text-2xl lg:leading-relaxed">
+        <div className="flex flex-col gap-4 text-lg leading-relaxed text-body-medium md:gap-6 lg:text-2xl lg:leading-relaxed">
           <p>{slide.subtitle}</p>
           <p>{slide.description}</p>
         </div>

--- a/src/components/Homepage/TrustLogos.tsx
+++ b/src/components/Homepage/TrustLogos.tsx
@@ -50,22 +50,22 @@ const TrustLogos = async ({
           </div>
 
           <FloatingCard className="absolute top-8 -left-4 z-10 shadow-lg md:top-12 lg:-left-8">
-            <p className="text-body text-lg font-bold md:text-xl lg:text-2xl">
+            <p className="text-lg font-bold text-body md:text-xl lg:text-2xl">
               {t("page-index-trust-never-offline")}
             </p>
             <div className="mt-1 flex items-center gap-1 md:mt-2">
-              <Check className="text-success size-3 md:size-4" />
-              <span className="text-success text-xs font-semibold md:text-sm">
+              <Check className="size-3 text-success md:size-4" />
+              <span className="text-xs font-semibold text-success md:text-sm">
                 {t("page-index-trust-uptime", { uptime })}
               </span>
             </div>
           </FloatingCard>
 
           <FloatingCard className="absolute -right-4 bottom-12 z-10 shadow-lg md:-right-6 lg:-right-12">
-            <p className="text-body text-lg font-bold md:text-xl lg:text-2xl">
+            <p className="text-lg font-bold text-body md:text-xl lg:text-2xl">
               {t("page-index-trust-years", { count })}
             </p>
-            <p className="text-body-medium mt-1 text-xs md:text-sm">
+            <p className="mt-1 text-xs text-body-medium md:text-sm">
               {t("page-index-trust-since")}
             </p>
           </FloatingCard>
@@ -80,7 +80,7 @@ const TrustLogos = async ({
           </SectionHeader>
         </div>
 
-        <div className="text-body-medium flex flex-col gap-6 text-lg leading-relaxed lg:text-2xl lg:leading-relaxed">
+        <div className="flex flex-col gap-6 text-lg leading-relaxed text-body-medium lg:text-2xl lg:leading-relaxed">
           <p>{t("page-index-trust-description-1")}</p>
           <p>{t("page-index-trust-description-2")}</p>
         </div>

--- a/src/components/Image/ParallaxImage/loading.tsx
+++ b/src/components/Image/ParallaxImage/loading.tsx
@@ -1,8 +1,8 @@
 import { Spinner } from "@/components/ui/spinner"
 
 const Loading = () => (
-  <div className="animate-pulse-light absolute inset-0 grid place-items-center">
-    <Spinner className="text-accent-b text-6xl" />
+  <div className="absolute inset-0 grid animate-pulse-light place-items-center">
+    <Spinner className="text-6xl text-accent-b" />
   </div>
 )
 

--- a/src/components/IssuesList/index.tsx
+++ b/src/components/IssuesList/index.tsx
@@ -21,7 +21,7 @@ const IssuesList = ({ issues, className }: IssuesListProps) => {
     >
       {issues.map((issue) => (
         <Stack
-          className="border-border gap-4 rounded-md border p-4"
+          className="gap-4 rounded-md border border-border p-4"
           key={issue.title}
         >
           <Stack className="gap-2">

--- a/src/components/LanguagePicker/Desktop.tsx
+++ b/src/components/LanguagePicker/Desktop.tsx
@@ -43,7 +43,7 @@ const DesktopLanguagePicker = ({
         <Button
           name={DESKTOP_LANGUAGE_BUTTON_NAME}
           variant="ghost"
-          className="animate-fade-in text-body active:bg-primary-low-contrast active:text-primary-hover data-[state='open']:bg-primary-low-contrast data-[state='open']:text-primary-hover gap-0 px-2 transition-transform duration-500 max-md:hidden xl:px-3 [&_svg]:transition-transform [&_svg]:duration-500 [&_svg]:hover:rotate-12"
+          className="animate-fade-in gap-0 px-2 text-body transition-transform duration-500 active:bg-primary-low-contrast active:text-primary-hover data-[state='open']:bg-primary-low-contrast data-[state='open']:text-primary-hover max-md:hidden xl:px-3 [&_svg]:transition-transform [&_svg]:duration-500 [&_svg]:hover:rotate-12"
         >
           <Languages className="align-middle text-2xl" />
           &nbsp;
@@ -54,7 +54,7 @@ const DesktopLanguagePicker = ({
       <PopoverContent
         align="end"
         className={cn(
-          "bg-background-highlight flex w-[320px] flex-col p-0",
+          "flex w-[320px] flex-col bg-background-highlight p-0",
           className
         )}
       >

--- a/src/components/LanguagePicker/LanguagePickerMenu.tsx
+++ b/src/components/LanguagePicker/LanguagePickerMenu.tsx
@@ -49,7 +49,7 @@ const LanguagePickerMenu = ({
         return 0
       }}
     >
-      <div className="text-body-medium text-xs">
+      <div className="text-xs text-body-medium">
         {t("page-languages-filter-label")}{" "}
         <span className="lowercase">
           ({languages.length} {t("common:languages")})

--- a/src/components/LanguagePicker/MenuItem.tsx
+++ b/src/components/LanguagePicker/MenuItem.tsx
@@ -21,7 +21,7 @@ const MenuItem = ({ displayInfo, ...props }: ItemProps) => {
     <CommandItem
       value={localeOption}
       className={cn(
-        "group text-body hover:bg-primary-low-contrast mb-1 flex-col items-start rounded pt-2",
+        "group mb-1 flex-col items-start rounded pt-2 text-body hover:bg-primary-low-contrast",
         isCurrent
           ? "bg-background hover:bg-primary-low-contrast"
           : "bg-transparent"
@@ -33,19 +33,19 @@ const MenuItem = ({ displayInfo, ...props }: ItemProps) => {
           <div className="flex items-center gap-2">
             <p
               className={cn(
-                "language-name group-aria-selected:text-primary text-lg",
+                "language-name text-lg group-aria-selected:text-primary",
                 isCurrent ? "text-primary-high-contrast" : "text-body"
               )}
             >
               {targetName}
             </p>
           </div>
-          <p className="text-body text-xs uppercase">{sourceName}</p>
+          <p className="text-xs text-body uppercase">{sourceName}</p>
         </div>
         {isCurrent && (
           <Check
             aria-hidden={true}
-            className="text-primary-high-contrast text-2xl"
+            className="text-2xl text-primary-high-contrast"
           />
         )}
       </div>

--- a/src/components/Layer2NetworksTable/NetworksNoResults.tsx
+++ b/src/components/Layer2NetworksTable/NetworksNoResults.tsx
@@ -24,7 +24,7 @@ const FindWalletsNoResults = ({ resetFilters }) => {
   }
 
   return (
-    <div className="border-body-light m-24 border-2 border-dashed">
+    <div className="m-24 border-2 border-dashed border-body-light">
       <div className="p-12">
         <h3 className="mb-6 text-3xl font-normal">
           {t("page-layer-2-networks-no-results-title")}

--- a/src/components/Layer2NetworksTable/NetworksSubComponent.tsx
+++ b/src/components/Layer2NetworksTable/NetworksSubComponent.tsx
@@ -33,11 +33,11 @@ const NetworkSubComponent = ({ network }: NetworkSubComponentProps) => {
   return (
     <div className="flex w-full flex-col gap-4 px-6 pb-4">
       <div className="flex flex-col gap-8 md:flex-row">
-        <div className="bg-background flex h-fit flex-1 flex-col gap-4 p-4">
+        <div className="flex h-fit flex-1 flex-col gap-4 bg-background p-4">
           <div className="flex flex-row gap-4">
             <div className="flex-1">
               <div>
-                <p className="text-body-medium text-xs font-bold">
+                <p className="text-xs font-bold text-body-medium">
                   {t("page-layer-2-networks-age")}&nbsp;
                   <Tooltip
                     content={
@@ -83,7 +83,7 @@ const NetworkSubComponent = ({ network }: NetworkSubComponentProps) => {
             </div>
             <div className="flex-1">
               <div>
-                <p className="text-body-medium text-xs font-bold">
+                <p className="text-xs font-bold text-body-medium">
                   {t("page-layer-2-networks-wallet-support")}&nbsp;
                   <Tooltip
                     content={
@@ -118,7 +118,7 @@ const NetworkSubComponent = ({ network }: NetworkSubComponentProps) => {
           <div className="flex flex-row gap-4">
             <div className="flex-1">
               <div>
-                <p className="text-body-medium text-xs font-bold">
+                <p className="text-xs font-bold text-body-medium">
                   {t("page-layer-2-networks-active-address")}&nbsp;
                   <Tooltip
                     content={
@@ -156,7 +156,7 @@ const NetworkSubComponent = ({ network }: NetworkSubComponentProps) => {
             </div>
             <div className="flex-1">
               <div>
-                <p className="text-body-medium text-xs font-bold">
+                <p className="text-xs font-bold text-body-medium">
                   {t("page-layer-2-networks-fee-token")}&nbsp;
                   <Tooltip
                     content={
@@ -181,7 +181,7 @@ const NetworkSubComponent = ({ network }: NetworkSubComponentProps) => {
         </div>
         <div className="flex-1 gap-2">
           <div>
-            <p className="text-body-medium text-xs font-bold">
+            <p className="text-xs font-bold text-body-medium">
               {t("page-layer-2-networks-network-usage")}&nbsp;
               <Tooltip
                 content={
@@ -218,7 +218,7 @@ const NetworkSubComponent = ({ network }: NetworkSubComponentProps) => {
       </div>
       <div className="flex flex-col gap-6 p-4">
         <div className="flex flex-col gap-1">
-          <p className="text-body-medium text-xs">
+          <p className="text-xs text-body-medium">
             {t("page-layer-2-networks-links")}
           </p>
           <div className="flex flex-col gap-4">
@@ -247,7 +247,7 @@ const NetworkSubComponent = ({ network }: NetworkSubComponentProps) => {
                   {t("page-layer-2-networks-risk-analysis")}
                 </InlineLink>
               </div>
-              <p className="text-body-medium text-xs">
+              <p className="text-xs text-body-medium">
                 {t("page-layer-2-networks-assessment-by-l2beat")}
               </p>
             </div>
@@ -264,14 +264,14 @@ const NetworkSubComponent = ({ network }: NetworkSubComponentProps) => {
                   {t("page-layer-2-networks-detailed-analytics")}
                 </InlineLink>
               </div>
-              <p className="text-body-medium text-xs">
+              <p className="text-xs text-body-medium">
                 {t("page-layer-2-networks-assessment-by-growthepie")}
               </p>
             </div>
           </div>
         </div>
         <div className="flex flex-col gap-1">
-          <p className="text-body-medium text-xs">Actions</p>
+          <p className="text-xs text-body-medium">Actions</p>
           <div className="flex flex-col gap-4 sm:flex-row">
             <ButtonLink
               href={network.bridgeLink}

--- a/src/components/Layer2NetworksTable/NetworksWalletSelectInput.tsx
+++ b/src/components/Layer2NetworksTable/NetworksWalletSelectInput.tsx
@@ -60,7 +60,7 @@ const NetworksWalletSelectInput = ({
           avoidCollisions={true}
         >
           <div
-            className="bg-background sticky top-0 z-10 p-2"
+            className="sticky top-0 z-10 bg-background p-2"
             onKeyDown={(e) => e.stopPropagation()}
             onClick={(e) => e.stopPropagation()}
           >
@@ -79,7 +79,7 @@ const NetworksWalletSelectInput = ({
               </SelectItem>
             ))
           ) : (
-            <div className="text-body-medium p-2 text-center">
+            <div className="p-2 text-center text-body-medium">
               {t("page-layer-2-networks-no-wallet-found")}
             </div>
           )}

--- a/src/components/Layer2NetworksTable/hooks/useNetworkColumns.tsx
+++ b/src/components/Layer2NetworksTable/hooks/useNetworkColumns.tsx
@@ -75,7 +75,7 @@ export const useNetworkColumns: ColumnDef<ExtendedRollup & { id: string }>[] = [
             <div className="flex flex-row gap-4 lg:hidden">
               <div className="w-[24px]" />
               <div>
-                <p className="text-body-medium text-xs">
+                <p className="text-xs text-body-medium">
                   <Translation id="page-layer-2-networks:page-layer-2-networks-avg-transaction-fee" />
                 </p>
                 <p>
@@ -88,7 +88,7 @@ export const useNetworkColumns: ColumnDef<ExtendedRollup & { id: string }>[] = [
                 </p>
               </div>
               <div>
-                <p className="text-body-medium text-xs">
+                <p className="text-xs text-body-medium">
                   <Translation id="page-layer-2-networks:page-layer-2-networks-market-share" />
                 </p>
                 <p>

--- a/src/components/Layer2ProductCard.tsx
+++ b/src/components/Layer2ProductCard.tsx
@@ -38,7 +38,7 @@ const Layer2ProductCard = ({
   const { t } = useTranslation("page-layer-2")
 
   return (
-    <Card className="bg-background-highlight flex flex-col justify-between rounded-md border-0 p-2 shadow-lg transition-transform duration-100 hover:scale-[1.02]">
+    <Card className="flex flex-col justify-between rounded-md border-0 bg-background-highlight p-2 shadow-lg transition-transform duration-100 hover:scale-[1.02]">
       <div
         className="mb-4 flex min-h-[200px] items-center justify-center border-b"
         style={{ backgroundColor: background }}
@@ -73,7 +73,7 @@ const Layer2ProductCard = ({
           {bridge && (
             <InlineLink
               href={bridge}
-              className="text-primary hover:text-primary/80 block underline"
+              className="block text-primary underline hover:text-primary/80"
             >
               {name} {t("layer-2-bridge")}
             </InlineLink>
@@ -82,7 +82,7 @@ const Layer2ProductCard = ({
           {ecosystemPortal && (
             <InlineLink
               href={ecosystemPortal}
-              className="text-primary hover:text-primary/80 block underline"
+              className="block text-primary underline hover:text-primary/80"
             >
               {name} {t("layer-2-ecosystem-portal")}
             </InlineLink>
@@ -91,7 +91,7 @@ const Layer2ProductCard = ({
           {tokenLists && (
             <InlineLink
               href={tokenLists}
-              className="text-primary hover:text-primary/80 block underline"
+              className="block text-primary underline hover:text-primary/80"
             >
               {name} {t("layer-2-token-lists")}
             </InlineLink>

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -32,7 +32,7 @@ const Leaderboard = ({ content, limit = 100 }: LeaderboardProps) => {
 
   return (
     <List
-      className="bg-background shadow-table-box ms-0 mb-8 w-full list-none"
+      className="ms-0 mb-8 w-full list-none bg-background shadow-table-box"
       aria-label={t("page-upgrades-bug-bounty-leaderboard-list")}
     >
       {content
@@ -54,7 +54,7 @@ const Leaderboard = ({ content, limit = 100 }: LeaderboardProps) => {
           return (
             <ListItem className="mb-0" key={username}>
               <LinkBox
-                className="shadow-table-item-box hover:bg-background-highlight hover:shadow-primary mb-1 flex w-full items-center justify-between p-4 hover:rounded-lg hover:no-underline"
+                className="mb-1 flex w-full items-center justify-between p-4 shadow-table-item-box hover:rounded-lg hover:bg-background-highlight hover:no-underline hover:shadow-primary"
                 key={idx}
               >
                 <div className="me-4 opacity-40">{idx + 1}</div>
@@ -80,7 +80,7 @@ const Leaderboard = ({ content, limit = 100 }: LeaderboardProps) => {
                     )}
                   </LinkOverlay>
 
-                  <div className="text-body-medium text-sm">
+                  <div className="text-sm text-body-medium">
                     {score} {t("page-upgrades-bug-bounty-leaderboard-points")}
                   </div>
                 </Flex>

--- a/src/components/ListenToPlayer/PlayerWidget/index.tsx
+++ b/src/components/ListenToPlayer/PlayerWidget/index.tsx
@@ -140,7 +140,7 @@ const PlayerWidget = ({
   return (
     <div
       className={cn(
-        "bg-background shadow-widget w-80 border",
+        "w-80 border bg-background shadow-widget",
         isExpanded ? "rounded-2xl p-4" : "rounded-t-2xl p-2"
       )}
     >
@@ -148,10 +148,10 @@ const PlayerWidget = ({
         className={cn("flex flex-col gap-2", isExpanded ? "block" : "hidden")}
       >
         <div className="flex justify-between">
-          <p className="leading-base text-sm font-bold">{title}</p>
+          <p className="text-sm leading-base font-bold">{title}</p>
           <Tooltip content={"Collapse"} asChild>
             <button
-              className="text-body-medium hover:text-body cursor-pointer"
+              className="cursor-pointer text-body-medium hover:text-body"
               aria-label={"Collapse"}
               onClick={() => {
                 setIsExpanded(!isExpanded)
@@ -169,23 +169,23 @@ const PlayerWidget = ({
         <div className="flex items-center justify-between">
           <div
             ref={scrubBarRef}
-            className="bg-background-highlight relative h-0.5 w-[240px] cursor-pointer rounded"
+            className="relative h-0.5 w-[240px] cursor-pointer rounded bg-background-highlight"
             onMouseDown={handleMouseDown}
           >
             <div
-              className="bg-primary absolute top-0 left-0 h-full rounded"
+              className="absolute top-0 left-0 h-full rounded bg-primary"
               style={{
                 width: `${Number.isFinite(progress) && progress >= 0 ? progress : 0}%`,
               }}
             />
             <div
-              className="bg-primary absolute top-1/2 h-2 w-2 -translate-x-1/2 -translate-y-1/2 rounded-full shadow-md transition-transform hover:scale-110"
+              className="absolute top-1/2 h-2 w-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary shadow-md transition-transform hover:scale-110"
               style={{
                 left: `${Number.isFinite(progress) && progress >= 0 ? progress : 0}%`,
               }}
             />
           </div>
-          <div className="text-body-medium text-sm">
+          <div className="text-sm text-body-medium">
             {`${Math.floor(timeRemaining / 60)}:${String(Math.floor(timeRemaining % 60)).padStart(2, "0")}`}
           </div>
         </div>
@@ -193,7 +193,7 @@ const PlayerWidget = ({
           <div className="relative">
             <PlayerButton tooltipContent={"Playback speed"}>
               <button
-                className="leading-base text-body-medium hover:text-body w-[24px] cursor-pointer text-right text-xs font-bold"
+                className="w-[24px] cursor-pointer text-right text-xs leading-base font-bold text-body-medium hover:text-body"
                 onClick={() => setShowSpeedMenu(!showSpeedMenu)}
                 title={`Playback speed`}
                 aria-label={"Playback speed"}
@@ -204,12 +204,12 @@ const PlayerWidget = ({
             {showSpeedMenu && (
               <div
                 ref={speedMenuRef}
-                className="bg-background absolute bottom-full left-0 mb-2 rounded-lg border shadow-lg"
+                className="absolute bottom-full left-0 mb-2 rounded-lg border bg-background shadow-lg"
               >
                 {speedOptions.map((speed) => (
                   <button
                     key={speed}
-                    className="hover:bg-background-highlight cursor-pointer px-4 py-1 text-xs"
+                    className="cursor-pointer px-4 py-1 text-xs hover:bg-background-highlight"
                     onClick={() => {
                       handlePlaybackSpeed(speed)
                       setShowSpeedMenu(false)
@@ -224,7 +224,7 @@ const PlayerWidget = ({
           <PlayerButton tooltipContent={"Previous"}>
             <button
               className={cn(
-                "hover:text-primary cursor-pointer text-2xl",
+                "cursor-pointer text-2xl hover:text-primary",
                 currentTrackIndex === 0 ? "text-disabled" : "text-body-medium"
               )}
               onClick={handlePrevious}
@@ -236,7 +236,7 @@ const PlayerWidget = ({
           </PlayerButton>
           <PlayerButton tooltipContent={isPlaying ? "Pause" : "Play"}>
             <button
-              className="text-//[32px] text-primary hover:text-primary-hover cursor-pointer"
+              className="text-//[32px] cursor-pointer text-primary hover:text-primary-hover"
               onClick={handlePlayPause}
               title={isPlaying ? "Pause" : "Play"}
               aria-label={isPlaying ? "Pause" : "Play"}
@@ -251,7 +251,7 @@ const PlayerWidget = ({
           <PlayerButton tooltipContent={"Next"}>
             <button
               className={cn(
-                "hover:text-primary cursor-pointer text-2xl",
+                "cursor-pointer text-2xl hover:text-primary",
                 currentTrackIndex === totalTracks - 1
                   ? "text-disabled"
                   : "text-body-medium"
@@ -291,7 +291,7 @@ const PlayerWidget = ({
         <div className="flex flex-row items-center gap-2">
           <PlayerButton tooltipContent={isPlaying ? "Pause" : "Play"}>
             <button
-              className="text-primary hover:text-primary-hover cursor-pointer"
+              className="cursor-pointer text-primary hover:text-primary-hover"
               onClick={handlePlayPause}
               title={isPlaying ? "Pause" : "Play"}
               aria-label={isPlaying ? "Pause" : "Play"}
@@ -303,14 +303,14 @@ const PlayerWidget = ({
               )}
             </button>
           </PlayerButton>
-          <div className="text-body-medium text-sm">
+          <div className="text-sm text-body-medium">
             {`${Math.floor(timeRemaining / 60)}:${String(Math.floor(timeRemaining % 60)).padStart(2, "0")}`}
           </div>
         </div>
         <div className="flex flex-row gap-6">
           <PlayerButton tooltipContent={"Expand"}>
             <button
-              className="text-disabled hover:text-body cursor-pointer"
+              className="cursor-pointer text-disabled hover:text-body"
               title={"Expand"}
               aria-label={"Expand"}
               onClick={() => {
@@ -327,7 +327,7 @@ const PlayerWidget = ({
           </PlayerButton>
           <PlayerButton tooltipContent={"Close"}>
             <button
-              className="text-disabled hover:text-body cursor-pointer"
+              className="cursor-pointer text-disabled hover:text-body"
               title={"Close"}
               aria-label={"Close"}
               onClick={() => {

--- a/src/components/ListenToPlayer/TopOfPagePlayer/index.tsx
+++ b/src/components/ListenToPlayer/TopOfPagePlayer/index.tsx
@@ -22,7 +22,7 @@ const TopOfPagePlayer = ({
   return (
     <Button
       variant="ghost"
-      className="bg-background-low hover:bg-background-medium inline-block w-full rounded-lg p-2 lg:w-auto"
+      className="inline-block w-full rounded-lg bg-background-low p-2 hover:bg-background-medium lg:w-auto"
       onClick={() => {
         if (startedPlaying) {
           trackCustomEvent({
@@ -34,7 +34,7 @@ const TopOfPagePlayer = ({
         handlePlayPause()
       }}
     >
-      <div className="text-primary hover:text-primary-hover flex flex-row items-center gap-2">
+      <div className="flex flex-row items-center gap-2 text-primary hover:text-primary-hover">
         {startedPlaying ? (
           isPlaying ? (
             <CirclePause />
@@ -44,7 +44,7 @@ const TopOfPagePlayer = ({
         ) : (
           <CirclePlay />
         )}
-        <div className="text-body-medium text-sm">
+        <div className="text-sm text-body-medium">
           {startedPlaying ? (
             `${Math.floor(timeRemaining / 60)}:${String(Math.floor(timeRemaining % 60)).padStart(2, "0")}`
           ) : (

--- a/src/components/ListenToPlayer/loading.tsx
+++ b/src/components/ListenToPlayer/loading.tsx
@@ -4,7 +4,7 @@ import { Spinner } from "../ui/spinner"
 const Loading = () => (
   <div className="relative flex h-10.5 w-full items-center overflow-hidden rounded-lg lg:w-56">
     <Skeleton className="absolute size-full" />
-    <Spinner className="animate-pulse-light ms-2 text-2xl" />
+    <Spinner className="ms-2 animate-pulse-light text-2xl" />
   </div>
 )
 

--- a/src/components/MatomoOptOut.tsx
+++ b/src/components/MatomoOptOut.tsx
@@ -32,8 +32,8 @@ const MatomoOptOut = () => {
     clearMatomoOptOutCache()
   }
   return (
-    <div className="border-body-light bg-background mt-8 mb-4 flex flex-col rounded border p-6">
-      <p className="text-error mb-5">
+    <div className="mt-8 mb-4 flex flex-col rounded border border-body-light bg-background p-6">
+      <p className="mb-5 text-error">
         You can opt out of being tracked by Matomo Analytics and prevent the
         website from analysing the actions you take using the website. This will
         prevent us from learning from your actions and creating a better website

--- a/src/components/MdComponents/index.tsx
+++ b/src/components/MdComponents/index.tsx
@@ -96,7 +96,7 @@ export const Heading4 = ({
 
 export const Pre = (props: ChildOnlyProp) => (
   <pre
-    className="bg-background-highlight max-w-full overflow-x-scroll rounded border p-4 whitespace-pre-wrap"
+    className="max-w-full overflow-x-scroll rounded border bg-background-highlight p-4 whitespace-pre-wrap"
     {...props}
   />
 )
@@ -109,13 +109,13 @@ export const Paragraph = ({ className, ...props }: ParagraphProps) => (
 
 export const Blockquote = (props: ChildOnlyProp) => (
   <blockquote
-    className="border-accent-a bg-accent-a/10 mt-8 mb-4 border-s-2 p-6 [&>:first-child]:mt-0 [&>:last-child]:mb-0"
+    className="mt-8 mb-4 border-s-2 border-accent-a bg-accent-a/10 p-6 [&>:first-child]:mt-0 [&>:last-child]:mb-0"
     {...props}
   />
 )
 
 export const HR = () => (
-  <hr className="border-body-medium mt-8 mb-4 inline-block w-full opacity-60" />
+  <hr className="mt-8 mb-4 inline-block w-full border-body-medium opacity-60" />
 )
 
 // All base html element components

--- a/src/components/MergeInfographic/index.tsx
+++ b/src/components/MergeInfographic/index.tsx
@@ -56,7 +56,7 @@ const MergeInfographic = () => {
     >
       <div>
         <HStack
-          className="text-background absolute top-[40%] left-[2%] z-[2] h-[18%] max-h-[2em] w-[81%] justify-center text-center text-[0.625em] leading-[1em] sm:text-[0.875em] md:text-[1.125em] lg:text-[1.375em]"
+          className="absolute top-[40%] left-[2%] z-[2] h-[18%] max-h-[2em] w-[81%] justify-center text-center text-[0.625em] leading-[1em] text-background sm:text-[0.875em] md:text-[1.125em] lg:text-[1.375em]"
           aria-hidden="true"
         >
           <Translation id="page-upgrades:page-upgrades-merge-infographic-el" />

--- a/src/components/MobileButtonDropdown.tsx
+++ b/src/components/MobileButtonDropdown.tsx
@@ -2,7 +2,7 @@ import ButtonDropdown, { type ButtonDropdownProps } from "./ButtonDropdown"
 
 const MobileButtonDropdown = (props: ButtonDropdownProps) => {
   return (
-    <div className="z-sticky bg-background sticky bottom-0 w-full p-8 shadow-md lg:hidden">
+    <div className="sticky bottom-0 z-sticky w-full bg-background p-8 shadow-md lg:hidden">
       <ButtonDropdown {...props} className="w-full lg:w-auto" />
     </div>
   )

--- a/src/components/Nav/Menu/MenuContent.tsx
+++ b/src/components/Nav/Menu/MenuContent.tsx
@@ -62,7 +62,7 @@ const MenuContent = ({ items, isOpen, sections }: MenuContentProps) => {
     <Content asChild>
       <motion.div
         className={cn(
-          "border-body-light bg-background absolute inset-x-0 top-19 border shadow-md",
+          "absolute inset-x-0 top-19 border border-body-light bg-background shadow-md",
           base()
         )}
         variants={containerVariants}

--- a/src/components/Nav/Menu/index.tsx
+++ b/src/components/Nav/Menu/index.tsx
@@ -55,7 +55,7 @@ const Menu = ({ ...props }: NavMenuProps) => {
                     {isActive && (
                       <motion.div
                         layoutId="active-section-highlight"
-                        className="bg-primary-low-contrast absolute inset-0 z-0 rounded"
+                        className="absolute inset-0 z-0 rounded bg-primary-low-contrast"
                       />
                     )}
                     <span className="relative z-10">{label}</span>

--- a/src/components/Nav/MobileMenu/ExpandIcon.tsx
+++ b/src/components/Nav/MobileMenu/ExpandIcon.tsx
@@ -2,9 +2,9 @@ import { Minus, Plus } from "lucide-react"
 
 const ExpandIcon = () => (
   <>
-    <Minus className="group-hover/menu:text-primary-hover hidden size-6 stroke-[3] p-1 group-data-[state=open]/menu:block" />
+    <Minus className="hidden size-6 stroke-[3] p-1 group-hover/menu:text-primary-hover group-data-[state=open]/menu:block" />
 
-    <Plus className="group-hover/menu:text-primary-hover block size-6 stroke-[3] p-1 group-data-[state=open]/menu:hidden" />
+    <Plus className="block size-6 stroke-[3] p-1 group-hover/menu:text-primary-hover group-data-[state=open]/menu:hidden" />
   </>
 )
 

--- a/src/components/Nav/MobileMenu/FooterButton.tsx
+++ b/src/components/Nav/MobileMenu/FooterButton.tsx
@@ -11,7 +11,7 @@ const FooterButton = forwardRef<HTMLButtonElement, FooterButtonProps>(
   ({ icon: Icon, children, ...props }, ref) => (
     <Button
       ref={ref}
-      className="text-body data-[state=active]:text-primary-hover flex h-fit flex-col items-center px-1"
+      className="flex h-fit flex-col items-center px-1 text-body data-[state=active]:text-primary-hover"
       variant="ghost"
       {...props}
     >

--- a/src/components/Nav/MobileMenu/FooterItemText.tsx
+++ b/src/components/Nav/MobileMenu/FooterItemText.tsx
@@ -2,7 +2,7 @@ import { ChildOnlyProp } from "@/lib/types"
 
 const FooterItemText = (props: ChildOnlyProp) => (
   <p
-    className="leading-base mt-2 text-center text-sm font-normal tracking-wider uppercase opacity-70 hover:opacity-100"
+    className="mt-2 text-center text-sm leading-base font-normal tracking-wider uppercase opacity-70 hover:opacity-100"
     {...props}
   />
 )

--- a/src/components/Nav/MobileMenu/HamburgerButton.tsx
+++ b/src/components/Nav/MobileMenu/HamburgerButton.tsx
@@ -35,13 +35,13 @@ const HamburgerButton = forwardRef<HTMLButtonElement, HamburgerProps>(
         id={HAMBURGER_BUTTON_ID}
         data-testid="mobile-menu-hamburger"
         aria-label={t("aria-toggle-menu-button")}
-        className={cn("text-body px-2 py-0", className)}
+        className={cn("px-2 py-0 text-body", className)}
         variant="ghost"
         {...props}
       >
         <svg
           viewBox="0 0 24 40"
-          className="stroke-body hover:stroke-primary-hover hover:text-primary-hover hover:[&>path]:stroke-primary-hover relative !h-10 !w-6 stroke-2 [&>path]:fill-none"
+          className="relative !h-10 !w-6 stroke-body stroke-2 hover:stroke-primary-hover hover:text-primary-hover [&>path]:fill-none hover:[&>path]:stroke-primary-hover"
           strokeLinecap="round"
           strokeLinejoin="round"
         >

--- a/src/components/Nav/MobileMenu/LvlAccordion.tsx
+++ b/src/components/Nav/MobileMenu/LvlAccordion.tsx
@@ -57,11 +57,11 @@ const LvlAccordion = ({
           return (
             <div
               key={label}
-              className="border-body-light border-t last:border-b"
+              className="border-t border-body-light last:border-b"
             >
               <Button
                 className={cn(
-                  "text-body flex h-full justify-start px-4 py-4 text-start whitespace-normal no-underline",
+                  "flex h-full justify-start px-4 py-4 text-start whitespace-normal text-body no-underline",
                   nestedAccordionSpacingMap[lvl + 2]
                 )}
                 variant="ghost"
@@ -104,7 +104,7 @@ const LvlAccordion = ({
         return (
           <CollapsibleTracked
             key={label}
-            className="border-body-light border-t last:border-b"
+            className="border-t border-body-light last:border-b"
             eventCategory="Mobile navigation menu"
             eventAction={`Level ${lvl - 1} section changed`}
             openEventName={`Open section: ${label} - ${description.slice(0, 16)}...`}
@@ -113,15 +113,15 @@ const LvlAccordion = ({
             <CollapsibleTrigger
               data-testid={`mobile-menu-collapsible-${slugify(label)}`}
               className={cn(
-                "group/menu hover:bg-background-highlight hover:text-primary-hover focus-visible:outline-primary-hover group-data-[state=open]/menu:bg-background-highlight group-data-[state=open]/menu:text-primary-high-contrast flex w-full flex-1 items-center justify-between gap-2 px-4 py-4 font-medium transition-all focus-visible:outline-1 focus-visible:-outline-offset-1 md:px-4 [&[data-state=open]_[data-label=icon-container]>svg]:-rotate-90 [&[data-state=open]:dir(rtl)_[data-label=icon-container]>svg]:rotate-90",
-                "text-body flex h-full justify-start px-4 py-4 text-start whitespace-normal no-underline",
+                "group/menu flex w-full flex-1 items-center justify-between gap-2 px-4 py-4 font-medium transition-all group-data-[state=open]/menu:bg-background-highlight group-data-[state=open]/menu:text-primary-high-contrast hover:bg-background-highlight hover:text-primary-hover focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-primary-hover md:px-4 [&[data-state=open]_[data-label=icon-container]>svg]:-rotate-90 [&[data-state=open]:dir(rtl)_[data-label=icon-container]>svg]:rotate-90",
+                "flex h-full justify-start px-4 py-4 text-start whitespace-normal text-body no-underline",
                 "text-body",
                 nestedAccordionSpacingMap[lvl]
               )}
             >
               <ExpandIcon />
               <div>
-                <p className="text-md text-body flex-1 leading-tight font-bold">
+                <p className="flex-1 text-md leading-tight font-bold text-body">
                   {label}
                 </p>
                 <p
@@ -137,7 +137,7 @@ const LvlAccordion = ({
 
             <CollapsibleContent
               className={cn(
-                "data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm transition-all",
+                "overflow-hidden text-sm transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down",
                 "mt-0 p-0",
                 backgroundColorPerLevel[lvl]
               )}

--- a/src/components/Nav/MobileMenu/MenuAccordion.tsx
+++ b/src/components/Nav/MobileMenu/MenuAccordion.tsx
@@ -66,7 +66,7 @@ const AccordionTrigger = ({
       <Heading>
         <AccordionPrimitive.Trigger
           className={cn(
-            "group hover:bg-background-highlight focus-visible:outline-primary-hover [&[data-state=open]]:bg-background-highlight [&[data-state=open]]:text-primary-high-contrast flex flex-1 items-center justify-start gap-2 rounded px-4 py-4 text-start font-medium transition-all focus-visible:outline focus-visible:outline-4 focus-visible:-outline-offset-1 md:px-4",
+            "group flex flex-1 items-center justify-start gap-2 rounded px-4 py-4 text-start font-medium transition-all hover:bg-background-highlight focus-visible:outline focus-visible:outline-4 focus-visible:-outline-offset-1 focus-visible:outline-primary-hover md:px-4 [&[data-state=open]]:bg-background-highlight [&[data-state=open]]:text-primary-high-contrast",
             className
           )}
           {...props}

--- a/src/components/Nav/MobileMenu/MenuHeader.tsx
+++ b/src/components/Nav/MobileMenu/MenuHeader.tsx
@@ -7,10 +7,10 @@ const MenuHeader = () => {
 
   return (
     <div className="flex items-center justify-between p-6">
-      <SheetTitle className="text-md text-body-medium p-0 uppercase">
+      <SheetTitle className="p-0 text-md text-body-medium uppercase">
         {t("site-title")}
       </SheetTitle>
-      <SheetClose className="text-md w-fit" data-testid="mobile-menu-close">
+      <SheetClose className="w-fit text-md" data-testid="mobile-menu-close">
         {t("close")}
       </SheetClose>
     </div>

--- a/src/components/Nav/MobileMenu/MobileMenuClient.tsx
+++ b/src/components/Nav/MobileMenu/MobileMenuClient.tsx
@@ -33,7 +33,7 @@ function MobileMenuContentSkeleton() {
         {Array.from({ length: 5 }).map((_, i) => (
           <div
             key={i}
-            className="border-body-light flex items-center gap-2 border-b px-4 py-4 first:border-t"
+            className="flex items-center gap-2 border-b border-body-light px-4 py-4 first:border-t"
           >
             <Skeleton className="h-4 w-4" />
             <Skeleton className="h-5 w-36" />
@@ -42,7 +42,7 @@ function MobileMenuContentSkeleton() {
       </div>
 
       {/* Footer (3-column grid) */}
-      <div className="border-body-light grid h-[108px] shrink-0 grid-cols-3 border-t px-4">
+      <div className="grid h-[108px] shrink-0 grid-cols-3 border-t border-body-light px-4">
         {Array.from({ length: 3 }).map((_, i) => (
           <div
             key={i}
@@ -112,13 +112,13 @@ const MobileMenuClient = ({ className, side }: MobileMenuClientProps) => {
                 <p className="text-body-medium">{t("loading-error")}</p>
                 <div className="flex gap-3">
                   <button
-                    className="bg-primary hover:bg-primary-hover rounded-md px-4 py-2 text-sm text-white"
+                    className="rounded-md bg-primary px-4 py-2 text-sm text-white hover:bg-primary-hover"
                     onClick={() => window.location.reload()}
                   >
                     {t("refresh")}
                   </button>
                   <button
-                    className="border-body-light text-body hover:bg-background-highlight rounded-md border px-4 py-2 text-sm"
+                    className="rounded-md border border-body-light px-4 py-2 text-sm text-body hover:bg-background-highlight"
                     onClick={() => handleOpenChange(false)}
                   >
                     {t("close")}

--- a/src/components/Nav/MobileMenu/MobileMenuContent.tsx
+++ b/src/components/Nav/MobileMenu/MobileMenuContent.tsx
@@ -65,7 +65,7 @@ export default function MobileMenuContent() {
           <LanguageContent className="flex min-h-0 flex-1 flex-col" />
         </TabsPrimitive.Content>
 
-        <SheetFooter className="border-body-light h-[108px] shrink-0 justify-center border-t px-4 py-0">
+        <SheetFooter className="h-[108px] shrink-0 justify-center border-t border-body-light px-4 py-0">
           <TabsPrimitive.List className="grid h-auto w-full grid-cols-3">
             <div className="flex flex-col items-center gap-1 py-2">
               <TabsPrimitive.Trigger value="languages" asChild>
@@ -110,12 +110,12 @@ function NavigationContent({ className }: { className?: string }) {
         return (
           <Collapsible
             key={key}
-            className="border-body-light border-b first:border-t"
+            className="border-b border-body-light first:border-t"
           >
             <CollapsibleTrigger
               data-testid={`mobile-menu-collapsible-${slugify(label)}`}
               className={cn(
-                "group/menu hover:bg-background-highlight hover:text-primary-hover focus-visible:outline-primary-hover group-data-[state=open]/menu:bg-background-highlight group-data-[state=open]/menu:text-primary-high-contrast flex w-full flex-1 items-center justify-between gap-2 px-4 py-4 font-medium transition-all focus-visible:outline-1 focus-visible:-outline-offset-1 md:px-4 [&[data-state=open]_[data-label=icon-container]>svg]:-rotate-90 [&[data-state=open]:dir(rtl)_[data-label=icon-container]>svg]:rotate-90",
+                "group/menu flex w-full flex-1 items-center justify-between gap-2 px-4 py-4 font-medium transition-all group-data-[state=open]/menu:bg-background-highlight group-data-[state=open]/menu:text-primary-high-contrast hover:bg-background-highlight hover:text-primary-hover focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-primary-hover md:px-4 [&[data-state=open]_[data-label=icon-container]>svg]:-rotate-90 [&[data-state=open]:dir(rtl)_[data-label=icon-container]>svg]:rotate-90",
                 "text-body"
               )}
             >
@@ -127,8 +127,8 @@ function NavigationContent({ className }: { className?: string }) {
 
             <CollapsibleContent
               className={cn(
-                "data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm transition-all",
-                "bg-background-low mt-0 p-0"
+                "overflow-hidden text-sm transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down",
+                "mt-0 bg-background-low p-0"
               )}
             >
               <LvlAccordion

--- a/src/components/Nav/MobileNav.tsx
+++ b/src/components/Nav/MobileNav.tsx
@@ -8,7 +8,7 @@ const MobileNav = ({ className }: { className?: string }) => {
   return (
     <div className={cn("flex items-center", className)}>
       <Search />
-      <MobileMenu className="animate-fade-in flex md:hidden" />
+      <MobileMenu className="flex animate-fade-in md:hidden" />
     </div>
   )
 }

--- a/src/components/Nav/ThemeToggleButton.tsx
+++ b/src/components/Nav/ThemeToggleButton.tsx
@@ -12,7 +12,7 @@ export const ThemeToggleButton = () => {
       aria-label={themeIconAriaLabel}
       variant="ghost"
       isSecondary
-      className="group animate-fade-in [&>svg]:hover:text-primary-hover px-2 max-md:hidden xl:px-3 [&>svg]:transition-transform [&>svg]:duration-500 [&>svg]:hover:rotate-12"
+      className="group animate-fade-in px-2 max-md:hidden xl:px-3 [&>svg]:transition-transform [&>svg]:duration-500 [&>svg]:hover:rotate-12 [&>svg]:hover:text-primary-hover"
       onClick={toggleColorMode}
     >
       <ThemeIcon className="transform-transform duration-500 group-hover:rotate-12 group-hover:transition-transform group-hover:duration-500" />

--- a/src/components/Nav/index.tsx
+++ b/src/components/Nav/index.tsx
@@ -19,7 +19,7 @@ const Nav = async () => {
   return (
     <>
       <nav
-        className="z-sticky bg-background sticky top-0 flex h-19 w-full max-w-screen-2xl items-center justify-between border-b p-4 md:items-stretch md:justify-normal xl:px-8"
+        className="sticky top-0 z-sticky flex h-19 w-full max-w-screen-2xl items-center justify-between border-b bg-background p-4 md:items-stretch md:justify-normal xl:px-8"
         aria-label={t("nav-primary")}
       >
         <BaseLink

--- a/src/components/PageHero.tsx
+++ b/src/components/PageHero.tsx
@@ -68,14 +68,14 @@ const PageHero = ({
           "me-0 lg:me-4"
         )}
       >
-        <h1 className="text-md !leading-xs mt-0 mb-4 font-normal uppercase lg:mt-8">
+        <h1 className="mt-0 mb-4 text-md !leading-xs font-normal uppercase lg:mt-8">
           {title}
         </h1>
 
-        <h2 className="!leading-xs mt-8 mb-0 max-w-full text-[2.5rem] font-bold lg:mt-12 lg:text-5xl">
+        <h2 className="mt-8 mb-0 max-w-full text-[2.5rem] !leading-xs font-bold lg:mt-12 lg:text-5xl">
           {header}
         </h2>
-        <p className="!leading-xs mt-4 mb-8 text-xl lg:text-2xl">{subtitle}</p>
+        <p className="mt-4 mb-8 text-xl !leading-xs lg:text-2xl">{subtitle}</p>
 
         {buttons && (
           <Flex className="gap-2 overflow-visible [&_ul]:m-0">

--- a/src/components/PieChart/index.tsx
+++ b/src/components/PieChart/index.tsx
@@ -182,7 +182,7 @@ export function PieChart({
     const percentage = ((data.value / total) * 100).toFixed(1)
 
     return (
-      <div className="bg-background rounded-lg border p-2 shadow-lg">
+      <div className="rounded-lg border bg-background p-2 shadow-lg">
         <p className="font-medium">{data.name}</p>
         <p className="text-muted-foreground text-sm">
           {showPercentage ? `${percentage}%` : data.value}

--- a/src/components/ProductList.tsx
+++ b/src/components/ProductList.tsx
@@ -32,7 +32,7 @@ const ProductList = ({ actionLabel, content, category }: ProductListProps) => {
       {category && (
         <h3
           id={CATEGORY_NAME}
-          className="border-border mt-10 mb-0 border-b-2 pb-4 text-2xl"
+          className="mt-10 mb-0 border-b-2 border-border pb-4 text-2xl"
         >
           {category}
         </h3>
@@ -68,7 +68,7 @@ const ProductList = ({ actionLabel, content, category }: ProductListProps) => {
                     alt={alt}
                     width={66}
                     height={66}
-                    className="dark:shadow-body-light rounded-xl shadow-lg"
+                    className="rounded-xl shadow-lg dark:shadow-body-light"
                   />
                 )}
               </div>

--- a/src/components/ProductTable/Filter.tsx
+++ b/src/components/ProductTable/Filter.tsx
@@ -101,7 +101,7 @@ const Filter = ({ filter, filterIndex, onChange }: FilterProps) => {
       className="bg-background-highlight p-6"
     >
       <AccordionTrigger className="border-b md:px-0">
-        <p className="text-body text-base font-bold">{filter.title}</p>
+        <p className="text-base font-bold text-body">{filter.title}</p>
       </AccordionTrigger>
       <AccordionContent className="p-0 md:p-0">
         {filter.items.map((item, itemIndex) => {

--- a/src/components/ProductTable/FilterInputs/SwitchFilterInput.tsx
+++ b/src/components/ProductTable/FilterInputs/SwitchFilterInput.tsx
@@ -43,7 +43,7 @@ const SwitchFilterInput = ({
           }}
         />
       </div>
-      <p className="text-body-medium ms-8">{description}</p>
+      <p className="ms-8 text-body-medium">{description}</p>
     </>
   )
 }

--- a/src/components/ProductTable/Filters.tsx
+++ b/src/components/ProductTable/Filters.tsx
@@ -26,7 +26,7 @@ const Filters = ({
 
   return (
     <div className="w-full lg:w-80" data-testid="filters-container">
-      <div className="width-full border-b-background-highlight bg-background sticky top-0 z-10 mb-2 flex flex-row items-center justify-between border-b px-2 py-1.5 lg:top-[76px] lg:px-6">
+      <div className="width-full sticky top-0 z-10 mb-2 flex flex-row items-center justify-between border-b border-b-background-highlight bg-background px-2 py-1.5 lg:top-[76px] lg:px-6">
         <p className="text-md font-bold">
           {t("table-filters")} ({activeFiltersCount})
         </p>

--- a/src/components/ProductTable/List.tsx
+++ b/src/components/ProductTable/List.tsx
@@ -104,7 +104,7 @@ const List = <T extends { id: string }>({
             // so we need to preserve the open state when the item is unmounted
             open={!!expanded[item.id]}
             onOpenChange={(open) => handleExpandedChange(open, item)}
-            className="group/collapsible hover:bg-background-highlight data-[state=open]:bg-background-highlight absolute top-0 left-0 flex w-full cursor-pointer flex-col border-b"
+            className="group/collapsible absolute top-0 left-0 flex w-full cursor-pointer flex-col border-b hover:bg-background-highlight data-[state=open]:bg-background-highlight"
             style={{
               transform: `translateY(${virtualItem.start - virtualizer.options.scrollMargin}px)`,
             }}

--- a/src/components/ProductTable/MobileFilters.tsx
+++ b/src/components/ProductTable/MobileFilters.tsx
@@ -56,7 +56,7 @@ const MobileFilters = ({
   }
 
   return (
-    <div className="border-b-background-highlight border-b">
+    <div className="border-b border-b-background-highlight">
       <Sheet open={mobileFiltersOpen} onOpenChange={handleOpenChange}>
         <SheetTrigger className="px-4" asChild>
           <Button
@@ -69,7 +69,7 @@ const MobileFilters = ({
               <p>{t("table-filters")}</p>
               <p className="text-body-medium">{` ${activeFiltersCount} ${t("table-active")}`}</p>
             </div>
-            <div className="border-primary text-primary grid size-8 place-items-center rounded-full border">
+            <div className="grid size-8 place-items-center rounded-full border border-primary text-primary">
               <ListFilter className="-mb-0.5 size-6 stroke-1" />
             </div>
           </Button>

--- a/src/components/ProductTable/PresetFilters.tsx
+++ b/src/components/ProductTable/PresetFilters.tsx
@@ -148,8 +148,8 @@ const PresetFilters = ({
             >
               <button
                 className={cn(
-                  "group shadow-svg-button-link hover:bg-background-highlight flex h-[164px] w-full cursor-pointer flex-col items-start rounded-2xl border p-3 transition-all duration-50 lg:h-full lg:p-6",
-                  "focus-visible:outline-primary-hover focus-visible:outline focus-visible:outline-4 focus-visible:-outline-offset-4",
+                  "group flex h-[164px] w-full cursor-pointer flex-col items-start rounded-2xl border p-3 shadow-svg-button-link transition-all duration-50 hover:bg-background-highlight lg:h-full lg:p-6",
+                  "focus-visible:outline focus-visible:outline-4 focus-visible:-outline-offset-4 focus-visible:outline-primary-hover",
                   activePresets.includes(idx)
                     ? "border-primary"
                     : "border-primary-low-contrast",
@@ -166,7 +166,7 @@ const PresetFilters = ({
                     )}
                   >
                     {activePresets.includes(idx) && (
-                      <Check className="text-background size-4 stroke-[3]" />
+                      <Check className="size-4 stroke-[3] text-background" />
                     )}
                   </div>
                   <h3
@@ -184,7 +184,7 @@ const PresetFilters = ({
                   </h3>
                 </div>
                 {!showMobileSidebar && (
-                  <p className="text-body p-2 text-left text-sm transition-colors duration-500">
+                  <p className="p-2 text-left text-sm text-body transition-colors duration-500">
                     {preset.description}
                   </p>
                 )}

--- a/src/components/Quiz/QuizItem.tsx
+++ b/src/components/Quiz/QuizItem.tsx
@@ -31,7 +31,7 @@ const QuizItem = ({
     <ListItem
       className={cn(
         isCompleted ? "text-body-medium" : "text-body",
-        "border-disabled mb-0 border-b py-4 font-bold [counter-increment:_list-counter] lg:px-4"
+        "mb-0 border-b border-disabled py-4 font-bold [counter-increment:_list-counter] lg:px-4"
       )}
     >
       <Flex className="justify-between max-lg:flex-col lg:items-center">

--- a/src/components/Quiz/QuizWidget/QuizRadioGroup.tsx
+++ b/src/components/Quiz/QuizWidget/QuizRadioGroup.tsx
@@ -126,8 +126,8 @@ const CustomRadio = ({
       data-answer-visible={isAnswerVisible || undefined}
       data-selected-correct={isSelectedCorrect || undefined}
       className={cn(
-        "bg-background-highlight text-body w-full cursor-pointer gap-2 rounded p-2 text-start data-[answer-visible]:cursor-default",
-        "hover:outline-primary hover:outline hover:outline-1 hover:data-[answer-visible]:outline-hidden",
+        "w-full cursor-pointer gap-2 rounded bg-background-highlight p-2 text-start text-body data-[answer-visible]:cursor-default",
+        "hover:outline hover:outline-1 hover:outline-primary hover:data-[answer-visible]:outline-hidden",
         "data-[state='checked']:data-[answer-visible]:bg-error",
         "data-[state='checked']:data-[answer-visible]:data-[selected-correct]:bg-success",
         "data-[state='checked']:text-white",
@@ -138,7 +138,7 @@ const CustomRadio = ({
       <RadioGroup.Item {...itemProps}>
         <Center
           className={cn(
-            "bg-disabled size-6 shrink-0 grow-0 rounded-full text-white",
+            "size-6 shrink-0 grow-0 rounded-full bg-disabled text-white",
             "[:is([data-state='checked'],:hover)_>_&]:text-white",
             "[:is([data-state='checked'],:hover)_>_&]:bg-primary-action",
             "[:is([data-state='checked'],:hover)[data-answer-visible]_>_&]:bg-white",

--- a/src/components/Quiz/QuizWidget/QuizSummary.tsx
+++ b/src/components/Quiz/QuizWidget/QuizSummary.tsx
@@ -42,7 +42,7 @@ export const QuizSummary = ({
         {isPassingScore ? t("passed") : t("your-results")}
       </h3>
       <HStack
-        className="bg-background shadow-drop mx-auto justify-center gap-4 overflow-x-hidden px-8 py-4 [&_>_div]:py-4"
+        className="mx-auto justify-center gap-4 overflow-x-hidden bg-background px-8 py-4 shadow-drop [&_>_div]:py-4"
         separator={<div className="border-disabled" />}
       >
         <VStack>

--- a/src/components/Quiz/QuizWidget/index.tsx
+++ b/src/components/Quiz/QuizWidget/index.tsx
@@ -118,7 +118,7 @@ const QuizWidget = ({
             "relative w-full gap-8",
             // Reduce padding when showing Spinner
             !quizData ? "pt-10 pb-5" : "pt-5 pb-4 md:pt-12 md:pb-8",
-            isStandaloneQuiz && "shadow-drop px-4"
+            isStandaloneQuiz && "px-4 shadow-drop"
           )}
         >
           <Center

--- a/src/components/Quiz/QuizzesStats.tsx
+++ b/src/components/Quiz/QuizzesStats.tsx
@@ -67,7 +67,7 @@ const QuizzesStats = ({
     <div>
       <Stack className="gap-4 lg:mt-12 lg:gap-2">
         {/* user stats */}
-        <div className="bg-background-highlight grid columns-1 gap-6 rounded-none border-none p-8 lg:columns-2 lg:gap-4 lg:rounded-lg">
+        <div className="grid columns-1 gap-6 rounded-none border-none bg-background-highlight p-8 lg:columns-2 lg:gap-4 lg:rounded-lg">
           <div className="order-1 self-center">
             <span className="text-xl font-bold max-lg:text-center">
               {t("your-total")}
@@ -93,10 +93,10 @@ const QuizzesStats = ({
           <div className="order-2 lg:order-3 lg:col-span-2">
             <Stack className="gap-2">
               <HStack className="gap-4 max-lg:justify-center">
-                <Center className="bg-primary size-16 rounded-full">
-                  <TrophyIcon className="text-background text-[35.62px]" />
+                <Center className="size-16 rounded-full bg-primary">
+                  <TrophyIcon className="text-[35.62px] text-background" />
                 </Center>
-                <span className="leading-base text-5xl font-bold">
+                <span className="text-5xl leading-base font-bold">
                   {totalCorrectAnswers}
                   <span className="text-body-medium">
                     /{totalQuizzesPoints}
@@ -106,7 +106,7 @@ const QuizzesStats = ({
 
               <Progress
                 value={(totalCorrectAnswers / totalQuizzesPoints) * 100}
-                className="bg-primary-low-contrast [&>div]:bg-primary h-2.5"
+                className="h-2.5 bg-primary-low-contrast [&>div]:bg-primary"
               />
 
               <Flex className="gap-x-10 max-lg:flex-col">
@@ -124,7 +124,7 @@ const QuizzesStats = ({
         </div>
 
         {/* community stats */}
-        <Stack className="bg-background-highlight gap-6 border-none p-8 lg:rounded-lg">
+        <Stack className="gap-6 border-none bg-background-highlight p-8 lg:rounded-lg">
           <span className="text-xl font-bold">{t("community-stats")}</span>
 
           <Flex className="m-0 gap-x-20 gap-y-6 max-md:flex-col" asChild>

--- a/src/components/Search/SearchButton.tsx
+++ b/src/components/Search/SearchButton.tsx
@@ -16,7 +16,7 @@ const SearchButton = forwardRef<HTMLButtonElement, ButtonProps>(
         ref={ref}
         aria-label={t("aria-toggle-search-button")}
         className={cn(
-          "group [&>svg]:hover:text-primary-hover px-2 ease-in-out [&>svg]:transition-all [&>svg]:duration-500 [&>svg]:hover:rotate-12",
+          "group px-2 ease-in-out [&>svg]:transition-all [&>svg]:duration-500 [&>svg]:hover:rotate-12 [&>svg]:hover:text-primary-hover",
           className
         )}
         variant="ghost"

--- a/src/components/Search/SearchInputButton.tsx
+++ b/src/components/Search/SearchInputButton.tsx
@@ -18,7 +18,7 @@ const SearchInputButton = React.forwardRef<HTMLButtonElement, ButtonProps>(
         data-testid="search-input-button"
         variant="ghost"
         className={cn(
-          "group border-disabled hover:border-primary-hover me-3 border",
+          "group me-3 border border-disabled hover:border-primary-hover",
           className
         )}
         {...props}

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -139,18 +139,18 @@ const Search = ({ asChild = false, children }: SearchProps) => {
         {isOpen && (
           <ErrorBoundary
             fallback={() => (
-              <div className="z-modal fixed inset-0 flex items-center justify-center bg-black/50">
-                <div className="bg-background mx-4 flex flex-col items-center gap-4 rounded-lg p-8 text-center shadow-lg">
+              <div className="fixed inset-0 z-modal flex items-center justify-center bg-black/50">
+                <div className="mx-4 flex flex-col items-center gap-4 rounded-lg bg-background p-8 text-center shadow-lg">
                   <p className="text-body-medium">{t("loading-error")}</p>
                   <div className="flex gap-3">
                     <button
-                      className="bg-primary hover:bg-primary-hover rounded-md px-4 py-2 text-sm text-white"
+                      className="rounded-md bg-primary px-4 py-2 text-sm text-white hover:bg-primary-hover"
                       onClick={() => window.location.reload()}
                     >
                       {t("refresh")}
                     </button>
                     <button
-                      className="border-body-light text-body hover:bg-background-highlight rounded-md border px-4 py-2 text-sm"
+                      className="rounded-md border border-body-light px-4 py-2 text-sm text-body hover:bg-background-highlight"
                       onClick={onClose}
                     >
                       {t("close")}

--- a/src/components/SideNav.tsx
+++ b/src/components/SideNav.tsx
@@ -36,7 +36,7 @@ const innerLinksVariants = {
 
 const LinkContainer = ({ children }: ChildOnlyProp) => {
   return (
-    <HStack className="hover:bg-background-highlight w-full justify-between py-2 ps-8 pe-4">
+    <HStack className="w-full justify-between py-2 ps-8 pe-4 hover:bg-background-highlight">
       {children}
     </HStack>
   )
@@ -45,7 +45,7 @@ const LinkContainer = ({ children }: ChildOnlyProp) => {
 const SideNavLink = ({ children, ...props }: LinkProps) => {
   return (
     <BaseLink
-      className="text-body hover:text-primary w-full font-normal no-underline"
+      className="w-full font-normal text-body no-underline hover:text-primary"
       {...props}
     >
       {children}
@@ -97,7 +97,7 @@ const NavLink = ({ item, path, isTopLevel }: NavLinkProps) => {
             variants={dropdownIconContainerVariant}
             animate={isOpen ? "open" : "closed"}
           >
-            <ChevronRight className="text-body-medium h-6 w-6" />
+            <ChevronRight className="h-6 w-6 text-body-medium" />
           </motion.div>
         </LinkContainer>
         <motion.div
@@ -137,7 +137,7 @@ const SideNav = ({ path }: SideNavProps) => {
 
   return (
     <nav
-      className="bg-background sticky top-[4.75rem] hidden h-[calc(100vh-80px)] w-[calc((100%-1448px)/2+256px)] min-w-[256px] overflow-y-auto border-e pt-8 pb-16 shadow-[1px_0px_0px_rgba(0,0,0,0.1)] transition-transform duration-200 lg:block"
+      className="sticky top-[4.75rem] hidden h-[calc(100vh-80px)] w-[calc((100%-1448px)/2+256px)] min-w-[256px] overflow-y-auto border-e bg-background pt-8 pb-16 shadow-[1px_0px_0px_rgba(0,0,0,0.1)] transition-transform duration-200 lg:block"
       aria-label={t("common:nav-developers-docs")}
     >
       {docLinks.map((item, idx) => (

--- a/src/components/SideNavMobile.tsx
+++ b/src/components/SideNavMobile.tsx
@@ -59,7 +59,7 @@ const LinkContainer = ({ children }: ChildOnlyProp) => {
 const SideNavLink = ({ children, ...props }: LinkProps) => {
   return (
     <BaseLink
-      className="text-body hover:text-primary w-full no-underline"
+      className="w-full text-body no-underline hover:text-primary"
       {...props}
     >
       {children}
@@ -98,7 +98,7 @@ const NavLink = ({ item, path, toggle }: NavLinkProps) => {
             variants={dropdownIconContainerVariant}
             animate={isOpen ? "open" : "closed"}
           >
-            <ChevronRight className="text-body-medium h-6 w-6" />
+            <ChevronRight className="h-6 w-6 text-body-medium" />
           </motion.div>
         </LinkContainer>
         <motion.div
@@ -141,10 +141,10 @@ const SideNavMobile = ({ path }: SideNavMobileProps) => {
     getPageTitleId(path + "/", docLinks) || ("Change page" as TranslationKey)
 
   return (
-    <div className="z-sticky bg-background-highlight sticky top-[75px] h-auto w-full lg:hidden">
+    <div className="sticky top-[75px] z-sticky h-auto w-full bg-background-highlight lg:hidden">
       <motion.div>
         <Center
-          className="bg-background-highlight text-primary box-border cursor-pointer border-b px-8 py-4 font-medium"
+          className="box-border cursor-pointer border-b bg-background-highlight px-8 py-4 font-medium text-primary"
           onClick={() => setIsOpen(!isOpen)}
         >
           <div>{t(pageTitleId)}</div>
@@ -153,7 +153,7 @@ const SideNavMobile = ({ path }: SideNavMobileProps) => {
             variants={dropdownIconContainerVariant}
             animate={isOpen ? "open" : "closed"}
           >
-            <ChevronRight className="text-body-medium h-6 w-6" />
+            <ChevronRight className="h-6 w-6 text-body-medium" />
           </motion.div>
         </Center>
       </motion.div>

--- a/src/components/Simulator/ClickAnimation.tsx
+++ b/src/components/Simulator/ClickAnimation.tsx
@@ -35,7 +35,7 @@ export const ClickAnimation = ({
   return visible ? (
     <MotionFlex
       className={cn(
-        "text-primary absolute inset-x-0 justify-center",
+        "absolute inset-x-0 justify-center text-primary",
         topClass,
         bottomClass
       )}

--- a/src/components/Simulator/Explanation.tsx
+++ b/src/components/Simulator/Explanation.tsx
@@ -72,7 +72,7 @@ export const Explanation = ({
       </Button>
       <Flex className="gap-3 md:flex-col md:gap-2">
         {/* Step counter */}
-        <div className="bg-body-light grid h-8 w-9 place-items-center rounded-lg p-2 text-xs">
+        <div className="grid h-8 w-9 place-items-center rounded-lg bg-body-light p-2 text-xs">
           <span className="leading-none font-bold">
             {step + 1}/{totalSteps}
           </span>

--- a/src/components/Simulator/MoreInfoPopover.tsx
+++ b/src/components/Simulator/MoreInfoPopover.tsx
@@ -27,7 +27,7 @@ export const MoreInfoPopover = ({ isFirstStep, children }: MoreInfoPopover) => {
       <PopoverTrigger asChild>
         <MotionButton
           variant="ghost"
-          className="text-body-medium relative min-h-0 p-0 text-sm"
+          className="relative min-h-0 p-0 text-sm text-body-medium"
           onClick={() => setClicked(true)}
           data-testid="more-info-popover-trigger"
         >
@@ -37,7 +37,7 @@ export const MoreInfoPopover = ({ isFirstStep, children }: MoreInfoPopover) => {
         </MotionButton>
       </PopoverTrigger>
       <PopoverContent
-        className="bg-background-highlight relative start-4 w-[calc(100vw-3rem)] max-w-xs px-4 py-6 text-sm shadow-none sm:start-8 sm:w-[calc(100vw-5rem)]"
+        className="relative start-4 w-[calc(100vw-3rem)] max-w-xs bg-background-highlight px-4 py-6 text-sm shadow-none sm:start-8 sm:w-[calc(100vw-5rem)]"
         data-testid="more-info-popover-content"
       >
         <PopoverClose className="absolute end-2 top-1 ms-auto flex size-6 items-center justify-center text-xl leading-none">

--- a/src/components/Simulator/PathButton.tsx
+++ b/src/components/Simulator/PathButton.tsx
@@ -25,7 +25,7 @@ export const PathButton = ({ pathSummary, handleClick }: PathButtonProps) => {
             {primaryText}
           </span>
           {secondaryText && (
-            <span className="text-body-medium m-0 text-xs leading-5">
+            <span className="m-0 text-xs leading-5 text-body-medium">
               {secondaryText}
             </span>
           )}

--- a/src/components/Simulator/Phone.tsx
+++ b/src/components/Simulator/Phone.tsx
@@ -3,7 +3,7 @@ import type { ChildOnlyProp } from "@/lib/types"
 export const Phone = ({ children }: ChildOnlyProp) => (
   <figure className="mx-auto max-w-[min(100%,322px)] min-w-[min(100%,322px)]">
     {/* Phone frame */}
-    <div className="border-body-medium bg-background relative z-0 h-[480px] max-h-full w-full overflow-hidden rounded-3xl border-[5px] md:h-[600px]">
+    <div className="relative z-0 h-[480px] max-h-full w-full overflow-hidden rounded-3xl border-[5px] border-body-medium bg-background md:h-[600px]">
       {children}
     </div>
     {/* Phone drop shadow */}

--- a/src/components/Simulator/PulseAnimation.tsx
+++ b/src/components/Simulator/PulseAnimation.tsx
@@ -23,7 +23,7 @@ export const PulseAnimation = ({ type = CIRCLE }: PulseAnimationProps) => {
   return (
     <motion.div
       className={cn(
-        "border-primary absolute border-2",
+        "absolute border-2 border-primary",
         insetClass,
         borderRadiusClass
       )}

--- a/src/components/Simulator/WalletHome/AddressPill.tsx
+++ b/src/components/Simulator/WalletHome/AddressPill.tsx
@@ -16,7 +16,7 @@ export const AddressPill = ({ ...btnProps }: AddressPillProps) => {
       content={t("sim-address-tooltip")}
     >
       <Flex
-        className="border-border bg-background-highlight text-disabled gap-2 self-center rounded-full border px-2 py-1 text-center text-xs"
+        className="gap-2 self-center rounded-full border border-border bg-background-highlight px-2 py-1 text-center text-xs text-disabled"
         {...btnProps}
       >
         <p>{FAKE_DEMO_ADDRESS}</p>

--- a/src/components/Simulator/WalletHome/CategoryTabs.tsx
+++ b/src/components/Simulator/WalletHome/CategoryTabs.tsx
@@ -25,7 +25,7 @@ export const CategoryTabs = ({
           variant="ghost"
           className={cn(
             fontWeightClass,
-            "text-body p-0 pb-2",
+            "p-0 pb-2 text-body",
             isActiveIndex && "!text-[initial]"
           )}
           disabled={isActiveIndex}

--- a/src/components/Simulator/WalletHome/SendReceiveButton.tsx
+++ b/src/components/Simulator/WalletHome/SendReceiveButton.tsx
@@ -37,19 +37,19 @@ export const SendReceiveButton = ({
     >
       <div
         className={cn(
-          "bg-primary group-hover:bg-primary-hover relative grid aspect-square w-10 place-items-center rounded-full md:w-16",
+          "relative grid aspect-square w-10 place-items-center rounded-full bg-primary group-hover:bg-primary-hover md:w-16",
           isHighlighted
             ? "group-disabled:bg-primary"
             : "group-disabled:bg-body-light"
         )}
       >
         {!isDisabled && isAnimated && <PulseAnimation type="circle" />}
-        <Icon className="text-background size-4 md:size-6" />
+        <Icon className="size-4 text-background md:size-6" />
       </div>
       <div className="relative">
         <p
           className={cn(
-            "text-primary group-hover:text-primary-hover relative text-center font-bold",
+            "relative text-center font-bold text-primary group-hover:text-primary-hover",
             isHighlighted
               ? "group-disabled:text-primary"
               : "group-disabled:text-body-medium"

--- a/src/components/Simulator/WalletHome/WalletBalance.tsx
+++ b/src/components/Simulator/WalletHome/WalletBalance.tsx
@@ -15,10 +15,10 @@ export const WalletBalance = ({ usdAmount = 0 }: WalletBalanceProps) => {
   const t = useTranslations("component-wallet-simulator")
   return (
     <div className="z-[1]">
-      <p className="text-body-medium mb-2 text-center md:mb-4">
+      <p className="mb-2 text-center text-body-medium md:mb-4">
         {t("sim-your-total")}
       </p>
-      <p className="!leading-base text-center text-3xl font-bold md:text-5xl">
+      <p className="text-center text-3xl !leading-base font-bold md:text-5xl">
         {formatWalletUsd(usdAmount)}
       </p>
       <Flex className="mb-4 justify-center">

--- a/src/components/Simulator/WalletHome/index.tsx
+++ b/src/components/Simulator/WalletHome/index.tsx
@@ -38,12 +38,12 @@ export const WalletHome = ({
     0
   )
   return (
-    <Flex className="bg-background absolute inset-0 flex-col items-center">
+    <Flex className="absolute inset-0 flex-col items-center bg-background">
       <Flex className="w-full flex-1 flex-col justify-between px-6 pt-8 pb-4">
         <WalletBalance usdAmount={totalAmounts} />
         <SendReceiveButtons nav={nav} isEnabled={isEnabled} />
       </Flex>
-      <Flex className="bg-background-highlight w-full flex-1 flex-col justify-between gap-6 p-6">
+      <Flex className="w-full flex-1 flex-col justify-between gap-6 bg-background-highlight p-6">
         <CategoryTabs
           categories={[t("sim-crypto"), t("sim-nfts")]}
           activeIndex={activeTabIndex}

--- a/src/components/Simulator/index.tsx
+++ b/src/components/Simulator/index.tsx
@@ -146,9 +146,9 @@ export const Simulator = ({ children, data }: SimulatorProps) => {
   return (
     <div
       id={SIMULATOR_ID}
-      className="from-accent-a/10 to-accent-c/10 dark:from-primary/20 dark:via-accent-a/20 dark:to-accent-c/20 grid w-full scroll-mt-[5rem] place-items-center scroll-smooth bg-linear-to-r p-4 md:p-16 dark:bg-linear-to-tr dark:from-20% dark:via-60% dark:to-95%"
+      className="grid w-full scroll-mt-[5rem] place-items-center scroll-smooth bg-linear-to-r from-accent-a/10 to-accent-c/10 p-4 md:p-16 dark:bg-linear-to-tr dark:from-primary/20 dark:from-20% dark:via-accent-a/20 dark:via-60% dark:to-accent-c/20 dark:to-95%"
     >
-      <Flex className="bg-background w-full max-w-[1000px] items-center gap-16 px-4 py-8 text-center max-md:flex-col md:p-16 md:text-start md:max-lg:gap-8">
+      <Flex className="w-full max-w-[1000px] items-center gap-16 bg-background px-4 py-8 text-center max-md:flex-col md:p-16 md:text-start md:max-lg:gap-8">
         {/* TEXT CONTENT */}
         <Flex className="flex-col px-4">{children}</Flex>
         {/* Button stack for path options */}

--- a/src/components/Simulator/screens/ConnectWeb3/Browser.tsx
+++ b/src/components/Simulator/screens/ConnectWeb3/Browser.tsx
@@ -36,14 +36,14 @@ export const Browser = ({ ...props }: BrowserProps) => {
   }
 
   return (
-    <Flex className="bg-body-light h-full flex-col" {...props}>
-      <div className="bg-background-highlight w-full px-3 pt-9 pb-3">
+    <Flex className="h-full flex-col bg-body-light" {...props}>
+      <div className="w-full bg-background-highlight px-3 pt-9 pb-3">
         <NotificationPopover
           title={t("sim-example-walkthrough")}
           content={t("sim-try-login-app")}
         >
-          <HStack className="bg-background text-disabled cursor-default gap-0 rounded px-3 py-2">
-            <div className="border-background-highlight flex-1 border-e">
+          <HStack className="cursor-default gap-0 rounded bg-background px-3 py-2 text-disabled">
+            <div className="flex-1 border-e border-background-highlight">
               {typing ? (
                 <motion.p
                   className="text-body-medium"
@@ -67,10 +67,10 @@ export const Browser = ({ ...props }: BrowserProps) => {
       </div>
 
       <Flex className="flex-1 justify-center pt-20 md:pt-24">
-        <BrowserGlobe className="text-disabled size-24 stroke-1" />
+        <BrowserGlobe className="size-24 stroke-1 text-disabled" />
       </Flex>
 
-      <Flex className="bg-background-highlight text-disabled w-full justify-around px-3 pt-4 pb-9 text-xl">
+      <Flex className="w-full justify-around bg-background-highlight px-3 pt-4 pb-9 text-xl text-disabled">
         <Triangle className="-rotate-90" />
         <Triangle className="rotate-90" />
         <Search />

--- a/src/components/Simulator/screens/ConnectWeb3/Slider.tsx
+++ b/src/components/Simulator/screens/ConnectWeb3/Slider.tsx
@@ -32,7 +32,7 @@ export const Slider = ({ isConnected, displayUrl, children }: SliderProps) => {
         transition={{ duration: 0.75, ease: "easeOut" }}
         data-testid="slider-box"
       >
-        <VStack className="bg-background size-full gap-0 rounded-t-2xl px-6 py-8">
+        <VStack className="size-full gap-0 rounded-t-2xl bg-background px-6 py-8">
           {isConnected ? (
             <VStack className="gap-4 pt-8">
               <motion.div
@@ -61,9 +61,9 @@ export const Slider = ({ isConnected, displayUrl, children }: SliderProps) => {
               </p>
               {/* URL Pill */}
               <HStack className="mb-6 rounded-full bg-black/5 px-2 py-1 text-xs">
-                <div className="bg-body grid size-5 place-items-center rounded-full">
+                <div className="grid size-5 place-items-center rounded-full bg-body">
                   {/* TODO: Remove important flags and `size` class when icon is migrated */}
-                  <EthGlyphIcon className="!text-background !size-[1em] !text-sm" />
+                  <EthGlyphIcon className="!size-[1em] !text-sm !text-background" />
                 </div>
                 <p className="me-0.5">{displayUrl}</p>
               </HStack>

--- a/src/components/Simulator/screens/ConnectWeb3/Web3App.tsx
+++ b/src/components/Simulator/screens/ConnectWeb3/Web3App.tsx
@@ -24,7 +24,7 @@ export const Web3App = ({
   const t = useTranslations("component-wallet-simulator")
   return (
     <div
-      className={cn("bg-background-highlight size-full", className)}
+      className={cn("size-full bg-background-highlight", className)}
       {...rest}
     >
       <div className="bg-[#e8e8e8] p-1 dark:bg-[#171717]">
@@ -45,7 +45,7 @@ export const Web3App = ({
               </>
             )}
           </div>
-          <Menu className="[&>path]:stroke-body size-[1em]" />
+          <Menu className="size-[1em] [&>path]:stroke-body" />
         </HStack>
       </NotificationPopover>
       {children}

--- a/src/components/Simulator/screens/ConnectWeb3/index.tsx
+++ b/src/components/Simulator/screens/ConnectWeb3/index.tsx
@@ -134,7 +134,7 @@ export const ConnectWeb3 = ({ nav, ctaLabel }: PhoneScreenProps) => {
                   side="top"
                 >
                   <Flex className="flex-col items-start gap-1 text-start text-xs sm:text-sm">
-                    <p className="text-md ms-2 mb-auto font-bold">
+                    <p className="ms-2 mb-auto text-md font-bold">
                       {t("sim-cw-nft-title")}
                     </p>
                     <Button variant="link" disabled>
@@ -157,7 +157,7 @@ export const ConnectWeb3 = ({ nav, ctaLabel }: PhoneScreenProps) => {
                 content={t("sim-try-real-app")}
                 side="top"
               >
-                <div className="md:text-md text-sm">
+                <div className="text-sm md:text-md">
                   <Button className="block" variant="link" disabled>
                     {t("sim-cw-browse-artwork")}
                   </Button>

--- a/src/components/Simulator/screens/CreateAccount/GeneratingKeys.tsx
+++ b/src/components/Simulator/screens/CreateAccount/GeneratingKeys.tsx
@@ -54,7 +54,7 @@ export const GeneratingKeys = ({
   }, [loading])
 
   return (
-    <div className="bg-background-highlight grid h-full place-items-center">
+    <div className="grid h-full place-items-center bg-background-highlight">
       <Flex className="flex-col items-center gap-4">
         {/* eslint-disable-next-line no-constant-condition */}
         {loading ? (

--- a/src/components/Simulator/screens/CreateAccount/HomeScreen.tsx
+++ b/src/components/Simulator/screens/CreateAccount/HomeScreen.tsx
@@ -26,7 +26,7 @@ export const HomeScreen = ({ nav, ...props }: HomeScreenProps) => {
         {step === 1 ? (
           <motion.button
             className={cn(
-              "hover:outline-primary-hover, border-body bg-body grid shadow-md duration-300 hover:outline hover:outline-2 hover:outline-offset-2",
+              "hover:outline-primary-hover, grid border-body bg-body shadow-md duration-300 hover:outline hover:outline-2 hover:outline-offset-2",
               sharedIconClasses
             )}
             initial={{ opacity: 0 }}
@@ -34,18 +34,18 @@ export const HomeScreen = ({ nav, ...props }: HomeScreenProps) => {
             exit={{ opacity: 0 }}
             onClick={nav.progressStepper}
           >
-            <EthGlyphIcon className="text-background size-[1em] text-2xl sm:text-3xl" />
+            <EthGlyphIcon className="size-[1em] text-2xl text-background sm:text-3xl" />
           </motion.button>
         ) : (
           <motion.div
             className={cn(
               sharedIconClasses,
-              "border-disabled bg-background grid border-dashed duration-200"
+              "grid border-dashed border-disabled bg-background duration-200"
             )}
             initial={{ opacity: 1 }}
             exit={{ opacity: 0 }}
           >
-            <ArrowDown className="!text-disabled !size-[1em] !text-2xl sm:!text-3xl" />
+            <ArrowDown className="!size-[1em] !text-2xl !text-disabled sm:!text-3xl" />
           </motion.div>
         )}
       </AnimatePresence>

--- a/src/components/Simulator/screens/CreateAccount/RecoveryPhraseNotice.tsx
+++ b/src/components/Simulator/screens/CreateAccount/RecoveryPhraseNotice.tsx
@@ -6,7 +6,7 @@ export const RecoveryPhraseNotice = () => {
 
   return (
     <motion.div
-      className="bg-background-highlight md:text-md h-full px-4 py-8 text-sm md:px-8 [&_p]:mb-4 [&_p]:md:mb-6"
+      className="h-full bg-background-highlight px-4 py-8 text-sm md:px-8 md:text-md [&_p]:mb-4 [&_p]:md:mb-6"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.25 }}

--- a/src/components/Simulator/screens/CreateAccount/WelcomeScreen.tsx
+++ b/src/components/Simulator/screens/CreateAccount/WelcomeScreen.tsx
@@ -12,12 +12,12 @@ export const WelcomeScreen = () => {
 
   return (
     <MotionFlex
-      className="bg-background-highlight h-full flex-col items-center pt-16"
+      className="h-full flex-col items-center bg-background-highlight pt-16"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.8 }}
     >
-      <EthGlyphIcon className="text-body my-4 h-[110px] w-auto md:h-[190px]" />
+      <EthGlyphIcon className="my-4 h-[110px] w-auto text-body md:h-[190px]" />
       <p className="px-4 text-center text-2xl leading-8 md:px-8">
         {t("sim-ca-welcome-to")}
         <span className="block font-bold">{t("sim-ca-wallet-simulator")}</span>

--- a/src/components/Simulator/screens/CreateAccount/WordList.tsx
+++ b/src/components/Simulator/screens/CreateAccount/WordList.tsx
@@ -91,7 +91,7 @@ export const WordList = ({ words, wordsSelected }: WordListProps) => {
   }
 
   return (
-    <div className="bg-background grid grid-cols-2 gap-x-7 px-4 whitespace-nowrap md:px-8">
+    <div className="grid grid-cols-2 gap-x-7 bg-background px-4 whitespace-nowrap md:px-8">
       <OrderedList className={styles} start={1}>
         {words.map(wordMapping).slice(0, splitIndex)}
       </OrderedList>

--- a/src/components/Simulator/screens/CreateAccount/WordSelectorButtons.tsx
+++ b/src/components/Simulator/screens/CreateAccount/WordSelectorButtons.tsx
@@ -66,7 +66,7 @@ export const WordSelectorButtons = ({
 
   return (
     <div
-      className="bg-background-highlight absolute bottom-0 w-full p-4"
+      className="absolute bottom-0 w-full bg-background-highlight p-4"
       data-testid="word-selector-buttons"
     >
       <div className="grid h-[90px] w-full grid-cols-4 gap-2 overflow-hidden whitespace-nowrap md:h-[152px]">
@@ -76,12 +76,12 @@ export const WordSelectorButtons = ({
             variant="solid"
             onClick={incrementWordsSelected}
             disabled={index !== wordsSelected}
-            className="group bg-primary-hover text-background disabled:bg-body-light disabled:text-body relative rounded-xl px-1"
+            className="group relative rounded-xl bg-primary-hover px-1 text-background disabled:bg-body-light disabled:text-body"
           >
             <>
               {word}
               {index === wordsSelected && (
-                <Pointer className="z-popover stroke-body absolute start-[65%] top-[65%] transition-opacity duration-200 group-hover:opacity-0 group-hover:transition-opacity group-hover:duration-200" />
+                <Pointer className="absolute start-[65%] top-[65%] z-popover stroke-body transition-opacity duration-200 group-hover:opacity-0 group-hover:transition-opacity group-hover:duration-200" />
               )}
             </>
           </Button>

--- a/src/components/Simulator/screens/SendReceive/ReceiveEther.tsx
+++ b/src/components/Simulator/screens/SendReceive/ReceiveEther.tsx
@@ -19,7 +19,7 @@ export const ReceiveEther = () => {
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
       transition={{ duration: 0.25 }}
-      className="bg-background-highlight md:text-md h-full px-4 py-6 text-sm md:px-6 md:py-8"
+      className="h-full bg-background-highlight px-4 py-6 text-sm md:px-6 md:py-8 md:text-md"
     >
       <p className="mb-3 text-xl font-bold md:mb-6 md:text-2xl">
         {t("sim-receive-title")}
@@ -31,19 +31,19 @@ export const ReceiveEther = () => {
         content={t("sim-receive-qr-share")}
         side="top"
       >
-        <div className="bg-background relative mx-auto mb-3 w-fit p-3 md:mb-5">
+        <div className="relative mx-auto mb-3 w-fit bg-background p-3 md:mb-5">
           <Image
             alt=""
             src={QrImage}
             className="size-[6rem] rounded p-1 md:size-[7.5rem] dark:invert"
           />
-          <div className="bg-primary-action absolute top-1/2 left-1/2 size-10 -translate-x-1/2 -translate-y-1/2 transform rounded-full" />
+          <div className="absolute top-1/2 left-1/2 size-10 -translate-x-1/2 -translate-y-1/2 transform rounded-full bg-primary-action" />
           <EthGlyph className="absolute top-1/2 left-1/2 size-6 -translate-x-1/2 -translate-y-1/2 transform text-white" />
         </div>
       </NotificationPopover>
       <Flex className="relative mb-3 w-full items-center justify-between gap-2 rounded border px-3 py-2 md:mb-5">
         <div>
-          <p className="text-body-medium m-0 text-xs">
+          <p className="m-0 text-xs text-body-medium">
             {t("sim-receive-your-address")}
           </p>
           <p className="m-0 text-sm">{FAKE_DEMO_ADDRESS}</p>
@@ -54,7 +54,7 @@ export const ReceiveEther = () => {
           side="top"
           align="end"
         >
-          <Button className="bg-body-light text-body h-fit rounded-lg px-2 py-1.5 text-xs font-bold">
+          <Button className="h-fit rounded-lg bg-body-light px-2 py-1.5 text-xs font-bold text-body">
             {t("sim-receive-copy")}
           </Button>
         </NotificationPopover>

--- a/src/components/Simulator/screens/SendReceive/ReceivedEther.tsx
+++ b/src/components/Simulator/screens/SendReceive/ReceivedEther.tsx
@@ -82,7 +82,7 @@ export const ReceivedEther = ({
         {showToast && !hidden && (
           <motion.div
             key="toast"
-            className="bg-primary-high-contrast text-md text-background absolute inset-4 top-auto bottom-32 flex h-fit items-center gap-3 rounded p-4"
+            className="absolute inset-4 top-auto bottom-32 flex h-fit items-center gap-3 rounded bg-primary-high-contrast p-4 text-md text-background"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}

--- a/src/components/Simulator/screens/SendReceive/SendEther.tsx
+++ b/src/components/Simulator/screens/SendReceive/SendEther.tsx
@@ -56,7 +56,7 @@ export const SendEther = ({
         </p>
         <p className="md:mb-6">{t("sim-send-how-much")}</p>
       </div>
-      <Flex className="border-background-highlight text-body-medium justify-between gap-4 border-y px-6 py-4 text-xs md:py-6">
+      <Flex className="justify-between gap-4 border-y border-background-highlight px-6 py-4 text-xs text-body-medium md:py-6">
         {/* Left side: Displayed send amount */}
         <NotificationPopover
           title={t("sim-example-walkthrough")}
@@ -82,10 +82,10 @@ export const SendEther = ({
             content={t("sim-send-eth-only-note")}
           >
             {/* Token selector pill */}
-            <HStack className="bg-body-light mb-4 gap-0 rounded-full px-2 py-1">
+            <HStack className="mb-4 gap-0 rounded-full bg-body-light px-2 py-1">
               {/* TODO: remove flags and `size` class when icon is migrated */}
               <EthTokenIcon className="!me-1.5 !size-[1em] !text-xl" />
-              <p className="text-body m-0 font-bold">ETH</p>
+              <p className="m-0 font-bold text-body">ETH</p>
             </HStack>
           </NotificationPopover>
           {/* Balances */}
@@ -95,8 +95,8 @@ export const SendEther = ({
           <p dir="ltr">{ethAmount} ETH</p>
         </Flex>
       </Flex>
-      <div className="bg-background-highlight h-full">
-        <Flex className="bg-background-highlight relative flex-nowrap justify-between p-6 font-bold">
+      <div className="h-full bg-background-highlight">
+        <Flex className="relative flex-nowrap justify-between bg-background-highlight p-6 font-bold">
           {/* Amount buttons */}
           {AMOUNTS.map((amount, i) => (
             <Button

--- a/src/components/Simulator/screens/SendReceive/SendFromContacts.tsx
+++ b/src/components/Simulator/screens/SendReceive/SendFromContacts.tsx
@@ -36,7 +36,7 @@ export const SendFromContacts = ({
         >
           <Button
             variant="outline"
-            className="border-disabled text-disabled hover:!text-disabled w-full cursor-auto py-4 hover:shadow-none"
+            className="w-full cursor-auto border-disabled py-4 text-disabled hover:!text-disabled hover:shadow-none"
           >
             <Search />
             <span className="me-auto">{t("sim-contacts-search")}</span>
@@ -44,7 +44,7 @@ export const SendFromContacts = ({
           </Button>
         </NotificationPopover>
       </div>
-      <div className="bg-background-highlight h-full px-6 py-8">
+      <div className="h-full bg-background-highlight px-6 py-8">
         <CategoryTabs
           categories={[t("sim-contacts-my-contacts"), t("sim-contacts-recent")]}
           activeIndex={1}
@@ -55,13 +55,13 @@ export const SendFromContacts = ({
             <Button
               key={name + i}
               disabled={i > 0}
-              className="group disabled:bg-background disabled:text-body hover:[&_path]:fill-primary-hover gap-2"
+              className="group gap-2 disabled:bg-background disabled:text-body hover:[&_path]:fill-primary-hover"
               onClick={() => handleSelection(name)}
             >
-              <EthTokenIcon className="[&_path]:fill-primary-action [&_circle]:fill-white" />
+              <EthTokenIcon className="[&_circle]:fill-white [&_path]:fill-primary-action" />
               <span className="flex-1">
                 <span className="block text-start font-bold">{name}</span>
-                <span className="group-disabled:text-body-medium block text-start text-sm text-white">
+                <span className="block text-start text-sm text-white group-disabled:text-body-medium">
                   {t("sim-contact-last-action")}
                 </span>
               </span>

--- a/src/components/Simulator/screens/SendReceive/SendSummary.tsx
+++ b/src/components/Simulator/screens/SendReceive/SendSummary.tsx
@@ -43,12 +43,12 @@ export const SendSummary = ({
             {formatChosenAmount}
           </p>
         </Flex>
-        <p dir="ltr" className="text-body-medium text-xs">
+        <p dir="ltr" className="text-xs text-body-medium">
           {formatWalletToken(chosenAmount / ethPrice, locale)} ETH
         </p>
       </div>
       {/* Bottom section */}
-      <Flex className="bg-background-highlight md:text-md h-full flex-col gap-3 px-6 py-4 text-sm md:gap-6 md:py-8">
+      <Flex className="h-full flex-col gap-3 bg-background-highlight px-6 py-4 text-sm md:gap-6 md:py-8 md:text-md">
         <div>
           <p>{t("sim-summary-to")}</p>
           <p className="font-bold">{recipient}</p>
@@ -61,7 +61,7 @@ export const SendSummary = ({
           <p>{t("sim-summary-fees")}</p>
           <p className="font-bold">
             {formatWalletUsd(usdFee)}
-            <span className="text-body-medium ms-2 text-xs font-normal">
+            <span className="ms-2 text-xs font-normal text-body-medium">
               (
               {formatWalletToken(ethTransferFee, locale, {
                 maximumFractionDigits: 6,

--- a/src/components/Simulator/screens/SendReceive/Success.tsx
+++ b/src/components/Simulator/screens/SendReceive/Success.tsx
@@ -70,7 +70,7 @@ export const Success = ({
         </motion.div>
       ) : (
         <Flex
-          className="bg-background-highlight h-full justify-center max-md:pt-24 md:items-center"
+          className="h-full justify-center bg-background-highlight max-md:pt-24 md:items-center"
           asChild
         >
           <motion.div

--- a/src/components/SkipLink.tsx
+++ b/src/components/SkipLink.tsx
@@ -11,7 +11,7 @@ export const SkipLink = async () => {
     <div className="bg-primary-low-contrast focus-within:p-4">
       <BaseLink
         href={"#" + MAIN_CONTENT_ID}
-        className="bg-primary text-background absolute -top-14 rounded border px-4 py-2 leading-8 no-underline hover:no-underline focus:static"
+        className="absolute -top-14 rounded border bg-primary px-4 py-2 leading-8 text-background no-underline hover:no-underline focus:static"
       >
         {t("skip-to-main-content")}
       </BaseLink>

--- a/src/components/StablecoinAccordion/AccordionCustomItem.tsx
+++ b/src/components/StablecoinAccordion/AccordionCustomItem.tsx
@@ -54,7 +54,7 @@ export const AccordionCustomItem = (props: AccordionCustomItemProps) => {
   return (
     <AccordionItem value={contentObj.title} className="border">
       <AccordionTrigger
-        className="text-body-medium hover:text-body-medium items-center justify-between py-0 ps-0"
+        className="items-center justify-between py-0 ps-0 text-body-medium hover:text-body-medium"
         onClick={handleOpen}
       >
         <Flex
@@ -67,7 +67,7 @@ export const AccordionCustomItem = (props: AccordionCustomItemProps) => {
           />
           <div>
             <Flex className="mb-2 items-center">
-              <h3 className="text-body hover:text-body text-xl md:text-2xl">
+              <h3 className="text-xl text-body hover:text-body md:text-2xl">
                 {t(contentObj.title)}
               </h3>
               {!!contentObj.tag && (
@@ -79,13 +79,13 @@ export const AccordionCustomItem = (props: AccordionCustomItemProps) => {
                 </Tag>
               )}
             </Flex>
-            <p className="text-md text-body-medium text-start">
+            <p className="text-start text-md text-body-medium">
               {t(contentObj.textPreview)}
             </p>
           </div>
         </Flex>
       </AccordionTrigger>
-      <AccordionContent className="border-border bg-background text-md -mx-px mt-0 -mb-px border p-0 md:p-0">
+      <AccordionContent className="-mx-px mt-0 -mb-px border border-border bg-background p-0 text-md md:p-0">
         <Flex className="flex-col justify-between p-8 lg:flex-row">
           {children}
         </Flex>

--- a/src/components/StablecoinAccordion/index.tsx
+++ b/src/components/StablecoinAccordion/index.tsx
@@ -37,7 +37,7 @@ const StepBox = (
   const { t } = useTranslation("page-stablecoins")
 
   return (
-    <LinkBox className="bg-background hover:bg-background-highlight flex flex-col items-start border p-4 transition-transform duration-200 not-[:first-child]:-mt-px hover:scale-105 md:flex-row md:items-stretch">
+    <LinkBox className="flex flex-col items-start border bg-background p-4 transition-transform duration-200 not-[:first-child]:-mt-px hover:scale-105 hover:bg-background-highlight md:flex-row md:items-stretch">
       <Flex className="w-full items-center justify-between">
         <div>
           <LinkOverlay asChild>

--- a/src/components/StablecoinsTable.tsx
+++ b/src/components/StablecoinsTable.tsx
@@ -184,7 +184,7 @@ const StablecoinsTable = ({ content, hasError }: StablecoinsTableProps) => {
       <DropdownMenuTrigger className="ms-auto flex items-center gap-2 text-end">
         {t("page-stablecoins-stablecoins-table-header-column-3")}
         {activeTypeCount !== totalTypeCount && (
-          <span className="text-body-medium self-baseline text-sm">
+          <span className="self-baseline text-sm text-body-medium">
             ({activeTypeCount})
           </span>
         )}
@@ -205,7 +205,7 @@ const StablecoinsTable = ({ content, hasError }: StablecoinsTableProps) => {
             <Button
               variant="link"
               size="sm"
-              className="text-body-medium h-auto px-1 py-0 text-xs no-underline hover:underline"
+              className="h-auto px-1 py-0 text-xs text-body-medium no-underline hover:underline"
               onClick={(e) => {
                 e.preventDefault()
                 e.stopPropagation()
@@ -221,7 +221,7 @@ const StablecoinsTable = ({ content, hasError }: StablecoinsTableProps) => {
             <Button
               variant="link"
               size="sm"
-              className="text-body-medium text-xs no-underline hover:underline"
+              className="text-xs text-body-medium no-underline hover:underline"
               onClick={(e) => {
                 e.preventDefault()
                 e.stopPropagation()
@@ -238,7 +238,7 @@ const StablecoinsTable = ({ content, hasError }: StablecoinsTableProps) => {
       <DropdownMenuTrigger className="ms-auto flex items-center gap-2 text-end">
         {t("page-stablecoins-stablecoins-table-header-column-4")}
         {activePegCount !== totalPegCount && (
-          <span className="text-body-medium text-xs">({activePegCount})</span>
+          <span className="text-xs text-body-medium">({activePegCount})</span>
         )}
         <ListFilter className="size-[1em]" />
       </DropdownMenuTrigger>
@@ -257,7 +257,7 @@ const StablecoinsTable = ({ content, hasError }: StablecoinsTableProps) => {
             <Button
               variant="link"
               size="sm"
-              className="text-body-medium h-auto px-1 py-0 text-xs no-underline hover:underline"
+              className="h-auto px-1 py-0 text-xs text-body-medium no-underline hover:underline"
               onClick={(e) => {
                 e.preventDefault()
                 e.stopPropagation()
@@ -273,7 +273,7 @@ const StablecoinsTable = ({ content, hasError }: StablecoinsTableProps) => {
             <Button
               variant="link"
               size="sm"
-              className="text-body-medium text-xs no-underline hover:underline"
+              className="text-xs text-body-medium no-underline hover:underline"
               onClick={(e) => {
                 e.preventDefault()
                 e.stopPropagation()
@@ -290,7 +290,7 @@ const StablecoinsTable = ({ content, hasError }: StablecoinsTableProps) => {
 
   return (
     <div className="mx-auto w-full max-w-screen-xl overflow-x-auto px-8 py-4">
-      <Table className="bg-background my-8 min-w-[720px]">
+      <Table className="my-8 min-w-[720px] bg-background">
         <TableHeader>
           <Suspense fallback={<Skeleton className="h-8 w-full" />}>
             <TableRow>
@@ -342,7 +342,7 @@ const StablecoinsTable = ({ content, hasError }: StablecoinsTableProps) => {
                       )}
                       <span>
                         {name}{" "}
-                        <span className="text-body-medium text-sm uppercase">
+                        <span className="text-sm text-body-medium uppercase">
                           {symbol}
                         </span>
                       </span>
@@ -384,7 +384,7 @@ const StablecoinsTable = ({ content, hasError }: StablecoinsTableProps) => {
       </div>
       {displayedContent.length === 0 && !noFiltersActive && (
         <div className="flex flex-col items-center justify-center py-12">
-          <p className="text-body-medium mb-4 text-lg">
+          <p className="mb-4 text-lg text-body-medium">
             {t("page-stablecoins-no-results")}
           </p>
           <Button variant="outline" onClick={resetFilters}>

--- a/src/components/Staking/StakingComparison.tsx
+++ b/src/components/Staking/StakingComparison.tsx
@@ -49,7 +49,7 @@ const StakingComparison = ({ page, className }: StakingComparisonProps) => {
     },
     colorClassName: "text-staking-gold",
     glyph: (
-      <StakingGlyphCPUIcon className="text-staking-gold h-[50px] w-[50px]" />
+      <StakingGlyphCPUIcon className="h-[50px] w-[50px] text-staking-gold" />
     ),
   }
   const saas: DataType = {
@@ -63,7 +63,7 @@ const StakingComparison = ({ page, className }: StakingComparisonProps) => {
     },
     colorClassName: "text-staking-green",
     glyph: (
-      <StakingGlyphCloudIcon className="text-staking-green h-[28px] w-[50px]" />
+      <StakingGlyphCloudIcon className="h-[28px] w-[50px] text-staking-green" />
     ),
   }
   const pools: DataType = {
@@ -77,7 +77,7 @@ const StakingComparison = ({ page, className }: StakingComparisonProps) => {
     },
     colorClassName: "text-staking-blue",
     glyph: (
-      <StakingGlyphTokenWalletIcon className="text-staking-blue h-[39px] w-[50px]" />
+      <StakingGlyphTokenWalletIcon className="h-[39px] w-[50px] text-staking-blue" />
     ),
   }
   const data: {
@@ -123,7 +123,7 @@ const StakingComparison = ({ page, className }: StakingComparisonProps) => {
     <Flex
       className={cn(
         "mt-16 flex-col gap-8 px-6 py-8 md:px-8",
-        "from-accent-a/10 to-accent-c/10 dark:from-accent-a/20 dark:to-accent-c-hover/20 bg-linear-to-r",
+        "bg-linear-to-r from-accent-a/10 to-accent-c/10 dark:from-accent-a/20 dark:to-accent-c-hover/20",
         className
       )}
     >

--- a/src/components/Staking/StakingConsiderations/index.tsx
+++ b/src/components/Staking/StakingConsiderations/index.tsx
@@ -82,7 +82,7 @@ const StakingConsiderations = ({ page }: StakingConsiderationsProps) => {
                   trackCustomEvent(matomo)
                 }}
                 className={cn(
-                  "transition-background hover:bg-background-highlight hover:text-body relative mb-0 table h-8 w-full cursor-pointer p-3 duration-500",
+                  "transition-background relative mb-0 table h-8 w-full cursor-pointer p-3 duration-500 hover:bg-background-highlight hover:text-body",
                   idx === activeIndex
                     ? "bg-background-highlight text-body"
                     : "text-primary"
@@ -94,7 +94,7 @@ const StakingConsiderations = ({ page }: StakingConsiderationsProps) => {
           </List>
         )}
       </div>
-      <Flex className="bg-background-highlight min-h-[410px] flex-[2] flex-col items-center p-6">
+      <Flex className="min-h-[410px] flex-[2] flex-col items-center bg-background-highlight p-6">
         <StyledSvg />
         <h3 className="mt-10 text-2xl leading-[1.4] font-bold">{title}</h3>
         <p>{description}</p>

--- a/src/components/Staking/StakingHierarchy.tsx
+++ b/src/components/Staking/StakingHierarchy.tsx
@@ -22,7 +22,7 @@ type SectionGridProps = ChildOnlyProp
 
 const SectionGrid = ({ children }: SectionGridProps) => {
   return (
-    <div className="staking-grid-stacked md:staking-grid relative grid grid-cols-1 gap-4 md:grid-cols-[5rem_1fr_5rem] md:gap-x-8 md:gap-y-0">
+    <div className="relative grid grid-cols-1 gap-4 staking-grid-stacked md:grid-cols-[5rem_1fr_5rem] md:gap-x-8 md:gap-y-0 md:staking-grid">
       {children}
     </div>
   )
@@ -30,7 +30,7 @@ const SectionGrid = ({ children }: SectionGridProps) => {
 
 const StyledEtherSvg = ({ className = "size-full" }: { className: string }) => {
   return (
-    <Center className="area-ether z-[2] mx-auto w-full max-w-20">
+    <Center className="z-[2] mx-auto w-full max-w-20 area-ether">
       <StakingGlyphEtherCircleIcon className={className} />
     </Center>
   )
@@ -43,7 +43,7 @@ const Line = () => {
 const Header = ({ children, className }: HTMLAttributes<HTMLDivElement>) => (
   <Flex
     className={cn(
-      "area-header flex-col items-center justify-center gap-2 md:items-start",
+      "flex-col items-center justify-center gap-2 area-header md:items-start",
       className
     )}
   >
@@ -96,7 +96,7 @@ const Glyph = ({ glyphIcon: GlyphIcon, className }: GlyphProps) => (
 )
 
 const Content = ({ children }: ChildOnlyProp) => (
-  <Flex className="area-content flex-col gap-4 md:mt-4 md:mb-12">
+  <Flex className="flex-col gap-4 area-content md:mt-4 md:mb-12">
     {children}
   </Flex>
 )
@@ -105,9 +105,9 @@ const StakingHierarchy = () => {
   const { t } = useTranslation("page-staking")
 
   return (
-    <VStack className="bg-gradient-staking gap-16 p-8 md:gap-0 md:rounded-lg">
+    <VStack className="gap-16 bg-gradient-staking p-8 md:gap-0 md:rounded-lg">
       <SectionGrid>
-        <StyledEtherSvg className="text-staking-gold size-[100%]" />
+        <StyledEtherSvg className="size-[100%] text-staking-gold" />
         <Line />
         <Header className="text-staking-gold">
           <HeadingEl>{t("page-staking-hierarchy-solo-h2")}</HeadingEl>
@@ -145,7 +145,7 @@ const StakingHierarchy = () => {
         </Content>
       </SectionGrid>
       <SectionGrid>
-        <StyledEtherSvg className="text-staking-green size-[90%]" />
+        <StyledEtherSvg className="size-[90%] text-staking-green" />
         <Line />
         <Header className="text-staking-green">
           <HeadingEl>{t("page-staking-dropdown-saas")}</HeadingEl>
@@ -181,7 +181,7 @@ const StakingHierarchy = () => {
         </Content>
       </SectionGrid>
       <SectionGrid>
-        <StyledEtherSvg className="text-staking-blue size-[80%]" />
+        <StyledEtherSvg className="size-[80%] text-staking-blue" />
         <Line />
         <Header className="text-staking-blue">
           <HeadingEl>{t("page-staking-dropdown-pools")}</HeadingEl>
@@ -229,7 +229,7 @@ const StakingHierarchy = () => {
         </Content>
       </SectionGrid>
       <SectionGrid>
-        <StyledEtherSvg className="text-staking-red size-[70%]" />
+        <StyledEtherSvg className="size-[70%] text-staking-red" />
         <Line />
         <Header className="text-staking-red">
           <HeadingEl>{t("page-staking-hierarchy-cex-h2")}</HeadingEl>

--- a/src/components/Staking/StakingLaunchpadWidget.tsx
+++ b/src/components/Staking/StakingLaunchpadWidget.tsx
@@ -57,10 +57,10 @@ const StakingLaunchpadWidget = () => {
     <Flex
       className={cn(
         "flex-col rounded p-6 md:p-8",
-        "from-accent-a/10 to-accent-c/10 dark:from-accent-a/20 dark:to-accent-c-hover/20 bg-linear-to-r"
+        "bg-linear-to-r from-accent-a/10 to-accent-c/10 dark:from-accent-a/20 dark:to-accent-c-hover/20"
       )}
     >
-      <span className="text-body-medium leading-6">
+      <span className="leading-6 text-body-medium">
         <Translation id="page-staking:page-staking-launchpad-widget-span" />
       </span>
       <div className="my-4 md:max-w-[50%]">

--- a/src/components/Staking/StakingProductsCardGrid/StakingProductCard.tsx
+++ b/src/components/Staking/StakingProductsCardGrid/StakingProductCard.tsx
@@ -160,13 +160,13 @@ export const StakingProductCard = ({
   ].filter(({ status }) => !!status)
 
   return (
-    <div className="rounded-base bg-background-highlight flex flex-col transition-transform hover:scale-101">
+    <div className="rounded-base flex flex-col bg-background-highlight transition-transform hover:scale-101">
       <div className="flex max-h-24 space-x-3 p-6">
         {!!Svg && <Svg className="size-12" />}
         <div className="flex flex-col justify-center">
           <h4 className="text-xl">{name}</h4>
           {typeof minEth !== "undefined" && (
-            <p className="text-body-medium text-sm font-normal">
+            <p className="text-sm font-normal text-body-medium">
               {minEth > 0 ? (
                 <>
                   {t("common:from")} <span dir="ltr">{minEth} ETH</span>
@@ -215,7 +215,7 @@ export const StakingProductCard = ({
         </ButtonLink>
         <div className="flex h-7.5 items-center justify-center">
           {validSocials.length > 0 && (
-            <p className="text-body-medium me-2">
+            <p className="me-2 text-body-medium">
               {t("page-staking-products-follow")}
             </p>
           )}
@@ -223,7 +223,7 @@ export const StakingProductCard = ({
           {validSocials.map(([platform, url], idx) => (
             <Link key={idx} href={url} hideArrow>
               <SocialListItem
-                className="text-body [&>svg]:text-body size-8"
+                className="size-8 text-body [&>svg]:text-body"
                 socialIcon={
                   platform as
                     | "twitter"

--- a/src/components/Staking/StakingProductsCardGrid/index.tsx
+++ b/src/components/Staking/StakingProductsCardGrid/index.tsx
@@ -14,7 +14,7 @@ const StakingProductsCardGrid = ({
   const { rankedProducts } = useStakingProductsCardGrid({ category })
 
   return (
-    <div className={"grid-cols-fill-4 mx-0 my-12 grid gap-6"}>
+    <div className={"mx-0 my-12 grid grid-cols-fill-4 gap-6"}>
       {rankedProducts.map((product) => (
         <StakingProductCard key={product.name} product={product} />
       ))}

--- a/src/components/Staking/StakingStatsBox.tsx
+++ b/src/components/Staking/StakingStatsBox.tsx
@@ -17,7 +17,7 @@ const Cell = ({ children }: ChildOnlyProp) => (
 )
 
 const Value = ({ children }: ChildOnlyProp) => (
-  <code className="font-monospace text-primary inline-block bg-none p-0 pe-1 text-3xl font-bold">
+  <code className="inline-block bg-none p-0 pe-1 font-monospace text-3xl font-bold text-primary">
     {children}
   </code>
 )
@@ -31,7 +31,7 @@ const Label = ({ children }: ChildOnlyProp) => (
 // BeaconchainTooltip component
 const BeaconchainTooltip = ({ children }: ChildOnlyProp) => (
   <Tooltip content={children}>
-    <Info className="active:primary focus:primary text-md hover:text-primary size-[1em]" />
+    <Info className="active:primary focus:primary size-[1em] text-md hover:text-primary" />
   </Tooltip>
 )
 

--- a/src/components/Staking/WithdrawalsTabComparison.tsx
+++ b/src/components/Staking/WithdrawalsTabComparison.tsx
@@ -42,7 +42,7 @@ const WithdrawalsTabComparison = () => {
 
       <TabsContent
         value="current"
-        className="bg-background-highlight space-y-4"
+        className="space-y-4 bg-background-highlight"
       >
         <h3>{t("comp-withdrawal-comparison-current-title")}</h3>
         <UnorderedList>
@@ -63,7 +63,7 @@ const WithdrawalsTabComparison = () => {
               <InlineLink href="https://beaconcha.in">{chunks}</InlineLink>
             ),
             prefix: (chunks) => (
-              <span className="text-warning-border dark:text-warning font-mono font-bold">
+              <span className="font-mono font-bold text-warning-border dark:text-warning">
                 {chunks}
               </span>
             ),
@@ -73,7 +73,7 @@ const WithdrawalsTabComparison = () => {
         <WithdrawalCredentials />
       </TabsContent>
 
-      <TabsContent value="new" className="bg-background-highlight space-y-4">
+      <TabsContent value="new" className="space-y-4 bg-background-highlight">
         <h3>{t("comp-withdrawal-comparison-new-title")}</h3>
         <UnorderedList>
           <ListItem>{t("comp-withdrawal-comparison-new-li-1")}</ListItem>

--- a/src/components/StartWithEthereumFlow/ConnectYourWallet/index.tsx
+++ b/src/components/StartWithEthereumFlow/ConnectYourWallet/index.tsx
@@ -51,7 +51,7 @@ const ConnectYourWallet = ({
         <div className="hidden flex-col items-center justify-center gap-4 lg:flex">
           {isConnected && <Emoji text="🎉" className="text-[72px]" />}
           {isConnected && (
-            <p className="text-md text-center font-bold">
+            <p className="text-center text-md font-bold">
               {t("page-start-connect-wallet-account-message")}
             </p>
           )}
@@ -102,7 +102,7 @@ const ConnectYourWallet = ({
         <div className="mb-2.5 flex w-full flex-col items-center justify-center gap-4 sm:mb-0 lg:hidden">
           {isConnected && <Emoji text="🎉" className="text-[72px]" />}
           {isConnected && (
-            <p className="text-md text-center font-bold">
+            <p className="text-center text-md font-bold">
               {t("page-start-connect-wallet-account-message")}
             </p>
           )}

--- a/src/components/StartWithEthereumFlow/DownloadAWallet/index.tsx
+++ b/src/components/StartWithEthereumFlow/DownloadAWallet/index.tsx
@@ -42,7 +42,7 @@ const DownloadAWallet = ({
         </div>
         <div className="hidden flex-col gap-8 lg:flex">
           <div
-            className="group hover:text-primary-hover flex cursor-pointer flex-row items-center gap-2"
+            className="group flex cursor-pointer flex-row items-center gap-2 hover:text-primary-hover"
             onClick={() => {
               setHasWallet(!hasWallet)
               trackCustomEvent({
@@ -72,11 +72,11 @@ const DownloadAWallet = ({
         </div>
       </div>
       <div className="flex w-full flex-1 flex-col gap-8">
-        <div className="shadow-window-box flex flex-col overflow-hidden rounded-2xl border">
+        <div className="flex flex-col overflow-hidden rounded-2xl border shadow-window-box">
           {newToCryptoWallets.map((wallet) => (
             <LinkBox
               key={wallet.name}
-              className="border-body-light bg-background hover:bg-background-highlight flex flex-col gap-4 border-b p-4 last:border-b-0 sm:p-6"
+              className="flex flex-col gap-4 border-b border-body-light bg-background p-4 last:border-b-0 hover:bg-background-highlight sm:p-6"
             >
               <div className="flex flex-row items-center justify-between gap-2">
                 <div className="flex w-full max-w-[200px] flex-row items-center gap-4">
@@ -90,7 +90,7 @@ const DownloadAWallet = ({
                   </div>
                   <p>
                     <LinkOverlay
-                      className="text-body hover:text-body no-underline"
+                      className="text-body no-underline hover:text-body"
                       asChild
                     >
                       <InlineLink
@@ -119,7 +119,7 @@ const DownloadAWallet = ({
         </div>
         <div className="flex flex-col gap-8 lg:hidden">
           <div
-            className="group hover:text-primary-hover flex cursor-pointer flex-row items-center gap-2"
+            className="group flex cursor-pointer flex-row items-center gap-2 hover:text-primary-hover"
             onClick={() => {
               setHasWallet(!hasWallet)
               trackCustomEvent({

--- a/src/components/StartWithEthereumFlow/LetUseSomeApps/index.tsx
+++ b/src/components/StartWithEthereumFlow/LetUseSomeApps/index.tsx
@@ -108,7 +108,7 @@ const LetUseSomeApps = ({
           {dappsList.map((dapp) => (
             <LinkBox
               key={dapp.name}
-              className="group border-background hover:bg-background-highlight flex cursor-pointer flex-col items-center justify-between gap-4 rounded-xl border-b p-4 last:border-b-0 sm:flex-row"
+              className="group flex cursor-pointer flex-col items-center justify-between gap-4 rounded-xl border-b border-background p-4 last:border-b-0 hover:bg-background-highlight sm:flex-row"
               onClick={() => {
                 window.open(dapp.url, "_blank")
                 trackCustomEvent({
@@ -131,7 +131,7 @@ const LetUseSomeApps = ({
                     <p className="text-xl font-bold">{dapp.name}</p>
                     {dapp.tag}
                   </div>
-                  <p className="text-body-medium text-sm">{dapp.description}</p>
+                  <p className="text-sm text-body-medium">{dapp.description}</p>
                 </div>
               </div>
               <div className="w-full sm:w-auto">
@@ -139,7 +139,7 @@ const LetUseSomeApps = ({
                   href={dapp.url}
                   variant="outline"
                   size="sm"
-                  className="group-hover:!text-primary-hover w-full group-hover:shadow-[4px_4px_hsla(var(--primary-low-contrast))] sm:w-auto"
+                  className="w-full group-hover:!text-primary-hover group-hover:shadow-[4px_4px_hsla(var(--primary-low-contrast))] sm:w-auto"
                 >
                   {t("page-start-apps-go")}
                 </ButtonLink>

--- a/src/components/StartWithEthereumFlow/ShareModal.tsx
+++ b/src/components/StartWithEthereumFlow/ShareModal.tsx
@@ -53,7 +53,7 @@ const ShareModal = () => {
           <Button
             onClick={() => onCopy(window.location.href)}
             variant="ghost"
-            className="hover:bg-background-highlight flex flex-col"
+            className="flex flex-col hover:bg-background-highlight"
           >
             {hasCopied ? (
               <>
@@ -69,7 +69,7 @@ const ShareModal = () => {
           </Button>
           <Button
             variant="ghost"
-            className="hover:bg-background-highlight flex flex-col"
+            className="flex flex-col hover:bg-background-highlight"
             onClick={handleTwitterShare}
           >
             <Twitter />

--- a/src/components/StartWithEthereumFlow/index.tsx
+++ b/src/components/StartWithEthereumFlow/index.tsx
@@ -20,14 +20,14 @@ import { Skeleton, SkeletonLines } from "../ui/skeleton"
 const WalletProviders = dynamic(() => import("@/components/WalletProviders"), {
   ssr: false,
   loading: () => (
-    <Skeleton className="bg-primary/20 grid h-[32rem] grid-cols-1 rounded-2xl p-12 md:grid-cols-2">
+    <Skeleton className="grid h-[32rem] grid-cols-1 rounded-2xl bg-primary/20 p-12 md:grid-cols-2">
       <div className="">
         <SkeletonLines
           noOfLines={5}
           className="flex h-full flex-col justify-center opacity-20"
         />
       </div>
-      <Skeleton className="bg-background h-full rounded-2xl" />
+      <Skeleton className="h-full rounded-2xl bg-background" />
     </Skeleton>
   ),
 })

--- a/src/components/Stat/index.tsx
+++ b/src/components/Stat/index.tsx
@@ -40,7 +40,7 @@ const Stat = ({ tooltipProps, value, label, isError }: StatProps) => {
 
   return (
     <Flex className="flex-col-reverse">
-      <div className="text-body-medium flex items-center space-x-2 leading-none">
+      <div className="flex items-center space-x-2 leading-none text-body-medium">
         <span>{label}</span>
         {!!tooltipProps && (
           <Tooltip {...tooltipProps} asChild>

--- a/src/components/StatErrorMessage.tsx
+++ b/src/components/StatErrorMessage.tsx
@@ -8,7 +8,7 @@ const StatErrorMessage = ({
   className,
   ...props
 }: HTMLAttributes<HTMLSpanElement>) => (
-  <span className={cn("leading-xs text-3xl", className)} {...props}>
+  <span className={cn("text-3xl leading-xs", className)} {...props}>
     <Translation id="loading-error-refresh" />
   </span>
 )

--- a/src/components/SubpageCard.tsx
+++ b/src/components/SubpageCard.tsx
@@ -34,7 +34,7 @@ const SubpageCard = ({
   return (
     <LinkBox
       className={cn(
-        "bg-card-gradient-secondary hover:bg-card-gradient-secondary-hover flex flex-col gap-3 rounded-3xl border border-[rgba(159,43,212,0.11)] p-6 hover:shadow-lg",
+        "flex flex-col gap-3 rounded-3xl border border-[rgba(159,43,212,0.11)] bg-card-gradient-secondary p-6 hover:bg-card-gradient-secondary-hover hover:shadow-lg",
         className
       )}
     >
@@ -42,7 +42,7 @@ const SubpageCard = ({
         <div className="text-primary">{icon}</div>
         <h3 className="text-xl">{title}</h3>
       </div>
-      <p className="text-body-medium m-0 p-0">{description}</p>
+      <p className="m-0 p-0 text-body-medium">{description}</p>
 
       {inlineLink ? (
         <LinkOverlay asChild>

--- a/src/components/SupportedLanguagesTooltip/index.tsx
+++ b/src/components/SupportedLanguagesTooltip/index.tsx
@@ -25,7 +25,7 @@ export const SupportedLanguagesTooltip = ({
 
   return (
     <Tooltip content={tooltipContent}>
-      <span className="text-md text-primary font-normal">+ {rest}</span>
+      <span className="text-md font-normal text-primary">+ {rest}</span>
     </Tooltip>
   )
 }

--- a/src/components/TableOfContents/TableOfContentsLink.tsx
+++ b/src/components/TableOfContents/TableOfContentsLink.tsx
@@ -48,7 +48,7 @@ const Link = ({
       <div
         data-label="marker"
         className={cn(
-          "border-primary-hover bg-background absolute top-1/2 -mt-1 hidden h-2 w-2 rounded-full border group-hover:inline-block",
+          "absolute top-1/2 -mt-1 hidden h-2 w-2 rounded-full border border-primary-hover bg-background group-hover:inline-block",
           isActive && "inline-block"
         )}
         style={{

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -104,7 +104,7 @@ const Tooltip = ({
     >
       <Trigger
         asChild={asChild}
-        className="focus-visible:outline-primary-hover focus-visible:rounded-xs focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+        className="focus-visible:rounded-xs focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-hover"
       >
         {children}
       </Trigger>

--- a/src/components/Translatathon/DatesAndTimeline.tsx
+++ b/src/components/Translatathon/DatesAndTimeline.tsx
@@ -112,7 +112,7 @@ export const DatesAndTimeline = () => {
                         <Button
                           className={cn(
                             "mt-2",
-                            !isLive ? "text-disabled pointer-events-none" : ""
+                            !isLive ? "pointer-events-none text-disabled" : ""
                           )}
                           variant="outline"
                           disabled={!isLive}

--- a/src/components/Translatathon/StepByStepInstructions.tsx
+++ b/src/components/Translatathon/StepByStepInstructions.tsx
@@ -79,11 +79,11 @@ export const StepByStepInstructions = () => {
         return (
           <Flex
             key={index}
-            className="border-body-light w-full flex-col items-start justify-between gap-4 border-b p-4 md:flex-row md:items-center"
+            className="w-full flex-col items-start justify-between gap-4 border-b border-body-light p-4 md:flex-row md:items-center"
           >
             <Flex className="flex-col items-start gap-4 md:flex-row md:items-center">
-              <Center className="bg-background h-[46px] max-w-[46px] min-w-[46px] rounded-lg p-1 shadow">
-                <p className="text-primary text-4xl font-bold">{index + 1}</p>
+              <Center className="h-[46px] max-w-[46px] min-w-[46px] rounded-lg bg-background p-1 shadow">
+                <p className="text-4xl font-bold text-primary">{index + 1}</p>
               </Center>
               <Flex className="flex-col">
                 <p className="text-xl font-bold">{instruction.title}</p>

--- a/src/components/Translatathon/TranslatathonCalendar.tsx
+++ b/src/components/Translatathon/TranslatathonCalendar.tsx
@@ -50,7 +50,7 @@ export const TranslatathonCalendar = () => {
       <Flex
         className={cn(
           "w-full flex-col gap-6 px-8 py-16 text-center lg:w-1/2",
-          "from-accent-a/10 to-accent-c/10 dark:from-accent-a/20 dark:to-accent-c-hover/20 bg-linear-to-r"
+          "bg-linear-to-r from-accent-a/10 to-accent-c/10 dark:from-accent-a/20 dark:to-accent-c-hover/20"
         )}
       >
         <h3 className="text-2xl font-bold">Translatathon calls</h3>
@@ -68,7 +68,7 @@ export const TranslatathonCalendar = () => {
           Join Discord
         </ButtonLink>
       </Flex>
-      <Flex className="bg-background-highlight w-full flex-col p-8 lg:w-1/2">
+      <Flex className="w-full flex-col bg-background-highlight p-8 lg:w-1/2">
         <p className="mb-2 text-lg font-bold">Translatathon calls</p>
         {events.map((event, index) => (
           <Flex className="mb-4 gap-6" key={index}>

--- a/src/components/Translatathon/TranslatathonPrizes.tsx
+++ b/src/components/Translatathon/TranslatathonPrizes.tsx
@@ -73,7 +73,7 @@ const TranslatathonPrizes = () => {
         <div className="flex flex-col">
           <p className="text-body-base text-lg">+ Participation prizes</p>
         </div>
-        <div className="text-body-medium flex flex-col text-sm">
+        <div className="flex flex-col text-sm text-body-medium">
           <Link href="/contributing/translation-program/translatathon/terms-and-conditions/">
             See full Terms & Conditions here
           </Link>

--- a/src/components/TranslationBanner.tsx
+++ b/src/components/TranslationBanner.tsx
@@ -45,7 +45,7 @@ const TranslationBanner = ({
   return (
     <aside
       className={cn(
-        "z-popover bg-background-highlight fixed end-0 bottom-0 rounded md:end-8 md:bottom-8",
+        "fixed end-0 bottom-0 z-popover rounded bg-background-highlight md:end-8 md:bottom-8",
         isOpen ? "block" : "hidden"
       )}
       dir={dir}
@@ -86,7 +86,7 @@ const TranslationBanner = ({
         <Button
           variant="ghost"
           size="sm"
-          className="hover:text-primary absolute end-0 top-0 m-2"
+          className="absolute end-0 top-0 m-2 hover:text-primary"
           onClick={() => setIsOpen(false)}
         >
           <X className="h-4 w-4" />

--- a/src/components/TranslationBannerLegal.tsx
+++ b/src/components/TranslationBannerLegal.tsx
@@ -35,7 +35,7 @@ const TranslationBannerLegal = ({
   return (
     <aside
       className={cn(
-        "z-popover bg-background-highlight fixed",
+        "fixed z-popover bg-background-highlight",
         "bottom-0 md:bottom-8",
         "right-0 md:right-8",
         isOpen ? "block" : "hidden"

--- a/src/components/TranslationLeaderboard.tsx
+++ b/src/components/TranslationLeaderboard.tsx
@@ -83,7 +83,7 @@ const RadioCard = ({ value, children, checked, onChange }) => {
         checked && "border-primary text-primary shadow-md"
       )}
     >
-      <span className="text-md text-center leading-none font-semibold md:text-lg md:font-normal">
+      <span className="text-center text-md leading-none font-semibold md:text-lg md:font-normal">
         {children}
       </span>
     </Button>
@@ -156,7 +156,7 @@ const TranslationLeaderboard = ({
           )}
         </RadioCard>
       </Flex>
-      <div className="bg-background-highlight mb-8 w-full shadow-md">
+      <div className="mb-8 w-full bg-background-highlight shadow-md">
         <Flex className="bg-muted text-foreground mb-[1px] w-full items-center justify-between p-4">
           <Flex>
             <div className="w-10 opacity-40">#</div>
@@ -235,7 +235,7 @@ const TranslationLeaderboard = ({
           onClick={filterAmount === 10 ? showMore : showLess}
           className="m-2 mx-0 flex h-full w-full items-center justify-center rounded-full px-6 py-4 lg:mx-2 lg:w-auto"
         >
-          <span className="text-md text-center leading-none font-semibold md:text-lg md:font-normal">
+          <span className="text-center text-md leading-none font-semibold md:text-lg md:font-normal">
             {t(
               filterAmount === 10
                 ? "page-contributing-translation-program-acknowledgements-translation-leaderboard-show-more"

--- a/src/components/Trilemma/Triangle.tsx
+++ b/src/components/Trilemma/Triangle.tsx
@@ -117,7 +117,7 @@ export const TriangleSVG = ({
       xmlns="http://www.w3.org/2000/svg"
       height="620"
       viewBox="-100 100 850 915"
-      className="fill-background w-full lg:mt-32 lg:mr-32 lg:w-auto"
+      className="w-full fill-background lg:mt-32 lg:mr-32 lg:w-auto"
     >
       <Path />
       <Path />

--- a/src/components/Trilemma/Trilemma.stories.tsx
+++ b/src/components/Trilemma/Trilemma.stories.tsx
@@ -10,7 +10,7 @@ const meta = {
   },
   decorators: [
     (Story) => (
-      <div className="from-accent-a/10 to-accent-c/10 my-8 w-full bg-linear-to-r p-8">
+      <div className="my-8 w-full bg-linear-to-r from-accent-a/10 to-accent-c/10 p-8">
         <Story />
       </div>
     ),

--- a/src/components/TutorialMetadata.tsx
+++ b/src/components/TutorialMetadata.tsx
@@ -41,7 +41,7 @@ const TutorialMetadata = ({
   const address = frontmatter.address
 
   return (
-    <Flex className="border-border flex-col justify-between border-b-0 pb-2 lg:border-b">
+    <Flex className="flex-col justify-between border-b-0 border-border pb-2 lg:border-b">
       <Flex className="mb-8 w-full items-center justify-between">
         <Flex className="w-full flex-wrap">
           <TutorialTags tags={frontmatter.tags} />
@@ -80,7 +80,7 @@ const TutorialMetadata = ({
         <Flex className="text-text300 -mt-4 mb-6 flex-wrap text-sm">
           <CopyToClipboard text={address}>
             {(isCopied) => (
-              <div className="bg-background-highlight text-primary hover:bg-primary-hover hover:text-body-inverse cursor-pointer overflow-hidden px-1 font-mono text-sm text-ellipsis">
+              <div className="cursor-pointer overflow-hidden bg-background-highlight px-1 font-mono text-sm text-ellipsis text-primary hover:bg-primary-hover hover:text-body-inverse">
                 <span className="uppercase">
                   <Translation id="page-developers-tutorials:comp-tutorial-metadata-tip-author" />
                 </span>{" "}

--- a/src/components/UpgradeStatus.tsx
+++ b/src/components/UpgradeStatus.tsx
@@ -21,7 +21,7 @@ const UpgradeStatus = ({
     <aside
       className={cn(
         "my-8 flex w-full flex-col gap-6 rounded p-6 shadow-2xl lg:mt-0",
-        "from-accent-c/10 bg-black/80 bg-linear-to-b",
+        "bg-black/80 bg-linear-to-b from-accent-c/10",
         "dark:border-2 dark:bg-gray-700 dark:from-transparent",
         isShipped
           ? "bg-success-light dark:border-success"

--- a/src/components/UpgradeTableOfContents.tsx
+++ b/src/components/UpgradeTableOfContents.tsx
@@ -22,7 +22,7 @@ const TableOfContentsLink = ({
     <BaseLink
       href={url}
       className={cn(
-        "hover:text-primary relative !mb-4 inline-block text-xl font-normal text-gray-500 no-underline hover:no-underline dark:text-gray-400",
+        "relative !mb-4 inline-block text-xl font-normal text-gray-500 no-underline hover:text-primary hover:no-underline dark:text-gray-400",
         isActive && "text-primary"
       )}
     >

--- a/src/components/Videos/VideoWatch/index.tsx
+++ b/src/components/Videos/VideoWatch/index.tsx
@@ -43,7 +43,7 @@ const VideoWatch = async ({ slug, startTime, className }: VideoWatchProps) => {
   return (
     <Card
       className={cn(
-        "bg-background-highlight my-8 max-w-xl space-y-4 border p-4 md:p-6",
+        "my-8 max-w-xl space-y-4 border bg-background-highlight p-4 md:p-6",
         className
       )}
     >

--- a/src/components/WhitepaperBridge/index.tsx
+++ b/src/components/WhitepaperBridge/index.tsx
@@ -38,7 +38,7 @@ const WhitepaperBridge = async () => {
   ] as const
 
   return (
-    <Section className="border-primary-low-contrast bg-radial-a my-8 space-y-6 rounded-2xl border p-6 md:p-8">
+    <Section className="my-8 space-y-6 rounded-2xl border border-primary-low-contrast bg-radial-a p-6 md:p-8">
       {/* Eyebrow tag - uses warning status for attention */}
       <Tag status="warning" variant="outline" size="small" className="gap-1.5">
         <Info className="size-3.5" />
@@ -47,10 +47,10 @@ const WhitepaperBridge = async () => {
 
       {/* Main heading */}
       <div className="space-y-3">
-        <h2 className="text-body text-2xl font-bold md:text-3xl">
+        <h2 className="text-2xl font-bold text-body md:text-3xl">
           {t("heading")}
         </h2>
-        <p className="text-body-medium max-w-2xl">
+        <p className="max-w-2xl text-body-medium">
           {t.rich("description", {
             strong: (chunks) => <strong className="text-body">{chunks}</strong>,
           })}
@@ -73,16 +73,16 @@ const WhitepaperBridge = async () => {
       </Flex>
 
       {/* What's changed card - uses card-gradient-secondary */}
-      <Card className="border-primary-low-contrast bg-card-gradient-secondary border">
+      <Card className="border border-primary-low-contrast bg-card-gradient-secondary">
         <CardContent className="p-4 md:p-6">
-          <p className="text-body-medium mb-4 text-sm font-semibold tracking-wide uppercase">
+          <p className="mb-4 text-sm font-semibold tracking-wide text-body-medium uppercase">
             {t("whats-changed")}
           </p>
           <UnorderedList className="ms-0 space-y-3">
             {evolutionKeys.map((key) => (
               <Flex key={key} className="gap-3">
-                <CheckCircle2 className="text-success mt-0.5 size-5 shrink-0" />
-                <span className="text-body-medium flex-1">{t(key)}</span>
+                <CheckCircle2 className="mt-0.5 size-5 shrink-0 text-success" />
+                <span className="flex-1 text-body-medium">{t(key)}</span>
               </Flex>
             ))}
           </UnorderedList>

--- a/src/components/WindowBox/index.tsx
+++ b/src/components/WindowBox/index.tsx
@@ -12,11 +12,11 @@ type WindowBoxProps = {
 const WindowBox = ({ title, svg, children, className }: WindowBoxProps) => (
   <div
     className={cn(
-      "shadow-window-box flex max-w-screen-md flex-col overflow-hidden rounded-2xl border",
+      "flex max-w-screen-md flex-col overflow-hidden rounded-2xl border shadow-window-box",
       className
     )}
   >
-    <div className="from-primary-hover/5 dark:from-primary-hover/20 flex items-center gap-4 bg-linear-to-b p-4">
+    <div className="flex items-center gap-4 bg-linear-to-b from-primary-hover/5 p-4 dark:from-primary-hover/20">
       <div className="grid size-10 place-items-center rounded-lg border">
         {svg}
       </div>

--- a/src/components/icons/CheckCircle.tsx
+++ b/src/components/icons/CheckCircle.tsx
@@ -8,13 +8,13 @@ export const CheckCircle = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "bg-success/20 my-1 grid h-fit place-items-center rounded-full p-1",
+      "my-1 grid h-fit place-items-center rounded-full bg-success/20 p-1",
       className
     )}
     {...props}
   >
     <Check
-      className="text-success size-3 stroke-[4]"
+      className="size-3 stroke-[4] text-success"
       strokeLinecap="square"
       strokeLinejoin="miter"
     />

--- a/src/components/icons/Icons.stories.tsx
+++ b/src/components/icons/Icons.stories.tsx
@@ -192,7 +192,7 @@ const items = iconsDefinitions.map(({ Icon, label }, idx) => {
   return (
     <Flex
       key={idx}
-      className="border-background-highlight flex-col gap-4 border p-4"
+      className="flex-col gap-4 border border-background-highlight p-4"
     >
       <Center>
         <Icon className="size-[50px]" />

--- a/src/components/ui/Link.tsx
+++ b/src/components/ui/Link.tsx
@@ -192,7 +192,7 @@ export const LinkWithArrow = forwardRef<HTMLAnchorElement, LinkProps>(
     return (
       <BaseLink
         className={cn(
-          "group visited:text-primary-visited block w-fit no-underline",
+          "group block w-fit no-underline visited:text-primary-visited",
           className
         )}
         ref={ref}

--- a/src/components/ui/TabNav.tsx
+++ b/src/components/ui/TabNav.tsx
@@ -18,7 +18,7 @@ export const StickyContainer = ({
   className,
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn("z-dropdown sticky top-20", className)} {...props} />
+  <div className={cn("sticky top-20 z-dropdown", className)} {...props} />
 )
 
 interface TabNavProps {
@@ -48,7 +48,7 @@ const TabNav = ({
 
   return (
     <div className={cn("flex w-full justify-center", className)}>
-      <nav className="bg-background mx-4 flex w-full max-w-full gap-1 overflow-x-auto rounded-2xl border p-0.5 shadow md:max-w-[calc(100%-2rem)] md:shadow-lg lg:w-auto">
+      <nav className="mx-4 flex w-full max-w-full gap-1 overflow-x-auto rounded-2xl border bg-background p-0.5 shadow md:max-w-[calc(100%-2rem)] md:shadow-lg lg:w-auto">
         {sections.map(({ key, href: sectionHref, label, icon }) => {
           const isActive = activeKey.toLowerCase() === key.toLowerCase()
           const sharedProps = {
@@ -67,10 +67,10 @@ const TabNav = ({
                   (useMotion ? (
                     <motion.div
                       layoutId={motionLayoutId}
-                      className="bg-primary-low-contrast absolute inset-0 z-0 rounded-xl"
+                      className="absolute inset-0 z-0 rounded-xl bg-primary-low-contrast"
                     />
                   ) : (
-                    <div className="bg-primary-low-contrast absolute inset-0 z-0 rounded-xl" />
+                    <div className="absolute inset-0 z-0 rounded-xl bg-primary-low-contrast" />
                   ))}
                 {icon && <span className="relative z-10 text-lg">{icon}</span>}
                 <span className="relative z-10">{label}</span>

--- a/src/components/ui/__stories__/EdgeScrollContainer.stories.tsx
+++ b/src/components/ui/__stories__/EdgeScrollContainer.stories.tsx
@@ -23,7 +23,7 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 const SampleCard = ({ children }: { children: React.ReactNode }) => (
-  <div className="border-body-light bg-background-highlight flex h-48 w-72 items-center justify-center rounded-2xl border p-6 shadow-md">
+  <div className="flex h-48 w-72 items-center justify-center rounded-2xl border border-body-light bg-background-highlight p-6 shadow-md">
     {children}
   </div>
 )
@@ -61,7 +61,7 @@ export const AsChildExample: Story = {
         <EdgeScrollItem key={i} asChild className="ms-6">
           <a
             href="#"
-            className="border-body-light bg-background-highlight hover:bg-primary-low-contrast flex h-48 w-72 items-center justify-center rounded-2xl border p-6 shadow-md transition-colors"
+            className="flex h-48 w-72 items-center justify-center rounded-2xl border border-body-light bg-background-highlight p-6 shadow-md transition-colors hover:bg-primary-low-contrast"
           >
             Clickable Card {i}
           </a>

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -25,7 +25,7 @@ const AccordionTrigger = React.forwardRef<
     <AccordionPrimitive.Trigger
       ref={ref}
       className={cn(
-        "hover:bg-background-highlight hover:text-primary-hover focus-visible:outline-primary-hover [&[data-state=open]]:bg-background-highlight [&[data-state=open]]:text-primary-high-contrast flex flex-1 items-center justify-between gap-2 px-2 py-2 font-medium transition-all focus-visible:outline-1 focus-visible:-outline-offset-1 md:px-4 [&[data-state=open]_[data-label=icon-container]>svg]:-rotate-90 [&[data-state=open]:dir(rtl)_[data-label=icon-container]>svg]:rotate-90",
+        "flex flex-1 items-center justify-between gap-2 px-2 py-2 font-medium transition-all hover:bg-background-highlight hover:text-primary-hover focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-primary-hover md:px-4 [&[data-state=open]]:bg-background-highlight [&[data-state=open]]:text-primary-high-contrast [&[data-state=open]_[data-label=icon-container]>svg]:-rotate-90 [&[data-state=open]:dir(rtl)_[data-label=icon-container]>svg]:rotate-90",
         className
       )}
       {...props}
@@ -49,7 +49,7 @@ const AccordionContent = React.forwardRef<
 >(({ className, children, ...props }, ref) => (
   <AccordionPrimitive.Content
     ref={ref}
-    className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm transition-all"
+    className="overflow-hidden text-sm transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
     {...props}
   >
     <div className={cn("p-2 md:p-4", className)}>{children}</div>

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -85,7 +85,7 @@ const AlertCloseButton = React.forwardRef<
   <Button
     ref={ref}
     variant="ghost"
-    className={cn("text-body -me-4 rounded-full", className)}
+    className={cn("-me-4 rounded-full text-body", className)}
     {...props}
   >
     <X className="h-6 w-6" />

--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -57,7 +57,7 @@ const BreadcrumbLink = React.forwardRef<
     <Comp
       ref={ref}
       className={cn(
-        "!text-body-medium hover:!text-primary uppercase no-underline transition-colors",
+        "!text-body-medium uppercase no-underline transition-colors hover:!text-primary",
         className
       )}
       {...props}
@@ -107,7 +107,7 @@ const BreadcrumbEllipsis = ({
     className={cn("flex h-9 w-9 items-center justify-center", className)}
     {...props}
   >
-    <MoreHorizontal className="text-md size-4" />
+    <MoreHorizontal className="size-4 text-md" />
     <span className="sr-only">More</span>
   </span>
 )

--- a/src/components/ui/buttons/SvgButtonLink.tsx
+++ b/src/components/ui/buttons/SvgButtonLink.tsx
@@ -47,7 +47,7 @@ const SvgButtonLink = ({
         className={cn(
           "header",
           "relative grid aspect-square size-[5em] shrink-0 place-items-center",
-          "shadow-svg-button-link rounded-2xl border transition-all duration-200",
+          "rounded-2xl border shadow-svg-button-link transition-all duration-200",
           "group-hover:shadow-svg-button-link-hover group-hover:transition-all group-hover:duration-200",
           "group-focus:shadow-none group-focus:transition-all group-focus:duration-200"
         )}

--- a/src/components/ui/card.stories.tsx
+++ b/src/components/ui/card.stories.tsx
@@ -16,7 +16,7 @@ export default meta
 export const FitCover = {
   render: () => (
     <VStack className="max-w-md items-stretch gap-4">
-      <p className="text-body-medium text-sm">
+      <p className="text-sm text-body-medium">
         Default fit=&quot;cover&quot; - image fills container, may be cropped
       </p>
       <CardBanner background="accent-a">
@@ -30,7 +30,7 @@ export const FitCover = {
 export const FitContain = {
   render: () => (
     <VStack className="max-w-md items-stretch gap-4">
-      <p className="text-body-medium text-sm">
+      <p className="text-sm text-body-medium">
         fit=&quot;contain&quot; - blur background auto-generated from single
         image
       </p>
@@ -49,7 +49,7 @@ export const BackgroundVariants = {
         ["accent-a", "accent-b", "accent-c", "primary", "body", "none"] as const
       ).map((bg) => (
         <div key={bg}>
-          <p className="text-body-medium mb-2 text-sm">background: {bg}</p>
+          <p className="mb-2 text-sm text-body-medium">background: {bg}</p>
           <CardBanner background={bg}>
             <Image
               src="/images/dapps/uni.png"

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -50,7 +50,7 @@ const ChartContainer = React.forwardRef<
         data-chart={chartId}
         ref={ref}
         className={cn(
-          "[&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border flex aspect-video justify-center text-xs [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
+          "[&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted flex aspect-video justify-center text-xs [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
           className
         )}
         {...props}
@@ -177,7 +177,7 @@ const ChartTooltipContent = React.forwardRef<
       <div
         ref={ref}
         className={cn(
-          "border-border/50 bg-background grid min-w-[8rem] items-start gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl",
+          "grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl",
           className
         )}
       >

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -14,7 +14,7 @@ const Command = React.forwardRef<
   <CommandPrimitive
     ref={ref}
     className={cn(
-      "bg-background-highlight text-body flex h-full w-full flex-col overflow-hidden rounded-md",
+      "flex h-full w-full flex-col overflow-hidden rounded-md bg-background-highlight text-body",
       className
     )}
     {...props}
@@ -28,7 +28,7 @@ const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">
-        <Command className="[&_[cmdk-group-heading]]:text-disabled [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-disabled [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>
       </DialogContent>
@@ -50,19 +50,19 @@ const CommandInput = React.forwardRef<
   const Icon = icon
   return (
     <div
-      className="border-body flex items-center rounded border px-3"
+      className="flex items-center rounded border border-body px-3"
       cmdk-input-wrapper=""
     >
       <CommandPrimitive.Input
         ref={ref}
         className={cn(
-          "placeholder:text-disabled flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-hidden placeholder:text-disabled disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         {...props}
       />
       {kbdShortcut && (
-        <kbd className="border-disabled text-disabled rounded border border-solid px-1 text-sm">
+        <kbd className="rounded border border-solid border-disabled px-1 text-sm text-disabled">
           {kbdShortcut}
         </kbd>
       )}
@@ -108,7 +108,7 @@ const CommandGroup = React.forwardRef<
   <CommandPrimitive.Group
     ref={ref}
     className={cn(
-      "text-foreground [&_[cmdk-group-heading]]:text-disabled overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium",
+      "text-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-disabled",
       className
     )}
     {...props}
@@ -123,7 +123,7 @@ const CommandSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <CommandPrimitive.Separator
     ref={ref}
-    className={cn("bg-border -mx-1 h-px", className)}
+    className={cn("-mx-1 h-px bg-border", className)}
     {...props}
   />
 ))
@@ -136,7 +136,7 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      "aria-selected:bg-body-inverse aria-selected:text-body relative flex cursor-default items-center rounded-xs px-2 py-1.5 text-sm outline-hidden select-none data-[disabled='true']:pointer-events-none data-[disabled='true']:opacity-50",
+      "relative flex cursor-default items-center rounded-xs px-2 py-1.5 text-sm outline-hidden select-none aria-selected:bg-body-inverse aria-selected:text-body data-[disabled='true']:pointer-events-none data-[disabled='true']:opacity-50",
       className
     )}
     {...props}
@@ -151,7 +151,7 @@ const CommandShortcut = ({
 }: React.HTMLAttributes<HTMLSpanElement>) => {
   return (
     <span
-      className={cn("text-disabled ml-auto text-xs tracking-widest", className)}
+      className={cn("ml-auto text-xs tracking-widest text-disabled", className)}
       {...props}
     />
   )

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -19,7 +19,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "z-modal data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 bg-black/80",
+      "fixed inset-0 z-modal bg-black/80 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
       className
     )}
     {...props}
@@ -36,13 +36,13 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "z-modal bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed top-[50%] left-[50%] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 sm:rounded-lg",
+        "fixed top-[50%] left-[50%] z-modal grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground ring-offset-background absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+      <DialogPrimitive.Close className="focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/src/components/ui/divider.tsx
+++ b/src/components/ui/divider.tsx
@@ -8,7 +8,7 @@ const Divider = forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("bg-primary-high-contrast my-16 h-1 w-[10%]", className)}
+    className={cn("my-16 h-1 w-[10%] bg-primary-high-contrast", className)}
     {...props}
   />
 ))

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -26,7 +26,7 @@ const DrawerOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DrawerPrimitive.Overlay
     ref={ref}
-    className={cn("z-overlay fixed inset-0 bg-black/80", className)}
+    className={cn("fixed inset-0 z-overlay bg-black/80", className)}
     {...props}
   />
 ))
@@ -41,7 +41,7 @@ const DrawerContent = React.forwardRef<
     <DrawerPrimitive.Content
       ref={ref}
       className={cn(
-        "z-modal bg-background fixed inset-x-0 bottom-0 mt-24 flex h-auto flex-col border",
+        "fixed inset-x-0 bottom-0 z-modal mt-24 flex h-auto flex-col border bg-background",
         className
       )}
       {...props}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -45,7 +45,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-popover bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 min-w-[8rem] overflow-hidden rounded-md border p-1",
+      "z-popover min-w-[8rem] overflow-hidden rounded-md border bg-background p-1 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
       className
     )}
     {...props}
@@ -63,7 +63,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-popover border-body bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 min-w-[8rem] overflow-hidden rounded border py-2",
+        "z-popover min-w-[8rem] overflow-hidden rounded border border-body bg-background py-2 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
         className
       )}
       {...props}
@@ -81,7 +81,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "focus:bg-background-highlight focus:text-primary-hover relative flex cursor-default items-center p-2 outline-hidden transition-colors select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default items-center p-2 outline-hidden transition-colors select-none focus:bg-background-highlight focus:text-primary-hover data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       inset && "pl-8",
       className
     )}
@@ -97,7 +97,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "focus:bg-background-highlight focus:text-primary-hover relative flex cursor-default items-center rounded-xs py-1.5 pr-2 pl-8 text-sm outline-hidden transition-colors select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default items-center rounded-xs py-1.5 pr-2 pl-8 text-sm outline-hidden transition-colors select-none focus:bg-background-highlight focus:text-primary-hover data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     checked={checked}

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -27,7 +27,7 @@ const PopoverContent = React.forwardRef<
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          "text-popover-foreground z-popover border-background-highlight bg-background-highlight data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 w-72 rounded border p-4 shadow-lg outline-hidden",
+          "text-popover-foreground z-popover w-72 rounded border border-background-highlight bg-background-highlight p-4 shadow-lg outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           className
         )}
         {...props}

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -31,7 +31,7 @@ const Progress = React.forwardRef<
   <ProgressPrimitive.Root
     ref={ref}
     className={cn(
-      "bg-body-light relative h-4 w-full overflow-hidden rounded-full",
+      "relative h-4 w-full overflow-hidden rounded-full bg-body-light",
       color === "primary" ? "bg-background" : "bg-body-light",
       className
     )}

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -38,7 +38,7 @@ const ScrollBar = React.forwardRef<
     )}
     {...props}
   >
-    <ScrollAreaPrimitive.ScrollAreaThumb className="bg-border relative flex-1 rounded-full" />
+    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
   </ScrollAreaPrimitive.ScrollAreaScrollbar>
 ))
 ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName

--- a/src/components/ui/section.tsx
+++ b/src/components/ui/section.tsx
@@ -35,7 +35,7 @@ const SectionBanner = React.forwardRef<
     ref={ref}
     className={cn(
       "w-full overflow-hidden rounded-4xl md:max-w-96 lg:max-w-128",
-      "from-accent-a/10 to-accent-a/0 dark:from-accent-a/15 dark:to-accent-a/5 bg-linear-to-b",
+      "bg-linear-to-b from-accent-a/10 to-accent-a/0 dark:from-accent-a/15 dark:to-accent-a/5",
       "[&_img]:min-h-full [&_img]:object-cover [&_img]:object-center",
       className
     )}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -17,14 +17,14 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "placeholder:text-muted-foreground focus:ring-ring border-body ring-offset-background flex h-10 w-full items-center justify-between rounded-md border bg-transparent px-3 py-2 text-sm focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "placeholder:text-muted-foreground focus:ring-ring flex h-10 w-full items-center justify-between rounded-md border border-body bg-transparent px-3 py-2 text-sm ring-offset-background focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className
     )}
     {...props}
   >
     {children}
     <SelectPrimitive.Icon asChild>
-      <ChevronDown className="stroke-body text-md h-4 w-4 opacity-50" />
+      <ChevronDown className="h-4 w-4 stroke-body text-md opacity-50" />
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
 ))
@@ -42,7 +42,7 @@ const SelectScrollUpButton = React.forwardRef<
     )}
     {...props}
   >
-    <ChevronUp className="text-md h-4 w-4" />
+    <ChevronUp className="h-4 w-4 text-md" />
   </SelectPrimitive.ScrollUpButton>
 ))
 SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName
@@ -59,7 +59,7 @@ const SelectScrollDownButton = React.forwardRef<
     )}
     {...props}
   >
-    <ChevronDown className="text-md h-4 w-4" />
+    <ChevronDown className="h-4 w-4 text-md" />
   </SelectPrimitive.ScrollDownButton>
 ))
 SelectScrollDownButton.displayName =
@@ -73,7 +73,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "bg-popover text-popover-foreground z-modal border-body bg-background-highlight data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative max-h-96 min-w-[8rem] overflow-hidden rounded-md border shadow-md",
+        "bg-popover text-popover-foreground relative z-modal max-h-96 min-w-[8rem] overflow-hidden rounded-md border border-body bg-background-highlight shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className
@@ -116,7 +116,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "focus:bg-accent focus:text-accent-foreground bg-background-highlight relative flex w-full cursor-default items-center rounded-xs py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "focus:bg-accent focus:text-accent-foreground relative flex w-full cursor-default items-center rounded-xs bg-background-highlight py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     {...props}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -34,7 +34,7 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      "z-modal data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 bg-gray-800 opacity-70",
+      "fixed inset-0 z-modal bg-gray-800 opacity-70 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
       className
     )}
     {...props}

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -28,7 +28,7 @@ const Skeleton = ({ className, ...props }: SkeletonProps) => {
   return (
     <div
       className={cn(
-        "animate-pulse-light bg-disabled h-4 rounded opacity-5 dark:opacity-60",
+        "h-4 animate-pulse-light rounded bg-disabled opacity-5 dark:opacity-60",
         className
       )}
       {...props}

--- a/src/components/ui/swiper.tsx
+++ b/src/components/ui/swiper.tsx
@@ -96,7 +96,7 @@ const SwiperNavContainer = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "bg-background-highlight mx-auto flex h-6 w-fit items-center gap-4 rounded-full",
+      "mx-auto flex h-6 w-fit items-center gap-4 rounded-full bg-background-highlight",
       className
     )}
     {...props}

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -13,7 +13,7 @@ const Switch = React.forwardRef<
     <SwitchPrimitives.Root
       className={cn(
         commonControlClasses,
-        "bg-body-medium w-[26px] rounded-full p-px data-[state=unchecked]:disabled:bg-transparent",
+        "w-[26px] rounded-full bg-body-medium p-px data-[state=unchecked]:disabled:bg-transparent",
         "hover:[@media(hover:hover)_and_(pointer:fine)]:border-primary-hover hover:[@media(hover:hover)_and_(pointer:fine)]:bg-primary-hover",
         className
       )}
@@ -22,7 +22,7 @@ const Switch = React.forwardRef<
     >
       <SwitchPrimitives.Thumb
         className={cn(
-          "bg-background data-[state=unchecked]:data-[disabled]:border-disabled pointer-events-none block size-3 rounded-full transition-transform data-[state=checked]:translate-x-2.5 data-[state=unchecked]:translate-x-0 data-[state=unchecked]:data-[disabled]:border"
+          "pointer-events-none block size-3 rounded-full bg-background transition-transform data-[state=checked]:translate-x-2.5 data-[state=unchecked]:translate-x-0 data-[state=unchecked]:data-[disabled]:border data-[state=unchecked]:data-[disabled]:border-disabled"
         )}
       />
     </SwitchPrimitives.Root>

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -179,7 +179,7 @@ const TableCaption = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <caption
     ref={ref}
-    className={cn("text-body-medium mt-4 text-sm", className)}
+    className={cn("mt-4 text-sm text-body-medium", className)}
     {...props}
   />
 ))

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -12,7 +12,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "bg-background flex w-full max-w-fit gap-1 overflow-x-auto rounded-2xl !p-0.5 shadow md:border md:shadow-lg lg:w-auto",
+      "flex w-full max-w-fit gap-1 overflow-x-auto rounded-2xl bg-background !p-0.5 shadow md:border md:shadow-lg lg:w-auto",
       className
     )}
     {...props}
@@ -31,7 +31,7 @@ const TabsTrigger = React.forwardRef<
       "rounded-[14px] px-4 py-2 text-sm text-nowrap [&_svg]:shrink-0 [&_svg]:text-sm",
       "before:absolute before:inset-0 before:-z-10 before:rounded-[14px]",
       "data-[state=active]:!text-primary data-[state=active]:before:bg-primary-low-contrast",
-      "ring-offset-background focus-visible:outline-primary-hover focus-visible:outline focus-visible:outline-4 focus-visible:-outline-offset-2 disabled:pointer-events-none disabled:opacity-50",
+      "ring-offset-background focus-visible:outline focus-visible:outline-4 focus-visible:-outline-offset-2 focus-visible:outline-primary-hover disabled:pointer-events-none disabled:opacity-50",
       className
     )}
     {...props}
@@ -46,7 +46,7 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      "ring-offset-background focus-visible:outline-primary-hover mt-4 rounded-lg border p-6 focus-visible:outline focus-visible:outline-4 focus-visible:-outline-offset-1",
+      "mt-4 rounded-lg border p-6 ring-offset-background focus-visible:outline focus-visible:outline-4 focus-visible:-outline-offset-1 focus-visible:outline-primary-hover",
       className
     )}
     {...props}

--- a/src/components/ui/terminal-typewriter.tsx
+++ b/src/components/ui/terminal-typewriter.tsx
@@ -57,7 +57,7 @@ export function TerminalTypewriter({
     <div className={cn("w-full max-w-2xl", className)}>
       <div
         dir="ltr"
-        className="dark bg-background-highlight rounded-lg border px-5 py-4"
+        className="dark rounded-lg border bg-background-highlight px-5 py-4"
       >
         <div className="mb-3 flex items-center gap-1.5">
           <span className="size-3 rounded-full bg-red-500/90" />

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -17,7 +17,7 @@ const TooltipContent = React.forwardRef<
     ref={ref}
     sideOffset={sideOffset}
     className={cn(
-      "z-popover border-background-highlight bg-background-highlight text-body animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 overflow-hidden rounded-md border p-4 text-sm shadow-md",
+      "z-popover animate-in overflow-hidden rounded-md border border-background-highlight bg-background-highlight p-4 text-sm text-body shadow-md fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
       className
     )}
     {...props}

--- a/src/layouts/Docs.tsx
+++ b/src/layouts/Docs.tsx
@@ -49,7 +49,7 @@ const H2 = (props: HTMLAttributes<HTMLHeadingElement>) => (
   <MdHeading2
     className={cn(
       baseHeadingClasses,
-      "max-md:leading-4xs mt-12 border-b border-[#e5e5e5] pb-2 text-2xl dark:border-[#333]"
+      "mt-12 border-b border-[#e5e5e5] pb-2 text-2xl max-md:leading-4xs dark:border-[#333]"
     )}
     {...props}
   />
@@ -130,7 +130,7 @@ export const DocsLayout = ({
         </BannerNotification>
       )}
       <div
-        className="bg-background-highlight flex justify-between lg:pe-8"
+        className="flex justify-between bg-background-highlight lg:pe-8"
         dir={contentNotTranslated ? "ltr" : "unset"}
       >
         <SideNav path={addSlashes(slug)} />

--- a/src/layouts/Tutorial.tsx
+++ b/src/layouts/Tutorial.tsx
@@ -38,14 +38,14 @@ const Heading2 = (props: HTMLAttributes<HTMLHeadingElement>) => (
 
 const Heading3 = (props: HTMLAttributes<HTMLHeadingElement>) => (
   <MdHeading3
-    className="max-md:text-md scroll-mt-40 font-semibold"
+    className="scroll-mt-40 font-semibold max-md:text-md"
     {...props}
   />
 )
 
 const Heading4 = (props: HTMLAttributes<HTMLHeadingElement>) => (
   <MdHeading4
-    className="max-md:text-md scroll-mt-40 font-semibold"
+    className="scroll-mt-40 font-semibold max-md:text-md"
     {...props}
   />
 )
@@ -56,7 +56,7 @@ const Paragraph = (props: HTMLAttributes<HTMLParagraphElement>) => (
 
 const KBD = (props: HTMLAttributes<HTMLElement>) => (
   <kbd
-    className="border-primary rounded-xs border-2 px-2 py-0.5 align-middle"
+    className="rounded-xs border-2 border-primary px-2 py-0.5 align-middle"
     {...props}
   />
 )

--- a/src/layouts/md/Staking.tsx
+++ b/src/layouts/md/Staking.tsx
@@ -32,11 +32,11 @@ const Heading1 = (props: HTMLAttributes<HTMLHeadingElement>) => (
 )
 
 const Heading4 = (props: HTMLAttributes<HTMLHeadingElement>) => (
-  <MdHeading4 className="max-md:text-md font-semibold" {...props} />
+  <MdHeading4 className="font-semibold max-md:text-md" {...props} />
 )
 
 export const InfoGrid = (props: ChildOnlyProp) => (
-  <div className="grid-cols-fill-3 grid gap-8" {...props} />
+  <div className="grid grid-cols-fill-3 gap-8" {...props} />
 )
 
 const CardGrid = (props: ChildOnlyProp) => (

--- a/src/layouts/md/Translatathon.tsx
+++ b/src/layouts/md/Translatathon.tsx
@@ -58,13 +58,13 @@ const HowDoesItWorkColumn = (props: ChildOnlyProp) => (
 )
 
 const CardContent = (props: ChildOnlyProp) => (
-  <Flex className="border-body-light my-auto w-full flex-1 flex-col rounded border px-8 pb-8 lg:m-0">
+  <Flex className="my-auto w-full flex-1 flex-col rounded border border-body-light px-8 pb-8 lg:m-0">
     {props.children}
   </Flex>
 )
 
 const CardContainer = (props: ChildOnlyProp) => (
-  <div className="grid-cols-fill-4 mt-8 mb-20 grid gap-8 lg:mt-0">
+  <div className="mt-8 mb-20 grid grid-cols-fill-4 gap-8 lg:mt-0">
     {props.children}
   </div>
 )

--- a/src/layouts/md/UseCases.tsx
+++ b/src/layouts/md/UseCases.tsx
@@ -22,7 +22,7 @@ import { ContentLayout } from "../ContentLayout"
 import { useTranslation } from "@/hooks/useTranslation"
 
 const CardGrid = (props: ChildOnlyProp) => (
-  <div className="grid-cols-fill-4 grid gap-8" {...props} />
+  <div className="grid grid-cols-fill-4 gap-8" {...props} />
 )
 
 // UseCases layout components

--- a/src/layouts/stories/ContentLayout.stories.tsx
+++ b/src/layouts/stories/ContentLayout.stories.tsx
@@ -31,7 +31,7 @@ export default meta
 export const ContentLayout: StoryObj<typeof meta> = {
   args: {
     children: (
-      <Center className="border-primary h-[497px] border-2 border-dashed">
+      <Center className="h-[497px] border-2 border-dashed border-primary">
         Content Here
       </Center>
     ),
@@ -77,7 +77,7 @@ export const ContentLayout: StoryObj<typeof meta> = {
     ],
     lastEditLocaleTimestamp: "MM DD, YY",
     heroSection: (
-      <Center className="border-primary h-[400px] border-2 border-dashed">
+      <Center className="h-[400px] border-2 border-dashed border-primary">
         Hero section
       </Center>
     ),


### PR DESCRIPTION
## Summary

Follow-up to #18038. The reformat in that PR was run on a branch based on `dev` *before* #18029 merged, so `.prettierrc` didn't yet have `tailwindStylesheet: ./src/styles/global.css`.

Without that option, `prettier-plugin-tailwindcss` couldn't see the project's Tailwind v4 `@utility` definitions in `src/styles/utilities.css` (`bg-card-gradient-secondary`, `bg-background`, `text-body-medium`, `border-accent-*`, etc.) and sorted them as unknown classes — at the head of the className string instead of in their proper category position.

This PR re-runs `pnpm format` against current `dev` so the custom utilities are sorted correctly and `pnpm format` is a no-op going forward.

### Why this happened (timeline on `dev`)

- `bc3cd6cfb6` — #18029 merged (added `tailwindStylesheet` to `.prettierrc`)
- `850dd24230` — #18038 commit run on a branch whose merge-base with `bc3cd6cfb6` is `b5dd2b4fd3` (the older `.prettierrc` without `tailwindStylesheet`)
- The format PR was never rebased to pick up the new config before the formatter ran.

### Scope

- 282 `.tsx` files
- Pure className reordering — no semantic changes
- Sample diff:
  ```diff
  - "bg-card-gradient-secondary flex w-full ... rounded-2xl p-4 ..."
  + "flex w-full ... rounded-2xl bg-card-gradient-secondary p-4 ..."
  ```

## Test plan

- [ ] CI green (lint, typecheck, build)
- [ ] Spot-check a handful of pages locally — visuals unchanged
- [ ] Confirm `pnpm format` is a no-op after merging