### PR TITLE
Automate weekly release preparation

### DIFF
--- a/.claude/commands/review-release.md
+++ b/.claude/commands/review-release.md
@@ -1,20 +1,23 @@
 ---
 description: Review a release/deploy PR by checking key changes on staging with a browser
-allowed-tools: Bash, Read, Glob, Grep, Agent, Skill, AskUserQuestion
-argument-hints: [<pr-number> (auto-detects latest deploy PR)]
+allowed-tools: Bash, Read, Glob, Grep, Agent, Skill
+argument-hints: [<pr-number>] [--post-comment]
 ---
 
 # Review Release
 
 Review a release/deploy PR by fetching its description, identifying the most important changes, and verifying them on the staging deploy using the browser.
 
+This command NEVER approves or requests changes on the PR. By default it only prints the summary in the terminal. Pass `--post-comment` to additionally post the summary as a comment on the PR (informational, not a review).
+
 ## Arguments
 
-`$ARGUMENTS` may contain the PR number to review. If empty, auto-detect the latest deploy PR:
-
-```bash
-gh pr list -B master -H staging -s open -S "Deploy" --json number -q ".[0].number" -L 1
-```
+`$ARGUMENTS` may contain:
+- A PR number to review. If omitted, auto-detect the latest deploy PR:
+  ```bash
+  gh pr list -B master -H staging -s open -S "Deploy" --json number -q ".[0].number" -L 1
+  ```
+- `--post-comment` flag. If present, after producing the summary, post it as a PR comment via `gh pr comment`. Without this flag, the summary is only printed to the terminal.
 
 ## Workflow
 
@@ -57,24 +60,26 @@ Present a summary table with:
 |------|--------|-------|
 | Page name | Pass/Fail | What was checked and confirmed |
 
-Flag any issues found. If everything looks good, confirm the deploy is ready to ship.
+Flag any issues found. If everything looks good, note that the deploy looks ready to ship.
 
-### Step 5: Submit Review
+### Step 5: Optionally Post as PR Comment
 
-After presenting results, ask the user if they want to submit a review on the PR. Offer two options:
-
-1. **Approve** — if all checks passed
-2. **Request changes** — if issues were found
-
-Ask the user which action to take (or skip). If they choose to submit, post the summary table as the review body using:
+If `--post-comment` was passed in `$ARGUMENTS`, post the summary table as a PR comment:
 
 ```bash
-gh pr review <PR_NUMBER> --repo ethereum/ethereum-org-website --approve --body "..."
-# or
-gh pr review <PR_NUMBER> --repo ethereum/ethereum-org-website --request-changes --body "..."
+gh pr comment <PR_NUMBER> --repo ethereum/ethereum-org-website --body "$(cat <<'EOF'
+## /review-release summary
+
+<summary table here>
+
+_Informational only — this is not a PR review. Approval and merge remain manual._
+EOF
+)"
 ```
 
-Do NOT submit a review without explicit user confirmation.
+If `--post-comment` is NOT present, do nothing further — the terminal output is the only artifact.
+
+This command must NEVER call `gh pr review --approve` or `gh pr review --request-changes`. Approval and merge stay with humans.
 
 ## Tips
 

--- a/.github/actions/discord-notify/action.yml
+++ b/.github/actions/discord-notify/action.yml
@@ -1,0 +1,52 @@
+name: Discord notify
+description: Post or edit a Discord webhook message. Returns the message ID so downstream steps can keep updating the same message instead of spamming new ones.
+
+inputs:
+  webhook:
+    description: Discord webhook URL (pass an empty string to skip).
+    required: true
+  message:
+    description: Message content to post (or replace, if editing).
+    required: true
+  message_id:
+    description: If set, EDIT this message ID instead of creating a new one. If empty, a new message is created and its ID is returned.
+    required: false
+    default: ""
+
+outputs:
+  message_id:
+    description: ID of the created or edited message (empty if the webhook is missing or the request failed).
+    value: ${{ steps.notify.outputs.message_id }}
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      id: notify
+      env:
+        WEBHOOK: ${{ inputs.webhook }}
+        MSG: ${{ inputs.message }}
+        MESSAGE_ID: ${{ inputs.message_id }}
+      run: |
+        if [[ -z "$WEBHOOK" ]]; then
+          echo "No Discord webhook configured — skipping."
+          exit 0
+        fi
+        body=$(jq -nc --arg c "$MSG" '{content: $c}')
+        if [[ -n "$MESSAGE_ID" ]]; then
+          # Edit the existing message — Discord PATCH returns the updated object.
+          response=$(curl -fsSL -X PATCH -H 'Content-Type: application/json' \
+            -d "$body" "$WEBHOOK/messages/$MESSAGE_ID") || {
+            echo "::warning::Discord PATCH failed — message not updated."
+            exit 0
+          }
+        else
+          # Create new message — ?wait=true returns the message body so we can capture the ID.
+          response=$(curl -fsSL -X POST -H 'Content-Type: application/json' \
+            -d "$body" "${WEBHOOK}?wait=true") || {
+            echo "::warning::Discord POST failed — continuing."
+            exit 0
+          }
+        fi
+        id=$(echo "$response" | jq -r '.id // empty')
+        echo "message_id=$id" >> "$GITHUB_OUTPUT"

