### PR TITLE
fix(codeblock): actually switch shiki theme to vitesse

### DIFF
--- a/src/lib/shiki.ts
+++ b/src/lib/shiki.ts
@@ -6,8 +6,8 @@ import {
 } from "shiki"
 
 const THEMES = {
-  light: "one-light",
-  dark: "one-dark-pro",
+  light: "vitesse-light",
+  dark: "vitesse-dark",
 } as const satisfies Record<string, BundledTheme>
 
 const LANGS = [


### PR DESCRIPTION
## Summary

Follow-up to #18195. That PR was titled \"switch theme to vitesse\" and its description listed \`vitesse-light\` / \`vitesse-dark\` as the new themes, but the actual theme constants in \`src/lib/shiki.ts\` were never updated — only \`CodeblockClient.tsx\`, \`index.tsx\` and \`codeblock.css\` were touched. As a result, the deployed code blocks (verified on staging for the v11.7.0 deploy) still render with \`one-light\` / \`one-dark-pro\`.

```diff
 const THEMES = {
-  light: \"one-light\",
-  dark: \"one-dark-pro\",
+  light: \"vitesse-light\",
+  dark: \"vitesse-dark\",
 } as const satisfies Record<string, BundledTheme>
```

Both \`vitesse-light\` and \`vitesse-dark\` are valid \`BundledTheme\` values in shiki — no new dependency needed. The codeblock CSS already drives token colors through shiki's emitted \`--shiki-light\` / \`--shiki-dark\` CSS variables, so this single source change is enough.

## How it was caught

Surfaced during the \`/review-release\` browser check on the v11.7.0 deploy PR (#18258). Snapshot of a \`.shiki\` element on staging showed:

```html
<pre class=\"shiki shiki-themes one-light one-dark-pro\" ...>
```

## Test plan

- [ ] Visit a docs page with code blocks on the deploy preview (e.g. \`/developers/docs/smart-contracts/anatomy/\`) and confirm the rendered \`<pre>\` is \`shiki-themes vitesse-light vitesse-dark\`
- [ ] Verify both light and dark theme variants look visually correct
- [ ] Confirm no regression on the homepage Codeblock (\`fromHomepage\` variant)