### PR TITLE
patch(ui): footer padding to use px-page

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -55,8 +55,8 @@ const Footer = async ({ lastDeployLocaleTimestamp }: FooterProps) => {
     "text-body-medium no-underline hover:text-primary hover:after:text-primary"
 
   return (
-    <footer className="border-t">
-      <div className="flex flex-wrap items-center justify-center gap-8 p-4 md:justify-between">
+    <footer className="border-t *:px-page">
+      <div className="flex flex-wrap items-center justify-center gap-8 py-4 md:justify-between">
         <p className="text-sm text-body-medium italic">
           {t("website-last-updated")}:{" "}
           {/* Deploy date changes every release; exclude it from visual diffs
@@ -67,7 +67,7 @@ const Footer = async ({ lastDeployLocaleTimestamp }: FooterProps) => {
         <GoToTopButton label={t("go-to-top")} />
       </div>
 
-      <div className="p-4">
+      <div className="py-4">
         <BaseLink
           href="/"
           className="text-lg font-bold no-underline hover:text-primary"
@@ -76,7 +76,7 @@ const Footer = async ({ lastDeployLocaleTimestamp }: FooterProps) => {
         </BaseLink>
       </div>
 
-      <div className="grid auto-cols-auto justify-between gap-4 px-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-5">
+      <div className="grid auto-cols-auto justify-between gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-5">
         {linkSections.map((section: FooterLinkSection, idx) => (
           <div key={idx}>
             <h3 className="my-5 text-sm">{section.title}</h3>
@@ -96,7 +96,7 @@ const Footer = async ({ lastDeployLocaleTimestamp }: FooterProps) => {
           </div>
         ))}
       </div>
-      <div className="flex flex-col items-center justify-center bg-background-highlight p-6 text-sm">
+      <div className="flex flex-col items-center justify-center bg-background-highlight py-6 text-sm">
         <div className="flex gap-4">
           {socialLinks.map(({ href, ariaLabel, icon: Icon }) => (
             <BaseLink


### PR DESCRIPTION
Aligns the footer's horizontal padding with the rest of the site by using the responsive `px-page` token instead of the previous ad-hoc `p-4`/`px-4`/`p-6` mix.

Applied via `*:px-page` on the `<footer>` so all sections share one source of truth; vertical padding per section is unchanged and the highlight band stays full-bleed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)