### PR TITLE
fix(layouts): fall back to description in topic hero

### DIFF
--- a/src/layouts/Topic.tsx
+++ b/src/layouts/Topic.tsx
@@ -77,6 +77,8 @@ export const TopicLayout = async ({
         <ListItem key={idx}>{point}</ListItem>
       ))}
     </List>
+  ) : frontmatter.description ? (
+    <p className="text-lg">{frontmatter.description}</p>
   ) : undefined
 
   const heroDescription =


### PR DESCRIPTION
## Summary

- Hero description text was missing on all roadmap sub-pages (e.g. `/roadmap/security`, `/roadmap/scaling`) — regression caught by Chromatic.
- Root cause: the `feat(layouts): consolidate topic layouts` refactor (cba15c3405) made `TopicLayout` read the hero description from `frontmatter.summary` / `frontmatter.summaryPoints`. The previous `RoadmapLayout` spread the whole frontmatter into `ContentHero`, so `frontmatter.description` rendered as the hero text. 11 roadmap pages (security, scaling, user-experience, fusaka, dencun, pectra, glamsterdam, single-slot-finality, statelessness, pbs, zkevm) only set `description`, so their heroes went blank.
- Fix: fall back to `frontmatter.description` in `TopicLayout` when neither `summary` nor `summaryPoints` is set.

## Test plan

- [x] `pnpm type-check` passes
- [x] Verified locally that `/roadmap/security` and `/roadmap/scaling` heroes render the expected description, matching prod
- [ ] Chromatic green on deploy preview