### PR TITLE
fix all-contributors link on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you're looking for the Ethereum blockchain itself, there is no single repo. I
 
 ## How to contribute
 
-This project follows the [all-contributors](https://allcontributors.org/docs/en/overview) specification. Contributions of any kind are welcome!
+This project follows the [all-contributors](https://allcontributors.org/en/reference/) specification. Contributions of any kind are welcome!
 
 Before you start, please take a moment to read our [CONTRIBUTING.md](CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 


### PR DESCRIPTION
## Description

Updates the outdated all-contributors specification link in the README to the current documentation URL.


## Related Issue

Closes #18479