### PR TITLE
patch(ui): text-body for all headers inside CardContent

### DIFF
--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -117,7 +117,7 @@ const CardContent = React.forwardRef<
     className={cn(
       childSpacingVariants({ spacing }),
       "flex-1 space-y-(--content-space) p-(--card-pad)",
-      "text-body-medium **:data-[label=card-title]:text-body **:[strong]:text-body",
+      "text-body-medium **:data-[label=card-title]:text-body **:[:is(h2,h3,h4,h5,h6,strong)]:text-body",
       className
     )}
     {...props}


### PR DESCRIPTION
## Description
- Expands text-body override to headers along with strong tags inside `CardContent` sub-component
- Fixes /bug-bounty/ MarkdownCards which contain sub-headers that were having text-body-medium applied

<img width="1241" height="803" alt="image" src="https://github.com/user-attachments/assets/33dd05b7-5ac0-41fa-bef0-f06cf3917035" />


## Related Issue
Fixes:
<img width="1236" height="933" alt="image" src="https://github.com/user-attachments/assets/fc555adc-bb86-4777-b258-ee59ee43ea75" />
