### PR TITLE
feat(storybook): add display primitive stories

### DIFF
--- a/src/components/ui/__stories__/Breadcrumb.stories.tsx
+++ b/src/components/ui/__stories__/Breadcrumb.stories.tsx
@@ -14,6 +14,7 @@ const meta = {
   title: "UI / Primitives / Breadcrumb",
   component: Breadcrumb,
   parameters: {
+    chromatic: { disableSnapshot: true },
     docs: {
       description: {
         component:

--- a/src/components/ui/__stories__/Breadcrumb.stories.tsx
+++ b/src/components/ui/__stories__/Breadcrumb.stories.tsx
@@ -1,0 +1,124 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import {
+  Breadcrumb,
+  BreadcrumbEllipsis,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "../breadcrumb"
+
+const meta = {
+  title: "UI / Primitives / Breadcrumb",
+  component: Breadcrumb,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Hierarchy navigation. Compose `Breadcrumb` > `BreadcrumbList` > `BreadcrumbItem` with `BreadcrumbLink` (clickable) or `BreadcrumbPage` (current page, non-link). Separators default to a chevron icon.",
+      },
+    },
+  },
+} satisfies Meta<typeof Breadcrumb>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const TwoLevel: Story = {
+  render: () => (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="/">Home</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>Layer 2</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  ),
+}
+
+export const ThreeLevel: Story = {
+  render: () => (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="/">Home</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink href="/layer-2">Layer 2</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>Optimistic rollups</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  ),
+}
+
+export const WithCurrentPage: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`BreadcrumbPage` marks the current page with `aria-current='page'` and renders in the primary color.",
+      },
+    },
+  },
+  render: () => (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="/">Home</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink href="/learn">Learn</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>What is Ethereum?</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  ),
+}
+
+export const WithEllipsis: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Use `BreadcrumbEllipsis` to collapse intermediate levels in deep hierarchies.",
+      },
+    },
+  },
+  render: () => (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="/">Home</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbEllipsis />
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink href="/developers/docs">Docs</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>Smart contracts</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  ),
+}

