### PR TITLE
docs: add dweb3 and web3compass to decentralized storage references

### DIFF
--- a/public/content/developers/docs/storage/index.md
+++ b/public/content/developers/docs/storage/index.md
@@ -205,6 +205,15 @@ Proof-of-stake based:
 - [Documentation](https://docs.spheron.network/)
 - [GitHub](https://github.com/spheronFdn)
 
+**dweb3 - _Resolver for decentralized webpages, similar to eth.limo, supporting all types and not limited to ENS and IPFS._**
+
+- [dweb3.wtf](https://dweb3.wtf)
+
+**web3compass - _Search engine for IPFS + ENS backed decentralized websites._**
+
+- [web3compass.net](https://www.web3compass.net/)
+- [Documentation](https://www.web3compass.net/statistics)
+
 ## Further reading {#further-reading}
 
 - [What Is Decentralized Storage?](https://coinmarketcap.com/academy/article/what-is-decentralized-storage-a-deep-dive-by-filecoin) - _CoinMarketCap_

--- a/public/content/developers/tutorials/ipfs-decentralized-ui/index.md
+++ b/public/content/developers/tutorials/ipfs-decentralized-ui/index.md
@@ -67,9 +67,9 @@ You cannot reliably delete IPFS files, so as long as you're modifying your user 
 
 Additionally, some packages have a problem with IPFS, so if your web site is very complicated that may not be a good solution. And of course, anything that relies on server integration cannot be decentralized just by having the client side on IPFS.
 
-## Additionally {#additionally}
+## Discoverability via ENS {#discoverability}
 
-If the website created is also pointed by ENS name (like vitalik.eth) it will be considered as a fully decentralized webpage and will be automatically pinned by [dweb3.wtf](https://dweb3.wtf) service and be searchable through [web3compass.net](https://web3compass.net) search engine just like google does for web2.
+If you point an ENS name (like vitalik.eth) to your website, it will be considered a fully decentralized webpage and will be automatically pinned by the [dweb3.wtf](https://dweb3.wtf) service, as well as made searchable through the [web3compass.net](https://web3compass.net) search engine, much like DuckDuckGo, Brave Search or Google does for the traditional web.
 
 ## Conclusion {#conclusion}
 

--- a/public/content/developers/tutorials/ipfs-decentralized-ui/index.md
+++ b/public/content/developers/tutorials/ipfs-decentralized-ui/index.md
@@ -67,6 +67,10 @@ You cannot reliably delete IPFS files, so as long as you're modifying your user 
 
 Additionally, some packages have a problem with IPFS, so if your web site is very complicated that may not be a good solution. And of course, anything that relies on server integration cannot be decentralized just by having the client side on IPFS.
 
+## Additionally {#additionally}
+
+If the website created is also pointed by ENS name (like vitalik.eth) it will be considered as a fully decentralized webpage and will be automatically pinned by [dweb3.wtf](https://dweb3.wtf) service and be searchable through [web3compass.net](https://web3compass.net) search engine just like google does for web2.
+
 ## Conclusion {#conclusion}
 
 Just as Ethereum lets you decentralize the database and business logic aspects of your dapp, IPFS lets you decentralize the user interface. This lets you shut off one more attack vector against your dapp.


### PR DESCRIPTION
## Description
Two related additions covering IPFS/ENS website discoverability tooling:

1. `developers/docs/storage/`: adds dweb3 (decentralized webpage resolver)
   and web3compass (IPFS+ENS search engine) to the Related tools list.
2. `developers/tutorials/ipfs-decentralized-ui/`: adds a short note pointing
   readers to those tools for ENS-linked IPFS sites.

## Related Issue
N/A — additive content addition.