### PR TITLE
fix(e2e): update start page wallet selector after redesign

### DIFF
--- a/tests/e2e/pages/StartPage.ts
+++ b/tests/e2e/pages/StartPage.ts
@@ -32,10 +32,7 @@ export class StartPage extends BasePage {
    * Navigate through the start flow and open the wallet connection modal.
    */
   async openWalletConnectionModal() {
-    await this.page
-      .getByRole("paragraph")
-      .filter({ hasText: "I have a wallet." })
-      .click()
+    await this.page.getByRole("checkbox", { name: "I have a wallet." }).click()
     await this.page.getByRole("button", { name: "Continue" }).click()
     await this.page
       .getByRole("button", { name: "Sign in with Ethereum" })


### PR DESCRIPTION
## Summary

The weekly release e2e suite (PR #18513) failed on `start.spec.ts › wallet modal opens with wallet options` across all 4 browsers.

**Root cause:** the Start-page redesign (#18427) changed the "I have a wallet." text from a `<p>` to a checkbox `<label htmlFor>`. The e2e page object still queried `getByRole("paragraph").filter({ hasText: "I have a wallet." })`, which now matches nothing, so the click timed out (10s) on every browser. The page itself is healthy — this is stale test selector drift, not a product bug. (E2E only runs on PRs, so it surfaced on the deploy PR rather than on dev.)

**Fix:** query the checkbox by its accessible label instead:
```diff
-      .getByRole("paragraph")
-      .filter({ hasText: "I have a wallet." })
+      .getByRole("checkbox", { name: "I have a wallet." })
```

## Verification

Ran the test against the #18513 deploy preview — **4/4 passed** (desktop + mobile chrome), including the previously-failing wallet-modal test.