--- a/src/components/ui/__stories__/Chart.stories.tsx
+++ b/src/components/ui/__stories__/Chart.stories.tsx
@@ -27,6 +27,7 @@ const meta = {
   title: "UI / Chart",
   component: ChartContainer,
   parameters: {
+    chromatic: { disableSnapshot: true },
     docs: {
       description: {
         component:

--- a/src/components/ui/__stories__/Chart.stories.tsx
+++ b/src/components/ui/__stories__/Chart.stories.tsx
@@ -1,0 +1,231 @@
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Line,
+  LineChart,
+  Pie,
+  PieChart,
+  XAxis,
+  YAxis,
+} from "recharts"
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "../chart"
+
+const meta = {
+  title: "UI / Chart",
+  component: ChartContainer,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Recharts wrapper. `ChartContainer` accepts a `config` map (`{ key: { label, color | theme, icon? } }`) and renders any Recharts chart inside a responsive container. `ChartTooltipContent` and `ChartLegendContent` adapt the default Recharts UI to the design system. Color tokens are exposed as CSS variables (`--color-<key>`) you reference via `fill='var(--color-foo)'`.",
+      },
+    },
+  },
+} satisfies Meta<typeof ChartContainer>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+const monthlyData = [
+  { month: "Jan", mainnet: 186, l2: 80 },
+  { month: "Feb", mainnet: 305, l2: 200 },
+  { month: "Mar", mainnet: 237, l2: 120 },
+  { month: "Apr", mainnet: 73, l2: 190 },
+  { month: "May", mainnet: 209, l2: 130 },
+  { month: "Jun", mainnet: 214, l2: 140 },
+]
+
+const monthlyConfig = {
+  mainnet: { label: "Mainnet", color: "hsl(var(--primary))" },
+  l2: { label: "Layer 2", color: "hsl(var(--accent-a))" },
+} satisfies ChartConfig
+
+export const BarUsage: Story = {
+  args: { config: monthlyConfig, children: <></> },
+  render: (args) => (
+    <ChartContainer
+      {...args}
+      config={monthlyConfig}
+      className="h-[280px] w-[640px]"
+    >
+      <BarChart data={monthlyData}>
+        <CartesianGrid vertical={false} />
+        <XAxis dataKey="month" tickLine={false} axisLine={false} />
+        <YAxis tickLine={false} axisLine={false} />
+        <ChartTooltip content={<ChartTooltipContent />} />
+        <ChartLegend content={<ChartLegendContent />} />
+        <Bar dataKey="mainnet" fill="var(--color-mainnet)" radius={4} />
+        <Bar dataKey="l2" fill="var(--color-l2)" radius={4} />
+      </BarChart>
+    </ChartContainer>
+  ),
+}
+
+export const LineUsage: Story = {
+  args: { config: monthlyConfig, children: <></> },
+  render: (args) => (
+    <ChartContainer
+      {...args}
+      config={monthlyConfig}
+      className="h-[280px] w-[640px]"
+    >
+      <LineChart data={monthlyData}>
+        <CartesianGrid vertical={false} />
+        <XAxis dataKey="month" tickLine={false} axisLine={false} />
+        <YAxis tickLine={false} axisLine={false} />
+        <ChartTooltip content={<ChartTooltipContent />} />
+        <ChartLegend content={<ChartLegendContent />} />
+        <Line
+          dataKey="mainnet"
+          stroke="var(--color-mainnet)"
+          strokeWidth={2}
+          dot={false}
+        />
+        <Line
+          dataKey="l2"
+          stroke="var(--color-l2)"
+          strokeWidth={2}
+          dot={false}
+        />
+      </LineChart>
+    </ChartContainer>
+  ),
+}
+
+export const AreaUsage: Story = {
+  args: { config: monthlyConfig, children: <></> },
+  render: (args) => (
+    <ChartContainer
+      {...args}
+      config={monthlyConfig}
+      className="h-[280px] w-[640px]"
+    >
+      <AreaChart data={monthlyData}>
+        <CartesianGrid vertical={false} />
+        <XAxis dataKey="month" tickLine={false} axisLine={false} />
+        <YAxis tickLine={false} axisLine={false} />
+        <ChartTooltip content={<ChartTooltipContent indicator="line" />} />
+        <ChartLegend content={<ChartLegendContent />} />
+        <Area
+          dataKey="mainnet"
+          type="monotone"
+          fill="var(--color-mainnet)"
+          stroke="var(--color-mainnet)"
+          fillOpacity={0.3}
+          stackId="a"
+        />
+        <Area
+          dataKey="l2"
+          type="monotone"
+          fill="var(--color-l2)"
+          stroke="var(--color-l2)"
+          fillOpacity={0.3}
+          stackId="a"
+        />
+      </AreaChart>
+    </ChartContainer>
+  ),
+}
+
+const pieData = [
+  { name: "ethereum", value: 60 },
+  { name: "arbitrum", value: 18 },
+  { name: "base", value: 12 },
+  { name: "op", value: 10 },
+]
+
+const pieConfig = {
+  ethereum: { label: "Ethereum", color: "hsl(var(--primary))" },
+  arbitrum: { label: "Arbitrum", color: "hsl(var(--accent-a))" },
+  base: { label: "Base", color: "hsl(var(--accent-b))" },
+  op: { label: "OP Mainnet", color: "hsl(var(--accent-c))" },
+} satisfies ChartConfig
+
+export const PieUsage: Story = {
+  args: { config: pieConfig, children: <></> },
+  render: (args) => (
+    <ChartContainer
+      {...args}
+      config={pieConfig}
+      className="h-[280px] w-[420px]"
+    >
+      <PieChart>
+        <ChartTooltip content={<ChartTooltipContent hideLabel />} />
+        <ChartLegend content={<ChartLegendContent />} />
+        <Pie data={pieData} dataKey="value" nameKey="name" innerRadius={50}>
+          {pieData.map((entry) => (
+            <Cell key={entry.name} fill={`var(--color-${entry.name})`} />
+          ))}
+        </Pie>
+      </PieChart>
+    </ChartContainer>
+  ),
+}
+
+export const TooltipIndicators: Story = {
+  args: { config: monthlyConfig, children: <></> },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`ChartTooltipContent` accepts an `indicator` prop: `dot` (default), `line`, or `dashed`. Hover the bars to compare.",
+      },
+    },
+  },
+  render: (args) => (
+    <ChartContainer
+      {...args}
+      config={monthlyConfig}
+      className="h-[280px] w-[640px]"
+    >
+      <BarChart data={monthlyData}>
+        <CartesianGrid vertical={false} />
+        <XAxis dataKey="month" tickLine={false} axisLine={false} />
+        <ChartTooltip content={<ChartTooltipContent indicator="dashed" />} />
+        <ChartLegend content={<ChartLegendContent />} />
+        <Bar dataKey="mainnet" fill="var(--color-mainnet)" radius={4} />
+        <Bar dataKey="l2" fill="var(--color-l2)" radius={4} />
+      </BarChart>
+    </ChartContainer>
+  ),
+}
+
+export const HiddenLabel: Story = {
+  args: { config: monthlyConfig, children: <></> },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`hideLabel` on `ChartTooltipContent` removes the X-axis category from the tooltip header. Useful for non-categorical charts.",
+      },
+    },
+  },
+  render: (args) => (
+    <ChartContainer
+      {...args}
+      config={monthlyConfig}
+      className="h-[280px] w-[640px]"
+    >
+      <BarChart data={monthlyData}>
+        <CartesianGrid vertical={false} />
+        <XAxis dataKey="month" tickLine={false} axisLine={false} />
+        <ChartTooltip content={<ChartTooltipContent hideLabel />} />
+        <Bar dataKey="mainnet" fill="var(--color-mainnet)" radius={4} />
+      </BarChart>
+    </ChartContainer>
+  ),
+}

