### PR TITLE
fix: dead CriptoAtivos Wiki domain

### DIFF
--- a/public/content/community/language-resources/index.md
+++ b/public/content/community/language-resources/index.md
@@ -39,7 +39,7 @@ If you are bilingual and want to help us reach more people, you can also get inv
 - [web3dev](https://www.web3dev.com.br/) - Content hub and Discord community for web 3 developers.
 - [Web3Brasil](https://github.com/web3brasil/web3brasil) - resources for learning Web3 and DeFi
 - [CriptoFacil](http://www.criptofacil.com/ultimas-noticias/) - cryptocurrency news and education, including ‘Ethereum for beginners’ and ‘DeFi’ for beginners
-- [CriptoAtivos](http://www.criptoativos.wiki.br/) - insights from the cryptocurrency space, education and blog
+- [CriptoAtivos](https://web.archive.org/web/20220916210708/https://www.criptoativos.wiki.br/) - insights from the cryptocurrency space, education and blog
 - [Cointimes](http://www.cointimes.com.br/) - cryptocurrency news and education
 - [Web3 starter pack](https://docs.google.com/document/d/1X8PSTFH7FTw9J-gbKWM6Y430SWCBT8d4t4pJgFQHJ8E/) - a guide answering the most frequently asked and fundamental crypto questions
 


### PR DESCRIPTION
## Description

Replaces the dead (http://www.criptoativos.wiki.br/) link with an Internet Archive snapshot.

## Related Issue

Fixes #18557