### PR TITLE
fix: broken http link to JSON-RPC specification

### DIFF
--- a/public/content/developers/docs/apis/json-rpc/index.md
+++ b/public/content/developers/docs/apis/json-rpc/index.md
@@ -1889,7 +1889,7 @@ This was just a brief introduction into some of the most common tasks, demonstra
 
 ## Related topics {#related-topics}
 
-- [JSON-RPC specification](http://www.jsonrpc.org/specification)
+- [JSON-RPC specification](https://www.jsonrpc.org/specification)
 - [Nodes and clients](/developers/docs/nodes-and-clients/)
 - [JavaScript APIs](/developers/docs/apis/javascript/)
 - [Backend APIs](/developers/docs/apis/backend/)


### PR DESCRIPTION
## Description

Upgrades (http://www.jsonrpc.org/specification) to (https://www.jsonrpc.org/specification), matching the HTTPS link already used on line 11 of the same file.

## Related Issue

Fixes #18550