### PR TITLE
fix(footer): exclude deploy date from Chromatic visual diffs

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -58,7 +58,10 @@ const Footer = async ({ lastDeployLocaleTimestamp }: FooterProps) => {
     <footer className="px-4 py-4">
       <div className="flex flex-wrap items-center justify-center gap-8 border-t border-body-light px-4 py-4 md:justify-between">
         <p className="text-sm text-body-medium italic">
-          {t("website-last-updated")}: {lastDeployLocaleTimestamp}
+          {t("website-last-updated")}:{" "}
+          {/* Deploy date changes every release; exclude it from visual diffs
+              so it doesn't flake every page snapshot in Chromatic. */}
+          <span data-chromatic="ignore">{lastDeployLocaleTimestamp}</span>
         </p>
 
         <GoToTopButton label={t("go-to-top")} />


### PR DESCRIPTION
## Summary

The footer's "Website last updated" date is read from `published.json`, which is bumped on every release. Because the footer renders on **every page**, this date drifts from commit to commit and was flaking nearly all page visual snapshots in Chromatic (most failures traced back to this single line).

## Change

Wrap the timestamp in `<span data-chromatic="ignore">` so Chromatic excludes only that region from visual diffs. The element is still rendered (layout preserved) and the static `Website last updated` label stays fully regression-tested — only the volatile date string, which carries no visual-regression signal, is ignored.

This uses Chromatic's purpose-built ignore mechanism (honored by the `@chromatic-com/playwright` archive flow), so there are **no build-config hacks, no tracked-file mutation, and no test-env branching in app logic** — just one annotation on the dynamic value.

## Testing

- Built with `pnpm test:visual:build` and confirmed the attribute is server-rendered into the footer on every page (`en.html`, `_not-found.html`, etc.): `data-chromatic="ignore">June 4, 2026`.
- The diff-exclusion itself takes effect in Chromatic's cloud diff and will show as an ignored region on the next run.