### PR TITLE
feat: port Matomo AI tracker to Netlify Edge Functions

### DIFF
--- a/netlify/edge-functions/matomo-ai-tracker/README.md
+++ b/netlify/edge-functions/matomo-ai-tracker/README.md
@@ -1,0 +1,27 @@
+# Matomo AI Tracker (Netlify Edge Function)
+
+Netlify Edge Function port of the upstream Cloudflare Worker from:
+
+https://github.com/matomo-org/tracker-cloudflare
+
+Original project license: BSD-3-Clause.
+
+## Purpose
+
+Tracks user-driven AI chatbot traffic (ChatGPT-User, Claude-User, Gemini-Deep-Research, Perplexity-User, Google-NotebookLM, etc.) through the Matomo Measurement Protocol so requests from AI assistants can appear in Matomo AI Chatbots reports.
+
+This implementation is intentionally dormant and is not yet wired into `netlify.toml`.
+
+## Local development
+
+Run locally with:
+
+```bash
+netlify dev
+```
+
+Example request:
+
+```bash
+curl -H "User-Agent: ChatGPT-User" http://localhost:8888/en/learn/
+```

--- a/netlify/edge-functions/matomo-ai-tracker/README.md
+++ b/netlify/edge-functions/matomo-ai-tracker/README.md
@@ -56,3 +56,13 @@ curl -H "User-Agent: ChatGPT-User" http://localhost:8888/en/learn/
 
 The Matomo Measurement Protocol payload sets `source` to `Netlify` for this
 port.
+
+## Testing
+
+Unit tests ported from the upstream suite live in `tests/unit/matomo-ai-tracker/` and run with the repo's Playwright unit project:
+
+```bash
+pnpm test:unit
+```
+
+Type checking uses the scoped `netlify/edge-functions/tsconfig.json` (Deno-style `.ts`-extension imports), run as part of `pnpm type-check`.

