### PR TITLE
feat(storybook): add overlay primitive stories

### DIFF
--- a/src/components/ui/__stories__/Command.stories.tsx
+++ b/src/components/ui/__stories__/Command.stories.tsx
@@ -1,0 +1,252 @@
+import { Calendar, Settings, Smile, User, Wallet } from "lucide-react"
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import { Button } from "../buttons/Button"
+import {
+  Command,
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+  CommandShortcut,
+} from "../command"
+
+const meta = {
+  title: "UI / Primitives / Command",
+  component: Command,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Command palette built on `cmdk`. Compose `Command` > `CommandInput` + `CommandList` containing `CommandGroup`s of `CommandItem`s. `CommandSeparator` divides groups, `CommandShortcut` annotates an item with a keyboard hint, `CommandEmpty` renders when filtering yields no matches. Wrap in `CommandDialog` for a modal palette (Cmd-K style).",
+      },
+    },
+  },
+} satisfies Meta<typeof Command>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: () => (
+    <Command className="max-w-md rounded-lg border">
+      <CommandInput placeholder="Type a command or search..." />
+      <CommandList>
+        <CommandEmpty>No results found.</CommandEmpty>
+        <CommandGroup>
+          <CommandItem>Calendar</CommandItem>
+          <CommandItem>Settings</CommandItem>
+          <CommandItem>Profile</CommandItem>
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  ),
+}
+
+export const WithGroups: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Multiple `CommandGroup`s with headings let users scan by category.",
+      },
+    },
+  },
+  render: () => (
+    <Command className="max-w-md rounded-lg border">
+      <CommandInput placeholder="Search..." />
+      <CommandList>
+        <CommandEmpty>No results found.</CommandEmpty>
+        <CommandGroup heading="Suggestions">
+          <CommandItem>
+            <Calendar />
+            Calendar
+          </CommandItem>
+          <CommandItem>
+            <Smile />
+            Search emoji
+          </CommandItem>
+        </CommandGroup>
+        <CommandGroup heading="Settings">
+          <CommandItem>
+            <User />
+            Profile
+          </CommandItem>
+          <CommandItem>
+            <Settings />
+            Preferences
+          </CommandItem>
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  ),
+}
+
+export const WithSeparators: Story = {
+  render: () => (
+    <Command className="max-w-md rounded-lg border">
+      <CommandInput placeholder="Search..." />
+      <CommandList>
+        <CommandGroup heading="Suggestions">
+          <CommandItem>Calendar</CommandItem>
+          <CommandItem>Search emoji</CommandItem>
+        </CommandGroup>
+        <CommandSeparator />
+        <CommandGroup heading="Settings">
+          <CommandItem>Profile</CommandItem>
+          <CommandItem>Preferences</CommandItem>
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  ),
+}
+
+export const WithShortcuts: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`CommandShortcut` renders a right-aligned hint inside an item. Useful for surfacing keyboard accelerators.",
+      },
+    },
+  },
+  render: () => (
+    <Command className="max-w-md rounded-lg border">
+      <CommandInput placeholder="Search commands..." />
+      <CommandList>
+        <CommandGroup heading="Quick actions">
+          <CommandItem>
+            New file
+            <CommandShortcut>Ctrl+N</CommandShortcut>
+          </CommandItem>
+          <CommandItem>
+            Open
+            <CommandShortcut>Ctrl+O</CommandShortcut>
+          </CommandItem>
+          <CommandItem>
+            Save
+            <CommandShortcut>Ctrl+S</CommandShortcut>
+          </CommandItem>
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  ),
+}
+
+export const WithDisabledItem: Story = {
+  render: () => (
+    <Command className="max-w-md rounded-lg border">
+      <CommandInput placeholder="Search..." />
+      <CommandList>
+        <CommandGroup>
+          <CommandItem>Connect wallet</CommandItem>
+          <CommandItem disabled>Send transaction (no wallet)</CommandItem>
+          <CommandItem>View history</CommandItem>
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  ),
+}
+
+export const Empty: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`CommandEmpty` renders when the active filter excludes every item. Pre-set the input value to show the empty state without typing.",
+      },
+    },
+  },
+  render: () => (
+    <Command className="max-w-md rounded-lg border">
+      <CommandInput placeholder="Search..." defaultValue="zzz no match" />
+      <CommandList>
+        <CommandEmpty>No results found for that query.</CommandEmpty>
+        <CommandGroup>
+          <CommandItem>Calendar</CommandItem>
+          <CommandItem>Settings</CommandItem>
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  ),
+}
+
+export const InputWithKbdShortcut: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`CommandInput` accepts `kbdShortcut` to render a right-aligned hint instead of the search icon.",
+      },
+    },
+  },
+  render: () => (
+    <Command className="max-w-md rounded-lg border">
+      <CommandInput placeholder="Search..." kbdShortcut="Cmd+K" />
+      <CommandList>
+        <CommandGroup>
+          <CommandItem>Calendar</CommandItem>
+          <CommandItem>Settings</CommandItem>
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  ),
+}
+
+export const InputWithCustomIcon: Story = {
+  render: () => (
+    <Command className="max-w-md rounded-lg border">
+      <CommandInput placeholder="Search wallets..." icon={Wallet} />
+      <CommandList>
+        <CommandGroup>
+          <CommandItem>Connect MetaMask</CommandItem>
+          <CommandItem>Connect Rainbow</CommandItem>
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  ),
+}
+
+const DialogDemo = () => (
+  <CommandDialog defaultOpen>
+    <CommandInput placeholder="Type a command or search..." />
+    <CommandList>
+      <CommandEmpty>No results found.</CommandEmpty>
+      <CommandGroup heading="Suggestions">
+        <CommandItem>
+          <Calendar />
+          Calendar
+        </CommandItem>
+        <CommandItem>
+          <Smile />
+          Search emoji
+        </CommandItem>
+        <CommandItem>
+          <User />
+          Profile
+        </CommandItem>
+      </CommandGroup>
+    </CommandList>
+  </CommandDialog>
+)
+
+export const AsDialog: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`CommandDialog` wraps `Command` in `Dialog` + `DialogContent` for a modal palette.",
+      },
+    },
+  },
+  render: () => (
+    <>
+      <Button variant="outline">Open command palette</Button>
+      <DialogDemo />
+    </>
+  ),
+}

