### PR TITLE
Fix broken BeInCrypto Brazil link (HTTP 403 Forbidden)

### DIFF
--- a/public/content/community/language-resources/index.md
+++ b/public/content/community/language-resources/index.md
@@ -26,7 +26,7 @@ If you are bilingual and want to help us reach more people, you can also get inv
 
 **News**
 
-- [BeInCrypto](http://www.beincrypto.com.br) - cryptocurrency news and articles, including a list of exchanges, available in Brazil
+- [BeInCrypto](https://br.beincrypto.com/) - cryptocurrency news and articles, including a list of exchanges, available in Brazil
 - [Cointelegraph](http://cointelegraph.com.br/category/analysis) - Brazilian version of Cointelegraph, a major cryptocurrency news outlet
 - [Livecoins](http://www.livecoins.com.br/ethereum) - cryptocurrency news and tools
 - [Seudinheiro](http://www.seudinheiro.com/criptomoedas/) - cryptocurrency news and reports


### PR DESCRIPTION
The old domain beincrypto.com.br returns HTTP 403. The site has moved to br.beincrypto.com. (https://br.beincrypto.com/)

Closes #18567