### PR TITLE
Glamsterdam update - devnet edits 

### DIFF
--- a/public/content/roadmap/glamsterdam/index.md
+++ b/public/content/roadmap/glamsterdam/index.md
@@ -83,11 +83,11 @@ By replacing off-protocol middleware and relays with in-protocol mechanics, ePBS
 
 Today’s Ethereum is like a single-lane road; because the network doesn’t know what data a transaction will need or change (like which accounts a transaction will touch) until a transaction has been run, validators must process transactions one by one in a strict, sequential line. If they tried to process the transactions all at once, without knowing these dependencies, two transactions might accidentally try to change the exact same data at the same time, causing errors.
 
-**Block-Level Access Lists (BALs, or EIP-7928)** are like a map that’s included in every block, telling the network which parts of the database will be accessed before the work begins. BALs require every block to include the hash of every account change that the transactions will touch, along with the final results of those changes (the hash record of all state accesses and post-execution values).
+**Block-Level Access Lists (BALs, or EIP-7928)** function like a map for the network, detailing which parts of the database will be accessed before the work begins. The execution layer stores the full Block Access List, including every account change that the transactions will touch, along with the final results of those changes (all state accesses and post-execution values). To keep blocks lightweight, the block header contains a new field with a unique digital fingerprint (the hash record) of this list.
 
 Because they give instant visibility into which transactions don’t overlap, BALs allow nodes to perform parallel disk reads, fetching information for many transactions simultaneously. The network can safely group unrelated transactions and process them in parallel.
 
-Because the BAL includes the final results of transactions (the post-execution values), when the network’s nodes need to sync to the network’s current state, they can copy those final results to update their records. Validators no longer have to replay all the complicated transactions from scratch to know what happened, making it faster and easier for new nodes to join the network.
+As the BAL includes the final results of transactions (the post-execution values), when the network’s nodes need to sync to the network’s current state, they can copy those final results to update their records. Validators no longer have to replay all the complicated transactions from scratch to know what happened, making it faster and easier for new nodes to join the network.
 
 The parallel disk reads enabled by BALs will be a significant step toward a future where Ethereum can process many transactions at once, significantly increasing the network’s speed.
 
@@ -107,14 +107,14 @@ As the Ethereum network grows faster, it’s important to ensure that the cost o
 ### State creation gas cost increase {#state-creation-gas-cost-increase}
 
 - Ensures that the fees to create new accounts or smart contracts accurately reflect the long-term burden they place on Ethereum's database
