### PR TITLE
fix: wallet logo span, title alignment

### DIFF
--- a/src/components/FindWalletProductTable/WalletInfo.tsx
+++ b/src/components/FindWalletProductTable/WalletInfo.tsx
@@ -69,7 +69,7 @@ const WalletInfo = ({ wallet }: WalletInfoProps) => {
           <Image
             src={wallet.image}
             alt=""
-            className="size-6 self-center object-contain lg:row-span-full lg:size-14 lg:self-start"
+            className="size-6 self-center object-contain lg:row-span-2 lg:size-14 lg:self-start"
           />
 
           <p className="self-center text-xl font-bold lg:self-start">


### PR DESCRIPTION
## Description
- Updates `lg:row-span-full` to `lg:row-span-2` to explicitly span 2 rows for logo

<img width="494" height="284" alt="image" src="https://github.com/user-attachments/assets/6baffbce-d8c7-4440-adf2-809e4bf0ea5b" />


## Related Issue
<img width="390" height="299" alt="image" src="https://github.com/user-attachments/assets/18b16e15-94d2-4416-a40c-f5849c98ee6f" />
