### PR TITLE
Add a SECURITY header-note

### DIFF
--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -15,7 +15,12 @@ const INTRO = `# Ethereum.org
 
 > The official Ethereum website providing comprehensive education, resources, and community information about Ethereum — the decentralized world computer that enables smart contracts and decentralized applications.
 
-Ethereum.org is the primary educational hub for Ethereum, offering beginner-friendly explanations alongside advanced technical documentation. The site covers everything from basic concepts like "What is Ethereum?" to detailed developer guides, staking information, and protocol research. For the developer-documentation-only index, see ${SITE_URL}/developers/docs/llms.txt.`
+Ethereum.org is the primary educational hub for Ethereum, offering beginner-friendly explanations alongside advanced technical documentation. The site covers everything from basic concepts like "What is Ethereum?" to detailed developer guides, staking information, and protocol research. For the developer-documentation-only index, see ${SITE_URL}/developers/docs/llms.txt. To report a security vulnerability in Ethereum's core protocol, clients, or key smart contracts, see the Ethereum Foundation Bug Bounty Program at ${SITE_URL}/bug-bounty (summarized under "Security & Bug Bounty" below).`
+
+const SECURITY = `## Security & Bug Bounty
+
+- [Ethereum Foundation Bug Bounty Program](${SITE_URL}/bug-bounty): rewards for vulnerabilities in Ethereum's core protocol, execution and consensus clients, Solidity/Vyper, and key smart contracts.
+- [Bug bounty submission guidance for AI agents](https://bbp-form.ethereum.org/llms.txt): in-scope targets, proof-of-concept requirements (a Kurtosis devnet or a reproducible state test), and the validation checklist to run before confirming an issue.`
 
 export const GET = async () => {
   const t = await getTranslations({ locale: "en", namespace: "common" })
@@ -34,6 +39,7 @@ export const GET = async () => {
     renderNavSection(nav.build, findFooter(nav.build.label)),
     renderNavSection(nav.participate, findFooter(nav.participate.label)),
     renderNavSection(nav.research, findFooter(nav.research.label)),
+    SECURITY,
     renderLegalSection(dipperLinks),
     "",
   ].join("\n\n")


### PR DESCRIPTION
We get a lot of AI-slop submissions on the Bounty, we have added a `/robots.txt` + `/llms.txt` to the subdomain https://bbp-form.ethereum.org/

We think adding this on the main website could help too (depending on the route of the AI agents submitting the bugs)
It could be straight to the form, or fetching ethereum.org, then bounty page. 