### PR TITLE
fix: stabilize product table filter state

### DIFF
--- a/src/components/FindWalletProductTable/hooks/useWalletFilters.tsx
+++ b/src/components/FindWalletProductTable/hooks/useWalletFilters.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react"
+import { useMemo, useRef } from "react"
 import { Brain, LayersPlus } from "lucide-react"
 import { useLocale } from "next-intl"
 
@@ -21,12 +21,13 @@ export const useWalletFilters = (): FilterOption[] => {
   const locale = useLocale()
   const { t } = useTranslation("page-wallets-find-wallet")
   const prevNetworkArray = useRef<string[]>([])
-  return [
-    {
-      title: t("page-find-wallet-device"),
-      showFilterOption: true,
-      items: [
-        {
+  return useMemo(
+    () => [
+      {
+        title: t("page-find-wallet-device"),
+        showFilterOption: true,
+        items: [
+          {
           filterKey: "mobile",
           filterLabel: t("page-find-wallet-mobile"),
           description: "",
@@ -1045,6 +1046,8 @@ export const useWalletFilters = (): FilterOption[] => {
           options: [],
         },
       ],
-    },
-  ]
+      },
+    ],
+    [locale, t]
+  )
 }

--- a/src/components/Layer2NetworksTable/hooks/useNetworkFilters.tsx
+++ b/src/components/Layer2NetworksTable/hooks/useNetworkFilters.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from "react"
+
 import { FilterOption } from "@/lib/types"
 
 import {
@@ -16,12 +18,13 @@ import useTranslation from "@/hooks/useTranslation"
 export const useNetworkFilters = (): FilterOption[] => {
   const { t } = useTranslation("page-layer-2-networks")
 
-  return [
-    {
-      title: t("page-layer-2-networks-wallet-support"),
-      showFilterOption: true,
-      items: [
-        {
+  return useMemo(
+    () => [
+      {
+        title: t("page-layer-2-networks-wallet-support"),
+        showFilterOption: true,
+        items: [
+          {
           filterKey: "wallets_supported",
           filterLabel: "wallets_supported",
           description: "",
@@ -174,6 +177,8 @@ export const useNetworkFilters = (): FilterOption[] => {
           options: [],
         },
       ],
-    },
-  ]
+      },
+    ],
+    [t]
+  )
 }

--- a/src/components/ProductTable/index.tsx
+++ b/src/components/ProductTable/index.tsx
@@ -4,6 +4,7 @@ import {
   useDeferredValue,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react"
 
@@ -41,6 +42,66 @@ interface ProductTableProps<T extends { id: string }> {
   }) => React.ReactNode | undefined
 }
 
+const getInitialFiltersKey = (filters: FilterOption[]) => {
+  return JSON.stringify(
+    filters.map(({ title, showFilterOption, items }) => ({
+      title,
+      showFilterOption,
+      items: items.map(
+        ({
+          filterKey,
+          filterLabel,
+          description,
+          inputState,
+          ignoreFilterReset,
+          optionsLegend,
+          options,
+        }) => ({
+          filterKey,
+          filterLabel,
+          description,
+          inputState,
+          ignoreFilterReset,
+          optionsLegend,
+          options: options.map(
+            ({
+              filterKey,
+              filterLabel,
+              description,
+              inputState,
+              ignoreFilterReset,
+            }) => ({
+              filterKey,
+              filterLabel,
+              description,
+              inputState,
+              ignoreFilterReset,
+            })
+          ),
+        })
+      ),
+    }))
+  )
+}
+
+const hydrateFiltersFromQuery = (
+  filters: FilterOption[],
+  query: Record<string, string>
+) => {
+  return filters.map((filter) => ({
+    ...filter,
+    items: filter.items.map((item) => ({
+      ...item,
+      inputState: parseQueryParams(query[item.filterKey]) || item.inputState,
+      options: item.options.map((option) => ({
+        ...option,
+        inputState:
+          parseQueryParams(query[option.filterKey]) || option.inputState,
+      })),
+    })),
+  }))
+}
+
 const ProductTable = <T extends { id: string }>({
   data,
   filters: initialFilters,
@@ -52,6 +113,8 @@ const ProductTable = <T extends { id: string }>({
 }: ProductTableProps<T>) => {
   const [filters, setFilters] = useState<FilterOption[]>(initialFilters)
   const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false)
+  const initialFiltersKey = getInitialFiltersKey(initialFilters)
+  const syncedInitialFiltersKey = useRef(initialFiltersKey)
 
   // Hydrate filters from URL params once on mount. Reads window.location.search
   // directly (not useSearchParams) to avoid Next's CSR bailout on this SSG page.
@@ -63,23 +126,20 @@ const ProductTable = <T extends { id: string }>({
     )
 
     if (Object.keys(query).length > 0) {
-      const updatedFilters = filters.map((filter) => ({
-        ...filter,
-        items: filter.items.map((item) => ({
-          ...item,
-          inputState:
-            parseQueryParams(query[item.filterKey]) || item.inputState,
-          options: item.options.map((option) => ({
-            ...option,
-            inputState:
-              parseQueryParams(query[option.filterKey]) || option.inputState,
-          })),
-        })),
-      }))
-      setFilters(updatedFilters)
+      setFilters((currentFilters) =>
+        hydrateFiltersFromQuery(currentFilters, query)
+      )
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  useEffect(() => {
+    if (syncedInitialFiltersKey.current === initialFiltersKey) return
+
+    syncedInitialFiltersKey.current = initialFiltersKey
+    startTransition(() => {
+      setFilters(initialFilters)
+    })
+  }, [initialFilters, initialFiltersKey])
 
   const updateFilters = useCallback(
     (filters: FilterOption | FilterOption[]) => {

--- a/src/hooks/useTranslation.ts
+++ b/src/hooks/useTranslation.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react"
 import { useTranslations } from "next-intl"
 
 /**
@@ -18,39 +19,42 @@ const DEFAULT_NAMESPACE = "common"
 
 export function useTranslation(namespaces?: string[] | string) {
   const t = useTranslations()
+  const namespace = Array.isArray(namespaces)
+    ? namespaces[0]
+    : namespaces || DEFAULT_NAMESPACE
 
-  const customT = (
-    fullKey: string,
-    values?: Record<string, string | number | Date>
-  ) => {
-    try {
-      if (fullKey.includes(":")) {
-        const [namespace, key] = fullKey.split(":")
+  const customT = useMemo(() => {
+    const translate = (
+      fullKey: string,
+      values?: Record<string, string | number | Date>
+    ) => {
+      try {
+        if (fullKey.includes(":")) {
+          const [namespace, key] = fullKey.split(":")
 
-        if (values) {
-          return t(`${namespace}.${key}`, values)
+          if (values) {
+            return t(`${namespace}.${key}`, values)
+          }
+
+          return t.raw(`${namespace}.${key}`)
         }
 
-        return t.raw(`${namespace}.${key}`)
+        return t.raw(`${namespace}.${fullKey}`)
+      } catch (error) {
+        // Suppress errors by default, enable if needed to debug
+        // console.error(error)
+        return fullKey
       }
-
-      const namespace = Array.isArray(namespaces)
-        ? namespaces[0]
-        : namespaces || DEFAULT_NAMESPACE
-
-      return t.raw(`${namespace}.${fullKey}`)
-    } catch (error) {
-      // Suppress errors by default, enable if needed to debug
-      // console.error(error)
-      return fullKey
     }
-  }
 
-  // keep the original methods
-  customT.raw = t.raw
-  customT.rich = t.rich
-  customT.markup = t.markup
-  customT.has = t.has
+    // keep the original methods
+    translate.raw = t.raw
+    translate.rich = t.rich
+    translate.markup = t.markup
+    translate.has = t.has
+
+    return translate
+  }, [namespace, t])
 
   return { t: customT }
 }


### PR DESCRIPTION
## Description

Fixes the ProductTable filter synchronization workaround by addressing the unstable filter inputs that could cause repeated renders.

- Adds semantic comparison for `initialFilters` before syncing ProductTable state.
- Reintroduces guarded filter state synchronization without relying on array identity.
- Updates URL query hydration to use the current filter state and removes the exhaustive-deps workaround.
- Stabilizes `useTranslation()` so its returned `t` function can be used safely in memo dependencies.
- Memoizes wallet and layer 2 filter definitions to avoid recreating filter arrays every render.

## Related Issue

Fixes #18581