### PR TITLE
fix: wrap sub-filter options to prevent desktop filter sidebar overflow

### DIFF
--- a/src/components/ProductTable/Filter.tsx
+++ b/src/components/ProductTable/Filter.tsx
@@ -102,7 +102,7 @@ const Filter = ({ filter, filterIndex, onChange }: FilterProps) => {
       className="bg-background-highlight p-6"
     >
       <AccordionTrigger className="border-b md:px-0">
-        <p className="text-base font-bold text-body">{filter.title}</p>
+        <p className="text-body text-base font-bold">{filter.title}</p>
       </AccordionTrigger>
       <AccordionContent className="p-0 md:p-0">
         <FieldSet className="gap-0">
@@ -120,7 +120,7 @@ const Filter = ({ filter, filterIndex, onChange }: FilterProps) => {
                   handleChange
                 )}
                 {item.inputState === true && item.options.length ? (
-                  <FieldSet className="flex flex-row gap-6 px-2 pb-4">
+                  <FieldSet className="flex flex-row flex-wrap gap-x-6 gap-y-2 px-2 pb-4">
                     {item.optionsLegend && (
                       <FieldLegend className="sr-only">
                         {item.optionsLegend}

--- a/src/components/ProductTable/Filter.tsx
+++ b/src/components/ProductTable/Filter.tsx
@@ -102,7 +102,7 @@ const Filter = ({ filter, filterIndex, onChange }: FilterProps) => {
       className="bg-background-highlight p-6"
     >
       <AccordionTrigger className="border-b md:px-0">
-        <p className="text-body text-base font-bold">{filter.title}</p>
+        <p className="text-base font-bold text-body">{filter.title}</p>
       </AccordionTrigger>
       <AccordionContent className="p-0 md:p-0">
         <FieldSet className="gap-0">

--- a/src/components/ProductTable/FilterInputs/SwitchFilterInput.tsx
+++ b/src/components/ProductTable/FilterInputs/SwitchFilterInput.tsx
@@ -38,7 +38,7 @@ const SwitchFilterInput = ({
       <div className="flex flex-row items-center justify-between gap-2">
         <FieldLabel
           htmlFor={id}
-          className="flex w-fit cursor-pointer flex-row items-center gap-0 text-base font-normal leading-normal"
+          className="flex w-fit cursor-pointer flex-row items-center gap-0 text-base leading-normal font-normal"
         >
           <span className="h-8 w-8">
             {Icon && (
@@ -59,7 +59,7 @@ const SwitchFilterInput = ({
       {description && (
         <FieldDescription
           id={descriptionId}
-          className="text-body-medium ps-8 text-base font-normal leading-normal"
+          className="ps-8 text-base leading-normal font-normal text-body-medium"
         >
           {description}
         </FieldDescription>

--- a/src/components/ProductTable/FilterInputs/SwitchFilterInput.tsx
+++ b/src/components/ProductTable/FilterInputs/SwitchFilterInput.tsx
@@ -38,7 +38,7 @@ const SwitchFilterInput = ({
       <div className="flex flex-row items-center justify-between gap-2">
         <FieldLabel
           htmlFor={id}
-          className="flex w-fit cursor-pointer flex-row items-center gap-0 text-base leading-normal font-normal"
+          className="flex w-fit cursor-pointer flex-row items-center gap-0 text-base font-normal leading-normal"
         >
           <span className="h-8 w-8">
             {Icon && (
@@ -59,7 +59,7 @@ const SwitchFilterInput = ({
       {description && (
         <FieldDescription
           id={descriptionId}
-          className="ms-8 text-base leading-normal font-normal text-body-medium"
+          className="text-body-medium ps-8 text-base font-normal leading-normal"
         >
           {description}
         </FieldDescription>


### PR DESCRIPTION
## Summary

Fixes #18358

Two layout bugs in the desktop filter sidebar on the Find a Wallet page (and any other `ProductTable` page).

### 1. Sub-filter options row overflows (`Filter.tsx`)

When the **Desktop** device filter is toggled on, a row of sub-option checkboxes (Linux / Windows / macOS) is rendered with `flex flex-row` and no wrapping. Inside the `w-80` sidebar (with `p-6` padding, leaving ~272px of usable width), the three checkboxes overflow horizontally — pushing the sidebar beyond its intended width and shoving the wallet results column off-screen.

**Fix:** `flex-row` → `flex-row flex-wrap` with `gap-x-6 gap-y-2` so the sub-option row wraps cleanly.

### 2. Filter description text clips on the right (`SwitchFilterInput.tsx`)

`Field` applies `[&>*]:w-full` to all its direct children. `FieldDescription` had `ms-8` (margin-start), which shifts the element 32px from the left *but keeps its width at 100% of the container* — overflowing 32px past the right edge.

**Fix:** `ms-8` → `ps-8` (padding-start). Same visual indent (text aligns under the label, past the icon), but the element stays within its container bounds.

## Test plan
- [ ] Go to https://ethereum.org/wallets/find-wallet/
- [ ] Open the **Filters** panel on a desktop viewport
- [ ] Toggle **Desktop** on under Device — Linux / Windows / macOS checkboxes should wrap to the next line instead of overflowing the sidebar
- [ ] Wallet results column should remain fully visible alongside the open filter panel
- [ ] Filter descriptions (e.g. "You can connect to applications that support WalletConnect…") should wrap within the sidebar without clipping on the right edge

## Preview link
https://deploy-preview-18360.ethereum.it/wallets/find-wallet