### PR TITLE
fix(seo): normalize locale codes to BCP 47 for lang and hreflang attributes

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -10,6 +10,7 @@ import Matomo from "@/components/Matomo"
 
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
 import { getLocaleTimestamp } from "@/lib/utils/time"
+import { toLanguageTag } from "@/lib/utils/url"
 
 import Providers from "./providers"
 
@@ -66,7 +67,7 @@ export default async function LocaleLayout(props: {
 
   return (
     <html
-      lang={locale}
+      lang={toLanguageTag(locale)}
       className={`${inter.variable} ${ibmPlexMono.variable}`}
       suppressHydrationWarning
     >

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from "next"
 
-import { getFullUrl } from "@/lib/utils/url"
+import { getFullUrl, toLanguageTag } from "@/lib/utils/url"
 
 import { DEFAULT_LOCALE } from "@/lib/constants"
 
@@ -21,7 +21,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
               "x-default": getFullUrl(DEFAULT_LOCALE, normalizedSlug),
               ...Object.fromEntries(
                 translatedLocales.map((locale) => [
-                  locale,
+                  toLanguageTag(locale),
                   getFullUrl(locale, normalizedSlug),
                 ])
               ),

--- a/src/lib/utils/metadata.ts
+++ b/src/lib/utils/metadata.ts
@@ -9,7 +9,7 @@ import {
 
 import { getTranslatedLocales } from "../i18n/translationRegistry"
 
-import { getFullUrl } from "./url"
+import { getFullUrl, toLanguageTag } from "./url"
 
 import { routing } from "@/i18n/routing"
 
@@ -103,7 +103,10 @@ export const getMetadata = async ({
         languages: {
           "x-default": xDefault,
           ...Object.fromEntries(
-            localesForHreflang.map((loc) => [loc, getFullUrl(loc, slugString)])
+            localesForHreflang.map((loc) => [
+              toLanguageTag(loc),
+              getFullUrl(loc, slugString),
+            ])
           ),
         },
       }),

--- a/src/lib/utils/url.ts
+++ b/src/lib/utils/url.ts
@@ -115,6 +115,18 @@ export const slugify = (text: string): string => {
   )
 }
 
+/**
+ * Converts an internal locale code to a valid BCP 47 language tag.
+ * Internal codes use lowercase region subtags (e.g. "pt-br", "zh-tw")
+ * for use as URL path segments, but HTML lang and hreflang attributes
+ * require uppercase region subtags per BCP 47 (e.g. "pt-BR", "zh-TW").
+ */
+export const toLanguageTag = (locale: string): string => {
+  const parts = locale.split("-")
+  if (parts.length === 2) return `${parts[0]}-${parts[1].toUpperCase()}`
+  return locale
+}
+
 export const normalizeUrlForJsonLd = (
   locale: string | Lang | undefined,
   pathWithoutLocale: string


### PR DESCRIPTION
## Summary

- Adds `toLanguageTag()` utility in `src/lib/utils/url.ts` that converts internal locale codes to valid BCP 47 language tags (`pt-br` → `pt-BR`, `zh-tw` → `zh-TW`)
- Applies it to the HTML `<html lang>` attribute in `app/[locale]/layout.tsx`
- Applies it to hreflang language keys in `src/lib/utils/metadata.ts` and `app/sitemap.ts`

## Context

Identified via ahrefs weekly crawl (20 May 2026): 142 "HTML lang attribute invalid" errors.

Internal locale codes use lowercase region subtags (e.g. `pt-br`, `zh-tw`) as URL path segments — that is intentional and unchanged. But the same raw codes were being used as HTML `lang` attributes and hreflang language keys, which require BCP 47 format with uppercase region subtags (`pt-BR`, `zh-TW`). All other locales (single-segment like `en`, `fr`, `ar`) are unaffected.

## Test plan

- [x] Verify `<html lang="pt-BR">` and `<html lang="zh-TW">` are rendered on those locale pages
- [x] Verify hreflang tags in page `<head>` use `pt-BR` / `zh-TW` as language keys
- [x] Verify sitemap hreflang alternates use BCP 47 casing
- [x] Verify URL paths (`/pt-br/`, `/zh-tw/`) are unchanged