### PR TITLE
fix broken Peera community forum link

### DIFF
--- a/public/content/community/online/index.md
+++ b/public/content/community/online/index.md
@@ -54,7 +54,7 @@ If you believe a community should be added or removed based on these guidelines,
 <SocialListItem socialIcon="discord"><Link href="https://discord.matos.club/">Matos Discord</Link> - web3 creators community where builders, industrial figureheads, and Ethereum enthusiasts hang out. We're passionate about web3 development, design, and culture. Come build with us.</SocialListItem>
 <SocialListItem socialIcon="webpage"><Link href="https://matrix.to/#/#ethereum_solidity:gitter.im">Solidity Matrix</Link> - chat for solidity development (Matrix)</SocialListItem>
 <SocialListItem socialIcon="webpage"><Link href="https://ethereum.stackexchange.com/">Ethereum Stack Exchange</Link> <i>- question and answer forum</i></SocialListItem>
-<SocialListItem socialIcon="webpage"><Link href="https://app.peera.ai/">Peera Community Forum</Link> <i>- decentralized question and answer forum</i></SocialListItem>
+<SocialListItem socialIcon="webpage"><Link href="https://www.peera.ai/community-forum">Peera Community Forum</Link> <i>- decentralized question and answer forum</i></SocialListItem>
 
 ## YouTube and X (formerly Twitter) {#youtube-and-twitter}
 


### PR DESCRIPTION
## Description

Replaces the dead Peera community forum link with the current Peera website.

## Related Issue

Fixes #18532