### PR TITLE
fix(leaderboard): remove hover border-radius from list items

### DIFF
--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -32,7 +32,7 @@ const Leaderboard = ({ content, limit = 100 }: LeaderboardProps) => {
 
   return (
     <List
-      className="ms-0 mb-8 w-full list-none bg-background shadow-table-box"
+      className="bg-background shadow-table-box mb-8 ms-0 w-full list-none"
       aria-label={t("page-upgrades-bug-bounty-leaderboard-list")}
     >
       {content
@@ -54,7 +54,7 @@ const Leaderboard = ({ content, limit = 100 }: LeaderboardProps) => {
           return (
             <ListItem className="mb-0" key={username}>
               <LinkBox
-                className="mb-1 flex w-full items-center justify-between p-4 shadow-table-item-box hover:rounded-lg hover:bg-background-highlight hover:no-underline hover:shadow-primary"
+                className="shadow-table-item-box hover:bg-background-highlight hover:shadow-primary mb-1 flex w-full items-center justify-between p-4 hover:no-underline"
                 key={idx}
               >
                 <div className="me-4 opacity-40">{idx + 1}</div>
@@ -80,7 +80,7 @@ const Leaderboard = ({ content, limit = 100 }: LeaderboardProps) => {
                     )}
                   </LinkOverlay>
 
-                  <div className="text-sm text-body-medium">
+                  <div className="text-body-medium text-sm">
                     {score} {t("page-upgrades-bug-bounty-leaderboard-points")}
                   </div>
                 </Flex>

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -32,7 +32,7 @@ const Leaderboard = ({ content, limit = 100 }: LeaderboardProps) => {
 
   return (
     <List
-      className="bg-background shadow-table-box mb-8 ms-0 w-full list-none"
+      className="ms-0 mb-8 w-full list-none bg-background shadow-table-box"
       aria-label={t("page-upgrades-bug-bounty-leaderboard-list")}
     >
       {content
@@ -54,7 +54,7 @@ const Leaderboard = ({ content, limit = 100 }: LeaderboardProps) => {
           return (
             <ListItem className="mb-0" key={username}>
               <LinkBox
-                className="shadow-table-item-box hover:bg-background-highlight hover:shadow-primary mb-1 flex w-full items-center justify-between p-4 hover:no-underline"
+                className="flex w-full items-center justify-between p-4 shadow-table-item-box hover:bg-background-highlight hover:no-underline hover:shadow-primary"
                 key={idx}
               >
                 <div className="me-4 opacity-40">{idx + 1}</div>
@@ -80,7 +80,7 @@ const Leaderboard = ({ content, limit = 100 }: LeaderboardProps) => {
                     )}
                   </LinkOverlay>
 
-                  <div className="text-body-medium text-sm">
+                  <div className="text-sm text-body-medium">
                     {score} {t("page-upgrades-bug-bounty-leaderboard-points")}
                   </div>
                 </Flex>


### PR DESCRIPTION
## Summary

- Removes `hover:rounded-lg` from the `LinkBox` inside `Leaderboard` list items
- The list container has no border-radius, so rounding individual items on hover produced orphaned rounded corners that looked incorrect — visible on the hero leaderboard and both full leaderboards on `/bug-bounty`

## Root cause

`Leaderboard.tsx` had `hover:rounded-lg` on each row's `LinkBox`. Since the surrounding `List` is straight-edged (no border-radius), the per-item rounding clipped visually against the container edges on hover.

https://deploy-preview-18272.ethereum.it/bug-bounty

## Related

Closes #18271