### PR TITLE
Add NodeFlare to nodes-as-a-service providers

### DIFF
--- a/public/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
+++ b/public/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
@@ -271,6 +271,15 @@ Here is a list of some of the most popular Ethereum node providers, feel free to
     - Multi-chain support
     - Get started for free
 
+- [**NodeFlare**](https://nodeflare.app/)
+  - [Docs](https://nodeflare.app/docs/quick-start)
+  - Features
+    - 8 EVM chains: Ethereum, Base, BNB Chain, Arbitrum One, Optimism, Avalanche, Viction, HyperEVM
+    - 4 regions (Europe, Asia, North America) with automatic failover to nearest healthy node
+    - Free public endpoint (no API key) + free plan with 3M compute units/month
+    - Compute Unit billing — pay only for what you use, heavier calls cost more
+    - No throttling on paid plans
+
 - [**NOWNodes**](https://nownodes.io/)
   - Features
     - Access to 50+ blockchain nodes

--- a/public/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
+++ b/public/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
@@ -274,7 +274,7 @@ Here is a list of some of the most popular Ethereum node providers, feel free to
 - [**NodeFlare**](https://nodeflare.app/)
   - [Docs](https://nodeflare.app/docs/quick-start)
   - Features
-    - 8 EVM chains: Ethereum, Base, BNB Chain, Arbitrum One, Optimism, Avalanche, Viction, HyperEVM
+    - 8 EVM chains including Ethereum, Base, Arbitrum One, and Optimism
     - 4 regions (Europe, Asia, North America) with automatic failover to nearest healthy node
     - Free public endpoint (no API key) + free plan with 3M compute units/month
     - Compute Unit billing — pay only for what you use, heavier calls cost more


### PR DESCRIPTION
## What does this PR add?

Adds [NodeFlare](https://nodeflare.app) to the "Popular node services" section of the nodes-as-a-service documentation page.

NodeFlare is a multi-region EVM RPC provider supporting 8 chains (Ethereum, Base, BNB Chain, Arbitrum One, Optimism, Avalanche, Viction, HyperEVM) with nodes across 4 regions (Europe, Asia, North America) and automatic failover to the nearest healthy node.

**Free tier:** 3M compute units/month, no credit card required.  
**Public endpoint:** `https://rpc.nodeflare.app/eth/public` (no API key, rate-limited to 3 req/s).

## Checklist

- [x] Added in alphabetical order (between NodeReal MegaNode and NOWNodes)
- [x] Format matches existing entries
- [x] Links verified and working