### PR TITLE
fix: update nixorokish contributor profile link from http to https

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -13427,7 +13427,7 @@
       "login": "nixorokish",
       "name": "nixo",
       "avatar_url": "https://avatars.githubusercontent.com/u/23272494?v=4",
-      "profile": "http://ethereum.org",
+      "profile": "https://ethereum.org",
       "contributions": [
         "content",
         "maintenance"


### PR DESCRIPTION
## Summary

- Every locale variant of `/contributing/` was flagged by Ahrefs for having an `http://` outlink (25 rows in `Error-indexable-HTTPS_page_has_internal_links_to_HTTP.csv`)
- Root cause: contributor **nixorokish** in `.all-contributorsrc` had `"profile": "http://ethereum.org"` — rendered as a plain `<a href>` by `ContributorsView`
- Fix: one-character change, `http://` → `https://`

## Test plan

- [ ] Verify the Contributors section on `/contributing/` no longer emits an `http://` link in rendered HTML
- [ ] After next Ahrefs crawl: `Error-indexable-HTTPS_page_has_internal_links_to_HTTP.csv` row count for `ethereum.org` should drop from 25 to 0