### PR TITLE
fix(e2e): update find-wallet persona filter locator

### DIFF
--- a/tests/e2e/pages/FindWalletPage.ts
+++ b/tests/e2e/pages/FindWalletPage.ts
@@ -56,19 +56,27 @@ export class FindWalletPage extends BasePage {
    * Click on a persona filter and return the expected count
    */
   async selectPersonaFilter(personaName: string) {
-    const personaButton = this.presetFiltersContainer.getByRole("button", {
-      name: new RegExp(personaName, "i"),
+    const personaNamePattern = new RegExp(personaName, "i")
+
+    // Persona cards are <label>s wrapping a visually hidden checkbox
+    // (PresetFilters.tsx); clicking the label forwards to the checkbox
+    const personaCard = this.presetFiltersContainer
+      .locator("label")
+      .filter({ hasText: personaNamePattern })
+    const personaCheckbox = this.presetFiltersContainer.getByRole("checkbox", {
+      name: personaNamePattern,
     })
 
-    await personaButton.click()
+    await personaCard.click()
+    await expect(personaCheckbox).toBeChecked()
 
-    // Extract the counter from the button text
-    const counterText = await personaButton.textContent()
+    // Extract the counter from the card text
+    const counterText = await personaCard.textContent()
     const match = counterText?.match(/\((\d+)\)/)
 
     if (!match) {
       throw new Error(
-        `Could not extract count from persona button: ${counterText}`
+        `Could not extract count from persona card: ${counterText}`
       )
     }
 


### PR DESCRIPTION
## Description

The e2e suite currently fails on PRs into `staging`, blocking the v11.10.0 deploy CI (see #18393 / #18395). Root cause: #18158 rewrote the find-wallet persona cards from `<button>`s into `<FieldLabel>`s wrapping a visually hidden Radix checkbox (`role="checkbox"`), but the Playwright page object still targeted `getByRole("button", ...)`, so `find-wallet.spec.ts:18` times out on every browser project. The e2e job only runs for PRs into `master`/`staging`/`test/**`, so the mismatch never surfaced on the original dev PR.

Test-only change to `tests/e2e/pages/FindWalletPage.ts`:

- Locate the persona card `<label>` and click it -- native label forwarding toggles the checkbox, the same path a real user hits (see the comment in `PresetFilters.tsx` about label clicks forwarding to the checkbox)
- Assert the checkbox is actually checked after the click, which also guards against the double-toggle regression the component comment warns about
- Read the `(N)` counter from the card label text (the parenthesized count only exists in the visual span, so the regex stays unambiguous)

This fixes 4 of the 6 deploy-blocking e2e failures (`find-wallet.spec.ts:18` across all four projects). The two mobile-chrome-only failures at `:29`/`:46` (pointer interception / element instability) are a separate issue and not addressed here.

Note: this targets `dev`; to green the deploy CI it also needs to reach `staging` (cherry-pick or retarget as preferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)