### PR TITLE
feat(ui): extract reusable TagFilter component

### DIFF
--- a/.claude/skills/design-system/references/canonical-imports.md
+++ b/.claude/skills/design-system/references/canonical-imports.md
@@ -294,9 +294,10 @@ Don't inline a `<div className="rounded-full">` for a user avatar -- use `Avatar
 
 ```tsx
 import { Tag, TagButton } from "@/components/ui/tag"
+import TagFilter from "@/components/ui/tag-filter"
 ```
 
-Big variant matrix: `status` × `variant` × `size`. See `references/components.md` for the full set.
+Big variant matrix: `status` × `variant` × `size`. See `references/components.md` for the full set. `TagFilter` is the controlled multi-select chip filter for tag-filtered lists -- prefer it over a hand-rolled `TagButton` row.
 
 ## Tables
 

--- a/.claude/skills/design-system/references/components.md
+++ b/.claude/skills/design-system/references/components.md
@@ -391,6 +391,25 @@ Big variant matrix.
 **`variant`**: `subtle | high-contrast | solid | outline`
 **`size`**: `small | medium`
 
+### `TagFilter`
+
+```tsx
+import TagFilter from "@/components/ui/tag-filter"
+```
+
+Controlled, presentational multi-select chip filter built on `TagButton` -- a wrapping chip row with an optional show-more/show-less expander. **Reach for this instead of hand-rolling a `TagButton` row** whenever a page filters a list by tags. Selection and match semantics (AND vs OR) live in the parent; the component only renders chips and reports toggles.
+
+```tsx
+<TagFilter
+  tags={getTagCounts(items, (i) => i.tags)} // [name, count][], caller pre-sorts/filters
+  value={selectedTags}
+  onChange={setSelectedTags}
+  defaultVisible={12} // chips before the expander; selected-but-hidden tags stay pinned-visible
+/>
+```
+
+**Props**: `tags` (`[name, count][]`, rendered as-is), `value` / `onChange` (controlled), `defaultVisible` (cutoff; omit to show all), `showCount` (default `true`, formats via `numberFormat(locale)`), `className`. Pair with `getTagCounts` from `@/lib/utils/tags` to build count-descending entries from any item list.
+
 ### `Alert`
 
 ```tsx

--- a/app/[locale]/developers/tutorials/_components/tutorials.tsx
+++ b/app/[locale]/developers/tutorials/_components/tutorials.tsx
@@ -1,15 +1,7 @@
 "use client"
 
-import React, {
-  type ButtonHTMLAttributes,
-  forwardRef,
-  useEffect,
-  useMemo,
-  useState,
-} from "react"
+import React, { useEffect, useMemo, useState } from "react"
 import {
-  ChevronDown,
-  ChevronUp,
   Code,
   ExternalLink,
   GraduationCap,
@@ -31,14 +23,13 @@ import { Flex } from "@/components/ui/flex"
 import Input from "@/components/ui/input"
 import { BaseLink } from "@/components/ui/Link"
 import TabNav from "@/components/ui/TabNav"
-import { Tag, TagButton } from "@/components/ui/tag"
+import { Tag } from "@/components/ui/tag"
+import TagFilter from "@/components/ui/tag-filter"
 
 import { trackCustomEvent } from "@/lib/utils/matomo"
+import { getTagCounts } from "@/lib/utils/tags"
 import { getLocaleTimestamp } from "@/lib/utils/time"
-import {
-  filterTutorialsByLang,
-  getSortedTutorialTagsForLang,
-} from "@/lib/utils/tutorial"
+import { filterTutorialsByLang } from "@/lib/utils/tutorial"
 
 import externalTutorials from "@/data/externalTutorials.json"
 
@@ -47,26 +38,6 @@ import { DEFAULT_LOCALE } from "@/lib/constants"
 import useTranslation from "@/hooks/useTranslation"
 
 const MAX_DEFAULT_TAGS = 12
-
-const FilterTag = forwardRef<
-  HTMLButtonElement,
-  { isActive: boolean; name: string } & ButtonHTMLAttributes<HTMLButtonElement>
->((props, ref) => {
-  const { isActive, name, ...rest } = props
-  return (
-    <TagButton
-      ref={ref}
-      variant={isActive ? "solid" : "outline"}
-      status={isActive ? "tag" : "normal"}
-      className="justify-center"
-      {...rest}
-    >
-      {name}
-    </TagButton>
-  )
-})
-
-FilterTag.displayName = "FilterTag"
 
 const published = (locale: string, published: string) => {
   const localeTimestamp = getLocaleTimestamp(locale as Lang, published)
@@ -104,8 +75,13 @@ const TutorialsList = ({ internalTutorials }: TutorialsListProps) => {
     [internalTutorials, effectiveLocale]
   )
 
-  const allTags = useMemo(
-    () => getSortedTutorialTagsForLang(filteredTutorialsByLang),
+  // Count-descending tag entries, dropping one-off tags (count <= 1) which add
+  // noise to the filter row.
+  const eligibleTags = useMemo(
+    () =>
+      getTagCounts(filteredTutorialsByLang, (tutorial) => tutorial.tags).filter(
+        ([, count]) => count > 1
+      ),
     [filteredTutorialsByLang]
   )
 
@@ -149,27 +125,6 @@ const TutorialsList = ({ internalTutorials }: TutorialsListProps) => {
   const [selectedTags, setSelectedTags] = useState<Array<string>>([])
   const [selectedSkill, setSelectedSkill] = useState<string>("all")
   const [searchQuery, setSearchQuery] = useState("")
-  const [showAllTags, setShowAllTags] = useState(false)
-
-  // Split tags into popular (top N by count) and niche (the rest)
-  const { popularTags, nicheTags } = useMemo(() => {
-    const eligible: Array<[string, number]> = []
-
-    Object.entries(allTags).forEach(([tagName, tagCount]) => {
-      const count = tagCount as number
-      if (count <= 1) return
-      eligible.push([tagName, count])
-    })
-
-    // Sort by count descending for visual hierarchy
-    eligible.sort((a, b) => b[1] - a[1])
-
-    // Top tags shown by default, rest behind expander
-    const popular = eligible.slice(0, MAX_DEFAULT_TAGS)
-    const niche = eligible.slice(MAX_DEFAULT_TAGS)
-
-    return { popularTags: popular, nicheTags: niche }
-  }, [allTags])
 
   // Combined filtering: skill + tags + search
   useEffect(() => {
@@ -206,27 +161,22 @@ const TutorialsList = ({ internalTutorials }: TutorialsListProps) => {
     setFilteredTutorials(tutorials)
   }, [filteredTutorialsByLang, selectedTags, selectedSkill, searchQuery])
 
-  const handleTagSelect = (tagName: string) => {
-    const tempSelectedTags = [...selectedTags]
+  // Assumes a single-tag delta per call (chip toggle or one active-filter
+  // removal) and reports exactly one Matomo event. A multi-tag change (e.g. a
+  // future "clear all") would only track the first diff.
+  const handleTagsChange = (next: Array<string>) => {
+    const added = next.find((tag) => !selectedTags.includes(tag))
+    const removed = selectedTags.find((tag) => !next.includes(tag))
 
-    const index = tempSelectedTags.indexOf(tagName)
-    if (index > -1) {
-      tempSelectedTags.splice(index, 1)
+    if (added || removed) {
       trackCustomEvent({
         eventCategory: "tutorial tags",
         eventAction: "click",
-        eventName: `${tagName} remove`,
-      })
-    } else {
-      tempSelectedTags.push(tagName)
-      trackCustomEvent({
-        eventCategory: "tutorial tags",
-        eventAction: "click",
-        eventName: `${tagName} add`,
+        eventName: `${added ?? removed} ${added ? "add" : "remove"}`,
       })
     }
 
-    setSelectedTags(tempSelectedTags)
+    setSelectedTags(next)
   }
 
   const handleSkillSelect = (key: string) => {
@@ -253,8 +203,6 @@ const TutorialsList = ({ internalTutorials }: TutorialsListProps) => {
     selectedTags.length > 0 ||
     selectedSkill !== "all" ||
     searchQuery.trim() !== ""
-
-  const visibleTags = showAllTags ? [...popularTags, ...nicheTags] : popularTags
 
   return (
     <>
@@ -299,42 +247,12 @@ const TutorialsList = ({ internalTutorials }: TutorialsListProps) => {
         <p className="mb-space-half text-xs tracking-wider text-body-medium uppercase">
           <Translation id="page-developers-tutorials:page-tutorial-topics" />
         </p>
-        <div className="flex flex-wrap gap-2">
-          {visibleTags.map(([tagName, tagCount]) => {
-            const isActive = selectedTags.includes(tagName)
-            return (
-              <FilterTag
-                key={tagName}
-                onClick={() => handleTagSelect(tagName)}
-                name={`${tagName} (${tagCount})`}
-                isActive={isActive}
-              />
-            )
-          })}
-
-          {/* Show more / Show less toggle */}
-          {nicheTags.length > 0 && (
-            <button
-              onClick={() => setShowAllTags(!showAllTags)}
-              className="inline-flex items-center gap-1 rounded-full border border-dashed border-body-medium px-3 py-0.5 text-xs text-body-medium uppercase transition-colors hover:border-primary hover:text-primary"
-            >
-              {showAllTags ? (
-                <>
-                  <Translation id="show-less" />{" "}
-                  <ChevronUp className="size-3" />
-                </>
-              ) : (
-                <>
-                  <Translation
-                    id="page-developers-tutorials:page-tutorial-more-tags"
-                    values={{ count: nicheTags.length }}
-                  />{" "}
-                  <ChevronDown className="size-3" />
-                </>
-              )}
-            </button>
-          )}
-        </div>
+        <TagFilter
+          tags={eligibleTags}
+          value={selectedTags}
+          onChange={handleTagsChange}
+          defaultVisible={MAX_DEFAULT_TAGS}
+        />
 
         {/* Row 3: Active filters summary (only when filters active) */}
         {hasActiveFilters && (
@@ -361,7 +279,9 @@ const TutorialsList = ({ internalTutorials }: TutorialsListProps) => {
                 status="tag"
                 variant="solid"
                 className="cursor-pointer gap-1"
-                onClick={() => handleTagSelect(tag)}
+                onClick={() =>
+                  handleTagsChange(selectedTags.filter((t) => t !== tag))
+                }
               >
                 {tag}
                 <X className="size-3" />

--- a/src/components/ui/__stories__/TagFilter.stories.tsx
+++ b/src/components/ui/__stories__/TagFilter.stories.tsx
@@ -1,0 +1,119 @@
+import { useState } from "react"
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import TagFilter, { type TagFilterProps } from "../tag-filter"
+
+const meta = {
+  title: "UI / TagFilter",
+  component: TagFilter,
+  decorators: [
+    (Story) => (
+      <div className="w-[640px]">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Controlled, presentational multi-select tag filter: a wrapping row of toggle chips with an optional show-more / show-less expander. Selection state and match semantics (AND vs OR) live in the parent -- the component only renders chips and reports toggles via `onChange`. The caller passes `[name, count]` entries already ordered and filtered to taste; `defaultVisible` controls how many show before the expander. Selected tags beyond the cutoff stay visible while collapsed so an active filter never disappears.",
+      },
+    },
+  },
+} satisfies Meta<typeof TagFilter>
+
+export default meta
+
+type Story = StoryObj
+
+// Count-descending entries, the shape `getTagCounts` returns.
+const TAGS: Array<[string, number]> = [
+  ["solidity", 42],
+  ["smart contracts", 31],
+  ["security", 24],
+  ["defi", 19],
+  ["nft", 15],
+  ["testing", 12],
+  ["hardhat", 9],
+  ["foundry", 7],
+  ["layer 2", 6],
+  ["oracles", 5],
+  ["governance", 4],
+  ["staking", 3],
+  ["zk", 2],
+  ["mev", 2],
+]
+
+const Controlled = ({
+  initial = [],
+  ...props
+}: { initial?: Array<string> } & Omit<
+  TagFilterProps,
+  "value" | "onChange"
+>) => {
+  const [value, setValue] = useState<Array<string>>(initial)
+  return <TagFilter {...props} value={value} onChange={setValue} />
+}
+
+export const Collapsed: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "With `defaultVisible`, tags beyond the cutoff collapse behind a show-more toggle that reports the hidden count.",
+      },
+    },
+  },
+  render: () => <Controlled tags={TAGS} defaultVisible={8} />,
+}
+
+export const Expanded: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "No `defaultVisible` -- every tag is shown and there is no expander.",
+      },
+    },
+  },
+  render: () => <Controlled tags={TAGS} />,
+}
+
+export const WithSelection: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Selected chips render in the solid/active style. Match semantics are the parent's concern.",
+      },
+    },
+  },
+  render: () => (
+    <Controlled tags={TAGS} defaultVisible={8} initial={["solidity", "defi"]} />
+  ),
+}
+
+export const ActiveHiddenTag: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "A selected tag that falls beyond `defaultVisible` (`mev`) stays pinned-visible while collapsed, so the active filter is never hidden.",
+      },
+    },
+  },
+  render: () => <Controlled tags={TAGS} defaultVisible={6} initial={["mev"]} />,
+}
+
+export const NoCount: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`showCount={false}` renders bare tag names without the occurrence count.",
+      },
+    },
+  },
+  render: () => <Controlled tags={TAGS} defaultVisible={8} showCount={false} />,
+}

--- a/src/components/ui/tag-filter.tsx
+++ b/src/components/ui/tag-filter.tsx
@@ -106,7 +106,7 @@ const TagFilter = ({
             </>
           ) : (
             <>
-              {t("show-more")} ({formatCount(tags.length - cutoff)}){" "}
+              {t("show-more")} ({formatCount(tags.length - visible.length)}){" "}
               <ChevronDown className="size-3" />
             </>
           )}

--- a/src/components/ui/tag-filter.tsx
+++ b/src/components/ui/tag-filter.tsx
@@ -1,0 +1,119 @@
+"use client"
+
+import { useState } from "react"
+import { ChevronDown, ChevronUp } from "lucide-react"
+import { useLocale } from "next-intl"
+
+import { TagButton } from "@/components/ui/tag"
+
+import { cn } from "@/lib/utils/cn"
+import { numberFormat } from "@/lib/utils/numbers"
+
+import useTranslation from "@/hooks/useTranslation"
+
+export interface TagFilterProps {
+  /**
+   * Tag entries to render, as `[name, count]`. The caller controls ordering and
+   * which tags are eligible (e.g. pre-sort by count, drop tags below a
+   * threshold) -- the component renders them as-is.
+   */
+  tags: Array<[string, number]>
+  /** Currently selected tag names (controlled). */
+  value: Array<string>
+  /** Called with the next selection whenever a chip is toggled. */
+  onChange: (next: Array<string>) => void
+  /**
+   * How many tags to show before collapsing the rest behind a "show more"
+   * toggle. Selected tags beyond the cutoff stay visible while collapsed.
+   * Defaults to showing all tags.
+   */
+  defaultVisible?: number
+  /** Render the occurrence count next to each tag name. Defaults to `true`. */
+  showCount?: boolean
+  className?: string
+}
+
+/**
+ * Controlled, presentational multi-select tag filter: a wrapping row of toggle
+ * chips with an optional "show more / show less" expander. Selection state and
+ * match semantics (AND vs OR) live in the parent -- this component only renders
+ * chips and reports toggles via `onChange`.
+ */
+const TagFilter = ({
+  tags,
+  value,
+  onChange,
+  defaultVisible,
+  showCount = true,
+  className,
+}: TagFilterProps) => {
+  const { t } = useTranslation("common")
+  const locale = useLocale()
+  const [expanded, setExpanded] = useState(false)
+
+  const cutoff = defaultVisible ?? tags.length
+  const hasOverflow = tags.length > cutoff
+  const collapsed = hasOverflow && !expanded
+
+  const base = collapsed ? tags.slice(0, cutoff) : tags
+  // Keep selected-but-hidden tags visible while collapsed so an active filter
+  // never disappears behind the expander.
+  const baseNames = new Set(base.map(([name]) => name))
+  const pinned = collapsed
+    ? tags.filter(([name]) => value.includes(name) && !baseNames.has(name))
+    : []
+  const visible = [...base, ...pinned]
+
+  const formatCount = (count: number) => numberFormat(locale).format(count)
+
+  const toggle = (name: string) => {
+    onChange(
+      value.includes(name)
+        ? value.filter((tag) => tag !== name)
+        : [...value, name]
+    )
+  }
+
+  return (
+    <div className={cn("flex flex-wrap gap-2", className)}>
+      {visible.map(([name, count]) => {
+        const isActive = value.includes(name)
+        return (
+          <TagButton
+            key={name}
+            type="button"
+            variant={isActive ? "solid" : "outline"}
+            status={isActive ? "tag" : "normal"}
+            className="justify-center"
+            aria-pressed={isActive}
+            onClick={() => toggle(name)}
+          >
+            {showCount ? `${name} (${formatCount(count)})` : name}
+          </TagButton>
+        )
+      })}
+
+      {hasOverflow && (
+        <button
+          type="button"
+          onClick={() => setExpanded((prev) => !prev)}
+          aria-expanded={expanded}
+          className="inline-flex items-center gap-1 rounded-full border border-dashed border-body-medium px-3 py-0.5 text-xs text-body-medium uppercase transition-colors hover:border-primary hover:text-primary"
+        >
+          {expanded ? (
+            <>
+              {t("show-less")} <ChevronUp className="size-3" />
+            </>
+          ) : (
+            <>
+              {t("show-more")} ({formatCount(tags.length - cutoff)}){" "}
+              <ChevronDown className="size-3" />
+            </>
+          )}
+        </button>
+      )}
+    </div>
+  )
+}
+
+export default TagFilter

--- a/src/intl/en/page-developers-tutorials.json
+++ b/src/intl/en/page-developers-tutorials.json
@@ -23,6 +23,5 @@
   "page-tutorial-all": "All",
   "page-tutorial-topics": "Topics",
   "page-tutorial-search-placeholder": "Search tutorials...",
-  "page-tutorial-filtering-by": "Filtering by:",
-  "page-tutorial-more-tags": "+{count} more"
+  "page-tutorial-filtering-by": "Filtering by:"
 }

--- a/src/lib/utils/tags.ts
+++ b/src/lib/utils/tags.ts
@@ -1,0 +1,24 @@
+/**
+ * Aggregate tag occurrences across a list of items into count-sorted entries.
+ *
+ * Generic over the item type -- pass a `getTags` selector to pull the tag list
+ * off each item. Returns `[tag, count]` entries sorted by count descending;
+ * ties keep first-seen order (Map iteration order + stable sort).
+ *
+ * Does NOT normalize tag strings (casing, trimming). Each data source stays
+ * responsible for its own tag hygiene at ingestion.
+ */
+export const getTagCounts = <T>(
+  items: T[],
+  getTags: (item: T) => Array<string> | undefined
+): Array<[string, number]> => {
+  const counts = new Map<string, number>()
+
+  for (const item of items) {
+    for (const tag of getTags(item) ?? []) {
+      counts.set(tag, (counts.get(tag) ?? 0) + 1)
+    }
+  }
+
+  return [...counts.entries()].sort((a, b) => b[1] - a[1])
+}

--- a/src/lib/utils/tutorial.ts
+++ b/src/lib/utils/tutorial.ts
@@ -53,32 +53,3 @@ export const filterTutorialsByLang = (
 
   return filteredTutorials
 }
-
-export const getSortedTutorialTagsForLang = (
-  filteredTutorialsByLang: Array<ITutorial> = []
-) => {
-  const allTags = filteredTutorialsByLang.reduce<Array<string>>(
-    (tags, tutorial) => {
-      return [...tags, ...(tutorial.tags || [])]
-    },
-    []
-  )
-
-  const reducedTags = allTags.reduce((acc, tag) => {
-    if (acc[tag]) {
-      acc[tag] = acc[tag] + 1
-    } else {
-      acc[tag] = 1
-    }
-    return acc
-  }, {})
-
-  const sortedTags = Object.keys(reducedTags)
-    .sort()
-    .reduce((obj, key) => {
-      obj[key] = reducedTags[key]
-      return obj
-    }, {})
-
-  return sortedTags
-}


### PR DESCRIPTION
## Summary

Extracts the tag-filtering logic from `/developers/tutorials` into a reusable, controlled `TagFilter` component plus a generic `getTagCounts` util. This is **PR 1 of 2** — a follow-up PR will adopt `TagFilter` on the new `/latest` page (with OR match semantics).

## What's new

- **`src/lib/utils/tags.ts`** — generic `getTagCounts<T>(items, getTags)` returning count-descending `[name, count]` entries. No tag normalization (each data source owns its own hygiene).
- **`src/components/ui/TagFilter/`** — controlled, presentational multi-select chip filter:
  - `value` / `onChange` controlled selection; match semantics (AND/OR) stay in the parent.
  - `defaultVisible` cutoff with a show-more/less expander; selected tags beyond the cutoff stay pinned-visible while collapsed so an active filter never disappears.
  - `showCount` (default true); counts rendered via `numberFormat(locale)` (honours Urdu/Arabic numbering rules).
  - Expander chrome reads `show-more` / `show-less` from the `common` namespace; `aria-pressed` on chips, `aria-expanded` on the expander.
- **`TagFilter.stories.tsx`** — Storybook coverage (collapsed, expanded, with-selection, active-hidden-tag, no-count).

## Refactor

- **`tutorials.tsx`** — replaces the inline `FilterTag` + popular/niche tag-splitting with `<TagFilter>`. The skill + tags + search matching `useEffect` is unchanged (AND semantics preserved). Matomo tracking moved into a single-delta `onChange` handler.
- **`tutorial.ts`** — removes the now-unused `getSortedTutorialTagsForLang` (no remaining callers).
- **`page-developers-tutorials.json`** — drops the orphaned `page-tutorial-more-tags` key. The expander now reads "Show more (N)" (from `common`) instead of "+N more". Non-English locales will be reconciled by the intl-pipeline.

## Verification

- `pnpm type-check` ✓ · `pnpm lint` ✓
- Storybook render verified for all states (count-desc ordering, cutoff + correct hidden count, active styling, pinned-visible selection).
- Note: the live tutorials page can't be rendered locally (requires Netlify Blobs secrets); page-level visual coverage is left to Chromatic on this PR.