--- a/src/components/ui/__stories__/Command.stories.tsx
+++ b/src/components/ui/__stories__/Command.stories.tsx
@@ -18,6 +18,7 @@ const meta = {
   title: "UI / Primitives / Command",
   component: Command,
   parameters: {
+    chromatic: { disableSnapshot: true },
     docs: {
       description: {
         component:

--- a/src/components/ui/__stories__/Dialog.stories.tsx
+++ b/src/components/ui/__stories__/Dialog.stories.tsx
@@ -1,0 +1,131 @@
+import { fn } from "storybook/test"
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import { Button } from "../buttons/Button"
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "../dialog"
+import { Flex } from "../flex"
+
+const meta = {
+  title: "UI / Primitives / Dialog",
+  component: Dialog,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Vanilla shadcn `Dialog`. For most app use, prefer `Modal` (`UI / Modal`), which wraps this primitive with `size`, `variant`, and `actionButton` props. The overlay is always rendered as part of `DialogContent`. Width is constrained to `max-w-lg` by default; override via `className` on `DialogContent`.",
+      },
+    },
+  },
+} satisfies Meta<typeof Dialog>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Dialog {...args}>
+      <DialogTrigger asChild>
+        <Button variant="outline">Open dialog</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Dialog title</DialogTitle>
+          <DialogDescription>
+            A short description of what this dialog does.
+          </DialogDescription>
+        </DialogHeader>
+      </DialogContent>
+    </Dialog>
+  ),
+}
+
+export const WithFooter: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Dialog {...args}>
+      <DialogTrigger asChild>
+        <Button variant="outline">Open dialog</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Confirm action</DialogTitle>
+          <DialogDescription>
+            This action cannot be undone. Are you sure you want to proceed?
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Flex className="justify-end gap-2">
+            <DialogClose asChild>
+              <Button variant="outline" isSecondary>
+                Cancel
+              </Button>
+            </DialogClose>
+            <Button onClick={fn()}>Confirm</Button>
+          </Flex>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  ),
+}
+
+export const Widths: Story = {
+  args: { defaultOpen: true },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`DialogContent` defaults to `max-w-lg`. Override via `className` for narrower or wider dialogs.",
+      },
+    },
+  },
+  render: (args) => (
+    <Dialog {...args}>
+      <DialogTrigger asChild>
+        <Button variant="outline">Open wide dialog</Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Wide dialog (max-w-2xl)</DialogTitle>
+          <DialogDescription>
+            For wider content, pass a Tailwind width class to `DialogContent`.
+            For canonical app sizing, use `Modal` instead.
+          </DialogDescription>
+        </DialogHeader>
+      </DialogContent>
+    </Dialog>
+  ),
+}
+
+export const LongContent: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Dialog {...args}>
+      <DialogTrigger asChild>
+        <Button variant="outline">Open dialog</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Terms of use</DialogTitle>
+          <DialogDescription>
+            Long-form content scrolls within the dialog when it overflows the
+            viewport. Ethereum is a decentralized, open-source blockchain
+            featuring smart-contract functionality. Ether is the native
+            cryptocurrency of the platform. Among cryptocurrencies, ether is
+            second only to bitcoin in market capitalization.
+          </DialogDescription>
+        </DialogHeader>
+      </DialogContent>
+    </Dialog>
+  ),
+}

