### PR TITLE
fix: narrow tsconfig include patterns

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,9 +42,11 @@
   },
   "include": [
     "./src/**/*",
+    "./app/**/*",
+    "./tests/**/*",
     "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
+    "./*.ts",
+    "./*.tsx",
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],


### PR DESCRIPTION
## Description

Narrows the TypeScript project include patterns to avoid checking TypeScript files inside `node_modules`.

- Removes broad `**/*.ts` and `**/*.tsx` include patterns.
- Adds explicit project scopes for `app`, `tests`, root TypeScript files, and existing generated Next.js types.
- Keeps `src` coverage unchanged.
- Preserves the existing `node_modules` exclusion.

## Related Issue

Fixes #18578