### PR TITLE
remove dead Sekto ETHKL article link

### DIFF
--- a/public/content/community/events/organizing/index.md
+++ b/public/content/community/events/organizing/index.md
@@ -217,4 +217,4 @@ Twitter space:
 
 Articles:
 
-- [Building ETHKL, by Danny H.](https://sekto.tech/ethkl24)
+


### PR DESCRIPTION
## Description

Removes the dead Sekto ETHKL article link since the domain no longer resolves and no usable archive or replacement was found.

## Related Issue

Fixes #18531