--- a/src/components/ui/__stories__/Collapsible.stories.tsx
+++ b/src/components/ui/__stories__/Collapsible.stories.tsx
@@ -1,0 +1,136 @@
+import { ChevronDown, ChevronUp } from "lucide-react"
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import { Button } from "../buttons/Button"
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "../collapsible"
+import { HStack, VStack } from "../flex"
+
+const meta = {
+  title: "UI / Primitives / Collapsible",
+  component: Collapsible,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Disclosure primitive built on Radix Collapsible. Compose `Collapsible` > `CollapsibleTrigger` (use `asChild` to wrap any focusable element) + `CollapsibleContent`. For multi-section flows, prefer `Accordion`.",
+      },
+    },
+  },
+} satisfies Meta<typeof Collapsible>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Closed: Story = {
+  render: () => (
+    <Collapsible className="w-[320px] rounded border p-3">
+      <CollapsibleTrigger asChild>
+        <Button variant="outline" size="sm">
+          Show details
+        </Button>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="pt-3 text-sm">
+        Hidden content. The trigger toggles the open state.
+      </CollapsibleContent>
+    </Collapsible>
+  ),
+}
+
+export const Open: Story = {
+  render: () => (
+    <Collapsible defaultOpen className="w-[320px] rounded border p-3">
+      <CollapsibleTrigger asChild>
+        <Button variant="outline" size="sm">
+          Hide details
+        </Button>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="pt-3 text-sm">
+        Visible content. Use `defaultOpen` to start expanded.
+      </CollapsibleContent>
+    </Collapsible>
+  ),
+}
+
+export const WithCustomTrigger: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`CollapsibleTrigger` renders as a `button` by default; pass `asChild` to render a custom element. Use `data-state` to swap the icon based on open state.",
+      },
+    },
+  },
+  render: () => (
+    <Collapsible className="w-[320px] rounded border">
+      <CollapsibleTrigger asChild>
+        <button
+          type="button"
+          className="group flex w-full items-center justify-between p-3 text-left text-sm font-medium"
+        >
+          <span>Frequently asked questions</span>
+          <ChevronDown className="size-4 transition-transform group-data-[state=open]:hidden" />
+          <ChevronUp className="hidden size-4 transition-transform group-data-[state=open]:block" />
+        </button>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="space-y-2 px-3 pb-3 text-sm">
+        <p>Custom triggers can pull in any element via `asChild`.</p>
+        <p>The chevron flips using `data-state=open` on the trigger.</p>
+      </CollapsibleContent>
+    </Collapsible>
+  ),
+}
+
+export const ListOfDetails: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Multiple independent collapsibles in a list. Each manages its own state. For grouped behavior, use `Accordion` instead.",
+      },
+    },
+  },
+  render: () => (
+    <VStack className="w-[420px] gap-2">
+      {[
+        {
+          title: "What is a layer 2?",
+          body: "Layer 2 networks scale Ethereum by handling transactions off the main chain.",
+        },
+        {
+          title: "What is a rollup?",
+          body: "Rollups bundle many transactions into a single proof posted to layer 1.",
+        },
+        {
+          title: "What is a validator?",
+          body: "Validators secure the network by proposing and attesting to blocks.",
+        },
+      ].map(({ title, body }) => (
+        <Collapsible key={title} className="rounded border">
+          <CollapsibleTrigger asChild>
+            <button
+              type="button"
+              className="group flex w-full items-center justify-between p-3 text-left text-sm font-medium"
+            >
+              <span>{title}</span>
+              <HStack className="gap-1 text-xs text-body-medium">
+                <span className="group-data-[state=open]:hidden">Show</span>
+                <span className="hidden group-data-[state=open]:inline">
+                  Hide
+                </span>
+                <ChevronDown className="size-4 transition-transform group-data-[state=open]:rotate-180" />
+              </HStack>
+            </button>
+          </CollapsibleTrigger>
+          <CollapsibleContent className="px-3 pb-3 text-sm text-body-medium">
+            {body}
+          </CollapsibleContent>
+        </Collapsible>
+      ))}
+    </VStack>
+  ),
+}

