### PR TITLE
fix: canonical `staking` topic dropdown links

### DIFF
--- a/app/[locale]/staking/page.tsx
+++ b/app/[locale]/staking/page.tsx
@@ -42,6 +42,8 @@ import { getAppPageContributorInfo } from "@/lib/utils/contributors"
 import { getMetadata } from "@/lib/utils/metadata"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 
+import { staking } from "@/data/topics/staking"
+
 import StakingCommunityCallout from "./_components/StakingCommunityCallout"
 import StakingPageJsonLD from "./page-jsonld"
 
@@ -134,64 +136,17 @@ const Page = async (props: { params: Promise<PageParams> }) => {
   ]
 
   const dropdownLinks: ButtonDropdownList = {
-    text: t("page-staking-dropdown-staking-options"),
-    ariaLabel: t("page-staking-dropdown-staking-options-alt"),
-    items: [
-      {
-        text: t("page-staking-dropdown-home"),
-        href: "/staking/",
-        matomo: {
-          eventCategory: `Staking dropdown`,
-          eventAction: `Clicked`,
-          eventName: "clicked staking home",
-        },
+    text: t(staking.dropdown.textKey),
+    ariaLabel: t(staking.dropdown.ariaLabelKey),
+    items: staking.dropdown.items.map((item) => ({
+      text: t(item.textKey),
+      href: item.href,
+      matomo: {
+        eventCategory: staking.dropdown.matomoCategory,
+        eventAction: "Clicked",
+        eventName: item.matomoEvent,
       },
-      {
-        text: t("page-staking-dropdown-solo"),
-        href: "/staking/solo/",
-        matomo: {
-          eventCategory: `Staking dropdown`,
-          eventAction: `Clicked`,
-          eventName: "clicked solo staking",
-        },
-      },
-      {
-        text: t("page-staking-dropdown-saas"),
-        href: "/staking/saas/",
-        matomo: {
-          eventCategory: `Staking dropdown`,
-          eventAction: `Clicked`,
-          eventName: "clicked staking as a service",
-        },
-      },
-      {
-        text: t("page-staking-dropdown-pools"),
-        href: "/staking/pools/",
-        matomo: {
-          eventCategory: `Staking dropdown`,
-          eventAction: `Clicked`,
-          eventName: "clicked pooled staking",
-        },
-      },
-      {
-        text: t("page-staking-dropdown-withdrawals"),
-        href: "/staking/withdrawals/",
-        matomo: {
-          eventCategory: `Staking dropdown`,
-          eventAction: `Clicked`,
-          eventName: "clicked about withdrawals",
-        },
-      },
-      {
-        text: t("page-staking-dropdown-dvt"),
-        href: "/staking/dvt/",
-        matomo: {
-          eventCategory: `Staking dropdown`,
-          eventAction: `Clicked`,
-          eventName: "clicked about dvt",
-        },
-      },
-    ],
+    })),
   }
 
   const tocItems = {

--- a/src/data/topics/staking.ts
+++ b/src/data/topics/staking.ts
@@ -32,6 +32,11 @@ export const staking: TopicConfig = {
         href: "/staking/withdrawals/",
         matomoEvent: "clicked about withdrawals",
       },
+      {
+        textKey: "page-staking-dropdown-dvt",
+        href: "/staking/dvt/",
+        matomoEvent: "clicked about dvt",
+      },
     ],
   },
 }


### PR DESCRIPTION
## Description
- Adds `/dvt/` page to canonical staking topic dropdown items
- Imports canonical `staking` config to `/staking/` page, removing redundant copy (preventing them from straying again)

## Preview link
https://deploy-preview-18381.ethereum.it/staking

## Screenshot
<img width="751" height="965" alt="image" src="https://github.com/user-attachments/assets/f545406a-482e-4816-bc30-e78b6bd939f0" />

## Related Issue
- Fixes #18333