### PR TITLE
fix: support rtl carousel direction

### DIFF
--- a/app/[locale]/roadmap/_components/ReleaseCarousel.tsx
+++ b/app/[locale]/roadmap/_components/ReleaseCarousel.tsx
@@ -1,8 +1,9 @@
 "use client"
 
-// TODO: Fix RTL compatibility; currently forced to LTR flow
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { useLocale } from "next-intl"
+
+import type { Lang } from "@/lib/types"
 
 import { Image } from "@/components/Image"
 import { ButtonLink } from "@/components/ui/buttons/Button"
@@ -17,6 +18,7 @@ import {
 
 import { cn } from "@/lib/utils/cn"
 import { dateTimeFormat, formatDate } from "@/lib/utils/date"
+import { isLangRightToLeft } from "@/lib/utils/translations"
 
 import { getReleasesData, Release } from "@/data/roadmap/releases"
 
@@ -25,6 +27,8 @@ import { useTranslation } from "@/hooks/useTranslation"
 const ReleaseCarousel = () => {
   const locale = useLocale()
   const { t } = useTranslation("page-roadmap")
+  const isRtl = isLangRightToLeft(locale as Lang)
+  const carouselDirection = isRtl ? "rtl" : "ltr"
 
   const releasesData = useMemo(() => getReleasesData(t), [t])
 
@@ -111,7 +115,10 @@ const ReleaseCarousel = () => {
   }
 
   return (
-    <div className="w-full max-w-[100vw] overflow-hidden" dir="ltr">
+    <div
+      className="w-full max-w-[100vw] overflow-hidden"
+      dir={carouselDirection}
+    >
       <div className="mx-auto w-full max-w-screen-2xl px-4 sm:px-6">
         <div className="w-full rounded-base bg-background-highlight py-6">
           <div className="flex flex-col gap-6">
@@ -122,7 +129,7 @@ const ReleaseCarousel = () => {
               opts={{
                 align: "center",
                 containScroll: false,
-                direction: "ltr",
+                direction: carouselDirection,
                 loop: false,
                 startIndex,
               }}
@@ -182,7 +189,10 @@ const ReleaseCarousel = () => {
                               "flex h-1 flex-1",
                               index !== 0
                                 ? status === "soon"
-                                  ? "bg-linear-to-r from-primary to-primary-low-contrast"
+                                  ? cn(
+                                      "from-primary to-primary-low-contrast",
+                                      isRtl ? "bg-linear-to-l" : "bg-linear-to-r"
+                                    )
                                   : status === "prod"
                                     ? "bg-primary"
                                     : "bg-primary-low-contrast"
@@ -236,7 +246,7 @@ const ReleaseCarousel = () => {
               opts={{
                 align: "center",
                 containScroll: false,
-                direction: "ltr",
+                direction: carouselDirection,
                 loop: false,
                 startIndex,
               }}
@@ -245,7 +255,7 @@ const ReleaseCarousel = () => {
                 {releasesData.map((release: Release) => (
                   <CarouselItem
                     key={release.releaseName}
-                    className="w-full pl-4"
+                    className="w-full ps-4"
                   >
                     <div className="flex w-full flex-col gap-6 lg:flex-row">
                       <div className="w-full flex-1 rounded-base">

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -1,5 +1,3 @@
-// TODO: Fix RTL compatibility
-
 import * as React from "react"
 import useEmblaCarousel, {
   type UseEmblaCarouselType,
@@ -55,14 +53,22 @@ const Carousel = React.forwardRef<
       plugins,
       className,
       children,
+      dir,
       ...props
     },
     ref
   ) => {
+    const isRtl =
+      dir === "rtl" ||
+      opts?.direction === "rtl" ||
+      (typeof document !== "undefined" && document.dir === "rtl")
+    const direction = isRtl ? "rtl" : "ltr"
+
     const [carouselRef, api] = useEmblaCarousel(
       {
         ...opts,
         axis: orientation === "horizontal" ? "x" : "y",
+        direction,
       },
       plugins
     )
@@ -90,13 +96,13 @@ const Carousel = React.forwardRef<
       (event: React.KeyboardEvent<HTMLDivElement>) => {
         if (event.key === "ArrowLeft") {
           event.preventDefault()
-          scrollPrev()
+          direction === "rtl" ? scrollNext() : scrollPrev()
         } else if (event.key === "ArrowRight") {
           event.preventDefault()
-          scrollNext()
+          direction === "rtl" ? scrollPrev() : scrollNext()
         }
       },
-      [scrollPrev, scrollNext]
+      [direction, scrollPrev, scrollNext]
     )
 
     React.useEffect(() => {
@@ -139,6 +145,7 @@ const Carousel = React.forwardRef<
           ref={ref}
           onKeyDownCapture={handleKeyDown}
           className={cn("relative", className)}
+          dir={direction}
           role="region"
           aria-roledescription="carousel"
           {...props}
@@ -163,7 +170,7 @@ const CarouselContent = React.forwardRef<
         ref={ref}
         className={cn(
           "flex",
-          orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
+          orientation === "horizontal" ? "-ms-4" : "-mt-4 flex-col",
           className
         )}
         {...props}
@@ -210,14 +217,14 @@ const CarouselPrevious = React.forwardRef<
         "absolute h-8 w-8 rounded-full",
         orientation === "horizontal"
           ? "start-5 top-1/2 -translate-y-1/2"
-          : "start-1/2 -top-12 -translate-x-1/2 rotate-90",
+          : "start-1/2 -top-12 -translate-x-1/2 rotate-90 rtl:translate-x-1/2",
         className
       )}
       disabled={!canScrollPrev}
       onClick={scrollPrev}
       {...props}
     >
-      <ChevronLeft className="size-6" />
+      <ChevronLeft className="size-6 rtl:-scale-x-100" />
       <span className="sr-only">Previous slide</span>
     </Button>
   )
@@ -239,14 +246,14 @@ const CarouselNext = React.forwardRef<
         "absolute h-8 w-8 rounded-full",
         orientation === "horizontal"
           ? "end-5 top-1/2 -translate-y-1/2"
-          : "start-1/2 -bottom-12 -translate-x-1/2 rotate-90",
+          : "start-1/2 -bottom-12 -translate-x-1/2 rotate-90 rtl:translate-x-1/2",
         className
       )}
       disabled={!canScrollNext}
       onClick={scrollNext}
       {...props}
     >
-      <ChevronRight className="size-6" />
+      <ChevronRight className="size-6 rtl:-scale-x-100" />
       <span className="sr-only">Next slide</span>
     </Button>
   )


### PR DESCRIPTION
## Description

Improves RTL support for shared carousel components and the roadmap release carousel.

- Removes forced LTR flow from the roadmap release carousel.
- Detects RTL locales and passes the correct direction to Embla.
- Updates carousel keyboard navigation so left/right arrows behave correctly in RTL.
- Replaces physical spacing with logical spacing (`ms`/`ps`).
- Mirrors carousel arrow icons in RTL.
- Makes the roadmap release timeline gradient direction-aware.

## Related Issue

Fixes #18580