### PR TITLE
fix(ui): accordion sections cannot be closed (forceMount collapse)

### DIFF
--- a/src/components/ExpandableCard.tsx
+++ b/src/components/ExpandableCard.tsx
@@ -98,11 +98,7 @@ const ExpandableCard = ({
           </AccordionTrigger>
           <AccordionContent
             forceMount={forceMount}
-            className={cn(
-              "p-6! pt-0! text-md",
-              forceMount &&
-                "in-data-[state=closed]:hidden in-data-[state=closed]:h-0"
-            )}
+            className="p-6! pt-0! text-md"
           >
             <div className="space-y-[1lh] border-t pt-6 [&>p]:first:mt-0 [&>p]:last:mb-0">
               {children}

--- a/src/components/Faq/index.tsx
+++ b/src/components/Faq/index.tsx
@@ -74,10 +74,7 @@ const FaqContent = React.forwardRef<
 >(({ className, children, ...props }, ref) => (
   <AccordionContent
     ref={ref}
-    className={cn(
-      "w-full overflow-hidden px-4 text-sm md:px-8",
-      "transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
-    )}
+    className="w-full px-4 text-sm md:px-8"
     {...props}
   >
     <div className={cn("border-t border-body-light py-3 md:py-6", className)}>

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -56,13 +56,23 @@ const AccordionContent = React.forwardRef<
   React.ComponentRef<typeof AccordionPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>
 >(({ className, forceMount = true, children, ...props }, ref) => (
+  // With forceMount, Radix never hides closed content, so collapse is
+  // CSS-only: grid rows animate 1fr <-> 0fr. duration-200! (important) is
+  // required because Radix zeroes this node's inline transition-duration
+  // while re-measuring on every toggle. The visibility transition drops
+  // closed content from the tab order without removing it from the DOM.
   <AccordionPrimitive.Content
     ref={ref}
     forceMount={forceMount} // forceMount keeps content in DOM for SEO crawlers
-    className="overflow-hidden text-sm transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+    className="grid grid-rows-[1fr] text-sm transition-[grid-template-rows,visibility] duration-200! ease-out data-[state=closed]:invisible data-[state=closed]:grid-rows-[0fr]"
     {...props}
   >
-    <div className={cn("p-2 md:p-4", className)}>{children}</div>
+    {/* The grid item must clip overflow and carry no vertical padding
+        (padding floors a box's height, so the 0fr row could never fully
+        collapse); padding lives one level deeper instead. */}
+    <div className="min-h-0 overflow-hidden">
+      <div className={cn("p-2 md:p-4", className)}>{children}</div>
+    </div>
   </AccordionPrimitive.Content>
 ))
 


### PR DESCRIPTION
## Description

Accordion sections across the site cannot be closed: the trigger arrow animates and `data-state` flips to `closed`, but the content stays visible. Affects every bare `AccordionContent` consumer -- the /wallets/find-wallet filter sidebar, FAQ, layer-2, staking, gas, bug-bounty, roadmap, videos, and collectibles pages. Not a v11.10 regression: it has shipped since the `forceMount` default landed (in releases since v11.7.0).

### Root cause

`AccordionContent` defaults to `forceMount` (d51b16f819, intentional -- keeps content in the DOM for SEO). Under `forceMount`, Radix never applies its `hidden` attribute to closed content (`present: forceMount || open` is always true), so collapsing is entirely CSS's job. The only closed-state CSS was `data-[state=closed]:animate-accordion-up`, a 0.2s keyframe with no fill mode: it collapses for 200ms, finishes, and the height snaps back to auto.

`ExpandableCard` had patched around this with an `in-data-[state=closed]:hidden` hack but exhibited a second `forceMount` artifact: Radix's `--radix-collapsible-content-height` is measured one toggle behind (0px at mount while its content was `display:none`), so cards snapped open with no animation while still sliding closed.

### Fix

Drop the Radix measured-height keyframes and animate `grid-template-rows: 1fr <-> 0fr` on the Content node (the standard animate-to-auto-height pattern, no JS measurement needed):

- `duration-200!` (important) is required because Radix zeroes the node's inline `transition-duration` while re-measuring on every toggle; an important class beats the non-important inline style
- a `visibility` transition removes closed content from the tab order at the end of the collapse (fixes closed-but-focusable controls, a latent a11y issue) while keeping it in the DOM, preserving the `forceMount` SEO intent
- the grid item must clip overflow and carry no vertical padding (padding floors a box's height, so a `0fr` row could never fully collapse) -- hence one new wrapper div; the padded inner div is the same one shadcn ships upstream
- `ExpandableCard` drops its workaround and now animates in both directions; `Faq` drops dead animation classes that were landing on an element with no `data-state` attribute

Deliberately untouched: the mobile nav uses `ui/collapsible` (raw Radix, no `forceMount`) where the keyframes work as designed, so the `theme.css` keyframes stay.

## Testing

Browser-verified on the branch: find-wallet sidebar filter sections open and close with animation in both directions, ExpandableCard animates open (previously snapped) and closed, and `forceMount` still holds -- collapsed content is present in the DOM on page load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Preview links
https://deploy-preview-18400.ethereum.it/wallets/find-wallet
https://deploy-preview-18400.ethereum.it/staking#faq