--- a/src/components/ui/__stories__/Dialog.stories.tsx
+++ b/src/components/ui/__stories__/Dialog.stories.tsx
@@ -18,6 +18,7 @@ const meta = {
   title: "UI / Primitives / Dialog",
   component: Dialog,
   parameters: {
+    chromatic: { disableSnapshot: true },
     docs: {
       description: {
         component:

--- a/src/components/ui/__stories__/DropdownMenu.stories.tsx
+++ b/src/components/ui/__stories__/DropdownMenu.stories.tsx
@@ -1,0 +1,176 @@
+import { useState } from "react"
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import { Button } from "../buttons/Button"
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "../dropdown-menu"
+
+const meta = {
+  title: "UI / Primitives / DropdownMenu",
+  component: DropdownMenu,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Anchored menu built on Radix DropdownMenu. Supports plain items, checkbox items, radio groups, submenus, labels, separators, and shortcut hints.",
+      },
+    },
+  },
+} satisfies Meta<typeof DropdownMenu>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <DropdownMenu {...args}>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline">Open menu</Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuItem>Profile</DropdownMenuItem>
+        <DropdownMenuItem>Settings</DropdownMenuItem>
+        <DropdownMenuItem>Sign out</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  ),
+}
+
+export const WithSubmenus: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <DropdownMenu {...args}>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline">Open menu</Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuItem>New file</DropdownMenuItem>
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>Share</DropdownMenuSubTrigger>
+          <DropdownMenuSubContent>
+            <DropdownMenuItem>Copy link</DropdownMenuItem>
+            <DropdownMenuItem>Email</DropdownMenuItem>
+            <DropdownMenuItem>Embed</DropdownMenuItem>
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+        <DropdownMenuItem>Delete</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  ),
+}
+
+const CheckboxMenu = () => {
+  const [showToolbar, setShowToolbar] = useState(true)
+  const [showSidebar, setShowSidebar] = useState(false)
+  const [showStatus, setShowStatus] = useState(true)
+
+  return (
+    <DropdownMenu defaultOpen>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline">View options</Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuLabel>Appearance</DropdownMenuLabel>
+        <DropdownMenuCheckboxItem
+          checked={showToolbar}
+          onCheckedChange={setShowToolbar}
+        >
+          Toolbar
+        </DropdownMenuCheckboxItem>
+        <DropdownMenuCheckboxItem
+          checked={showSidebar}
+          onCheckedChange={setShowSidebar}
+        >
+          Sidebar
+        </DropdownMenuCheckboxItem>
+        <DropdownMenuCheckboxItem
+          checked={showStatus}
+          onCheckedChange={setShowStatus}
+        >
+          Status bar
+        </DropdownMenuCheckboxItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+export const WithCheckboxItems: Story = {
+  render: () => <CheckboxMenu />,
+}
+
+const RadioMenu = () => {
+  const [theme, setTheme] = useState("system")
+
+  return (
+    <DropdownMenu defaultOpen>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline">Theme</Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuLabel>Theme</DropdownMenuLabel>
+        <DropdownMenuRadioGroup value={theme} onValueChange={setTheme}>
+          <DropdownMenuRadioItem value="light">Light</DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="dark">Dark</DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="system">System</DropdownMenuRadioItem>
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+export const WithRadioItems: Story = {
+  render: () => <RadioMenu />,
+}
+
+export const WithSeparators: Story = {
+  args: { defaultOpen: true },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Combines labels, items, separators, and shortcut hints to model a typical app menu.",
+      },
+    },
+  },
+  render: (args) => (
+    <DropdownMenu {...args}>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline">File</Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuLabel>File</DropdownMenuLabel>
+        <DropdownMenuItem>
+          New <DropdownMenuShortcut>Ctrl+N</DropdownMenuShortcut>
+        </DropdownMenuItem>
+        <DropdownMenuItem>
+          Open <DropdownMenuShortcut>Ctrl+O</DropdownMenuShortcut>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel>Edit</DropdownMenuLabel>
+        <DropdownMenuItem>
+          Cut <DropdownMenuShortcut>Ctrl+X</DropdownMenuShortcut>
+        </DropdownMenuItem>
+        <DropdownMenuItem>
+          Copy <DropdownMenuShortcut>Ctrl+C</DropdownMenuShortcut>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem>Sign out</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  ),
+}

--- a/src/components/ui/__stories__/DropdownMenu.stories.tsx
+++ b/src/components/ui/__stories__/DropdownMenu.stories.tsx
@@ -22,6 +22,7 @@ const meta = {
   title: "UI / Primitives / DropdownMenu",
   component: DropdownMenu,
   parameters: {
+    chromatic: { disableSnapshot: true },
     docs: {
       description: {
         component:

--- a/src/components/ui/__stories__/Modal.stories.tsx
+++ b/src/components/ui/__stories__/Modal.stories.tsx
@@ -6,6 +6,9 @@ import ModalComponent from "../dialog-modal"
 const meta = {
   title: "UI / Modal",
   component: ModalComponent,
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
   args: {
     defaultOpen: true,
     title: "Modal title",

--- a/src/components/ui/__stories__/Modal.stories.tsx
+++ b/src/components/ui/__stories__/Modal.stories.tsx
@@ -1,16 +1,16 @@
 import { fn } from "storybook/test"
-import { Meta, StoryObj } from "@storybook/nextjs"
+import type { Meta, StoryObj } from "@storybook/nextjs"
 
 import ModalComponent from "../dialog-modal"
 
 const meta = {
-  title: "Molecules/Overlay Content/Modal",
+  title: "UI / Modal",
   component: ModalComponent,
   args: {
     defaultOpen: true,
-    title: "Modal Title",
+    title: "Modal title",
     children:
-      "This is the base component to be used in the modal window. Please change the text to preview final content for ethereum.org",
+      "Base content for the modal. Replace this with the final copy and components for your screen.",
     actionButton: {
       label: "Save",
       onClick: fn(),
@@ -22,10 +22,59 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
-export const Modal: Story = {}
+export const Default: Story = {}
 
-export const Xl: Story = {
+export const SizeMd: Story = {
+  args: { size: "md" },
+}
+
+export const SizeLg: Story = {
+  args: { size: "lg" },
+}
+
+export const SizeXl: Story = {
+  args: { size: "xl" },
+}
+
+export const VariantSimulator: Story = {
+  args: { variant: "simulator" },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`simulator` variant moves the close button inline with the header content; used for embedded simulator-style modals.",
+      },
+    },
+  },
+}
+
+export const VariantUnstyled: Story = {
   args: {
-    size: "xl",
+    variant: "unstyled",
+    actionButton: undefined,
+    children:
+      "Unstyled content area. Use when the modal needs to render fully custom layout without the default padding, rounding, or background.",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`unstyled` variant strips the default content padding, rounding, and background so the consumer can render custom chrome.",
+      },
+    },
+  },
+}
+
+export const WithoutActionButton: Story = {
+  args: {
+    actionButton: undefined,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Without `actionButton`, the footer is omitted and the modal becomes informational. Closes via the X button or escape.",
+      },
+    },
   },
 }

--- a/src/components/ui/__stories__/PersistentPanel.stories.tsx
+++ b/src/components/ui/__stories__/PersistentPanel.stories.tsx
@@ -1,0 +1,156 @@
+import { useRef, useState } from "react"
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import { Button } from "../buttons/Button"
+import { PersistentPanel } from "../persistent-panel"
+
+const meta = {
+  title: "UI / PersistentPanel",
+  component: PersistentPanel,
+  args: {
+    open: false,
+    children: null,
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Custom side-panel overlay tuned for expensive content. Unlike `Sheet` (which mounts/unmounts on every open), `PersistentPanel` lazy-mounts on first open and then stays mounted -- toggles only flip CSS visibility. Use for heavy filter forms, virtualized lists, or any content where re-mount cost matters. For lighter cases, prefer `Sheet`.",
+      },
+    },
+  },
+} satisfies Meta<typeof PersistentPanel>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+type DemoProps = {
+  side?: "left" | "right" | "top" | "bottom"
+  initialOpen?: boolean
+  ariaLabel: string
+  body?: React.ReactNode
+}
+
+const PanelDemo = ({
+  side = "left",
+  initialOpen = true,
+  ariaLabel,
+  body,
+}: DemoProps) => {
+  const [open, setOpen] = useState(initialOpen)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+
+  return (
+    <>
+      <Button
+        ref={triggerRef}
+        variant="outline"
+        onClick={() => setOpen((prev) => !prev)}
+      >
+        {open ? "Close panel" : "Open panel"}
+      </Button>
+      <PersistentPanel
+        open={open}
+        side={side}
+        onOpenChange={setOpen}
+        triggerRef={triggerRef}
+        aria-label={ariaLabel}
+      >
+        <div className="flex h-full flex-col gap-4">
+          <h2 className="text-lg font-semibold">{ariaLabel}</h2>
+          {body ?? (
+            <p className="text-sm text-body-medium">
+              Panel content stays mounted between opens. Open/close several
+              times — the children do not unmount.
+            </p>
+          )}
+          <Button
+            className="mt-auto"
+            variant="outline"
+            onClick={() => setOpen(false)}
+          >
+            Close
+          </Button>
+        </div>
+      </PersistentPanel>
+    </>
+  )
+}
+
+export const Default: Story = {
+  render: () => <PanelDemo ariaLabel="Default panel" />,
+}
+
+export const SideLeft: Story = {
+  render: () => <PanelDemo side="left" ariaLabel="Left panel" />,
+}
+
+export const SideRight: Story = {
+  render: () => <PanelDemo side="right" ariaLabel="Right panel" />,
+}
+
+export const SideTop: Story = {
+  render: () => <PanelDemo side="top" ariaLabel="Top panel" />,
+}
+
+export const SideBottom: Story = {
+  render: () => <PanelDemo side="bottom" ariaLabel="Bottom panel" />,
+}
+
+const LazyMountProbe = () => {
+  const [renderCount, setRenderCount] = useState(0)
+
+  // Counts every render of the panel children
+  return (
+    <div>
+      <p className="text-sm text-body-medium">
+        Render count: <strong>{renderCount}</strong>
+      </p>
+      <Button
+        size="sm"
+        variant="outline"
+        onClick={() => setRenderCount((n) => n + 1)}
+      >
+        Bump
+      </Button>
+    </div>
+  )
+}
+
+export const LazyMountAndPersistence: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Open the panel, bump the counter, close, then reopen — the counter retains its value because children are not unmounted. Compare this against `Sheet`, where each open is a fresh mount.",
+      },
+    },
+  },
+  render: () => (
+    <PanelDemo
+      side="left"
+      initialOpen={false}
+      ariaLabel="Lazy-mount probe"
+      body={<LazyMountProbe />}
+    />
+  ),
+}
+
+export const StartsClosed: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Demonstrates lazy mount: the panel children do not render until the first open. Inspect the DOM before clicking — there is no panel element until then.",
+      },
+    },
+  },
+  render: () => (
+    <PanelDemo
+      side="left"
+      initialOpen={false}
+      ariaLabel="Initially-closed panel"
+    />
+  ),
+}

