### PR TITLE
remove: scam link from dev docs /scaling/state-channels/

### DIFF
--- a/public/content/developers/docs/scaling/state-channels/index.md
+++ b/public/content/developers/docs/scaling/state-channels/index.md
@@ -244,7 +244,6 @@ Some state channels solve this problem by using a "full-duplex" design that sepa
 Multiple projects provide implementations of state channels that you can integrate into your dapps:
 
 - [Connext](https://connext.network/)
-- [Kchannels](https://www.kchannels.io/)
 - [Perun](https://perun.network/)
 - [Raiden](https://raiden.network/)
 - [Statechannels.org](https://statechannels.org/)


### PR DESCRIPTION
scam site seo hacked/url swapped

<!--- Provide a general summary of your changes in the Title above -->

kchannels is a fake url. change this out. this is bad link building. old url now leads to chemexper (.) net

scam site seo hacked/url swapped

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
