### PR TITLE
feat(intl-pipeline): partial-success runs ship; failures surface in PR

### DIFF
--- a/src/scripts/intl-pipeline/lib/workflows/pr-creation.ts
+++ b/src/scripts/intl-pipeline/lib/workflows/pr-creation.ts
@@ -43,6 +43,12 @@ function generateInitialPRBody(): string {
   ].join("\n")
 }
 
+export interface RunFailure {
+  locale: string
+  file: string
+  message: string
+}
+
 /**
  * Generate a run summary to append to the PR body
  */
@@ -50,7 +56,8 @@ export function generateRunSummary(
   langCodes: string[],
   committedFiles: CommittedFile[],
   mode: string,
-  workflowRunUrl?: string
+  workflowRunUrl?: string,
+  failures: RunFailure[] = []
 ): string {
   const now = new Date().toISOString().replace("T", " ").slice(0, 19) + " UTC"
 
@@ -69,6 +76,20 @@ export function generateRunSummary(
 
   if (workflowRunUrl) {
     parts.push(`- [View workflow run](${workflowRunUrl})`)
+  }
+
+  if (failures.length > 0) {
+    parts.push("", `**${failures.length} task(s) failed:**`, "")
+    for (const f of failures) {
+      parts.push(`- \`${f.file}\` (${f.locale}): ${f.message}`)
+    }
+    parts.push("", "Rerun the failed combinations:", "", "```")
+    for (const f of failures) {
+      parts.push(
+        `gh workflow run "Intl Pipeline" -f target_path="${f.file}" -f target_languages="${f.locale}"`
+      )
+    }
+    parts.push("```")
   }
 
   parts.push("")
@@ -99,7 +120,8 @@ export async function createOrUpdateTranslationPR(
   branch: string,
   committedFiles: CommittedFile[],
   languagePairs: LanguagePair[],
-  mode: string
+  mode: string,
+  failures: RunFailure[] = []
 ): Promise<{ number: number; html_url: string }> {
   logSection("Pull Request")
 
@@ -109,7 +131,8 @@ export async function createOrUpdateTranslationPR(
     langCodes,
     committedFiles,
     mode,
-    workflowRunUrl
+    workflowRunUrl,
+    failures
   )
 
   // Check for existing open PR

--- a/src/scripts/intl-pipeline/main.ts
+++ b/src/scripts/intl-pipeline/main.ts
@@ -706,6 +706,11 @@ async function main() {
 
   const committedFiles: Array<{ path: string; content: string }> = []
   let hasCommits = false
+  // Per-task failures captured with file context. Populated by submitWithContext
+  // wrapper so we can report rich failure info in the PR body and surface
+  // copy-pasteable rerun commands. Pool's own error tracking still runs in
+  // parallel for the orchestration-level "did anything fail" check.
+  const failures: Array<{ locale: string; file: string; message: string }> = []
 
   // Resolve target paths in five passes:
   //   1. Normalize  (log-level: auto-prefix and strip accidental locale paths)
@@ -783,6 +788,24 @@ async function main() {
     },
   })
 
+  // Wraps pool.submit to attach file context to any thrown error -- the pool
+  // only knows the locale; we want (locale, file, reason) for PR reporting.
+  const submitWithContext = (
+    locale: string,
+    filePath: string,
+    fn: () => Promise<TaskResult | void>
+  ) => {
+    pool.submit(locale, async () => {
+      try {
+        return await fn()
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        failures.push({ locale, file: filePath, message })
+        throw err
+      }
+    })
+  }
+
   // Submit all file x language tasks to the pool
   for (const file of englishFiles) {
     for (const locale of targetLanguages) {
@@ -815,7 +838,7 @@ async function main() {
           continue
         }
 
-        pool.submit(locale, () =>
+        submitWithContext(locale, file.path, () =>
           runFullTranslation(
             file,
             locale,
@@ -839,7 +862,7 @@ async function main() {
 
       if (config.stampOnly) {
         log(`[${locale}] ${file.path}: stamp only`)
-        pool.submit(locale, async () => {
+        submitWithContext(locale, file.path, async () => {
           const sourceManifest =
             file.type === "markdown"
               ? buildMarkdownManifest(file.content, file.path, baseBranchSha)
@@ -854,7 +877,7 @@ async function main() {
         continue
       }
 
-      pool.submit(locale, () =>
+      submitWithContext(locale, file.path, () =>
         runIncremental(
           file,
           locale,
@@ -872,15 +895,24 @@ async function main() {
   // Wait for all tasks to complete
   await pool.drain()
 
-  // Check for task failures
-  if (pool.hasErrors()) {
-    const errors = pool.getErrors()
-    console.error(`[pipeline] ${errors.length} task(s) failed:`)
-    for (const { language, error } of errors) {
-      console.error(`  [${language}] ${error.message}`)
+  // Log task failures but don't abort -- partial successes ship. Failures are
+  // recorded with file context (via submitWithContext) and surfaced in the PR
+  // body with rerun commands. Per-file manifests are only stamped on success,
+  // so a rerun of just the failed combinations naturally retries them without
+  // touching the work that landed this run.
+  if (failures.length > 0) {
+    log(`${failures.length} task(s) failed (continuing with successes):`, "warn")
+    for (const f of failures) {
+      log(`  [${f.locale}] ${f.file}: ${f.message}`, "warn")
     }
+  }
+
+  // Hard abort only if literally nothing succeeded -- a fully-failed run
+  // shouldn't produce an empty PR. (committedFiles excludes manifest-only stamp
+  // commits, so we also check hasCommits for the stamp-only path.)
+  if (failures.length > 0 && committedFiles.length === 0 && !hasCommits) {
     throw new Error(
-      `Pipeline aborted: ${errors.length} translation task(s) failed. Temp branch ${tempBranch} preserved with partial progress.`
+      `Pipeline aborted: all ${failures.length} translation task(s) failed. Temp branch ${tempBranch} preserved.`
     )
   }
 
@@ -942,7 +974,8 @@ async function main() {
         targetBranch,
         committedFiles,
         languagePairs,
-        config.mode
+        config.mode,
+        failures
       )
     } catch (error) {
       console.warn(


### PR DESCRIPTION
## Summary

A single failed (file, locale) combination no longer aborts the whole run. The pipeline now ships partial-success runs and reports failures in the PR body with copy-pasteable rerun commands.

## Why

Real example: a 12-language run translating `public/content/videos/` (58 files × 12 = 696 tasks) hit Gemini's `RECITATION` filter on one combination. The whole run aborted, stranding 695 successful translations on the temp branch. Manual recovery was needed to squash and merge per-language. With ~24 locales and growing content, single-task failures will only get more common.

## Changes

- `main.ts`: `submitWithContext()` wraps `pool.submit()` to capture file context on failure. The `pool.hasErrors() -> throw` block becomes log-and-continue. Hard abort retained only for the all-failed case (no empty PR).
- `pr-creation.ts`: `generateRunSummary` and `createOrUpdateTranslationPR` accept an optional `failures[]` array and render a "**N task(s) failed:**" section with each `(file, locale, message)` plus rerun commands.

Per-file manifest stamping is unchanged: failed files don't stamp, so a rerun naturally retries only the failed combinations.

## Test plan

- [ ] Run with all tasks succeeding -> behaves identically to before, no failures section in PR body.
- [ ] Run with at least one task failing (e.g., dispatch with a known RECITATION-tripping file) -> PR body includes failures block + rerun commands; successful translations land normally.
- [ ] Run with all tasks failing -> hard abort, no empty PR created.
- [ ] Rerun via the suggested command -> retries only the failed combinations.

_Generated by Claude (Opus 4.7)_