### PR TITLE
chore: gitignore .playwright-cli session folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ storybook-static-pages
 
 # Hide skill eval workspaces
 .claude/skills/*-workspace
+
+# Playwright CLI session state
+.playwright-cli


### PR DESCRIPTION
Adds `.playwright-cli` to `.gitignore` so the Playwright CLI's local session-state folder isn't tracked.

- The `playwright-cli` tool writes browser session state to a `.playwright-cli/` directory at the repo root.
- This is local, machine-specific state that should never be committed.