### PR TITLE
fix(weekly-release): grant id-token permission and require RELEASE_BOT_TOKEN

### DIFF
--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      # Use a bot token so the auto-created deploy PR triggers downstream
-      # pull_request workflows (GITHUB_TOKEN-authored PRs don't).
-      GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+      # Required: deploy PR must be authored by a bot token so downstream
+      # pull_request workflows fire.
+      GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
     outputs:
       skipped: ${{ steps.skip_check.outputs.skip }}
       skip_reason: ${{ steps.skip_check.outputs.reason }}
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_BOT_TOKEN }}
 
       - name: Configure git identity
         run: |

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 concurrency:
   group: weekly-release


### PR DESCRIPTION
## Summary

Two fixes to `weekly-release.yml` after the first manual test run on `dev` ([run 26290559253](https://github.com/ethereum/ethereum-org-website/actions/runs/26290559253)) failed:

- **Grant `id-token: write`** at the workflow level. `anthropics/claude-code-action@v1` authenticates with Anthropic via GitHub OIDC and the failed run logged `Could not fetch an OIDC token. Did you remember to add 'id-token: write' to your workflow permissions?`
- **Drop the `secrets.GITHUB_TOKEN` fallback** for `RELEASE_BOT_TOKEN`. The fallback looked safe but silently degraded: with `GITHUB_TOKEN` authoring the deploy PR, no `pull_request` workflows would fire on it (CI, Netlify preview), while Discord still reported success. Better to fail loudly if the bot token isn't set.

## Test plan

- [ ] Confirm `RELEASE_BOT_TOKEN` is set in repo secrets (currently a PAT scoped to `ethereum/ethereum-org-website` with Contents, PRs, Workflows R/W).
- [ ] Re-trigger `weekly-release.yml` via `workflow_dispatch` and confirm the `Run /prepare-release` step no longer fails on OIDC.
- [ ] Confirm the deploy PR (if one is opened) shows the bot identity as author and triggers downstream CI + Netlify preview.
- [ ] If `RELEASE_BOT_TOKEN` is unset, confirm the workflow fails fast at the checkout / `gh` step instead of silently degrading.