### PR TITLE
hotfix(videos): clone frontmatter to prevent gray-matter cache pollution

### DIFF
--- a/src/lib/utils/videos.ts
+++ b/src/lib/utils/videos.ts
@@ -50,11 +50,14 @@ export async function getVideoData(
   const cached = videoDataCache.get(cacheKey)
   if (cached) return cached
 
-  // Always read English source for full metadata
+  // Always read English source for full metadata.
+  // gray-matter has a global content-keyed cache that returns a shallow copy
+  // (`data` shared by reference), so we spread to avoid mutating the cached
+  // object — otherwise overriding title/description below leaks across locales.
   const enPath = videoPath(slug, DEFAULT_LOCALE)
   const enRaw = await readFile(enPath, "utf-8")
   const enParsed = matter(enRaw)
-  const frontmatter = enParsed.data as VideoFrontmatter
+  const frontmatter = { ...enParsed.data } as VideoFrontmatter
 
   // gray-matter auto-converts YAML dates to Date objects; coerce back to string
   if ((frontmatter.uploadDate as unknown) instanceof Date) {


### PR DESCRIPTION
## Summary

Hotfix for the production `/videos/` gallery rendering all video titles and descriptions in Chinese (e.g. `区块链基础知识：可视化演示`) instead of English.

## Root cause

`gray-matter` keeps a process-wide content-keyed cache and returns a **shallow** copy on hit (`Object.assign({}, cached)` in `node_modules/gray-matter/index.js:39`). The parsed `data` object is shared by reference across every caller that parses the same English source file.

`getVideoData` in `src/lib/utils/videos.ts` reads the English source for every locale, then overrides `frontmatter.title` / `frontmatter.description` in place when a translated file is found. That mutation lands on gray-matter's cached `data` object. Whichever non-English locale was processed last during static generation left its translated strings sitting in the shared English-source cache, so the subsequently-rendered English `/videos/` page picked up those translated titles.

Reproduction:
```js
const a = matter(enRaw); a.data.title = 'MUTATED';
const b = matter(enRaw);
// b.data.title === 'MUTATED'  → cache aliasing confirmed
```

## Fix

Spread the parsed data into a fresh object before mutating, so the locale override stays local to this call and never touches gray-matter's cache.

```ts
const frontmatter = { ...enParsed.data } as VideoFrontmatter
```

Other gray-matter callers in the repo (`src/lib/utils/md.ts`, `src/data-layer/fetchers/fetchVideoThumbnails.ts`, JSON-LD pages) only read `data` and don't mutate it, so they're unaffected.

## Test plan

- [x] Reproduced gray-matter shallow-copy aliasing in isolation
- [x] Reproduced the cross-locale leak end-to-end via `tsx` against `getVideoData` (zh→ja→en sequence; English title preserved with the fix, polluted without)
- [x] Local `/videos/` renders English titles
- [x] `tsc --noEmit` and ESLint clean
- [x] Verify on deploy preview: English `/videos/` gallery renders English titles
- [x] Spot-check a non-English locale (e.g. `/zh/videos/`) still renders translated titles