### PR TITLE
patch(ui): space between blockquote elements

### DIFF
--- a/src/components/ui/blockquote.tsx
+++ b/src/components/ui/blockquote.tsx
@@ -5,7 +5,10 @@ const Blockquote = ({
   ...props
 }: React.HTMLAttributes<HTMLElement>) => (
   <blockquote
-    className={cn("border-s-2 border-accent-a bg-accent-a/10 p-6", className)}
+    className={cn(
+      "space-y-[1lh] border-s-2 border-accent-a bg-accent-a/10 p-6",
+      className
+    )}
     {...props}
   />
 )


### PR DESCRIPTION
## Description
- Adds `1lh` (one line-height) spacing between elements inside `Blockquote` component, consistent with `ui/card` `CardContent` spacing.

<img width="868" height="472" alt="image" src="https://github.com/user-attachments/assets/ae93612a-00e5-4b0f-acfa-04de193e1621" />

## Related Issue
No space between separate block elements within `Blockquote`

<img width="863" height="409" alt="image" src="https://github.com/user-attachments/assets/ee11586e-7380-405b-84b5-0d7bae069054" />
