### PR TITLE
fix: remove excessive min-height gap in staking product cards

### DIFF
--- a/src/components/Staking/StakingProductsCardGrid/StakingProductCard.tsx
+++ b/src/components/Staking/StakingProductsCardGrid/StakingProductCard.tsx
@@ -178,7 +178,7 @@ export const StakingProductCard = ({
           )}
         </div>
       </div>
-      <div className="flex min-h-75 flex-wrap items-start gap-1 p-6 pt-0">
+      <div className="flex flex-wrap items-start gap-1 p-6 pt-0">
         {platforms.map((platform, idx) => (
           <StakingBadge type="platform" key={idx}>
             {platform}


### PR DESCRIPTION
## Summary

- The Chakra → Tailwind migration translated `minHeight={75}` directly to `min-h-75`, which resolves to ~300px (75 × 0.25rem) and reserved a large empty gap below the platform/UI badges in every staking product card
- Grid layout already equalizes card heights across rows and `mt-auto` keeps the footer aligned, so no min-height is needed on the badges container
- Affects all four staking product grids: `/staking/solo/`, `/staking/saas/`, `/staking/pools/`, and the keyGen grid

## Test plan

- [x] Visit `/staking/solo/` — cards no longer show a large empty gap between the platform/UI badges and the considerations list
- [x] Visit `/staking/saas/` and `/staking/pools/` — cards still align properly across rows
- [ ] Spot-check a card with the most badges (Launchnodes, stakefish — 6 badges) — badges still wrap and lay out correctly