### PR TITLE
chore(design-system): shared layout Storybook stories (PR 5 of #18191)

### DIFF
--- a/src/components/Footer/Footer.stories.tsx
+++ b/src/components/Footer/Footer.stories.tsx
@@ -1,0 +1,37 @@
+import { Meta, StoryObj } from "@storybook/nextjs"
+
+import Footer from "."
+
+const meta = {
+  title: "Components / Layout / Footer",
+  component: Footer,
+  parameters: {
+    chromatic: { disableSnapshot: true },
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "Site footer rendered through `BaseLayout`. Async server component (`getTranslations`), so the linked labels come from the active locale. Surfaces five link-section columns, social icons, dipper links (privacy, terms, etc.), and the `GoToTopButton`. `lastDeployLocaleTimestamp` is a pre-formatted string -- the caller is responsible for locale-formatting before passing it in.",
+      },
+    },
+  },
+} satisfies Meta<typeof Footer>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    lastDeployLocaleTimestamp: "May 15, 2026, 9:42 AM",
+  },
+}
+
+export const MobileViewport: Story = {
+  args: {
+    lastDeployLocaleTimestamp: "May 15, 2026, 9:42 AM",
+  },
+  parameters: {
+    viewport: { defaultViewport: "mobile1" },
+  },
+}

--- a/src/components/Nav/Nav.stories.tsx
+++ b/src/components/Nav/Nav.stories.tsx
@@ -1,0 +1,30 @@
+import { Meta, StoryObj } from "@storybook/nextjs"
+
+import Nav from "."
+
+const meta = {
+  title: "Components / Layout / Nav",
+  component: Nav,
+  parameters: {
+    chromatic: { disableSnapshot: true },
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "Top-level site navigation wrapper rendered through `BaseLayout`. Composes the home-icon logo, the desktop nav (`DesktopNav`), the mobile nav (`MobileNav`), and the SEO `CrawlableNav`. Async server component -- async `getTranslations` is supported by Storybook's `experimentalRSC` flag. Sub-components are intentionally not storied separately; the top-level composition is the visual canon.",
+      },
+    },
+  },
+} satisfies Meta<typeof Nav>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const MobileViewport: Story = {
+  parameters: {
+    viewport: { defaultViewport: "mobile1" },
+  },
+}


### PR DESCRIPTION
## Summary

PR 5 of #18191. Adds Storybook stories for the two top-level layout components rendered site-wide via `BaseLayout`. Taken before PR 4 so the Callout/Banner work can wait on #18133 coordination.

Components covered:
- `Nav` (async server top-level wrapper) -- `Default` desktop story plus a `MobileViewport` story. Per the issue rubric, sub-components (`DesktopNav`, `MobileNav`, `MobileMenu`, `ThemeToggleButton`) stay un-storied since the top-level Nav composition is the visual canon.
- `Footer` (async server) -- `Default` plus `MobileViewport`. `GoToTopButton` is intentionally left without a standalone story per the issue's "optional if visual is non-trivial" guidance -- its visual is a labelled outline button, which the Footer story already exhibits in context.

Each story uses the `Components / Layout / <Name>` title pattern and opts out of Chromatic snapshots at the meta level per the #18121 convention. Both meta entries use `layout: "fullscreen"` so the bars render against the iframe edge.

Related to #18191. Does not close the issue.

## Test plan

- [ ] `pnpm storybook` -- both new entries appear under `Components / Layout / *` and render without console errors at desktop and `mobile1` viewports
- [ ] a11y addon panel is clean on each story
- [ ] Footer: `GoToTopButton` renders and labels correctly inside the Footer composition
- [ ] Nav: locale switch via storybook-next-intl re-renders the labels (English / German etc.) without breaking the layout

Claude (Opus 4.7) co-authored these changes.