### PR TITLE
Fix broken Pomiager blog link (SSL certificate error)

### DIFF
--- a/public/content/developers/docs/programming-languages/dot-net/index.md
+++ b/public/content/developers/docs/programming-languages/dot-net/index.md
@@ -50,7 +50,7 @@ Need a more basic primer first? Check out [ethereum.org/learn](/learn/) or [ethe
 - [VSCode Codegen Plugin for Solidity](https://docs.nethereum.com/docs/aspire-templates/guide-codegen)
 - [Unity and Ethereum: Why and How](https://www.raywenderlich.com/5509-unity-and-ethereum-why-and-how)
 - [Create ASP.NET Core Web API for Ethereum dapps](https://tech-mint.com/blockchain/create-asp-net-core-web-api-for-ethereum-dapps/)
-- [Using Nethereum Web3 to Implement a Supply Chain Tracking System](http://blog.pomiager.com/post/using-nethereum-web3-to-implement-a-supply-chain-traking-system4)
+- [Using Nethereum Web3 to Implement a Supply Chain Tracking System](https://web.archive.org/web/20220526020350/http://blog.pomiager.com/post/using-nethereum-web3-to-implement-a-supply-chain-traking-system4)
 - [Nethereum Blockchain Processing](https://docs.nethereum.com/docs/data-and-indexing/guide-blockchain-processing)
 - [Nethereum Websocket Streaming](https://nethereum.readthedocs.io/en/latest/nethereum-subscriptions-streaming/)
 - [Kaleido and Nethereum](https://kaleido.io/kaleido-and-nethereum/)


### PR DESCRIPTION
The original URL http://blog.pomiager.com/... has an SSL error. Replaced with Internet Archive snapshot. (https://web.archive.org/web/20220526020350/http://blog.pomiager.com/post/using-nethereum-web3-to-implement-a-supply-chain-traking-system4)

Also found that the post has moved to https://us.pomiager.com/using-nethereum-web3-to-implement-a-supply-chain-traking-system4/ but that URL also rejects automated requests, so using the Wayback Machine snapshot.

Closes #18568