### PR TITLE
fix(qa): filter past hackathons and add site name to page titles

### DIFF
--- a/app/[locale]/developers/utils.tsx
+++ b/app/[locale]/developers/utils.tsx
@@ -103,9 +103,14 @@ export const getVideoCourses = async (): Promise<VideoCourse[]> => {
 export const getHackathons = async (): Promise<EventItem[]> => {
   const events = await getEventsData()
   if (!events) return []
-  return events.filter(
-    (e) =>
+  const now = new Date()
+  return events.filter((e) => {
+    const isHackathon =
       e.eventTypes?.includes("hackathon") ||
       e.tags?.some((tag) => tag.toLowerCase() === "hackathon")
-  )
+    if (!isHackathon) return false
+    // Guard against stale cached data showing past events
+    const cutoff = e.endTime ? new Date(e.endTime) : new Date(e.startTime)
+    return cutoff >= now
+  })
 }

--- a/src/intl/en/page-developers-index.json
+++ b/src/intl/en/page-developers-index.json
@@ -1,5 +1,5 @@
 {
-  "page-developer-meta-title": "Ethereum Developer Resources",
+  "page-developer-meta-title": "Ethereum Developer Resources | ethereum.org",
   "page-developers-account-desc": "Contracts or people on the network",
   "page-developers-accounts-link": "Accounts",
   "page-developers-api-desc": "Using libraries to interact with smart contracts",

--- a/src/intl/en/page-get-eth.json
+++ b/src/intl/en/page-get-eth.json
@@ -46,7 +46,7 @@
   "page-get-eth-hero-image-alt": "Get ETH hero image",
   "page-get-eth-keep-it-safe": "Keeping your ETH safe",
   "page-get-eth-meta-description": "Ways to get ETH: buy on an exchange, swap on a DEX, earn from DAOs, receive from peers, or earn staking rewards. Find the best option based on where you live.",
-  "page-get-eth-meta-title": "How to get Ethereum (ETH)",
+  "page-get-eth-meta-title": "How to get Ethereum (ETH) | ethereum.org",
   "page-get-eth-need-wallet": "You will need a wallet to use a DEX.",
   "page-get-eth-new-to-eth": "New to ETH? Here's an overview to get you started.",
   "page-get-eth-other-cryptos": "Buy with other crypto",

--- a/src/intl/en/page-layer-2.json
+++ b/src/intl/en/page-layer-2.json
@@ -10,7 +10,7 @@
   "page-layer-2-calloutCard-2-description": "Whether you are making a quick payment or engaging in decentralized finance (DeFi), all transactions take only a few seconds.",
   "page-layer-2-calloutCard-3-title": "Backed by Ethereum",
   "page-layer-2-calloutCard-3-description": "Ethereum's time-proven and decentralized blockchain functions as the settlement layer for other newer networks.",
-  "page-layer-2-meta-title": "Intro to Ethereum Layer 2: benefits and uses",
+  "page-layer-2-meta-title": "Intro to Ethereum Layer 2: benefits and uses | ethereum.org",
   "page-layer-2-meta-description": "Learn about Ethereum layer 2 networks: what they are, how they help improve the Ethereum experience, and where to get started exploring",
   "page-layer-2-powered-by-ethereum-title": "Powered by Ethereum",
   "page-layer-2-powered-by-ethereum-description-1": "<a href=\"/\">Ethereum</a> is no longer just a single network.",


### PR DESCRIPTION
## Summary
Fixes three issues found in the weekly automated QA review (2026-05-11).

### Changes
- **Past hackathons on /developers/**: `getHackathons()` now applies a runtime date guard so events past their end date are never shown, even if the cached event data is stale.
- **Missing \`| ethereum.org\` in page titles**: Added consistent site-name suffix to the meta titles for \`/developers/\`, \`/get-eth/\`, and \`/layer-2/\`, matching the pattern already used on the homepage and roadmap pages.

### Not included
The "roadmap for 2025" heading on \`/what-is-ethereum/\` is already fixed on \`dev\` (says 2026) — it just hasn't shipped to production yet.