### PR TITLE
add new-page skill

### DIFF
--- a/.claude/skills/new-page/SKILL.md
+++ b/.claude/skills/new-page/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: new-page
+description: Interview-then-scaffold guide for adding a new page to ethereum.org. Forks first on markdown-backed vs App Router page, then picks the layout and hero, maps the Figma design to existing components, and builds it reuse-first. Invoke with /new-page.
+disable-model-invocation: true
+---
+
+# New Page
+
+A new ethereum.org page is **reuse-first**: every region maps to a layout, hero, primitive, or variant that already exists — you *configure* what's there, you don't build a parallel version of it. This skill interviews you for the missing context, then scaffolds the page against the design system.
+
+Work the steps in order. Each ends on a checkable condition — don't start the next until the current one is met.
+
+## Step 0 — Load the design system
+
+Invoke the `design-system` skill and read its `SKILL.md` fully before asking anything else. It is the source of truth for component choices, tokens, layouts, RTL/i18n, and the server/client boundary. **Do not restate its catalog here** — when you need the layout inventory read `design-system/references/layouts.md`, and verify it against `src/layouts/index.ts` (layouts get refactored).
+
+**Done when:** `design-system` SKILL.md has been read this session.
+
+## Step 1 — Interview
+
+The primary fork is **markdown-backed or not**. It decides the layout system, the build, and how the page is translated — so settle it first. It is an *authoring* decision (how the content is written and maintained), **not** a visual one: a hero-topped prose page can be either, because `ContentLayout` gives markdown `TopicLayout` and App Router pages the same hero + card-TOC chrome. So **ask it; never infer it from the design.**
+
+Use `AskUserQuestion`:
+
+1. **Markdown page or App Router page?**
+   - *Markdown page* — content authored in `public/content/<route>/index.md`, rendered through `[...slug]`, translated by the intl-pipeline, built from a fixed set of MDX shortcodes. Choose for editorial/educational content a writer maintains in markdown.
+   - *App Router page* — a hand-built `app/[locale]/<route>/page.tsx` that composes `ContentLayout`. Choose when the page is interactive, data-backed, or needs layout/components the markdown shortcodes can't express. Translated via `getTranslations` JSON keys.
+2. **Route** — the URL path (e.g. `/stablecoins/`). The folder name *is* the route.
+3. **Design source** — a Figma link/selection, a written description, or none.
+4. **Content** (markdown only) — does the user have the body ready, or should you draft it?
+
+Then **check the route is free**: no existing `public/content/<route>/index.md` or `app/[locale]/<route>/page.tsx`. If one exists you're *editing*, not creating — surface it and confirm before any write; never silently overwrite a page you didn't author.
+
+**Done when:** markdown-vs-App-Router, route, and design source are known, and the route is confirmed free (or editing is okayed).
+
+## Step 2 — Pull the design (only if Figma was provided)
+
+Read the design **fresh** with the Figma MCP (designs change between runs — never rely on a read from an earlier turn): `get_metadata` for the frame tree, then `get_design_context` / `get_screenshot` on each region; `search_design_system` / `get_code_connect_map` for existing code mappings. Load the `figma-use` skill before any `use_figma` call.
+
+Produce a **component map** and **always show it to the user as a table** — three columns: **Region** (each design region, top to bottom) · **Maps to** (the existing primitive + variant that renders it — `PageHero`, `Card`, `BigNumber`, …) · **Status** (`reuse`, `missing asset`, `placeholder copy`, `missing data`, …). The map must be **exhaustive** — walk the frame top to bottom; a region you don't map is a region that silently won't ship. The table is the user's only window into what you saw in the frame — it's how they catch a misread or omission *before* it ships, so render it every run; never just reason about the mapping internally.
+
+**Node names lie.** A node called `Screenshot 2026-…` or `Frame 1789` is routinely real content — a stat band (`BigNumber`), a video embed (`YouTube`), a callout (`Alert`) — not a throwaway. Never omit a region because its name *looks* like a draft; `get_screenshot` it and see what it actually is before deciding.
+
+**Missing data → ask, don't guess.** When a region needs a value the design doesn't carry — a YouTube ID behind a thumbnail, a real destination URL, a live data source — you can't extract it from the frame. Flag it and ask the user; a guessed embed or invented link is worse than an open question.
+
+**Match, don't mimic.** Reproduce the design with existing components and their variants. Do **not** layer custom Tailwind/CSS on a primitive to chase pixel parity. If a region has no fitting primitive or variant, the answer is *add a variant* (`references/variant-vs-new.md`) — never a one-off component or bespoke styles. Flag any such gap and confirm before inventing.
+
+**Pressure-test the authoring fork.** The map can reveal a region markdown shortcodes can't express — an interactive widget, a data-backed list, a bespoke multi-column grid, or cards with **lucide** icons (the markdown `<Card>`/`MarkdownCard` shortcode takes only an `emoji` prop, no lucide). Any of these means the page wants to be App Router. If Step 1 said markdown, surface the conflict and re-confirm before scaffolding — flipping it later is a rewrite.
+
+**Done when:** the component-map table has been shown to the user and they've confirmed or corrected it; every region is accounted for — mapped, flagged for an approved variant, or raised as missing data — and the authoring fork still holds.
+
+## Step 3 — Pick the layout and hero
+
+Branches on Step 1.
+
+### Markdown page — pick the `template:`
+
+The layout is selected by the `template:` frontmatter value (default `static`). Full inventory in `design-system/references/layouts.md`; live set in `src/layouts/index.ts`.
+
+| `template:` | Layout | Use for | Hero it renders |
+|---|---|---|---|
+| `static` (default) | `StaticLayout` | one-off editorial prose, no sub-nav | title + breadcrumbs only (`PageHero variant="no-divider"`, **no image**) |
+| `use-cases` / `staking` / `roadmap` / `upgrade` | `TopicLayout` | topic hub: full side-image hero + sibling sub-nav | image `PageHero` from frontmatter `image` / `summary` / `buttons` |
+| `docs` | `DocsLayout` | developer docs with the docs sidebar | — |
+| `tutorial` | `TutorialLayout` | developer tutorial with author/date/skill metadata | — |
+
+- Each Topic template carries a distinct **MDX component list** (`componentsMapping`, `src/layouts/index.ts`) — pick the one whose shortcodes match the content.
+- **Side-image hero in the design → a Topic template.** If there's no sub-nav across sibling pages, add `showDropdown: false` (exemplar: `public/content/what-are-apps/index.md`). **`static` renders only a title hero, never a side-image one** — so a side-image design on `static` is wrong; switch templates, don't fight it with custom markup.
+- A new layout is essentially never the answer. A new topic hub is a `src/data/topics/<key>.ts` config + `layoutMapping`/`componentsMapping` entries + a translation namespace — not a new layout file.
+
+### App Router page — compose `ContentLayout`, pass the hero that fits
+
+Hand-build `app/[locale]/<route>/page.tsx` composing `ContentLayout`, and choose the hero from the design:
+
+- `PageHero` — breadcrumbs + title + optional `heroImg` + description + buttons. The workhorse; covers both image and title-only heroes.
+- `HubHero` — large hub hero (exemplar: `/learn/`).
+
+Build the `tocItems` array by hand and wrap each prose section in `<Section id>`. `ContentLayout` owns the card TOC, contributors block, and feedback. Exemplars: `/learn/`, `/what-is-ethereum/`.
+
+**Done when:** markdown → `template:` (and `showDropdown` if relevant) chosen; App Router → hero component chosen. Confirmed with the user.
+
+## Step 4 — Scaffold
+
+Build from the Step 2 component map. Reuse-first throughout — no raw `<a>`/`<button>`, no hex colors, logical CSS props (`ms-`/`me-`/…), locale-aware `numberFormat()`/`dateTimeFormat()`. Icons: **lucide in `.tsx`, emoji in markdown** (the `<Card>` shortcode is emoji-only).
+
+**Markdown page:**
+- Create `public/content/<route>/index.md` with frontmatter (`title`, `description`, `lang: en`, plus `template:` unless static). English only — never hand-write translated copies; the intl-pipeline propagates them.
+- **Inline images co-locate**: drop them next to `index.md` and reference them relatively (`![alt](./hero.png)`). A `/images/...` path on an inline image 500s the MDX render. (The frontmatter `image:` hero on `TopicLayout` is the exception — it takes a `/images/...` public path.)
+- Every h1–h4 needs a `{#kebab-id}`; run `pnpm lint:md:fix`.
+- If using `TopicLayout`: add `src/data/topics/<key>.ts`, wire `layoutMapping`/`componentsMapping` in `src/layouts/index.ts`, and add `src/intl/en/page-<key>.json`.
+
+**App Router page:**
+- Create `app/[locale]/<route>/page.tsx` composing `ContentLayout` (mirror `/learn/` or `/what-is-ethereum/`): pass `heroSection`, the hand-built `tocItems`, and `contributors`; wrap prose in `<Section id>`. Server Component unless it needs state/effects/handlers.
+- All user-facing strings via `getTranslations`; add keys to `src/intl/en/`.
+
+**Done when:** the page renders through its layout with content/strings in place and no inlined reinventions of existing primitives.
+
+## Step 5 — Verify (static checks)
+
+- `pnpm type-check` (catches invalid chain names and type errors).
+- Walk the design-system **Pre-Merge Smoke Test** checklist.
+- Add a `.stories.tsx` for any genuinely new UI primitive.
+
+**Done when:** type-check passes and the smoke checklist is clean.
+
+## Step 6 — QA via the adversarial review loop
+
+Static checks pass on pages that are visibly broken — a wrong image path, a failed MDX compile, a section that silently didn't render. So the page must be run and audited. QA here is **not** an eyeball comparison — it's the **adversarial reviewer loop**: copy and design-system reviewer subagents audit the live page against the design, you triage and fix, and re-review until a fresh round comes back **green**. Scaffolding a page and not running this loop is leaving the job half-done.
+
+1. **Run it.** Start `pnpm dev`, wait for "Ready", load the page (locale-stripped for `en`: `/<route>/`). Confirm **HTTP 200** — a 500 is almost always an MDX or asset error; read the dev log (a non-co-located inline image is the classic one). There is nothing to review on a broken page.
+2. **Run the review loop.** Read `review-page/SKILL.md` and execute its loop (its Steps 1–5) against this route: capture the Figma + live-page artifacts, spawn the two reviewers from `review-page/reviewers/` in parallel, triage their findings, fix, and re-review until green. You already hold the design source and route from Steps 1–2, so its Step 0 (running page + known design source) is already satisfied — go straight into capture-and-spawn. Read and run that procedure; don't try to invoke `/review-page` as a skill from here.
+   - **A hero finding is a template bug, not a CSS gap.** When the design-system reviewer flags a title-only hero against a side-image design: on a markdown page that's a wrong-`template:` (use a Topic template, not `static`); on an App Router page, pass `heroImg` to `PageHero`. Never rebuild a hero with custom markup.
+3. **Hand off.** Leave the dev server running and give the user the local URL the server printed (e.g. `http://localhost:3000/<route>/`).
+
+**Done when:** the review loop is green (or hits its round cap with the remaining findings handed off), and the user has the live URL.

