### PR TITLE
fix(netlify): include hub-route MD in the function bundle

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -259,6 +259,34 @@ module.exports = (phase) => {
           ".manifests",
         ],
       },
+      /**
+       * Re-include MD that hub/index routes enumerate at runtime. These pages
+       * read from `public/content/` and may be opted into ISR via other data
+       * getters; without per-route includes the global `public/content` exclude
+       * above leaves those reads empty inside the Netlify function.
+       *
+       * Keys match the normalized App Router route via picomatch with
+       * `contains: true`. Bracketed segments are picomatch character classes,
+       * so the `[locale]` brackets must be escaped to match literally.
+       */
+      outputFileTracingIncludes: {
+        "\\[locale\\]/developers/blog": [
+          "./public/content/developers/blog/**/*.md",
+          "./public/content/translations/*/developers/blog/**/*.md",
+        ],
+        "\\[locale\\]/developers/tutorials": [
+          "./public/content/developers/tutorials/**/*.md",
+          "./public/content/translations/*/developers/tutorials/**/*.md",
+        ],
+        "\\[locale\\]/videos": [
+          "./public/content/videos/**/*.md",
+          "./public/content/translations/*/videos/**/*.md",
+        ],
+        "\\[locale\\]/developers": [
+          "./public/content/developers/blog/**/*.md",
+          "./public/content/translations/*/developers/blog/**/*.md",
+        ],
+      },
     }
   }
 


### PR DESCRIPTION
## Summary

Hub/index routes (`/[locale]/developers`, `/[locale]/developers/blog`, `/[locale]/developers/tutorials`, `/[locale]/videos`) read frontmatter from `public/content/` at render time and may be opted into ISR via revalidating data getters (events, video thumbnails, contributors). The global `outputFileTracingExcludes` rule for `public/content` then leaves those reads empty inside the Netlify serverless function on ISR re-render — listings silently degrade to empty until the next deploy. This is the failure mode behind the empty blog/tutorials listings observed on preview deploys.

Add per-route `outputFileTracingIncludes` to re-pull the MD subset each hub reads (English + per-locale translations). Per-route includes win over the global exclude, so only the affected functions carry the extra MD.

Picomatch detail: keys are matched against the normalized App Router route via `picomatch({ contains: true })`. `[locale]` is a picomatch character class — the brackets must be escaped to match the literal segment.

> [!NOTE]
> This is a temporary patch. A more robust solution — likely a build-time frontmatter index that the bundler picks up naturally — is being considered as a follow-up.

## Test plan

Verified on the deploy preview after a manual `/api/revalidate` of all hub paths:

- [x] `/developers/blog/`, `/developers/tutorials/`, `/videos/`, `/developers/` — listings populated on prerendered locales (`en`, `es`)
- [x] Same paths under `/de/...` — listings populated on the non-prerendered function path
- [x] Post-revalidation function renders (`cache-status: "Netlify Durable"; fwd=uri-miss; stored`) produce populated listings instead of empty ones
- [x] No regression on catch-all MDX pages (`/developers/docs/intro-to-ethereum/`), blog post pages, or video slug pages