### PR TITLE
fix(e2e): align tests with SSR wallet list and renamed nav subsection

### DIFF
--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -40,7 +40,7 @@ test.describe("Home Page", () => {
     await homePage.verifyMobileNavigation()
     await homePage.navigateFromMobileMenu(
       "learn",
-      "basics",
+      "ethereum explained",
       "what is ethereum",
       /.*\/what-is-ethereum/
     )

--- a/tests/e2e/pages/FindWalletPage.ts
+++ b/tests/e2e/pages/FindWalletPage.ts
@@ -30,9 +30,11 @@ export class FindWalletPage extends BasePage {
     this.mobileFiltersSubmitButton = page.getByTestId(
       "mobile-filters-submit-button"
     )
+    // SSR renders all wallets and hides filtered-out rows via `.hidden`.
+    // Exclude them so assertions only run against visible rows.
     this.walletRows = page
       .getByTestId("wallet-list")
-      .locator(":scope > details")
+      .locator(":scope > details:not(.hidden)")
     this.rowCounter = page.getByText(/Showing all wallets \(\d+\)/i)
   }
 


### PR DESCRIPTION
## Summary

Two unrelated regressions in the v11.6.0 release broke `Tests / e2e-tests` ([failed run](https://github.com/ethereum/ethereum-org-website/actions/runs/25213164599/job/73927822875)). Both are test-side fixes; no product behavior changes.

- **`FindWalletPage.walletRows`** — #18067 changed the find-wallet list from a virtualizer to render-all-and-hide for SSR. Filtered-out wallets are still in the DOM with `class="hidden"`, so `verifyFilteredResults` was iterating over hidden rows that legitimately don't contain the chosen OS keyword. Narrowed the locator to `:scope > details:not(.hidden)`.
- **`home.spec.ts` mobile nav** — #18058 renamed the `learn/basics` subsection to `learn/ethereum-explained` (label `"Ethereum explained"`). The literal `"basics"` no longer matches any button in the mobile sidebar. Updated to `"ethereum explained"`.

## Test plan

- [x] `find-wallet sidebar filters - desktop` (e2e) passes locally
- [x] `find-wallet sidebar filters - mobile` (e2e-mobile-chrome) passes locally
- [x] `home navigation menu - mobile` (e2e-mobile-chrome) passes locally
- [x] `Tests / e2e-tests` workflow goes green on this PR