### PR TITLE
fix: prevent find-wallet persona cards from causing horizontal page scroll on mobile

### DIFF
--- a/src/components/ProductTable/PresetFilters.tsx
+++ b/src/components/ProductTable/PresetFilters.tsx
@@ -241,7 +241,7 @@ const PresetFilters = ({
   )
 
   return (
-    <FieldSet className="gap-0">
+    <FieldSet className="relative min-w-0 gap-0 overflow-x-clip">
       <FieldLegend className="sr-only">
         {t("page-find-wallet-persona-legend")}
       </FieldLegend>

--- a/tests/e2e/horizontal-overflow.spec.ts
+++ b/tests/e2e/horizontal-overflow.spec.ts
@@ -3,21 +3,24 @@ import { expect, test } from "@playwright/test"
 /**
  * Regression test for https://github.com/ethereum/ethereum-org-website/issues/17777
  *
- * Pages that use EdgeScrollContainer must not leak horizontal overflow to the
+ * Pages with inner horizontal scroll areas (EdgeScrollContainer, the
+ * find-wallet persona strip, etc.) must not leak horizontal overflow into the
  * document scroll area. Asserting on both `scrollWidth` and an actual
  * `scrollBy` is intentional: each catches a different class of regression
  * (layout vs. containment).
  */
 
-const pagesWithEdgeScroll = [
+const pagesWithInnerHorizontalScroll = [
   "/community/events/",
   "/community/events/conferences/",
   "/developers/",
   "/developers/tools/",
+  // Persona filter strip — see PresetFilters (FieldSet `relative overflow-x-clip`)
+  "/wallets/find-wallet/",
 ]
 
 test.describe("No horizontal page overflow", () => {
-  for (const url of pagesWithEdgeScroll) {
+  for (const url of pagesWithInnerHorizontalScroll) {
     test(url, async ({ page }) => {
       const response = await page.goto(url)
       expect(response?.status(), `failed to load ${url}`).toBeLessThan(400)


### PR DESCRIPTION
## 🐛 Hotfix: find-wallet persona cards cause horizontal page scroll on mobile

### Description

A visual regression on **`/wallets/find-wallet/`** (mobile) shipped in v11.10.0 (#18393), detected by Chromatic — the persona filter row makes the whole page scroll horizontally.

### Root cause

The persona-card row is an intentional horizontal-scroll strip (`grid-flow-col` + `overflow-x-auto`). Two issues let it leak into the **document** scroll width on mobile:

1. **`<fieldset>` min-content (the Chromatic flag).** #18158 (`a11y: ProductTable persona cards semantics`) wrapped the strip in a `<fieldset>` (`FieldSet`). A `<fieldset>` has a UA-default `min-width: min-content`, so it refused to shrink below its content width (~1096px), pushing the document wider than the viewport.
2. **Inner scroll-area leak (what reviewers still saw on the preview).** Even once the fieldset was constrained, the inner `overflow-x-auto` strip leaked its scroll width into the document — a real, draggable horizontal page scroll on WebKit/iOS Safari.

### Fix

`relative min-w-0 overflow-x-clip` on the `FieldSet`:

```diff
-    <FieldSet className="gap-0">
+    <FieldSet className="relative min-w-0 gap-0 overflow-x-clip">
```

- `min-w-0` — overrides the `<fieldset>` `min-width: min-content` so it shrinks to the viewport width.
- `relative overflow-x-clip` — contains the inner scroll area so it can't leak into page scroll width. This is the **same pattern as `EdgeScrollContainer`** in #18167; `position: relative` is required for `overflow-x: clip` to contain the leak in Chromium.

The persona strip still scrolls horizontally **within itself** — only the document-level overflow is removed. Card shadows / vertical padding are unaffected (`overflow-y` stays visible).

### Verification

- `document.documentElement.scrollWidth === clientWidth` after load ✅
- `window.scrollX` stays `0` after `scrollBy({ left: 5000 })` ✅
- Persona strip still scrolls horizontally internally ✅
- Card shadows / layout visually unchanged vs. baseline ✅
- Added `/wallets/find-wallet/` to `tests/e2e/horizontal-overflow.spec.ts` (the #18167 regression suite) — passes on `e2e-mobile-chrome`.
