### PR TITLE
fix flipForRtl api

### DIFF
--- a/.claude/skills/design-system/references/i18n-rtl.md
+++ b/.claude/skills/design-system/references/i18n-rtl.md
@@ -94,7 +94,7 @@ export function NextLink() {
 }
 ```
 
-`twFlipForRtl` returns the static `"rtl:-scale-x-100"` variant class (it no longer branches on locale -- the variant itself is a no-op in LTR), so it's safe to drop into any `className` unconditionally. The deprecated `flipForRtl` (a `scaleX(-1)` transform string) should not be used in new code.
+`twFlipForRtl` returns the static `"rtl:-scale-x-100"` variant class (it no longer branches on locale -- the variant itself is a no-op in LTR), so it's safe to drop into any `className` unconditionally. The older `flipForRtl` transform-string API (`scaleX(-1)`) has been removed -- use the `twFlipForRtl` class instead.
 
 ### Pattern: pre-flipped icons
 

--- a/src/hooks/useRtlFlip.ts
+++ b/src/hooks/useRtlFlip.ts
@@ -5,8 +5,6 @@ import type { Lang } from "@/lib/types"
 import { isLangRightToLeft } from "@/lib/utils/translations"
 
 type UseDirection = {
-  /** @deprecated */
-  flipForRtl: "scaleX(-1)" | undefined // transform (deprecated)
   twFlipForRtl: "rtl:-scale-x-100" // className
   isRtl: boolean
   direction: "ltr" | "rtl"
@@ -14,14 +12,13 @@ type UseDirection = {
 
 /**
  * Custom hook that determines the direction and transformation for right-to-left (RTL) languages.
- * @example const { flipForRtl } = useRtlFlip(); transform={flipForRtl}
+ * @example const { twFlipForRtl } = useRtlFlip()
  * @returns An object containing the Tailwind className, RTL flag, and direction.
  */
 export const useRtlFlip = (): UseDirection => {
   const locale = useLocale()
   const isRtl = isLangRightToLeft(locale as Lang)
   return {
-    flipForRtl: isRtl ? "scaleX(-1)" : undefined, // transform (deprecated)
     twFlipForRtl: "rtl:-scale-x-100", // className (preferred)
     isRtl,
     direction: isRtl ? "rtl" : "ltr",

--- a/src/lib/utils/direction.ts
+++ b/src/lib/utils/direction.ts
@@ -3,8 +3,6 @@ import type { Lang } from "@/lib/types"
 import { isLangRightToLeft } from "@/lib/utils/translations"
 
 type DirectionData = {
-  /** @deprecated */
-  flipForRtl: "scaleX(-1)" | undefined // transform (deprecated)
   twFlipForRtl: "rtl:-scale-x-100" // className
   isRtl: boolean
   direction: "ltr" | "rtl"
@@ -14,12 +12,11 @@ type DirectionData = {
  * Determines the direction and transformation for right-to-left (RTL) languages.
  * @param locale The language locale
  * @returns An object containing the Tailwind className, RTL flag, and direction.
- * @example const { twFlipForRtl } = getDirectionData('ar');
+ * @example const { twFlipForRtl } = getDirection('ar');
  */
 export const getDirection = (locale: Lang): DirectionData => {
   const isRtl = isLangRightToLeft(locale)
   return {
-    flipForRtl: isRtl ? "scaleX(-1)" : undefined, // transform (deprecated)
     twFlipForRtl: "rtl:-scale-x-100", // className (preferred)
     isRtl,
     direction: isRtl ? "rtl" : "ltr",


### PR DESCRIPTION
## Description

Removes the deprecated `flipForRtl` API from the RTL direction helpers.

- Removes `flipForRtl` from `useRtlFlip()`.
- Removes `flipForRtl` from `getDirection()`.
- Keeps the recommended `twFlipForRtl` class-based API, plus `isRtl` and `direction`.
- Updates JSDoc examples to reference `twFlipForRtl`.

## Related Issue

Fixes #18584