--- a/src/components/ui/__stories__/Collapsible.stories.tsx
+++ b/src/components/ui/__stories__/Collapsible.stories.tsx
@@ -13,6 +13,7 @@ const meta = {
   title: "UI / Primitives / Collapsible",
   component: Collapsible,
   parameters: {
+    chromatic: { disableSnapshot: true },
     docs: {
       description: {
         component:

--- a/src/components/ui/__stories__/List.stories.tsx
+++ b/src/components/ui/__stories__/List.stories.tsx
@@ -1,0 +1,87 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import { List, ListItem, OrderedList, UnorderedList } from "../list"
+
+const meta = {
+  title: "UI / List",
+  component: List,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Prose lists. `UnorderedList` (alias of `List`) renders a `<ul>`, `OrderedList` renders an `<ol>`. Wrap items in `ListItem` for consistent spacing. Both lists use `asChild` via `Slot` to inherit semantics from the parent element.",
+      },
+    },
+  },
+} satisfies Meta<typeof List>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Unordered: Story = {
+  render: () => (
+    <UnorderedList className="list-disc">
+      <ListItem>Smart contracts run on the EVM.</ListItem>
+      <ListItem>Validators secure the network.</ListItem>
+      <ListItem>Layer 2 rollups scale throughput.</ListItem>
+    </UnorderedList>
+  ),
+}
+
+export const Ordered: Story = {
+  render: () => (
+    <OrderedList className="list-decimal">
+      <ListItem>Connect a wallet.</ListItem>
+      <ListItem>Pick a layer 2 network.</ListItem>
+      <ListItem>Bridge ETH to start transacting.</ListItem>
+    </OrderedList>
+  ),
+}
+
+export const Nested: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Nested lists pick up `mt-3` between parent `ListItem` and the nested list via the `[&_ol]:mt-3 [&_ul]:mt-3` selector on `ListItem`.",
+      },
+    },
+  },
+  render: () => (
+    <UnorderedList className="list-disc">
+      <ListItem>
+        Layer 1
+        <UnorderedList className="list-disc">
+          <ListItem>Ethereum mainnet</ListItem>
+        </UnorderedList>
+      </ListItem>
+      <ListItem>
+        Layer 2
+        <OrderedList className="list-decimal">
+          <ListItem>Arbitrum One</ListItem>
+          <ListItem>Base</ListItem>
+          <ListItem>OP Mainnet</ListItem>
+        </OrderedList>
+      </ListItem>
+    </UnorderedList>
+  ),
+}
+
+export const PlainList: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Without an explicit `list-*` class the markers are hidden, leaving plain stacked items.",
+      },
+    },
+  },
+  render: () => (
+    <List>
+      <ListItem>First entry</ListItem>
+      <ListItem>Second entry</ListItem>
+      <ListItem>Third entry</ListItem>
+    </List>
+  ),
+}

--- a/src/components/ui/__stories__/List.stories.tsx
+++ b/src/components/ui/__stories__/List.stories.tsx
@@ -6,6 +6,7 @@ const meta = {
   title: "UI / List",
   component: List,
   parameters: {
+    chromatic: { disableSnapshot: true },
     docs: {
       description: {
         component:

--- a/src/components/ui/__stories__/Progress.stories.tsx
+++ b/src/components/ui/__stories__/Progress.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import { VStack } from "../flex"
+import { Progress } from "../progress"
+
+const meta = {
+  title: "UI / Primitives / Progress",
+  component: Progress,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Determinate progress bar built on Radix Progress. `value` is 0-100. `color: disabled` (default) renders a muted bar; `color: primary` switches the indicator and track to the brand pair.",
+      },
+    },
+  },
+} satisfies Meta<typeof Progress>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: () => (
+    <div className="w-[320px]">
+      <Progress value={50} />
+    </div>
+  ),
+}
+
+export const Colors: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`color` prop variants. `disabled` is the default (muted), `primary` uses the brand color.",
+      },
+    },
+  },
+  render: () => (
+    <VStack className="w-[320px] gap-4">
+      <Progress value={66} color="disabled" />
+      <Progress value={66} color="primary" />
+    </VStack>
+  ),
+}
+
+export const Values: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`value` is 0-100. The indicator translates with a CSS transition.",
+      },
+    },
+  },
+  render: () => (
+    <VStack className="w-[320px] gap-4">
+      <Progress value={0} color="primary" />
+      <Progress value={25} color="primary" />
+      <Progress value={50} color="primary" />
+      <Progress value={75} color="primary" />
+      <Progress value={100} color="primary" />
+    </VStack>
+  ),
+}
+
+export const WithLabel: Story = {
+  render: () => (
+    <VStack className="w-[320px] gap-1">
+      <div className="flex justify-between text-sm">
+        <span>Uploading</span>
+        <span>42%</span>
+      </div>
+      <Progress value={42} color="primary" />
+    </VStack>
+  ),
+}

