### PR TITLE
patch: rm invalid outline-color button variant

### DIFF
--- a/docs/solutions/integration-issues/sanitizer-test-research.md
+++ b/docs/solutions/integration-issues/sanitizer-test-research.md
@@ -68,7 +68,7 @@
 | 52 | Orphaned opening backtick with missing closer | pl #17445 | `` `<nazwa opcodu>(...). `` -- opening backtick with no closing backtick; `repairUnclosedBackticks` needs English comparison and may miss cases where English also has backticks but the translated line lost one | High -- exposed MDX tags |
 | 53 | Crowdin misplaces closing backtick before JSX fragment closer | sw #17521 | EN: `` (`<> ... </>`) `` -> SW: `` (`<> ...` </>) `` -- Crowdin moves closing backtick before `</>`, then `escapeMdxAngleBrackets` escapes the exposed `</>` as `\</>`. Fix: detect `` `<content>` </>) `` pattern and move closing backtick to include `</>` | Critical -- breaks MDX display |
 | 54 | Double punctuation after orphaned tag removal | sw #17521 | `kutoa.</em></em>.` -> `kutoa..` -- `removeOrphanedClosingTags` strips orphaned `</em>` tags but leaves behind double periods where the tag sat between two periods. Fix: collapse `..` to `.` after orphan removal | Low -- cosmetic but noticeable |
-| 55 | Escaped quotes `\"` in MDX JSX attributes | sw #17521 | `<ButtonLink variant=\"outline-color\" href=\"/roadmap/\">` -- Crowdin backslash-escapes quotes in JSX attributes; valid in JSON but breaks MDX compilation | Critical -- breaks build |
+| 55 | Escaped quotes `\"` in MDX JSX attributes | sw #17521 | `<ButtonLink variant=\"outline\" href=\"/roadmap/\">` -- Crowdin backslash-escapes quotes in JSX attributes; valid in JSON but breaks MDX compilation | Critical -- breaks build |
 | 56 | Translated interpolation placeholders in JSON | sw #17521 | EN: `{days}` -> SW: `{siku}` -- Crowdin translates the variable name inside `{}` braces; the app expects the English key name | Critical -- breaks rendering |
 
 ## Patterns Already Handled by Sanitizer (Confirmed Working)

--- a/public/content/roadmap/scaling/index.md
+++ b/public/content/roadmap/scaling/index.md
@@ -39,13 +39,13 @@ The second stage of expanding blob data is complicated because it requires new m
 
 This second step is known as ["Danksharding"](/roadmap/danksharding/). Implementation work continues, with progress being made on prerequisites like [separating block building and block proposal](/roadmap/pbs) and new network designs that enable the network to efficiently confirm that data is available by randomly sampling a few kilobytes at a time, known as [data availability sampling (DAS)](/developers/docs/data-availability).
 
