### PR TITLE
Add BoltRPC to the nodes-as-a-service providers list

### DIFF
--- a/public/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
+++ b/public/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
@@ -147,6 +147,17 @@ Here is a list of some of the most popular Ethereum node providers, feel free to
     - Pay in crypto
     - Direct support & Technical support
 
+- [**BoltRPC**](https://boltrpc.io/)
+  - [Docs](https://boltrpc.io/docs)
+  - Features
+    - Dedicated endpoints for Ethereum Mainnet, Sepolia and Hoodi testnets plus the Beacon Chain API
+    - HTTPS and WebSocket access on every plan
+    - Globally distributed infrastructure with automatic failover
+    - Transparent request-unit pricing with fixed, published per-method weights
+    - ISO/IEC 27001:2022 certified operator
+    - Free 2-week trial, no credit card required
+    - Pay by card or in crypto
+
 - [**Chainbase**](https://www.chainbase.com/)
   - [Docs](https://docs.chainbase.com)
   - Features


### PR DESCRIPTION
## Description

Adds BoltRPC to the node service providers list on the nodes-as-a-service page, following the invitation on the page ("Feel free to add any that are missing!").

BoltRPC is a dedicated RPC provider serving Ethereum Mainnet, the Sepolia and Hoodi testnets and the Beacon Chain API, alongside 20+ other networks.

**Disclosure:** I work with BoltRPC. The feature list sticks to factual, verifiable capabilities in line with the other entries.