### PR TITLE
fix(ci): gate weekly-release wait on required checks only

### DIFF
--- a/.github/actions/wait-for-pr-checks/action.yml
+++ b/.github/actions/wait-for-pr-checks/action.yml
@@ -64,6 +64,17 @@ runs:
                 ((.context // "") | test($name; "i"))
               )]
             ')
+          elif [[ -n "$REQUIRED_CHECKS" ]]; then
+            # Gate only on the required checks. Other checks (e.g. Chromatic
+            # "UI Review"/"UI Tests") sit PENDING awaiting manual approval and
+            # must not block success — that approval is a post-review human step.
+            filtered=$(echo "$rollup" | jq --arg req "$REQUIRED_CHECKS" '
+              ($req | split(",") | map(ascii_downcase | gsub("^\\s+|\\s+$"; ""))) as $needles
+              | [.[] | select(
+                  ((.name // .context // "") | ascii_downcase) as $n
+                  | [$needles[] | . as $needle | $n | contains($needle)] | any
+                )]
+            ')
           else
             filtered="$rollup"
           fi


### PR DESCRIPTION
## Problem

The first live run of `weekly-release.yml` ([run 26960223758](https://github.com/ethereum/ethereum-org-website/actions/runs/26960223758)) timed out after 60 min and skipped the automated `/review-release`, even though every required check was green and the deploy preview was ready.

Root cause: `wait-for-pr-checks` computed pending/terminal state over **all** checks on the PR. Chromatic's `UI Review` / `UI Tests` checks sit `PENDING` until a human approves snapshots — a documented *post-review* manual step — so the success gate (`pending == 0`) could never be reached. The log showed `Waiting — 4 of 20 checks not terminal yet` on a loop until `Timed out waiting after 3600s`.

`required_checks` was only used to detect *missing* checks, not to scope which checks must reach terminal.

## Fix

When `required_checks` is set (and no single `check_name`), scope the pending/failure/success evaluation to just the required checks. Chromatic approval stays a manual post-review step, matching the workflow's own "Remaining manual steps: approve Chromatic" message.

The `missing` guard (required checks that never posted) is unchanged, so false-success is still prevented.

Validated the new jq filter against PR #18354's live rollup: it selects exactly the 3 required checks (all SUCCESS) → `count=3 pending=0 failed=[]` → success.

## Note on the in-flight release

Run 26960223758 already completed (timed out → handed off to human). A plain re-dispatch will `skip` because deploy PR #18354 is open; re-running the single job would reuse the old action SHA. So this only takes effect on the next run (or a dispatch once #18354 is merged/closed). #18354 itself still needs its manual approve + merge.