### PR TITLE
fix(intl): make the translation pipeline reliable (manifest race, crash-safety, PR body, RECITATION)

### DIFF
--- a/.claude/skills/intl-pipeline/references/gotchas.md
+++ b/.claude/skills/intl-pipeline/references/gotchas.md
@@ -17,10 +17,12 @@ The Gemini adapter at `src/scripts/intl-pipeline/lib/llm/gemini.ts` checks `resp
 - `STOP` — normal completion
 - `MAX_TOKENS` — output truncated; section probably too large
 - `SAFETY` — content filter blocked it. Safety settings are `BLOCK_NONE` in the adapter, but blocks can still trigger on some edge content (mining/attack descriptions in certain non-Latin languages). If `BLOCK_NONE` doesn't help, the prompt or content needs rework, not the safety settings.
-- `RECITATION` — model declined to reproduce training data. Rare; restart usually resolves.
+- `RECITATION` — model declined to reproduce training data. **Deterministic per file+language**, NOT transient: the adapter retries the byte-identical prompt up to 3x and gets the identical `RECITATION` every time (`tokens_out=0`), then gives up. The file+lang is then skipped — it ships untranslated (keeps its prior/English state), is recorded as a failed task, and listed in the PR body's failure block. Restarting the whole run will hit the exact same combos. Recurring victims are long reference docs (consensus-mechanisms `pos`/`poa`, `defi`, `ethash`, whitepaper) in fr/es/pt-br. The real fix is upstream of a plain retry: mutate before retrying (smaller chunks, secondary model, reworded prompt) or accept the skip and handle those files out-of-band. Don't burn time expecting a re-run to clear them.
 - `OTHER` — bucket catchall. Log shows full response; debug case-by-case.
 
 Non-STOP finish reasons are logged at WARNING level. Search workflow logs for `FINISH_REASON` if a section seems to be missing translation output.
+
+**Beware: a "success" workflow conclusion does not mean a clean run.** Per-file+lang tasks that fail (RECITATION, blob/build errors) are emitted as `[WARN]`, listed in the PR body's "N task(s) failed" block, and the run still goes green. Always read the PR body's failure block and grep the log before trusting a green run. See `recovery.md` -> "Diagnosing a completed run."
 
 ## `intl-content-tree` is a separate npm package
 

--- a/.claude/skills/intl-pipeline/references/recovery.md
+++ b/.claude/skills/intl-pipeline/references/recovery.md
@@ -6,6 +6,8 @@ Load this when "the pipeline did something wrong" — bad translation in product
 
 | Symptom | First check | Likely fix |
 |---|---|---|
+| Run reported "success" but content looks incomplete | Read the PR body's "N task(s) failed" block + grep the log | "Success" ships partial failures; see "Diagnosing a completed run" below |
+| Lots of content changed but few/no manifests in the PR diff | Content and manifests desynced (manifest drift) | See "Manifest drift after a run" below |
 | Translation looks wrong, not yet merged | Is it a glossary deviation? | Re-run pipeline targeting that file+locale; auto-fix should correct |
 | Translation already merged to `dev`, looks wrong | Is the English version up to date? | Re-run with `mode: full` for that file |
 | Manifest file is invalid / missing | One of the two manifests gone? | Delete both manifests for that file+locale; pipeline auto-runs full mode |
@@ -14,6 +16,68 @@ Load this when "the pipeline did something wrong" — bad translation in product
 | LLM returned garbage / refused | Check `finishReason` in logs | Retry with same content; if persistent, file/Latinize the input and retry |
 | English-locale structural mismatch (locale missing inline element vs English) | Look at the manifest's element mapping | Re-run `mode: full` for that file; pipeline regenerates from scratch |
 | Hand-edit slipped through review | Was it pre- or post-English-change? | If pre-: leave it, manifest still valid. If post-: re-run pipeline; will overwrite OR conflict |
+
+## Diagnosing a completed run
+
+A run finished. Before trusting it, audit it — a green "success" conclusion can still hide skipped files (RECITATION etc.). This is the recipe; it's faster than reading the whole log top-to-bottom.
+
+**1. Read the PR body first.** The pipeline's PR body carries the per-run summary and a "N task(s) failed" block with copy-paste rerun commands. That block is the authoritative list of what did NOT translate. (If the PR step itself failed — see "PR body too large" below — the body may be a hand-written recovery summary instead.)
+
+**2. Grep the log for the high-signal lines** (logs are huge; the head is just ~30k-file checkout noise — grep, don't scroll):
+
+```bash
+gh run view <run-id> --log > /tmp/run.log
+grep -iE "\[ERROR\]|##\[error\]|RECITATION|finishReason|Failed to update ref|Merge conflict|TARGET_PATH|task\(s\) failed" /tmp/run.log
+# RECITATION victims (discount large chunked files like apis/json-rpc — chunk fan-out inflates counts):
+grep -oE "file=public/content/[^ ]+ lang=[a-z-]+" /tmp/run.log | sort | uniq -c | sort -rn
+```
+
+**3. Verify content/manifest parity on the branch** (catches manifest drift — see next section):
+
+```bash
+git fetch origin
+git diff --name-only origin/dev...origin/intl/pending-dev > /tmp/changed.txt
+grep -c "content/translations/.*\.md$" /tmp/changed.txt     # translated markdown
+grep -c "^src/intl/.*\.json$" /tmp/changed.txt              # translated JSON (minus manifests)
+grep -c "^\.manifests/.*source\.json$" /tmp/changed.txt     # source manifests
+grep -c "^\.manifests/.*translation\.json$" /tmp/changed.txt # translation manifests
+```
+
+Healthy run: every translated content file has a matching `.manifests/<destPath>/source.json` (+ `translation.json` where placeholders apply). Manifests live in `.manifests/{destPath}/` — NOT next to the locale file. If content counts vastly exceed manifest counts, you have drift.
+
+Error-string -> source map (where to look when a signature appears):
+
+| Log signature | Source |
+|---|---|
+| `Failed to update ref` / squash errors | `lib/github/commits.ts` (`SharedCommitter`) |
+| `Key set mismatch` / `Suspiciously short` / refusal | `lib/llm/output-validation.ts` |
+| `FINISH_REASON` / `RECITATION` | `lib/llm/gemini.ts` |
+| PR body assembly / length | `lib/workflows/pr-creation.ts` |
+| rate-limit backoff (403/429) | `lib/utils/fetch.ts` |
+
+## Manifest drift after a run
+
+**Symptom:** the PR diff shows many translated content files but few/no `.manifests/` updates (content/manifest parity check in step 3 above fails badly).
+
+**What it means:** content shipped without its manifest. The manifest still reflects the pre-run English state, so the NEXT run sees those files as still-needing-translation and re-translates all of them — a churn loop that also blocks running the pipeline on every merge.
+
+**Historical cause (FIXED):** the `SharedCommitter` used to advance the branch ref on every per-file commit. Under the task pool's concurrency those ref updates raced and returned `422 not a fast forward`; a content commit that threw on the 422 aborted before its manifest commit, and the end-of-run squash shipped the (already-recorded) content blob without the (never-recorded) manifest. Fix: `commitFile` now only creates+records a blob and never touches the ref; the squash force-updates once; per task, manifests are built before any blob is recorded so a builder error strands nothing. Guarded by `tests/unit/intl-pipeline/commit-ref-race.spec.ts`. If you see fresh drift on a run AFTER this fix, suspect a new throw point between a content commit and its manifest commit in `main.ts` (`runFullTranslation`/`runIncremental`), not the committer.
+
+**Recovery for a branch already in a drift state** (e.g. PR #18471): the content on the branch is correct, only the manifests are stale. Cheapest correct path is to discard and re-run clean now that the cause is fixed (the job is a few dollars and a re-run validates the fix end to end); the alternative is a `stamp_only` pass to regenerate the missing manifests against the committed content, which is fragile and only worth it to preserve an expensive run.
+
+## PR body too large
+
+**Symptom:** the run translates fine but the pipeline's own PR-creation step fails because the auto-generated body (which lists every changed file) exceeds GitHub's 65,536-char limit. Common on full-tree runs (~900+ files).
+
+**Recovery:** open the PR manually with a consolidated summary (per-language + per-area counts, omit the per-file list), pointing at the run. The translations are already committed to `intl/pending-{base}`; only the PR-body generation failed. Durable fix: cap/clip the body in `lib/workflows/pr-creation.ts`.
+
+## Wedged pending branch (`intl/pending-intl-pending-*`)
+
+**Symptom:** runs fail at the pre-flight merge gate with a doubled branch name like `intl/pending-intl-pending-dev`, and dispatch retries keep cancelling each other under the workflow's concurrency group.
+
+**Cause:** a run was dispatched with a `target_branch`/base that produced a doubled `intl/pending-` prefix; that branch has conflicts so every retry aborts.
+
+**Recovery:** delete the wedged branch, then re-run with the correct (blank or `dev`) base so the target resolves to plain `intl/pending-dev`.
 
 ## Bad translation (not yet merged)
 

--- a/src/scripts/intl-pipeline/lib/github/commits.ts
+++ b/src/scripts/intl-pipeline/lib/github/commits.ts
@@ -21,17 +21,21 @@ interface TreeItem {
 /**
  * Shared committer for parallel language translation.
  *
- * Creates individual chained commits (each parented on the previous)
- * so multiple languages can interleave safely. Each file appears on the
- * branch immediately for crash safety.
+ * commitFile() only creates a git blob and records it per-language; it does
+ * NOT touch the branch ref. squashByLanguage() (called once after all tasks
+ * drain) builds the real commit chain from the recorded blobs and force-updates
+ * the ref a single time.
  *
- * After all translations complete, call squashByLanguage() to collapse
- * the individual commits into one per language for a clean history.
+ * This deliberately does NOT advance the branch ref per file. An earlier design
+ * created a chained commit + ref update for every file, but under the pool's
+ * concurrency those per-file ref updates raced and returned 422 "not a fast
+ * forward". A task that threw on that 422 had already recorded its content blob
+ * but aborted before recording its manifest blob(s), so the squash shipped
+ * content WITHOUT its manifest -- silently desyncing the manifest tracking that
+ * the whole incremental pipeline depends on. The per-file ref update was also
+ * redundant: the squash rebuilds everything from blobsByLanguage regardless.
  */
 export class SharedCommitter {
-  private currentCommitSha = ""
-  private currentTreeSha = ""
-  private queue: Promise<void> = Promise.resolve()
   private baseUrl = `https://api.github.com/repos/${config.ghOrganization}/${config.ghRepo}`
   /** Track blob SHAs per language for squashing */
   private blobsByLanguage = new Map<string, TreeItem[]>()
