### PR TITLE
content(grants): add Etherscan Grant Directory to comprehensive directories

### DIFF
--- a/public/content/community/grants/index.md
+++ b/public/content/community/grants/index.md
@@ -32,7 +32,7 @@ These resources compile and organize various grant opportunities across the Ethe
 These general platforms offer broad coverage of grants across the entire Web3 space and are useful starting points for anyone looking for funding:
 
 - [Karma Funding Map](https://gap.karmahq.xyz/funding-map) - Directory of all the web3 grant programs, updated on weekly basis
-- [Etherscan Grant Directory](https://etherscan.io/directory/Others/Grant) - _Curated list of grants on the Ethereum block explorer_
+- [Etherscan Grant Directory](https://etherscan.io/directory/Others/Grant) - Curated list of grants on the Ethereum block explorer
 
 ### For developers and builders {#for-developers-and-builders}
 

--- a/public/content/community/grants/index.md
+++ b/public/content/community/grants/index.md
@@ -32,6 +32,7 @@ These resources compile and organize various grant opportunities across the Ethe
 These general platforms offer broad coverage of grants across the entire Web3 space and are useful starting points for anyone looking for funding:
 
 - [Karma Funding Map](https://gap.karmahq.xyz/funding-map) - Directory of all the web3 grant programs, updated on weekly basis
+- [Etherscan Grant Directory](https://etherscan.io/directory/Others/Grant) - _Curated list of grants on the Ethereum block explorer_
 
 ### For developers and builders {#for-developers-and-builders}
 


### PR DESCRIPTION
## Summary

Adds [Etherscan Grant Directory](https://etherscan.io/directory/Others/Grant) to the "For all grant seekers: Comprehensive directories" section on `/community/grants/`.

PR #17709 removed two broken links from this section, leaving only Karma Funding Map. #17712 evaluated four candidate replacements and recommended Etherscan as the safest immediate addition because it's a trusted, maintained Ethereum-ecosystem resource (rather than a third-party blog post or a directory with SSL issues).

## Change

```diff
 - [Karma Funding Map](https://gap.karmahq.xyz/funding-map) - Directory of all the web3 grant programs, updated on weekly basis
+- [Etherscan Grant Directory](https://etherscan.io/directory/Others/Grant) - _Curated list of grants on the Ethereum block explorer_
```

One line added in `public/content/community/grants/index.md`.

## Verification

- URL `https://etherscan.io/directory/Others/Grant` confirmed live (HTTP 200) at the time this PR was opened.

## Out of scope (intentional)

The other candidates evaluated in #17712 were not added:

- **RockNBlock** — a blog post, not a living directory; flagged as likely to go stale.
- **FindBlockchainGrants.com** — flagged for an expired SSL cert as of March 2026; should be re-checked before listing.
- **blockchaingrants.org** — was the one removed in #17709 due to SSL cert mismatch; can be re-added separately if SSL is fixed.

Refs #17712.