-- Automatically adjusts these data-creation fees based on the network's overall capacity, targeting a safe and predictable growth rate so standard physical hardware can continue running the network
+- Sets a fixed cost per state byte (CPSB) targeting a safe and predictable growth rate of 100 GiB/year, ensuring standard physical hardware can continue running the network
 - Separates the accounting for these specific fees to a new reservoir, removing old transaction limits and allowing developers to deploy larger, more complex applications
 
 Adding new accounts, tokens, and [smart contracts](/glossary/#smart-contract) creates permanent data (known as "state") that every computer running the network must store indefinitely. The current fees to add or read this data are inconsistent and don’t necessarily reflect the actual, long-term storage burden they place on the network's hardware.
 
 Some actions that create state on Ethereum, like creating new accounts or deploying large smart contracts, have been relatively low-cost compared to the permanent storage space they take up on the network’s nodes, for example, contract deployment is significantly cheaper per byte than creating storage slots.
 
-Without adjustment, Ethereum’s state could grow by nearly 200 GiB a year if the network scales to a 100M gas limit, eventually outstripping common hardware.
+Without adjustment, Ethereum’s state growth would become unsustainable as the network scales toward the 200M gas limit floor enabled by Glamsterdam.
 
 **State creation gas cost increase (or EIP-8037)** harmonizes costs by tying them to the actual size of the data being created, updating the fees so they are proportional to the amount of permanent data an operation creates or accesses.
 
@@ -288,11 +288,11 @@ Existing contracts will continue to function normally after Glamsterdam. Develop
 - Increase maximum contract size (or EIP-7954) allows developers to deploy larger applications, raising the maximum contract size limit from roughly 24KiB to 32KiB.
 - Deterministic factory predeploy (or EIP-7997) introduces a universal, built-in factory contract. It allows developers to deploy their applications and smart contract wallets to the exact same address across all participating EVM chains.
 - If your app relies on complex tracing to find ETH transfers, ETH transfers and burns emit a log (or EIP-7708) will allow you to switch to using logs for more simple and reliable accounting.
-- State creation gas cost increase (or EIP-8037) and state-access gas cost update (or EIP-8038) introduce new sustainability models that will change certain contract deployment costs, as creating new accounts or permanent storage will have a dynamically-adjusting fee.
+- State creation gas cost increase (or EIP-8037) and state-access gas cost update (or EIP-8038) introduce new sustainability models that will change certain contract deployment costs, as creating new accounts or permanent storage will have a new standardized fixed fee based on the size of the data created.
 
 ### How will Glamsterdam affect node storage and hardware requirements? {#how-will-glamsterdam-affect-node-storage-and-hardware-requirements}
 
 Multiple EIPs under consideration for Glamsterdam address the performance cliff of state growth:
 
-- State creation gas cost increase (or EIP-8037) introduces a dynamic pricing model to target a state database growth rate of 100 GiB/year, ensuring standard physical hardware can continue running the network efficiently.
+- State creation gas cost increase (or EIP-8037) introduces a fixed-cost framework (CPSB) to target a state database growth rate of 100 GiB/year, ensuring standard physical hardware can continue running the network efficiently.
 - eth/70 partial block receipt lists (or EIP-7975) allows nodes to request paginated block receipts, which breaks data-heavy block receipt lists into smaller chunks to prevent crashes and syncs as Ethereum scales.

--- a/public/content/roadmap/glamsterdam/index.md
+++ b/public/content/roadmap/glamsterdam/index.md
@@ -9,7 +9,7 @@ lang: en
 <Alert variant="update">
 <AlertContent>
 <AlertTitle>
-Glamsterdam is an upcoming Ethereum upgrade planned for H1 2026
+Glamsterdam is an upcoming Ethereum upgrade planned for H2 2026
 </AlertTitle>
 <AlertDescription>
 The Glamsterdam upgrade is only a single step in Ethereum's long-term development goals. Learn more about [the protocol roadmap](/roadmap/) and [previous upgrades](/ethereum-forks/).

--- a/public/content/roadmap/glamsterdam/index.md
+++ b/public/content/roadmap/glamsterdam/index.md
@@ -32,7 +32,7 @@ These improvements ensure Ethereum remains fast, affordable, and decentralized a
 <Alert variant="info">
 <AlertContent>
 <AlertDescription>
-Note: This article currently highlights a selection of EIPs being considered for inclusion in Glamsterdam. For the latest status updates, view the [Glamsterdam upgrade on Forkcast](https://forkcast.org/upgrade/glamsterdam).
+Note: This article currently highlights a selection of EIPs being considered for inclusion in Glamsterdam. Additional proposals actively being tested in devnets include EIP-7778, EIP-7843, EIP-7976, EIP-7981, and EIP-8024. For the latest status updates, view the [Glamsterdam upgrade on Forkcast](https://forkcast.org/upgrade/glamsterdam).
 
 If you want to add an EIP that’s under consideration for Glamsterdam, but hasn’t been added to this page yet, [learn how to contribute to ethereum.org here](/contributing/).
 </AlertDescription>
@@ -56,6 +56,7 @@ Meaningful L1 scaling requires moving away from off-protocol trust assumptions a
 - Removes off-protocol trust assumptions and reliance on third-party relays
 - Supports L1 scaling by allowing much larger payloads through extended propagation windows
 - Introduces trustless builder payments directly into the protocol 
+- Requires architectural updates for staking pools to enable trustless monitoring, though overall staking user experience is improved by a refined builder selection process
 
 Currently, the process of proposing and building blocks includes a hand-off between block proposers and block builders. The relationship between proposers and builders isn’t part of the core Ethereum protocol, so it relies on trusted third-party middleware, software (relays), and off-protocol trust between entities.
 
@@ -93,7 +94,7 @@ The parallel disk reads enabled by BALs will be a significant step toward a futu
 
 #### eth/71 Block Access List Exchange {#bale}
 
-Block Access List Exchange (eth/71 or EIP-8159) is the direct networking companion to block-level access lists. While BALs unlock parallel execution, eth/71 upgrades the peer-to-peer protocol to allow nodes to actually share these lists over the network. Implementing the block access list exchange will enable faster syncing and allow nodes to perform executionless state updates.
+Block Access List Exchange (eth/71 or EIP-8159) is the direct networking companion to block-level access lists. While BALs unlock parallel execution, eth/71 upgrades the peer-to-peer protocol to allow nodes to actually share these lists over the network. Now required for all Execution Layer clients, the block access list exchange will enable faster syncing and allow nodes to perform executionless state updates.
 
 **Resources**:
 
@@ -107,18 +108,18 @@ As the Ethereum network grows faster, it’s important to ensure that the cost o
 ### State creation gas cost increase {#state-creation-gas-cost-increase}
 
 - Ensures that the fees to create new accounts or smart contracts accurately reflect the long-term burden they place on Ethereum's database
-- Sets a fixed cost per state byte (CPSB) targeting a safe and predictable growth rate of 100 GiB/year, ensuring standard physical hardware can continue running the network
+- Sets a fixed cost per state byte (CPSB) targeting a safe and predictable growth rate of 120 GiB/year, ensuring standard physical hardware can continue running the network
 - Separates the accounting for these specific fees to a new reservoir, removing old transaction limits and allowing developers to deploy larger, more complex applications
 
 Adding new accounts, tokens, and [smart contracts](/glossary/#smart-contract) creates permanent data (known as "state") that every computer running the network must store indefinitely. The current fees to add or read this data are inconsistent and don’t necessarily reflect the actual, long-term storage burden they place on the network's hardware.
 
 Some actions that create state on Ethereum, like creating new accounts or deploying large smart contracts, have been relatively low-cost compared to the permanent storage space they take up on the network’s nodes, for example, contract deployment is significantly cheaper per byte than creating storage slots.
 
-Without adjustment, Ethereum’s state growth would become unsustainable as the network scales toward the 200M gas limit floor enabled by Glamsterdam.
+Without adjustment, Ethereum’s state growth would become unsustainable as the network scales toward the 200M gas limit floor enabled by Glamsterdam (with developers currently testing at a 150M reference block gas limit to derive accurate state pricing).
 
 **State creation gas cost increase (or EIP-8037)** harmonizes costs by tying them to the actual size of the data being created, updating the fees so they are proportional to the amount of permanent data an operation creates or accesses.
 
-EIP-8037 also introduces a reservoir model to manage these costs more predictably; state gas charges draw from the `state_gas_reservoir` first, and the `GAS` opcode only returns `gas_left`, preventing execution frames from miscalculating available gas.
+EIP-8037 also introduces a reservoir model to manage these costs more predictably; state gas charges draw from the `state_gas_reservoir` first, and the `GAS` opcode only returns `gas_left`, preventing execution frames from miscalculating available gas. To support this, essential background tasks are given an extra fuel allowance that goes straight into this dedicated reserve, ensuring critical network operations won't fail simply because storing permanent data requires more resources.
 
 Before EIP-8037, both the computational work (the active processing) and the permanent data storage (saving the smart contract to the network's database) share the same gas limit. The reservoir model splits accounting: the gas limit for the actual computational work of the transaction (processing) and for long-term data storage (state gas). Separating the two helps prevent the sheer size of an application's data from capping out the gas limit; as long as developers provide enough funds to fill the reservoir for data storage, they can deploy much larger and more complex smart contracts.
 
@@ -234,7 +235,7 @@ This will make it much easier and more reliable for wallets, exchanges, and brid
 
 As we increase the amount of work Ethereum can do, the lists of receipts for those actions (the data records of these transactions) are getting so large that they could potentially cause the network’s nodes to fail when trying to sync data with one another.
 
-eth/70 partial block receipt lists (or EIP-7975) introduces a new way for nodes to talk to each other (eth/70) that allows these large lists to be broken into smaller, more manageable pieces. eth/70 introduces a pagination system for the network's communication protocol that allows nodes to break block receipt lists down and safely request the data in smaller, more manageable chunks.
+Now a requirement for all Execution Layer clients, eth/70 partial block receipt lists (or EIP-7975) introduces a new way for nodes to talk to each other (eth/70) that allows these large lists to be broken into smaller, more manageable pieces. eth/70 introduces a pagination system for the network's communication protocol that allows nodes to break block receipt lists down and safely request the data in smaller, more manageable chunks.
 
 This change would prevent network sync failures during periods of heavy activity. Ultimately, it paves the way for Ethereum to increase its block capacity, and process more transactions per block in the future, without overwhelming the physical hardware syncing the chain.
 
@@ -294,5 +295,5 @@ Existing contracts will continue to function normally after Glamsterdam. Develop
 
 Multiple EIPs under consideration for Glamsterdam address the performance cliff of state growth:
 
-- State creation gas cost increase (or EIP-8037) introduces a fixed-cost framework (CPSB) to target a state database growth rate of 100 GiB/year, ensuring standard physical hardware can continue running the network efficiently.
+- State creation gas cost increase (or EIP-8037) introduces a fixed-cost framework (CPSB) to target a state database growth rate of 120 GiB/year, ensuring standard physical hardware can continue running the network efficiently.
 - eth/70 partial block receipt lists (or EIP-7975) allows nodes to request paginated block receipts, which breaks data-heavy block receipt lists into smaller chunks to prevent crashes and syncs as Ethereum scales.

--- a/public/content/roadmap/glamsterdam/index.md
+++ b/public/content/roadmap/glamsterdam/index.md
@@ -17,7 +17,7 @@ The Glamsterdam upgrade is only a single step in Ethereum's long-term developmen
 </AlertContent>
 </Alert>
 
-[Ethereum’s](/) upcoming Glamsterdam upgrade is designed to clear the path for the next generation of scaling. Glamsterdam is named from the combination of "Amsterdam" (execution layer upgrade, named after a previous Devconnect location) and "Gloas" (consensus layer upgrade, named after a star).
+[Ethereum's](/) upcoming Glamsterdam upgrade is designed to clear the path for the next generation of scaling. Glamsterdam is named from the combination of "Amsterdam" (execution layer upgrade, named after a previous Devconnect location) and "Gloas" (consensus layer upgrade, named after a star).
 
 Following the progress made in the [Fusaka](/roadmap/fusaka/) upgrade, Glamsterdam focuses on scaling the L1 by reorganizing how the network processes transactions and manages its growing database, fundamentally updating how Ethereum creates and verifies blocks.
 
@@ -34,7 +34,7 @@ These improvements ensure Ethereum remains fast, affordable, and decentralized a
 <AlertDescription>
 Note: This article currently highlights a selection of EIPs being considered for inclusion in Glamsterdam. Additional proposals actively being tested in devnets include EIP-7778, EIP-7843, EIP-7976, EIP-7981, and EIP-8024. For the latest status updates, view the [Glamsterdam upgrade on Forkcast](https://forkcast.org/upgrade/glamsterdam).
 
-If you want to add an EIP that’s under consideration for Glamsterdam, but hasn’t been added to this page yet, [learn how to contribute to ethereum.org here](/contributing/).
+If you want to add an EIP that's under consideration for Glamsterdam, but hasn't been added to this page yet, [learn how to contribute to ethereum.org here](/contributing/).
 </AlertDescription>
 </AlertContent>
 </Alert>
@@ -58,7 +58,7 @@ Meaningful L1 scaling requires moving away from off-protocol trust assumptions a
 - Introduces trustless builder payments directly into the protocol 
 - Requires architectural updates for staking pools to enable trustless monitoring, though overall staking user experience is improved by a refined builder selection process
 
-Currently, the process of proposing and building blocks includes a hand-off between block proposers and block builders. The relationship between proposers and builders isn’t part of the core Ethereum protocol, so it relies on trusted third-party middleware, software (relays), and off-protocol trust between entities.
+Currently, the process of proposing and building blocks includes a hand-off between block proposers and block builders. The relationship between proposers and builders isn't part of the core Ethereum protocol, so it relies on trusted third-party middleware, software (relays), and off-protocol trust between entities.
 
 The out-of-protocol relationship between proposers and builders also creates a "hot path" during block validation that forces [validators](/glossary/#validator) to rush through transaction broadcasting and execution in a tight 2-second window, limiting how much data the network can handle.
 
@@ -82,15 +82,15 @@ By replacing off-protocol middleware and relays with in-protocol mechanics, ePBS
 - Allows nodes to update their records by reading the final results without needing to replay every transaction (executionless sync), making it much faster to sync a node to the network
 - Eliminates guesswork, allowing validators to pre-load all necessary data at once instead of discovering it step-by-step, which makes validation much faster
 
-Today’s Ethereum is like a single-lane road; because the network doesn’t know what data a transaction will need or change (like which accounts a transaction will touch) until a transaction has been run, validators must process transactions one by one in a strict, sequential line. If they tried to process the transactions all at once, without knowing these dependencies, two transactions might accidentally try to change the exact same data at the same time, causing errors.
+Today's Ethereum is like a single-lane road; because the network doesn't know what data a transaction will need or change (like which accounts a transaction will touch) until a transaction has been run, validators must process transactions one by one in a strict, sequential line. If they tried to process the transactions all at once, without knowing these dependencies, two transactions might accidentally try to change the exact same data at the same time, causing errors.
 
 **Block-Level Access Lists (BALs, or EIP-7928)** function like a map for the network, detailing which parts of the database will be accessed before the work begins. The execution layer stores the full Block Access List, including every account change that the transactions will touch, along with the final results of those changes (all state accesses and post-execution values). To keep blocks lightweight, the block header contains a new field with a unique digital fingerprint (the hash record) of this list.
 
-Because they give instant visibility into which transactions don’t overlap, BALs allow nodes to perform parallel disk reads, fetching information for many transactions simultaneously. The network can safely group unrelated transactions and process them in parallel.
+Because they give instant visibility into which transactions don't overlap, BALs allow nodes to perform parallel disk reads, fetching information for many transactions simultaneously. The network can safely group unrelated transactions and process them in parallel.
 
-As the BAL includes the final results of transactions (the post-execution values), when the network’s nodes need to sync to the network’s current state, they can copy those final results to update their records. Validators no longer have to replay all the complicated transactions from scratch to know what happened, making it faster and easier for new nodes to join the network.
+As the BAL includes the final results of transactions (the post-execution values), when the network's nodes need to sync to the network's current state, they can copy those final results to update their records. Validators no longer have to replay all the complicated transactions from scratch to know what happened, making it faster and easier for new nodes to join the network.
 
-The parallel disk reads enabled by BALs will be a significant step toward a future where Ethereum can process many transactions at once, significantly increasing the network’s speed.
+The parallel disk reads enabled by BALs will be a significant step toward a future where Ethereum can process many transactions at once, significantly increasing the network's speed.
 
 #### eth/71 Block Access List Exchange {#bale}
 
@@ -103,7 +103,7 @@ Block Access List Exchange (eth/71 or EIP-8159) is the direct networking compani
 
 ## Network sustainability {#network-sustainability}
 
-As the Ethereum network grows faster, it’s important to ensure that the cost of using it matches the wear-and-tear on the hardware that runs Ethereum. The network needs to increase its overall capacity limits in order to safely scale and process more transactions.
+As the Ethereum network grows faster, it's important to ensure that the cost of using it matches the wear-and-tear on the hardware that runs Ethereum. The network needs to increase its overall capacity limits in order to safely scale and process more transactions.
 
 ### State creation gas cost increase {#state-creation-gas-cost-increase}
 
@@ -111,11 +111,11 @@ As the Ethereum network grows faster, it’s important to ensure that the cost o
 - Sets a fixed **cost per state byte (CPSB)** targeting a safe and predictable growth rate of 120 GiB/year, ensuring standard physical hardware can continue running the network
 - Separates the accounting for these specific fees to a new reservoir, removing old transaction limits and allowing developers to deploy larger, more complex applications
 
-Adding new accounts, tokens, and [smart contracts](/glossary/#smart-contract) creates permanent data (known as "state") that every computer running the network must store indefinitely. The current fees to add or read this data are inconsistent and don’t necessarily reflect the actual, long-term storage burden they place on the network's hardware.
+Adding new accounts, tokens, and [smart contracts](/glossary/#smart-contract) creates permanent data (known as "state") that every computer running the network must store indefinitely. The current fees to add or read this data are inconsistent and don't necessarily reflect the actual, long-term storage burden they place on the network's hardware.
 
-Some actions that create state on Ethereum, like creating new accounts or deploying large smart contracts, have been relatively low-cost compared to the permanent storage space they take up on the network’s nodes, for example, contract deployment is significantly cheaper per byte than creating storage slots.
+Some actions that create state on Ethereum, like creating new accounts or deploying large smart contracts, have been relatively low-cost compared to the permanent storage space they take up on the network's nodes, for example, contract deployment is significantly cheaper per byte than creating storage slots.
 
-Without adjustment, Ethereum’s state growth would become unsustainable as the network scales toward the 200M gas limit floor enabled by Glamsterdam (with developers currently testing at a 150M reference block gas limit to derive accurate state pricing).
+Without adjustment, Ethereum's state growth would become unsustainable as the network scales toward the 200M gas limit floor enabled by Glamsterdam (with developers currently testing at a 150M reference block gas limit to derive accurate state pricing).
 
 **State creation gas cost increase (or EIP-8037)** harmonizes costs by tying them to the actual size of the data being created, updating the fees so they are proportional to the amount of permanent data an operation creates or accesses.
 
@@ -123,7 +123,7 @@ EIP-8037 also introduces a reservoir model to manage these costs more predictabl
 
 Before EIP-8037, both the computational work (the active processing) and the permanent data storage (saving the smart contract to the network's database) share the same gas limit. The reservoir model splits accounting: the gas limit for the actual computational work of the transaction (processing) and for long-term data storage (state gas). Separating the two helps prevent the sheer size of an application's data from capping out the gas limit; as long as developers provide enough funds to fill the reservoir for data storage, they can deploy much larger and more complex smart contracts.
 
-Pricing data storage more accurately and predictably will help Ethereum safely increase its speed and capacity without bloating the database. This sustainability will allow node operators to continue using (relatively) affordable hardware for years to come, keeping home staking accessible to maintain the network’s decentralization.
+Pricing data storage more accurately and predictably will help Ethereum safely increase its speed and capacity without bloating the database. This sustainability will allow node operators to continue using (relatively) affordable hardware for years to come, keeping home staking accessible to maintain the network's decentralization.
 
 **Resources**: [EIP-8037 technical specification](https://eips.ethereum.org/EIPS/eip-8037)
 
@@ -132,7 +132,7 @@ Pricing data storage more accurately and predictably will help Ethereum safely i
 - Increases the gas costs for when applications read or update information permanently stored on Ethereum (state-access opcodes) to accurately match the compute work these commands require
 - Strengthens network resilience by preventing denial-of-service attacks that exploit artificially cheap data-reading operations
 
-As Ethereum’s state has grown, the act of searching for and reading old data ("state access") has become heavier and slower for nodes to process. The fees for these actions have remained the same even though it is now slightly more expensive to look up information (in terms of compute power).
+As Ethereum's state has grown, the act of searching for and reading old data ("state access") has become heavier and slower for nodes to process. The fees for these actions have remained the same even though it is now slightly more expensive to look up information (in terms of compute power).
 
 As a result, some specific commands are currently underpriced relative to the work they force a node to do. `EXTCODESIZE` and `EXTCODECOPY` are underpriced, for example, because they require two separate database reads—one for the account object, and a second for the actual code size or bytecode.
 
@@ -173,7 +173,7 @@ Since the [Pectra upgrade](/roadmap/pectra) increased the maximum effective bala
 
 To break down how this works today:
 
-- Ethereum’s churn limit is a safety limit on the rate at which validators can enter, exit, or merge (consolidate) their staked ETH, to ensure the network's security is never destabilized
+- Ethereum's churn limit is a safety limit on the rate at which validators can enter, exit, or merge (consolidate) their staked ETH, to ensure the network's security is never destabilized
 - Because a validator consolidation is a heavier action with more moving parts than a standard validator exit, it eats up a larger portion of this safety budget (churn limit)
 - Specifically, the protocol dictates that the exact security cost of one standard exit is two-thirds (2/3) the cost of one consolidation
 
@@ -185,7 +185,7 @@ Democratizing access to the consolidation queue will increase the speed at which
 
 ## Improve user & developer experience {#improve-user-developer-experience}
 
-Ethereum’s Glamsterdam upgrade aims to improve the user experience, enhance data discoverability, and handle rising message sizes to prevent sync failures. This makes it easier to track what’s happening onchain while preventing technical hiccups as the network scales.
+Ethereum's Glamsterdam upgrade aims to improve the user experience, enhance data discoverability, and handle rising message sizes to prevent sync failures. This makes it easier to track what's happening onchain while preventing technical hiccups as the network scales.
 
 ### Reduce intrinsic transaction gas costs {#reduce-intrinsic-transaction-gas-costs}
 
@@ -196,7 +196,7 @@ All Ethereum transactions have a flat base gas fee today, regardless of how simp
 
 Reduce intrinsic transaction gas works by breaking down the transaction fee to reflect only the basic, essential work the computers running the network actually do, like verifying a digital signature and updating a balance. Because a basic ETH payment doesn't execute complex code or carry extra data, this proposal would reduce its fee to match its lightweight footprint.
 
-The proposal introduces an exception for creating brand-new accounts to keep lower fees from overwhelming the network’s state. If a transfer sends ETH to an empty, non-existent address, the network must create a permanent new record for it. A gas surcharge is added for that account creation to help cover its long-term storage burden.
+The proposal introduces an exception for creating brand-new accounts to keep lower fees from overwhelming the network's state. If a transfer sends ETH to an empty, non-existent address, the network must create a permanent new record for it. A gas surcharge is added for that account creation to help cover its long-term storage burden.
 
 Together, the EIP-2780 aims to make everyday transfers between existing accounts more affordable while ensuring the network is still protected against database bloat by accurately pricing true state growth.
 
@@ -233,7 +233,7 @@ This will make it much easier and more reliable for wallets, exchanges, and brid
 
 ### eth/70 partial block receipt lists {#eth-70-partial-block-receipt-lists}
 
-As we increase the amount of work Ethereum can do, the lists of receipts for those actions (the data records of these transactions) are getting so large that they could potentially cause the network’s nodes to fail when trying to sync data with one another.
+As we increase the amount of work Ethereum can do, the lists of receipts for those actions (the data records of these transactions) are getting so large that they could potentially cause the network's nodes to fail when trying to sync data with one another.
 
 Now a requirement for all execution layer clients, eth/70 partial block receipt lists (or EIP-7975) introduces a new way for nodes to talk to each other (eth/70) that allows these large lists to be broken into smaller, more manageable pieces. eth/70 introduces a pagination system for the network's communication protocol that allows nodes to break block receipt lists down and safely request the data in smaller, more manageable chunks.
 

--- a/public/content/roadmap/glamsterdam/index.md
+++ b/public/content/roadmap/glamsterdam/index.md
@@ -235,7 +235,7 @@ This will make it much easier and more reliable for wallets, exchanges, and brid
 
 As we increase the amount of work Ethereum can do, the lists of receipts for those actions (the data records of these transactions) are getting so large that they could potentially cause the network’s nodes to fail when trying to sync data with one another.
 
-Now a requirement for all Execution Layer clients, eth/70 partial block receipt lists (or EIP-7975) introduces a new way for nodes to talk to each other (eth/70) that allows these large lists to be broken into smaller, more manageable pieces. eth/70 introduces a pagination system for the network's communication protocol that allows nodes to break block receipt lists down and safely request the data in smaller, more manageable chunks.
+Now a requirement for all execution layer clients, eth/70 partial block receipt lists (or EIP-7975) introduces a new way for nodes to talk to each other (eth/70) that allows these large lists to be broken into smaller, more manageable pieces. eth/70 introduces a pagination system for the network's communication protocol that allows nodes to break block receipt lists down and safely request the data in smaller, more manageable chunks.
 
 This change would prevent network sync failures during periods of heavy activity. Ultimately, it paves the way for Ethereum to increase its block capacity, and process more transactions per block in the future, without overwhelming the physical hardware syncing the chain.
 

--- a/public/content/roadmap/glamsterdam/index.md
+++ b/public/content/roadmap/glamsterdam/index.md
@@ -94,7 +94,7 @@ The parallel disk reads enabled by BALs will be a significant step toward a futu
 
 #### eth/71 Block Access List Exchange {#bale}
 
-Block Access List Exchange (eth/71 or EIP-8159) is the direct networking companion to block-level access lists. While BALs unlock parallel execution, eth/71 upgrades the peer-to-peer protocol to allow nodes to actually share these lists over the network. Now required for all Execution Layer clients, the block access list exchange will enable faster syncing and allow nodes to perform executionless state updates.
+Block Access List Exchange (eth/71 or EIP-8159) is the direct networking companion to block-level access lists. While BALs unlock parallel execution, eth/71 upgrades the peer-to-peer protocol to allow nodes to actually share these lists over the network. Now required for all execution layer clients, the block access list exchange will enable faster syncing and allow nodes to perform executionless state updates.
 
 **Resources**:
 

--- a/public/content/roadmap/glamsterdam/index.md
+++ b/public/content/roadmap/glamsterdam/index.md
@@ -108,7 +108,7 @@ As the Ethereum network grows faster, it’s important to ensure that the cost o
 ### State creation gas cost increase {#state-creation-gas-cost-increase}
 
 - Ensures that the fees to create new accounts or smart contracts accurately reflect the long-term burden they place on Ethereum's database
-- Sets a fixed cost per state byte (CPSB) targeting a safe and predictable growth rate of 120 GiB/year, ensuring standard physical hardware can continue running the network
+- Sets a fixed **cost per state byte (CPSB)** targeting a safe and predictable growth rate of 120 GiB/year, ensuring standard physical hardware can continue running the network
 - Separates the accounting for these specific fees to a new reservoir, removing old transaction limits and allowing developers to deploy larger, more complex applications
 
 Adding new accounts, tokens, and [smart contracts](/glossary/#smart-contract) creates permanent data (known as "state") that every computer running the network must store indefinitely. The current fees to add or read this data are inconsistent and don’t necessarily reflect the actual, long-term storage burden they place on the network's hardware.

--- a/src/data/roadmap/releases.tsx
+++ b/src/data/roadmap/releases.tsx
@@ -178,7 +178,7 @@ export const getReleasesData = (t: TranslationFunction): Release[] => [
     image: GlamsterdamImage,
     releaseName: "Glamsterdam",
     plannedReleaseYear: "2026",
-    displayDate: "H1 2026",
+    displayDate: "H2 2026",
     href: "/roadmap/glamsterdam/",
     content: (
       <div>

--- a/src/intl/en/page-what-is-ethereum.json
+++ b/src/intl/en/page-what-is-ethereum.json
@@ -156,7 +156,7 @@
   "page-what-is-ethereum-roadmap-title": "What is the Ethereum roadmap for 2026?",
   "page-what-is-ethereum-roadmap-intro-1": "Ethereum doesn't follow a fixed roadmap. It follows a shared vision.",
   "page-what-is-ethereum-roadmap-intro-2": "Network upgrades are made as EIPs and developed in public by contributors around the world. There's no central team deciding what happens, just people building what they believe is useful based on users' needs.",
-  "page-what-is-ethereum-roadmap-intro-3": "Fusaka is the most recent upgrade, launched in December 2025. It introduced PeerDAS for more efficient L2 data availability and raised the default gas limit to ~60M. Looking ahead to 2026, Glamsterdam is in development and expected in H1 2026.",
+  "page-what-is-ethereum-roadmap-intro-3": "Fusaka is the most recent upgrade, launched in December 2025. It introduced PeerDAS for more efficient L2 data availability and raised the default gas limit to ~60M. Looking ahead to 2026, Glamsterdam is in development and expected in H2 2026.",
   "page-what-is-ethereum-roadmap-priorities-intro": "<a>Looking ahead</a>, Ethereum's priorities include:",
   "page-what-is-ethereum-roadmap-priority-1": "Making the core protocol and its L2s faster and cheaper for everyone",
   "page-what-is-ethereum-roadmap-priority-2": "Improving the experience for users and developers",


### PR DESCRIPTION
## Description

Updating the existing Glamsterdam roadmap page to align with new estimated release dates, updates from Interop, and latest testnet specs. 
- Update estimated date from H1 to H2 2026
- Clarify that ePBS will require staking pool updates 
- Update gas limit floor enabled by Glamsterdam to 200M w/ testing at 150M reference block gas limit 
- Revise description of 8037 to remove outdated references to dynamic pricing, reflect fixed-cost framework (CPSB) targeting state database growth rate of 120GiB/year, and add explanation of the system call gas limit increase 
- Clarify that BlockAccessList is not included in block body; hash is included in block header
- Update 'not all EIPs included' note to include some recently added to testing 
- Note that eth/70 and eth/71 are now required for all execution clients 

Updated mentions of Glamsterdam H1 2026 estimated date to H2 on other pages where target date is mentioned. 
