### PR TITLE
feat(intl): use locale for speech synthesis, /deposit-contract/ page

### DIFF
--- a/app/[locale]/staking/deposit-contract/_components/deposit-contract.tsx
+++ b/app/[locale]/staking/deposit-contract/_components/deposit-contract.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from "react"
 import makeBlockie from "ethereum-blockies-base64"
 import { Clipboard, ClipboardCheck } from "lucide-react"
+import { useLocale } from "next-intl"
 
 import type { ChildOnlyProp, TranslationKey } from "@/lib/types"
 
@@ -104,6 +105,7 @@ const CHUNKED_ADDRESS =
 const blockieSrc = makeBlockie(DEPOSIT_CONTRACT_ADDRESS)
 
 const DepositContractPage = () => {
+  const locale = useLocale()
   const pathname = usePathname()
 
   const { t } = useTranslation("page-staking-deposit-contract")
@@ -131,8 +133,8 @@ const DepositContractPage = () => {
     if (!browserHasTextToSpeechSupport) return
     // Create textToSpeechRequest
     const speech = new SpeechSynthesisUtterance()
-    speech.lang = "en-US"
-    speech.text = DEPOSIT_CONTRACT_ADDRESS.split("").join(",")
+    speech.lang = locale
+    speech.text = DEPOSIT_CONTRACT_ADDRESS.split("").join(", ")
     speech.volume = 1
     speech.rate = 1
     speech.pitch = 1


### PR DESCRIPTION
## Description
- fix: comma _with space_ separation to avoid languages reading the "comma"
- Use `locale` for `speech.lang` to read in the locale of the page
- Subject to browser support, falls back to browser default language if not available

## Related Issue
- SpeechSynthesis for deposit-contract address hard-coded to `en-US`, not reading address in language of the selected page locale.
- Joining characters by raw `","` causing the comma to be read out loud in some languages