### PR TITLE
Fix translation banner for untranslated content

### DIFF
--- a/src/components/TranslationBanner/index.tsx
+++ b/src/components/TranslationBanner/index.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from "react"
 import { X } from "lucide-react"
 import { useLocale } from "next-intl"
 
-import { Button } from "@/components/ui/buttons/Button"
+import { Button, ButtonLink } from "@/components/ui/buttons/Button"
 
 import { cn } from "@/lib/utils/cn"
 
@@ -14,7 +14,11 @@ import useTranslation from "@/hooks/useTranslation"
 import { usePathname } from "@/i18n/navigation"
 import { DO_NOT_TRANSLATE_PATHS } from "@/scripts/intl-pipeline/constants"
 
-const TranslationBanner = () => {
+type TranslationBannerProps = {
+  contentNotTranslated?: boolean
+}
+
+const TranslationBanner = ({ contentNotTranslated }: TranslationBannerProps) => {
   const locale = useLocale()
   const pathname = usePathname()
 
@@ -23,33 +27,41 @@ const TranslationBanner = () => {
   // Default to isOpen being false, and let the useEffect set this.
   const [isOpen, setIsOpen] = useState(false)
 
+  const isContentBanner = contentNotTranslated === true
+  const shouldCheckDoNotTranslatePaths = contentNotTranslated === undefined
+
+  const isDNTPath =
+    shouldCheckDoNotTranslatePaths &&
+    DO_NOT_TRANSLATE_PATHS.some((path) => pathname.includes(path))
+
+  const bannerType = isContentBanner
+    ? "content-not-translated"
+    : isDNTPath
+      ? "do-not-translate"
+      : null
+
   const lsKey = useMemo(
-    () => `dont-show-translation-banner-${pathname}`,
-    [pathname]
+    () => `dont-show-translation-banner-${bannerType}-${pathname}`,
+    [bannerType, pathname]
   )
 
   useEffect(() => {
-    if (localStorage.getItem(lsKey) === "true") {
+    if (!bannerType || locale === DEFAULT_LOCALE) {
       setIsOpen(false)
-    } else {
-      setIsOpen(true)
+      return
     }
-  }, [lsKey])
 
-  const isDNTPath = DO_NOT_TRANSLATE_PATHS.reduce(
-    (acc, curr) => acc || pathname.includes(curr),
-    false
-  )
+    setIsOpen(localStorage.getItem(lsKey) !== "true")
+  }, [bannerType, locale, lsKey])
 
-  /**
-   * If English page, not a Do Not Translate page, or closed: return early
-   */
-  if (!isOpen || locale === DEFAULT_LOCALE || !isDNTPath) return
+  if (!isOpen || locale === DEFAULT_LOCALE || !bannerType) return null
 
   const handleDontShow = () => {
     localStorage.setItem(lsKey, "true")
     setIsOpen(false)
   }
+
+  const isUntranslatedContentBanner = bannerType === "content-not-translated"
 
   return (
     <aside
@@ -67,11 +79,39 @@ const TranslationBanner = () => {
         <X className="size-4" />
       </Button>
 
-      <h3 className="mb-2">{t("translation-banner-no-bugs-title")}</h3>
-      <p className="mb-6">{t("translation-banner-no-bugs-content")}</p>
-      <Button onClick={handleDontShow} className="max-sm:w-full">
-        {t("translation-banner-no-bugs-dont-show-again")}
-      </Button>
+      <h3 className="mb-2">
+        {isUntranslatedContentBanner
+          ? t("translation-banner-title-new")
+          : t("translation-banner-no-bugs-title")}
+      </h3>
+      <p className="mb-6">
+        {isUntranslatedContentBanner
+          ? t("translation-banner-body-new")
+          : t("translation-banner-no-bugs-content")}
+      </p>
+
+      {isUntranslatedContentBanner ? (
+        <div className="flex flex-wrap gap-3 max-sm:flex-col">
+          <ButtonLink
+            href={pathname}
+            locale={DEFAULT_LOCALE}
+            className="max-sm:w-full"
+          >
+            {t("translation-banner-button-see-english")}
+          </ButtonLink>
+          <ButtonLink
+            href="/contributing/translation-program/"
+            variant="outline"
+            className="max-sm:w-full"
+          >
+            {t("translation-banner-button-translate-page")}
+          </ButtonLink>
+        </div>
+      ) : (
+        <Button onClick={handleDontShow} className="max-sm:w-full">
+          {t("translation-banner-no-bugs-dont-show-again")}
+        </Button>
+      )}
     </aside>
   )
 }

--- a/src/layouts/Docs.tsx
+++ b/src/layouts/Docs.tsx
@@ -18,6 +18,7 @@ import SideNav from "@/components/SideNav"
 import SideNavMobile from "@/components/SideNavMobile"
 import TableOfContents from "@/components/TableOfContents"
 import Translation from "@/components/Translation"
+import TranslationBanner from "@/components/TranslationBanner"
 import { Alert } from "@/components/ui/alert"
 import { ButtonLink } from "@/components/ui/buttons/Button"
 import { Divider } from "@/components/ui/hr"
@@ -66,6 +67,8 @@ export const DocsLayout = ({
 
   return (
     <div className="flex w-full flex-col border-b">
+      <TranslationBanner contentNotTranslated={contentNotTranslated} />
+
       <SideNavMobile path={slug} />
       {isPageIncomplete && (
         <Alert variant="banner">

--- a/src/layouts/Static.tsx
+++ b/src/layouts/Static.tsx
@@ -16,6 +16,7 @@ import MatomoOptOut from "@/components/MatomoOptOut"
 import PageActions from "@/components/PageActions"
 import SocialListItem from "@/components/SocialListItem"
 import TableOfContents from "@/components/TableOfContents"
+import TranslationBanner from "@/components/TranslationBanner"
 import TranslationChartImage from "@/components/TranslationChartImage"
 import { Alert } from "@/components/ui/alert"
 import Callout from "@/components/ui/callout"
@@ -72,6 +73,8 @@ export const StaticLayout = ({
 
   return (
     <div dir={contentNotTranslated ? "ltr" : "unset"}>
+      <TranslationBanner contentNotTranslated={contentNotTranslated} />
+
       {isGuidesHub ? (
         <HubHero
           heroImg={guideHeroImg}

--- a/src/layouts/Topic.tsx
+++ b/src/layouts/Topic.tsx
@@ -7,6 +7,7 @@ import type { List as ButtonDropdownList } from "@/components/ButtonDropdown"
 import Emoji from "@/components/Emoji"
 import PageHero from "@/components/Hero/PageHero"
 import PageActions from "@/components/PageActions"
+import TranslationBanner from "@/components/TranslationBanner"
 import { Alert } from "@/components/ui/alert"
 import InlineLink from "@/components/ui/Link"
 import { List, ListItem } from "@/components/ui/list"
@@ -126,28 +127,32 @@ export const TopicLayout = async ({
   )
 
   return (
-    <ContentLayout
-      dir={contentNotTranslated ? "ltr" : "unset"}
-      tocItems={tocItems}
-      dropdownLinks={dropdownLinks}
-      contributors={contributors}
-      lastEditLocaleTimestamp={lastEditLocaleTimestamp}
-      heroSection={heroSection}
-      showDropdown={frontmatter.showDropdown ?? true}
-    >
-      {/*
-        The `!` overrides defeat the `flow` region's `*:first:mt-0` (which
-        would zero PageActions' mobile top spacing) and zero out the default
-        prose top margin on the following h2 that PageActions displaces from
-        first-child position.
-      */}
-      <PageActions
-        slug={slug}
-        isTranslated={!contentNotTranslated}
-        editPath={getEditPath(slug)}
-        className="-ms-2 mb-8 [&+h2]:mt-0!"
-      />
-      {children}
-    </ContentLayout>
+    <>
+      <TranslationBanner contentNotTranslated={contentNotTranslated} />
+
+      <ContentLayout
+        dir={contentNotTranslated ? "ltr" : "unset"}
+        tocItems={tocItems}
+        dropdownLinks={dropdownLinks}
+        contributors={contributors}
+        lastEditLocaleTimestamp={lastEditLocaleTimestamp}
+        heroSection={heroSection}
+        showDropdown={frontmatter.showDropdown ?? true}
+      >
+        {/*
+          The `!` overrides defeat the `flow` region's `*:first:mt-0` (which
+          would zero PageActions' mobile top spacing) and zero out the default
+          prose top margin on the following h2 that PageActions displaces from
+          first-child position.
+        */}
+        <PageActions
+          slug={slug}
+          isTranslated={!contentNotTranslated}
+          editPath={getEditPath(slug)}
+          className="-ms-2 mb-8 [&+h2]:mt-0!"
+        />
+        {children}
+      </ContentLayout>
+    </>
   )
 }

--- a/src/layouts/Tutorial.tsx
+++ b/src/layouts/Tutorial.tsx
@@ -15,6 +15,7 @@ import MarkdownCard from "@/components/MarkdownCard"
 import PageActions from "@/components/PageActions"
 import TableOfContents from "@/components/TableOfContents"
 import TutorialMetadata from "@/components/TutorialMetadata"
+import TranslationBanner from "@/components/TranslationBanner"
 import { ButtonLink } from "@/components/ui/buttons/Button"
 import { mdxTableComponents } from "@/components/ui/mdx-table-components"
 import YouTube from "@/components/YouTube"
@@ -61,6 +62,8 @@ export const TutorialLayout = ({
 
   return (
     <div className="flex justify-between gap-8">
+      <TranslationBanner contentNotTranslated={contentNotTranslated} />
+
       <main
         className="max-w-4xl min-w-0 px-4 py-8 md:px-8 lg:py-16"
         dir={contentNotTranslated ? "ltr" : "unset"}


### PR DESCRIPTION
## Description

Fixes the translation banner logic so pages marked with `contentNotTranslated` display the untranslated-content banner correctly.

This updates `TranslationBanner` to support both existing do-not-translate pages and untranslated content pages, with separate localStorage dismissal keys for each banner type. It also renders the banner from layouts that already receive `contentNotTranslated`: Static, Topic, Docs, and Tutorial.

## Related Issue

Fixes #18577