### PR TITLE
fix: add missing docs-nav-data-availability-description translation key

### DIFF
--- a/src/intl/en/page-developers-docs.json
+++ b/src/intl/en/page-developers-docs.json
@@ -21,6 +21,7 @@
   "docs-nav-data-and-analytics": "Data and analytics",
   "docs-nav-data-and-analytics-description": "How blockchain data is aggregated, organized and implemented into dapps",
   "docs-nav-data-availability": "Data availability",
+  "docs-nav-data-availability-description": "An overview of problems and solutions relating to data availability in Ethereum",
   "docs-nav-data-availability-storage-strategies": "Blockchain data storage strategies",
   "docs-nav-dart": "Dart",
   "docs-nav-delphi": "Delphi",


### PR DESCRIPTION
Noticed this small thing in the "Overview" page, under the "Advanced" section. The "Data Availability" didn't have a description - it was rendering the raw translation key `docs-nav-data-availability-description` instead of actual text:

<img width="837" height="243" alt="image" src="https://github.com/user-attachments/assets/9b526eef-4a54-450b-a818-cd3fa0697221" />
