### PR TITLE
fix: add navigation arrows to BuilderSwiper and VideoCourseSwiper

### DIFF
--- a/app/[locale]/developers/_components/BuilderSwiper/index.tsx
+++ b/app/[locale]/developers/_components/BuilderSwiper/index.tsx
@@ -1,6 +1,10 @@
 "use client"
 
-import { Swiper, SwiperSlide } from "@/components/ui/swiper"
+import {
+  Swiper,
+  SwiperNavigation,
+  SwiperSlide,
+} from "@/components/ui/swiper"
 
 import type { DevelopersPath } from "../../types"
 import BuilderCard from "../BuilderCard"
@@ -37,6 +41,7 @@ const BuilderSwiper = ({ paths, speedRunDetails }: BuilderSwiperProps) => {
       <SwiperSlide>
         <SpeedRunCard {...speedRunDetails} className="me-16" />
       </SwiperSlide>
+      <SwiperNavigation />
     </Swiper>
   )
 }

--- a/app/[locale]/developers/_components/VideoCourseSwiper/index.tsx
+++ b/app/[locale]/developers/_components/VideoCourseSwiper/index.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Swiper, SwiperSlide } from "@/components/ui/swiper"
+import { Swiper, SwiperNavigation, SwiperSlide } from "@/components/ui/swiper"
 
 import type { VideoCourse } from "../../types"
 import VideoCourseCard from "../VideoCourseCard"
@@ -19,6 +19,7 @@ const VideoCourseSwiper = ({ courses }: VideoCourseSwiperProps) => (
         <VideoCourseCard course={course} />
       </SwiperSlide>
     ))}
+    <SwiperNavigation />
   </Swiper>
 )
 


### PR DESCRIPTION
## Summary

Fixes #17945

Two carousels on the `/developers` page were missing the `<SwiperNavigation />` component, leaving users with no prev/next arrows to navigate slides.

### Root cause

Every other Swiper-based component in the codebase (`AdoptionSwiper`, `InnovationSwiper`, `WhySwiper`, `AppsSwiper`, `ScreenshotSwiper`, `TorchHistorySwiper`, `SavingsCarousel`) already includes `<SwiperNavigation />`. These two were the only ones missing it.

### Changes

- `app/[locale]/developers/_components/BuilderSwiper/index.tsx` — added `SwiperNavigation` import and `<SwiperNavigation />` as last child of `<Swiper>`
- `app/[locale]/developers/_components/VideoCourseSwiper/index.tsx` — same

No logic or layout changes — one line added to each file.