### PR TITLE
feat(ui): add CardButtonFake

### DIFF
--- a/src/components/Homepage/GetStartedGrid.tsx
+++ b/src/components/Homepage/GetStartedGrid.tsx
@@ -5,6 +5,7 @@ import { Image } from "@/components/Image"
 import {
   Card,
   CardBanner,
+  CardButtonFake,
   CardContent,
   CardFooter,
   CardHeader,
@@ -162,10 +163,10 @@ const GetStartedGrid = async ({
                 </ul>
               </CardContent>
               <CardFooter>
-                <p className="inline-flex items-center font-bold text-primary group-hover/link:text-primary-hover">
+                <CardButtonFake>
                   {card.cta}
                   <ChevronNext className="size-5" />
-                </p>
+                </CardButtonFake>
               </CardFooter>
             </Card>
           ))}

--- a/src/components/ui/buttons/Button.tsx
+++ b/src/components/ui/buttons/Button.tsx
@@ -18,8 +18,10 @@ const buttonVariants = cva(
     "inline-flex gap-2 items-center justify-center rounded border border-solid transition [&>svg]:shrink-0",
     // Base default styling is "outline" pattern, primary color for text, border matches, no bg
     "text-primary border-current",
-    // Hover: Default hover adds box-shadow, text (border) to --primary-hover
-    "hover:!text-primary-hover hover:shadow-[4px_4px_hsla(var(--primary-low-contrast))]",
+    // Hover: Default hover adds box-shadow, text (border) to --primary-hover.
+    // `hover-link` also fires when an ancestor `group/link` (e.g. a clickable Card) is
+    // hovered, so a Button rendered as a non-interactive child mirrors the card's hover.
+    "hover-link:!text-primary-hover hover-link:shadow-[4px_4px_hsla(var(--primary-low-contrast))]",
     // Focus: Add 4px outline to all buttons, --primary-hover
     "focus-visible:outline focus-visible:outline-primary-hover focus-visible:outline-4 focus-visible:-outline-offset-1",
     // Active: text (border) to --primary-hover instead of primary, hide shadow
@@ -34,13 +36,13 @@ const buttonVariants = cva(
       variant: {
         solid: cn(
           "text-white bg-primary-action border-transparent",
-          "hover:!text-white hover:bg-primary-action-hover", // Hover
+          "hover-link:!text-white hover-link:bg-primary-action-hover", // Hover
           "active:bg-primary-action-hover", // Active
           "disabled:bg-disabled disabled:text-background" // Disabled
         ),
         outline: "", // Base styling
-        ghost: "border-transparent hover:shadow-none",
-        link: "border-transparent hover:shadow-none underline !min-h-0 !py-0 !px-1 active:text-primary",
+        ghost: "border-transparent hover-link:shadow-none",
+        link: "border-transparent hover-link:shadow-none underline !min-h-0 !py-0 !px-1 active:text-primary",
       },
       size: {
         lg: "text-lg py-3 px-8 [&>svg]:size-6 rounded-lg focus-visible:rounded-lg",

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -6,6 +6,7 @@ import Emoji from "@/components/Emoji"
 
 import { cn } from "@/lib/utils/cn"
 
+import { Button, type ButtonProps } from "./buttons/Button"
 import { BaseLink, LinkProps } from "./Link"
 
 const cardVariants = cva(
@@ -135,6 +136,28 @@ const CardFooter = React.forwardRef<
   />
 ))
 CardFooter.displayName = "CardFooter"
+
+/**
+ * Presentational mirror of `Button` rendered as a non-interactive `<div>`, for use
+ * inside a `Card` that has an `href` (where the whole card is the anchor and a real
+ * `Button`/`ButtonLink` would nest an interactive element inside the link). Reuses all
+ * Button styling via `asChild`; Button's `hover-link` variant makes its hover state
+ * fire off the card's `group/link`, so hovering anywhere on the card is visually
+ * identical to hovering the button itself -- no hover styles are duplicated here.
+ */
+type CardButtonFakeProps = React.HTMLAttributes<HTMLDivElement> &
+  Pick<ButtonProps, "variant" | "size" | "isSecondary">
+
+const CardButtonFake = React.forwardRef<HTMLDivElement, CardButtonFakeProps>(
+  ({ className, variant, size, isSecondary, children, ...props }, ref) => (
+    <Button asChild variant={variant} size={size} isSecondary={isSecondary}>
+      <div ref={ref} data-label="button-link" className={className} {...props}>
+        {children}
+      </div>
+    </Button>
+  )
+)
+CardButtonFake.displayName = "CardButtonFake"
 
 const CardEmoji = React.forwardRef<
   HTMLDivElement,
@@ -324,6 +347,7 @@ CardParagraph.displayName = "CardParagraph"
 export {
   Card,
   CardBanner,
+  CardButtonFake,
   CardContent,
   CardEmoji,
   CardFooter,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -17,3 +17,9 @@
 @import "./codeblock.css";
 
 @custom-variant dark (&:where(.dark, .dark *));
+
+/* Fires on the element's own hover OR when an ancestor marked `group/link` is hovered.
+   Lets a Button rendered as a non-interactive child (e.g. CardButtonFake inside a
+   clickable Card) mirror its hover state from the surrounding card anchor, so hovering
+   anywhere on the card is visually identical to hovering the button itself. */
+@custom-variant hover-link (&:hover, &:where(.group\/link:hover *));


### PR DESCRIPTION
## Description
Adds "fake" button to ui/card exports for use when a button is visually desired inside a full-card link

- Semantic `div` with styling mirroring `ui/button` for use nested inside `ui/card` when `Card` component passed an `href` (thus semantically an anchor element, disallowing the nesting of another anchor or button)
- Enabled `hover-link` custom tailwind variant for proper hover handling on "buttons" that end up  either `button`, `a` or `div` element variations
- Implements on homepage cards
- Handled as it's own server-side component in lieu of using `useContext` to decide based on surrounding div if a "ButtonLink" should be re-styled or not.


## Related Issue
Homepage cards: request to use button for visual recognition inside full-card link -- cc: @konopkja 