--- a/src/components/ui/__stories__/PersistentPanel.stories.tsx
+++ b/src/components/ui/__stories__/PersistentPanel.stories.tsx
@@ -12,6 +12,7 @@ const meta = {
     children: null,
   },
   parameters: {
+    chromatic: { disableSnapshot: true },
     docs: {
       description: {
         component:

--- a/src/components/ui/__stories__/Popover.stories.tsx
+++ b/src/components/ui/__stories__/Popover.stories.tsx
@@ -1,0 +1,129 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import { Button } from "../buttons/Button"
+import { HStack } from "../flex"
+import {
+  Popover,
+  PopoverClose,
+  PopoverContent,
+  PopoverTrigger,
+} from "../popover"
+
+const meta = {
+  title: "UI / Primitives / Popover",
+  component: Popover,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Anchored floating panel built on Radix Popover. The arrow is always rendered as part of `PopoverContent`. Use `align` to shift the panel relative to its trigger.",
+      },
+    },
+  },
+} satisfies Meta<typeof Popover>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Popover {...args}>
+      <PopoverTrigger asChild>
+        <Button variant="outline">Open popover</Button>
+      </PopoverTrigger>
+      <PopoverContent>
+        <p className="text-sm">
+          Popovers anchor to their trigger and surface secondary information or
+          short forms.
+        </p>
+      </PopoverContent>
+    </Popover>
+  ),
+}
+
+export const Alignments: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "All three `align` options shown side-by-side. `start` left-aligns to the trigger, `end` right-aligns, `center` is the default.",
+      },
+    },
+  },
+  render: () => (
+    <HStack className="gap-8 pt-32">
+      <Popover defaultOpen>
+        <PopoverTrigger asChild>
+          <Button variant="outline">align=start</Button>
+        </PopoverTrigger>
+        <PopoverContent align="start">
+          <p className="text-sm">Aligned to the start edge of the trigger.</p>
+        </PopoverContent>
+      </Popover>
+
+      <Popover defaultOpen>
+        <PopoverTrigger asChild>
+          <Button variant="outline">align=center</Button>
+        </PopoverTrigger>
+        <PopoverContent align="center">
+          <p className="text-sm">Centered under the trigger (default).</p>
+        </PopoverContent>
+      </Popover>
+
+      <Popover defaultOpen>
+        <PopoverTrigger asChild>
+          <Button variant="outline">align=end</Button>
+        </PopoverTrigger>
+        <PopoverContent align="end">
+          <p className="text-sm">Aligned to the end edge of the trigger.</p>
+        </PopoverContent>
+      </Popover>
+    </HStack>
+  ),
+}
+
+export const WithRichContent: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Popover {...args}>
+      <PopoverTrigger asChild>
+        <Button variant="outline">Show details</Button>
+      </PopoverTrigger>
+      <PopoverContent>
+        <div className="space-y-3">
+          <h4 className="font-semibold">Network details</h4>
+          <p className="text-sm text-body-medium">
+            Layer 2 networks scale Ethereum by handling transactions off the
+            main chain while inheriting its security guarantees.
+          </p>
+          <Button size="sm" variant="outline">
+            Learn more
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  ),
+}
+
+export const WithCloseAction: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Popover {...args}>
+      <PopoverTrigger asChild>
+        <Button variant="outline">Open</Button>
+      </PopoverTrigger>
+      <PopoverContent>
+        <div className="space-y-3">
+          <p className="text-sm">
+            Use `PopoverClose` to dismiss the panel from inside the content.
+          </p>
+          <PopoverClose asChild>
+            <Button size="sm">Got it</Button>
+          </PopoverClose>
+        </div>
+      </PopoverContent>
+    </Popover>
+  ),
+}

