### PR TITLE
Add Titanoboa and Moccasin to the Python developer tooling list

### DIFF
--- a/public/content/developers/docs/programming-languages/python/index.md
+++ b/public/content/developers/docs/programming-languages/python/index.md
@@ -59,6 +59,8 @@ Need a more basic primer first? Check out [ethereum.org/learn](/learn/) or [ethe
 
 - [Web3.py](https://github.com/ethereum/web3.py) - _Python library for interacting with Ethereum_
 - [Vyper](https://github.com/ethereum/vyper/) - _Pythonic Smart Contract Language for the EVM_
+- [Titanoboa](https://github.com/vyperlang/titanoboa/) - _Vyper's native testing tool; an interpreter with mainnet forking, debugging, and pretty tracebacks_
+- [Moccasin](https://github.com/Cyfrin/moccasin) - _A smart contract development and testing framework for Vyper and Python, built on Titanoboa_
 - [Ape](https://github.com/ApeWorX/ape) - _The smart contract development tool for Pythonistas, Data Scientists, and Security Professionals_
 - [py-evm](https://github.com/ethereum/py-evm) - _implementation of the Ethereum Virtual Machine_
 - [eth-tester](https://github.com/ethereum/eth-tester) - _tools for testing Ethereum-based applications_


### PR DESCRIPTION
Adds two actively-maintained, open-source Vyper tools to the "Active" list on the Python developers page (currently flagged `incomplete`). Both are Python-based and were missing.

- **Titanoboa** (vyperlang/titanoboa) - Vyper's native testing tool; listed in the Vyper docs.
- **Moccasin** (Cyfrin/moccasin) - Vyper/Python dev & testing framework built on Titanoboa, mentioned in the Vyper docs.

Descriptions are taken from the Vyper documentation.

Relates to #18511. 