### PR TITLE
fix(ui): first element alignment in markdown MainArticle

### DIFF
--- a/src/components/MdComponents/index.tsx
+++ b/src/components/MdComponents/index.tsx
@@ -160,7 +160,7 @@ export const Title = (props: ChildOnlyProp) => (
 export const ContentContainer = (props: ComponentProps<"article">) => {
   return (
     <MainArticle
-      className="relative flex-[1_1_992px] px-8 pb-8 [&>h2:first-child]:mt-0"
+      className="relative flex-[1_1_992px] px-8 pb-8 *:first:mt-0"
       {...props}
     />
   )


### PR DESCRIPTION
## Description
- Force remove top margin from the first element inside MainArticle for markdown pages
- Fixes inappropriate space when starting with anything other than h2

<img width="1547" height="540" alt="image" src="https://github.com/user-attachments/assets/047386bd-b697-4573-a156-56f445265485" />

## Related issue
<img width="1546" height="569" alt="image" src="https://github.com/user-attachments/assets/45d76719-4641-494a-844f-1f763f059cbe" />
