### PR TITLE
feat: ETH to USD converter on EthPriceCard (rebased #17015)

### DIFF
--- a/src/components/EthPriceCard.tsx
+++ b/src/components/EthPriceCard.tsx
@@ -1,9 +1,11 @@
 "use client"
 
+import { useState } from "react"
 import { ArrowUpRight, Info } from "lucide-react"
 import { useLocale } from "next-intl"
 
 import Tooltip from "@/components/Tooltip"
+import Input from "@/components/ui/input"
 import InlineLink from "@/components/ui/Link"
 import { Skeleton } from "@/components/ui/skeleton"
 
@@ -22,10 +24,21 @@ const EthPriceCard = ({
   const locale = useLocale()
   const { t } = useTranslation()
   const { ethPrice, ethPercentChange24h } = useGasEthPrice()
+  const [ethAmount, setEthAmount] = useState("1")
 
   const isLoading = ethPrice === 0
   const hasChange = typeof ethPercentChange24h === "number"
   const isNegativeChange = hasChange && ethPercentChange24h < 0
+
+  const handleEthAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value
+    // Allow empty string, numbers, and decimals up to 4 places
+    if (value === "" || /^\d*\.?\d{0,4}$/.test(value)) {
+      setEthAmount(value)
+    }
+  }
+
+  const convertedValue = (parseFloat(ethAmount) || 0) * ethPrice
 
   const tooltipContent = (
     <div>
@@ -39,7 +52,7 @@ const EthPriceCard = ({
   return (
     <Flex
       className={cn(
-        "max-h-48 w-full max-w-[420px] flex-col items-center justify-between rounded-base border p-6",
+        "w-full max-w-[420px] flex-col items-center justify-between rounded-base border p-6",
         isNegativeChange
           ? "bg-linear-to-b from-error/10 dark:border-error/50"
           : "bg-linear-to-t from-success/20 dark:border-success/50",
@@ -93,6 +106,39 @@ const EthPriceCard = ({
           ({t("last-24-hrs")})
         </div>
       </Flex>
+
+      {/* ETH to USD converter */}
+      <div className="mt-4 w-full border-t pt-4">
+        <p className="mb-2 text-center text-sm text-body-medium">
+          {t("eth-convert-to-usd")}
+        </p>
+        <Flex className="flex-col items-center gap-3 sm:flex-row">
+          <div className="relative flex-1">
+            <span className="absolute start-3 top-1/2 -translate-y-1/2 text-sm text-body-medium">
+              ETH
+            </span>
+            <Input
+              type="text"
+              inputMode="decimal"
+              value={ethAmount}
+              onChange={handleEthAmountChange}
+              placeholder="0.0000"
+              disabled={isLoading}
+              className="w-full ps-12 text-end"
+            />
+          </div>
+          <span className="px-2 text-xl text-body-medium">=</span>
+          <div className="flex-1 rounded border bg-background p-2 text-end">
+            {isLoading ? (
+              <Skeleton className="h-6 w-full" />
+            ) : (
+              <span className="text-lg font-medium">
+                {formatPriceUSD(convertedValue, locale)}
+              </span>
+            )}
+          </div>
+        </Flex>
+      </div>
     </Flex>
   )
 }

--- a/src/intl/en/common.json
+++ b/src/intl/en/common.json
@@ -93,6 +93,7 @@
   "error-page-description": "You can help us improve by reporting this issue on our <a href='https://github.com/ethereum/ethereum-org-website/issues/new?label%3A%22bug%20%F0%9F%90%9B%22&template=bug_report.yaml'>GitHub repository</a>.",
   "error-page-home-link": "Return to the home page",
   "esp": "Ecosystem Support Program",
+  "eth-convert-to-usd": "Convert ETH to USD",
   "eth-current-price": "Current ETH price (USD)",
   "ethereum": "Ethereum",
   "ethereum-brand-assets": "Ethereum brand assets",


### PR DESCRIPTION
Re-applies the ETH→USD converter from #17015 on top of the current `dev` codebase.

The original PR (#17015, opened Jan 2026) had gone stale and was conflicting — `EthPriceCard` was since refactored to use the `useGasEthPrice` hook + `formatPriceUSD`/`numberToPercent` instead of the old `LoadingState`/`useEffect` data-fetching. This PR ports the feature cleanly onto that new structure so it can be reviewed against an up-to-date base.

## What it does
- Adds an ETH amount input to `EthPriceCard` that converts to USD using the live price (defaults to `1`).
- Input is restricted to numbers with up to 4 decimal places.
- New i18n string `eth-convert-to-usd`.

## Notable differences from #17015 (due to the refactor)
- Built on `useGasEthPrice()` / `formatPriceUSD(value, locale)` instead of the removed `state.data.currentPriceUSD` + inline `Intl.NumberFormat`.
- Uses a `Skeleton` for the converted-value while the price loads, and disables the input during load (matches the card's current loading pattern).
- Uses RTL-aware logical utilities (`start-*`, `ps-*`, `text-end`) instead of the original `left/pl/text-right`, per the project's i18n conventions.
- Dropped `max-h-48` (the converter row needs the extra height).

## Verification
- `pnpm type-check` ✅
- `pnpm lint` (EthPriceCard) ✅

Closes #17015 (superseded).