### PR TITLE
fix dead DAOstack link

### DIFF
--- a/public/content/dao/index.md
+++ b/public/content/dao/index.md
@@ -139,7 +139,6 @@ _Typically used for decentralized development and governance of protocols and [d
 - [Start a Governor DAO with Tally](https://www.tally.xyz/get-started)
 - [Create an Aragon-powered DAO](https://aragon.org/product)
 - [Start a colony](https://colony.io/)
-- [Create a DAO with DAOstack's holographic consensus](https://alchemy.daostack.io/daos/create)
 - [Launch a DAO with the DeGov Launcher](https://docs.degov.ai/integration/deploy)
 
 ## Further reading {#further-reading}


### PR DESCRIPTION
## Description

Removes the dead DAOstack Alchemy launch link from the canonical English DAO page. The linked `alchemy.daostack.io` host no longer resolves, and no maintained DAO creation flow was available as a direct replacement.

Only the canonical English content is changed; the intl pipeline can propagate the update to translations.

## Validation

- Confirmed the diff only changes `public/content/dao/index.md`
- Confirmed the dead URL no longer appears in the canonical file
- `git diff --check`

## Related Issue

Fixes #18444