### PR TITLE
fix: wrap sub-filter options to prevent desktop filter sidebar overflow

### DIFF
--- a/src/components/ProductTable/Filter.tsx
+++ b/src/components/ProductTable/Filter.tsx
@@ -102,7 +102,7 @@ const Filter = ({ filter, filterIndex, onChange }: FilterProps) => {
       className="bg-background-highlight p-6"
     >
       <AccordionTrigger className="border-b md:px-0">
-        <p className="text-base font-bold text-body">{filter.title}</p>
+        <p className="text-body text-base font-bold">{filter.title}</p>
       </AccordionTrigger>
       <AccordionContent className="p-0 md:p-0">
         <FieldSet className="gap-0">
@@ -120,7 +120,7 @@ const Filter = ({ filter, filterIndex, onChange }: FilterProps) => {
                   handleChange
                 )}
                 {item.inputState === true && item.options.length ? (
-                  <FieldSet className="flex flex-row gap-6 px-2 pb-4">
+                  <FieldSet className="flex flex-row flex-wrap gap-x-6 gap-y-2 px-2 pb-4">
                     {item.optionsLegend && (
                       <FieldLegend className="sr-only">
                         {item.optionsLegend}

--- a/src/components/ProductTable/Filter.tsx
+++ b/src/components/ProductTable/Filter.tsx
@@ -102,7 +102,7 @@ const Filter = ({ filter, filterIndex, onChange }: FilterProps) => {
       className="bg-background-highlight p-6"
     >
       <AccordionTrigger className="border-b md:px-0">
-        <p className="text-body text-base font-bold">{filter.title}</p>
+        <p className="text-base font-bold text-body">{filter.title}</p>
       </AccordionTrigger>
       <AccordionContent className="p-0 md:p-0">
         <FieldSet className="gap-0">

--- a/src/components/ProductTable/FilterInputs/SwitchFilterInput.tsx
+++ b/src/components/ProductTable/FilterInputs/SwitchFilterInput.tsx
@@ -38,7 +38,7 @@ const SwitchFilterInput = ({
       <div className="flex flex-row items-center justify-between gap-2">
         <FieldLabel
           htmlFor={id}
-          className="flex w-fit cursor-pointer flex-row items-center gap-0 text-base font-normal leading-normal"
+          className="flex w-fit cursor-pointer flex-row items-center gap-0 text-base leading-normal font-normal"
         >
           <span className="h-8 w-8">
             {Icon && (
@@ -59,7 +59,7 @@ const SwitchFilterInput = ({
       {description && (
         <FieldDescription
           id={descriptionId}
-          className="text-body-medium ps-8 text-base font-normal leading-normal"
+          className="ps-8 text-base leading-normal font-normal text-body-medium"
         >
           {description}
         </FieldDescription>

--- a/src/components/ProductTable/FilterInputs/SwitchFilterInput.tsx
+++ b/src/components/ProductTable/FilterInputs/SwitchFilterInput.tsx
@@ -38,7 +38,7 @@ const SwitchFilterInput = ({
       <div className="flex flex-row items-center justify-between gap-2">
         <FieldLabel
           htmlFor={id}
-          className="flex w-fit cursor-pointer flex-row items-center gap-0 text-base leading-normal font-normal"
+          className="flex w-fit cursor-pointer flex-row items-center gap-0 text-base font-normal leading-normal"
         >
           <span className="h-8 w-8">
             {Icon && (
@@ -59,7 +59,7 @@ const SwitchFilterInput = ({
       {description && (
         <FieldDescription
           id={descriptionId}
-          className="ms-8 text-base leading-normal font-normal text-body-medium"
+          className="text-body-medium ps-8 text-base font-normal leading-normal"
         >
           {description}
         </FieldDescription>


### PR DESCRIPTION
## Summary

Fixes #18358

When the **Desktop** device filter is toggled on the Find a Wallet page, a row of sub-option checkboxes (Linux / Windows / macOS) is rendered in a `flex flex-row` container with no wrapping. Inside the `w-80` sidebar (with `p-6` padding, leaving ~272px of usable width), the three checkboxes overflow horizontally — pushing the sidebar beyond its intended width and shoving the wallet results column off-screen.

**Change:** one line in `src/components/ProductTable/Filter.tsx` — `flex-row` → `flex-row flex-wrap` with `gap-x-6 gap-y-2` so the sub-option row wraps cleanly when it exceeds the sidebar width.

This component is shared across all `ProductTable` usages (wallets, layer-2, etc.), so any other page with multi-option sub-filters also benefits.

## Test plan
- [ ] Go to https://ethereum.org/wallets/find-wallet/
- [ ] Open the Filters panel on a desktop viewport
- [ ] Toggle **Desktop** on under Device — Linux / Windows / macOS checkboxes should wrap to the next line instead of overflowing
- [ ] Wallet results column should remain visible and correctly positioned
- [ ] Verify the same filter works on the Layer-2 networks page if it has sub-option filters