### PR TITLE
Add media images to latest RSS feed

### DIFF
--- a/app/[locale]/latest/feed/route.ts
+++ b/app/[locale]/latest/feed/route.ts
@@ -1,6 +1,8 @@
 import type { NextRequest } from "next/server"
 import { getTranslations } from "next-intl/server"
 
+import { SITE_URL } from "@/lib/constants"
+import { getBlogFallbackHero } from "@/lib/utils/blog"
 import { getBlogPostsData } from "@/lib/utils/md"
 import { getFullUrl } from "@/lib/utils/url"
 
@@ -16,6 +18,25 @@ const XML_ESCAPE: Record<string, string> = {
 
 const escapeXml = (value: string): string =>
   value.replace(/[&<>"']/g, (c) => XML_ESCAPE[c])
+
+const IMAGE_MIME_TYPES: Record<string, string> = {
+  ".avif": "image/avif",
+  ".gif": "image/gif",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png",
+  ".svg": "image/svg+xml",
+  ".webp": "image/webp",
+}
+
+const getImageUrl = (path: string): string => new URL(path, SITE_URL).href
+
+const getImageMimeType = (path: string): string => {
+  const pathname = new URL(path, SITE_URL).pathname.toLowerCase()
+  const extension = pathname.match(/\.[^.]+$/)?.[0] ?? ""
+
+  return IMAGE_MIME_TYPES[extension] ?? "image/jpeg"
+}
 
 export async function GET(
   _: NextRequest,
@@ -45,6 +66,10 @@ export async function GET(
       const categories = (post.tags ?? [])
         .map((tag) => `<category>${escapeXml(tag)}</category>`)
         .join("")
+      const imageSrc = post.image ?? getBlogFallbackHero(post.href).src
+      const imageUrl = getImageUrl(imageSrc)
+      const imageType = getImageMimeType(imageSrc)
+
       return [
         "<item>",
         `<title>${escapeXml(post.title)}</title>`,
@@ -54,6 +79,8 @@ export async function GET(
         creator,
         `<pubDate>${pubDate}</pubDate>`,
         categories,
+        `<media:content url="${escapeXml(imageUrl)}" medium="image" type="${imageType}" />`,
+        `<media:thumbnail url="${escapeXml(imageUrl)}" />`,
         "</item>",
       ].join("")
     })
@@ -62,7 +89,7 @@ export async function GET(
   const lastBuildDate = new Date().toUTCString()
   const xml = [
     '<?xml version="1.0" encoding="UTF-8"?>',
-    '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">',
+    '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:media="http://search.yahoo.com/mrss/">',
     "<channel>",
     `<title>${escapeXml(channelTitle)}</title>`,
     `<link>${channelLink}</link>`,

--- a/app/[locale]/latest/feed/route.ts
+++ b/app/[locale]/latest/feed/route.ts
@@ -1,10 +1,11 @@
 import type { NextRequest } from "next/server"
 import { getTranslations } from "next-intl/server"
 
-import { SITE_URL } from "@/lib/constants"
 import { getBlogFallbackHero } from "@/lib/utils/blog"
 import { getBlogPostsData } from "@/lib/utils/md"
 import { getFullUrl } from "@/lib/utils/url"
+
+import { SITE_URL } from "@/lib/constants"
 
 export const dynamic = "force-static"
 

--- a/app/[locale]/latest/feed/route.ts
+++ b/app/[locale]/latest/feed/route.ts
@@ -32,11 +32,13 @@ const IMAGE_MIME_TYPES: Record<string, string> = {
 
 const getImageUrl = (path: string): string => new URL(path, SITE_URL).href
 
-const getImageMimeType = (path: string): string => {
+// Undefined for unrecognized extensions: `medium="image"` already conveys the
+// class, and a guessed MIME type is worse than an absent one.
+const getImageMimeType = (path: string): string | undefined => {
   const pathname = new URL(path, SITE_URL).pathname.toLowerCase()
   const extension = pathname.match(/\.[^.]+$/)?.[0] ?? ""
 
-  return IMAGE_MIME_TYPES[extension] ?? "image/jpeg"
+  return IMAGE_MIME_TYPES[extension]
 }
 
 export async function GET(
@@ -70,6 +72,7 @@ export async function GET(
       const imageSrc = post.image ?? getBlogFallbackHero(post.href).src
       const imageUrl = getImageUrl(imageSrc)
       const imageType = getImageMimeType(imageSrc)
+      const imageTypeAttr = imageType ? ` type="${imageType}"` : ""
 
       return [
         "<item>",
@@ -80,7 +83,7 @@ export async function GET(
         creator,
         `<pubDate>${pubDate}</pubDate>`,
         categories,
-        `<media:content url="${escapeXml(imageUrl)}" medium="image" type="${imageType}" />`,
+        `<media:content url="${escapeXml(imageUrl)}" medium="image"${imageTypeAttr} />`,
         `<media:thumbnail url="${escapeXml(imageUrl)}" />`,
         "</item>",
       ].join("")


### PR DESCRIPTION
## Description

Adds Media RSS image metadata to the `/latest/feed.xml` route so feed readers can show thumbnails for latest posts.

## Changes

- Adds the `media` RSS namespace to the feed.
- Emits one `<media:content>` element per RSS item.
- Emits a matching `<media:thumbnail>` element for reader compatibility.
- Uses `post.image` when present.
- Falls back to `getBlogFallbackHero(post.href)` when a post has no image.
- Resolves image paths against `SITE_URL` so feed image URLs are absolute.
- Derives image MIME type from the file extension.

## Related issue

Closes #18305

## Testing

- Ran `git diff --check`.
- Did not run lint/build locally because dependencies were not installed in the checkout.