### PR TITLE
fix(ui): ui/callout overflow

### DIFF
--- a/src/components/ui/callout.tsx
+++ b/src/components/ui/callout.tsx
@@ -38,11 +38,7 @@ const CalloutRoot = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof variants>
 >(({ className, variant, children, ...props }, ref) => (
-  <aside
-    ref={ref}
-    className={cn("min-h-full", variants({ variant }), className)}
-    {...props}
-  >
+  <aside ref={ref} className={cn(variants({ variant }), className)} {...props}>
     <div
       className={cn(
         "flex flex-col @3xl/callout:flex-row-reverse",


### PR DESCRIPTION
## Description
- Remove unnecessary `min-w-full` class from CalloutRoot `aside`
- Fixes overflow bug on markdown pages when no parent wrapper present

## Related Issue
Fixes:
<img width="688" height="712" alt="image" src="https://github.com/user-attachments/assets/e6d9d6e8-f7d7-4fee-af1c-316e615b5b9f" />
