### PR TITLE
fix: prevent EF logo from stretching on foundation page

### DIFF
--- a/src/components/Logo/index.tsx
+++ b/src/components/Logo/index.tsx
@@ -14,7 +14,7 @@ const Logo = () => {
   return (
     <Image
       src={image}
-      className="h-[100px] w-auto"
+      className="h-[100px] w-fit"
       alt={t("ethereum-foundation-logo")}
     />
   )


### PR DESCRIPTION
## Summary

Fixes #18361

The EF logo on [/foundation](https://ethereum.org/foundation/) was rendering stretched horizontally. The `Logo` component used `w-auto`, but Next.js `<Image>` renders as `display: block`, causing `width: auto` to fill the container (~768px) rather than computing from the aspect ratio. With the default `object-fit: fill`, the image was stretched to 768×100px.

**Fix:** `w-auto` → `w-fit` (`width: fit-content`), which shrinks the element to its intrinsic width instead of filling the container.

## Test plan
- [ ] Go to https://ethereum.org/foundation/
- [ ] The EF diamond logo below the page title should render at correct proportions (not squashed/flat)
- [ ] Verify in both light and dark mode