### PR TITLE
fix broken 2077 Research EIP-7503 article link

### DIFF
--- a/public/content/zero-knowledge-proofs/index.md
+++ b/public/content/zero-knowledge-proofs/index.md
@@ -234,5 +234,5 @@ ZK-STARK is considered immune to the threat of quantum computing, as it only rel
 - [ZK-STARKs — Create Verifiable Trust, even against Quantum Computers](https://medium.com/coinmonks/zk-starks-create-verifiable-trust-even-against-quantum-computers-dd9c6a2bb13d) — _Adam Luciano_
 - [An approximate introduction to how zk-SNARKs are possible](https://vitalik.eth.limo/general/2021/01/26/snarks.html) — _Vitalik Buterin_
 - [Why Zero Knowledge Proofs (ZKPs) is a Game Changer for Self-Sovereign Identity](https://frankiefab.hashnode.dev/why-zero-knowledge-proofs-zkps-is-a-game-changer-for-self-sovereign-identity) — _Franklin Ohaegbulam_
-- [EIP-7503 Explained: Enabling Private Transfers On Ethereum With ZK Proofs](https://research.2077.xyz/eip-7503-zero-knowledge-wormholes-for-private-ethereum-transactions#introduction) — _Emmanuel Awosika_
+- [EIP-7503 Explained: Enabling Private Transfers On Ethereum With ZK Proofs](https://web.archive.org/web/20251116093505/https://research.2077.xyz/eip-7503-zero-knowledge-wormholes-for-private-ethereum-transactions/) — _Emmanuel Awosika_
 - [ZK Card Game: game to learn ZK fundamentals and real-life use cases](https://github.com/ZK-card/zk-cards) - _ZK-Cards_


### PR DESCRIPTION
## Description

Replaces the dead 2077 Research article link for EIP-7503 with an Internet Archive snapshot on the zero-knowledge proofs page.

## Related Issue

Fixes #18535