### PR TITLE
fix: use unique key for list items

### DIFF
--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -52,7 +52,7 @@ const Leaderboard = ({ content, limit = 100 }: LeaderboardProps) => {
           }
 
           return (
-            <ListItem className="mb-0" key={username}>
+            <ListItem className="mb-0" key={name + username + score}>
               <LinkBox
                 className="mb-1 flex w-full items-center justify-between p-4 shadow-table-item-box hover:rounded-lg hover:bg-background-highlight hover:no-underline hover:shadow-primary"
                 key={idx}


### PR DESCRIPTION
## Description
Expands `key` on /bug-bounty/page `Leaderboard` component to include name and score for uniqueness. Previous usage of `username` resulted in duplicates as a result of numerous entries having `""` for `username` value.

## Related Issue
```
[browser] Encountered two children with the same key, ``. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
```
