### PR TITLE
fix(contributors): defer .all-contributorsrc read to fix Storybook bundle

### DIFF
--- a/src/components/Contributors/index.tsx
+++ b/src/components/Contributors/index.tsx
@@ -17,22 +17,35 @@ type AllContributorsRc = {
   contributors: (Contributor & { contributions?: string[] })[]
 }
 
-// Read `.all-contributorsrc` (bot-maintained) once at module load.
-const raw = readFileSync(join(process.cwd(), ".all-contributorsrc"), "utf-8")
-const { contributors: rawContributors } = JSON.parse(raw) as AllContributorsRc
+let shuffledContributors: Contributor[] | undefined
 
-// Trim to the fields the card actually renders and shuffle once per SSG worker.
-const shuffledContributors: Contributor[] = shuffle(
-  rawContributors.map(({ login, name, avatar_url, profile }) => ({
-    login,
-    name,
-    avatar_url,
-    profile,
-  }))
-)
+// Read `.all-contributorsrc` (bot-maintained) on first render and cache.
+// Deferred (not module-load) so non-Next bundlers like Storybook can import
+// this module without evaluating Node's `fs`.
+const getShuffledContributors = (): Contributor[] => {
+  if (!shuffledContributors) {
+    const raw = readFileSync(
+      join(process.cwd(), ".all-contributorsrc"),
+      "utf-8"
+    )
+    const { contributors: rawContributors } = JSON.parse(
+      raw
+    ) as AllContributorsRc
+
+    shuffledContributors = shuffle(
+      rawContributors.map(({ login, name, avatar_url, profile }) => ({
+        login,
+        name,
+        avatar_url,
+        profile,
+      }))
+    )
+  }
+  return shuffledContributors
+}
 
 const Contributors = ({ contributors }: ContributorsProps = {}) => (
-  <ContributorsView contributors={contributors ?? shuffledContributors} />
+  <ContributorsView contributors={contributors ?? getShuffledContributors()} />
 )
 
 export default Contributors


### PR DESCRIPTION
## Summary

Fixes the Chromatic failure on the v11.6.0 release PR (#18104):

```
Error: page.evaluate: TypeError: (0 , fs_ignored_.readFileSync) is not a function
    at ./src/components/MdComponents/index.tsx
    at ./src/components/MdComponents/MdComponents.stories.tsx
```

### Root cause

`src/components/Contributors/index.tsx` (added in #18073) called `readFileSync(".all-contributorsrc")` at **module top level**. `MdComponents/index.tsx` barrels in `Contributors`, and the `MdComponents.stories.tsx` story imports that barrel — so Storybook's webpack pulls `Contributors` into the browser bundle.

Storybook stubs `fs` (`fs_ignored_`), so evaluating the module hit the stub and crashed. The `import "server-only"` directive only enforces against the Next.js client bundler, not Storybook.

### Fix

Wrap the read in a memoized getter (`getShuffledContributors()`). Importing the module is now side-effect free; the read still happens once per SSG worker, on first render of `<Contributors />`.

## Test plan

- [x] Local `pnpm build-storybook` succeeds
- [x] Built bundle no longer evaluates `readFileSync` at top level (call is now inside the function: `()=>{if(!shuffledContributors){const raw=(0,fs_ignored_.readFileSync)(...)`)
- [x] `npx tsc --noEmit` passes
- [x] Chromatic check on this PR goes green
- [ ] After merge into `staging`, Chromatic on the release PR (#18104) goes green