### PR TITLE
seo: patch layer-2 description and find-wallet heading levels

### DIFF
--- a/app/[locale]/wallets/find-wallet/page.tsx
+++ b/app/[locale]/wallets/find-wallet/page.tsx
@@ -13,6 +13,7 @@ import I18nProvider from "@/components/I18nProvider"
 import ListingMethodology from "@/components/ListingMethodology"
 import MainArticle from "@/components/MainArticle"
 import { UnorderedList } from "@/components/ui/list"
+import { Section } from "@/components/ui/section"
 
 import { getAppPageContributorInfo } from "@/lib/utils/contributors"
 import { formatDate } from "@/lib/utils/date"
@@ -88,7 +89,12 @@ const Page = async (props: { params: Promise<PageParams> }) => {
             </p>
           </div>
 
-          <FindWalletProductTable wallets={wallets} />
+          <Section id="wallets">
+            <h2 className="sr-only select-none">
+              {t("page-find-wallet-table-title")}
+            </h2>
+            <FindWalletProductTable wallets={wallets} />
+          </Section>
 
           <ListingMethodology
             heading={t("page-find-wallet-methodology-title")}

--- a/src/intl/en/page-layer-2.json
+++ b/src/intl/en/page-layer-2.json
@@ -11,7 +11,7 @@
   "page-layer-2-calloutCard-3-title": "Backed by Ethereum",
   "page-layer-2-calloutCard-3-description": "Ethereum's time-proven and decentralized blockchain functions as the settlement layer for other newer networks.",
   "page-layer-2-meta-title": "Intro to Ethereum Layer 2: benefits and uses",
-  "page-layer-2-meta-description": "Learn about Ethereum layer 2 networks",
+  "page-layer-2-meta-description": "Learn about Ethereum layer 2 networks: what they are, how they help improve the Ethereum experience, and where to get started exploring",
   "page-layer-2-powered-by-ethereum-title": "Powered by Ethereum",
   "page-layer-2-powered-by-ethereum-description-1": "<a href=\"/\">Ethereum</a> is no longer just a single network.",
   "page-layer-2-powered-by-ethereum-description-2": "With hundreds of blockchains now built on top of it, Ethereum has become more cost-effective, faster, and accessible for everyday use.",

--- a/src/intl/en/page-wallets-find-wallet.json
+++ b/src/intl/en/page-wallets-find-wallet.json
@@ -7,6 +7,7 @@
   "page-find-wallet-meta-description": "Compare Ethereum wallets side by side. Filter by features like hardware wallet support, open source, self-custody, multi-chain, staking, NFT support, and more to find the right wallet for you.",
   "page-find-wallet-meta-title": "Find and compare Ethereum wallets | ethereum.org",
   "page-find-wallet-title": "Choose your wallet",
+  "page-find-wallet-table-title": "Browse all wallets",
   "page-find-wallet-try-removing": "Try removing a feature or two",
   "page-stake-eth": "Stake ETH",
   "page-find-wallet-open-source": "Open source",


### PR DESCRIPTION
## Description
- Updates `og:description` metadata for `/layer-2/` page to range between 120-160 characters (135) per guidelines
- Adds `h2.sr-only.select-none` element above table and persona filters on `/wallets/find-wallet/` page

## Related Issue
Ongoing SEO auditing/improvements

cc: @mnelsonBT 