--- a/src/components/ui/__stories__/Popover.stories.tsx
+++ b/src/components/ui/__stories__/Popover.stories.tsx
@@ -13,6 +13,7 @@ const meta = {
   title: "UI / Primitives / Popover",
   component: Popover,
   parameters: {
+    chromatic: { disableSnapshot: true },
     docs: {
       description: {
         component:

--- a/src/components/ui/__stories__/Select.stories.tsx
+++ b/src/components/ui/__stories__/Select.stories.tsx
@@ -16,6 +16,7 @@ const meta = {
   title: "UI / Primitives / Select",
   component: Select,
   parameters: {
+    chromatic: { disableSnapshot: true },
     docs: {
       description: {
         component:

--- a/src/components/ui/__stories__/Select.stories.tsx
+++ b/src/components/ui/__stories__/Select.stories.tsx
@@ -1,0 +1,173 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import { VStack } from "../flex"
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from "../select"
+
+const meta = {
+  title: "UI / Primitives / Select",
+  component: Select,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Single-select dropdown built on Radix Select. Use `SelectGroup` + `SelectLabel` to group items, `SelectSeparator` between groups. Note: `Select` does not currently expose a `hasError` variant — error styling is applied via `className` on `SelectTrigger`.",
+      },
+    },
+  },
+} satisfies Meta<typeof Select>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+const FRUITS = ["Apple", "Banana", "Cherry", "Date", "Elderberry"] as const
+
+export const WithPlaceholder: Story = {
+  render: () => (
+    <div className="w-[220px]">
+      <Select>
+        <SelectTrigger>
+          <SelectValue placeholder="Pick a fruit" />
+        </SelectTrigger>
+        <SelectContent>
+          {FRUITS.map((fruit) => (
+            <SelectItem key={fruit} value={fruit.toLowerCase()}>
+              {fruit}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  ),
+}
+
+export const WithDefaultValue: Story = {
+  render: () => (
+    <div className="w-[220px]">
+      <Select defaultValue="banana">
+        <SelectTrigger>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {FRUITS.map((fruit) => (
+            <SelectItem key={fruit} value={fruit.toLowerCase()}>
+              {fruit}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  ),
+}
+
+export const WithGroups: Story = {
+  render: () => (
+    <div className="w-[260px]">
+      <Select>
+        <SelectTrigger>
+          <SelectValue placeholder="Pick a network" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            <SelectLabel>Layer 1</SelectLabel>
+            <SelectItem value="mainnet">Ethereum</SelectItem>
+          </SelectGroup>
+          <SelectSeparator />
+          <SelectGroup>
+            <SelectLabel>Layer 2</SelectLabel>
+            <SelectItem value="arbitrum">Arbitrum One</SelectItem>
+            <SelectItem value="base">Base</SelectItem>
+            <SelectItem value="op">OP Mainnet</SelectItem>
+            <SelectItem value="zksync">zkSync Era</SelectItem>
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+    </div>
+  ),
+}
+
+export const Disabled: Story = {
+  render: () => (
+    <VStack className="w-[220px]">
+      <Select disabled>
+        <SelectTrigger>
+          <SelectValue placeholder="Disabled (no value)" />
+        </SelectTrigger>
+        <SelectContent>
+          {FRUITS.map((fruit) => (
+            <SelectItem key={fruit} value={fruit.toLowerCase()}>
+              {fruit}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Select disabled defaultValue="apple">
+        <SelectTrigger>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {FRUITS.map((fruit) => (
+            <SelectItem key={fruit} value={fruit.toLowerCase()}>
+              {fruit}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </VStack>
+  ),
+}
+
+export const ErrorState: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`Select` lacks a built-in `hasError` variant. Apply `border-error` (and matching focus token) on `SelectTrigger` to mirror the error styling used by `Input` and `Textarea`.",
+      },
+    },
+  },
+  render: () => (
+    <div className="w-[220px]">
+      <Select>
+        <SelectTrigger className="border-error focus-visible:outline-error hover:not-disabled:border-error">
+          <SelectValue placeholder="Required" />
+        </SelectTrigger>
+        <SelectContent>
+          {FRUITS.map((fruit) => (
+            <SelectItem key={fruit} value={fruit.toLowerCase()}>
+              {fruit}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  ),
+}
+
+export const WithDisabledItem: Story = {
+  render: () => (
+    <div className="w-[220px]">
+      <Select>
+        <SelectTrigger>
+          <SelectValue placeholder="Pick a fruit" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="apple">Apple</SelectItem>
+          <SelectItem value="banana" disabled>
+            Banana (out of stock)
+          </SelectItem>
+          <SelectItem value="cherry">Cherry</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  ),
+}

--- a/src/components/ui/__stories__/Sheet.stories.tsx
+++ b/src/components/ui/__stories__/Sheet.stories.tsx
@@ -1,0 +1,175 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import { Button } from "../buttons/Button"
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "../sheet"
+
+const meta = {
+  title: "UI / Primitives / Sheet",
+  component: Sheet,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Side-panel overlay built on Radix Dialog. Use `side` to choose entry edge, and `hideOverlay` when the sheet should appear without dimming the page (e.g., persistent filter panels). For lazy-mount + stay-mounted behavior, see `PersistentPanel`.",
+      },
+    },
+  },
+} satisfies Meta<typeof Sheet>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+const SAMPLE_BODY = (
+  <p className="text-sm text-body-medium">
+    Sheets are good for secondary tasks that should not pull the user away from
+    the main page context, like filters, settings, or a navigation drawer.
+  </p>
+)
+
+export const Default: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Sheet {...args}>
+      <SheetTrigger asChild>
+        <Button variant="outline">Open sheet</Button>
+      </SheetTrigger>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>Sheet title</SheetTitle>
+          <SheetDescription>A short description of the sheet.</SheetDescription>
+        </SheetHeader>
+        <div className="py-4">{SAMPLE_BODY}</div>
+      </SheetContent>
+    </Sheet>
+  ),
+}
+
+export const SideRight: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Sheet {...args}>
+      <SheetTrigger asChild>
+        <Button variant="outline">Open right</Button>
+      </SheetTrigger>
+      <SheetContent side="right">
+        <SheetHeader>
+          <SheetTitle>Right sheet</SheetTitle>
+        </SheetHeader>
+        <div className="py-4">{SAMPLE_BODY}</div>
+      </SheetContent>
+    </Sheet>
+  ),
+}
+
+export const SideLeft: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Sheet {...args}>
+      <SheetTrigger asChild>
+        <Button variant="outline">Open left</Button>
+      </SheetTrigger>
+      <SheetContent side="left">
+        <SheetHeader>
+          <SheetTitle>Left sheet</SheetTitle>
+        </SheetHeader>
+        <div className="py-4">{SAMPLE_BODY}</div>
+      </SheetContent>
+    </Sheet>
+  ),
+}
+
+export const SideTop: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Sheet {...args}>
+      <SheetTrigger asChild>
+        <Button variant="outline">Open top</Button>
+      </SheetTrigger>
+      <SheetContent side="top">
+        <SheetHeader>
+          <SheetTitle>Top sheet</SheetTitle>
+        </SheetHeader>
+        <div className="py-4">{SAMPLE_BODY}</div>
+      </SheetContent>
+    </Sheet>
+  ),
+}
+
+export const SideBottom: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Sheet {...args}>
+      <SheetTrigger asChild>
+        <Button variant="outline">Open bottom</Button>
+      </SheetTrigger>
+      <SheetContent side="bottom">
+        <SheetHeader>
+          <SheetTitle>Bottom sheet</SheetTitle>
+        </SheetHeader>
+        <div className="py-4">{SAMPLE_BODY}</div>
+      </SheetContent>
+    </Sheet>
+  ),
+}
+
+export const WithoutOverlay: Story = {
+  args: { defaultOpen: true },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`hideOverlay` skips the dimmed backdrop so the sheet sits beside live page content.",
+      },
+    },
+  },
+  render: (args) => (
+    <Sheet {...args}>
+      <SheetTrigger asChild>
+        <Button variant="outline">Open without overlay</Button>
+      </SheetTrigger>
+      <SheetContent hideOverlay>
+        <SheetHeader>
+          <SheetTitle>No overlay</SheetTitle>
+          <SheetDescription>
+            The page behind stays interactive.
+          </SheetDescription>
+        </SheetHeader>
+        <div className="py-4">{SAMPLE_BODY}</div>
+      </SheetContent>
+    </Sheet>
+  ),
+}
+
+export const WithHeaderAndFooter: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Sheet {...args}>
+      <SheetTrigger asChild>
+        <Button variant="outline">Open settings</Button>
+      </SheetTrigger>
+      <SheetContent className="flex flex-col">
+        <SheetHeader>
+          <SheetTitle>Edit profile</SheetTitle>
+          <SheetDescription>
+            Make changes to your profile and save when you are done.
+          </SheetDescription>
+        </SheetHeader>
+        <div className="flex-1 py-4">{SAMPLE_BODY}</div>
+        <SheetFooter>
+          <SheetClose>Cancel</SheetClose>
+          <Button>Save changes</Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  ),
+}