--- a/src/components/ui/__stories__/Progress.stories.tsx
+++ b/src/components/ui/__stories__/Progress.stories.tsx
@@ -7,6 +7,7 @@ const meta = {
   title: "UI / Primitives / Progress",
   component: Progress,
   parameters: {
+    chromatic: { disableSnapshot: true },
     docs: {
       description: {
         component:

--- a/src/components/ui/__stories__/ScrollArea.stories.tsx
+++ b/src/components/ui/__stories__/ScrollArea.stories.tsx
@@ -1,0 +1,100 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import { ScrollArea, ScrollBar } from "../scroll-area"
+
+const meta = {
+  title: "UI / Primitives / ScrollArea",
+  component: ScrollArea,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Custom-styled scroll viewport built on Radix ScrollArea. Vertical scrollbar is wired by default; for horizontal scrolling, render an additional `ScrollBar orientation='horizontal'`.",
+      },
+    },
+  },
+} satisfies Meta<typeof ScrollArea>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+const NETWORKS = [
+  "Ethereum",
+  "Arbitrum One",
+  "Base",
+  "OP Mainnet",
+  "zkSync Era",
+  "Linea",
+  "Scroll",
+  "Polygon zkEVM",
+  "Mantle",
+  "Mode",
+  "Blast",
+  "Manta Pacific",
+  "Taiko",
+  "Zora",
+  "Fraxtal",
+  "Lisk",
+  "Cyber",
+  "Mint",
+  "Re.al",
+  "Redstone",
+]
+
+export const VerticalScroll: Story = {
+  render: () => (
+    <ScrollArea className="h-[200px] w-[280px] rounded-md border p-4">
+      <ul className="space-y-2 text-sm">
+        {NETWORKS.map((network) => (
+          <li key={network}>{network}</li>
+        ))}
+      </ul>
+    </ScrollArea>
+  ),
+}
+
+export const HorizontalScroll: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Render an explicit `ScrollBar orientation='horizontal'` and wrap content in a single-row flex container wider than the viewport.",
+      },
+    },
+  },
+  render: () => (
+    <ScrollArea className="w-[480px] rounded-md border whitespace-nowrap">
+      <div className="flex gap-4 p-4">
+        {NETWORKS.map((network) => (
+          <div
+            key={network}
+            className="shrink-0 rounded-md border bg-background-highlight px-4 py-2 text-sm"
+          >
+            {network}
+          </div>
+        ))}
+      </div>
+      <ScrollBar orientation="horizontal" />
+    </ScrollArea>
+  ),
+}
+
+export const ShortContent: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "When content fits the viewport, the scrollbar is not visible. Useful as a sanity check for the `overflow-hidden` framing.",
+      },
+    },
+  },
+  render: () => (
+    <ScrollArea className="h-[200px] w-[280px] rounded-md border p-4">
+      <p className="text-sm">
+        Short content does not trigger the scrollbar. The viewport keeps its
+        rounded corners thanks to `rounded-[inherit]` on the inner viewport.
+      </p>
+    </ScrollArea>
+  ),
+}

--- a/src/components/ui/__stories__/ScrollArea.stories.tsx
+++ b/src/components/ui/__stories__/ScrollArea.stories.tsx
@@ -6,6 +6,7 @@ const meta = {
   title: "UI / Primitives / ScrollArea",
   component: ScrollArea,
   parameters: {
+    chromatic: { disableSnapshot: true },
     docs: {
       description: {
         component:

--- a/src/components/ui/__stories__/Skeleton.stories.tsx
+++ b/src/components/ui/__stories__/Skeleton.stories.tsx
@@ -1,0 +1,109 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import { VStack } from "../flex"
+import {
+  Skeleton,
+  SkeletonCard,
+  SkeletonCardContent,
+  SkeletonCardGrid,
+  SkeletonLines,
+} from "../skeleton"
+
+const meta = {
+  title: "UI / Skeleton",
+  component: Skeleton,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Loading placeholders. Use `Skeleton` for arbitrary-shape blocks, `SkeletonLines` for paragraph-style stacks, and `SkeletonCard` / `SkeletonCardContent` / `SkeletonCardGrid` for card layouts.",
+      },
+    },
+  },
+} satisfies Meta<typeof Skeleton>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Base `Skeleton` is a single block. Set width/height via Tailwind classes (`h-*`, `w-*`).",
+      },
+    },
+  },
+  render: () => (
+    <VStack className="w-[320px] gap-3">
+      <Skeleton className="h-6 w-full" />
+      <Skeleton className="h-4 w-2/3" />
+      <Skeleton className="size-12 rounded-full" />
+    </VStack>
+  ),
+}
+
+export const Lines: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`SkeletonLines` renders multiple `Skeleton` blocks at varying widths. Control with `noOfLines`.",
+      },
+    },
+  },
+  render: () => (
+    <div className="w-[480px]">
+      <SkeletonLines noOfLines={5} />
+    </div>
+  ),
+}
+
+export const CardContent: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`SkeletonCardContent` is the body half of a card placeholder, suitable when the consumer already provides the outer card frame.",
+      },
+    },
+  },
+  render: () => (
+    <div className="w-[320px] rounded-lg border">
+      <SkeletonCardContent />
+    </div>
+  ),
+}
+
+export const Card: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`SkeletonCard` is a full-card placeholder including a banner area and content lines.",
+      },
+    },
+  },
+  render: () => (
+    <div className="w-[320px]">
+      <SkeletonCard />
+    </div>
+  ),
+}
+
+export const CardGrid: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`SkeletonCardGrid` renders 1, 2, or 3 cards depending on viewport width (responsive).",
+      },
+    },
+  },
+  render: () => (
+    <div className="w-full max-w-[960px]">
+      <SkeletonCardGrid />
+    </div>
+  ),
+}

