### PR TITLE
patch(ui): PresetCard label to font-bold

### DIFF
--- a/src/components/ProductTable/PresetFilters.tsx
+++ b/src/components/ProductTable/PresetFilters.tsx
@@ -115,7 +115,7 @@ const PresetCard = ({
           </span>
           <span
             className={cn(
-              "text-left text-xl hyphens-auto transition-all duration-50",
+              "text-left text-xl font-bold hyphens-auto transition-all duration-50",
               colors.text[colorIdx]
             )}
           >


### PR DESCRIPTION
## Description
- `font-bold` to labels on Persona cards (PresetFilters)

## Related Issue
- Fixes find-wallet regression after change to span from header