### PR TITLE
fix(data-layer): scope video-thumbnail discovery to videos subtree

### DIFF
--- a/src/data-layer/fetchers/fetchVideoThumbnails.ts
+++ b/src/data-layer/fetchers/fetchVideoThumbnails.ts
@@ -43,7 +43,12 @@ function youtubeThumbnailUrl(youtubeId: string, quality: "sd" | "hq"): string {
  * under public/content/videos/ that have an index.md).
  */
 async function discoverVideoSlugs(token: string): Promise<string[]> {
-  const url = `${GITHUB_API_BASE}/git/trees/master?recursive=1`
+  // Fetch only the videos subtree, not the whole repo recursively. A recursive
+  // tree of the full repo exceeds GitHub's truncation limit (~100k entries / 7MB),
+  // and when truncated the public/content/videos/ paths are silently dropped,
+  // yielding zero slugs (and an empty thumbnail map that wipes the cached blob).
+  const treePath = encodeURIComponent("public/content/videos")
+  const url = `${GITHUB_API_BASE}/git/trees/master:${treePath}`
   const response = await fetchRetry(url, {
     headers: {
       Authorization: `Bearer ${token}`,
@@ -52,26 +57,22 @@ async function discoverVideoSlugs(token: string): Promise<string[]> {
   })
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch repo tree: ${response.status}`)
+    throw new Error(`Failed to fetch videos tree: ${response.status}`)
   }
 
   const data = await response.json()
-  const tree: GitTreeItem[] = data.tree
-
-  const slugs: string[] = []
-  for (const item of tree) {
-    if (item.type !== "blob") continue
-    if (!item.path.startsWith(VIDEOS_PATH_PREFIX)) continue
-    if (!item.path.endsWith(VIDEO_INDEX_SUFFIX)) continue
-
-    const inner = item.path.slice(
-      VIDEOS_PATH_PREFIX.length,
-      -VIDEO_INDEX_SUFFIX.length
+  // The videos directory holds ~dozens of entries, well under the truncation
+  // limit, but guard defensively: a truncated response would under-report slugs.
+  if (data.truncated) {
+    throw new Error(
+      "Videos tree response was truncated; aborting to avoid wiping the thumbnail map"
     )
-    // Skip nested paths (none expected, kept defensive)
-    if (!inner.includes("/")) slugs.push(inner)
   }
-  return slugs
+
+  // Subtree entries are relative to the videos directory: each immediate
+  // subdirectory (type "tree") is a video slug.
+  const tree: GitTreeItem[] = data.tree
+  return tree.filter((item) => item.type === "tree").map((item) => item.path)
 }
 
 /**
@@ -181,6 +182,15 @@ export async function fetchVideoThumbnails(): Promise<Record<string, string>> {
   console.log(
     `Video thumbnail sync complete: ${Object.keys(thumbnailMap).length}/${slugs.length} uploaded`
   )
+
+  // Never persist an empty map: a fully-empty result always signals a fetch
+  // failure (there are always videos in the repo). Throwing here leaves the
+  // previously cached blob intact instead of wiping every thumbnail sitewide.
+  if (Object.keys(thumbnailMap).length === 0) {
+    throw new Error(
+      "Video thumbnail sync produced an empty map; refusing to overwrite cached blob"
+    )
+  }
 
   return thumbnailMap
 }


### PR DESCRIPTION
## Problem

The `/stories` and `/videos` pages render video thumbnails from a slug→URL map cached in the data layer (`VIDEO_THUMBNAILS`), populated by the `fetchVideoThumbnails` Trigger.dev task.

After the v11.12.0 release, the task started logging **`Found 0 videos in repo tree`** and wrote an **empty map**, which overwrote the cached blob — wiping every video thumbnail site-wide (the S3 image objects themselves were unaffected).

### Root cause

`discoverVideoSlugs` enumerated videos via `GET /git/trees/master?recursive=1`, a **recursive tree of the entire repo**. The repo tree is now large enough (the release merged thousands of translation files) that GitHub **truncates** this response — it returns `truncated: true` with ~51k entries, and **none** of the `public/content/videos/` paths survive the cutoff. The code never checked `truncated`, so it silently saw zero videos → empty map → blob overwritten with `{}`.

## Fix

1. **Fetch only the videos subtree** — `GET /git/trees/master:public/content/videos` — which returns the ~60 immediate subdirectories (one per slug), untruncated. Added a defensive `data.truncated` guard.
2. **Never persist an empty map** — `fetchVideoThumbnails` now throws if it produces an empty result, so the `set()` is skipped and the last good blob survives instead of being wiped by any future failure mode.

## Verification

- New `discoverVideoSlugs` against the live API: **60 slugs** (was 0), `truncated: false`.
- Manual dev run of the fixed task produced a full **60-entry map**, zero empty URLs.
- All 60 resulting S3 thumbnail URLs return **HTTP 200**, including the two `/stories` community videos that were previously broken (`community-eth-episode-1`, `ethereum-everywhere-santiago-palladino`).
- ESLint + type-check clean.

## Deploy / recovery note

Once this deploys to the Trigger.dev tasks, re-run `fetch-video-thumbnails` (it'll find all 60 videos and rebuild the map), then redeploy the site so the static pages pick up the refreshed blob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
