### PR TITLE
fix(seo): fall back to source URL when S3 tool image upload fails

### DIFF
--- a/src/data-layer/fetchers/developer-tools/index.ts
+++ b/src/data-layer/fetchers/developer-tools/index.ts
@@ -24,10 +24,12 @@ async function uploadToolImages(
   return Promise.all(
     tools.map(async (tool) => {
       const thumbnail_url = tool.thumbnail_url
-        ? ((await uploadToS3(tool.thumbnail_url, "tools/thumbnails")) ?? "")
+        ? ((await uploadToS3(tool.thumbnail_url, "tools/thumbnails")) ??
+          tool.thumbnail_url)
         : tool.thumbnail_url
       const banner_url = tool.banner_url
-        ? ((await uploadToS3(tool.banner_url, "tools/banners")) ?? "")
+        ? ((await uploadToS3(tool.banner_url, "tools/banners")) ??
+          tool.banner_url)
         : tool.banner_url
 
       return { ...tool, thumbnail_url, banner_url }


### PR DESCRIPTION
## Summary

- `uploadToolImages()` was storing an empty string (`""`) when S3 upload returned `null` (on failure)
- Changed to fall back to the original source URL (`tool.thumbnail_url` / `tool.banner_url`) instead
- Source images come from `storage.googleapis.com` which is already whitelisted in `next.config.js` `remotePatterns`

## Context

Identified via Ahrefs Site Audit (`Error-Page_has_broken_image.csv`, 2,691 rows). The S3 endpoint `s3-dcl1.ethquokkaops.io` is currently returning 504 for tool thumbnails, causing `/_next/image` to 504 on all `/developers/tools/*` pages in every locale.

**This code fix prevents future data syncs from storing broken empty-string URLs.** The existing cached data with broken S3 URLs will continue to 504 until:
1. The S3 infrastructure issue is resolved, OR
2. A developer-tools data pipeline re-run is triggered (which will use the fallback path from this fix)

## Test plan

- [ ] Trigger a developer-tools data pipeline re-run and verify `thumbnail_url` / `banner_url` are populated with `storage.googleapis.com` URLs when S3 is unavailable
- [ ] Confirm `/developers/tools/*` pages no longer show broken images after the pipeline re-runs