### PR TITLE
ci(data-layer): pass TRIGGER_PROJECT_REF to trigger deploy

### DIFF
--- a/.github/workflows/deploy-data-layer.yml
+++ b/.github/workflows/deploy-data-layer.yml
@@ -33,3 +33,4 @@ jobs:
         run: pnpm exec trigger deploy
         env:
           TRIGGER_ACCESS_TOKEN: ${{ secrets.TRIGGER_ACCESS_TOKEN }}
+          TRIGGER_PROJECT_REF: ${{ secrets.TRIGGER_PROJECT_REF }}


### PR DESCRIPTION
## Summary

The `Deploy Data Layer` job has failed on every run since it was added (Apr 13, Apr 17, Apr 24 — including the most recent weekly release in #18104) with:

```
✘ [ERROR] Project not found: undefined. Ensure you are using the correct project ref and CLI profile
```

`trigger.config.ts:9` reads the project ref from `process.env.TRIGGER_PROJECT_REF`, but the workflow only forwarded `TRIGGER_ACCESS_TOKEN`. The CLI saw `undefined` and bailed.

This wires `TRIGGER_PROJECT_REF` (already configured as a GitHub Actions secret) into the deploy step's env, mirroring how `TRIGGER_ACCESS_TOKEN` is passed.

## Test plan

- [x] Confirm `TRIGGER_PROJECT_REF` secret is set at the repo / org level so it's available to this workflow.
- [ ] After merge to `master`, watch the next push that touches `src/data-layer/**`, `trigger.config.ts`, or `package.json` and verify the `Deploy Data Layer` job goes green.