### PR TITLE
fix: /review-translations filter API field

### DIFF
--- a/.claude/commands/review-translations.md
+++ b/.claude/commands/review-translations.md
@@ -240,7 +240,7 @@ curl -sf "$GLOSSARY_HOST/llms.txt" \
 ENGLISH_SOURCE=$(cat "$WORKTREE_PATH/public/content/{path}.md")
 curl -sf -X POST "$GLOSSARY_API_URL/filter" \
   -H "Content-Type: application/json" \
-  -d "$(jq -n --arg text "$ENGLISH_SOURCE" --arg lang "{LANGUAGE_CODE}" '{text: $text, language: $lang}')"
+  -d "$(jq -n --arg content "$ENGLISH_SOURCE" --arg lang "{LANGUAGE_CODE}" '{content: $content, language: $lang}')"
 ```
 
 **Fallback — full language** when filtering per file is impractical or the endpoint is unreachable:


### PR DESCRIPTION
## Summary

The ETHGlossary `POST /api/v1/filter` endpoint expects a `content` field, but `.claude/commands/review-translations.md` sent `text`. The API returns a Zod validation error, so agent-run reviews silently fall back to memory-based heuristics instead of querying the glossary.

This was a contributing factor to the false-positive criticals on PR #18273, where acronym transliterations that exactly matched ETHGlossary entries were flagged as needing reversion to Latin.

## Test plan

- [x] Verified the fixed payload returns matches against `ethglossary.visual-20-hoists.workers.dev/api/v1/filter`
- [x] Confirmed only one occurrence on dev (the skill-side reference on `intl-knowledge-base` is patched separately)