### PR TITLE
fix: match Ethereum stablecoin entry by name (auto)

### DIFF
--- a/src/data-layer/fetchers/fetchEthereumStablecoinsMcap.ts
+++ b/src/data-layer/fetchers/fetchEthereumStablecoinsMcap.ts
@@ -6,10 +6,10 @@ export const FETCH_ETHEREUM_STABLECOINS_MCAP_TASK_ID =
   "fetch-ethereum-stablecoins-mcap"
 
 export type LlamaStablecoinchainsResponseItem = {
-  gecko_id: string | null
   totalCirculatingUSD: Record<string, number>
-  tokenSymbol: string | null
   name: string
+  gecko_id?: string | null
+  tokenSymbol?: string | null
 }
 
 /**
@@ -32,7 +32,7 @@ export async function fetchEthereumStablecoinsMcap(): Promise<MetricReturnData> 
 
   const data: LlamaStablecoinchainsResponseItem[] = await response.json()
 
-  const ethereumData = data.find(({ gecko_id }) => gecko_id === "ethereum")
+  const ethereumData = data.find(({ name }) => name === "Ethereum")
   if (!ethereumData) {
     throw new Error("Ethereum stablecoin data not found")
   }


### PR DESCRIPTION
## Summary

- The `fetch-ethereum-stablecoins-mcap` Trigger.dev task has been failing repeatedly (6 failed runs in 24h) with `Error: Ethereum stablecoin data not found`.
- Llama.fi's `/stablecoinchains` endpoint no longer returns the `gecko_id` field, so the lookup `data.find(({ gecko_id }) => gecko_id === "ethereum")` never matches.
- Switch the lookup to match on `name === "Ethereum"`, which is still present in the response (verified against the live API — exactly one matching entry).

## Error Context

- **Source:** trigger-dev
- **Item ID:** trigger-fetch-ethereum-stablecoins-mcap-ethereum-stablecoin-data-not-found
- **Task:** fetch-ethereum-stablecoins-mcap
- **Run ID:** run_cmp73vif86mwh0hlpqse2mzhm
- **Status:** FAILED (2 attempts)
- **Hit count:** 6 failed runs in last 24h
- **First seen:** 2026-05-15T16:02:20.981Z
- **Dashboard:** https://cloud.trigger.dev/projects/v3/proj_jnkvoplayqkrsnovqsdr/runs/run_cmp73vif86mwh0hlpqse2mzhm

## Changes

- `src/data-layer/fetchers/fetchEthereumStablecoinsMcap.ts`
  - Changed `data.find(({ gecko_id }) => gecko_id === "ethereum")` → `data.find(({ name }) => name === "Ethereum")`.
  - Marked `gecko_id` and `tokenSymbol` as optional in `LlamaStablecoinchainsResponseItem` since the upstream API no longer returns them.

## Analysis

A live request to `https://stablecoins.llama.fi/stablecoinchains` returns 198 items, each with only `totalCirculatingUSD` and `name` keys — `gecko_id` and `tokenSymbol` have been removed by Llama.fi. The Ethereum entry is present as `{ name: "Ethereum", totalCirculatingUSD: { peggedUSD: 163051852612.97598, ... } }`, so matching on `name` restores correct behaviour.

## Test Plan

- [x] Re-run the `fetch-ethereum-stablecoins-mcap` Trigger.dev task and confirm it succeeds with a non-zero `value`.
- [x] Confirm the metric still surfaces correctly downstream wherever `KEYS.ETHEREUM_STABLECOINS_MCAP` is consumed.

---
*Opened automatically by the Recovery Agent.*