@@ -40,7 +44,7 @@ export class SharedCommitter {
 
   constructor(private branch: string) {}
 
-  /** Snapshot the current branch state. */
+  /** Snapshot the base commit the squash will build on top of. */
   async init(): Promise<void> {
     const refRes = await fetchWithRetry(
       `${this.baseUrl}/git/ref/heads/${this.branch}`,
@@ -51,48 +55,24 @@ export class SharedCommitter {
       throw new Error(`SharedCommitter init ref (${refRes.status}): ${body}`)
     }
     const refData: { object: { sha: string } } = await refRes.json()
-    this.currentCommitSha = refData.object.sha
     this.originalBaseSha = refData.object.sha
-
-    const commitRes = await fetchWithRetry(
-      `${this.baseUrl}/git/commits/${this.currentCommitSha}`,
-      { headers: gitHubBearerHeaders }
-    )
-    if (!commitRes.ok) {
-      const body = await commitRes.text().catch(() => "")
-      throw new Error(
-        `SharedCommitter init commit (${commitRes.status}): ${body}`
-      )
-    }
-    const commitData: { tree: { sha: string } } = await commitRes.json()
-    this.currentTreeSha = commitData.tree.sha
   }
 
   /**
-   * Queue a file commit. Serialized so concurrent languages don't race.
-   * Each commit chains on the previous (not amending).
+   * Record a file for committing: creates a git blob and tracks it under its
+   * language. Does NOT touch the branch ref -- squashByLanguage() builds the
+   * commit chain from the tracked blobs at the end of the run.
+   *
+   * Safe to call concurrently across languages and files: blob creation is an
+   * independent API call and the per-language array push is atomic on the JS
+   * event loop. Crucially, this never throws on a branch-ref race, so a task
+   * always reaches its manifest commits after its content commit.
    */
-  commitFile(
+  async commitFile(
     filePath: string,
     content: string,
     language: string
   ): Promise<void> {
-    const result = this.queue.then(() =>
-      this._doCommit(filePath, content, language)
-    )
-    this.queue = result.then(
-      () => {},
-      () => {}
-    )
-    return result
-  }
-
-  private async _doCommit(
-    filePath: string,
-    content: string,
-    language: string
-  ): Promise<void> {
-    // 1. Create blob
     const blobRes = await fetchWithRetry(`${this.baseUrl}/git/blobs`, {
       method: "POST",
       headers: { ...gitHubBearerHeaders, "Content-Type": "application/json" },
@@ -116,62 +96,12 @@ export class SharedCommitter {
       sha: blobData.sha,
     }
 
-    // Track blob for squashing
     if (!this.blobsByLanguage.has(language)) {
       this.blobsByLanguage.set(language, [])
     }
     this.blobsByLanguage.get(language)!.push(item)
 
-    // 2. Create tree on top of current tree
-    const treeRes = await fetchWithRetry(`${this.baseUrl}/git/trees`, {
-      method: "POST",
-      headers: { ...gitHubBearerHeaders, "Content-Type": "application/json" },
-      body: JSON.stringify({
-        base_tree: this.currentTreeSha,
-        tree: [item],
-      }),
-    })
-    if (!treeRes.ok) {
-      const body = await treeRes.text().catch(() => "")
-      throw new Error(`Failed to create tree (${treeRes.status}): ${body}`)
-    }
-    const treeData: { sha: string } = await treeRes.json()
-
-    // 3. Create commit parented on the current tip (chaining, not amending)
-    const commitRes = await fetchWithRetry(`${this.baseUrl}/git/commits`, {
-      method: "POST",
-      headers: { ...gitHubBearerHeaders, "Content-Type": "application/json" },
-      body: JSON.stringify({
-        message: `i18n(${language}): ${filePath.split("/").pop()}`,
-        tree: treeData.sha,
-        parents: [this.currentCommitSha],
-      }),
-    })
-    if (!commitRes.ok) {
-      const body = await commitRes.text().catch(() => "")
-      throw new Error(`Failed to create commit (${commitRes.status}): ${body}`)
-    }
-    const commitData: { sha: string } = await commitRes.json()
-
-    // 4. Update branch ref (no force needed -- linear chain)
-    const updateRes = await fetchWithRetry(
-      `${this.baseUrl}/git/refs/heads/${this.branch}`,
-      {
-        method: "PATCH",
-        headers: { ...gitHubBearerHeaders, "Content-Type": "application/json" },
-        body: JSON.stringify({ sha: commitData.sha }),
-      }
-    )
-    if (!updateRes.ok) {
-      const body = await updateRes.text().catch(() => "")
-      throw new Error(`Failed to update ref (${updateRes.status}): ${body}`)
-    }
-
-    // Advance internal state
-    this.currentCommitSha = commitData.sha
-    this.currentTreeSha = treeData.sha
-
-    debugLog(`SharedCommitter [${language}]: committed ${filePath}`)
+    debugLog(`SharedCommitter [${language}]: recorded ${filePath}`)
   }
 
   /**
@@ -264,10 +194,6 @@ export class SharedCommitter {
         `Failed to update ref after squash (${updateRes.status}): ${body}`
       )
     }
-
-    // Update internal state
-    this.currentCommitSha = parentSha
-    this.currentTreeSha = currentTree
 
     console.log(
       `[SharedCommitter] Squash complete: ${languages.length} commits`

--- a/src/scripts/intl-pipeline/lib/github/commits.ts
+++ b/src/scripts/intl-pipeline/lib/github/commits.ts
@@ -19,6 +19,14 @@ interface TreeItem {
 }
 
 /**
+ * Recorded files between crash-safety checkpoints. A checkpoint flushes
+ * everything recorded so far to the branch, so at most this many files' worth
+ * of LLM output is at risk if the job dies mid-run. Tuned for a balance between
+ * durability and the extra commits/API calls each checkpoint costs.
+ */
+export const CHECKPOINT_EVERY = 50
+
+/**
  * Shared committer for parallel language translation.
  *
  * commitFile() only creates a git blob and records it per-language; it does
@@ -41,10 +49,20 @@ export class SharedCommitter {
   private blobsByLanguage = new Map<string, TreeItem[]>()
   /** SHA of the original base before any translations */
   private originalBaseSha = ""
+  /** Tree of the original base, captured once in init(). */
+  private baseTreeSha = ""
+  /** Files recorded since the last checkpoint (drives periodic flushing). */
+  private recordedSinceCheckpoint = 0
+  /**
+   * Single-writer lock serializing every branch-ref update (periodic
+   * checkpoints + the final squash). Exactly one ref update is ever in flight,
+   * so they cannot race into the 422 the per-file commits used to.
+   */
+  private refLock: Promise<void> = Promise.resolve()
 
   constructor(private branch: string) {}
 
-  /** Snapshot the base commit the squash will build on top of. */
+  /** Snapshot the base commit the checkpoints/squash build on top of. */
   async init(): Promise<void> {
     const refRes = await fetchWithRetry(
       `${this.baseUrl}/git/ref/heads/${this.branch}`,
@@ -56,6 +74,46 @@ export class SharedCommitter {
     }
     const refData: { object: { sha: string } } = await refRes.json()
     this.originalBaseSha = refData.object.sha
+
+    const commitRes = await fetchWithRetry(
+      `${this.baseUrl}/git/commits/${this.originalBaseSha}`,
+      { headers: gitHubBearerHeaders }
+    )
+    if (!commitRes.ok) {
+      const body = await commitRes.text().catch(() => "")
+      throw new Error(
+        `SharedCommitter init commit (${commitRes.status}): ${body}`
+      )
+    }
+    const commitData: { tree: { sha: string } } = await commitRes.json()
+    this.baseTreeSha = commitData.tree.sha
+  }
+
+  /**
+   * Flush everything recorded so far to the branch, serialized and non-fatal.
+   * This is just the squash run mid-stream: it rebuilds one commit per language
+   * from base and force-updates the ref, so costly LLM output survives a crash
+   * instead of waiting for the end-of-run squash. Granularity is per-file (via
+   * CHECKPOINT_EVERY), not per-language, so a large job can't lose a whole
+   * language's work. Fire-and-forget; failures are logged, never fatal -- the
+   * final squashByLanguage() re-commits everything regardless.
+   */
+  checkpoint(): Promise<void> {
+    this.refLock = this.refLock.then(async () => {
+      try {
+        await this._squashNow("Checkpoint")
+      } catch (err) {
+        console.warn(
+          `[SharedCommitter] Checkpoint failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`
+        )
+      }
+    })
+    return this.refLock
+  }
+
+  /** Await any in-flight checkpoint. */
+  async flushCheckpoints(): Promise<void> {
+    await this.refLock
   }
 
   /**
@@ -102,36 +160,46 @@ export class SharedCommitter {
     this.blobsByLanguage.get(language)!.push(item)
 
     debugLog(`SharedCommitter [${language}]: recorded ${filePath}`)
+
+    // Periodically flush to the branch for crash safety. Fire-and-forget: the
+    // checkpoint is serialized through refLock and awaited before the final
+    // squash. Reset the counter now (not on completion) so we don't queue a
+    // burst of redundant checkpoints while one is in flight.
+    if (++this.recordedSinceCheckpoint >= CHECKPOINT_EVERY) {
+      this.recordedSinceCheckpoint = 0
+      void this.checkpoint()
+    }
   }
 
   /**
-   * Squash all individual commits into one per language.
-   * Builds a new commit chain from the original base:
-   *   base -> lang1 (all files) -> lang2 (all files) -> ...
-   * Then force-updates the branch ref.
+   * Final consolidation: one commit per language from the recorded blobs,
+   * force-updating the branch ref once. Idempotent with the periodic
+   * checkpoints (both rebuild from base), so the end state is the same however
+   * many checkpoints ran. Called after the task pool drains.
    */
   async squashByLanguage(): Promise<void> {
+    // Wait for any in-flight checkpoint so it can't race this final ref update.
+    await this.flushCheckpoints()
+    await this._squashNow("Squash")
+  }
+
+  /**
+   * Rebuild one commit per language from blobsByLanguage on top of the base and
+   * force-update the ref. Used for both periodic checkpoints and the final
+   * squash. Reads blobsByLanguage as it goes; concurrent commitFile() appends
+   * are picked up by a later checkpoint (or the final squash), never lost.
+   */
+  private async _squashNow(label: string): Promise<void> {
     const languages = Array.from(this.blobsByLanguage.keys()).sort()
     if (languages.length === 0) return
 
     console.log(
-      `[SharedCommitter] Squashing ${languages.length} language(s): ${languages.join(", ")}`
+      `[SharedCommitter] ${label}: ${languages.length} language(s): ${languages.join(", ")}`
     )
 
     let parentSha = this.originalBaseSha
-    // Get the original base tree
-    const baseCommitRes = await fetchWithRetry(
-      `${this.baseUrl}/git/commits/${this.originalBaseSha}`,
-      { headers: gitHubBearerHeaders }
-    )
-    if (!baseCommitRes.ok) {
-      const body = await baseCommitRes.text().catch(() => "")
-      throw new Error(
-        `Failed to get base commit for squash (${baseCommitRes.status}): ${body}`
-      )
-    }
-    const baseCommitData: { tree: { sha: string } } = await baseCommitRes.json()
-    let currentTree = baseCommitData.tree.sha
+    // Base tree was captured in init().
+    let currentTree = this.baseTreeSha
 
     for (const lang of languages) {
       const blobs = this.blobsByLanguage.get(lang)!
@@ -196,7 +264,7 @@ export class SharedCommitter {
     }
 
     console.log(
-      `[SharedCommitter] Squash complete: ${languages.length} commits`
+      `[SharedCommitter] ${label} complete: ${languages.length} commits`
     )
   }
 

--- a/src/scripts/intl-pipeline/lib/llm/gemini.ts
+++ b/src/scripts/intl-pipeline/lib/llm/gemini.ts
@@ -1321,8 +1321,16 @@ export async function callGeminiRaw(
     for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
       const startTime = Date.now()
 
+      // Temperature 0 gives the best, deterministic translation on the first
+      // attempt. But RECITATION (Gemini's recitation/content checker) is
+      // deterministic at temp 0, so identical retries -- and even fallback
+      // models fed the same input -- get blocked identically. Escalate the
+      // temperature on retries to introduce variation that dodges the
+      // recitation match (e.g. on our own open-licensed whitepaper content).
+      const temperature = attempt === 1 ? 0 : Math.min(0.5 * (attempt - 1), 1)
+
       console.log(
-        `[${ts()}] [gemini] REQUEST model=${modelId} ${ctx}${attempt > 1 ? ` attempt=${attempt}` : ""}`
+        `[${ts()}] [gemini] REQUEST model=${modelId} ${ctx}${attempt > 1 ? ` attempt=${attempt} temp=${temperature}` : ""}`
       )
 
       if (verbose) {
@@ -1355,7 +1363,7 @@ export async function callGeminiRaw(
             model: modelId,
             contents: prompt,
             config: {
-              temperature: 0,
+              temperature,
               safetySettings: SAFETY_SETTINGS,
               abortSignal: controller.signal,
             },

--- a/src/scripts/intl-pipeline/lib/workflows/pr-creation.ts
+++ b/src/scripts/intl-pipeline/lib/workflows/pr-creation.ts
@@ -11,6 +11,26 @@ import type { CommittedFile, LanguagePair } from "./types"
 import { logSection } from "./utils"
 
 /**
+ * GitHub rejects PR bodies over 65,536 chars. Keep headroom and clamp before
+ * every create/update so a long failure list or accumulated run history can
+ * never block the PR (this previously failed full-tree runs -- see PR #18471).
+ */
+export const MAX_PR_BODY = 60_000
+/** Cap the per-run failure + rerun lists; full set is in the workflow log. */
+const MAX_FAILURES_LISTED = 40
+
+/**
+ * Clamp a PR body to MAX_PR_BODY, preserving the TAIL (the newest run summary
+ * is the most useful) and prefixing a truncation notice.
+ */
+export function clampBody(body: string): string {
+  if (body.length <= MAX_PR_BODY) return body
+  const notice =
+    "_[earlier content truncated to fit GitHub's PR body limit; see workflow logs for full history]_\n\n"
+  return notice + body.slice(body.length - (MAX_PR_BODY - notice.length))
+}
+
+/**
  * Generate PR title based on language count
  */
 export function generatePRTitle(
@@ -79,16 +99,21 @@ export function generateRunSummary(
   }
 
   if (failures.length > 0) {
-    parts.push("", `**${failures.length} task(s) failed:**`, "")
-    for (const f of failures) {
+    const shown = failures.slice(0, MAX_FAILURES_LISTED)
+    const extra = failures.length - shown.length
+    const cap = extra > 0 ? ` (showing first ${MAX_FAILURES_LISTED})` : ""
+    parts.push("", `**${failures.length} task(s) failed${cap}:**`, "")
+    for (const f of shown) {
       parts.push(`- \`${f.file}\` (${f.locale}): ${f.message}`)
     }
+    if (extra > 0) parts.push(`- ...and ${extra} more (see workflow log)`)
     parts.push("", "Rerun the failed combinations:", "", "```")
-    for (const f of failures) {
+    for (const f of shown) {
       parts.push(
         `gh workflow run "Intl Pipeline" -f target_path="${f.file}" -f target_languages="${f.locale}"`
       )
     }
+    if (extra > 0) parts.push(`# ...and ${extra} more (see workflow log)`)
     parts.push("```")
   }
 
@@ -139,8 +164,9 @@ export async function createOrUpdateTranslationPR(
   const existingPR = await findOpenPR(branch, config.baseBranch)
 
   if (existingPR) {
-    // Append run summary to existing PR body
-    const updatedBody = (existingPR.body || "") + "\n" + runSummary
+    // Append run summary to existing PR body (clamped so accumulated history
+    // can never exceed GitHub's limit).
+    const updatedBody = clampBody((existingPR.body || "") + "\n" + runSummary)
     await updatePRBody(existingPR.number, updatedBody)
     console.log(
       `[pr] Updated existing PR #${existingPR.number}: ${existingPR.html_url}`
@@ -150,7 +176,7 @@ export async function createOrUpdateTranslationPR(
 
   // Create new PR
   const prTitle = generatePRTitle(langCodes, config.allInternalCodes)
-  const prBody = generateInitialPRBody() + "\n" + runSummary
+  const prBody = clampBody(generateInitialPRBody() + "\n" + runSummary)
 
   const pr = await postPullRequest(branch, config.baseBranch, prTitle, prBody)
   console.log(`[pr] Created PR #${pr.number}: ${pr.html_url}`)

--- a/src/scripts/intl-pipeline/main.ts
+++ b/src/scripts/intl-pipeline/main.ts
@@ -469,20 +469,16 @@ async function runFullTranslation(
     }
   }
 
-  await committer.commitFile(destPath, finalContent, locale)
-  committedFiles.push({ path: destPath, content: finalContent })
-
-  // Build and commit source manifest
+  // Build the manifests BEFORE recording any blob. Manifest construction is
+  // pure and can throw (parse/serialize); doing it first means a builder error
+  // aborts the task without leaving content recorded sans its manifest -- the
+  // same content-without-manifest desync the ref-race fix already closed.
   const sourceManifest =
     file.type === "markdown"
       ? buildMarkdownManifest(file.content, file.path, baseBranchSha)
       : buildJsonManifest(file.content, file.path, baseBranchSha)
-
-  // Commit source manifest
   const smDest = getManifestPath(destPath, "source")
-  await committer.commitFile(smDest, sourceManifest, locale)
 
-  // Commit translation manifest
   const placeholderData =
     result.placeholderOrder && result.placeholderMap
       ? {
@@ -493,9 +489,11 @@ async function runFullTranslation(
         ? extractPlaceholderData(parseEnglishJson(file.content))
         : null
 
+  let translationManifest: string | null = null
+  let tmDest: string | null = null
   if (placeholderData) {
     const parsed = JSON.parse(sourceManifest)
-    const tm = buildLocaleTranslationManifest({
+    translationManifest = buildLocaleTranslationManifest({
       locale,
       englishManifestHash: parsed.rootHash,
       placeholderOrder: placeholderData.placeholderOrder,
@@ -504,8 +502,15 @@ async function runFullTranslation(
         _all: { translatedAt: new Date().toISOString(), status: "success" },
       },
     })
-    const tmDest = getManifestPath(destPath, "translation")
-    await committer.commitFile(tmDest, tm, locale)
+    tmDest = getManifestPath(destPath, "translation")
+  }
+
+  // Record content and its manifest(s) together, manifests last.
+  await committer.commitFile(destPath, finalContent, locale)
+  committedFiles.push({ path: destPath, content: finalContent })
+  await committer.commitFile(smDest, sourceManifest, locale)
+  if (translationManifest && tmDest) {
+    await committer.commitFile(tmDest, translationManifest, locale)
   }
 
   log(`[${locale}] ${destPath}: committed`)
@@ -614,15 +619,16 @@ async function runIncremental(
     }
   }
 
-  await committer.commitFile(destPath, finalContent, locale)
-  committedFiles.push({ path: destPath, content: finalContent })
-
+  // Build the source manifest before recording any blob (see runFullTranslation):
+  // a builder throw must not leave content recorded without its manifest.
   const sourceManifest =
     file.type === "markdown"
       ? buildMarkdownManifest(englishB, file.path, baseBranchSha)
       : buildJsonManifest(englishB, file.path, baseBranchSha)
-
   const smDest = getManifestPath(destPath, "source")
+
+  await committer.commitFile(destPath, finalContent, locale)
+  committedFiles.push({ path: destPath, content: finalContent })
   await committer.commitFile(smDest, sourceManifest, locale)
 
   log(`[${locale}] ${destPath}: committed (incremental)`)
@@ -907,9 +913,12 @@ async function main() {
 
   // Log task failures but don't abort -- partial successes ship. Failures are
   // recorded with file context (via submitWithContext) and surfaced in the PR
-  // body with rerun commands. Per-file manifests are only stamped on success,
-  // so a rerun of just the failed combinations naturally retries them without
-  // touching the work that landed this run.
+  // body with rerun commands. A failed task records NEITHER its content nor its
+  // manifest (content+manifests are built then recorded together per task, and
+  // commitFile no longer touches the branch ref mid-run -- see SharedCommitter),
+  // so a failed file simply doesn't appear this run and a rerun re-detects it.
+  // This invariant is what keeps manifest tracking in sync; before it, a
+  // ref-race could ship content without its manifest and desync every rerun.
   if (failures.length > 0) {
     log(
       `${failures.length} task(s) failed (continuing with successes):`,

--- a/tests/unit/intl-pipeline/commit-ref-race.spec.ts
+++ b/tests/unit/intl-pipeline/commit-ref-race.spec.ts
@@ -19,7 +19,10 @@ import { expect, test } from "@playwright/test"
 // because config.ts throws on a missing GITHUB_API_TOKEN at import time.
 import "./env-shim"
 
-import { SharedCommitter } from "@/scripts/intl-pipeline/lib/github/commits"
+import {
+  CHECKPOINT_EVERY,
+  SharedCommitter,
+} from "@/scripts/intl-pipeline/lib/github/commits"
 
 type Recorded = { method: string; path: string }
 
@@ -40,10 +43,15 @@ function jsonRes(status: number, body: unknown) {
  * and the body of every POST /git/trees. Returns a restore() to put the real
  * fetch back.
  */
-function installFakeGitHub() {
+function installFakeGitHub(opts: { failPatchNumbers?: number[] } = {}) {
   const calls: Recorded[] = []
   const treePayloads: { tree: { path: string }[] }[] = []
+  const commitPayloads: { message: string; parents: string[] }[] = []
+  const refUpdates: { sha: string; force?: boolean }[] = []
+  const failPatch = new Set(opts.failPatchNumbers ?? [])
   let blobN = 0
+  let commitN = 0
+  let patchN = 0
   const originalFetch = globalThis.fetch
 
   globalThis.fetch = (async (url: string | URL, init?: RequestInit) => {
@@ -60,14 +68,25 @@ function installFakeGitHub() {
       treePayloads.push(JSON.parse(String(init?.body)))
       return jsonRes(201, { sha: `TREE${treePayloads.length}` })
     }
-    if (u.endsWith("/git/commits")) return jsonRes(201, { sha: "NEWCOMMIT" })
-    if (u.includes("/git/refs/heads/")) return jsonRes(200, {})
+    if (u.endsWith("/git/commits")) {
+      commitPayloads.push(JSON.parse(String(init?.body)))
+      return jsonRes(201, { sha: `COMMIT${++commitN}` })
+    }
+    if (u.includes("/git/refs/heads/")) {
+      patchN++
+      if (failPatch.has(patchN))
+        return jsonRes(422, { message: "Update is not a fast forward" })
+      refUpdates.push(JSON.parse(String(init?.body)))
+      return jsonRes(200, {})
+    }
     throw new Error(`unexpected request: ${method} ${u}`)
   }) as typeof fetch
 
   return {
     calls,
     treePayloads,
+    commitPayloads,
+    refUpdates,
     restore: () => {
       globalThis.fetch = originalFetch
     },
@@ -149,6 +168,103 @@ test.describe("SharedCommitter ref-race safety", () => {
       const allPaths = treePayloads.flatMap((p) => p.tree.map((t) => t.path))
       expect(allPaths).toHaveLength(expected.size)
       for (const p of expected) expect(allPaths).toContain(p)
+    } finally {
+      restore()
+    }
+  })
+
+  test("checkpoint() flushes recorded work mid-run via a single serialized force-update", async () => {
+    const { treePayloads, refUpdates, restore } = installFakeGitHub()
+    try {
+      const committer = new SharedCommitter("intl/pending-dev")
+      await committer.init()
+
+      await committer.commitFile(
+        "public/content/translations/ko/x/index.md",
+        "c",
+        "ko"
+      )
+      await committer.commitFile(
+        ".manifests/public/content/translations/ko/x/index.md/source.json",
+        "{}",
+        "ko"
+      )
+      await committer.commitFile(
+        "public/content/translations/es/x/index.md",
+        "c",
+        "es"
+      )
+
+      // Two checkpoints fired "concurrently" must serialize through refLock and
+      // never issue overlapping ref updates.
+      await Promise.all([committer.checkpoint(), committer.checkpoint()])
+
+      // Each checkpoint is a full squash -> a force-update of the ref.
+      expect(refUpdates.length).toBeGreaterThanOrEqual(1)
+      expect(refUpdates.every((r) => r.force === true)).toBe(true)
+
+      // The checkpoint trees carry every recorded blob (content + manifest).
+      const allPaths = treePayloads.flatMap((p) => p.tree.map((t) => t.path))
+      expect(allPaths).toContain("public/content/translations/ko/x/index.md")
+      expect(allPaths).toContain(
+        ".manifests/public/content/translations/ko/x/index.md/source.json"
+      )
+      expect(allPaths).toContain("public/content/translations/es/x/index.md")
+    } finally {
+      restore()
+    }
+  })
+
+  test("commitFile auto-checkpoints every CHECKPOINT_EVERY files", async () => {
+    const { refUpdates, restore } = installFakeGitHub()
+    try {
+      const committer = new SharedCommitter("intl/pending-dev")
+      await committer.init()
+
+      // Exactly CHECKPOINT_EVERY files must trigger exactly one auto-flush.
+      for (let i = 0; i < CHECKPOINT_EVERY; i++) {
+        await committer.commitFile(
+          `public/content/translations/fr/p${i}/index.md`,
+          "c",
+          "fr"
+        )
+      }
+      await committer.flushCheckpoints()
+
+      expect(refUpdates).toHaveLength(1)
+      expect(refUpdates[0].force).toBe(true)
+    } finally {
+      restore()
+    }
+  })
+
+  test("a failed checkpoint is non-fatal: run continues and the final squash still ships everything", async () => {
+    // First ref PATCH (the checkpoint's force-update) returns 422.
+    const { treePayloads, refUpdates, restore } = installFakeGitHub({
+      failPatchNumbers: [1],
+    })
+    try {
+      const committer = new SharedCommitter("intl/pending-dev")
+      await committer.init()
+
+      const koContent = "public/content/translations/ko/x/index.md"
+      await committer.commitFile(koContent, "c", "ko")
+      await committer.commitFile(
+        "public/content/translations/es/x/index.md",
+        "c",
+        "es"
+      )
+
+      // Checkpoint's PATCH fails; must NOT throw and must NOT poison refLock.
+      await committer.checkpoint() // 422 -> caught, non-fatal
+      expect(refUpdates).toHaveLength(0) // failed PATCH not recorded
+
+      // The backstop: the final squash still ships everything from base.
+      await committer.squashByLanguage()
+      expect(refUpdates).toHaveLength(1) // squash's force-update landed
+      const allPaths = treePayloads.flatMap((p) => p.tree.map((t) => t.path))
+      expect(allPaths).toContain(koContent)
+      expect(allPaths).toContain("public/content/translations/es/x/index.md")
     } finally {
       restore()
     }

--- a/tests/unit/intl-pipeline/commit-ref-race.spec.ts
+++ b/tests/unit/intl-pipeline/commit-ref-race.spec.ts
@@ -1,0 +1,156 @@
+/**
+ * SharedCommitter ref-race regression -- guards the manifest-loss bug.
+ *
+ * Background: an earlier design advanced the branch ref on every per-file
+ * commit. Under the translation pool's concurrency those ref updates raced and
+ * returned 422 "not a fast forward". A task that threw on that 422 had already
+ * recorded its content blob but aborted before recording its manifest blob(s),
+ * so the end-of-run squash shipped content WITHOUT its manifest and silently
+ * desynced manifest tracking (see run 27984239227: ~733 files translated, ~0
+ * markdown manifests committed).
+ *
+ * Contract now: commitFile() only creates+records a blob and NEVER touches the
+ * branch ref. The single ref update happens once, in squashByLanguage().
+ */
+
+import { expect, test } from "@playwright/test"
+
+// Side-effect import: sets placeholder tokens before the @/scripts import below,
+// because config.ts throws on a missing GITHUB_API_TOKEN at import time.
+import "./env-shim"
+
+import { SharedCommitter } from "@/scripts/intl-pipeline/lib/github/commits"
+
+type Recorded = { method: string; path: string }
+
+function jsonRes(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+    clone() {
+      return this
+    },
+  } as unknown as Response
+}
+
+/**
+ * Install a fake GitHub git-data API on globalThis.fetch. Records every call
+ * and the body of every POST /git/trees. Returns a restore() to put the real
+ * fetch back.
+ */
+function installFakeGitHub() {
+  const calls: Recorded[] = []
+  const treePayloads: { tree: { path: string }[] }[] = []
+  let blobN = 0
+  const originalFetch = globalThis.fetch
+
+  globalThis.fetch = (async (url: string | URL, init?: RequestInit) => {
+    const u = String(url)
+    const method = init?.method ?? "GET"
+    calls.push({ method, path: u.replace(/.*\/git\//, "git/") })
+
+    if (u.includes("/git/ref/heads/"))
+      return jsonRes(200, { object: { sha: "BASESHA" } })
+    if (u.includes("/git/commits/") && method === "GET")
+      return jsonRes(200, { tree: { sha: "BASETREE" } })
+    if (u.endsWith("/git/blobs")) return jsonRes(201, { sha: `BLOB${++blobN}` })
+    if (u.endsWith("/git/trees")) {
+      treePayloads.push(JSON.parse(String(init?.body)))
+      return jsonRes(201, { sha: `TREE${treePayloads.length}` })
+    }
+    if (u.endsWith("/git/commits")) return jsonRes(201, { sha: "NEWCOMMIT" })
+    if (u.includes("/git/refs/heads/")) return jsonRes(200, {})
+    throw new Error(`unexpected request: ${method} ${u}`)
+  }) as typeof fetch
+
+  return {
+    calls,
+    treePayloads,
+    restore: () => {
+      globalThis.fetch = originalFetch
+    },
+  }
+}
+
+test.describe("SharedCommitter ref-race safety", () => {
+  test("commitFile records blobs without touching the ref; squash lands content+manifest together", async () => {
+    const { calls, treePayloads, restore } = installFakeGitHub()
+    try {
+      const committer = new SharedCommitter("intl/pending-dev")
+      await committer.init()
+
+      // The exact sequence that used to break: content commit, then its
+      // manifest commit, for the same task.
+      const content = "public/content/translations/ko/x/index.md"
+      const manifest =
+        ".manifests/public/content/translations/ko/x/index.md/source.json"
+      await committer.commitFile(content, "translated", "ko")
+      await committer.commitFile(manifest, "{}", "ko")
+
+      // No branch ref update during the run -- the race surface is gone.
+      expect(calls.filter((c) => c.method === "PATCH")).toHaveLength(0)
+
+      await committer.squashByLanguage()
+
+      // Exactly one ref update, performed once at squash time.
+      expect(calls.filter((c) => c.method === "PATCH")).toHaveLength(1)
+
+      // The squashed tree for ko carries BOTH content and its manifest.
+      const koTree = treePayloads[treePayloads.length - 1].tree.map(
+        (t) => t.path
+      )
+      expect(koTree).toContain(content)
+      expect(koTree).toContain(manifest)
+    } finally {
+      restore()
+    }
+  })
+
+  test("interleaved commitFile across languages records every content+manifest blob", async () => {
+    const { calls, treePayloads, restore } = installFakeGitHub()
+    try {
+      const committer = new SharedCommitter("intl/pending-dev")
+      await committer.init()
+
+      const langs = ["es", "ko", "ar"]
+      const files = ["guides/a/index.md", "guides/b/index.md"]
+      const expected = new Set<string>()
+
+      // Fire every content+manifest commit concurrently, mimicking the task
+      // pool's interleaving across languages. The old serialized/ref-advancing
+      // design would race here; the new one only creates+records blobs.
+      const work: Promise<void>[] = []
+      for (const lang of langs) {
+        for (const f of files) {
+          const content = `public/content/translations/${lang}/${f}`
+          const manifest = `.manifests/${content}/source.json`
+          expected.add(content)
+          expected.add(manifest)
+          // Per task, content is recorded before its manifest.
+          work.push(
+            committer
+              .commitFile(content, "c", lang)
+              .then(() => committer.commitFile(manifest, "{}", lang))
+          )
+        }
+      }
+      await Promise.all(work)
+
+      // Still no ref update until squash.
+      expect(calls.filter((c) => c.method === "PATCH")).toHaveLength(0)
+
+      await committer.squashByLanguage()
+
+      // One squash commit (one tree) per language, and the union of all
+      // squashed trees contains every blob recorded -- nothing dropped.
+      expect(treePayloads).toHaveLength(langs.length)
+      const allPaths = treePayloads.flatMap((p) => p.tree.map((t) => t.path))
+      expect(allPaths).toHaveLength(expected.size)
+      for (const p of expected) expect(allPaths).toContain(p)
+    } finally {
+      restore()
+    }
+  })
+})

--- a/tests/unit/intl-pipeline/pr-body-limit.spec.ts
+++ b/tests/unit/intl-pipeline/pr-body-limit.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * PR-body robustness -- guards against the >65,536-char failure that blocked
+ * the pipeline's own PR step on full-tree runs (see PR #18471, which had to be
+ * opened by hand). The body must always post: failure lists are capped and the
+ * assembled body is clamped under GitHub's limit.
+ */
+
+import { expect, test } from "@playwright/test"
+
+// Side-effect import: sets placeholder tokens before the @/scripts import below,
+// because config.ts throws on a missing GITHUB_API_TOKEN at import time.
+import "./env-shim"
+
+import {
+  clampBody,
+  generateRunSummary,
+  MAX_PR_BODY,
+  type RunFailure,
+} from "@/scripts/intl-pipeline/lib/workflows/pr-creation"
+
+test.describe("PR body limits", () => {
+  test("clampBody leaves short bodies untouched", () => {
+    const body = "## short body\n\nnothing to clamp"
+    expect(clampBody(body)).toBe(body)
+  })
+
+  test("clampBody truncates over-limit bodies, keeps the tail, stays under limit", () => {
+    const newest = "### Run: NEWEST -- this must survive"
+    const body = "x".repeat(MAX_PR_BODY * 2) + "\n" + newest
+    const clamped = clampBody(body)
+    expect(clamped.length).toBeLessThanOrEqual(MAX_PR_BODY)
+    expect(clamped).toContain(newest) // tail preserved
+    expect(clamped).toContain("truncated") // notice prefixed
+  })
+
+  test("generateRunSummary caps a huge failure list and still fits", () => {
+    const failures: RunFailure[] = Array.from({ length: 600 }, (_, i) => ({
+      locale: "fr",
+      file: `public/content/developers/docs/page-${i}/index.md`,
+      message: "Gemini returned no content (finishReason=RECITATION).",
+    }))
+    const summary = generateRunSummary(
+      ["fr", "es"],
+      [{ path: "public/content/x/index.md", content: "c" }],
+      "auto",
+      "https://example.com/run/1",
+      failures
+    )
+    expect(summary).toContain("600 task(s) failed (showing first 40)")
+    expect(summary).toContain("...and 560 more")
+    // Exactly 40 failure bullets and 40 rerun commands are emitted -- not all
+    // 600. (A regression that printed the cap text but still looped every
+    // failure would slip past a length-only check.)
+    const bulletLines = summary
+      .split("\n")
+      .filter((l) => /^- `public\/content\//.test(l))
+    const rerunLines = summary
+      .split("\n")
+      .filter((l) => l.startsWith("gh workflow run"))
+    expect(bulletLines).toHaveLength(40)
+    expect(rerunLines).toHaveLength(40)
+    // 600 raw failure+rerun lines would blow the limit; the capped summary
+    // must comfortably fit even before the final clampBody safety net.
+    expect(summary.length).toBeLessThan(MAX_PR_BODY)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes four intl-pipeline bugs that made full-tree runs unreliable, in one branch. The headline bug silently desynced manifests so the *next* run re-translated everything — blocking the goal of running the pipeline on every merge to `dev`.

## The bugs

**1. Committer ref race dropped manifests (root cause).** `SharedCommitter` advanced the branch ref on every per-file commit. Under the task pool's concurrency those ref updates raced and returned `422 not-a-fast-forward`. A content commit that threw on the 422 aborted *before* recording its manifest blob; the end-of-run squash rebuilds from recorded blobs, so content shipped **without its manifest**. Run [27984239227](https://github.com/ethereum/ethereum-org-website/actions/runs/27984239227) / PR #18471: ~733 files translated, ~0 markdown manifests committed (100% correlation: e.g. `ar` had 20/20 markdown content commits hit 422 and 0 manifests landed). The next run then sees every file as stale and re-translates all of them.

Fix: `commitFile` now only creates + records a blob and never touches the branch ref; `squashByLanguage` force-updates the ref once. Manifests are also built before the content blob is recorded, so a builder error strands neither.

**2. No crash-safety after #1.** Moving all persistence to the end-of-run squash meant a mid-run crash lost that run's costly LLM output. Restored incremental durability without the race: `commitFile` flushes everything recorded so far to the branch every 50 files (the squash run mid-stream), serialized through a single-writer lock so no two ref updates overlap. Per-file granularity (not per-language), non-fatal on failure, and the final squash still collapses to one commit per language.

**3. PR body exceeded GitHub's 65,536-char limit.** Full-tree runs failed to post their PR (the body listed every failure and grew unbounded across runs), forcing a hand-opened recovery PR (#18471). Failure lists are now capped at 40 and the body is clamped to 60,000 chars (tail-preserving) at both create and update.

**4. RECITATION blocked our own content deterministically.** Gemini requests were pinned to `temperature: 0`, so a `finishReason=RECITATION` block (false-positive on our open-licensed whitepaper/consensus docs) reproduced identically on every retry and fallback model. Retries now escalate temperature (0 -> 0.5 -> 1.0) to clear the recitation match. (Consolidated from work originally on `review-18471`.)

## Testing

- New unit specs: `tests/unit/intl-pipeline/commit-ref-race.spec.ts` (5 tests: no per-file ref update, squash lands content+manifest together, interleaved cross-language commits drop nothing, periodic checkpoint serialized force-update, auto-checkpoint every `CHECKPOINT_EVERY`, failed-checkpoint non-fatal) and `pr-body-limit.spec.ts` (3 tests: clamp + failure cap).
- Full intl-pipeline unit suite green (904 passed), `tsc` clean, `eslint` clean.
- Three adversarial code-review passes (final one over the whole branch, focused on the concurrent-checkpoint design): no blockers.

## Follow-up (not in this PR)

Once merged: close PR #18471 and delete `intl/pending-dev` (its content is salvageable but its manifests are drifted), then re-run the pipeline blank-target from clean `dev`. With these fixes a blank-target run skips files whose manifests match current English, translates the rest, and lands them all in one PR with correct manifests — gracefully skipping (and reporting) any RECITATION/transient failures instead of corrupting state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
