### PR TITLE
Fix table spacing and align handling

### DIFF
--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -6,12 +6,6 @@ import { tv, type VariantProps } from "tailwind-variants"
 
 import { cn } from "@/lib/utils/cn"
 
-/**
- * TODO: Currently, there are cell spacing issues with some table content.
- * Prefer `table-fixed` utility class in the future when content has been addressed
- * to provide equal cell widths.
- */
-
 const baseStyles = {
   th: "text-start border-b border-body text-body normal-case align-bottom p-4",
   tr: "not-[:last-of-type]:[&_th]:border-e-2 not-[:last-of-type]:[&_th]:border-e-background not-[:last-of-type]:[&_td]:border-e-2 not-[:last-of-type]:[&_td]:border-e-background",
@@ -23,7 +17,7 @@ const stripedTbody = "even:[&_tr]:bg-background-highlight"
 
 const tableVariants = tv({
   slots: {
-    table: "w-full",
+    table: "w-full border-collapse border-spacing-0",
     // slot key with empty string to establish the key name for variants (TypeScript)
     th: "",
     tr: "",
@@ -77,14 +71,23 @@ type TableVariants = VariantProps<typeof tableVariants>
 type TableVariantsReturnType = ReturnType<typeof tableVariants>
 
 /**
- * For `TableCell` and `TableHead` only
- *
- * Applies the `align` prop in name for the `textAlign` CSS property
- * instead of the `align` attribute. (The `align` attribute is deprecated)
+ * Supports the Markdown `align` prop while applying it as CSS `text-align`
+ * instead of forwarding the deprecated HTML `align` attribute.
  */
 type CellPropsWithAlign<C> = Omit<C, "align"> & {
   align?: React.CSSProperties["textAlign"]
 }
+
+const withTextAlign = (
+  style: React.CSSProperties | undefined,
+  textAlign: React.CSSProperties["textAlign"] | undefined
+) =>
+  textAlign === undefined
+    ? style
+    : {
+        ...style,
+        textAlign,
+      }
 
 const TableStylesContext = createContext<{
   [P in keyof TableVariantsReturnType]: TableVariantsReturnType[P]
@@ -144,13 +147,13 @@ TableRow.displayName = "TableRow"
 const TableHead = React.forwardRef<
   HTMLTableCellElement,
   CellPropsWithAlign<React.ThHTMLAttributes<HTMLTableCellElement>>
->(({ className, align, ...props }, ref) => {
+>(({ className, align, style, ...props }, ref) => {
   const { th } = useTableStyles()
   return (
     <th
       ref={ref}
       className={cn(th(), className)}
-      style={{ textAlign: align }}
+      style={withTextAlign(style, align)}
       {...props}
     />
   )
@@ -160,14 +163,14 @@ TableHead.displayName = "TableHead"
 const TableCell = React.forwardRef<
   HTMLTableCellElement,
   CellPropsWithAlign<React.TdHTMLAttributes<HTMLTableCellElement>>
->(({ className, align, children, ...props }, ref) => {
+>(({ className, align, children, style, ...props }, ref) => {
   const { td } = useTableStyles()
 
   return (
     <td
       ref={ref}
       className={cn(td(), className)}
-      style={{ textAlign: align }}
+      style={withTextAlign(style, align)}
       {...props}
     >
       {children}
@@ -182,7 +185,7 @@ const TableCaption = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <caption
     ref={ref}
-    className={cn("mt-4 text-sm text-body-medium", className)}
+    className={cn("text-body-medium mt-4 text-sm", className)}
     {...props}
   />
 ))

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -6,6 +6,12 @@ import { tv, type VariantProps } from "tailwind-variants"
 
 import { cn } from "@/lib/utils/cn"
 
+/**
+ * TODO: Currently, there are cell spacing issues with some table content.
+ * Prefer `table-fixed` utility class in the future when content has been addressed
+ * to provide equal cell widths.
+ */
+
 const baseStyles = {
   th: "text-start border-b border-body text-body normal-case align-bottom p-4",
   tr: "not-[:last-of-type]:[&_th]:border-e-2 not-[:last-of-type]:[&_th]:border-e-background not-[:last-of-type]:[&_td]:border-e-2 not-[:last-of-type]:[&_td]:border-e-background",
@@ -17,7 +23,7 @@ const stripedTbody = "even:[&_tr]:bg-background-highlight"
 
 const tableVariants = tv({
   slots: {
-    table: "w-full border-collapse border-spacing-0",
+    table: "w-full",
     // slot key with empty string to establish the key name for variants (TypeScript)
     th: "",
     tr: "",
@@ -71,8 +77,10 @@ type TableVariants = VariantProps<typeof tableVariants>
 type TableVariantsReturnType = ReturnType<typeof tableVariants>
 
 /**
- * Supports the Markdown `align` prop while applying it as CSS `text-align`
- * instead of forwarding the deprecated HTML `align` attribute.
+ * For `TableCell` and `TableHead` only
+ *
+ * Applies the `align` prop in name for the `textAlign` CSS property
+ * instead of the `align` attribute. (The `align` attribute is deprecated)
  */
 type CellPropsWithAlign<C> = Omit<C, "align"> & {
   align?: React.CSSProperties["textAlign"]
@@ -185,7 +193,7 @@ const TableCaption = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <caption
     ref={ref}
-    className={cn("text-body-medium mt-4 text-sm", className)}
+    className={cn("mt-4 text-sm text-body-medium", className)}
     {...props}
   />
 ))


### PR DESCRIPTION
## Description

Updates the shared table component to address the table tech debt noted in #18593.

Changes include:

- Explicitly resetting table border spacing with `border-collapse border-spacing-0`
- Removing the stale TODO about table cell spacing
- Keeping Markdown `align` support while applying it through CSS `text-align`
- Preserving any existing inline `style` values passed to `TableHead` or `TableCell`

## Related Issue

Ref: #18593