--- a/src/components/ui/__stories__/Sheet.stories.tsx
+++ b/src/components/ui/__stories__/Sheet.stories.tsx
@@ -16,6 +16,7 @@ const meta = {
   title: "UI / Primitives / Sheet",
   component: Sheet,
   parameters: {
+    chromatic: { disableSnapshot: true },
     docs: {
       description: {
         component:


### PR DESCRIPTION
## Summary

Adds Storybook stories for overlay primitives in `src/components/ui/`. This is PR 1 of 5 for #18121, scoped to overlay components. One commit per checkbox in the issue.

- `Dialog` — vanilla shadcn primitive (`UI / Primitives / Dialog`)
- `Modal` — expanded existing story to cover all sizes/variants/actionButton (`UI / Modal`)
- `Sheet` — sides, `hideOverlay`, header/footer composition (`UI / Primitives / Sheet`)
- `Popover` — alignment variations, rich content, explicit close (`UI / Primitives / Popover`)
- `DropdownMenu` — submenus, checkbox/radio items, separators (`UI / Primitives / DropdownMenu`)
- `Select` — placeholder, groups, disabled, error, disabled item (`UI / Primitives / Select`)
- `PersistentPanel` — sides, lazy-mount + persistence probe (`UI / PersistentPanel`)
- `Command` — default, groups, separators, shortcuts, disabled item, empty state, kbd-shortcut input, custom icon, `CommandDialog` (`UI / Primitives / Command`)

All new files live in `src/components/ui/__stories__/` to match `Modal.stories.tsx`, `Button.stories.tsx`, etc. Title hierarchy is `UI / [Name]` for canonical app components and `UI / Primitives / [Name]` for shadcn-regenerable primitives.

## Notes for review

- Vanilla `Dialog` doesn't expose `hideOverlay` or `size` props (only `Sheet` and `Modal` do); the Dialog story shows width via `className` override and points designers at `Modal` for canonical app sizing.
- `Select` has no built-in `hasError` variant — the error story applies `border-error` directly and flags this as a candidate for a future cleanup PR (would mirror `Input`/`Textarea`).
- `card.stories.tsx` location/expansion is out of scope here; separate concern.

## Test plan

- [ ] Eyeball each new story in Storybook (light + dark, locale toggle)
- [ ] a11y addon passes for each story

Refs: #18121