### PR TITLE
Remove dead ethereum-ecosystem.com links (HTTP 402)

### DIFF
--- a/public/content/developers/docs/networks/index.md
+++ b/public/content/developers/docs/networks/index.md
@@ -53,7 +53,6 @@ The two public testnets that client developers are currently maintaining are Sep
 - [Alchemy Sepolia Faucet](https://www.alchemy.com/faucets/ethereum-sepolia)
 - [Chain Platform Sepolia Faucet](https://faucet.chainplatform.co/faucets/ethereum-sepolia/)
 - [Chainstack Sepolia Faucet](https://faucet.chainstack.com/sepolia-testnet-faucet)
-- [Ethereum Ecosystem Faucet](https://www.ethereum-ecosystem.com/faucets/ethereum-sepolia)
 - [ethfaucet.com Sepolia Faucet](https://ethfaucet.com/networks/ethereum)
 - [Google Cloud Web3 Sepolia Faucet](https://cloud.google.com/application/web3/faucet/ethereum/sepolia)
 - [Grabteeth](https://grabteeth.xyz/)

--- a/public/content/developers/docs/scaling/optimistic-rollups/index.md
+++ b/public/content/developers/docs/scaling/optimistic-rollups/index.md
@@ -256,7 +256,6 @@ More of a visual learner? Watch Finematics explain optimistic rollups:
 ## Further reading on optimistic rollups {#further-reading-on-optimistic-rollups}
 
 - [How do optimistic rollups work (The Complete guide)](https://www.alchemy.com/overviews/optimistic-rollups)
-- [What is a Blockchain Rollup? A Technical Introduction](https://www.ethereum-ecosystem.com/blog/what-is-a-blockchain-rollup-a-technical-introduction)
 - [The Essential Guide to Arbitrum](https://www.bankless.com/the-essential-guide-to-arbitrum)
 - [The Practical Guide To Ethereum Rollups](https://web.archive.org/web/20241108192208/https://research.2077.xyz/the-practical-guide-to-ethereum-rollups)
 - [The State Of Fraud Proofs In Ethereum L2s](https://web.archive.org/web/20241124154627/https://research.2077.xyz/the-state-of-fraud-proofs-in-ethereum-l2s)

--- a/public/content/nft/index.md
+++ b/public/content/nft/index.md
@@ -108,7 +108,6 @@ Security issues relating to NFTs are most often related to phishing scams, smart
 - [Blockscout NFT tracker](https://eth.blockscout.com/tokens?type=ERC-721,ERC-1155,ERC-404)
 - [ERC-721 token standard](/developers/docs/standards/tokens/erc-721/)
 - [ERC-1155 token standard](/developers/docs/standards/tokens/erc-1155/)
-- [Popular NFT Apps and Tools](https://www.ethereum-ecosystem.com/blockchains/ethereum/nfts)
 - [NFT Standards wiki](https://nft-standards.gitbook.io/nft-standards-wiki)
 
 ## Other resources {#other-resources}


### PR DESCRIPTION
## Description

Closes #18456.

All `ethereum-ecosystem.com` URLs referenced in our content now return **HTTP 402**, so the links are removed from the affected resource lists.

| Source file | Removed link |
| --- | --- |
| `developers/docs/networks/index.md` | Ethereum Ecosystem Faucet |
| `developers/docs/scaling/optimistic-rollups/index.md` | What is a Blockchain Rollup? A Technical Introduction |
| `nft/index.md` | Popular NFT Apps and Tools |

Verified each returns 402:

```bash
curl -L -I https://www.ethereum-ecosystem.com/faucets/ethereum-sepolia
curl -L -I https://www.ethereum-ecosystem.com/blog/what-is-a-blockchain-rollup-a-technical-introduction
curl -L -I https://www.ethereum-ecosystem.com/blockchains/ethereum/nfts
```

## Notes

- Each removed entry was a standalone list item. The surrounding lists keep all their other entries, so no prose changes were needed.
- Only the English source files are edited here. The same links exist across translated copies; those will be dropped via the intl-pipeline on the next Crowdin import, keeping the translation manifests accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)