--- a/netlify/edge-functions/matomo-ai-tracker/README.md
+++ b/netlify/edge-functions/matomo-ai-tracker/README.md
@@ -12,12 +12,40 @@ Tracks user-driven AI chatbot traffic (ChatGPT-User, Claude-User, Gemini-Deep-Re
 
 This implementation is intentionally dormant and is not yet wired into `netlify.toml`.
 
+## Environment
+
+The edge function reads server-side environment variables via `Netlify.env`:
+
+- `MATOMO_URL` - Matomo base URL, with or without `/matomo.php`
+- `MATOMO_SITE_ID` - numeric Matomo site ID
+- `MATOMO_TIMEOUT_MS` - optional request timeout in milliseconds, defaults to `5000`
+- `LOG_LEVEL` - optional `silent`, `error`, `warn`, `info`, or `debug`
+- `HTTP_METHOD_ALLOWLIST` - optional comma-separated methods, defaults to `GET`
+- `USER_AGENT_ALLOWLIST_REGEX` - optional bot user-agent allowlist override
+- `URL_EXCLUDE_REGEX` - optional static asset exclusion override
+- `DOCUMENT_REGEX` - optional download/document URL detection override
+
+These are intentionally separate from the existing public `NEXT_PUBLIC_MATOMO_*`
+browser analytics variables.
+
 ## Local development
 
-Run locally with:
+Because this function is dormant, local requests will only route through it if
+you temporarily add an edge function declaration. Do not commit this wiring until
+the staged rollout is ready.
+
+Temporary local-only `netlify.toml` snippet:
+
+```toml
+[[edge_functions]]
+  function = "matomo-ai-tracker"
+  path = "/*"
+```
+
+Then run locally with the required env vars:
 
 ```bash
-netlify dev
+MATOMO_URL="https://example.matomo.cloud" MATOMO_SITE_ID="1" netlify dev
 ```
 
 Example request:
@@ -25,3 +53,6 @@ Example request:
 ```bash
 curl -H "User-Agent: ChatGPT-User" http://localhost:8888/en/learn/
 ```
+
+The Matomo Measurement Protocol payload sets `source` to `Netlify` for this
+port.

--- a/netlify/edge-functions/matomo-ai-tracker/config.ts
+++ b/netlify/edge-functions/matomo-ai-tracker/config.ts
@@ -1,0 +1,104 @@
+import type { Env, LogLevel, MatomoConfig } from "./types"
+
+const toInt = (value: string | undefined | null, fallback?: number) => {
+  if (value === undefined || value === null || value === "") return fallback
+  const parsed = Number.parseInt(value, 10)
+  if (Number.isNaN(parsed)) {
+    throw new Error(`Expected integer value, got "${value}"`)
+  }
+  return parsed
+}
+
+const escapeRegex = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+const defaultUserAgentPatterns = [
+  "ChatGPT-User",
+  "MistralAI-User",
+  "Gemini-Deep-Research",
+  "Claude-User",
+  "Perplexity-User",
+  "Google-NotebookLM",
+]
+const defaultAllowlistPattern = `(?:${defaultUserAgentPatterns
+  .map(escapeRegex)
+  .join("|")})`
+const defaultHttpMethodAllowlist = ["GET"]
+const defaultDocumentPattern =
+  "^[^?]+\\.(?:pdf|docx?|xlsx?|pptx?|csv|json|txt|xml|epub|mobi|azw3|mp3|mp4|mpe?g|webm|mov|avi|ogg|wav|flac|zip|gz|gzip|tgz|tar|bz2|tbz|7z|rar|dmg|exe|msi|apk|jar|md5|sig)(?:\\?|$)"
+const defaultUrlExcludePattern =
+  "^[^?]+\\.(?:css|js|mjs|map|json|xml|webmanifest|manifest|png|jpe?g|gif|webp|avif|svg|ico|bmp|tiff?|woff2?|ttf|otf|eot|rss|atom|wasm|txt)(?:\\?|$)"
+
+export function getConfig(
+  env: Partial<Env> & Record<string, string | undefined>
+): MatomoConfig {
+  const matomoUrl = env.MATOMO_URL
+  if (!matomoUrl) {
+    throw new Error("MATOMO_URL is required")
+  }
+
+  const siteIdRaw = env.MATOMO_SITE_ID
+  if (!siteIdRaw) {
+    throw new Error("MATOMO_SITE_ID is required")
+  }
+  const matomoSiteId = toInt(siteIdRaw)
+  if (matomoSiteId === undefined) {
+    throw new Error("MATOMO_SITE_ID is required")
+  }
+
+  const matomoTimeoutMs = toInt(env.MATOMO_TIMEOUT_MS, 5000) ?? 5000
+  const logLevel = (env.LOG_LEVEL || "warn").toLowerCase() as LogLevel
+  const httpMethodAllowlist =
+    env.HTTP_METHOD_ALLOWLIST && env.HTTP_METHOD_ALLOWLIST.trim()
+      ? env.HTTP_METHOD_ALLOWLIST.split(",").map((v) => v.trim().toUpperCase())
+      : defaultHttpMethodAllowlist
+  const normalizedHttpMethodAllowlist = Array.from(
+    new Set(httpMethodAllowlist.filter(Boolean))
+  )
+  if (normalizedHttpMethodAllowlist.length === 0) {
+    throw new Error("HTTP_METHOD_ALLOWLIST must include at least one method")
+  }
+  const invalidMethod = normalizedHttpMethodAllowlist.find(
+    (method) => !/^[A-Z]+$/.test(method)
+  )
+  if (invalidMethod) {
+    throw new Error(
+      `Invalid HTTP_METHOD_ALLOWLIST entry "${invalidMethod}" (expected letters only)`
+    )
+  }
+  const allowlistPattern =
+    env.USER_AGENT_ALLOWLIST_REGEX || defaultAllowlistPattern
+  const urlExcludePattern = env.URL_EXCLUDE_REGEX || defaultUrlExcludePattern
+  const documentPattern = env.DOCUMENT_REGEX || defaultDocumentPattern
+  let userAgentAllowlistRegex: RegExp | undefined
+  let urlExcludeRegex: RegExp | undefined
+  let documentRegex: RegExp | undefined
+  try {
+    userAgentAllowlistRegex = new RegExp(allowlistPattern, "i")
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    throw new Error(`Invalid USER_AGENT_ALLOWLIST_REGEX: ${message}`)
+  }
+  try {
+    urlExcludeRegex = new RegExp(urlExcludePattern, "i")
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    throw new Error(`Invalid URL_EXCLUDE_REGEX: ${message}`)
+  }
+  try {
+    documentRegex = new RegExp(documentPattern, "i")
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    throw new Error(`Invalid DOCUMENT_REGEX: ${message}`)
+  }
+
+  return {
+    matomoUrl,
+    matomoSiteId,
+    matomoTimeoutMs,
+    logLevel,
+    httpMethodAllowlist: normalizedHttpMethodAllowlist,
+    userAgentAllowlistRegex,
+    urlExcludeRegex,
+    documentRegex,
+  }
+}

--- a/netlify/edge-functions/matomo-ai-tracker/config.ts
+++ b/netlify/edge-functions/matomo-ai-tracker/config.ts
@@ -1,4 +1,4 @@
-import type { Env, LogLevel, MatomoConfig } from "./types"
+import type { Env, LogLevel, MatomoConfig } from "./types.ts"
 
 const toInt = (value: string | undefined | null, fallback?: number) => {
   if (value === undefined || value === null || value === "") return fallback

--- a/netlify/edge-functions/matomo-ai-tracker/http.ts
+++ b/netlify/edge-functions/matomo-ai-tracker/http.ts
@@ -1,0 +1,60 @@
+/* global RequestInfo, RequestInit */
+import { createLogger } from "./logger"
+import type { LogLevel, MatomoPayload } from "./types"
+
+export function buildMatomoRequestPayload(
+  payload: Record<string, string | number | boolean | null | undefined>
+): string {
+  const search = new URLSearchParams()
+  Object.entries(payload).forEach(([key, value]) => {
+    if (value !== undefined && value !== null && value !== "") {
+      search.append(key, String(value))
+    }
+  })
+  return `?${search.toString()}`
+}
+
+export async function sendMatomoHit(
+  matomoUrl: string,
+  payload: MatomoPayload,
+  timeoutMs = 5000,
+  logLevel: LogLevel = "info",
+  fetchImpl: (
+    input: RequestInfo | URL,
+    init?: RequestInit
+  ) => Promise<Response> = fetch
+): Promise<void> {
+  const query = buildMatomoRequestPayload(payload)
+  const baseUrl = new URL(matomoUrl)
+  const basePath = baseUrl.pathname || "/"
+  const strippedBasePath = /\/matomo\.php$/i.test(basePath)
+    ? basePath.replace(/\/matomo\.php$/i, "/")
+    : basePath
+  const normalizedBasePath = strippedBasePath.endsWith("/")
+    ? strippedBasePath
+    : `${strippedBasePath}/`
+  const url = new URL(baseUrl.toString())
+  url.pathname = `${normalizedBasePath}matomo.php`
+  url.search = query
+  url.hash = ""
+  const log = createLogger(logLevel)
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), timeoutMs)
+
+  try {
+    const res = await fetchImpl(url.toString(), {
+      method: "GET",
+      signal: controller.signal,
+    })
+    if (!res.ok) {
+      throw new Error(`Matomo responded with status ${res.status}`)
+    }
+    log.debug("Matomo response", { status: res.status })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    log.error("Matomo send failed", { error: message })
+    throw err
+  } finally {
+    clearTimeout(timeout)
+  }
+}

--- a/netlify/edge-functions/matomo-ai-tracker/http.ts
+++ b/netlify/edge-functions/matomo-ai-tracker/http.ts
@@ -1,6 +1,6 @@
 /* global RequestInfo, RequestInit */
