### PR TITLE
fix(intl-pipeline): support blank/root TARGET_PATH for full-tree runs

### DIFF
--- a/src/scripts/intl-pipeline/config.ts
+++ b/src/scripts/intl-pipeline/config.ts
@@ -173,11 +173,18 @@ export function normalizeTargetPath(
     p = `src/intl/en/${intlMatch[2]}`
   }
 
-  // 3. Auto-prefix by file type
-  const isJson = p.endsWith(".json")
-  if (isJson && !p.startsWith("src/intl/en/")) {
+  // 3. Auto-prefix by file type. Paths already at/under a source root (the
+  //    bare roots "src/intl/en" and "public/content" included) are left as-is;
+  //    only bare relative paths get prefixed. Note "public/content" has no
+  //    trailing slash, so the root itself must be matched explicitly.
+  const underJsonRoot = p === "src/intl/en" || p.startsWith("src/intl/en/")
+  const underMdRoot =
+    p === "public/content" || p.startsWith("public/content/")
+  if (underJsonRoot || underMdRoot) {
+    // already rooted -- no prefix needed
+  } else if (p.endsWith(".json")) {
     p = `src/intl/en/${p}`
-  } else if (!isJson && !p.startsWith("public/content/")) {
+  } else {
     p = `public/content/${p}`
   }
 

--- a/src/scripts/intl-pipeline/main.ts
+++ b/src/scripts/intl-pipeline/main.ts
@@ -164,6 +164,10 @@ async function loadGlossary(
 function walkForExt(dir: string, ext: string): string[] {
   const out: string[] = []
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    // Never descend into the translation output tree -- those are translated
+    // files, not source files (validateTargetPath rejects them). Matters when
+    // expanding the markdown root (public/content) for a full-tree run.
+    if (entry.isDirectory() && entry.name === "translations") continue
     const full = path.join(dir, entry.name)
     if (entry.isDirectory()) {
       out.push(...walkForExt(full, ext))
@@ -633,9 +637,15 @@ async function main() {
   const startTime = Date.now()
   logSection("Incremental Translation Pipeline")
 
+  // Blank TARGET_PATH means "translate everything": seed with the JSON and
+  // markdown source roots, which the directory-expansion pass below resolves to
+  // every source file (excluding the translation output tree and the
+  // do-not-translate list).
+  const targetPaths = config.targetPaths.length
+    ? config.targetPaths
+    : [config.jsonRoot, config.mdRoot]
   if (!config.targetPaths.length) {
-    console.error("[ERROR] TARGET_PATH is required")
-    process.exit(1)
+    log("TARGET_PATH is blank -- translating all source files (full tree)")
   }
 
   const targetLanguages = config.allInternalCodes
@@ -643,7 +653,7 @@ async function main() {
   const targetBranch = config.targetBranch
 
   log(`Target: ${targetBranch} (base: ${baseBranch})`)
-  log(`Files: ${config.targetPaths.join(", ")}`)
+  log(`Files: ${targetPaths.join(", ")}`)
   log(`Languages: ${targetLanguages.join(", ")}`)
   log(`Mode: ${config.mode}`)
   log(`Concurrency: ${config.concurrency}`)
@@ -718,7 +728,7 @@ async function main() {
   //   3. Expand     (directory entries -> their constituent files)
   //   4. Validate   (hard errors still throw)
   //   5. Excluded?  (warn-level: skip and continue; throw only if all excluded)
-  const normalizedPaths = config.targetPaths.map((fp) =>
+  const normalizedPaths = targetPaths.map((fp) =>
     normalizeTargetPath(fp, (from, to) =>
       log(`Normalizing "${from}" -> "${to}"`)
     )


### PR DESCRIPTION
## Problem

Running the intl pipeline with a blank `TARGET_PATH` — documented in the workflow input as *"blank for all"* — errors with `TARGET_PATH is required`. Passing the source roots explicitly (`public/content,src/intl/en`) also fails: `normalizeTargetPath` mangles them into `public/content/public/content` and `public/content/src/intl/en`, which then fail the on-disk existence check.

## Fixes

**`main.ts`**
- A blank `TARGET_PATH` now defaults to the two source roots (`config.jsonRoot`, `config.mdRoot`) instead of erroring; the existing directory-expansion pass resolves them to every source file.
- `walkForExt` skips the `translations/` subtree, so expanding `public/content` doesn't pull in translated files (which `validateTargetPath` rejects).

**`config.ts`**
- `normalizeTargetPath` now leaves paths already at/under a source root untouched — including the bare roots `public/content` (no trailing slash) and `src/intl/en` (a non-`.json` directory that was misclassified as markdown). Only bare relative paths get prefixed.

## Result

Blank **and** explicit-root runs both resolve to **62 JSON namespaces + 324 markdown files** (329 English minus the 5 `DO_NOT_TRANSLATE` legal pages), with no `translations/` leakage.

## Verification

- `normalizeTargetPath` checked across 8 cases (bare roots, rooted files, bare relative files, `translations/` strip, non-en strip) — all pass.
- Full-tree expansion replicated on the real dirs → 386 source files, zero `translations/` entries.
- eslint clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