--- a/.github/actions/wait-for-pr-checks/action.yml
+++ b/.github/actions/wait-for-pr-checks/action.yml
@@ -1,0 +1,127 @@
+name: Wait for PR checks
+description: Poll a PR's status checks via gh CLI until they reach a terminal state. Always exits 0 — read `outputs.outcome` and decide downstream.
+
+inputs:
+  github_token:
+    description: Token used for gh CLI calls.
+    required: true
+  pr_number:
+    description: Pull request number to poll.
+    required: true
+  check_name:
+    description: Case-insensitive substring matching a single check (name or context). If omitted, watches ALL checks on the PR.
+    required: false
+    default: ""
+  required_checks:
+    description: Comma-separated case-insensitive substrings that MUST each appear in the rollup before success. Guards against false-success when expected checks never posted. Empty = no requirement.
+    required: false
+    default: ""
+  timeout_seconds:
+    description: Hard cap before giving up.
+    required: false
+    default: "1800"
+  poll_interval_seconds:
+    description: Sleep between polls.
+    required: false
+    default: "30"
+
+outputs:
+  outcome:
+    description: One of `success`, `failure`, or `timeout`.
+    value: ${{ steps.wait.outputs.outcome }}
+  failed_checks:
+    description: Comma-separated names of checks in a failed terminal state (empty unless outcome is `failure`).
+    value: ${{ steps.wait.outputs.failed_checks }}
+  missing_checks:
+    description: Comma-separated `required_checks` that never appeared in the rollup (set only when outcome is `timeout`).
+    value: ${{ steps.wait.outputs.missing_checks }}
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      id: wait
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        PR_NUMBER: ${{ inputs.pr_number }}
+        CHECK_NAME: ${{ inputs.check_name }}
+        REQUIRED_CHECKS: ${{ inputs.required_checks }}
+        TIMEOUT: ${{ inputs.timeout_seconds }}
+        INTERVAL: ${{ inputs.poll_interval_seconds }}
+      run: |
+        deadline=$(( $(date +%s) + TIMEOUT ))
+        while [[ $(date +%s) -lt $deadline ]]; do
+          if ! rollup=$(gh pr view "$PR_NUMBER" --json statusCheckRollup -q '.statusCheckRollup' 2>&1); then
+            echo "::warning::gh pr view failed (transient?) — retrying after ${INTERVAL}s: $rollup"
+            sleep "$INTERVAL"
+            continue
+          fi
+
+          if [[ -n "$CHECK_NAME" ]]; then
+            filtered=$(echo "$rollup" | jq --arg name "$CHECK_NAME" '
+              [.[] | select(
+                ((.name    // "") | test($name; "i")) or
+                ((.context // "") | test($name; "i"))
+              )]
+            ')
+          else
+            filtered="$rollup"
+          fi
+
+          counts=$(echo "$filtered" | jq -r '
+            (length) as $count
+            | ([.[] | select(
+                (.conclusion // .state) as $s
+                | $s == null or $s == "" or
+                  $s == "QUEUED" or $s == "IN_PROGRESS" or
+                  $s == "PENDING" or $s == "EXPECTED"
+              )] | length) as $pending
+            | ([.[] | select(
+                (.conclusion // .state) as $s
+                | $s == "FAILURE" or $s == "TIMED_OUT" or
+                  $s == "CANCELLED" or $s == "ERROR" or
+                  $s == "ACTION_REQUIRED"
+              ) | (.name // .context)] | join(",")) as $failed
+            | "\($count)\t\($pending)\t\($failed)"
+          ')
+          count=$(echo "$counts" | cut -f1)
+          pending=$(echo "$counts" | cut -f2)
+          failed=$(echo "$counts" | cut -f3)
+
+          if [[ -n "$failed" ]]; then
+            echo "outcome=failure" >> "$GITHUB_OUTPUT"
+            echo "failed_checks=$failed" >> "$GITHUB_OUTPUT"
+            echo "Failure detected on: $failed"
+            exit 0
+          fi
+
+          missing=""
+          if [[ -n "$REQUIRED_CHECKS" ]]; then
+            missing=$(echo "$rollup" | jq -r --arg req "$REQUIRED_CHECKS" '
+              ($req | split(",") | map(ascii_downcase | gsub("^\\s+|\\s+$"; ""))) as $needles
+              | [.[] | (.name // .context // "") | ascii_downcase] as $names
+              | [$needles[] | . as $n | select([$names[] | contains($n)] | any | not)]
+              | join(",")
+            ')
+          fi
+
+          if [[ "$count" -gt 0 && "$pending" -eq 0 && -z "$missing" ]]; then
+            echo "outcome=success" >> "$GITHUB_OUTPUT"
+            echo "All $count checks reached terminal-success."
+            exit 0
+          fi
+
+          if [[ -n "$missing" ]]; then
+            echo "Waiting — required checks not yet posted: $missing (sleeping ${INTERVAL}s)"
+          else
+            echo "Waiting — $pending of $count checks not terminal yet (sleeping ${INTERVAL}s)"
+          fi
+          sleep "$INTERVAL"
+        done
+        echo "outcome=timeout" >> "$GITHUB_OUTPUT"
+        if [[ -n "$missing" ]]; then
+          echo "missing_checks=$missing" >> "$GITHUB_OUTPUT"
+          echo "Timed out after ${TIMEOUT}s — required checks never posted: $missing"
+        else
+          echo "Timed out waiting after ${TIMEOUT}s."
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,33 +136,17 @@ jobs:
         run: npx playwright install --with-deps
 
       - name: Wait for Netlify deploy preview to be ready
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SHA: ${{ github.event.pull_request.head.sha }}
-          REPO: ${{ github.repository }}
-          CHECK_NAME: netlify/ethereumorg/deploy-preview
+        id: netlify_wait
+        uses: ./.github/actions/wait-for-pr-checks
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          pr_number: ${{ github.event.pull_request.number }}
+          check_name: netlify/ethereumorg/deploy-preview
+
+      - name: Fail if Netlify preview is not ready
+        if: steps.netlify_wait.outputs.outcome != 'success'
         run: |
-          for _ in $(seq 1 60); do
-            STATE=$(curl -sf -H "Authorization: Bearer $GH_TOKEN" \
-              -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/$REPO/commits/$SHA/statuses" \
-              | python3 -c "import json,sys,os; d=json.load(sys.stdin); m=next((s for s in d if s['context']==os.environ['CHECK_NAME']), None); print(m['state'] if m else '')")
-            case "$STATE" in
-              "success")
-                echo "Deploy preview ready for $SHA"
-                exit 0
-                ;;
-              "failure"|"error")
-                echo "Deploy preview failed: $STATE"
-                exit 1
-                ;;
-              *)
-                echo "Deploy preview state='${STATE:-not yet posted}' — waiting 30s"
-                sleep 30
-                ;;
-            esac
-          done
-          echo "Timed out waiting for deploy preview status"
+          echo "::error::Netlify deploy preview outcome: ${{ steps.netlify_wait.outputs.outcome }}"
           exit 1
 
       - name: Warm up Netlify edge cache

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -1,0 +1,232 @@
+name: Weekly Release
+
+on:
+  schedule:
+    # Thursday 14:00 UTC year-round (11:00 ART; US/EU offsets shift with DST).
+    - cron: "0 14 * * 4"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: weekly-release
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      # Use a bot token so the auto-created deploy PR triggers downstream
+      # pull_request workflows (GITHUB_TOKEN-authored PRs don't).
+      GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+    outputs:
+      skipped: ${{ steps.skip_check.outputs.skip }}
+      skip_reason: ${{ steps.skip_check.outputs.reason }}
+      pr_number: ${{ steps.capture_pr.outputs.number }}
+      pr_url: ${{ steps.capture_pr.outputs.url }}
+      version: ${{ steps.capture_pr.outputs.version }}
+      discord_message_id: ${{ steps.announce_prepared.outputs.message_id }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Skip — is an open deploy PR already there?
+        id: skip_check
+        run: |
+          existing=$(gh pr list -B master -H staging -s open -S "Deploy" --json number -q ".[0].number")
+          if [[ -n "$existing" && "$existing" != "null" ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "reason=Open deploy PR #$existing already exists — leaving it alone." >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Announce skip
+        if: steps.skip_check.outputs.skip == 'true'
+        uses: ./.github/actions/discord-notify
+        with:
+          webhook: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
+          message: ":pause_button: Weekly release skipped — ${{ steps.skip_check.outputs.reason }}  •  <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>"
+
+      - name: Setup pnpm + node
+        if: steps.skip_check.outputs.skip == 'false'
+        uses: ./.github/actions/setup-pnpm-node
+
+      - name: Run /prepare-release
+        if: steps.skip_check.outputs.skip == 'false'
+        uses: anthropics/claude-code-action@v1
+        timeout-minutes: 25
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: |
+            --allowedTools "Read,Write,Bash(git:*),Bash(gh:*),Bash(./src/scripts/prepare-release.sh:*),Bash(pnpm:*),Bash(node:*),Bash(jq:*),Bash(cat:*),Bash(mkdir:*),Bash(rm:*)"
+          prompt: |
+            Execute /prepare-release per the instructions in
+            .claude/commands/prepare-release.md.
+
+            Important modifications for the CI context:
+            - Do NOT use AskUserQuestion — this is fully automated.
+            - No version flag is provided — analyze the draft release and
+              pick a version type yourself (the skill's Step 2 "If no flag
+              provided" path). DO NOT prompt; just decide and log your
+              reasoning. Bias toward --minor for substantive weeks and
+              --patch for low-activity weeks; never pick --major without a
+              clear stack/framework change.
+            - On any error, print the error and exit non-zero so the workflow
+              fails and the team is notified.
+
+      - name: Capture PR number / URL / version
+        if: steps.skip_check.outputs.skip == 'false'
+        id: capture_pr
+        run: |
+          pr_json=$(gh pr list -B master -H staging -s open -S "Deploy" \
+            --json number,url,title -L 1 -q ".[0]")
+          if [[ -z "$pr_json" || "$pr_json" == "null" ]]; then
+            echo "No deploy PR was created by /prepare-release."
+            exit 1
+          fi
+          number=$(echo "$pr_json" | jq -r '.number')
+          url=$(echo "$pr_json"    | jq -r '.url')
+          # Title shape: "Release candidate vX.Y.Z" or "Deploy vX.Y.Z"
+          version=$(echo "$pr_json" | jq -r '.title' | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+          echo "url=$url"       >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Announce prepared
+        id: announce_prepared
+        if: steps.skip_check.outputs.skip == 'false'
+        uses: ./.github/actions/discord-notify
+        with:
+          webhook: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
+          message: |
+            :rocket: **Weekly release prepared: ${{ steps.capture_pr.outputs.version }}**  •  ${{ steps.capture_pr.outputs.url }}
+            Waiting for preview deploy + CI before review…
+
+      - name: Announce prepare failure
+        if: failure()
+        uses: ./.github/actions/discord-notify
+        with:
+          webhook: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
+          message: |
+            :rotating_light: **Weekly release failed during `prepare`**  •  <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>
+            No deploy PR was created. Needs a human to look.
+
+  wait_and_review:
+    needs: prepare
+    if: needs.prepare.outputs.skipped == 'false'
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      # Checkout is needed so the claude-code-action below can read
+      # .claude/commands/review-release.md and so this job can use the
+      # ./.github/actions/discord-notify composite. Don't remove.
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Wait for all required checks
+        id: wait
+        uses: ./.github/actions/wait-for-pr-checks
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          pr_number: ${{ needs.prepare.outputs.pr_number }}
+          required_checks: "Build website,Lint,netlify/ethereumorg/deploy-preview"
+          timeout_seconds: "3600"
+          poll_interval_seconds: "120"
+
+      - name: Announce CI failure
+        if: steps.wait.outputs.outcome == 'failure'
+        uses: ./.github/actions/discord-notify
+        with:
+          webhook: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
+          message_id: ${{ needs.prepare.outputs.discord_message_id }}
+          message: |
+            :x: **Release ${{ needs.prepare.outputs.version }} — CI failed on: ${{ steps.wait.outputs.failed_checks }}**  •  ${{ needs.prepare.outputs.pr_url }}
+            Needs a human to look. Skipping automated review.
+
+      - name: Announce timeout
+        if: steps.wait.outputs.outcome == 'timeout'
+        uses: ./.github/actions/discord-notify
+        with:
+          webhook: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
+          message_id: ${{ needs.prepare.outputs.discord_message_id }}
+          message: |
+            :hourglass: **Release ${{ needs.prepare.outputs.version }} — checks still not finished after 60min**  •  ${{ needs.prepare.outputs.pr_url }}
+            ${{ steps.wait.outputs.missing_checks && format('Required checks never posted: `{0}`', steps.wait.outputs.missing_checks) || '' }}
+            Handing off to a human. Skipping automated review.
+
+      - name: Run /review-release
+        if: steps.wait.outputs.outcome == 'success'
+        uses: anthropics/claude-code-action@v1
+        timeout-minutes: 20
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: |
+            --allowedTools "Read,Glob,Grep,Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr comment:*),Bash(curl:*),Skill"
+          prompt: |
+            Execute /review-release for PR #${{ needs.prepare.outputs.pr_number }}
+            with the --post-comment flag, per .claude/commands/review-release.md.
+
+            Arguments: ${{ needs.prepare.outputs.pr_number }} --post-comment
+
+            CI context rules:
+            - Do NOT prompt with AskUserQuestion — fully automated.
+            - NEVER call `gh pr review --approve` or `--request-changes`. The
+              skill already forbids this; do not work around it.
+            - When done, write the markdown summary table to
+              /tmp/review-summary.md so the next workflow step can read it.
+
+      - name: Read review summary
+        if: steps.wait.outputs.outcome == 'success'
+        id: summary
+        run: |
+          if [[ -f /tmp/review-summary.md ]]; then
+            summary=$(head -n 30 /tmp/review-summary.md | head -c 1200)
+          else
+            summary="(no summary captured)"
+          fi
+          delim="EOF_$(uuidgen)"
+          {
+            echo "text<<$delim"
+            echo "$summary"
+            echo "$delim"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Announce ready for human
+        if: steps.wait.outputs.outcome == 'success'
+        uses: ./.github/actions/discord-notify
+        with:
+          webhook: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
+          message_id: ${{ needs.prepare.outputs.discord_message_id }}
+          message: |
+            :white_check_mark: **Release ${{ needs.prepare.outputs.version }} reviewed — ready for human approval + merge**  •  ${{ needs.prepare.outputs.pr_url }}
+
+            ${{ steps.summary.outputs.text }}
+
+            Remaining manual steps: approve Chromatic, approve PR, merge.
+
+      - name: Announce wait-and-review failure
+        if: failure()
+        uses: ./.github/actions/discord-notify
+        with:
+          webhook: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
+          message_id: ${{ needs.prepare.outputs.discord_message_id }}
+          message: |
+            :rotating_light: **Weekly release failed during `wait_and_review`**  •  ${{ needs.prepare.outputs.pr_url }}
+            Run: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>
+            PR is open but automation couldn't finish reviewing it. Needs a human.


### PR DESCRIPTION
## Summary

- New `weekly-release.yml` workflow: Thursday cron + manual dispatch that runs `/prepare-release`, waits for CI, runs `/review-release --post-comment`, and posts status to Discord by editing one rolling message.
- New composite actions: `discord-notify` (create/edit webhook message) and `wait-for-pr-checks` (poll `statusCheckRollup` with transient retry).
- Refactored `ci.yml` to use `wait-for-pr-checks` instead of inline curl+python.
- `/review-release`: dropped auto-approve/request-changes paths; added opt-in `--post-comment` flag for posting the summary as a non-review PR comment.

## Test plan

- [ ] Trigger `weekly-release.yml` via `workflow_dispatch` on a test run and confirm Discord receives a single rolling status message (created, then edited as the job progresses).
- [ ] Verify `/prepare-release` step opens the deploy PR as expected.
- [ ] Verify `wait-for-pr-checks` correctly polls `statusCheckRollup` and tolerates transient API failures.
- [ ] Run `/review-release --post-comment` against a real deploy PR and confirm it posts a comment (not a review) and does not approve or request changes.
- [ ] Re-run `ci.yml` and confirm the refactored `wait-for-pr-checks` step behaves the same as the previous inline curl+python.