### PR TITLE
docs: note Vyper's module system on the languages page

### DIFF
--- a/public/content/developers/docs/smart-contracts/languages/index.md
+++ b/public/content/developers/docs/smart-contracts/languages/index.md
@@ -101,6 +101,8 @@ This example should give you a sense of what Solidity contract syntax is like. F
   - Infinite-length loops
   - Binary fixed points
 
+Since v0.4.0, Vyper supports a [module system](https://docs.vyperlang.org/en/stable/using-modules.html). Code reuse is achieved through composition, rather than class inheritance.
+
 For more information, [read the Vyper rationale](https://vyper.readthedocs.io/en/latest/index.html).
 
 ### Important links {#important-links-1}


### PR DESCRIPTION
## Description

Adds one sentence to the Vyper section of the smart contract languages page, noting that Vyper supports code reuse through its module system (added in v0.4.0). The existing "Vyper does not support: … Inheritance" bullet is left unchanged; the addition corrects the impression that Vyper has no code-reuse mechanism.

## Related Issue
Closes #18613
