### PR TITLE
fix: broken http link to StorJ article by Jeff Garzik

### DIFF
--- a/public/content/whitepaper/index.md
+++ b/public/content/whitepaper/index.md
@@ -511,7 +511,7 @@ The concept of an arbitrary state transition function as implemented by the Ethe
 14. [Merkle trees](https://wikipedia.org/wiki/Merkle_tree)
 15. [Patricia trees](https://wikipedia.org/wiki/Patricia_tree)
 16. [GHOST](https://eprint.iacr.org/2013/881.pdf)
-17. [StorJ and Autonomous Agents, Jeff Garzik](https://web.archive.org/web/20180524103011/https://garzikrants.blogspot.com/2013/01/storj-and-bitcoin-autonomous-agents.html)
+17. [StorJ and Autonomous Agents, Jeff Garzik](https://garzikrants.blogspot.com/2013/01/storj-and-bitcoin-autonomous-agents.html)
 18. [Mike Hearn on Smart Property at Turing Festival](https://www.youtube.com/watch?v=MVyv4t0OKe4)
 19. [Ethereum RLP](/developers/docs/data-structures-and-encoding/rlp/)
 20. [Ethereum Merkle Patricia trees](/developers/docs/data-structures-and-encoding/patricia-merkle-trie/)

--- a/public/content/whitepaper/index.md
+++ b/public/content/whitepaper/index.md
@@ -511,7 +511,7 @@ The concept of an arbitrary state transition function as implemented by the Ethe
 14. [Merkle trees](https://wikipedia.org/wiki/Merkle_tree)
 15. [Patricia trees](https://wikipedia.org/wiki/Patricia_tree)
 16. [GHOST](https://eprint.iacr.org/2013/881.pdf)
-17. [StorJ and Autonomous Agents, Jeff Garzik](http://garzikrants.blogspot.ca/2013/01/storj-and-bitcoin-autonomous-agents.html)
+17. [StorJ and Autonomous Agents, Jeff Garzik](https://web.archive.org/web/20180524103011/https://garzikrants.blogspot.com/2013/01/storj-and-bitcoin-autonomous-agents.html)
 18. [Mike Hearn on Smart Property at Turing Festival](https://www.youtube.com/watch?v=MVyv4t0OKe4)
 19. [Ethereum RLP](/developers/docs/data-structures-and-encoding/rlp/)
 20. [Ethereum Merkle Patricia trees](/developers/docs/data-structures-and-encoding/patricia-merkle-trie/)


### PR DESCRIPTION
## Description

Replaces the dead Blogspot link to Jeff Garzik's StorJ article with an Internet Archive snapshot, using the more reliable (blogspot.com) domain over (blogspot.ca).

## Related Issue

Fixes #18549