### PR TITLE
patch: callout buttons, staking callout button styling

### DIFF
--- a/app/[locale]/staking/_components/StakingCommunityCallout.tsx
+++ b/app/[locale]/staking/_components/StakingCommunityCallout.tsx
@@ -1,6 +1,8 @@
 import React from "react"
 import { getTranslations } from "next-intl/server"
 
+import Discord from "@/components/icons/discord.svg"
+import Reddit from "@/components/icons/reddit.svg"
 import { ButtonLink } from "@/components/ui/buttons/Button"
 import Callout from "@/components/ui/callout"
 
@@ -20,26 +22,6 @@ const StakingCommunityCallout = async (
       {...props}
     >
       <ButtonLink
-        href="https://discord.gg/ethstaker"
-        customEventOptions={{
-          eventCategory: "StakingCommunityCallout",
-          eventAction: "Clicked",
-          eventName: "clicked discord",
-        }}
-      >
-        Discord
-      </ButtonLink>
-      <ButtonLink
-        href="https://reddit.com/r/ethstaker"
-        customEventOptions={{
-          eventCategory: "StakingCommunityCallout",
-          eventAction: "Clicked",
-          eventName: "clicked reddit",
-        }}
-      >
-        Reddit
-      </ButtonLink>
-      <ButtonLink
         href="https://ethstaker.cc"
         customEventOptions={{
           eventCategory: "StakingCommunityCallout",
@@ -49,6 +31,36 @@ const StakingCommunityCallout = async (
       >
         {tCommon("rollup-component-website")}
       </ButtonLink>
+      <div className="flex items-center justify-around gap-4 @max-sm/content:*:w-full">
+        <ButtonLink
+          href="https://discord.gg/ethstaker"
+          customEventOptions={{
+            eventCategory: "StakingCommunityCallout",
+            eventAction: "Clicked",
+            eventName: "clicked discord",
+          }}
+          variant="outline"
+          isSecondary
+          hideArrow
+        >
+          <Discord />
+          Discord
+        </ButtonLink>
+        <ButtonLink
+          href="https://reddit.com/r/ethstaker"
+          customEventOptions={{
+            eventCategory: "StakingCommunityCallout",
+            eventAction: "Clicked",
+            eventName: "clicked reddit",
+          }}
+          variant="outline"
+          isSecondary
+          hideArrow
+        >
+          <Reddit />
+          Reddit
+        </ButtonLink>
+      </div>
     </Callout>
   )
 }

--- a/src/components/ui/callout.tsx
+++ b/src/components/ui/callout.tsx
@@ -112,8 +112,8 @@ const CalloutButtons = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "pt-//4 mt-auto flex flex-wrap gap-4 max-sm:flex-col",
-      "*:w-full *:text-center sm:*:w-fit", // Button styling
+      "mt-auto flex flex-wrap gap-4 @max-md/content:flex-col",
+      "**:w-full **:text-center @md/content:*:w-fit", // Button styling
       className
     )}
     {...props}


### PR DESCRIPTION
## Description
- Patch `CalloutButtons` to use container query for layout; rm stray className
- Update `StakingCommunityCallout` button layout: reorder "website" to first, add icons to discord/reddit links and style as secondary outline buttons in row grid (terms not translated—space occupancy reliable)

cc: @konopkja 