### PR TITLE
Fix horizontal page overflow from EdgeScrollContainer

### DIFF
--- a/src/components/ui/edge-scroll-container.tsx
+++ b/src/components/ui/edge-scroll-container.tsx
@@ -26,6 +26,9 @@ import { cn } from "@/lib/utils/cn"
 const wrapperClasses = cn(
   // Negative margin to extend to screen edges
   "-mx-[var(--edge-spacing)]",
+  // Contain the inner scroll area so it doesn't leak into page scroll
+  // width. `relative` is required for `clip` to work in Chromium.
+  "relative overflow-x-clip",
   // Mask fade at 2xl+
   "2xl:[mask-image:linear-gradient(to_right,transparent,white_var(--edge-mask-size),white_calc(100%-var(--edge-mask-size)),transparent)]"
 )

--- a/tests/e2e/horizontal-overflow.spec.ts
+++ b/tests/e2e/horizontal-overflow.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "@playwright/test"
+
+/**
+ * Regression test for https://github.com/ethereum/ethereum-org-website/issues/17777
+ *
+ * Pages that use EdgeScrollContainer must not leak horizontal overflow to the
+ * document scroll area. Asserting on both `scrollWidth` and an actual
+ * `scrollBy` is intentional: each catches a different class of regression
+ * (layout vs. containment).
+ */
+
+const pagesWithEdgeScroll = [
+  "/community/events/",
+  "/community/events/conferences/",
+  "/developers/",
+  "/developers/tools/",
+]
+
+test.describe("No horizontal page overflow", () => {
+  for (const url of pagesWithEdgeScroll) {
+    test(url, async ({ page }) => {
+      const response = await page.goto(url)
+      expect(response?.status(), `failed to load ${url}`).toBeLessThan(400)
+      await page.waitForLoadState("networkidle")
+
+      const measurements = await page.evaluate(() => {
+        window.scrollTo(0, 0)
+        window.scrollBy({ left: 5000, behavior: "instant" })
+        return {
+          scrollX: window.scrollX,
+          scrollWidth: document.documentElement.scrollWidth,
+          clientWidth: document.documentElement.clientWidth,
+        }
+      })
+
+      expect(measurements.scrollX).toBe(0)
+      expect(measurements.scrollWidth).toBeLessThanOrEqual(
+        measurements.clientWidth
+      )
+    })
+  }
+})


### PR DESCRIPTION
## Summary

- Fixes #17777: `/community/events` had ~2300px of horizontal page overflow on mobile (and other viewports).
- Root cause: the inner `overflow-x: auto` flex scroll area inside `EdgeScrollContainer` was leaking into the document's scroll width despite ancestors having `overflow: visible`. The 8-card hubs instance had enough internal scroll width to make the leak user-visible; smaller instances on `/developers/tools`, `/developers`, and `/community/events/conferences` stayed below the threshold but were similarly affected.
- Fix: add `relative overflow-x-clip` on the `EdgeScrollContainer` outer wrapper. `position: relative` is required — `overflow-x: clip` alone does not contain the leak in Chromium (it prevents `window.scrollTo` from moving but real wheel/touch scrolling still produces overflow).

## Test plan

- [x] Mobile (375px): `/community/events` no longer scrolls horizontally
- [x] `document.documentElement.scrollWidth === clientWidth` after load
- [x] Hubs cards still scroll horizontally inside the container
- [x] Card shadows / vertical padding still visible (no clipping of `overflow-y`)
- [x] No regression on `/developers/tools`, `/developers`, `/community/events/conferences`
- [x] Visual: deploy preview screenshot of hubs section looks correct