### PR TITLE
fix(seo): use CollectionPage for /layer-2/networks JSON-LD

### DIFF
--- a/app/[locale]/layer-2/networks/page-jsonld.tsx
+++ b/app/[locale]/layer-2/networks/page-jsonld.tsx
@@ -27,7 +27,7 @@ export default async function Layer2NetworksPageJsonLD({
     "@graph": [
       ...BASE_GRAPH_NODES,
       {
-        "@type": "WebPage",
+        "@type": "CollectionPage",
         "@id": url,
         name: t("page-layer-2-networks-meta-title"),
         description: t("page-layer-2-networks-hero-description"),


### PR DESCRIPTION
## Summary

Updates `/layer-2/networks/page-jsonld.tsx` to use `CollectionPage` as the `@type` for the first `@graph` node, aligning with the pattern established in #17721 for `/wallets/find-wallet`.

`CollectionPage` is semantically more accurate than the generic `WebPage` for a list/comparison page.

## Change

```diff
-        "@type": "WebPage",
+        "@type": "CollectionPage",
```

One line, in `app/[locale]/layer-2/networks/page-jsonld.tsx` (line 30 — the `@graph[1]` node, after `BASE_GRAPH_NODES`). The `WebPage` references inside the breadcrumb/itemListElement nodes are intentionally untouched.

Closes #17724.

## Validation preview
https://validator.schema.org/#url=https%3A%2F%2Fdeploy-preview-18102.ethereum.it%2Flayer-2%2Fnetworks