--- a/.claude/skills/review-page/SKILL.md
+++ b/.claude/skills/review-page/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: review-page
+description: Adversarial review loop for a built ethereum.org page — spawns copy and design-system reviewer subagents against the Figma source, triages their findings, fixes, and re-reviews until a fresh round comes back clean. Invoke with /review-page.
+disable-model-invocation: true
+---
+
+# Review Page
+
+Audit a built page by turning two **adversarial** reviewers loose on it, fixing what they find, and re-running them until a fresh round comes back **green**. Each reviewer is a subagent prompted to assume the page is *wrong* and hunt for proof — never to rubber-stamp it. You (the orchestrator) own the Figma pull, the triage, and the fixes; the reviewers only report. This is the QA half of building a page — pair it with `/new-page`, or run it standalone against any existing page.
+
+Work the steps in order. Each ends on a checkable condition — don't start the next until the current one is met.
+
+## Step 0 — Ground truth
+
+You need two things before any review:
+
+1. **The live page.** Start `pnpm dev`, load the route (locale-stripped for `en`: `/<route>/`), confirm **HTTP 200**. A 500 is a build/asset error — fix that first; there is nothing to audit on a broken page.
+2. **The design source.** A Figma link/selection is the gold standard. A written spec serves the copy reviewer but not the pixel-level design checks. **No source at all → the copy reviewer has nothing to sync against; say so and confirm the user still wants a design-system-only pass.**
+
+**Done when:** the page serves 200 and the design source is known (or its absence is confirmed).
+
+## Step 1 — Capture both sides
+
+The reviewers compare *the page as it renders* against *the design as it's specified*. Capture both once, to a scratch dir, and pass the paths to the subagents — don't make each reviewer re-pull Figma (reads drift between pulls, and it burns rate limits).
+
+- **Design.** Read the Figma **fresh** — never a read from an earlier turn: `get_metadata` for the frame tree, `get_screenshot` per region, `get_design_context` for the text, `get_variable_defs` for tokens. Save the region screenshots; keep the text/token dump.
+- **Live page.** Full-page screenshot with `playwright-cli`, plus per-section shots for a long page. Save them beside the design shots.
+
+**Done when:** design and live-page artifacts are saved and their paths are known.
+
+## Step 2 — Spawn the adversarial reviewers
+
+Read both briefs in `reviewers/` and spawn **one subagent per brief, in parallel** — a single message with two `Agent` calls. Give each subagent its brief verbatim, the route, and the artifact paths from Step 1. Each returns a structured findings list — `{location, claim, evidence, fix, severity}` — and nothing else. **Reviewers report; they never edit** (two agents editing in parallel would collide).
+
+- `reviewers/copy.md` — every string on the page matches the Figma/source copy.
+- `reviewers/design-system.md` — components, spacing, heading sizes, and colors are the design system's, with no custom CSS bolted onto primitives.
+
+Reviewers are **adversarial**: each defaults to *fault found* and must cite evidence to clear a region. Expect over-reporting — that is the point; you filter next.
+
+**Done when:** both subagents have returned their findings lists.
+
+## Step 3 — Triage
+
+Adversarial reviewers over-report. **You** judge each finding before touching code — keep the real ones, drop the noise. Two calls need judgment:
+
+- **Intentional copy divergence.** A string differs because the *design is stale*, or because it's a templated/localized value — not a copy bug. Confirm against the source, not the reviewer's assumption.
+- **Justified custom CSS.** Custom CSS *chasing pixel parity* on a primitive is a finding; custom CSS the design *genuinely requires* (a one-off the system can't express) is acceptable per "match, don't mimic." Don't strip styling the design needs.
+
+Show the user the **confirmed** findings as a table — `Region · Finding · Fix · Severity` — and flag anything ambiguous for their call. This is their window into what the reviewers saw.
+
+**Done when:** every finding is confirmed or dropped, and the confirmed table has been shown to the user.
+
+## Step 4 — Fix
+
+Apply the confirmed findings yourself, reuse-first — a variant, not custom CSS; the right primitive, not a re-invention. Load the `design-system` skill if you haven't, for the component and token calls.
+
+**Done when:** every confirmed finding is fixed in the working tree.
+
+## Step 5 — Re-review until green
+
+Re-capture the **live page** (it changed; the Figma side didn't — reuse Step 1's design artifacts) and re-spawn the same reviewers. The loop is **green** when a fresh adversarial round returns **zero** confirmed findings. Until then: triage → fix → re-review.
+
+Cap it: if the loop isn't green after **3 rounds**, stop and hand the user the stubborn findings — a finding that survives three fixes usually needs a human design call, not another pass.
+
+**Done when:** a fresh round is green, or the 3-round cap is hit and the remaining findings are handed off.

--- a/.claude/skills/review-page/reviewers/copy.md
+++ b/.claude/skills/review-page/reviewers/copy.md
@@ -1,0 +1,33 @@
+# Copy Reviewer
+
+You are an **adversarial copy reviewer** for an ethereum.org page. Your job is to prove the page's copy is *out of sync* with the design source — not to confirm it's fine. Assume every string is wrong until the source proves it right.
+
+You will be given the route, full-page + per-section screenshots of the **live page**, and the **design source** (Figma region screenshots + extracted text, or a written spec). Work only from these — do not pull Figma yourself.
+
+## What to check, region by region
+
+Walk the page top to bottom. For every piece of user-facing text — headings, body, button labels, link text, eyebrows/kickers, captions, list items, empty/error states — compare the rendered string to the source string and report any mismatch:
+
+- **Wording** — text differs (added / dropped / reordered / reworded). Quote both sides.
+- **Missing copy** — a string in the design that isn't on the page.
+- **Extra copy** — a string on the page with no source counterpart (often leftover placeholder).
+- **Placeholder left in** — `Lorem ipsum`, `TODO`, `Frame 123`, dummy URLs, sample numbers presented as real.
+- **Casing & punctuation** — title vs sentence case, trailing periods, em-dash vs hyphen, smart vs straight quotes — but only where the design is internally consistent and the page deviates.
+- **Truncation / overflow** — copy visibly cut off or wrapping wrong in the live screenshot.
+
+Ignore font, size, color, spacing, and layout — those belong to the design-system reviewer. You judge *what the words are*, not how they look.
+
+## Distinguish a bug from a non-bug
+
+- A string that differs because the **design may be stale** is a candidate, not a verdict — report it and note "source may be outdated" so the orchestrator can judge.
+- Templated/interpolated values (`{count}`, dates, a data-fed wallet count) are **not** copy bugs when the surrounding template text matches.
+
+## Output
+
+Return **only** a JSON array of findings, each:
+
+```json
+{ "location": "<region / heading text>", "claim": "<what's wrong>", "evidence": "page: \"…\"  vs  source: \"…\"", "fix": "<the exact corrected string>", "severity": "high|medium|low" }
+```
+
+Return an empty array `[]` if — and only if — every string matches. Do not narrate.

--- a/.claude/skills/review-page/reviewers/design-system.md
+++ b/.claude/skills/review-page/reviewers/design-system.md
@@ -1,0 +1,35 @@
+# Design-System Reviewer
+
+You are an **adversarial design-system reviewer** for an ethereum.org page. Your job is to prove the page reinvents what the design system already provides — wrong components, ad-hoc spacing, hand-built headings, raw colors, custom CSS bolted onto primitives. Assume drift until the code proves otherwise.
+
+**First, load the standard.** Read these fully — they are what you audit against, so cite them in your findings:
+
+- `.claude/skills/design-system/SKILL.md`
+- `.claude/skills/design-system/references/spacing-typography.md`
+- `.claude/skills/design-system/references/tokens.md`
+- `.claude/skills/design-system/references/variant-vs-new.md`
+
+You will be given the route, the live-page screenshots, and the design region screenshots. Find the page's source — `app/[locale]/<route>/page.tsx` or `public/content/<route>/index.md` plus any components it renders — and read it. You audit the **code and the rendered result together**.
+
+## What to check
+
+- **Reinvented primitives.** A `flex … rounded border bg-… p-…` chain that is really a `<Card>`; a `<p className="text-4xl font-bold">` that is really `<BigNumber>` or an `<h*>`; a raw `<a>`/`<button>` instead of `<ButtonLink>`/`<Button>`. (Top Rules 1 & 3; variant-vs-new.)
+- **Heading sizes & weight.** Headings must be semantic `<h1>`–`<h6>` (or the `text-h*` utility on a non-heading element), never a hand-built `text-Xxl font-bold` pair. No re-applied `font-bold`/`font-semibold` on a real heading — it silently overrides the base `font-black`. (spacing-typography.)
+- **Spacing between sections.** Section rhythm comes from the layout / `<Section>` and the canonical spacing scale — not from ad-hoc `mt-[37px]` arbitrary values or one-off margins sprinkled per region. Flag arbitrary-value spacing (`[…px]`) and margins that fight the layout's own flow.
+- **Text color.** Semantic tokens only (`text-body`, `text-body-medium`, `text-primary`, …). Flag any hex / `rgb()` / `hsl()` literal, and any stale shadcn token (`text-muted-foreground`, `text-accent-foreground`, …) that doesn't resolve in this project.
+- **Custom CSS on primitives.** `className` overrides that re-skin a primitive's *owned* properties — padding / spacing / radius / color on `Card`/`CardContent` (owned by its variants), etc. The fix is a variant, not a `className`. (card-walkthrough.)
+- **Direction & format.** `left-`/`right-`/`ml-`/`pr-` instead of logical `ms-`/`me-`/`ps-`/`pe-`; native `toLocaleString` / `Intl.*` instead of `numberFormat()` / `dateTimeFormat()`.
+
+## Match, don't mimic — and its limit
+
+The bar is: reproduce the design with existing components and their variants. Custom CSS to chase pixel parity on a primitive is a finding. **But** custom CSS the design *genuinely requires* — a one-off the system can't express — is acceptable; when you flag custom CSS, state whether the design plausibly forces it so the orchestrator can judge. Never demand stripping styling the design needs.
+
+## Output
+
+Return **only** a JSON array of findings, each:
+
+```json
+{ "location": "<region / file:line>", "claim": "<what drifts + which rule/reference>", "evidence": "<the offending code or class chain>", "fix": "<the design-system-correct replacement>", "severity": "high|medium|low" }
+```
+
+Return an empty array `[]` if — and only if — the page is clean. Do not narrate.


### PR DESCRIPTION
## Summary

Adds two user-invoked skills for building ethereum.org pages, reuse-first against the design system. Draft — opening for feedback.

- **`/new-page`** — interview → scaffold → QA. Forks first on **markdown vs App Router** (an authoring decision, asked upfront), then picks the layout/hero, maps the Figma design to existing components, and builds. Key gate: an **exhaustive component-map table** shown for user sign-off before any code.
- **`/review-page`** — adversarial review loop (design-system + copy reviewers) used as `/new-page`'s QA pass.

## Notes

- Scope: **only** `.claude/skills/{new-page,review-page}/`. No app code — pages built while testing the skills live on separate branches.
- User-invoked (`disable-model-invocation: true`).