-import { createLogger } from "./logger"
-import type { LogLevel, MatomoPayload } from "./types"
+import { createLogger } from "./logger.ts"
+import type { LogLevel, MatomoPayload } from "./types.ts"
 
 export function buildMatomoRequestPayload(
   payload: Record<string, string | number | boolean | null | undefined>

--- a/netlify/edge-functions/matomo-ai-tracker/index.ts
+++ b/netlify/edge-functions/matomo-ai-tracker/index.ts
@@ -1,8 +1,8 @@
-import { getConfig } from "./config"
-import { sendMatomoHit } from "./http"
-import { createLogger } from "./logger"
-import { buildMatomoPayload } from "./matomo"
-import type { MatomoConfig } from "./types"
+import { getConfig } from "./config.ts"
+import { sendMatomoHit } from "./http.ts"
+import { createLogger } from "./logger.ts"
+import { buildMatomoPayload } from "./matomo.ts"
+import type { MatomoConfig } from "./types.ts"
 
 const trackRequest = async (
   request: Request,

--- a/netlify/edge-functions/matomo-ai-tracker/index.ts
+++ b/netlify/edge-functions/matomo-ai-tracker/index.ts
@@ -1,0 +1,94 @@
+import { getConfig } from "./config"
+import { sendMatomoHit } from "./http"
+import { createLogger } from "./logger"
+import { buildMatomoPayload } from "./matomo"
+import type { MatomoConfig } from "./types"
+
+const trackRequest = async (
+  request: Request,
+  response: Response,
+  durationMs: number,
+  config: MatomoConfig
+) => {
+  const log = createLogger(config.logLevel)
+
+  try {
+    const payload = buildMatomoPayload(
+      request,
+      response,
+      durationMs,
+      config,
+      new Date(Date.now() - durationMs)
+    )
+
+    if (!payload) {
+      log.debug("Tracking skipped")
+      return
+    }
+
+    await sendMatomoHit(
+      config.matomoUrl,
+      payload,
+      config.matomoTimeoutMs,
+      config.logLevel
+    )
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+
+    log.warn("Tracking failed", {
+      error: message,
+    })
+  }
+}
+
+export default async function handler(
+  request: Request,
+  context: {
+    env: Record<string, string | undefined>
+  }
+) {
+  let config: MatomoConfig | null = null
+
+  try {
+    config = getConfig(context.env)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+
+    console.error("Configuration error", {
+      error: message,
+    })
+
+    return fetch(request)
+  }
+
+  const log = createLogger(config.logLevel)
+
+  const start = Date.now()
+
+  try {
+    const response = await fetch(request)
+
+    const durationMs = Date.now() - start
+
+    // Fire-and-forget tracking
+    void trackRequest(request, response, durationMs, config)
+
+    return response
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+
+    log.error("Origin request failed", {
+      error: message,
+    })
+
+    const fallback = new Response("Bad Gateway", {
+      status: 502,
+    })
+
+    const durationMs = Date.now() - start
+
+    void trackRequest(request, fallback, durationMs, config)
+
+    return fallback
+  }
+}

--- a/netlify/edge-functions/matomo-ai-tracker/index.ts
+++ b/netlify/edge-functions/matomo-ai-tracker/index.ts
@@ -2,7 +2,13 @@ import { getConfig } from "./config.ts"
 import { sendMatomoHit } from "./http.ts"
 import { createLogger } from "./logger.ts"
 import { buildMatomoPayload } from "./matomo.ts"
-import type { MatomoConfig } from "./types.ts"
+import type { MatomoConfig, NetlifyEdgeContext } from "./types.ts"
+
+declare const Netlify: {
+  env: {
+    toObject: () => Record<string, string | undefined>
+  }
+}
 
 const trackRequest = async (
   request: Request,
@@ -43,14 +49,12 @@ const trackRequest = async (
 
 export default async function handler(
   request: Request,
-  context: {
-    env: Record<string, string | undefined>
-  }
+  context: NetlifyEdgeContext
 ) {
   let config: MatomoConfig | null = null
 
   try {
-    config = getConfig(context.env)
+    config = getConfig(Netlify.env.toObject())
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
 
@@ -58,7 +62,7 @@ export default async function handler(
       error: message,
     })
 
-    return fetch(request)
+    return context.next()
   }
 
   const log = createLogger(config.logLevel)
@@ -66,12 +70,11 @@ export default async function handler(
   const start = Date.now()
 
   try {
-    const response = await fetch(request)
+    const response = await context.next()
 
     const durationMs = Date.now() - start
 
-    // Fire-and-forget tracking
-    void trackRequest(request, response, durationMs, config)
+    context.waitUntil(trackRequest(request, response, durationMs, config))
 
     return response
   } catch (err) {
@@ -87,7 +90,7 @@ export default async function handler(
 
     const durationMs = Date.now() - start
 
-    void trackRequest(request, fallback, durationMs, config)
+    context.waitUntil(trackRequest(request, fallback, durationMs, config))
 
     return fallback
   }

--- a/netlify/edge-functions/matomo-ai-tracker/logger.ts
+++ b/netlify/edge-functions/matomo-ai-tracker/logger.ts
@@ -1,0 +1,22 @@
+import type { Logger, LogLevel } from "./types"
+
+const levels = ["silent", "error", "warn", "info", "debug"]
+
+export function createLogger(level: LogLevel = "info"): Logger {
+  const idx = levels.indexOf(level)
+  const enabled = (lvl: LogLevel) => levels.indexOf(lvl) <= idx && idx !== 0
+  return {
+    debug: (...args: unknown[]) => {
+      if (enabled("debug")) console.debug(...args)
+    },
+    info: (...args: unknown[]) => {
+      if (enabled("info")) console.info(...args)
+    },
+    warn: (...args: unknown[]) => {
+      if (enabled("warn")) console.warn(...args)
+    },
+    error: (...args: unknown[]) => {
+      if (enabled("error")) console.error(...args)
+    },
+  }
+}

--- a/netlify/edge-functions/matomo-ai-tracker/logger.ts
+++ b/netlify/edge-functions/matomo-ai-tracker/logger.ts
@@ -1,4 +1,4 @@
-import type { Logger, LogLevel } from "./types"
+import type { Logger, LogLevel } from "./types.ts"
 
 const levels = ["silent", "error", "warn", "info", "debug"]
 

--- a/netlify/edge-functions/matomo-ai-tracker/matomo.ts
+++ b/netlify/edge-functions/matomo-ai-tracker/matomo.ts
@@ -1,9 +1,9 @@
-import type { MatomoConfig, MatomoPayload } from "./types"
+import type { MatomoConfig, MatomoPayload } from "./types.ts"
 import {
   formatMatomoDateTime,
   getContentLength,
   isUserAgentAllowed,
-} from "./utils"
+} from "./utils.ts"
 
 export function buildMatomoPayload(
   request: Request,

--- a/netlify/edge-functions/matomo-ai-tracker/matomo.ts
+++ b/netlify/edge-functions/matomo-ai-tracker/matomo.ts
@@ -1,0 +1,65 @@
+import type { MatomoConfig, MatomoPayload } from "./types"
+import {
+  formatMatomoDateTime,
+  getContentLength,
+  isUserAgentAllowed,
+} from "./utils"
+
+export function buildMatomoPayload(
+  request: Request,
+  response: Response,
+  durationMs: number,
+  config: MatomoConfig,
+  timestamp: Date = new Date()
+): MatomoPayload | null {
+  if (!config || !config.matomoSiteId) {
+    throw new Error("matomoSiteId is required in config")
+  }
+
+  const method = request.method.toUpperCase()
+  if (
+    Array.isArray(config.httpMethodAllowlist) &&
+    config.httpMethodAllowlist.length > 0 &&
+    !config.httpMethodAllowlist.includes(method)
+  ) {
+    return null
+  }
+
+  const url = request.url
+  if (config.urlExcludeRegex && config.urlExcludeRegex.test(url)) {
+    return null
+  }
+  const ua = request.headers.get("user-agent") || ""
+  if (!isUserAgentAllowed(ua, config.userAgentAllowlistRegex)) {
+    return null
+  }
+
+  const payload: MatomoPayload = {
+    idsite: config.matomoSiteId,
+    rec: 1,
+    recMode: 1,
+    url,
+    source: "Cloudflare",
+    cdt: formatMatomoDateTime(timestamp),
+    ua,
+  }
+
+  if (response.status) {
+    payload.http_status = response.status
+  }
+
+  const bytes = getContentLength(response)
+  if (bytes !== undefined) {
+    payload.bw_bytes = bytes
+  }
+
+  if (durationMs >= 0) {
+    payload.pf_srv = Math.round(durationMs)
+  }
+
+  if (config.documentRegex && config.documentRegex.test(url)) {
+    payload.download = url
+  }
+
+  return payload
+}

--- a/netlify/edge-functions/matomo-ai-tracker/matomo.ts
+++ b/netlify/edge-functions/matomo-ai-tracker/matomo.ts
@@ -39,7 +39,7 @@ export function buildMatomoPayload(
     rec: 1,
     recMode: 1,
     url,
-    source: "Cloudflare",
+    source: "Netlify",
     cdt: formatMatomoDateTime(timestamp),
     ua,
   }

--- a/netlify/edge-functions/matomo-ai-tracker/types.ts
+++ b/netlify/edge-functions/matomo-ai-tracker/types.ts
@@ -1,0 +1,50 @@
+export type LogLevel = "silent" | "error" | "warn" | "info" | "debug"
+
+export interface Logger {
+  debug: (...args: unknown[]) => void
+  info: (...args: unknown[]) => void
+  warn: (...args: unknown[]) => void
+  error: (...args: unknown[]) => void
+}
+
+export interface Env {
+  MATOMO_URL: string
+  MATOMO_SITE_ID: string
+  MATOMO_TIMEOUT_MS?: string
+  LOG_LEVEL?: LogLevel
+  HTTP_METHOD_ALLOWLIST?: string
+  USER_AGENT_ALLOWLIST_REGEX?: string
+  URL_EXCLUDE_REGEX?: string
+  DOCUMENT_REGEX?: string
+  [key: string]: string | undefined
+}
+
+export interface MatomoConfig {
+  matomoUrl: string
+  matomoSiteId: number
+  matomoTimeoutMs: number
+  logLevel: LogLevel
+  httpMethodAllowlist: string[]
+  userAgentAllowlistRegex?: RegExp
+  urlExcludeRegex?: RegExp
+  documentRegex?: RegExp
+}
+
+export interface MatomoPayload {
+  [key: string]: string | number | boolean | undefined
+  idsite: number
+  rec: 1
+  recMode: 1
+  url: string
+  source: "Cloudflare"
+  cdt: string
+  ua: string
+  download?: string
+  http_status?: number | string
+  bw_bytes?: number | string
+  pf_srv?: number | string
+}
+
+export interface WorkerContext {
+  waitUntil(promise: Promise<unknown>): void
+}

--- a/netlify/edge-functions/matomo-ai-tracker/types.ts
+++ b/netlify/edge-functions/matomo-ai-tracker/types.ts
@@ -36,7 +36,7 @@ export interface MatomoPayload {
   rec: 1
   recMode: 1
   url: string
-  source: "Cloudflare"
+  source: "Netlify"
   cdt: string
   ua: string
   download?: string
@@ -47,4 +47,8 @@ export interface MatomoPayload {
 
 export interface WorkerContext {
   waitUntil(promise: Promise<unknown>): void
+}
+
+export interface NetlifyEdgeContext extends WorkerContext {
+  next(): Promise<Response>
 }

--- a/netlify/edge-functions/matomo-ai-tracker/utils.ts
+++ b/netlify/edge-functions/matomo-ai-tracker/utils.ts
@@ -1,0 +1,26 @@
+export const isUserAgentAllowed = (
+  userAgent: string | undefined | null,
+  regex?: RegExp
+): boolean => {
+  if (!regex) return true
+  if (!userAgent) return false
+  return regex.test(userAgent)
+}
+
+export const formatMatomoDateTime = (date: Date): string => {
+  const pad = (num: number) => num.toString().padStart(2, "0")
+  const year = date.getUTCFullYear()
+  const month = pad(date.getUTCMonth() + 1)
+  const day = pad(date.getUTCDate())
+  const hours = pad(date.getUTCHours())
+  const minutes = pad(date.getUTCMinutes())
+  const seconds = pad(date.getUTCSeconds())
+  return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`
+}
+
+export const getContentLength = (response: Response): number | undefined => {
+  const header = response.headers.get("content-length")
+  if (!header) return undefined
+  const parsed = Number.parseInt(header, 10)
+  return Number.isNaN(parsed) ? undefined : parsed
+}

--- a/netlify/edge-functions/tsconfig.json
+++ b/netlify/edge-functions/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  // Scoped config for Netlify Edge Functions (Deno-style `.ts`-extension
+  // imports), excluded from the root project. Checked in CI via `type-check`.
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["./**/*.ts", "../../tests/unit/matomo-ai-tracker/**/*.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "next start",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "type-check": "next typegen && tsc --noEmit",
+    "type-check": "next typegen && tsc --noEmit && tsc --noEmit -p netlify/edge-functions",
     "format": "prettier \"**/*.{js,jsx,ts,tsx}\" --write",
     "preversion": "bash ./src/scripts/updatePublishDate.sh",
     "storybook": "storybook dev -p 6006",

--- a/tests/unit/matomo-ai-tracker/config.spec.ts
+++ b/tests/unit/matomo-ai-tracker/config.spec.ts
@@ -1,0 +1,112 @@
+// Ported from matomo-org/tracker-cloudflare tests/config.test.ts
+
+import { expect, test } from "@playwright/test"
+
+import { getConfig } from "../../../netlify/edge-functions/matomo-ai-tracker/config"
+
+const baseEnv = {
+  MATOMO_URL: "https://analytics.example.com",
+  MATOMO_SITE_ID: "42",
+}
+
+test.describe("getConfig", () => {
+  test("reads required fields and defaults", () => {
+    const config = getConfig({ ...baseEnv })
+    expect(config).toMatchObject({
+      matomoUrl: baseEnv.MATOMO_URL,
+      matomoSiteId: 42,
+      matomoTimeoutMs: 5000,
+      logLevel: "warn",
+      httpMethodAllowlist: ["GET"],
+    })
+    expect(config.userAgentAllowlistRegex).toEqual(
+      /(?:ChatGPT-User|MistralAI-User|Gemini-Deep-Research|Claude-User|Perplexity-User|Google-NotebookLM)/i
+    )
+    expect(config.urlExcludeRegex).toEqual(
+      /^[^?]+\.(?:css|js|mjs|map|json|xml|webmanifest|manifest|png|jpe?g|gif|webp|avif|svg|ico|bmp|tiff?|woff2?|ttf|otf|eot|rss|atom|wasm|txt)(?:\?|$)/i
+    )
+    expect(config.documentRegex).toEqual(
+      /^[^?]+\.(?:pdf|docx?|xlsx?|pptx?|csv|json|txt|xml|epub|mobi|azw3|mp3|mp4|mpe?g|webm|mov|avi|ogg|wav|flac|zip|gz|gzip|tgz|tar|bz2|tbz|7z|rar|dmg|exe|msi|apk|jar|md5|sig)(?:\?|$)/i
+    )
+  })
+
+  test("uses optional overrides", () => {
+    const config = getConfig({
+      ...baseEnv,
+      MATOMO_TIMEOUT_MS: "8000",
+      LOG_LEVEL: "debug",
+      HTTP_METHOD_ALLOWLIST: "get, post",
+      USER_AGENT_ALLOWLIST_REGEX: "CustomBot",
+      URL_EXCLUDE_REGEX: "\\.(?:js|css)$",
+      DOCUMENT_REGEX: "\\.custom$",
+    })
+    expect(config).toMatchObject({
+      matomoUrl: baseEnv.MATOMO_URL,
+      matomoSiteId: 42,
+      matomoTimeoutMs: 8000,
+      logLevel: "debug",
+      httpMethodAllowlist: ["GET", "POST"],
+    })
+    expect(config.userAgentAllowlistRegex).toEqual(/CustomBot/i)
+    expect(config.urlExcludeRegex).toEqual(/\.(?:js|css)$/i)
+    expect(config.documentRegex).toEqual(/\.custom$/i)
+  })
+
+  test("defaults to GET when HTTP_METHOD_ALLOWLIST is empty/blank", () => {
+    expect(
+      getConfig({ ...baseEnv, HTTP_METHOD_ALLOWLIST: "" }).httpMethodAllowlist
+    ).toEqual(["GET"])
+    expect(
+      getConfig({ ...baseEnv, HTTP_METHOD_ALLOWLIST: "   " })
+        .httpMethodAllowlist
+    ).toEqual(["GET"])
+  })
+
+  test("throws on invalid regex config", () => {
+    expect(() =>
+      getConfig({ ...baseEnv, USER_AGENT_ALLOWLIST_REGEX: "[" })
+    ).toThrow(/Invalid USER_AGENT_ALLOWLIST_REGEX/)
+    expect(() => getConfig({ ...baseEnv, URL_EXCLUDE_REGEX: "[" })).toThrow(
+      /Invalid URL_EXCLUDE_REGEX/
+    )
+    expect(() => getConfig({ ...baseEnv, DOCUMENT_REGEX: "[" })).toThrow(
+      /Invalid DOCUMENT_REGEX/
+    )
+  })
+
+  test("throws on invalid HTTP_METHOD_ALLOWLIST", () => {
+    expect(() => getConfig({ ...baseEnv, HTTP_METHOD_ALLOWLIST: "$" })).toThrow(
+      /Invalid HTTP_METHOD_ALLOWLIST/
+    )
+    expect(() => getConfig({ ...baseEnv, HTTP_METHOD_ALLOWLIST: "," })).toThrow(
+      /HTTP_METHOD_ALLOWLIST must include at least one method/
+    )
+  })
+
+  test("throws when MATOMO_URL is missing", () => {
+    expect(() => getConfig({ MATOMO_SITE_ID: "1" })).toThrow(
+      /MATOMO_URL is required/
+    )
+  })
+
+  test("throws when MATOMO_SITE_ID is missing", () => {
+    expect(() => getConfig({ MATOMO_URL: baseEnv.MATOMO_URL })).toThrow(
+      /MATOMO_SITE_ID is required/
+    )
+  })
+
+  test("throws when MATOMO_SITE_ID is empty string", () => {
+    expect(() =>
+      getConfig({ MATOMO_URL: baseEnv.MATOMO_URL, MATOMO_SITE_ID: "" })
+    ).toThrow(/MATOMO_SITE_ID is required/)
+  })
+
+  test("throws when numeric fields are not integers", () => {
+    expect(() => getConfig({ ...baseEnv, MATOMO_SITE_ID: "abc" })).toThrow(
+      /Expected integer value/
+    )
+    expect(() => getConfig({ ...baseEnv, MATOMO_TIMEOUT_MS: "abc" })).toThrow(
+      /Expected integer value/
+    )
+  })
+})

--- a/tests/unit/matomo-ai-tracker/helpers.ts
+++ b/tests/unit/matomo-ai-tracker/helpers.ts
@@ -1,0 +1,60 @@
+// Manual spy/stub helpers standing in for the vi.* utilities used by the
+// upstream matomo-org/tracker-cloudflare suite (Playwright has no module mocks)
+
+type ConsoleMethod = "debug" | "info" | "warn" | "error"
+
+const consoleMethods: ConsoleMethod[] = ["debug", "info", "warn", "error"]
+
+export interface ConsoleSpies {
+  calls: Record<ConsoleMethod, unknown[][]>
+  restore: () => void
+}
+
+export const createConsoleSpies = (): ConsoleSpies => {
+  const originals = consoleMethods.map(
+    (method) => [method, console[method]] as const
+  )
+  const calls: ConsoleSpies["calls"] = {
+    debug: [],
+    info: [],
+    warn: [],
+    error: [],
+  }
+  for (const method of consoleMethods) {
+    console[method] = (...args: unknown[]) => {
+      calls[method].push(args)
+    }
+  }
+  return {
+    calls,
+    restore: () => {
+      for (const [method, original] of originals) {
+        console[method] = original
+      }
+    },
+  }
+}
+
+export type FetchArgs = [RequestInfo | URL, RequestInit | undefined]
+
+export interface FetchStub {
+  calls: FetchArgs[]
+  restore: () => void
+}
+
+export const stubGlobalFetch = (
+  impl: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+): FetchStub => {
+  const original = globalThis.fetch
+  const calls: FetchArgs[] = []
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push([input, init])
+    return impl(input, init)
+  }) as typeof fetch
+  return {
+    calls,
+    restore: () => {
+      globalThis.fetch = original
+    },
+  }
+}

--- a/tests/unit/matomo-ai-tracker/http.spec.ts
+++ b/tests/unit/matomo-ai-tracker/http.spec.ts
@@ -1,0 +1,132 @@
+// Ported from matomo-org/tracker-cloudflare tests/http.test.ts
+
+import { expect, test } from "@playwright/test"
+
+import {
+  buildMatomoRequestPayload,
+  sendMatomoHit,
+} from "../../../netlify/edge-functions/matomo-ai-tracker/http"
+import type { MatomoPayload } from "../../../netlify/edge-functions/matomo-ai-tracker/types"
+
+import { createConsoleSpies, type FetchArgs } from "./helpers"
+
+const basePayload: MatomoPayload = {
+  idsite: 1,
+  rec: 1,
+  recMode: 1,
+  url: "https://example.com/path?foo=bar",
+  source: "Netlify",
+  cdt: "2024-01-01 00:00:00",
+  ua: "AgentX",
+}
+
+test.describe("buildMatomoRequestPayload", () => {
+  test("builds query string payload", () => {
+    const qs = buildMatomoRequestPayload(basePayload)
+
+    expect(qs).toContain("idsite=1")
+    expect(qs).toContain("rec=1")
+    expect(qs).toContain("recMode=1")
+    expect(qs).toContain("source=Netlify")
+    expect(qs).toContain("url=https%3A%2F%2Fexample.com%2Fpath%3Ffoo%3Dbar")
+    expect(qs).toContain("ua=AgentX")
+    expect(qs.startsWith("?")).toBe(true)
+  })
+})
+
+test.describe("sendMatomoHit", () => {
+  const expectedQuery =
+    "idsite=1&rec=1&recMode=1&url=https%3A%2F%2Fexample.com%2Fpath%3Ffoo%3Dbar&source=Netlify&cdt=2024-01-01+00%3A00%3A00&ua=AgentX"
+
+  const cases: [name: string, baseUrl: string, expected: string][] = [
+    [
+      "root url",
+      "https://analytics.example.com",
+      `https://analytics.example.com/matomo.php?${expectedQuery}`,
+    ],
+    [
+      "subdirectory url",
+      "https://analytics.example.com/matomo",
+      `https://analytics.example.com/matomo/matomo.php?${expectedQuery}`,
+    ],
+    [
+      "subdirectory url with slash",
+      "https://analytics.example.com/matomo/",
+      `https://analytics.example.com/matomo/matomo.php?${expectedQuery}`,
+    ],
+    [
+      "matomo.php url",
+      "https://analytics.example.com/matomo.php",
+      `https://analytics.example.com/matomo.php?${expectedQuery}`,
+    ],
+  ]
+
+  for (const [name, baseUrl, expected] of cases) {
+    test(`sends a single hit via tracking API (${name})`, async () => {
+      const spies = createConsoleSpies()
+      const calls: FetchArgs[] = []
+      const fetchMock = (input: RequestInfo | URL, init?: RequestInit) => {
+        calls.push([input, init])
+        return Promise.resolve(new Response(null, { status: 204 }))
+      }
+
+      try {
+        await sendMatomoHit(baseUrl, basePayload, 1000, "debug", fetchMock)
+
+        expect(calls).toHaveLength(1)
+        const [url, options] = calls[0]
+        expect(url).toBe(expected)
+        expect(options?.method).toBe("GET")
+        expect(spies.calls.debug).toContainEqual([
+          "Matomo response",
+          { status: 204 },
+        ])
+      } finally {
+        spies.restore()
+      }
+    })
+  }
+
+  test("throws on non-ok response", async () => {
+    const spies = createConsoleSpies()
+    const fetchMock = () =>
+      Promise.resolve(new Response("bad", { status: 500 }))
+
+    try {
+      await expect(
+        sendMatomoHit(
+          "https://analytics.example.com",
+          basePayload,
+          1000,
+          "info",
+          fetchMock
+        )
+      ).rejects.toThrow(/Matomo responded with status 500/)
+    } finally {
+      spies.restore()
+    }
+  })
+
+  test("aborts when timeout elapses", async () => {
+    const spies = createConsoleSpies()
+    const fetchMock = () => Promise.reject(new Error("aborted"))
+
+    try {
+      await expect(
+        sendMatomoHit(
+          "https://analytics.example.com",
+          basePayload,
+          10,
+          "info",
+          fetchMock
+        )
+      ).rejects.toThrow(/aborted/)
+      expect(spies.calls.error).toContainEqual([
+        "Matomo send failed",
+        { error: "aborted" },
+      ])
+    } finally {
+      spies.restore()
+    }
+  })
+})

--- a/tests/unit/matomo-ai-tracker/index.spec.ts
+++ b/tests/unit/matomo-ai-tracker/index.spec.ts
@@ -1,0 +1,180 @@
+// Ported from matomo-org/tracker-cloudflare tests/index.test.ts, adapted to
+// the Netlify handler shape (Netlify.env global, context.next/waitUntil).
+// Module spies are unavailable here, so tracking is asserted at the fetch
+// boundary (sendMatomoHit's request to matomo.php) instead of vi.spyOn.
+
+import { expect, test } from "@playwright/test"
+
+import handler from "../../../netlify/edge-functions/matomo-ai-tracker/index"
+import type { NetlifyEdgeContext } from "../../../netlify/edge-functions/matomo-ai-tracker/types"
+
+import {
+  type ConsoleSpies,
+  createConsoleSpies,
+  type FetchStub,
+  stubGlobalFetch,
+} from "./helpers"
+
+const env = {
+  MATOMO_URL: "https://analytics.example.com",
+  MATOMO_SITE_ID: "7",
+  USER_AGENT_ALLOWLIST_REGEX: ".*",
+}
+
+const setNetlifyEnv = (values: Record<string, string | undefined>) => {
+  ;(globalThis as { Netlify?: unknown }).Netlify = {
+    env: { toObject: () => values },
+  }
+}
+
+const createContext = (next: () => Promise<Response>) => {
+  const tracked: Promise<unknown>[] = []
+  const context: NetlifyEdgeContext = {
+    next,
+    waitUntil: (promise) => {
+      tracked.push(promise)
+    },
+  }
+  return { context, tracked }
+}
+
+test.describe("Edge function handler", () => {
+  let consoleSpies: ConsoleSpies
+  let fetchStub: FetchStub | undefined
+
+  test.beforeEach(() => {
+    consoleSpies = createConsoleSpies()
+  })
+
+  test.afterEach(() => {
+    consoleSpies.restore()
+    fetchStub?.restore()
+    fetchStub = undefined
+    delete (globalThis as { Netlify?: unknown }).Netlify
+  })
+
+  test("proxies origin and schedules async tracking", async () => {
+    setNetlifyEnv(env)
+    fetchStub = stubGlobalFetch(() =>
+      Promise.resolve(new Response(null, { status: 204 }))
+    )
+    const { context, tracked } = createContext(() =>
+      Promise.resolve(
+        new Response("origin", {
+          status: 200,
+          headers: { "content-length": "6" },
+        })
+      )
+    )
+
+    const response = await handler(
+      new Request("https://example.com/path", {
+        headers: { "user-agent": "AgentX" },
+      }),
+      context
+    )
+
+    expect(response.status).toBe(200)
+    expect(tracked).toHaveLength(1)
+    await tracked[0]
+    expect(fetchStub.calls).toHaveLength(1)
+    const [url] = fetchStub.calls[0]
+    expect(String(url)).toContain(
+      "https://analytics.example.com/matomo.php?idsite=7"
+    )
+  })
+
+  test("returns fallback when origin fails but still tracks", async () => {
+    setNetlifyEnv(env)
+    fetchStub = stubGlobalFetch(() =>
+      Promise.resolve(new Response(null, { status: 204 }))
+    )
+    const { context, tracked } = createContext(() =>
+      Promise.reject(new Error("boom"))
+    )
+
+    const response = await handler(
+      new Request("https://example.com/path", {
+        headers: { "user-agent": "AgentX" },
+      }),
+      context
+    )
+
+    expect(response.status).toBe(502)
+    expect(tracked).toHaveLength(1)
+    await tracked[0]
+    expect(fetchStub.calls).toHaveLength(1)
+    expect(consoleSpies.calls.error).toContainEqual([
+      "Origin request failed",
+      { error: "boom" },
+    ])
+  })
+
+  test("skips tracking when user agent not allowed", async () => {
+    setNetlifyEnv({ ...env, USER_AGENT_ALLOWLIST_REGEX: "AllowedUA" })
+    fetchStub = stubGlobalFetch(() =>
+      Promise.resolve(new Response(null, { status: 204 }))
+    )
+    const { context, tracked } = createContext(() =>
+      Promise.resolve(new Response("origin", { status: 200 }))
+    )
+
+    const response = await handler(
+      new Request("https://example.com/path", {
+        headers: { "user-agent": "OtherUA" },
+      }),
+      context
+    )
+
+    expect(response.status).toBe(200)
+    expect(tracked).toHaveLength(1)
+    await tracked[0]
+    expect(fetchStub.calls).toHaveLength(0)
+  })
+
+  test("logs warning when tracking fails", async () => {
+    setNetlifyEnv(env)
+    fetchStub = stubGlobalFetch(() => Promise.reject(new Error("track fail")))
+    const { context, tracked } = createContext(() =>
+      Promise.resolve(new Response("origin", { status: 200 }))
+    )
+
+    const response = await handler(
+      new Request("https://example.com/path", {
+        headers: { "user-agent": "AgentX" },
+      }),
+      context
+    )
+
+    expect(response.status).toBe(200)
+    expect(tracked).toHaveLength(1)
+    await tracked[0]
+    expect(consoleSpies.calls.warn).toContainEqual([
+      "Tracking failed",
+      { error: "track fail" },
+    ])
+  })
+
+  test("returns origin response when config is invalid and skips tracking", async () => {
+    setNetlifyEnv({ MATOMO_SITE_ID: "7" })
+    fetchStub = stubGlobalFetch(() =>
+      Promise.resolve(new Response(null, { status: 204 }))
+    )
+    const { context, tracked } = createContext(() =>
+      Promise.resolve(new Response("origin", { status: 200 }))
+    )
+
+    const response = await handler(
+      new Request("https://example.com/path"),
+      context
+    )
+
+    expect(response.status).toBe(200)
+    expect(tracked).toHaveLength(0)
+    expect(fetchStub.calls).toHaveLength(0)
+    expect(consoleSpies.calls.error).toContainEqual([
+      "Configuration error",
+      { error: "MATOMO_URL is required" },
+    ])
+  })
+})

--- a/tests/unit/matomo-ai-tracker/logger.spec.ts
+++ b/tests/unit/matomo-ai-tracker/logger.spec.ts
@@ -1,0 +1,46 @@
+// Ported from matomo-org/tracker-cloudflare tests/logger.test.ts
+
+import { expect, test } from "@playwright/test"
+
+import { createLogger } from "../../../netlify/edge-functions/matomo-ai-tracker/logger"
+
+import { createConsoleSpies } from "./helpers"
+
+test.describe("createLogger", () => {
+  test("respects log levels", () => {
+    const spies = createConsoleSpies()
+    try {
+      const silentLog = createLogger("silent")
+      silentLog.debug("a")
+      silentLog.info("b")
+      silentLog.warn("c")
+      silentLog.error("d")
+      expect(spies.calls.debug).toHaveLength(0)
+      expect(spies.calls.info).toHaveLength(0)
+      expect(spies.calls.warn).toHaveLength(0)
+      expect(spies.calls.error).toHaveLength(0)
+
+      const warnLog = createLogger("warn")
+      warnLog.debug("x")
+      warnLog.info("y")
+      warnLog.warn("z")
+      warnLog.error("err")
+      expect(spies.calls.debug).toHaveLength(0)
+      expect(spies.calls.info).toHaveLength(0)
+      expect(spies.calls.warn).toHaveLength(1)
+      expect(spies.calls.error).toHaveLength(1)
+
+      const debugLog = createLogger("debug")
+      debugLog.debug("dbg")
+      debugLog.info("inf")
+      debugLog.warn("wrn")
+      debugLog.error("err")
+      expect(spies.calls.debug).toHaveLength(1)
+      expect(spies.calls.info).toHaveLength(1)
+      expect(spies.calls.warn).toHaveLength(2)
+      expect(spies.calls.error).toHaveLength(2)
+    } finally {
+      spies.restore()
+    }
+  })
+})

--- a/tests/unit/matomo-ai-tracker/matomo.spec.ts
+++ b/tests/unit/matomo-ai-tracker/matomo.spec.ts
@@ -1,0 +1,153 @@
+// Ported from matomo-org/tracker-cloudflare tests/matomo.test.ts
+
+import { expect, test } from "@playwright/test"
+
+import { getConfig } from "../../../netlify/edge-functions/matomo-ai-tracker/config"
+import { buildMatomoPayload } from "../../../netlify/edge-functions/matomo-ai-tracker/matomo"
+
+const config = getConfig({
+  MATOMO_URL: "https://analytics.example.com",
+  MATOMO_SITE_ID: "99",
+  USER_AGENT_ALLOWLIST_REGEX: ".*",
+})
+
+test.describe("buildMatomoPayload", () => {
+  const request = new Request("https://example.com/files/report.pdf?foo=bar", {
+    headers: { "user-agent": "AgentX" },
+  })
+
+  test("builds payload with response metadata", () => {
+    const response = new Response("ok", {
+      status: 201,
+      headers: { "content-length": "512" },
+    })
+    const payload = buildMatomoPayload(
+      request,
+      response,
+      1234,
+      config,
+      new Date("2025-02-18T12:00:00Z")
+    )
+
+    expect(payload).toEqual({
+      idsite: 99,
+      rec: 1,
+      recMode: 1,
+      url: request.url,
+      source: "Netlify",
+      cdt: "2025-02-18 12:00:00",
+      ua: "AgentX",
+      http_status: 201,
+      bw_bytes: 512,
+      pf_srv: 1234,
+      download: request.url,
+    })
+  })
+
+  test("omits optional fields when unavailable", () => {
+    const response = new Response(null, { status: 200 })
+    const payload = buildMatomoPayload(
+      new Request("https://example.com/path", {
+        headers: { "user-agent": "AgentX" },
+      }),
+      response,
+      5,
+      { ...config, documentRegex: undefined },
+      new Date("2025-02-18T12:00:01Z")
+    )
+
+    expect(payload).not.toHaveProperty("bw_bytes")
+    expect(payload).not.toHaveProperty("download")
+    expect(payload?.pf_srv).toBe(5)
+    expect(payload?.cdt).toBe("2025-02-18 12:00:01")
+  })
+
+  test("returns null when user agent is not allowlisted", () => {
+    const cfg = getConfig({
+      MATOMO_URL: "https://analytics.example.com",
+      MATOMO_SITE_ID: "99",
+      USER_AGENT_ALLOWLIST_REGEX: "AllowedUA",
+    })
+    const response = new Response(null, { status: 200 })
+    const payload = buildMatomoPayload(
+      new Request("https://example.com", {
+        headers: { "user-agent": "OtherUA" },
+      }),
+      response,
+      10,
+      cfg
+    )
+    expect(payload).toBeNull()
+  })
+
+  test("returns null when url is excluded", () => {
+    const response = new Response(null, { status: 200 })
+    const payload = buildMatomoPayload(
+      new Request("https://example.com/assets/app.js?ver=1", {
+        headers: { "user-agent": "AgentX" },
+      }),
+      response,
+      10,
+      config
+    )
+    expect(payload).toBeNull()
+  })
+
+  test("returns null when http method is not allowlisted", () => {
+    const response = new Response(null, { status: 200 })
+    const payload = buildMatomoPayload(
+      new Request("https://example.com/path", {
+        method: "POST",
+        headers: { "user-agent": "AgentX" },
+      }),
+      response,
+      10,
+      config
+    )
+    expect(payload).toBeNull()
+  })
+
+  test("tracks request when http method is allowlisted", () => {
+    const cfg = getConfig({
+      MATOMO_URL: "https://analytics.example.com",
+      MATOMO_SITE_ID: "99",
+      HTTP_METHOD_ALLOWLIST: "GET,POST",
+      USER_AGENT_ALLOWLIST_REGEX: ".*",
+    })
+    const response = new Response(null, { status: 200 })
+    const payload = buildMatomoPayload(
+      new Request("https://example.com/path", {
+        method: "POST",
+        headers: { "user-agent": "AgentX" },
+      }),
+      response,
+      10,
+      cfg
+    )
+    expect(payload).not.toBeNull()
+    expect(payload?.url).toBe("https://example.com/path")
+  })
+
+  test("uses defaults when user agent allowlist is disabled", () => {
+    const response = new Response(null, { status: 200 })
+    const payload = buildMatomoPayload(
+      new Request("https://example.com", { headers: {} }),
+      response,
+      10,
+      { ...config, userAgentAllowlistRegex: undefined }
+    )
+    expect(payload?.ua).toBe("")
+  })
+
+  test("throws when matomoSiteId is missing in config", () => {
+    const response = new Response("ok", { status: 200 })
+    expect(() =>
+      buildMatomoPayload(
+        new Request("https://example.com"),
+        response,
+        10,
+        {} as never
+      )
+    ).toThrow(/matomoSiteId is required/)
+  })
+})

--- a/tests/unit/matomo-ai-tracker/utils.spec.ts
+++ b/tests/unit/matomo-ai-tracker/utils.spec.ts
@@ -1,0 +1,37 @@
+// Ported from matomo-org/tracker-cloudflare tests/utils.test.ts
+
+import { expect, test } from "@playwright/test"
+
+import {
+  formatMatomoDateTime,
+  getContentLength,
+  isUserAgentAllowed,
+} from "../../../netlify/edge-functions/matomo-ai-tracker/utils"
+
+test.describe("utils", () => {
+  test("handles user agent allowlist correctly", () => {
+    const regex = /Allowed/
+    expect(isUserAgentAllowed("AllowedUA", regex)).toBe(true)
+    expect(isUserAgentAllowed("OtherUA", regex)).toBe(false)
+    expect(isUserAgentAllowed(undefined, regex)).toBe(false)
+    expect(isUserAgentAllowed("AnyUA")).toBe(true)
+  })
+
+  test("formats date with zero padding", () => {
+    const dt = new Date(Date.UTC(2025, 0, 2, 3, 4, 5))
+    expect(formatMatomoDateTime(dt)).toBe("2025-01-02 03:04:05")
+  })
+
+  test("parses content length safely", () => {
+    const response = new Response("ok", {
+      headers: { "content-length": "123" },
+    })
+    expect(getContentLength(response)).toBe(123)
+    const none = new Response("ok")
+    expect(getContentLength(none)).toBeUndefined()
+    const invalid = new Response("ok", {
+      headers: { "content-length": "abc" },
+    })
+    expect(getContentLength(invalid)).toBeUndefined()
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,6 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
@@ -53,6 +52,8 @@
     "node_modules",
     "./public",
     "./src/intl",
-    "./.storybook"
+    "./.storybook",
+    "./netlify/edge-functions",
+    "./tests/unit/matomo-ai-tracker"
   ]
 }


### PR DESCRIPTION
## Description

Ports the upstream Matomo Cloudflare Worker implementation to a dormant Netlify Edge Function for ethereum.org.

Adds the initial TypeScript implementation under `netlify/edge-functions/matomo-ai-tracker` along with local development instructions and curl-based verification examples in the README.

This PR intentionally does **not** wire the function into `netlify.toml` yet, following the staged rollout plan discussed in the issue.

## Related Issue

Closes #18219
