### PR TITLE
fix: remove dead molochdao.com link that redirects to spam

### DIFF
--- a/public/content/community/get-involved/index.md
+++ b/public/content/community/get-involved/index.md
@@ -126,7 +126,6 @@ The Ethereum ecosystem is on a mission to fund public goods and impactful projec
 - [LexDAO](https://lexdao.org) [@lex_DAO](https://twitter.com/lex_DAO) - _Legal engineering_
 - [MetaCartel Ventures](https://metacartel.xyz) [@VENTURE_DAO](https://twitter.com/VENTURE_DAO) - _Venture for pre-seed crypto projects_
 - [MetaFactory](https://metafactory.ai) [@TheMetaFactory](https://twitter.com/TheMetaFactory) - _Digiphysical Apparel Brands_
-- [MolochDAO](https://molochdao.com) [@MolochDAO](https://twitter.com/MolochDAO) - _Community focused on funding Ethereum development_
 - [Raid Guild](https://raidguild.org) [@RaidGuild](https://twitter.com/RaidGuild) - _Collective of Web3 builders_
 
 Please remember to abide by the ethereum.org [code of conduct](/community/code-of-conduct) whenever and however you contribute to ethereum.org!

--- a/public/content/dao/index.md
+++ b/public/content/dao/index.md
@@ -114,10 +114,6 @@ Share-based DAOs are more permissioned, but still quite open. Any prospective me
 
 _Typically used for more closer-knit, human-centric organizations like charities, worker collectives, and investment clubs. Can also govern protocols and tokens as well._
 
-#### A famous example {#share-example}
-
-[MolochDAO](https://molochdao.com/) – MolochDAO is focused on funding Ethereum projects. They require a proposal for membership so the group can assess whether you have the necessary expertise and capital to make informed judgments about potential grantees. You can't just buy access to the DAO on the open market.
-
 ### Reputation-based membership {#reputation-based-membership}
 
 Reputation represents proof of participation and grants voting power in the DAO. Unlike token or share-based membership, reputation-based DAOs don't transfer ownership to contributors. Reputation cannot be bought, transferred or delegated; DAO members must earn reputation through participation. Onchain voting is permissionless and prospective members can freely submit proposals to join the DAO and request to receive reputation and tokens as a reward in exchange for their contributions.


### PR DESCRIPTION
Description :                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                             
 The molochdao.com domain appears to be abandoned and now redirects to casino spam. This removes the MolochDAO entry from the DAO examples on the /dao/ page and from the community organizations list on /community/get-involved/. The GitHub link to MolochDAO's testing guide in the smart contracts testing page is kept since it still works fine.                                                                                                                                                                                               
   
Related Issue:
- Closes #18149                                                                                                                                                                                                                                                                                                                                                       