### PR TITLE
fix(ui): space between image and cta button

### DIFF
--- a/app/[locale]/reports/trillion-dollar-security/page.tsx
+++ b/app/[locale]/reports/trillion-dollar-security/page.tsx
@@ -1,4 +1,3 @@
-import React from "react"
 import Image from "next/image"
 import { getTranslations, setRequestLocale } from "next-intl/server"
 
@@ -6,7 +5,7 @@ import type { Lang, PageParams } from "@/lib/types"
 
 import MainArticle from "@/components/MainArticle"
 import { ButtonLink } from "@/components/ui/buttons/Button"
-import { Card, CardBanner, CardFooter, CardHeader } from "@/components/ui/card"
+import { Card, CardBanner, CardContent, CardHeader } from "@/components/ui/card"
 import InlineLink, { BaseLink as Link } from "@/components/ui/Link"
 
 import { getAppPageContributorInfo } from "@/lib/utils/contributors"
@@ -28,7 +27,7 @@ const ReportCard = ({ cta, altText }: { cta: string; altText: string }) => (
         />
       </CardBanner>
     </CardHeader>
-    <CardFooter>
+    <CardContent>
       <ButtonLink
         size="lg"
         href="/reports/trillion-dollar-security.pdf"
@@ -36,7 +35,7 @@ const ReportCard = ({ cta, altText }: { cta: string; altText: string }) => (
       >
         {cta}
       </ButtonLink>
-    </CardFooter>
+    </CardContent>
   </Card>
 )
 


### PR DESCRIPTION
## Description
- Fixes space between image and CTA button on Trillion Dollar Security page, report card
- Place CTA button for TDS report card in CardContent to apply appropriate spacing between image and button

<img width="412" height="594" alt="image" src="https://github.com/user-attachments/assets/106511ca-e1cd-4b21-a593-e79723816a87" />

## Preview link
https://deploy-preview-18327.ethereum.it/reports/trillion-dollar-security

## Related Issue
Fixes:
<img width="473" height="619" alt="image" src="https://github.com/user-attachments/assets/4f29b90e-edc8-48fe-bf46-bda9f4ec5053" />