--- a/src/components/ui/__stories__/Skeleton.stories.tsx
+++ b/src/components/ui/__stories__/Skeleton.stories.tsx
@@ -13,6 +13,7 @@ const meta = {
   title: "UI / Skeleton",
   component: Skeleton,
   parameters: {
+    chromatic: { disableSnapshot: true },
     docs: {
       description: {
         component:

--- a/src/components/ui/__stories__/Spinner.stories.tsx
+++ b/src/components/ui/__stories__/Spinner.stories.tsx
@@ -7,6 +7,7 @@ const meta = {
   title: "UI / Spinner",
   component: Spinner,
   parameters: {
+    chromatic: { disableSnapshot: true },
     docs: {
       description: {
         component:

--- a/src/components/ui/__stories__/Spinner.stories.tsx
+++ b/src/components/ui/__stories__/Spinner.stories.tsx
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import { HStack, VStack } from "../flex"
+import { Spinner } from "../spinner"
+
+const meta = {
+  title: "UI / Spinner",
+  component: Spinner,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Indeterminate loading indicator. Renders a rotating `Loader2` icon sized at `1em`, so spinner size scales with the parent's `font-size`. Apply Tailwind `text-*` classes to size it. Pair with sibling text for a label.",
+      },
+    },
+  },
+} satisfies Meta<typeof Spinner>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: () => <Spinner className="text-2xl" />,
+}
+
+export const Sizes: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Size scales with `font-size`. Use Tailwind text-size utilities on the spinner element.",
+      },
+    },
+  },
+  render: () => (
+    <HStack className="items-center gap-6">
+      <Spinner className="text-sm" />
+      <Spinner className="text-base" />
+      <Spinner className="text-xl" />
+      <Spinner className="text-2xl" />
+      <Spinner className="text-4xl" />
+    </HStack>
+  ),
+}
+
+export const WithLabel: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Spinner has no built-in label. Pair with sibling text and announce via aria-live for accessibility.",
+      },
+    },
+  },
+  render: () => (
+    <VStack className="items-start gap-4">
+      <HStack className="items-center gap-2">
+        <Spinner className="text-base" />
+        <span className="text-sm">Loading...</span>
+      </HStack>
+      <HStack className="items-center gap-2" aria-live="polite">
+        <Spinner className="text-base" />
+        <span className="text-sm">Fetching layer 2 networks</span>
+      </HStack>
+    </VStack>
+  ),
+}
+
+export const InsideButton: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: "Place inline with button text to indicate a pending action.",
+      },
+    },
+  },
+  render: () => (
+    <button
+      type="button"
+      disabled
+      className="inline-flex items-center gap-2 rounded border bg-background-highlight px-4 py-2 text-sm"
+    >
+      <Spinner className="text-sm" />
+      Saving
+    </button>
+  ),
+}

