### PR TITLE
ci: disable auto trigger for Claude translation review

### DIFF
--- a/.github/workflows/claude-review-translations.yml
+++ b/.github/workflows/claude-review-translations.yml
@@ -34,8 +34,10 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
-  pull_request:
-    types: [opened]
+  # Automatic trigger on PR open is disabled (cost/bug control).
+  # To re-enable, uncomment the block below and the matching clause in the `if:` below.
+  # pull_request:
+  #   types: [opened]
 
 jobs:
   review-translations:
@@ -57,14 +59,16 @@ jobs:
         contains(github.event.comment.body, '@claude') &&
         contains(github.event.comment.body, '/review-translations') &&
         contains(fromJSON('["pettinarip","wackerow","nloureiro","konopkja","mnelsonBT"]'), github.event.comment.user.login)
-      ) ||
-      (
-        github.event_name == 'pull_request' &&
-        startsWith(github.event.pull_request.title, 'i18n:') &&
-        startsWith(github.event.pull_request.head.ref, 'intl/pending-') &&
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        contains(fromJSON('["pettinarip","wackerow","nloureiro","konopkja","mnelsonBT"]'), github.event.pull_request.user.login)
       )
+      # Automatic pull_request trigger disabled -- see `on:` block above.
+      # To re-enable, uncomment the clause below and add a trailing ` ||` to the line above.
+      # || (
+      #   github.event_name == 'pull_request' &&
+      #   startsWith(github.event.pull_request.title, 'i18n:') &&
+      #   startsWith(github.event.pull_request.head.ref, 'intl/pending-') &&
+      #   github.event.pull_request.head.repo.full_name == github.repository &&
+      #   contains(fromJSON('["pettinarip","wackerow","nloureiro","konopkja","mnelsonBT"]'), github.event.pull_request.user.login)
+      # )
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

The `claude-review-translations.yml` workflow currently auto-runs whenever an `i18n:`-prefixed PR is opened from an `intl/pending-*` branch by an authorized user. That auto-trigger has known bugs and is burning API budget, so this PR comments out the automatic `pull_request: [opened]` trigger and its matching clause in the job's `if:` condition.

Manual entry points are unchanged: `workflow_dispatch` from the Actions tab, and the `@claude /review-translations` comment command (on issue comments and PR review comments). To re-enable the auto trigger later, uncomment the two marked blocks in the workflow file -- comments inline note exactly what to flip back on, including restoring the trailing ` ||` on the preceding `if:` line.

## Test plan

- [ ] Verify the next `i18n:` PR opened from an `intl/pending-*` branch does NOT auto-start the Claude Translation Review workflow.
- [ ] Verify `workflow_dispatch` still runs the workflow from the Actions tab with a supplied `pr_number`.
- [ ] Verify a `@claude /review-translations` comment from an authorized user on a PR still triggers the workflow.