### PR TITLE
Use country codes for centralized exchange exceptions

### DIFF
--- a/src/hooks/useCentralizedExchanges.ts
+++ b/src/hooks/useCentralizedExchanges.ts
@@ -2,14 +2,6 @@ import { useState } from "react"
 import { shuffle } from "lodash"
 import { useLocale } from "next-intl"
 
-// TODO: Remove unused?
-// import argent from "@/public/images/wallets/argent.png"
-// import binanceus from "@/public/images/exchanges/binance.png"
-// import imtoken from "@/public/images/wallets/imtoken.png"
-// import mycrypto from "@/public/images/wallets/mycrypto.png"
-// import myetherwallet from "@/public/images/wallets/myetherwallet.png"
-// import squarelink from "@/public/images/wallets/squarelink.png"
-// import trust from "@/public/images/wallets/trust.png"
 import type { ImageProps } from "@/components/Image"
 import { SelectOnChange } from "@/components/Select"
 
@@ -103,6 +95,7 @@ type ExchangeData = Record<Country, ExchangeKey[]>
 type ExchangeByCountryOption = {
   value: string
   label: string
+  countryCode: Country
   exchanges: string[]
 }
 
@@ -113,8 +106,6 @@ type FilteredData = {
   image: ImageProps["src"]
   alt: string
 }
-
-const UNITED_STATES = "United States of America (USA)"
 
 const exchanges: ExchangeDetails = {
   binance: {
@@ -345,9 +336,12 @@ export const useCentralizedExchanges = () => {
   const placeholderString = t("page-get-eth-exchanges-search")
 
   // Add `value` & `label` for Select component, sort alphabetically
-  const selectOptions: ExchangeByCountryOption[] = Object.entries(
-    exchangeData as ExchangeData
-  )
+  const exchangeEntries = Object.entries(exchangeData as ExchangeData) as [
+    Country,
+    ExchangeKey[],
+  ][]
+
+  const selectOptions: ExchangeByCountryOption[] = exchangeEntries
     .map(([countryCode, exchanges]) => {
       const countryName =
         countryCode.length === 2
@@ -357,6 +351,7 @@ export const useCentralizedExchanges = () => {
       return {
         value: countryName,
         label: countryName,
+        countryCode,
         exchanges,
       }
     })
@@ -393,10 +388,9 @@ export const useCentralizedExchanges = () => {
         .filter((exchange) => selectedCountry?.exchanges.includes(exchange))
         // Format array for <CardList/>
         .map((exchange) => {
-          // Add state exceptions if Country is USA
+          // Add state exceptions if the selected country is the United States
           let description: string | undefined
-          // TODO: Set up for i18n support; currently all country names in English:
-          if (selectedCountry.value === UNITED_STATES) {
+          if (selectedCountry.countryCode === "US") {
             const { usaExceptions } = exchanges[exchange]
             if (usaExceptions.length > 0) {
               description = `${t("page-get-eth-exchanges-except")} ${formatList(


### PR DESCRIPTION
## Description

- Confirms `useCentralizedExchanges` is still used by the Get ETH centralized exchanges UI and removes stale unused-code TODO comments.
- Stores the source country code on each select option so U.S.-specific exchange exceptions are detected by `US` instead of comparing against an English country label.
- Removes the obsolete i18n TODO now that localized country labels can still trigger the U.S. exception logic correctly.

## Related Issue

Fixes #18588

## Preview link
https://deploy-preview-18626.ethereum.it/get-eth