--- a/src/components/ui/__stories__/Tabs.stories.tsx
+++ b/src/components/ui/__stories__/Tabs.stories.tsx
@@ -6,6 +6,7 @@ const meta = {
   title: "UI / Primitives / Tabs",
   component: Tabs,
   parameters: {
+    chromatic: { disableSnapshot: true },
     docs: {
       description: {
         component:

--- a/src/components/ui/__stories__/Tabs.stories.tsx
+++ b/src/components/ui/__stories__/Tabs.stories.tsx
@@ -1,0 +1,97 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "../tabs"
+
+const meta = {
+  title: "UI / Primitives / Tabs",
+  component: Tabs,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Tabbed navigation built on Radix Tabs. Wrap with `Tabs`, render labels in `TabsList` + `TabsTrigger`, and one `TabsContent` per tab keyed by `value`. Active state is driven by `value`/`defaultValue` on the root.",
+      },
+    },
+  },
+} satisfies Meta<typeof Tabs>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: () => (
+    <Tabs defaultValue="overview" className="w-[480px]">
+      <TabsList>
+        <TabsTrigger value="overview">Overview</TabsTrigger>
+        <TabsTrigger value="details">Details</TabsTrigger>
+        <TabsTrigger value="history">History</TabsTrigger>
+      </TabsList>
+      <TabsContent value="overview">
+        Overview content. Switch tabs to see other panels.
+      </TabsContent>
+      <TabsContent value="details">
+        Details content. Each tab has its own panel.
+      </TabsContent>
+      <TabsContent value="history">
+        History content. Panels are siblings keyed by `value`.
+      </TabsContent>
+    </Tabs>
+  ),
+}
+
+export const WithDisabledTab: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Mark a tab unavailable with `disabled`. Disabled triggers are skipped during keyboard navigation.",
+      },
+    },
+  },
+  render: () => (
+    <Tabs defaultValue="active" className="w-[480px]">
+      <TabsList>
+        <TabsTrigger value="active">Active</TabsTrigger>
+        <TabsTrigger value="archived">Archived</TabsTrigger>
+        <TabsTrigger value="deleted" disabled>
+          Deleted
+        </TabsTrigger>
+      </TabsList>
+      <TabsContent value="active">Showing active items.</TabsContent>
+      <TabsContent value="archived">Showing archived items.</TabsContent>
+      <TabsContent value="deleted">Deleted items are not shown.</TabsContent>
+    </Tabs>
+  ),
+}
+
+export const ManyPanels: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The tab list scrolls horizontally on overflow (`overflow-x-auto`).",
+      },
+    },
+  },
+  render: () => (
+    <Tabs defaultValue="ethereum" className="w-[640px]">
+      <TabsList>
+        <TabsTrigger value="ethereum">Ethereum</TabsTrigger>
+        <TabsTrigger value="arbitrum">Arbitrum</TabsTrigger>
+        <TabsTrigger value="base">Base</TabsTrigger>
+        <TabsTrigger value="op">OP Mainnet</TabsTrigger>
+        <TabsTrigger value="zksync">zkSync Era</TabsTrigger>
+        <TabsTrigger value="linea">Linea</TabsTrigger>
+        <TabsTrigger value="scroll">Scroll</TabsTrigger>
+      </TabsList>
+      <TabsContent value="ethereum">Ethereum mainnet.</TabsContent>
+      <TabsContent value="arbitrum">Arbitrum One details.</TabsContent>
+      <TabsContent value="base">Base details.</TabsContent>
+      <TabsContent value="op">OP Mainnet details.</TabsContent>
+      <TabsContent value="zksync">zkSync Era details.</TabsContent>
+      <TabsContent value="linea">Linea details.</TabsContent>
+      <TabsContent value="scroll">Scroll details.</TabsContent>
+    </Tabs>
+  ),
+}

--- a/src/components/ui/__stories__/TruncatedText.stories.tsx
+++ b/src/components/ui/__stories__/TruncatedText.stories.tsx
@@ -7,6 +7,7 @@ const meta = {
   title: "UI / TruncatedText",
   component: TruncatedText,
   parameters: {
+    chromatic: { disableSnapshot: true },
     docs: {
       description: {
         component:

--- a/src/components/ui/__stories__/TruncatedText.stories.tsx
+++ b/src/components/ui/__stories__/TruncatedText.stories.tsx
@@ -1,0 +1,100 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import { VStack } from "../flex"
+import TruncatedText from "../TruncatedText"
+
+const meta = {
+  title: "UI / TruncatedText",
+  component: TruncatedText,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Prose with a clamped line count and a Show more / Show less toggle. `maxLines` accepts 1-4 (the values supported by `LINE_CLAMP_CLASS_MAPPING`). The toggle button is always rendered; click to expand or collapse.",
+      },
+    },
+  },
+} satisfies Meta<typeof TruncatedText>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+const SHORT_TEXT =
+  "Ethereum is a decentralized, open-source blockchain featuring smart-contract functionality."
+
+const LONG_TEXT =
+  "Ethereum is a decentralized, open-source blockchain featuring smart-contract functionality. Ether is the native cryptocurrency of the platform. Among cryptocurrencies, ether is second only to bitcoin in market capitalization. Ethereum was conceived in 2013 by programmer Vitalik Buterin. Additional founders of Ethereum included Gavin Wood, Charles Hoskinson, Anthony Di Iorio, and Joseph Lubin. In 2014, development work began and was crowdfunded, and the network went live on 30 July 2015. Ethereum allows anyone to deploy permanent and immutable decentralized applications onto it, with which users can interact."
+
+export const Default: Story = {
+  args: { children: LONG_TEXT },
+  render: (args) => (
+    <div className="w-[480px]">
+      <TruncatedText {...args} />
+    </div>
+  ),
+}
+
+export const OneLine: Story = {
+  args: { children: LONG_TEXT, maxLines: 1 },
+  render: (args) => (
+    <div className="w-[480px]">
+      <TruncatedText {...args} />
+    </div>
+  ),
+}
+
+export const ThreeLines: Story = {
+  args: { children: LONG_TEXT, maxLines: 3 },
+  render: (args) => (
+    <div className="w-[480px]">
+      <TruncatedText {...args} />
+    </div>
+  ),
+}
+
+export const FourLines: Story = {
+  args: { children: LONG_TEXT, maxLines: 4 },
+  render: (args) => (
+    <div className="w-[480px]">
+      <TruncatedText {...args} />
+    </div>
+  ),
+}
+
+export const LineCounts: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "All four supported `maxLines` values side-by-side for visual comparison.",
+      },
+    },
+  },
+  render: () => (
+    <VStack className="w-[480px] gap-8">
+      {[1, 2, 3, 4].map((n) => (
+        <div key={n}>
+          <p className="mb-2 text-xs text-body-medium">maxLines = {n}</p>
+          <TruncatedText maxLines={n}>{LONG_TEXT}</TruncatedText>
+        </div>
+      ))}
+    </VStack>
+  ),
+}
+
+export const ShortText: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "When the content fits within `maxLines`, the prose is not clamped, but the toggle button is still rendered. Consumers may want to gate `TruncatedText` behind a length check.",
+      },
+    },
+  },
+  render: () => (
+    <div className="w-[480px]">
+      <TruncatedText>{SHORT_TEXT}</TruncatedText>
+    </div>
+  ),
+}


