### PR TITLE
docs(data-layer): add fetcher isolation rule

### DIFF
--- a/.claude/skills/data-layer/SKILL.md
+++ b/.claude/skills/data-layer/SKILL.md
@@ -164,7 +164,7 @@ Always handle `null` returns (upload failures) with fallback/empty string.
 
 Fetchers run on Trigger.dev — a separate runtime, deployment, and bundle from the Next.js app. They cannot assume the app's filesystem, environment, or modules are available.
 
-Any import or runtime dependency reaching outside `src/data-layer/` is a warning sign. Allowed: types (`@/lib/types`, `@/lib/interfaces`), pure constants (`@/lib/constants`), and pure utility functions with no app-runtime dependencies. Not allowed: anything that reads `process.cwd()`, anything from `app/`, anything from `src/components/`, or `src/lib/data/` (which wraps the data layer and would create a cycle).
+Any import or runtime dependency reaching outside `src/data-layer/` is a warning sign. Allowed: types (`@/lib/types`, `@/lib/interfaces`), pure constants (`@/lib/constants`), and pure utility functions with no app-runtime dependencies. Not allowed: anything that reads `process.cwd()`, anything from `app/` or `public/`, anything from `src/components/`, or `src/lib/data/` (which wraps the data layer and would create a cycle).
 
 If a fetcher needs data that lives in the app — content files, frontmatter, etc. — fetch it over the network via the GitHub API and treat the repo as an external system. See `fetchGitHubContributors.ts` for the pattern. Don't work around this with `additionalFiles` in `trigger.config.ts`; bundling app files into the data-layer deployment re-creates the coupling.
 

--- a/.claude/skills/data-layer/SKILL.md
+++ b/.claude/skills/data-layer/SKILL.md
@@ -160,6 +160,14 @@ return { ...event, logoImage: logoUrl ?? "" }
 
 Always handle `null` returns (upload failures) with fallback/empty string.
 
+### 5. Keep fetchers isolated from the app
+
+Fetchers run on Trigger.dev — a separate runtime, deployment, and bundle from the Next.js app. They cannot assume the app's filesystem, environment, or modules are available.
+
+Any import or runtime dependency reaching outside `src/data-layer/` is a warning sign. Allowed: types (`@/lib/types`, `@/lib/interfaces`), pure constants (`@/lib/constants`), and pure utility functions with no app-runtime dependencies. Not allowed: anything that reads `process.cwd()`, anything from `app/`, anything from `src/components/`, or `src/lib/data/` (which wraps the data layer and would create a cycle).
+
+If a fetcher needs data that lives in the app — content files, frontmatter, etc. — fetch it over the network via the GitHub API and treat the repo as an external system. See `fetchGitHubContributors.ts` for the pattern. Don't work around this with `additionalFiles` in `trigger.config.ts`; bundling app files into the data-layer deployment re-creates the coupling.
+
 ## Adding a New Data Source
 
 1. **Create fetcher** in `src/data-layer/fetchers/fetchNewData.ts`:

--- a/src/data-layer/docs.md
+++ b/src/data-layer/docs.md
@@ -51,6 +51,10 @@ export const getEventsData = createCachedGetter(
 
 Direct `@/data-layer` imports work but have no caching.
 
+### 4. Keep fetchers isolated from the app
+
+Fetchers run on Trigger.dev — a separate runtime from the Next.js app — and cannot assume the app's filesystem or modules are available. Any import or runtime dependency reaching outside `src/data-layer/` is a warning sign; if a fetcher needs app data, fetch it via the GitHub API and treat the repo as an external system. See `fetchGitHubContributors.ts` for the pattern, and the data-layer skill (Rule 5) for the full allow/deny list.
+
 ## Adding a New Data Source
 
 1. **Create fetcher** in `src/data-layer/fetchers/fetchNewData.ts`


### PR DESCRIPTION
Adds a new rule to the `data-layer` skill (Rule 5) and a short pointer in `src/data-layer/docs.md` (Rule 4):

- Fetchers must stay isolated from the Next.js app — no `process.cwd()` reads, no imports from `app/`, `src/components/`, or `src/lib/data/`.
- Allowed: types, pure constants, pure utility functions.
- If a fetcher needs app data, fetch it via the GitHub API. Don't bundle app files via `additionalFiles` in `trigger.config.ts`.
- Points at `fetchGitHubContributors.ts` as the canonical pattern.