-<ButtonLink variant="outline-color" href="/roadmap/danksharding/">More on Danksharding</ButtonLink>
+<ButtonLink variant="outline" href="/roadmap/danksharding/">More on Danksharding</ButtonLink>
 
 ## Decentralizing rollups {#decentralizing-rollups}
 
 [Rollups](/layer-2) are already scaling Ethereum. A [rich ecosystem of rollup projects](https://l2beat.com/scaling/tvs) is enabling users to transact quickly and cheaply, with a range of security guarantees. However, rollups have been bootstrapped using centralized sequencers (computers that do all the transaction processing and aggregation before submitting them to Ethereum). This is vulnerable to censorship, because the sequencer operators can be sanctioned, bribed or otherwise compromised. At the same time, [rollups vary](https://l2beat.com/scaling/summary) in the way they validate incoming data. The best way is for "provers" to submit [fraud proofs](/glossary/#fraud-proof) or validity proofs, but not all rollups are there yet. Even those rollups that do use validity/fraud proofs use a small pool of known provers. Therefore, the next critical step in scaling Ethereum is to distribute responsibility for running sequencers and provers across more people.
 
-<ButtonLink variant="outline-color" href="/developers/docs/scaling/">More on rollups</ButtonLink>
+<ButtonLink variant="outline" href="/developers/docs/scaling/">More on rollups</ButtonLink>
 
 ## Current progress {#current-progress}
 

--- a/public/content/roadmap/security/index.md
+++ b/public/content/roadmap/security/index.md
@@ -15,7 +15,7 @@ There are also improvements that make censoring transactions much more difficult
 
 The upgrade from [proof-of-work](/glossary/#pow) to proof-of-stake began with Ethereum pioneers “staking” their ETH in a deposit contract. That ETH is used to protect the network. There was a second update on April 12, 2023 to allow validators to withdraw staked ETH. Since then validators can freely stake or withdraw ETH.
 
-<ButtonLink variant="outline-color" href="/staking/withdrawals/">Read about withdrawals</ButtonLink>
+<ButtonLink variant="outline" href="/staking/withdrawals/">Read about withdrawals</ButtonLink>
 
 ## Defending against attacks {#defending-against-attacks}
 
@@ -23,25 +23,25 @@ There are improvements that can be made to Ethereum's proof-of-stake protocol. O
 
 Reducing the time Ethereum takes to [finalize](/glossary/#finality) blocks would provide a better user experience and prevent sophisticated "reorg" attacks where attackers try to reshuffle very recent blocks to extract profit or censor certain transactions. [**Single slot finality (SSF)**](/roadmap/single-slot-finality/) is a **way to minimize the finalization delay**. Right now there are 15 mins worth of blocks that an attacker could theoretically convince other validators to reconfigure. With SSF, there are 0. Users, from individuals to apps and exchanges, benefit from fast assurance that their transactions will not be reverted, and the network benefits by shutting down a whole class of attacks.
 
-<ButtonLink variant="outline-color" href="/roadmap/single-slot-finality/">Read about single slot finality</ButtonLink>
+<ButtonLink variant="outline" href="/roadmap/single-slot-finality/">Read about single slot finality</ButtonLink>
 
 ## Defending against censorship {#defending-against-censorship}
 
 Decentralization prevents individuals or small groups of [validators](/glossary/#validator) from becoming too influential. New staking technologies can help to ensure Ethereum's validators stay as decentralized as possible while also defending them against hardware, software and network failures. This includes software that shares validator responsibilities across multiple [nodes](/glossary/#node). This is known as **distributed validator technology (DVT)**. [Staking pools](/glossary/#staking-pool) are incentivized to use DVT because it allows multiple computers to collectively participate in validation, adding redundancy and fault-tolerance. It also splits validator keys across several systems, rather than having single operators running multiple validators. This makes it harder for dishonest operators to coordinate attacks on Ethereum. Overall, the idea is to derive security benefits by running validators as _communities_ rather than as individuals.
 
-<ButtonLink variant="outline-color" href="/staking/dvt/">Read about distributed validator technology</ButtonLink>
+<ButtonLink variant="outline" href="/staking/dvt/">Read about distributed validator technology</ButtonLink>
 
 Implementing **proposer-builder separation (PBS)** will drastically improve Ethereum's built-in defenses against censorship. PBS allows one validator to create a block and another to broadcast it across the Ethereum network. This ensures that the gains from professional profit-maximizing block building algorithms are shared more fairly across the network, **preventing stake from concentrating** with the best-performing institutional stakers over time. The block proposer gets to select the most profitable block offered to them by a market of block builders. To censor, a block proposer would often have to choose a less profitable block, which would be **economically irrational and also obvious to the rest of the validators** on the network.
 
 There are potential add-ons to PBS, such as encrypted transactions and inclusion lists, that could further improve Ethereum's censorship resistance. These make the block builder and proposer blind to the actual transactions included in their blocks.
 
-<ButtonLink variant="outline-color" href="/roadmap/pbs/">Read about proposer-builder separation</ButtonLink>
+<ButtonLink variant="outline" href="/roadmap/pbs/">Read about proposer-builder separation</ButtonLink>
 
 ## Protecting validators {#protecting-validators}
 
 It is possible that a sophisticated attacker could identify upcoming validators and spam them to prevent them from proposing blocks; this is known as a **denial of service (DoS)** attack. Implementing [**secret leader election (SLE)**](/roadmap/secret-leader-election) will protect against this type of attack by preventing block proposers from being knowable in advance. This works by continually shuffling a set of cryptographic commitments representing candidate block proposers and using their order to determine which validator is selected in such a way that only the validators themselves know their ordering in advance.
 
-<ButtonLink variant="outline-color" href="/roadmap/secret-leader-election">Read about secret leader election</ButtonLink>
+<ButtonLink variant="outline" href="/roadmap/secret-leader-election">Read about secret leader election</ButtonLink>
 
 ## Current progress {#current-progress}
 

--- a/public/content/roadmap/statelessness/index.md
+++ b/public/content/roadmap/statelessness/index.md
@@ -70,7 +70,7 @@ For this to happen, [Verkle trees](/roadmap/verkle-trees/) must already have bee
 
 Statelessness relies on block builders maintaining a copy of the full state data so that they can generate witnesses that can be used to verify the block. Other nodes do not need access to the state data, all the information required to verify the block is available in the witness. This creates a situation where proposing a block is expensive, but verifying the block is cheap, which implies fewer operators will run a block proposing node. However, decentralization of block proposers is not critical as long as as many participants as possible can independently verify that the blocks they propose are valid.
 
-<ButtonLink variant="outline-color" href="https://notes.ethereum.org/WUUUXBKWQXORxpFMlLWy-w#So-why-is-it-ok-to-have-expensive-proposers">Read more on Dankrad's notes</ButtonLink>
+<ButtonLink variant="outline" href="https://notes.ethereum.org/WUUUXBKWQXORxpFMlLWy-w#So-why-is-it-ok-to-have-expensive-proposers">Read more on Dankrad's notes</ButtonLink>
 </ExpandableCard>
 
 Block proposers use the state data to create "witnesses" - the minimal set of data that prove the values of the state that are being changed by the transactions in a block. Other validators do not hold the state, they only store the state root (a hash of the entire state). They receive a block and a witness and use them to update their state root. This makes a validating node extremely lightweight.

--- a/public/content/roadmap/user-experience/index.md
+++ b/public/content/roadmap/user-experience/index.md
@@ -15,7 +15,7 @@ Ethereum accounts are protected by a pair of keys used to identify accounts (pub
 
 The solution to this is using [smart contract](/glossary/#smart-contract) wallets to interact with Ethereum. Smart contract wallets create ways to protect accounts if the keys are lost or stolen, opportunities for better fraud detection and defense, and allow wallets to get new functionality. Although smart contract wallets exist today, they are awkward to build because the Ethereum protocol needs to support them better. This additional support is known as account abstraction.
 
-<ButtonLink variant="outline-color" href="/roadmap/account-abstraction/">More on account abstraction</ButtonLink>
+<ButtonLink variant="outline" href="/roadmap/account-abstraction/">More on account abstraction</ButtonLink>
 
 ## Nodes for everyone {#nodes-for-everyone}
 
@@ -23,7 +23,7 @@ Users running [nodes](/glossary/#node) do not have to trust third parties to pro
 
 There are several upgrades that will make running nodes far easier and far less resource intensive. The way data is stored will be changed to use a more space-efficient structure known as a **Verkle Tree**. Also, with [statelessness](/roadmap/statelessness) or [data expiry](/roadmap/statelessness/#data-expiry), Ethereum nodes will not need to store a copy of the entire Ethereum state data, drastically reducing hard disk space requirements. [Light nodes](/developers/docs/nodes-and-clients/light-clients/) will offer many benefits of running a full node but can run easily on mobile phones or inside simple browser apps.
 
-<ButtonLink variant="outline-color" href="/roadmap/verkle-trees/">Read about Verkle trees</ButtonLink>
+<ButtonLink variant="outline" href="/roadmap/verkle-trees/">Read about Verkle trees</ButtonLink>
 
 With these upgrades, the barriers to running a node are reduced to effectively zero. Users will benefit from secure, permissionless access to Ethereum without having to sacrifice noticeable disk space or CPU on their computer or mobile phone, and will not have to rely on third parties for data or network access when they use apps.
 

--- a/src/scripts/intl-pipeline/intl-sanitizer.ts
+++ b/src/scripts/intl-pipeline/intl-sanitizer.ts
@@ -4083,7 +4083,7 @@ function fixImagePathDotSlash(content: string): {
  * Fix backslash-escaped quotes in JSX/MDX attributes.
  *
  * Crowdin sometimes backslash-escapes double quotes in JSX attributes:
- *   <ButtonLink variant=\"outline-color\" href=\"/path/\">
+ *   <ButtonLink variant=\"outline\" href=\"/path/\">
  * This is valid in JSON but breaks MDX compilation.
  * Fix: remove the backslash before quotes in JSX-like tag attributes.
  */

--- a/tests/unit/intl-pipeline/sanitizer/standalone-fixes.spec.ts
+++ b/tests/unit/intl-pipeline/sanitizer/standalone-fixes.spec.ts
@@ -2507,10 +2507,10 @@ author: Ori Pomerantz
   test.describe("fixEscapedQuotesInJsxAttributes", () => {
     test("removes backslash-escaped quotes in JSX attributes", () => {
       const input =
-        '<ButtonLink variant=\\"outline-color\\" href=\\"/roadmap/danksharding/\\">Zaidi</ButtonLink>'
+        '<ButtonLink variant=\\"outline\\" href=\\"/roadmap/danksharding/\\">Zaidi</ButtonLink>'
       const { content, fixCount } = fixEscapedQuotesInJsxAttributes(input)
       expect(content).toBe(
-        '<ButtonLink variant="outline-color" href="/roadmap/danksharding/">Zaidi</ButtonLink>'
+        '<ButtonLink variant="outline" href="/roadmap/danksharding/">Zaidi</ButtonLink>'
       )
       expect(fixCount).toBeGreaterThan(0)
     })


### PR DESCRIPTION
## Description

Several `<ButtonLink>` instances in the roadmap content used `variant="outline-color"`, which is not a valid button variant. It only rendered as an outline by coincidence: `cva` silently ignores the unknown value, and the button's base styling already is the outline pattern (the real `outline` variant is an empty string). Because these live in MDX content, TypeScript never caught the invalid prop.

This swaps all occurrences to the proper `variant="outline"` (identical render, correct semantics) and cleans up a few docs/tests that referenced the invalid name as incidental sample data.

The non-English copies of these pages still carry the old value; the intl-pipeline will propagate the `outline` fix to them deterministically (it's an inert, non-translatable attribute, so no re-translation is triggered).

## Changes

- `public/content/roadmap/{scaling,security,statelessness,user-experience}/index.md` — `outline-color` -> `outline`
- `src/scripts/intl-pipeline/intl-sanitizer.ts` — update docstring example
- `tests/unit/intl-pipeline/sanitizer/standalone-fixes.spec.ts` — update test fixture (still passes)
- `docs/solutions/integration-issues/sanitizer-test-research.md` — update bug-pattern example

🤖 Generated with [Claude Code](https://claude.com/claude-code)
