### PR TITLE
fix(docs): correct smart-contracts example URL in style guide

### DIFF
--- a/public/content/contributing/style-guide/content-standardization/index.md
+++ b/public/content/contributing/style-guide/content-standardization/index.md
@@ -181,13 +181,13 @@ When linking to another page on ethereum.org, use the relative path over the abs
 ```md
 <!-- Good -->
 
-Read more about [smart contracts](/docs/developers/smart-contracts/)
+Read more about [smart contracts](/developers/docs/smart-contracts/)
 
 <!-- Bad -->
 
-Read more about [smart contracts](/en/docs/developers/smart-contracts)
-Read more about [smart contracts](/docs/developers/smart-contracts)
-Read more about [smart contracts](https://ethereum.org/docs/developers/smart-contracts)
+Read more about [smart contracts](/en/developers/docs/smart-contracts)
+Read more about [smart contracts](/developers/docs/smart-contracts)
+Read more about [smart contracts](https://ethereum.org/developers/docs/smart-contracts)
 ```
 
 Please also add a trailing slash to all links. This keeps links consistent and avoids redirects, which hurts site performance.


### PR DESCRIPTION
## Summary

- The "Linking to internal pages" section of the content standardization style guide showed `/docs/developers/smart-contracts/` as the good example
- The actual path for smart contracts docs is `/developers/docs/smart-contracts/`
- Fixed the good and bad examples to use the correct path structure

## Context

Found while reviewing the style guide for internal linking guidance. The guide correctly explains not to hard-code `/en/` prefixes, but the example URL itself used the wrong path order.

## Test plan

- [ ] Verify the updated example URL `/developers/docs/smart-contracts/` resolves correctly on the site