### PR TITLE
fix: dead Cointelegraph Brazil analysis page (404)

### DIFF
--- a/public/content/community/language-resources/index.md
+++ b/public/content/community/language-resources/index.md
@@ -29,7 +29,7 @@ If you are bilingual and want to help us reach more people, you can also get inv
 **News**
 
 - [BeInCrypto](http://www.beincrypto.com.br) - cryptocurrency news and articles, including a list of exchanges, available in Brazil
-- [Cointelegraph](http://cointelegraph.com.br/category/analysis) - Brazilian version of Cointelegraph, a major cryptocurrency news outlet
+- [Cointelegraph](https://cointelegraph.com.br/) - Brazilian version of Cointelegraph, a major cryptocurrency news outlet
 - [Livecoins](http://www.livecoins.com.br/ethereum) - cryptocurrency news and tools
 - [Seudinheiro](http://www.seudinheiro.com/criptomoedas/) - cryptocurrency news and reports
 - [Modular Crypto](https://modularcrypto.xyz/) - cryptocurrency news and educational articles


### PR DESCRIPTION
## Description

Replaces the broken (http://cointelegraph.com.br/category/analysis) link (HTTP 404) with (https://cointelegraph.com.br/).

## Related Issue

Fixes #18558