### PR TITLE
Fix mobile wallet filters footer spacing

### DIFF
--- a/src/components/ProductTable/MobileFilters.tsx
+++ b/src/components/ProductTable/MobileFilters.tsx
@@ -111,7 +111,7 @@ const MobileFilters = ({
             activeFiltersCount={activeFiltersCount}
           />
         </div>
-        <div className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2">
+        <div className="flex flex-col-reverse pt-4 sm:flex-row sm:justify-end sm:space-x-2">
           <div className="grid w-full grid-cols-2 items-center sm:w-auto">
             <div>
               <Button variant="ghost" className="gap-1" onClick={resetFilters}>


### PR DESCRIPTION
## Description

Adds spacing above the action buttons in the mobile filters panel used on the find wallet page.

## Related Issue

Fixes #18382

## Testing

- Confirmed the diff only updates `src/components/ProductTable/MobileFilters.tsx`
- Ran `git diff --check`