### PR TITLE
fix: add alt text to contributor avatar images on /contributing/

### DIFF
--- a/src/components/Contributors/ContributorsView.tsx
+++ b/src/components/Contributors/ContributorsView.tsx
@@ -27,12 +27,12 @@ const ContributorCard = ({ contributor }: { contributor: Contributor }) => {
       <img
         className="size-[132px]"
         src={contributor.avatar_url}
-        alt=""
+        alt={contributor.name}
         loading="lazy"
         decoding="async"
       />
       <div className="p-4">
-        <h3 className="mt-2 mb-4 text-md text-body">{contributor.name}</h3>
+        <h3 className="text-md text-body mb-4 mt-2">{contributor.name}</h3>
       </div>
     </>
   )


### PR DESCRIPTION
## Summary

- Ahrefs flagged 73 main-site pages (`Warning-Missing_alt_text.csv`) for images missing alt text
- All flagged images were GitHub avatar `<img>` elements rendered by `ContributorsView` on every locale variant of `/contributing/`
- The component was using `alt=""` (empty string); changed to `alt={contributor.name}` so each avatar has a meaningful description for both SEO crawlers and screen readers

## Test plan

- [ ] `/contributing/` — inspect contributor avatar images in DevTools, confirm `alt` attributes contain contributor names
- [ ] After next Ahrefs crawl: `Warning-Missing_alt_text.csv` row count for `ethereum.org` should drop from 73 to 0