### PR TITLE
fix: center the stablecoins types tab navigation

### DIFF
--- a/app/[locale]/stablecoins/page.tsx
+++ b/app/[locale]/stablecoins/page.tsx
@@ -521,7 +521,7 @@ async function Page(props: { params: Promise<PageParams> }) {
             {t("page-stablecoins-types-intro")}
           </p>
           <Tabs defaultValue={types[0].title}>
-            <TabsList>
+            <TabsList className="mx-auto">
               {types.map((type) => (
                 <TabsTrigger key={type.title} value={type.title}>
                   {type.title}


### PR DESCRIPTION
## Description

Fixes #18617.

On the **/stablecoins** page, the category tab navigation (Fiat-backed / Crypto-backed / Precious metals / Algorithmic) in the "How stablecoins work" section rendered **left-aligned**, even though the section heading and intro paragraph above it are centered.

### Cause
`TabsList` is a block-level flex element with `max-w-fit` (clamps to content width). The parent `Section` uses `text-center`, which only centers inline content, not the `TabsList` block box, so it stayed at the left edge.

### Fix
Add `mx-auto` to the `TabsList` at this usage site, horizontally centering the block. This reuses the exact idiom already applied to the intro `<p className="mx-auto …">` one line above in the same section.

The fix is scoped to this page rather than the shared `src/components/ui/tabs.tsx` `TabsList`, because `TabsList` is also used in left-aligned contexts elsewhere (e.g. `what-is-ethereum`, `founders`, restaking, staking comparisons). Centering the shared component would shift those.

```diff
-            <TabsList>
+            <TabsList className="mx-auto">
```

## Verification
Ran locally against the dev server and measured the rendered tab list: equal left/right gaps (355px each) within its container, and confirmed visually it sits centered under the heading. Lint passes on the changed file.

## Preview
Before: tab bar flush-left under centered heading.
After: tab bar centered under the heading and intro.

## Related Issue
Closes #18617