### PR TITLE
Fix /start swiper cards overflowing below the active slide

### DIFF
--- a/src/components/StartWithEthereumFlow/index.tsx
+++ b/src/components/StartWithEthereumFlow/index.tsx
@@ -106,7 +106,10 @@ const StartWithEthereumFlow = ({
             "w-screen",
             "max-w-screen-2xl",
             "px-4 sm:px-8",
-            "[&_.swiper-slide]:overflow-visible [&_.swiper-slide]:rounded-2xl",
+            // Cards effect requires overflow-hidden on slides: the maxHeight
+            // stacking trick (getStyleFromIndex) only hides inactive-slide
+            // content if it's clipped
+            "[&_.swiper-slide]:overflow-hidden [&_.swiper-slide]:rounded-2xl",
             "[&_.swiper-slide]:min-h-[386px]",
             "[&_.swiper-slide-shadow]:!bg-transparent",
             "[&_.swiper]:mt-4 [&_.swiper]:!flex [&_.swiper]:h-fit [&_.swiper]:w-full [&_.swiper]:flex-col [&_.swiper]:items-center"


### PR DESCRIPTION
## Description

On `/start/`, the inactive swiper cards' content (wallet list, "Get wallet", "I have a wallet"/"Continue") bleeds out below the active card and overlaps the next page section.

**Root cause:** the Tailwind v4 migration moved swiper's vendor CSS from JS imports in `swiper.tsx` (which Next.js injected *after* the global stylesheet) into `@import ... layer(components)` in `global.css`. The cards effect relies on swiper's own `.swiper-cards .swiper-slide { overflow: hidden }` to clip slide content -- that's what makes the `maxHeight` stacking trick in `StartWithEthereumFlow` actually hide the inactive slides. The component's `[&_.swiper-slide]:overflow-visible` utility had always been dead code (it lost the cascade tie to the later-loaded vendor CSS), but with vendor CSS now in `layer(components)` -- which loses to the `utilities` layer -- it started winning, and nothing clips the slides anymore.

**Fix:** set `[&_.swiper-slide]:overflow-hidden` explicitly so the clipping no longer depends on the vendor rule's cascade position.

## Test plan

- On the preview deploy, visit `/start/` and click through all three steps: inactive cards should clip cleanly behind the active card with no content bleeding below the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)