### PR TITLE
fix(ui): stop card text blurring on hover-lift (use translate, not sub-pixel scale)

### DIFF
--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -160,20 +160,22 @@
     calc(--value(number) * var(--spacing)) hsla(var(--primary-low-contrast));
 }
 
+/* Whole-pixel translate instead of fractional scale: sub-pixel scale
+   rasterizes text into a composited layer and blurs it mid-transition. */
 @utility hover-lift-xs {
-  @apply scale-100 shadow-none duration-300 hover:scale-[1.005] hover:shadow hover:duration-300;
+  @apply translate-y-0 shadow-none duration-300 hover:-translate-y-0.5 hover:shadow hover:duration-300;
 }
 
 @utility hover-lift-base {
-  @apply scale-100 shadow-none duration-300 hover:scale-101 hover:shadow-md hover:duration-300;
+  @apply translate-y-0 shadow-none duration-300 hover:-translate-y-1 hover:shadow-md hover:duration-300;
 }
 
 @utility hover-lift-sm {
-  @apply scale-100 shadow-sm duration-300 hover:scale-101 hover:shadow-lg hover:duration-300;
+  @apply translate-y-0 shadow-sm duration-300 hover:-translate-y-1 hover:shadow-lg hover:duration-300;
 }
 
 @utility hover-lift-md {
-  @apply scale-100 shadow-md duration-300 hover:scale-101 hover:shadow-xl hover:duration-300;
+  @apply translate-y-0 shadow-md duration-300 hover:-translate-y-1 hover:shadow-xl hover:duration-300;
 }
 
 /* background-image (gradients) */


### PR DESCRIPTION
## Description

Cards using the hover-lift effect blur their text on hover and the font appears to subtly shift weight, then re-sharpens — most visible on the staking product cards at [/staking/pools/](https://ethereum.org/staking/pools/).

### Root cause

The lift effect applies a **non-integer scale transform** (`hover:scale-101` / `hover:scale-[1.005]`). A fractional scale promotes the card to a GPU compositing layer and rasterizes its text into a bitmap, then scales that bitmap: glyphs get resampled at sub-pixel boundaries (blur), and composited layers drop sub-pixel/LCD antialiasing in favour of grayscale AA (the apparent font-weight change). When the `duration-300` transition settles, the layer re-rasterizes and the text snaps sharp — hence "blurred, then sharp."

### Fix

> **Note (rebase):** this PR originally changed the `lift` variant inline in `src/components/ui/card.tsx`. `dev` has since moved the lift styles into the shared `hover-lift-*` utilities in `src/styles/utilities.css` (still using fractional scale), so the fix now lands there instead.

Replace the fractional scale with a whole-pixel `translate-y` in all four `hover-lift-*` utilities:

```diff
 @utility hover-lift-base {
-  @apply scale-100 shadow-none duration-300 hover:scale-101 hover:shadow-md hover:duration-300;
+  @apply translate-y-0 shadow-none duration-300 hover:-translate-y-1 hover:shadow-md hover:duration-300;
 }
```

(same pattern for `hover-lift-xs` → `-translate-y-0.5`, `hover-lift-sm` and `hover-lift-md` → `-translate-y-1`)

An integer-pixel `translate` keeps glyphs on the pixel grid (no resampling, no blur) and gives a more perceptible lift than a ~1% scale. These utilities are shared by `Card` (`hoverLift`), `SubpageCard`, `DocLink`, and the community events page, so the fix applies everywhere the lift effect is used.

## Related Issue

Fixes #18364

## Testing

- `eslint` / `prettier` clean (auto-run via lint-staged pre-commit).
- Pure utility swap inside the existing `@utility` blocks; no API or type changes.
- **Not** verified in a live browser in this session — the artifact is a transient hover-transition effect. Rationale is based on well-established CSS transform text-rasterization behavior. A reviewer hovering any staking pool card on the deploy preview before/after will see the difference.

## Preview

`/staking/pools/` — hover any staking provider card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
