### PR TITLE
hotfix: restore internal tutorials on /developers/tutorials/

### DIFF
--- a/src/lib/data/index.ts
+++ b/src/lib/data/index.ts
@@ -193,12 +193,6 @@ export const getTranslationGlossary = createCachedGetter(
   CACHE_REVALIDATE_DAY
 )
 
-export const getGitHubContributors = createCachedGetter(
-  dataLayer.getGitHubContributors,
-  ["github-contributors"],
-  CACHE_REVALIDATE_DAY
-)
-
 export const getVideoThumbnails = createCachedGetter(
   dataLayer.getVideoThumbnails,
   ["video-thumbnails"],

--- a/src/lib/utils/contributors.ts
+++ b/src/lib/utils/contributors.ts
@@ -13,7 +13,7 @@ import {
 import { getAppPageLastCommitDate } from "./gh"
 import { getLocaleTimestamp } from "./time"
 
-import { getGitHubContributors, getStaticGitHubContributors } from "@/lib/data"
+import { getStaticGitHubContributors } from "@/lib/data"
 
 /** Sort team members to the end, preserving relative order within each group. */
 const sortTeamToEnd = (contributors: FileContributor[]): FileContributor[] =>
@@ -54,7 +54,7 @@ export const getAppPageContributorInfo = async (
 ) => {
   // TODO: Incorporate Crowdin contributor information
 
-  const contributorsData = await getGitHubContributors()
+  const contributorsData = await getStaticGitHubContributors()
   const gitHubContributors = contributorsData?.appPages[pagePath] ?? []
 
   const uniqueGitHubContributors = gitHubContributors.filter(

--- a/tests/e2e/tutorials.spec.ts
+++ b/tests/e2e/tutorials.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "@playwright/test"
+
+import externalTutorials from "@/data/externalTutorials.json"
+import internalTutorialSlugs from "@/data/internalTutorials.json"
+
+const PAGE_URL = "/developers/tutorials/"
+
+test.describe("Tutorials Listing Page", () => {
+  test("lists both internal and external tutorials", async ({ page }) => {
+    await page.goto(PAGE_URL)
+
+    const internalSlug = internalTutorialSlugs[0]
+    await expect(
+      page.locator(`a[href*="/developers/tutorials/${internalSlug}"]`).first()
+    ).toBeVisible()
+
+    const externalUrl = externalTutorials.find((t) => t.lang === "en")!.url
+    await expect(page.locator(`a[href="${externalUrl}"]`).first()).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary

The internal tutorials list on https://ethereum.org/developers/tutorials/ is empty in production — the SSR HTML ships `\"internalTutorials\":[]`. Same on staging and dev.

### Root cause

1. `getTutorialsData` (`src/lib/utils/md.ts`) switched from dynamic `import()` to `fsp.readFile(public/content/...)` in #b8af05174d (Apr 1) to keep Turbopack from tracing 143k locale markdown files.
2. The tutorials page (`app/[locale]/developers/tutorials/page.tsx`) also calls `getAppPageContributorInfo`, which goes through `getGitHubContributors` — wrapped with `unstable_cache` + `revalidate: 1 day`. That **opts the page into ISR**.
3. After 24h, Netlify revalidates the page in its serverless function. `public/content/` is **not** in `netlify.toml` `[functions] included_files`, so `fsp.readFile` throws ENOENT for every tutorial slug. The `catch` block swallows it and returns `null` → filter strips them → empty array → silently cached for the next 24h.

This is the exact failure mode documented in `docs/solutions/integration-issues/netlify-isr-404-async-server-components.md`. The pre-Apr-1 dynamic `import()` baked markdown into webpack chunks, masking the ISR/`public/content` mismatch.

### Fix

Drop the revalidating `getGitHubContributors` wrapper and route `getAppPageContributorInfo` through `getStaticGitHubContributors` (no `revalidate`). Pages stay statically rendered with tutorial content baked in at build time. The upstream Trigger.dev job refreshes contributor data weekly, so daily revalidation was overhead anyway — contributors now refresh on deploy.

Cherry-picked from `d841f7a3c9` (originally on draft PR #18146).

E2E run: https://github.com/ethereum/ethereum-org-website/actions/runs/25671352238

## Test plan

- [x] Netlify deploy preview's `/developers/tutorials/` shows internal tutorials (the bug is invisible in `next dev` and `next start` — only the serverless re-render path exposes it)
- [x] View source on the preview confirms `\"internalTutorials\":[…]` is non-empty in the SSR payload
- [x] Contributors strip still renders on `/developers/tutorials/`, `/developers/`, `/apps/`, etc.