### PR TITLE
feat: add IPTF link to Build > Business nav

### DIFF
--- a/src/intl/en/common.json
+++ b/src/intl/en/common.json
@@ -327,6 +327,8 @@
   "nav-how-ethereum-works-label": "How Ethereum works",
   "nav-institution-enterprise-description": "Enterprise blockchain applications can be built on the public Ethereum Mainnet",
   "nav-institution-enterprise-label": "Institution & enterprise",
+  "nav-iptf-description": "Privacy guidance and technical solutions for institutional adoption.",
+  "nav-iptf-label": "Privacy for institutions and technical solutions",
   "nav-join-ethereum-org-description": "Help build the Ethereum community website",
   "nav-join-ethereum-org-label": "Join ethereum.org",
   "nav-l2-networks-description": "Introduction to Ethereum's network of networks",

--- a/src/lib/nav/buildNavigation.ts
+++ b/src/lib/nav/buildNavigation.ts
@@ -304,6 +304,11 @@ export const buildNavigation = (t: TranslateFn): NavSections => {
               description: t("nav-institution-enterprise-description"),
               href: ENTERPRISE_ETHEREUM_URL,
             },
+            {
+              label: t("nav-iptf-label"),
+              description: t("nav-iptf-description"),
+              href: "https://iptf.ethereum.org/",
+            },
           ],
         },
       ],


### PR DESCRIPTION
## Description

Adds a new link to the **Build → Business** navigation submenu:

- **Label:** Privacy for institutions and technical solutions
- **Description:** Privacy guidance and technical solutions for institutional adoption.
- **URL:** https://iptf.ethereum.org/ (Institutional Privacy Task Force)
- **Behavior:** external link, opens in a new tab

It sits alongside the existing **Institution & enterprise** item.

## Changes

- `src/lib/nav/buildNavigation.ts` — append the item to the `build/business` `items` array.
- `src/intl/en/common.json` — add `nav-iptf-label` and `nav-iptf-description` strings.

New-tab behavior is automatic: nav items render through `BaseLink`, which detects external URLs and opens them in a new tab (with the external-link arrow). No `target` prop needed.

Closes #18325

🤖 Generated with [Claude Code](https://claude.com/claude-code)