### PR DESCRIPTION
## Summary

Adds Storybook stories for the display primitives in `src/components/ui/`. This is PR 3 of 5 for #18121, scoped to display components. One commit per checkbox in the issue.

- **Tabs** — Default, WithDisabledTab, ManyPanels (overflow scroll). Title `UI / Primitives / Tabs`.
- **Skeleton** — Default block, Lines, CardContent, Card, CardGrid sub-components. Title `UI / Skeleton`.
- **Spinner** — Default, Sizes (em-scaled), WithLabel, InsideButton. Title `UI / Spinner`.
- **Progress** — Default, Colors (`disabled|primary`), Values (0/25/50/75/100), WithLabel. Title `UI / Primitives / Progress`.
- **Breadcrumb** — TwoLevel, ThreeLevel, WithCurrentPage, WithEllipsis. Title `UI / Primitives / Breadcrumb`.
- **ScrollArea** — VerticalScroll, HorizontalScroll (explicit `ScrollBar orientation`), ShortContent. Title `UI / Primitives / ScrollArea`.
- **List** — Unordered, Ordered, Nested (mixed), PlainList. Title `UI / List`.
- **Collapsible** — Closed, Open (`defaultOpen`), WithCustomTrigger (data-state icon swap), ListOfDetails. Title `UI / Primitives / Collapsible`.
- **TruncatedText** — Default, OneLine, ThreeLines, FourLines, LineCounts (all 4 side-by-side), ShortText edge case. Title `UI / TruncatedText`.
- **Chart** — BarUsage, LineUsage, AreaUsage (stacked), PieUsage, TooltipIndicators (`dot|line|dashed`), HiddenLabel. Title `UI / Chart`.

Title hierarchy follows the convention established in #18122 / #18123: `UI / Primitives / [Name]` for shadcn-regenerable primitives, `UI / [Name]` for app-canonical components with custom shapes.

## Notes for review

- `Spinner` has no built-in size prop; sizing is driven by `font-size`. Stories demonstrate scaling via Tailwind `text-*` utilities.
- `TruncatedText` uses client-side `useTranslation` for the Show more / Show less label; Storybook's preview wires `next-intl` so the toggle works without per-story setup.
- `Collapsible` `WithCustomTrigger` shows the canonical pattern for swapping chevrons via `group-data-[state=open]`.
- `ScrollArea` horizontal scrolling requires an explicit `ScrollBar orientation='horizontal'`; the default ScrollBar is vertical-only.
- `Breadcrumb` uses the project's i18n-aware `Link`; the storybook preview wires next-intl so links render without errors.
- `Chart` stories reference colors via `var(--color-<key>)` CSS variables generated from the `config` map — designers can recolor a chart by editing the config without touching the Recharts JSX.

## Test plan

- [ ] Eyeball each new story in Storybook (light + dark, locale toggle)
- [ ] a11y addon passes for each story
- [ ] Confirm `TruncatedText` toggle works with both Show more and Show less labels rendering

Refs: #18121