### PR TITLE
fix: update Vyper examples to compile on 0.4.x

### DIFF
--- a/public/content/developers/docs/smart-contracts/anatomy/index.md
+++ b/public/content/developers/docs/smart-contracts/anatomy/index.md
@@ -49,7 +49,7 @@ Other types include:
 
 For more explanation, take a look at the docs:
 
-- [See Vyper types](https://docs.vyperlang.org/en/v0.1.0-beta.6/types.html#value-types)
+- [See Vyper types](https://docs.vyperlang.org/en/stable/types.html#value-types)
 - [See Solidity types](https://docs.soliditylang.org/en/latest/types.html#value-types)
 
 ### Memory {#memory}
@@ -112,12 +112,12 @@ function balanceOf(address _owner) public view returns (uint256 _balance) {
 ```
 
 ```python
-dappName: public(string)
+dappName: public(String[64])
 
 @view
-@public
-def readName() -> string:
-  return dappName
+@external
+def readName() -> String[64]:
+  return self.dappName
 ```
 
 What is considered modifying state:
@@ -151,7 +151,7 @@ constructor() public {
 ```python
 # Vyper example
 
-@external
+@deploy
 def __init__(_beneficiary: address, _bidding_time: uint256):
     self.beneficiary = _beneficiary
     self.auctionStart = block.timestamp

--- a/public/content/developers/docs/smart-contracts/languages/index.md
+++ b/public/content/developers/docs/smart-contracts/languages/index.md
@@ -141,7 +141,7 @@ pendingReturns: public(HashMap[address, uint256])
 # Create a simple auction with `_bidding_time`
 # seconds bidding time on behalf of the
 # beneficiary address `_beneficiary`.
-@external
+@deploy
 def __init__(_beneficiary: address, _bidding_time: uint256):
     self.beneficiary = _beneficiary
     self.auctionStart = block.timestamp


### PR DESCRIPTION
## Description

Three Vyper examples in the developer docs use pre-0.4 syntax and don't compile on the current stable compiler (0.4.3). This updates them, plus one stale docs link on the same page.

- anatomy: @public -> @external, string -> String[64], @external __init__ -> @deploy
- languages: @external __init__ -> @deploy (auction)
- anatomy: point Vyper types link to /en/stable (was a v0.1.0-beta.6 pin)

Each fixed snippet compiles on vyper 0.4.3 (exit 0).

## Related Issue

Closes #18496
