### PR TITLE
fix: untrack next-env.d.ts and generate via next typegen

### DIFF
--- a/.claude/skills/design-system/references/new-component-checklist.md
+++ b/.claude/skills/design-system/references/new-component-checklist.md
@@ -225,6 +225,6 @@ Title hierarchy:
 - [ ] No commented-out code
 - [ ] No `console.log` debug statements
 - [ ] No TODO comments without an owner / issue link
-- [ ] Type errors clean (`npx tsc --noEmit`)
+- [ ] Type errors clean (`pnpm type-check`)
 - [ ] Lint clean (`pnpm lint`)
 - [ ] Format clean (`pnpm format`)

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ pnpm-lock.yaml.bak
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts
 
 # rss feeds
 feed.xml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,7 +194,7 @@ This project enforces type-safe chain names via TypeScript. When working with la
 
 1. **Always look up exact names** - Before adding `chainName` or `supported_chains`, search `chains.ts` for the exact `name` value
 2. **Names are case-sensitive and exact** - e.g., use `"Zircuit Mainnet"` not `"Zircuit"`, use `"OP Mainnet"` not `"Optimism"`
-3. **Run type checking** - Use `npx tsc --noEmit` to verify chain names are valid before committing
+3. **Run type checking** - Use `pnpm type-check` to verify chain names are valid before committing
 4. **Non-EVM chains** - For Starknet and other non-EVM chains, use `NonEVMChainName` type
 
 **Common Mistakes:**

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts"
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "next start",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "type-check": "tsc --noEmit",
+    "type-check": "next typegen && tsc --noEmit",
     "format": "prettier \"**/*.{js,jsx,ts,tsx}\" --write",
     "preversion": "bash ./src/scripts/updatePublishDate.sh",
     "storybook": "storybook dev -p 6006",


### PR DESCRIPTION
`next-env.d.ts` has shown up dirty after every `dev`/`build` since #18139. Next 16 writes a different path in dev vs build (`.next/dev/types/...` vs `.next/types/...` — [vercel/next.js#85738](https://github.com/vercel/next.js/issues/85738)), so no committed version is stable. [Official guidance](https://nextjs.org/docs/app/api-reference/config/typescript#next-envdts) is to gitignore it.

- Re-add `next-env.d.ts` to `.gitignore` (reverts that piece of #18139).
- `pnpm type-check` → `next typegen && tsc --noEmit`. `next typegen` (Next 15.5+) regenerates the file in ~600ms with no full build.