### PR TITLE
Make tutorial update script cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "chromatic:pages": "chromatic --playwright --zip --exit-zero-on-changes",
     "lint:md": "markdownlint-cli2 \"public/content/**/*.md\" \"!public/content/translations/**\"",
     "lint:md:fix": "markdownlint-cli2 --fix \"public/content/**/*.md\" \"!public/content/translations/**\"",
-    "update-tutorials": "ts-node -O '{ \"module\": \"commonjs\" }' src/scripts/update-tutorials-list.ts",
+    "update-tutorials": "ts-node --project tsconfig.scripts.json src/scripts/update-tutorials-list.ts",
     "prepare": "husky",
     "test": "pnpm test:unit && pnpm test:e2e",
     "test:unit": "USE_MOCK_DATA=true playwright test --project=unit",

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node"
+  },
+  "include": ["src/scripts/**/*.ts", "src/lib/**/*.ts"]
+}


### PR DESCRIPTION
## Description

- Replaces the inline `ts-node -O` JSON compiler options in `update-tutorials` with a dedicated `tsconfig.scripts.json`.
- Avoids shell-specific JSON quoting so the script runs correctly in Windows PowerShell as well as POSIX shells.

Note: `package.json` no longer contains a `markdown-checker` script, but the same broken inline JSON pattern from the issue is present in the current `update-tutorials` script.

## Related Issue

Fixes #18585