### PR TITLE
fix(ui): table of contents hover styling

### DIFF
--- a/src/components/TableOfContents/TableOfContentsLink.tsx
+++ b/src/components/TableOfContents/TableOfContentsLink.tsx
@@ -7,13 +7,13 @@ import { cn } from "@/lib/utils/cn"
 import { BaseLink } from "../ui/Link"
 
 const variants = cva(
-  "group relative inline-block w-full text-body-medium no-underline lg:w-auto",
+  "group relative inline-block w-full no-underline lg:w-auto",
   {
     variants: {
       variant: {
-        docs: "py-0.5",
-        card: "[&_[data-label='marker']]:!hidden inline leading-base",
-        left: "",
+        docs: "py-0.5 text-body-medium",
+        card: "[&_[data-label='marker']]:!hidden inline leading-base text-inherit",
+        left: "text-body-medium hover:text-primary-hover",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## Description
Fixes hover styling in the `TableOfContents` component.

- **`card` variant**: the full label (number included) now changes color on hover, instead of only the ordered-list numeral. The anchor inherits its color from the list item so the marker and label stay in sync.
- **`left` variant**: adds the missing hover color (`text-primary-hover`), matching the existing active-section color (`text-primary`).

## Preview links
https://deploy-preview-18350.ethereum.it/nft
https://deploy-preview-18350.ethereum.it/what-is-ethereum