### PR TITLE
fix: replace redirect links with final destinations

### DIFF
--- a/public/content/security/index.md
+++ b/public/content/security/index.md
@@ -22,7 +22,7 @@ Misunderstandings about how crypto works can lead to costly mistakes. For exampl
   What is Ethereum?
 </DocLink>
 
-<DocLink href="/eth/">
+<DocLink href="/what-is-ether/">
   What is ether?
 </DocLink>
 <Divider />

--- a/public/content/web3/index.md
+++ b/public/content/web3/index.md
@@ -115,7 +115,7 @@ Web3 solves these problems by allowing you to control your digital identity with
 Web2's payment infrastructure relies on banks and payment processors, excluding people without bank accounts or those who happen to live within the borders of the wrong country.
 Web3 uses tokens like [ETH](/glossary/#ether) to send money directly in the browser and requires no trusted third party.
 
-<ButtonLink href="/eth/">
+<ButtonLink href="/what-is-ether/">
   More on ETH
 </ButtonLink>
 

--- a/src/components/StablecoinAccordion/index.tsx
+++ b/src/components/StablecoinAccordion/index.tsx
@@ -24,11 +24,11 @@ import { useStablecoinAccordion } from "./useStablecoinAccordion"
 import { useTranslation } from "@/hooks/useTranslation"
 
 const SectionTitle = (props: ChildOnlyProp) => (
-  <h4 className="mb-8 mt-0 text-start text-xl font-bold" {...props} />
+  <h4 className="mt-0 mb-8 text-start text-xl font-bold" {...props} />
 )
 
 const StepBoxContainer = (props: ChildOnlyProp) => (
-  <div className="mb-8 mt-4" {...props} />
+  <div className="mt-4 mb-8" {...props} />
 )
 
 const StepBox = (
@@ -37,7 +37,7 @@ const StepBox = (
   const { t } = useTranslation("page-stablecoins")
 
   return (
-    <LinkBox className="bg-background not-[:first-child]:-mt-px hover:bg-background-highlight flex flex-col items-start border p-4 transition-transform duration-200 hover:scale-105 md:flex-row md:items-stretch">
+    <LinkBox className="flex flex-col items-start border bg-background p-4 transition-transform duration-200 not-[:first-child]:-mt-px hover:scale-105 hover:bg-background-highlight md:flex-row md:items-stretch">
       <Flex className="w-full items-center justify-between">
         <div>
           <LinkOverlay asChild>

--- a/src/components/StablecoinAccordion/index.tsx
+++ b/src/components/StablecoinAccordion/index.tsx
@@ -24,11 +24,11 @@ import { useStablecoinAccordion } from "./useStablecoinAccordion"
 import { useTranslation } from "@/hooks/useTranslation"
 
 const SectionTitle = (props: ChildOnlyProp) => (
-  <h4 className="mt-0 mb-8 text-start text-xl font-bold" {...props} />
+  <h4 className="mb-8 mt-0 text-start text-xl font-bold" {...props} />
 )
 
 const StepBoxContainer = (props: ChildOnlyProp) => (
-  <div className="mt-4 mb-8" {...props} />
+  <div className="mb-8 mt-4" {...props} />
 )
 
 const StepBox = (
@@ -37,7 +37,7 @@ const StepBox = (
   const { t } = useTranslation("page-stablecoins")
 
   return (
-    <LinkBox className="flex flex-col items-start border bg-background p-4 transition-transform duration-200 not-[:first-child]:-mt-px hover:scale-105 hover:bg-background-highlight md:flex-row md:items-stretch">
+    <LinkBox className="bg-background not-[:first-child]:-mt-px hover:bg-background-highlight flex flex-col items-start border p-4 transition-transform duration-200 hover:scale-105 md:flex-row md:items-stretch">
       <Flex className="w-full items-center justify-between">
         <div>
           <LinkOverlay asChild>
@@ -224,7 +224,7 @@ const StablecoinAccordion = () => {
           </SectionTitle>
           <p className="mb-6 leading-6">
             {t("page-stablecoins-accordion-borrow-risks-copy")}{" "}
-            <InlineLink href="/eth/">
+            <InlineLink href="/what-is-ether/">
               {t("page-stablecoins-accordion-borrow-risks-link")}
             </InlineLink>
           </p>

--- a/src/data/roadmap/releases.tsx
+++ b/src/data/roadmap/releases.tsx
@@ -66,7 +66,7 @@ export const getReleasesData = (t: TranslationFunction): Release[] => [
         </ul>
       </div>
     ),
-    href: "/upgrades/merge",
+    href: "/roadmap/merge/",
   },
   {
     image: QuizzesHubHeroImage,


### PR DESCRIPTION
## Summary

- Ahrefs flagged ~743 main-site pages (`Warning-indexable-Page_has_links_to_redirect.csv`) for internal links that pass through HTTP redirects instead of pointing to final destinations
- Two redirect patterns in English content and components:
  - `/eth/` (308 → `/what-is-ether/`) in `security/index.md`, `web3/index.md`, and `StablecoinAccordion`
  - `/upgrades/merge` (308 → `/roadmap/merge/`) in the roadmap releases timeline

## Changes

| File | Old | New |
|------|-----|-----|
| `public/content/security/index.md` | `/eth/` | `/what-is-ether/` |
| `public/content/web3/index.md` | `/eth/` | `/what-is-ether/` |
| `src/components/StablecoinAccordion/index.tsx` | `/eth/` | `/what-is-ether/` |
| `src/data/roadmap/releases.tsx` | `/upgrades/merge` | `/roadmap/merge/` |

Note: translated locale variants of these pages still link through redirects — those are Crowdin-managed strings and are not changed here.

## Test plan

- [ ] `/security/` — "What is ether?" DocLink goes directly to `/what-is-ether/`
- [ ] `/web3/` — "More on ETH" button goes directly to `/what-is-ether/`
- [ ] `/stablecoins/` — borrow-risks accordion link goes to `/what-is-ether/`
- [ ] `/roadmap/` — Paris (The Merge) timeline card links to `/roadmap/merge/`
- [ ] After next Ahrefs crawl: redirect-link row count for the above pages should drop