### PR TITLE
redesign(ui): FeedbackCard with text-h* utility classes

### DIFF
--- a/.claude/skills/design-system/SKILL.md
+++ b/.claude/skills/design-system/SKILL.md
@@ -63,7 +63,23 @@ Used in 5 places. Don't introduce new uses. Use Tailwind `dark:` variant + seman
 
 ### No `Heading` primitive -- use semantic tags
 
-`base.css` styles `<h1>`-`<h6>` with the right sizes and `font-black`. Just write `<h1>Title</h1>`. Override the size class on the heading element when really needed (`<h2 className="text-4xl">`), but don't re-apply a weight -- a utility-layer `font-bold` silently overrides the base `font-black`. Reinventing with `<div className="text-5xl font-bold">` loses semantics and screen-reader navigation.
+`base.css` styles `<h1>`-`<h6>` with the right sizes and `font-black`. Just write `<h1>Title</h1>`. Override the size on a heading element when really needed (`<h2 className="text-h1">` for an `h2` at `h1` size), but don't re-apply a weight -- a utility-layer `font-bold` silently overrides the base `font-black`. Reinventing with `<div className="text-5xl font-bold">` loses semantics and screen-reader navigation.
+
+### Match a heading size with `text-h1`-`text-h6`, never the raw responsive pair
+
+There are six size utilities -- `text-h1` through `text-h6` (`src/styles/utilities.css`) -- one per heading level. Each bundles the **font-size and line-height** for that level (responsive, e.g. `text-h2` = `text-3xl lg:text-4xl`). `base.css` itself `@apply`s these to the real `<h1>`-`<h6>` tags, so they are the single source of truth for heading sizing.
+
+Whenever you want a non-heading element (or a heading you're resizing) to read at a given heading level's size, use the utility -- **not** the responsive pair it expands to:
+
+```tsx
+// Wrong -- reconstructs h2 sizing by hand; drifts if the scale changes
+<p className="text-3xl lg:text-4xl">Looks like an h2</p>
+
+// Right -- one token, stays in sync with the heading scale
+<p className="text-h2">Looks like an h2</p>
+```
+
+`text-h*` sets size and line-height **only** -- it does *not* set `font-black`. Real headings get their weight from `base.css`; on other elements, set weight separately if you want it.
 
 ### One stray `toLocaleString` in `ui/chart.tsx:241`
 

--- a/.claude/skills/design-system/references/cleanup-playbook.md
+++ b/.claude/skills/design-system/references/cleanup-playbook.md
@@ -102,11 +102,23 @@ return <div className="bg-white dark:bg-gray-900" />
 <h1>Page Title</h1>  // base.css already styles this
 ```
 
-If you need a specific size that doesn't match `base.css` defaults, override on the heading:
+If you need a heading at a different level's size, reuse the matching `text-h*` utility on the element:
 
 ```tsx
-<h2 className="text-4xl">Custom-sized Heading</h2>
+<h2 className="text-h1">Custom-sized Heading</h2>  // h2 semantics, h1 size
 ```
+
+## `text-3xl lg:text-4xl` (to match a heading size) -> `text-h*`
+
+```tsx
+// Before -- hand-reconstructs h2 sizing; drifts when the scale changes:
+<p className="text-3xl lg:text-4xl">Looks like an h2</p>
+
+// After -- one token, tracks base.css (size + line-height only, no weight):
+<p className="text-h2">Looks like an h2</p>
+```
+
+The `text-h1`-`text-h6` utilities (`src/styles/utilities.css`) are the single source of truth for heading sizing. Anytime the intent is "match heading level N's size," use `text-hN` rather than the raw responsive size classes.
 
 ## `<p className="text-Xxl font-bold">number</p>` -> `BigNumber`
 

--- a/.claude/skills/design-system/references/components.md
+++ b/.claude/skills/design-system/references/components.md
@@ -689,9 +689,11 @@ Class component (`getDerivedStateFromError`), integrates with `@sentry/nextjs`. 
 There's a `Heading.stories.tsx` file but it just renders raw `<h1>` through `<h6>`. The headings are styled by `base.css` element defaults. Use semantic tags directly:
 
 ```tsx
-<h1>Title</h1>           // text-4xl lg:text-5xl, font-black (from base.css)
-<h2>Subtitle</h2>        // text-3xl lg:text-4xl, font-black
+<h1>Title</h1>           // text-h1 (text-4xl lg:text-5xl) + font-black, from base.css
+<h2>Subtitle</h2>        // text-h2 (text-3xl lg:text-4xl) + font-black
 ```
+
+Sizing is owned by the `text-h1`-`text-h6` utilities (`src/styles/utilities.css`), which `base.css` `@apply`s to each tag. To make a non-heading element match a heading level's size, apply the utility directly (`<p className="text-h2">`) -- it carries size + line-height only, not `font-black`. Don't hand-reconstruct `text-3xl lg:text-4xl`.
 
 For markdown-rendered content, sizing comes from `MdComponents`.
 

--- a/.claude/skills/design-system/references/gotchas.md
+++ b/.claude/skills/design-system/references/gotchas.md
@@ -62,7 +62,7 @@ Same problem -- bypasses focus rings, hover states, and a11y baseline. Use `Butt
 
 ### Reinventing a heading with a `<div>`
 
-`<div className="text-5xl font-bold">Hello</div>` is wrong. Headings are styled by `base.css` defaults on `<h1>` through `<h6>`. Use the semantic tag and override sizes via `className` only when really needed.
+`<div className="text-5xl font-bold">Hello</div>` is wrong. Headings are styled by `base.css` defaults on `<h1>` through `<h6>`. Use the semantic tag and override sizes only when really needed -- with the `text-h1`-`text-h6` utilities (e.g. `<h2 className="text-h1">`), never a hand-reconstructed `text-3xl lg:text-4xl`. Those same `text-h*` utilities are also how you give a non-heading element a heading-level size.
 
 ### Inlining instead of composing
 

--- a/.claude/skills/design-system/references/spacing-typography.md
+++ b/.claude/skills/design-system/references/spacing-typography.md
@@ -6,23 +6,39 @@ The most common source of "one-off styling" in this codebase is ad-hoc spacing a
 
 Headings (`<h1>`-`<h6>`) are styled by `src/styles/base.css` element defaults. **Just write the semantic tag.** Don't reinvent with `<div className="text-Xxl font-bold">`.
 
-All headings default to `font-black` (weight 900) via `base.css`. **Do not re-apply a weight** -- a hardcoded `font-bold`/`font-semibold` on a heading sits in the utilities layer and silently overrides the base `font-black`, which is exactly the drift the heading-weight standardization removed. If you need a lighter weight for an eyebrow/kicker/label, that's a deliberate `font-normal`/`font-medium` choice, not a default.
+Sizing for each level lives in one place: the `text-h1`-`text-h6` utilities in `src/styles/utilities.css`. Each bundles the **font-size and line-height** for that level (responsive). `base.css` `@apply`s `text-h1` to `<h1>`, `text-h2` to `<h2>`, and so on -- so these utilities are the single source of truth for heading sizing.
 
-| Tag | Default sizing | When to use |
-|---|---|---|
-| `<h1>` | `text-4xl lg:text-5xl font-black` | Page title -- ONE per page |
-| `<h2>` | `text-3xl lg:text-4xl font-black` | Top-level section title |
-| `<h3>` | `text-2xl lg:text-3xl font-black` | Subsection title |
-| `<h4>` | `text-xl lg:text-2xl font-black` | Sub-subsection title |
-| `<h5>` | `text-lg font-black` | Small heading |
-| `<h6>` | `text-base font-black` | Smallest heading; also used in `Alert`/`Callout` titles |
+All headings default to `font-black` (weight 900) via `base.css`. The `text-h*` utilities carry size/line-height **only** -- not the weight. **Do not re-apply a weight** on a real heading -- a hardcoded `font-bold`/`font-semibold` sits in the utilities layer and silently overrides the base `font-black`, which is exactly the drift the heading-weight standardization removed. If you need a lighter weight for an eyebrow/kicker/label, that's a deliberate `font-normal`/`font-medium` choice, not a default.
+
+| Tag | Sizing utility | Expands to | When to use |
+|---|---|---|---|
+| `<h1>` | `text-h1` | `text-4xl lg:text-5xl` | Page title -- ONE per page |
+| `<h2>` | `text-h2` | `text-3xl lg:text-4xl` | Top-level section title |
+| `<h3>` | `text-h3` | `text-2xl lg:text-3xl` | Subsection title |
+| `<h4>` | `text-h4` | `text-xl lg:text-2xl` | Sub-subsection title |
+| `<h5>` | `text-h5` | `text-md lg:text-xl` | Small heading |
+| `<h6>` | `text-h6` | `text-sm lg:text-md` | Smallest heading; also used in `Alert`/`Callout` titles |
+
+### Matching a heading size on any element
+
+To make a non-heading element read at a given heading level's size, apply the utility -- never reconstruct the responsive pair by hand:
+
+```tsx
+// Wrong -- hand-reconstructs h2 sizing; drifts when the scale changes
+<p className="text-3xl lg:text-4xl">Looks like an h2</p>
+
+// Right -- one token, stays in sync with base.css
+<p className="text-h2">Looks like an h2</p>
+```
+
+This is size and line-height only -- it does not apply `font-black`. Set weight separately on a non-heading element if the design wants it.
 
 ### Overrides
 
-If you need a heading at a different size (because the design calls for it), override on the element:
+If you need a real heading at a different level's size (because the design calls for it), reuse the matching utility on the element:
 
 ```tsx
-<h2 className="text-4xl lg:text-5xl">A larger h2</h2>
+<h2 className="text-h1">A larger h2</h2>
 ```
 
 Don't override structurally (e.g., using `<h1>` for an `<h3>`-sized element just to get the size). Heading hierarchy matters for screen readers.
@@ -146,6 +162,8 @@ Tailwind text size utilities. Pair with leading utilities (`leading-base`, `lead
 | `text-4xl` | 40px | h1 (mobile), h2 (desktop) |
 | `text-5xl` | 48px | h1 (desktop) |
 | `text-6xl` / `text-7xl` | 56-72px | Special: `HomeHero` only |
+
+The "Common use" column maps these raw sizes to heading levels for reference. When your intent is "match a heading level's size," reach for the `text-h1`-`text-h6` utilities (see "Heading Sizes" above) instead of the raw class -- they bundle the responsive size + line-height and track `base.css`.
 
 Use semantic tokens (`text-body`, `text-body-medium`, `text-body-light`, `text-primary`, etc.) for color. See `references/tokens.md`.
 

--- a/.claude/skills/design-system/references/tokens.md
+++ b/.claude/skills/design-system/references/tokens.md
@@ -196,15 +196,15 @@ The `useColorModeValue` hook (Chakra leftover) is **deprecated**. Don't introduc
 
 `<body>` automatically gets `bg-background font-body leading-base text-body`. You don't need to repeat these on top-level page wrappers.
 
-Headings (`<h1>` through `<h6>`) get sizing and `font-black` from `base.css`:
-- `<h1>`: `text-4xl lg:text-5xl`
-- `<h2>`: `text-3xl lg:text-4xl`
-- `<h3>`: `text-2xl lg:text-3xl`
-- `<h4>`: `text-xl lg:text-2xl`
-- `<h5>`: `text-lg`
-- `<h6>`: `text-base`
+Headings (`<h1>` through `<h6>`) get sizing and `font-black` from `base.css`. Sizing comes from the `text-h1`-`text-h6` utilities in `src/styles/utilities.css`, which `base.css` `@apply`s to each tag (size + line-height only -- the `font-black` is applied separately):
+- `<h1>` -> `text-h1` (`text-4xl lg:text-5xl`)
+- `<h2>` -> `text-h2` (`text-3xl lg:text-4xl`)
+- `<h3>` -> `text-h3` (`text-2xl lg:text-3xl`)
+- `<h4>` -> `text-h4` (`text-xl lg:text-2xl`)
+- `<h5>` -> `text-h5` (`text-md lg:text-xl`)
+- `<h6>` -> `text-h6` (`text-sm lg:text-md`)
 
-This means `<h1>Hello</h1>` already looks correct. Writing `<div className="text-5xl font-bold">Hello</div>` is reinventing -- and it loses semantics.
+This means `<h1>Hello</h1>` already looks correct. Writing `<div className="text-5xl font-bold">Hello</div>` is reinventing -- and it loses semantics. To make any element match a heading level's size, apply the `text-h*` utility (e.g. `text-h2`) rather than hand-reconstructing the responsive pair -- see `references/spacing-typography.md` "Heading Sizes."
 
 `<a>` tags get `text-primary` + underline + `focus-visible` outline.
 

--- a/src/components/FeedbackCard.tsx
+++ b/src/components/FeedbackCard.tsx
@@ -7,6 +7,7 @@ import type { Lang } from "@/lib/types"
 
 import { FeedbackThumbsUpIcon } from "@/components/icons"
 
+import { cn } from "@/lib/utils/cn"
 import { trackCustomEvent } from "@/lib/utils/matomo"
 import { isLangRightToLeft } from "@/lib/utils/translations"
 
@@ -63,41 +64,45 @@ const FeedbackCard = ({ prompt, isArticle, ...props }: FeedbackCardProps) => {
   }
 
   return (
-    <div
-      className="mt-8 mb-4 flex w-full flex-col rounded border border-body-light bg-feedback-gradient p-6"
+    <aside
+      className="mt-8 mb-4 flex w-full max-w-3xl flex-col gap-4"
       {...props}
       dir={dir}
     >
-      <div className="flex flex-col gap-4">
-        <h2 className="mb-2 text-xl lg:text-2xl">
-          {getTitle(feedbackSubmitted)}
-        </h2>
-        {feedbackSubmitted && (
-          <p>
-            {t("feedback-widget-thank-you-subtitle")}{" "}
-            <Translation id="feedback-widget-thank-you-subtitle-ext" />
-          </p>
-        )}
-        <div className="flex gap-4">
-          {!feedbackSubmitted ? (
-            <>
-              <Button variant="outline" onClick={() => handleSubmit(true)}>
-                <FeedbackThumbsUpIcon className="text-2xl" />
-                {t("yes")}
-              </Button>
-              <Button variant="outline" onClick={() => handleSubmit(false)}>
-                <FeedbackThumbsUpIcon className="-scale-y-100 text-2xl" />
-                {t("no")}
-              </Button>
-            </>
-          ) : (
-            <Button variant="outline" onClick={handleSurveyOpen}>
+      <h2 className="text-h3">{getTitle(feedbackSubmitted)}</h2>
+
+      <div
+        className={cn("flex gap-x-4 gap-y-8", feedbackSubmitted && "flex-col")}
+      >
+        {!feedbackSubmitted ? (
+          <>
+            <Button variant="outline" onClick={() => handleSubmit(true)}>
+              <FeedbackThumbsUpIcon className="text-2xl" />
+              {t("yes")}
+            </Button>
+            <Button variant="outline" onClick={() => handleSubmit(false)}>
+              <FeedbackThumbsUpIcon className="-scale-y-100 text-2xl" />
+              {t("no")}
+            </Button>
+          </>
+        ) : (
+          <>
+            <p>
+              {t("feedback-widget-thank-you-subtitle")}{" "}
+              <Translation id="feedback-widget-thank-you-subtitle-ext" />
+            </p>
+
+            <Button
+              variant="outline"
+              onClick={handleSurveyOpen}
+              className="w-fit max-sm:w-full"
+            >
               {t("feedback-widget-thank-you-cta")}
             </Button>
-          )}
-        </div>
+          </>
+        )}
       </div>
-    </div>
+    </aside>
   )
 }
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -35,27 +35,27 @@
   }
 
   h1 {
-    @apply text-4xl lg:text-5xl;
+    @apply text-h1;
   }
 
   h2 {
-    @apply text-3xl lg:text-4xl;
+    @apply text-h2;
   }
 
   h3 {
-    @apply text-2xl lg:text-3xl;
+    @apply text-h3;
   }
 
   h4 {
-    @apply text-xl lg:text-2xl;
+    @apply text-h4;
   }
 
   h5 {
-    @apply text-md lg:text-xl;
+    @apply text-h5;
   }
 
   h6 {
-    @apply text-sm lg:text-md;
+    @apply text-h6;
   }
 
   pre,

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -45,63 +45,27 @@
 }
 
 @utility text-h1 {
-  font-size: var(--text-4xl);
-  line-height: var(--tw-leading, var(--text-4xl--line-height));
-
-  @media (width >= theme(--breakpoint-lg)) {
-    font-size: var(--text-5xl);
-    line-height: var(--tw-leading, var(--text-5xl--line-height));
-  }
+  @apply text-4xl lg:text-5xl;
 }
 
 @utility text-h2 {
-  font-size: var(--text-3xl);
-  line-height: var(--tw-leading, var(--text-3xl--line-height));
-
-  @media (width >= theme(--breakpoint-lg)) {
-    font-size: var(--text-4xl);
-    line-height: var(--tw-leading, var(--text-4xl--line-height));
-  }
+  @apply text-3xl lg:text-4xl;
 }
 
 @utility text-h3 {
-  font-size: var(--text-2xl);
-  line-height: var(--tw-leading, var(--text-2xl--line-height));
-
-  @media (width >= theme(--breakpoint-lg)) {
-    font-size: var(--text-3xl);
-    line-height: var(--tw-leading, var(--text-3xl--line-height));
-  }
+  @apply text-2xl lg:text-3xl;
 }
 
 @utility text-h4 {
-  font-size: var(--text-xl);
-  line-height: var(--tw-leading, var(--text-xl--line-height));
-
-  @media (width >= theme(--breakpoint-lg)) {
-    font-size: var(--text-2xl);
-    line-height: var(--tw-leading, var(--text-2xl--line-height));
-  }
+  @apply text-xl lg:text-2xl;
 }
 
 @utility text-h5 {
-  font-size: var(--text-md);
-  line-height: var(--tw-leading, var(--text-md--line-height));
-
-  @media (width >= theme(--breakpoint-lg)) {
-    font-size: var(--text-xl);
-    line-height: var(--tw-leading, var(--text-xl--line-height));
-  }
+  @apply text-md lg:text-xl;
 }
 
 @utility text-h6 {
-  font-size: var(--text-sm);
-  line-height: var(--tw-leading, var(--text-sm--line-height));
-
-  @media (width >= theme(--breakpoint-lg)) {
-    font-size: var(--text-md);
-    line-height: var(--tw-leading, var(--text-md--line-height));
-  }
+  @apply text-sm lg:text-md;
 }
 
 /* Grid template columns */

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -44,6 +44,66 @@
   background-image: var(--ten-year-gradient);
 }
 
+@utility text-h1 {
+  font-size: var(--text-4xl);
+  line-height: var(--tw-leading, var(--text-4xl--line-height));
+
+  @media (width >= theme(--breakpoint-lg)) {
+    font-size: var(--text-5xl);
+    line-height: var(--tw-leading, var(--text-5xl--line-height));
+  }
+}
+
+@utility text-h2 {
+  font-size: var(--text-3xl);
+  line-height: var(--tw-leading, var(--text-3xl--line-height));
+
+  @media (width >= theme(--breakpoint-lg)) {
+    font-size: var(--text-4xl);
+    line-height: var(--tw-leading, var(--text-4xl--line-height));
+  }
+}
+
+@utility text-h3 {
+  font-size: var(--text-2xl);
+  line-height: var(--tw-leading, var(--text-2xl--line-height));
+
+  @media (width >= theme(--breakpoint-lg)) {
+    font-size: var(--text-3xl);
+    line-height: var(--tw-leading, var(--text-3xl--line-height));
+  }
+}
+
+@utility text-h4 {
+  font-size: var(--text-xl);
+  line-height: var(--tw-leading, var(--text-xl--line-height));
+
+  @media (width >= theme(--breakpoint-lg)) {
+    font-size: var(--text-2xl);
+    line-height: var(--tw-leading, var(--text-2xl--line-height));
+  }
+}
+
+@utility text-h5 {
+  font-size: var(--text-md);
+  line-height: var(--tw-leading, var(--text-md--line-height));
+
+  @media (width >= theme(--breakpoint-lg)) {
+    font-size: var(--text-xl);
+    line-height: var(--tw-leading, var(--text-xl--line-height));
+  }
+}
+
+@utility text-h6 {
+  font-size: var(--text-sm);
+  line-height: var(--tw-leading, var(--text-sm--line-height));
+
+  @media (width >= theme(--breakpoint-lg)) {
+    font-size: var(--text-md);
+    line-height: var(--tw-leading, var(--text-md--line-height));
+  }
+}
+
 /* Grid template columns */
 @utility grid-cols-bento {
   grid-template-columns: repeat(12, 1fr);


### PR DESCRIPTION
## Description
Update FeedbackCard component to latest designs

- feat: create custom tailwind utility classes (`utilities.css`) for all h1-6 `font-weight` and `line-height` styles, which can be applied using `text-h*`. Enables easy application of a specific header side to component elements.
- refactor: updated `base.css` to point h1-6 base `font-weight` and `line-height` styling to new utilities classes (e.g., `h1 { @apply text-4xl lg:text-5xl; }` -> `h1 { @apply text-h1; }`
- redesign: `FeedbackCard` to remove border, background and padding. Apply `text-h3` styling to `h2` element. Tidy spacing between elements, placing paragraph text closer to `h2` (1rem) than to the buttons (2rem). 

## Related Issue
Design system/theming