### PR TITLE
refactor(ui): Bug bounty elements alignment

### DIFF
--- a/app/[locale]/bug-bounty/page.tsx
+++ b/app/[locale]/bug-bounty/page.tsx
@@ -18,8 +18,7 @@ import Leaderboard from "@/components/Leaderboard"
 import MainArticle from "@/components/MainArticle"
 import { AccordionContainer } from "@/components/ui/accordion"
 import { ButtonLink } from "@/components/ui/buttons/Button"
-import { Divider } from "@/components/ui/divider"
-import { Center, Flex, VStack } from "@/components/ui/flex"
+import { Flex, Stack, VStack } from "@/components/ui/flex"
 import InlineLink from "@/components/ui/Link"
 import Link from "@/components/ui/Link"
 import { ListItem, UnorderedList } from "@/components/ui/list"
@@ -64,7 +63,7 @@ const Text = ({ className, ...props }: ComponentProps<"p">) => (
 )
 
 const FullLeaderboardContainer = (props: ChildOnlyProp) => (
-  <VStack className="mx-auto my-8 max-w-3xl px-8 py-0" {...props} />
+  <Stack className="w-full max-w-3xl" {...props} />
 )
 
 const ClientRow = (props: ChildOnlyProp) => (
@@ -727,48 +726,41 @@ export default async function Page(props: { params: Promise<Params> }) {
           </Content>
         </div>
         <Content>
-          <Row>
-            <div className="max-w-[100ch] flex-1">
-              <H2 id="submit-bug">{t("page-upgrades-bug-bounty-submit")}</H2>
-            </div>
-          </Row>
+          <H2 id="submit-bug">{t("page-upgrades-bug-bounty-submit")}</H2>
+          <BugBountyCards />
         </Content>
-        <BugBountyCards />
         <div
           id="leaderboard"
-          className="mt-8 w-full border-t bg-banner-grid-gradient px-0 py-16 shadow-table-item-box"
+          className={cn(
+            "flex w-full flex-col items-start justify-center lg:flex-row",
+            "mt-8 gap-x-16 gap-y-8 px-8 pt-20 pb-16",
+            "border-t bg-banner-grid-gradient shadow-table-item-box"
+          )}
         >
-          <Flex className="flex-col items-start justify-center lg:flex-row">
-            <FullLeaderboardContainer>
-              <H2 id="el-leaderboard" className="text-center">
-                {t("page-upgrades-bug-bounty-hunting-execution-leaderboard")}
-              </H2>
-              <Text>
-                {t(
-                  "page-upgrades-bug-bounty-hunting-execution-leaderboard-subtitle"
-                )}
-              </Text>
-              <Leaderboard content={executionBountyHunters} />
-            </FullLeaderboardContainer>
-            <FullLeaderboardContainer>
-              <H2 id="cl-leaderboard" className="text-center">
-                {t("page-upgrades-bug-bounty-hunting-leaderboard")}
-              </H2>
-              <Text>
-                {t("page-upgrades-bug-bounty-hunting-leaderboard-subtitle")}
-              </Text>
-              <Leaderboard content={consensusBountyHunters} />
-            </FullLeaderboardContainer>
-          </Flex>
-        </div>
-        <Divider />
-        <Content>
-          <Center>
-            <H2 id="faq" className="text-center">
-              {t("page-upgrades-question-title")}
+          <FullLeaderboardContainer>
+            <H2 id="el-leaderboard">
+              {t("page-upgrades-bug-bounty-hunting-execution-leaderboard")}
             </H2>
-          </Center>
-          <AccordionContainer className="mx-auto mt-16">
+            <Text>
+              {t(
+                "page-upgrades-bug-bounty-hunting-execution-leaderboard-subtitle"
+              )}
+            </Text>
+            <Leaderboard content={executionBountyHunters} />
+          </FullLeaderboardContainer>
+          <FullLeaderboardContainer>
+            <H2 id="cl-leaderboard">
+              {t("page-upgrades-bug-bounty-hunting-leaderboard")}
+            </H2>
+            <Text>
+              {t("page-upgrades-bug-bounty-hunting-leaderboard-subtitle")}
+            </Text>
+            <Leaderboard content={consensusBountyHunters} />
+          </FullLeaderboardContainer>
+        </div>
+        <div className="w-full space-y-16 px-8 py-4">
+          <H2 id="faq">{t("page-upgrades-question-title")}</H2>
+          <AccordionContainer>
             <ExpandableCard
               title={t("bug-bounty-faq-q2-title")}
               contentPreview={t("bug-bounty-faq-q2-contentPreview")}
@@ -818,11 +810,11 @@ export default async function Page(props: { params: Promise<Params> }) {
             </ExpandableCard>
           </AccordionContainer>
           <FileContributors
-            className="my-10 border-t"
+            className="border-t"
             contributors={contributors}
             lastEditLocaleTimestamp={lastEditLocaleTimestamp}
           />
-        </Content>
+        </div>
         <FeedbackCard />
       </MainArticle>
     </>

--- a/src/components/BugBountyCards.tsx
+++ b/src/components/BugBountyCards.tsx
@@ -1,13 +1,13 @@
 import { BaseHTMLAttributes } from "react"
+import { getTranslations } from "next-intl/server"
 
 import type { TranslationKey } from "@/lib/types"
 
 import { cn } from "@/lib/utils/cn"
 
 import { ButtonLink } from "./ui/buttons/Button"
+import { CardParagraph, CardTitle } from "./ui/card"
 import { Center } from "./ui/flex"
-
-import { useTranslation } from "@/hooks/useTranslation"
 
 type FlexProps = BaseHTMLAttributes<HTMLDivElement>
 
@@ -79,8 +79,8 @@ const bugBountyCardsInfo: BugBountyCardInfo[] = [
   },
 ]
 
-const BugBountyCards = () => {
-  const { t } = useTranslation("page-bug-bounty")
+const BugBountyCards = async () => {
+  const t = await getTranslations("page-bug-bounty")
 
   const Banner = ({ card }: { card: BugBountyCardInfo }) => {
     if (card.lowLabelTranslationId)
@@ -96,31 +96,28 @@ const BugBountyCards = () => {
     return <></>
   }
   return (
-    <div className="mx-4 grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4">
+    <div className="grid grid-cols-fill-4 gap-8">
       {bugBountyCardsInfo.map((card, idx) => (
         <div
           key={`bug-bounty-card-${idx}`}
           className={cn(
-            "row-span-6 m-4 grid grid-rows-subgrid",
             "overflow-hidden rounded border bg-background shadow-table-box",
             "hover:scale-[1.02] hover:rounded hover:bg-background-highlight hover:shadow-table-box-hover hover:transition-transform hover:duration-100"
           )}
         >
           <Banner card={card} />
 
-          <div className="row-span-5 grid grid-rows-subgrid gap-y-6 px-4 py-6">
-            <div className="space-y-2">
-              <h3 className="text-2xl/6 font-bold">
-                {t(card.h2TranslationId)}
-              </h3>
-              <p className="mb-6 text-xl opacity-60">
+          <div className="flex flex-col gap-y-8 p-4 md:p-6">
+            <div className="mb-8 space-y-2">
+              <CardTitle variant="bold">{t(card.h2TranslationId)}</CardTitle>
+              <CardParagraph variant="light" className="text-xl">
                 {t(card.descriptionTranslationId)}
-              </p>
+              </CardParagraph>
             </div>
 
-            <p className="mt-4 mb-2 text-sm uppercase opacity-60">
+            <CardParagraph size="sm" variant="light" className="uppercase">
               {t(card.subDescriptionTranslationId)}
-            </p>
+            </CardParagraph>
 
             <ButtonLink href="https://bbp-form.ethereum.org/">
               {t(card.styledButtonTranslationId)}


### PR DESCRIPTION
## Extends `expandablecard` branch, PR:
- #18214 (Would merge that first and allow re-targeting to dev)

## Description
- Simplifies layout logic of `BugBountyCards` to use full width approach, without centering, using existing card variant primitives for title and paragraphs.
- Converts `BugBountyCards` to server component given lack of state handling
-Update bug bounty contents to stay aligned to start consistent with site theming, removing centering (exception: client logos section)

## Related Issue
design system clean up

cc: @konopkja