### PR TITLE
fix: replace dead Beacon Node API link in run-a-node docs

### DIFF
--- a/public/content/developers/docs/nodes-and-clients/run-a-node/index.md
+++ b/public/content/developers/docs/nodes-and-clients/run-a-node/index.md
@@ -387,7 +387,7 @@ teku --network mainnet \
     --ee-jwt-secret-file "/path/to/jwtsecret"
 ```
 
-When a consensus client connects to the execution client to read the deposit contract and identify validators, it also connects to other Beacon Node peers and begins syncing consensus slots from genesis. Once the Beacon Node reaches the current epoch, the Beacon API becomes usable for your validators. Learn more about [Beacon Node APIs](https://eth2docs.vercel.app/).
+When a consensus client connects to the execution client to read the deposit contract and identify validators, it also connects to other Beacon Node peers and begins syncing consensus slots from genesis. Once the Beacon Node reaches the current epoch, the Beacon API becomes usable for your validators. Learn more about [Beacon Node APIs](https://ethereum.github.io/beacon-APIs).
 
 ### Adding Validators {#adding-validators}
 


### PR DESCRIPTION
## Description

Fixes #18455.

The **Beacon Node APIs** link in the run-a-node docs pointed to `https://eth2docs.vercel.app/`, which now returns **HTTP 402** (dead).

`public/content/developers/docs/nodes-and-clients/run-a-node/index.md:390`

## Fix

Repoint to the canonical Beacon API spec, `https://ethereum.github.io/beacon-APIs` (verified **200**) — which is **already the URL used later in the same file** (line 412), so this also makes the two references consistent.

```diff
- Learn more about [Beacon Node APIs](https://eth2docs.vercel.app/).
+ Learn more about [Beacon Node APIs](https://ethereum.github.io/beacon-APIs).
```

## Scope

English source only. The `intl-pipeline` will propagate this to the translated copies on its next pass.