### PR TITLE
fix: layer-2 secondary hero cta destination

### DIFF
--- a/app/[locale]/layer-2/page.tsx
+++ b/app/[locale]/layer-2/page.tsx
@@ -107,9 +107,9 @@ const Page = async (props: { params: Promise<PageParams> }) => {
       },
       {
         content: t("page-layer-2-hero-button-2-content"),
-        href: "#layer-2-powered-by-ethereum",
+        href: "/layer-2/learn",
         matomo: {
-          eventCategory: "l2_hub",
+          eventCategory: "l2_learn_page",
           eventAction: "button_click",
           eventName: "hero_get_started",
         },


### PR DESCRIPTION
## Description
Fix secondary hero CTA on /layer-2/ page to direct to /layer-2/learn/ page