### PR TITLE
fix: correct heading levels on Ethereum vs Bitcoin page

### DIFF
--- a/app/[locale]/ethereum-vs-bitcoin/page.tsx
+++ b/app/[locale]/ethereum-vs-bitcoin/page.tsx
@@ -52,6 +52,42 @@ const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
       title: t("page-ethereum-vs-bitcoin-differences-section-title"),
       url: "#differences",
     },
+    {
+      title: t("page-ethereum-vs-bitcoin-purpose-title"),
+      url: "#purpose",
+    },
+    {
+      title: t("page-ethereum-vs-bitcoin-usecases-and-adoption-title"),
+      url: "#usecases-and-adoption",
+    },
+    {
+      title: t("page-ethereum-vs-bitcoin-monetary-policy-title"),
+      url: "#monetary-policy",
+    },
+    {
+      title: t("page-ethereum-vs-bitcoin-developer-ecosystem-title"),
+      url: "#developer-ecosystem",
+    },
+    {
+      title: t("page-ethereum-vs-bitcoin-security-and-consensus-title"),
+      url: "#security-and-consensus",
+    },
+    {
+      title: t("page-ethereum-vs-bitcoin-underlying-technology-title"),
+      url: "#underlying-technology",
+    },
+    {
+      title: t("page-ethereum-vs-bitcoin-decentralization-title"),
+      url: "#decentralization",
+    },
+    {
+      title: t("page-ethereum-vs-bitcoin-environmental-impact-title"),
+      url: "#environmental-impact",
+    },
+    {
+      title: t("page-ethereum-vs-bitcoin-future-outlook-title"),
+      url: "#future-outlook",
+    },
   ]
 
   const getId = (input: string) => {
@@ -183,11 +219,14 @@ const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
             </div>
           </Section>
 
-          <Section className="-scroll-mt-80 space-y-14">
+          <Section
+            id={getId(tocItems[4].url)}
+            className="-scroll-mt-80 space-y-14"
+          >
             <div className="space-y-6">
-              <h3 className="scroll-mt-28">
-                {t("page-ethereum-vs-bitcoin-purpose-title")}
-              </h3>
+              <h2 id={getId(tocItems[4].url)} className="scroll-mt-28">
+                {tocItems[4].title}
+              </h2>
               <p>
                 {t.rich("page-ethereum-vs-bitcoin-purpose-1", {
                   strong: Strong,
@@ -203,7 +242,10 @@ const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
             </div>
           </Section>
 
-          <Section className="-scroll-mt-80 space-y-14">
+          <Section
+            id={getId(tocItems[5].url)}
+            className="-scroll-mt-80 space-y-14"
+          >
             <Image
               src={layer2HeroImg}
               alt="Layer 2 Hub Hero"
@@ -211,9 +253,9 @@ const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
               sizes={`(max-width: 832px) calc(100vw - 32px), (max-width: ${screens.lg}) 800px, (max-width: ${screens.xl}) calc(100vw - 480px), 800px`}
             />
             <div className="space-y-6">
-              <h3 className="scroll-mt-28">
-                {t("page-ethereum-vs-bitcoin-usecases-and-adoption-title")}
-              </h3>
+              <h2 id={getId(tocItems[5].url)} className="scroll-mt-28">
+                {tocItems[5].title}
+              </h2>
               <p>
                 {t.rich("page-ethereum-vs-bitcoin-usecases-and-adoption-1", {
                   strong: Strong,
@@ -242,11 +284,14 @@ const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
             </div>
           </Section>
 
-          <Section className="-scroll-mt-80 space-y-14">
+          <Section
+            id={getId(tocItems[6].url)}
+            className="-scroll-mt-80 space-y-14"
+          >
             <div className="space-y-6">
-              <h3 className="scroll-mt-28">
-                {t("page-ethereum-vs-bitcoin-monetary-policy-title")}
-              </h3>
+              <h2 id={getId(tocItems[6].url)} className="scroll-mt-28">
+                {tocItems[6].title}
+              </h2>
               <p>
                 {t.rich("page-ethereum-vs-bitcoin-monetary-policy-1", {
                   strong: Strong,
@@ -262,7 +307,10 @@ const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
             </div>
           </Section>
 
-          <Section className="-scroll-mt-80 space-y-14">
+          <Section
+            id={getId(tocItems[7].url)}
+            className="-scroll-mt-80 space-y-14"
+          >
             <Image
               src={guidesHubHeroImg}
               alt="Guides Hub Hero"
@@ -270,9 +318,9 @@ const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
               sizes={`(max-width: 832px) calc(100vw - 32px), (max-width: ${screens.lg}) 800px, (max-width: ${screens.xl}) calc(100vw - 480px), 800px`}
             />
             <div className="space-y-6">
-              <h3 className="scroll-mt-28">
-                {t("page-ethereum-vs-bitcoin-developer-ecosystem-title")}
-              </h3>
+              <h2 id={getId(tocItems[7].url)} className="scroll-mt-28">
+                {tocItems[7].title}
+              </h2>
               <p>
                 {t.rich("page-ethereum-vs-bitcoin-developer-ecosystem-1", {
                   strong: Strong,
@@ -292,11 +340,14 @@ const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
             </div>
           </Section>
 
-          <Section className="-scroll-mt-80 space-y-14">
+          <Section
+            id={getId(tocItems[8].url)}
+            className="-scroll-mt-80 space-y-14"
+          >
             <div className="space-y-6">
-              <h3 className="scroll-mt-28">
-                {t("page-ethereum-vs-bitcoin-security-and-consensus-title")}
-              </h3>
+              <h2 id={getId(tocItems[8].url)} className="scroll-mt-28">
+                {tocItems[8].title}
+              </h2>
               <p>{t("page-ethereum-vs-bitcoin-security-and-consensus-1")}</p>
               <p>
                 {t.rich("page-ethereum-vs-bitcoin-security-and-consensus-2", {
@@ -316,7 +367,10 @@ const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
             </div>
           </Section>
 
-          <Section className="-scroll-mt-80 space-y-14">
+          <Section
+            id={getId(tocItems[9].url)}
+            className="-scroll-mt-80 space-y-14"
+          >
             <Image
               src={enterpriseEthImg}
               alt="Enterprise ETH"
@@ -324,9 +378,9 @@ const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
               sizes="(max-width: 350px) 100vw, 350px"
             />
             <div className="space-y-6">
-              <h3 className="scroll-mt-28">
-                {t("page-ethereum-vs-bitcoin-underlying-technology-title")}
-              </h3>
+              <h2 id={getId(tocItems[9].url)} className="scroll-mt-28">
+                {tocItems[9].title}
+              </h2>
               <p>
                 {t.rich("page-ethereum-vs-bitcoin-underlying-technology-1", {
                   strong: Strong,
@@ -347,11 +401,14 @@ const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
             </div>
           </Section>
 
-          <Section className="-scroll-mt-80 space-y-14">
+          <Section
+            id={getId(tocItems[10].url)}
+            className="-scroll-mt-80 space-y-14"
+          >
             <div className="space-y-6">
-              <h3 className="scroll-mt-28">
-                {t("page-ethereum-vs-bitcoin-decentralization-title")}
-              </h3>
+              <h2 id={getId(tocItems[10].url)} className="scroll-mt-28">
+                {tocItems[10].title}
+              </h2>
               <p>{t("page-ethereum-vs-bitcoin-decentralization-1")}</p>
               <p>
                 {t.rich("page-ethereum-vs-bitcoin-decentralization-2", {
@@ -371,7 +428,10 @@ const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
             </div>
           </Section>
 
-          <Section className="-scroll-mt-80 space-y-14">
+          <Section
+            id={getId(tocItems[11].url)}
+            className="-scroll-mt-80 space-y-14"
+          >
             <Image
               src={hackathonImg}
               alt="Enterprise ETH"
@@ -379,9 +439,9 @@ const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
               sizes="(max-width: 350px) 100vw, 350px"
             />
             <div className="space-y-6">
-              <h3 className="scroll-mt-28">
-                {t("page-ethereum-vs-bitcoin-environmental-impact-title")}
-              </h3>
+              <h2 id={getId(tocItems[11].url)} className="scroll-mt-28">
+                {tocItems[11].title}
+              </h2>
               <p>
                 {t.rich("page-ethereum-vs-bitcoin-environmental-impact-1", {
                   strong: Strong,
@@ -402,11 +462,14 @@ const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
             </div>
           </Section>
 
-          <Section className="-scroll-mt-80 space-y-14">
+          <Section
+            id={getId(tocItems[12].url)}
+            className="-scroll-mt-80 space-y-14"
+          >
             <div className="space-y-6">
-              <h3 className="scroll-mt-28">
-                {t("page-ethereum-vs-bitcoin-future-outlook-title")}
-              </h3>
+              <h2 id={getId(tocItems[12].url)} className="scroll-mt-28">
+                {tocItems[12].title}
+              </h2>
               <p>{t("page-ethereum-vs-bitcoin-future-outlook-1")}</p>
               <p>{t("page-ethereum-vs-bitcoin-future-outlook-2")}</p>
               <p>

--- a/app/[locale]/ethereum-vs-bitcoin/page.tsx
+++ b/app/[locale]/ethereum-vs-bitcoin/page.tsx
@@ -141,9 +141,7 @@ const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
             className="-scroll-mt-80 space-y-14"
           >
             <div className="space-y-6">
-              <h2 id={getId(tocItems[1].url)} className="scroll-mt-28">
-                {tocItems[1].title}
-              </h2>
+              <h2>{tocItems[1].title}</h2>
               <p>
                 {t.rich("page-ethereum-vs-bitcoin-bitcoin-section-1", {
                   strong: Strong,
@@ -174,9 +172,7 @@ const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
               sizes="281px"
             />
             <div className="space-y-6">
-              <h2 id={getId(tocItems[2].url)} className="scroll-mt-28">
-                {tocItems[2].title}
-              </h2>
+              <h2>{tocItems[2].title}</h2>
               <p>
                 {t.rich("page-ethereum-vs-bitcoin-ethereum-section-1", {
                   strong: Strong,
@@ -211,9 +207,7 @@ const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
             className="-scroll-mt-80 space-y-14"
           >
             <div className="space-y-6">
-              <h2 id={getId(tocItems[3].url)} className="scroll-mt-28">
-                {tocItems[3].title}
-              </h2>
+              <h2>{tocItems[3].title}</h2>
               <p>{t("page-ethereum-vs-bitcoin-differences-section-1")}</p>
               <DifferencesTable />
             </div>
@@ -224,9 +218,7 @@ const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
             className="-scroll-mt-80 space-y-14"
           >
             <div className="space-y-6">
-              <h2 id={getId(tocItems[4].url)} className="scroll-mt-28">
-                {tocItems[4].title}
-              </h2>
+              <h2>{tocItems[4].title}</h2>
               <p>
                 {t.rich("page-ethereum-vs-bitcoin-purpose-1", {
                   strong: Strong,
@@ -253,9 +245,7 @@ const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
               sizes={`(max-width: 832px) calc(100vw - 32px), (max-width: ${screens.lg}) 800px, (max-width: ${screens.xl}) calc(100vw - 480px), 800px`}
             />
             <div className="space-y-6">
-              <h2 id={getId(tocItems[5].url)} className="scroll-mt-28">
-                {tocItems[5].title}
-              </h2>
+              <h2>{tocItems[5].title}</h2>
               <p>
                 {t.rich("page-ethereum-vs-bitcoin-usecases-and-adoption-1", {
                   strong: Strong,
@@ -289,9 +279,7 @@ const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
             className="-scroll-mt-80 space-y-14"
           >
             <div className="space-y-6">
-              <h2 id={getId(tocItems[6].url)} className="scroll-mt-28">
-                {tocItems[6].title}
-              </h2>
+              <h2>{tocItems[6].title}</h2>
               <p>
                 {t.rich("page-ethereum-vs-bitcoin-monetary-policy-1", {
                   strong: Strong,
@@ -318,9 +306,7 @@ const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
               sizes={`(max-width: 832px) calc(100vw - 32px), (max-width: ${screens.lg}) 800px, (max-width: ${screens.xl}) calc(100vw - 480px), 800px`}
             />
             <div className="space-y-6">
-              <h2 id={getId(tocItems[7].url)} className="scroll-mt-28">
-                {tocItems[7].title}
-              </h2>
+              <h2>{tocItems[7].title}</h2>
               <p>
                 {t.rich("page-ethereum-vs-bitcoin-developer-ecosystem-1", {
                   strong: Strong,
@@ -345,9 +331,7 @@ const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
             className="-scroll-mt-80 space-y-14"
           >
             <div className="space-y-6">
-              <h2 id={getId(tocItems[8].url)} className="scroll-mt-28">
-                {tocItems[8].title}
-              </h2>
+              <h2>{tocItems[8].title}</h2>
               <p>{t("page-ethereum-vs-bitcoin-security-and-consensus-1")}</p>
               <p>
                 {t.rich("page-ethereum-vs-bitcoin-security-and-consensus-2", {
@@ -378,9 +362,7 @@ const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
               sizes="(max-width: 350px) 100vw, 350px"
             />
             <div className="space-y-6">
-              <h2 id={getId(tocItems[9].url)} className="scroll-mt-28">
-                {tocItems[9].title}
-              </h2>
+              <h2>{tocItems[9].title}</h2>
               <p>
                 {t.rich("page-ethereum-vs-bitcoin-underlying-technology-1", {
                   strong: Strong,
@@ -406,9 +388,7 @@ const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
             className="-scroll-mt-80 space-y-14"
           >
             <div className="space-y-6">
-              <h2 id={getId(tocItems[10].url)} className="scroll-mt-28">
-                {tocItems[10].title}
-              </h2>
+              <h2>{tocItems[10].title}</h2>
               <p>{t("page-ethereum-vs-bitcoin-decentralization-1")}</p>
               <p>
                 {t.rich("page-ethereum-vs-bitcoin-decentralization-2", {
@@ -439,9 +419,7 @@ const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
               sizes="(max-width: 350px) 100vw, 350px"
             />
             <div className="space-y-6">
-              <h2 id={getId(tocItems[11].url)} className="scroll-mt-28">
-                {tocItems[11].title}
-              </h2>
+              <h2>{tocItems[11].title}</h2>
               <p>
                 {t.rich("page-ethereum-vs-bitcoin-environmental-impact-1", {
                   strong: Strong,
@@ -467,9 +445,7 @@ const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
             className="-scroll-mt-80 space-y-14"
           >
             <div className="space-y-6">
-              <h2 id={getId(tocItems[12].url)} className="scroll-mt-28">
-                {tocItems[12].title}
-              </h2>
+              <h2>{tocItems[12].title}</h2>
               <p>{t("page-ethereum-vs-bitcoin-future-outlook-1")}</p>
               <p>{t("page-ethereum-vs-bitcoin-future-outlook-2")}</p>
               <p>


### PR DESCRIPTION
## Summary

The section subheadings on the Ethereum vs Bitcoin page were marked up as `h3` but should be `h2`, matching the page's other top-level sections.

- Promote the nine `h3` section headings to `h2` and add each to the `tocItems` array (title + hash URL), so they appear in the table of contents alongside the existing sections.
- Move the anchor `id` onto the `Section` element rather than the heading, so navigating from the ToC scrolls to the top of the section (including its image) instead of jumping straight to the heading. This also removes the duplicate element IDs that previously sat on both the `Section` and its heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Preview link
https://deploy-preview-18351.ethereum.it/ethereum-vs-bitcoin