### PR TITLE
Fix rehype image buffer hashing type

### DIFF
--- a/src/lib/md/rehypeImg.ts
+++ b/src/lib/md/rehypeImg.ts
@@ -108,9 +108,10 @@ const setImagePlaceholders = async (
 
     // Load image data from file system as buffer
     const buffer: Buffer = fs.readFileSync(path.join("public", src))
+    const imageBytes = Uint8Array.from(buffer)
 
     // Get hash fingerprint of image data (no security implications; fast algorithm prioritized)
-    const hash = await getHashFromBuffer(buffer, {
+    const hash = await getHashFromBuffer(imageBytes, {
       algorithm: "SHA-1",
       length: 8,
     })


### PR DESCRIPTION
## Description

Fixes the TypeScript `Buffer<ArrayBufferLike>` incompatibility in `rehypeImg.ts` by converting the file `Buffer` to a `Uint8Array` before passing it to `getHashFromBuffer`.

The original `Buffer` is still used for `getPlaiceholder`, while the hash path now uses a standard `BufferSource`-compatible byte array.

Note: the issue also references `src/scripts/i18n/lib/crowdin/files.ts`, but that file does not exist in the current repository tree.

## Related Issue

Fixes #18575