### PR TITLE
fix(storybook): drop Pre from MdComponents story to unblock chromatic

### DIFF
--- a/src/components/MdComponents/MdComponents.stories.tsx
+++ b/src/components/MdComponents/MdComponents.stories.tsx
@@ -30,7 +30,6 @@ const {
   FeaturedText,
   Divider,
   hr: HR,
-  pre: Pre,
   Page,
 } = MdComponentSet
 
@@ -60,7 +59,6 @@ export const MdComponents: StoryObj = {
           <Title>Title</Title>
           <Para />
           <Divider />
-          <Pre>Lots of coding here</Pre>
           <HR />
           <FeaturedText>Feature Text</FeaturedText>
         </ContentContainer>


### PR DESCRIPTION
## Summary

`feat(md): render fenced code via Codeblock` (ba00561a5e) changed the shared `<Pre>` wrapper in `MdComponents` to render the **async** server component `Codeblock` (it `await`s shiki's `highlight()`). Chromatic's client-side test runner can't render async server components, so it bubbles up a generic *"Storybook preview hooks can only be called inside decorators and story functions"* error and fails the entire visual regression build.

Since `Codeblock` has its own dedicated story (with `chromatic.disableSnapshot` set for the same reason), the cleanest fix is to drop the `<Pre>` demo from `MdComponents.stories.tsx`. Every other md element (headings, paragraphs, title, divider, hr, featured text) is still covered visually.

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm build-storybook` succeeds
- [x] MdComponents story renders locally without `<Pre>`
- [ ] Chromatic build goes green