### PR TITLE
intl: ghost-heading sanitizer guard + ETHGlossary source-of-truth docs

### DIFF
--- a/.claude/skills/intl-review/references/ethglossary-usage.md
+++ b/.claude/skills/intl-review/references/ethglossary-usage.md
@@ -19,6 +19,14 @@ This doc focuses on the review-specific patterns (severity mapping, what to flag
 
 This is the determinism backbone. Reviewers don't argue terminology with the pipeline — both pipeline and reviewer defer to ETHGlossary. If a glossary entry looks wrong during review, flag it in the report; don't patch the locale to disagree with it.
 
+## Authority hierarchy — and what to do for items the glossary doesn't cover
+
+ETHGlossary is the source of truth for **term translations AND for transliteration/calque/keep-Latin guidance**. Apply it in this strict order; do not substitute your own instinct:
+
+1. **Term IS in ETHGlossary** → its per-term `script_rule` is the *only* authority for transliterate / calque / keep-latin / always-latin. Query it (`/filter` per file, or `/translations/{lang}/{termId}`). A deviation is CRITICAL.
+2. **Term is NOT in ETHGlossary** (author names, brand-new products, etc.) → apply the script-aware fallback in `known-patterns.md` §1: **transliterate** into non-Latin target scripts, **keep as-is** for Latin scripts.
+3. **Never infer a "default" `script_rule` for an unlisted term.** An absent entry means "use the fallback," **not** "keep Latin." Flagging a correctly-transliterated non-Latin author name (e.g. `te` "మారియో హావెల్" for "Mario Havel") as "should be Latin" is a **false positive** — the kind of fabricated critical that wastes reviewer time. When in doubt, query the API; if the term isn't there, the fallback decides, not you.
+
 ## How to query
 
 **Preferred — per-file `/filter`:**
@@ -26,7 +34,7 @@ This is the determinism backbone. Reviewers don't argue terminology with the pip
 ```bash
 curl -sf -X POST "$GLOSSARY_API_URL/filter" \
   -H "Content-Type: application/json" \
-  -d "$(jq -n --arg text "$ENGLISH_SOURCE" --arg lang "$LANG" '{text: $text, language: $lang}')"
+  -d "$(jq -n --arg content "$ENGLISH_SOURCE" --arg lang "$LANG" '{content: $content, language: $lang}')"
 ```
 
 Returns only the glossary terms that appear in the English source for the file being reviewed, with translations sorted by occurrence. Avoids pulling hundreds of irrelevant terms into review context.

--- a/.claude/translation-review/known-patterns.md
+++ b/.claude/translation-review/known-patterns.md
@@ -1,7 +1,7 @@
 # Known Translation Patterns & Issues
 
 > This is a living document. Updated after each language review.
-> Last updated: 2026-03-16 (updated with Gemini-confirmed transliteration policy from Hindi PR #17101)
+> Last updated: 2026-06-09 (PR #18375: added MDX duplicated-closer / dropped-`>` breakers, the duplicate ghost-heading migration artifact, and the ETHGlossary authority hierarchy for unlisted terms)
 
 ## Issue Categories
 
@@ -70,6 +70,12 @@ flag phonetic transliterations.
 
 **Transliteration authority:** ETHGlossary (https://ethglossary.visual-20-hoists.workers.dev) is the canonical source for term translations, including per-language transliterated forms for non-Latin scripts. The pipeline queries ETHGlossary directly; reviewers verify against the per-term `script_rule` returned by the API. The previous local bank at `.claude/translation-review/transliterations/` has been removed as of ETHGlossary v0.3.0.
 
+**Authority hierarchy — terms ETHGlossary covers vs. items it doesn't (READ THIS before flagging a transliteration/calque/keep-Latin "error"):**
+
+1. **For any term ETHGlossary covers, its per-term `script_rule` is the ONLY authority** for the transliterate / calque / keep-latin / always-latin decision. Query the API (`/filter` per file, or `/translations/{lang}/{termId}`); never assume.
+2. **For items ETHGlossary does NOT cover** (author names, brand-new product names not yet in the glossary, etc.), apply the script-aware fallback above: **transliterate** into non-Latin target scripts, **keep as-is** for Latin scripts.
+3. **Never infer a "default" `script_rule` for an unlisted term.** An absent glossary entry means "fall back to the script-aware policy," **NOT** "keep Latin." Example caught in PR #18375 review: a `te` author name "Mario Havel" rendered as "మారియో హావెల్" is **CORRECT** per the fallback — a reviewer flagging it as "should stay Latin" by assuming an `always_latin` default was a **false positive**. When ETHGlossary and a reviewer's instinct disagree, ETHGlossary (or, for unlisted items, this documented fallback) wins — there is one source of truth.
+
 ### 2. Cross-Script Contamination (CRITICAL)
 
 Crowdin translation memory leaks content from other language translations.
@@ -82,7 +88,7 @@ Crowdin translation memory leaks content from other language translations.
 
 ### 3. MDX Syntax Errors (CRITICAL — breaks builds)
 
-Four predictable categories that appear in every import:
+Predictable categories that appear in nearly every import:
 
 | Pattern | Example | Fix |
 |---------|---------|-----|
@@ -90,8 +96,20 @@ Four predictable categories that appear in every import:
 | Missing closing backtick | `` `<contract>.<function>() `` | Add closing backtick |
 | Misplaced backtick exposing JSX | ``(`<> ...` </>`)`` | Fix backtick placement |
 | Orphaned HTML closing tags | `</a>` from sentence restructuring | Remove orphaned tag |
+| Duplicated inner closer over a wrapper | `<ExpandableCard>…<ButtonLink>x</ButtonLink></ButtonLink>` (2nd should close the wrapper) | Restore the wrapper's real closing tag from the English source (`</ExpandableCard>`, `</Callout>`, …) |
+| Dropped `>` in angle-bracket link whose URL has parens | `[t](<https://en.wikipedia.org/wiki/Electra_(star))` | Restore the `>` before the final `)`: `…_(star)>)` |
 
-**Pattern:** These same 4 patterns recur in every Crowdin import. The first two are most common.
+**Pattern:** The first two are most common. The last two were the entire cause of the failing build in **PR #18375** (77 files, all 24 langs). **Detect deterministically** by compiling each changed file through `@mdx-js/mdx` (the parser `next-mdx-remote` uses) — strip frontmatter and `{#id}` heading anchors first (else every file false-positives on the custom heading-id syntax), and confirm the English sources compile clean as a control before trusting the run.
+
+### 3b. Duplicate "Ghost" Headings (CRITICAL — structural-migration artifact)
+
+When a base-branch change shifts page block structure — e.g. the h1 → `frontmatter.title` migration that removed leading `#` headings — the pipeline's incremental block-matching can mis-align and emit a section **twice**: an anchor-less "ghost" copy (often an older or differently-worded translation, sometimes a different formality register) immediately followed by the correct `{#anchor}` copy. The reader sees the section rendered twice in a row.
+
+**Signature:** a translated `h2`–`h4` heading **without** `{#id}` immediately followed (after blank lines and/or one duplicate paragraph) by a **same-level** heading **with** `{#id}`. English requires `{#id}` on every heading, so any anchor-less translated heading is the tell.
+
+**Fix:** delete the ghost block (the anchor-less heading + its duplicate paragraph) up to the anchored twin; keep the anchored version that matches the English source. Observed in **PR #18375** at **254 occurrences across 69 files** (24 langs × `community/grants`, `contributing/adding-videos`, `roadmap/glamsterdam`).
+
+**Detection:** scan changed translated files for `^#{2,4} ` lines lacking `{#` (outside code fences); classify each as ghost-twin (next same-level heading is anchored → safe to delete) vs. lone-missing-anchor (needs the anchor *added* from English) before fixing. **The durable fix belongs in the sanitizer** (collapse adjacent duplicate headings during sanitization) so future structural changes self-heal rather than shipping duplicates.
 
 ### 4. Semantic Inversions (CRITICAL)
 

--- a/.claude/translation-review/localization-rules-by-language-group.md
+++ b/.claude/translation-review/localization-rules-by-language-group.md
@@ -2,7 +2,7 @@
 
 > **Source:** Gemini (2026-03-18), confirmed by project maintainer
 > **Applies to:** All 13 non-Latin-script locales in the transliteration pipeline
-> **Used by:** sanitizer (post_import_sanitize.ts), transliteration script (transliterate.ts), review agents
+> **Used by:** sanitizer (`src/scripts/intl-pipeline/intl-sanitizer.ts`), ETHGlossary integration, review agents
 
 ## Quick Reference Table
 
@@ -141,7 +141,7 @@ acts as a strong RTL character that anchors the directionality:
 
 ## Impact on Sanitizer and Transliteration Scripts
 
-### Sanitizer (post_import_sanitize.ts)
+### Sanitizer (`src/scripts/intl-pipeline/intl-sanitizer.ts`)
 
 Current behavior and needed changes:
 

--- a/docs/solutions/integration-issues/sanitizer-test-research.md
+++ b/docs/solutions/integration-issues/sanitizer-test-research.md
@@ -75,7 +75,8 @@
 
 These patterns are covered by existing fix functions and should have regression tests:
 
-- **Duplicated headings** (`fixDuplicatedHeadings`) -- `## Text? Text? {#id}`
+- **Duplicated headings** (`fixDuplicatedHeadings`) -- `## Text? Text? {#id}` (intra-line text duplication)
+- **Duplicate ghost heading blocks** (`fixDuplicateHeadingBlocks`) -- an anchor-less "ghost" heading (often an older/differently-worded translation) immediately followed by the correct same-level heading WITH `{#anchor}`, emitted when a structural change to the English source (e.g. the h1 -> frontmatter.title migration) confuses the pipeline's incremental block-matching. Removes the ghost block (heading + duplicate prose up to the anchored twin), keeping the anchored version. Code-fence-safe; leaves lone anchor-less headings to `syncHeaderIdsWithEnglish`. Found in PR #18375 (254 occurrences, 69 files, all 24 langs).
 - **Broken markdown links** (`fixBrokenMarkdownLinks`) -- `] (url)` space
 - **Escaped bold/italic** (`fixEscapedBoldAndItalic`) -- `\*\*text\*\*`; uses lookbehind to skip `\*` used as multiplication (e.g., `operand\*operand`)
 - **ASCII guillemets** (`fixAsciiGuillemets`) -- `<<text>>`

--- a/src/scripts/intl-pipeline/intl-sanitizer.ts
+++ b/src/scripts/intl-pipeline/intl-sanitizer.ts
@@ -961,6 +961,82 @@ function fixDuplicatedHeadings(content: string): {
 }
 
 /**
+ * Remove duplicate "ghost" heading blocks.
+ *
+ * When a structural change to the English source shifts block layout (e.g. the
+ * h1 -> frontmatter.title migration that removed leading `#` page titles), the
+ * pipeline's incremental block-matching can emit a section twice: an
+ * anchor-less "ghost" heading (often an older or differently-worded
+ * translation, sometimes a different formality register) immediately followed
+ * by the correct same-level heading WITH a `{#anchor}`. The reader sees the
+ * section rendered twice in a row.
+ *
+ * This removes the ghost block (the anchor-less heading plus the duplicate
+ * prose up to the anchored twin), keeping the canonical anchored version that
+ * matches the English source. English requires `{#id}` on every heading and
+ * `syncHeaderIdsWithEnglish` runs before this, so any remaining anchor-less
+ * heading is an artifact.
+ *
+ * Conservative by design — only acts when the immediately-following heading is
+ * the SAME level and HAS an anchor, and the lines between contain no code
+ * fence. It never half-cuts a fenced block, and it leaves "lone" anchor-less
+ * headings (no anchored twin) untouched — those need an anchor ADDED, which is
+ * `syncHeaderIdsWithEnglish`'s job, not this one.
+ */
+function fixDuplicateHeadingBlocks(content: string): {
+  content: string
+  fixCount: number
+} {
+  const lines = content.split("\n")
+  const headingRe = /^(#{1,6})\s+\S/
+  const anchorRe = /\{#[^}]+\}/
+  const fenceRe = /^\s*(```|~~~)/
+
+  // Index headings, skipping fenced code blocks.
+  const heads: Array<{ idx: number; level: number; hasAnchor: boolean }> = []
+  let inFence = false
+  for (let i = 0; i < lines.length; i++) {
+    if (fenceRe.test(lines[i])) {
+      inFence = !inFence
+      continue
+    }
+    if (inFence) continue
+    const m = lines[i].match(headingRe)
+    if (m) {
+      heads.push({
+        idx: i,
+        level: m[1].length,
+        hasAnchor: anchorRe.test(lines[i]),
+      })
+    }
+  }
+
+  const drop = new Set<number>()
+  let fixCount = 0
+  for (let h = 0; h < heads.length - 1; h++) {
+    const ghost = heads[h]
+    const twin = heads[h + 1]
+    if (ghost.hasAnchor) continue
+    if (twin.level !== ghost.level || !twin.hasAnchor) continue
+    // The lines between the ghost heading and its anchored twin must contain no
+    // code fence — guarantees we never half-cut a fenced block.
+    let safe = true
+    for (let k = ghost.idx + 1; k < twin.idx; k++) {
+      if (fenceRe.test(lines[k])) {
+        safe = false
+        break
+      }
+    }
+    if (!safe) continue
+    for (let k = ghost.idx; k < twin.idx; k++) drop.add(k)
+    fixCount++
+  }
+
+  if (fixCount === 0) return { content, fixCount: 0 }
+  return { content: lines.filter((_, i) => !drop.has(i)).join("\n"), fixCount }
+}
+
+/**
  * Fix escaped bold/italic markers from Crowdin.
  * Crowdin often escapes markdown emphasis during translation:
  *   \*\*text\*\* → **text** (bold)
@@ -4490,6 +4566,10 @@ function processMarkdownFile(
     (n) => `Fixed ${n} duplicated headings`
   )
   applyFix(
+    () => fixDuplicateHeadingBlocks(content),
+    (n) => `Removed ${n} duplicate ghost heading block(s)`
+  )
+  applyFix(
     () => fixBrokenMarkdownLinks(content),
     (n) => `Fixed ${n} broken markdown links`
   )
@@ -5507,6 +5587,7 @@ function fixJsxAttributeSpacing(content: string): {
 export const _testOnly = {
   // Standalone fixes
   fixDuplicatedHeadings,
+  fixDuplicateHeadingBlocks,
   fixBrokenMarkdownLinks,
   fixEscapedBoldAndItalic,
   fixAsciiGuillemets,

--- a/tests/unit/intl-pipeline/sanitizer/standalone-fixes.spec.ts
+++ b/tests/unit/intl-pipeline/sanitizer/standalone-fixes.spec.ts
@@ -9,6 +9,7 @@ import { _testOnly } from "@/scripts/intl-pipeline/intl-sanitizer"
 
 const {
   fixDuplicatedHeadings,
+  fixDuplicateHeadingBlocks,
   fixBrokenMarkdownLinks,
   fixEscapedBoldAndItalic,
   fixAsciiGuillemets,
@@ -3013,6 +3014,57 @@ author: Ori Pomerantz
       const { content, fixCount } = fixMisalignedCodeFences(input)
       expect(content).toBe("    ~~~sh\n    cmd\n    ~~~")
       expect(fixCount).toBe(1)
+    })
+  })
+
+  test.describe("fixDuplicateHeadingBlocks", () => {
+    test("removes an anchor-less ghost heading block before its anchored twin", () => {
+      const input =
+        "Intro paragraph.\n\n## Skalierung\n\nGhost paragraph.\n\n## Skalierung neu {#scale}\n\nReal paragraph."
+      const { content, fixCount } = fixDuplicateHeadingBlocks(input)
+      expect(content).toBe(
+        "Intro paragraph.\n\n## Skalierung neu {#scale}\n\nReal paragraph."
+      )
+      expect(fixCount).toBe(1)
+    })
+
+    test("handles a ghost heading directly followed by the anchored twin", () => {
+      const input = "## FAQ\n## Häufig gestellte Fragen {#faq}\n\nBody."
+      const { content, fixCount } = fixDuplicateHeadingBlocks(input)
+      expect(content).toBe("## Häufig gestellte Fragen {#faq}\n\nBody.")
+      expect(fixCount).toBe(1)
+    })
+
+    test("leaves clean anchored headings unchanged", () => {
+      const input =
+        "## One {#one}\n\nA paragraph.\n\n## Two {#two}\n\nAnother paragraph."
+      const { content, fixCount } = fixDuplicateHeadingBlocks(input)
+      expect(content).toBe(input)
+      expect(fixCount).toBe(0)
+    })
+
+    test("leaves a lone anchor-less heading untouched (no anchored same-level twin)", () => {
+      // Next heading is a different level -> not a ghost twin; needs an anchor
+      // ADDED by syncHeaderIdsWithEnglish, not removal here.
+      const input = "## Lonely\n\npara\n\n### Sub {#sub}\n\nmore"
+      const { content, fixCount } = fixDuplicateHeadingBlocks(input)
+      expect(content).toBe(input)
+      expect(fixCount).toBe(0)
+    })
+
+    test("ignores heading-like lines inside code fences", () => {
+      const input = "## Real {#real}\n\npara\n\n```md\n## not a heading\nmore\n```"
+      const { content, fixCount } = fixDuplicateHeadingBlocks(input)
+      expect(content).toBe(input)
+      expect(fixCount).toBe(0)
+    })
+
+    test("does not delete across a code fence between ghost and twin", () => {
+      const input =
+        "## Ghost\n\n```text\n## fake\n```\n\n## Ghost real {#ghost}\n\nbody"
+      const { content, fixCount } = fixDuplicateHeadingBlocks(input)
+      expect(content).toBe(input)
+      expect(fixCount).toBe(0)
     })
   })
 })


### PR DESCRIPTION
## Summary

Two related intl-infrastructure improvements surfaced while reviewing the translation pipeline output in #18375. Both are docs/tooling only -- no translated content changes here.

### 1. Sanitizer guard for duplicate "ghost" headings (`feat`)

When a structural change to the English source shifts page block layout -- e.g. the `h1` -> `frontmatter.title` migration that removed leading `#` page titles -- the pipeline's incremental block-matching can emit a section **twice**: an anchor-less "ghost" heading (often an older or differently-worded translation) immediately followed by the correct same-level heading with a `{#anchor}`. The reader sees the section rendered twice.

`fixDuplicateHeadingBlocks` removes the ghost block (the anchor-less heading + duplicate prose up to the anchored twin), keeping the canonical anchored version. It is **code-fence-safe** (never half-cuts a fenced block) and **conservative** (leaves lone anchor-less headings to `syncHeaderIdsWithEnglish`, since those need an anchor *added*, not removal).

This was surfaced by #18375, where the artifact appeared **254 times across 69 files in all 24 languages** (`community/grants`, `contributing/adding-videos`, `roadmap/glamsterdam`). Those occurrences were hand-fixed in that PR; this makes the pipeline self-heal going forward.

- 6 new unit tests; full sanitizer suite passes (599).

### 2. ETHGlossary as the single source of truth (`docs`)

Makes explicit -- in the `intl-review` reference and the `known-patterns` KB -- that **ETHGlossary is authoritative for term translations AND transliteration/calque guidance**, with a strict hierarchy:

1. A term ETHGlossary covers -> its per-term `script_rule` governs.
2. Items it does **not** cover (author names, novel brands) -> the script-aware fallback (transliterate for non-Latin, keep-as-is for Latin).
3. **Never infer a "default" `script_rule`** for an unlisted term.

This resolves a false positive caught in #18375 review (a correctly transliterated `te` author name "మారియో హావెల్" for "Mario Havel" is correct, not a keep-Latin error).

Also in this PR:
- **Fixes a real doc bug:** the `/filter` example payload key was `text`, but the API requires `content` (it silently returns nothing with `text`).
- Catalogs the new MDX build-breaker variants (duplicated-inner-closer; dropped `>` in angle-bracket links with parens) and the ghost-heading artifact in `known-patterns.md`.
- Updates stale `post_import_sanitize.ts` references to the current `intl-sanitizer.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
