### PR TITLE
bug-bounty: add EngineAPI as explicit out-of-scope item

### DIFF
--- a/app/[locale]/bug-bounty/page.tsx
+++ b/app/[locale]/bug-bounty/page.tsx
@@ -559,6 +559,10 @@ export default async function Page(props: { params: Promise<Params> }) {
                         key: "page-upgrades-bug-bounty-not-included-li-9",
                         footnote: false,
                       },
+                      {
+                        key: "page-upgrades-bug-bounty-not-included-li-10",
+                        footnote: false,
+                      },
                     ] as const
                   ).map(({ key, footnote }) => (
                     <li key={key} className="flex items-start gap-3 text-sm">

--- a/app/[locale]/bug-bounty/page.tsx
+++ b/app/[locale]/bug-bounty/page.tsx
@@ -540,6 +540,10 @@ export default async function Page(props: { params: Promise<Params> }) {
                         footnote: false,
                       },
                       {
+                        key: "page-upgrades-bug-bounty-not-included-li-10",
+                        footnote: false,
+                      },
+                      {
                         key: "page-upgrades-bug-bounty-not-included-li-5",
                         footnote: false,
                       },
@@ -557,10 +561,6 @@ export default async function Page(props: { params: Promise<Params> }) {
                       },
                       {
                         key: "page-upgrades-bug-bounty-not-included-li-9",
-                        footnote: false,
-                      },
-                      {
-                        key: "page-upgrades-bug-bounty-not-included-li-10",
                         footnote: false,
                       },
                     ] as const

--- a/src/intl/en/page-bug-bounty.json
+++ b/src/intl/en/page-bug-bounty.json
@@ -151,9 +151,10 @@
   "page-upgrades-bug-bounty-not-included-li-2": "ERC-20 contract bugs",
   "page-upgrades-bug-bounty-not-included-li-3": "Ethereum Naming Service (ENS) bugs (maintained by the ENS foundation)",
   "page-upgrades-bug-bounty-not-included-li-4": "Vulnerabilities requiring the user to have publicly exposed an API, such as JSON-RPC or the Beacon API",
-  "page-upgrades-bug-bounty-not-included-li-5": "Typographical errors",
-  "page-upgrades-bug-bounty-not-included-li-6": "Tests",
-  "page-upgrades-bug-bounty-not-included-li-7": "High-effort (sustained, CPU or bandwidth intensive, and/or requires more than 1 packet or onchain transaction) single-peer DoS attacks",
-  "page-upgrades-bug-bounty-not-included-li-8": "Any publicly known issues (includes forum posts, PRs, github issues, commits, blog posts, public discord messages, etc.)",
-  "page-upgrades-bug-bounty-not-included-li-9": "Anything that does not currently have a direct impact on Ethereum mainnet."
+  "page-upgrades-bug-bounty-not-included-li-5": "EngineAPI is considered trusted and not meant to be publicly exposed",
+  "page-upgrades-bug-bounty-not-included-li-6": "Typographical errors",
+  "page-upgrades-bug-bounty-not-included-li-7": "Tests",
+  "page-upgrades-bug-bounty-not-included-li-8": "High-effort (sustained, CPU or bandwidth intensive, and/or requires more than 1 packet or onchain transaction) single-peer DoS attacks",
+  "page-upgrades-bug-bounty-not-included-li-9": "Any publicly known issues (includes forum posts, PRs, github issues, commits, blog posts, public discord messages, etc.)",
+  "page-upgrades-bug-bounty-not-included-li-10": "Anything that does not currently have a direct impact on Ethereum mainnet."
 }

--- a/src/intl/en/page-bug-bounty.json
+++ b/src/intl/en/page-bug-bounty.json
@@ -151,10 +151,10 @@
   "page-upgrades-bug-bounty-not-included-li-2": "ERC-20 contract bugs",
   "page-upgrades-bug-bounty-not-included-li-3": "Ethereum Naming Service (ENS) bugs (maintained by the ENS foundation)",
   "page-upgrades-bug-bounty-not-included-li-4": "Vulnerabilities requiring the user to have publicly exposed an API, such as JSON-RPC or the Beacon API",
-  "page-upgrades-bug-bounty-not-included-li-5": "EngineAPI is considered trusted and not meant to be publicly exposed",
-  "page-upgrades-bug-bounty-not-included-li-6": "Typographical errors",
-  "page-upgrades-bug-bounty-not-included-li-7": "Tests",
-  "page-upgrades-bug-bounty-not-included-li-8": "High-effort (sustained, CPU or bandwidth intensive, and/or requires more than 1 packet or onchain transaction) single-peer DoS attacks",
-  "page-upgrades-bug-bounty-not-included-li-9": "Any publicly known issues (includes forum posts, PRs, github issues, commits, blog posts, public discord messages, etc.)",
-  "page-upgrades-bug-bounty-not-included-li-10": "Anything that does not currently have a direct impact on Ethereum mainnet."
+  "page-upgrades-bug-bounty-not-included-li-5": "Typographical errors",
+  "page-upgrades-bug-bounty-not-included-li-6": "Tests",
+  "page-upgrades-bug-bounty-not-included-li-7": "High-effort (sustained, CPU or bandwidth intensive, and/or requires more than 1 packet or onchain transaction) single-peer DoS attacks",
+  "page-upgrades-bug-bounty-not-included-li-8": "Any publicly known issues (includes forum posts, PRs, github issues, commits, blog posts, public discord messages, etc.)",
+  "page-upgrades-bug-bounty-not-included-li-9": "Anything that does not currently have a direct impact on Ethereum mainnet.",
+  "page-upgrades-bug-bounty-not-included-li-10": "EngineAPI is considered trusted and not meant to be publicly exposed"
 }


### PR DESCRIPTION
Added EngineAPI as out-of-scope as it's considered to be trusted, right after the line already mentioning other stuff like API / JSON-RPC.