### PR TITLE
feat: indent nested items in ButtonDropdown

### DIFF
--- a/app/[locale]/staking/page.tsx
+++ b/app/[locale]/staking/page.tsx
@@ -7,7 +7,6 @@ import {
 
 import type { Lang, PageParams, StakingStatsData } from "@/lib/types"
 
-import { type List as ButtonDropdownList } from "@/components/ButtonDropdown"
 import ExpandableCard from "@/components/ExpandableCard"
 import PageHero from "@/components/Hero/PageHero"
 import I18nProvider from "@/components/I18nProvider"
@@ -28,6 +27,7 @@ import { cn } from "@/lib/utils/cn"
 import { getAppPageContributorInfo } from "@/lib/utils/contributors"
 import { getMetadata } from "@/lib/utils/metadata"
 import { computeStakingApr } from "@/lib/utils/staking"
+import { buildTopicDropdown } from "@/lib/utils/topicDropdown"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 
 import { staking } from "@/data/topics/staking"
@@ -97,19 +97,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
     },
   ]
 
-  const dropdownLinks: ButtonDropdownList = {
-    text: t(staking.dropdown.textKey),
-    ariaLabel: t(staking.dropdown.ariaLabelKey),
-    items: staking.dropdown.items.map((item) => ({
-      text: t(item.textKey),
-      href: item.href,
-      matomo: {
-        eventCategory: staking.dropdown.matomoCategory,
-        eventAction: "Clicked",
-        eventName: item.matomoEvent,
-      },
-    })),
-  }
+  const dropdownLinks = buildTopicDropdown(staking.dropdown, t, "Clicked")
 
   const tocItems = {
     whatIsStaking: {

--- a/src/components/ButtonDropdown.tsx
+++ b/src/components/ButtonDropdown.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { Fragment, useState } from "react"
 import { Menu } from "lucide-react"
 
 import { cn } from "@/lib/utils/cn"
@@ -24,6 +24,8 @@ export interface ListItem {
     eventName: string
   }
   callback?: (idx: number) => void
+  /** Nested sub-items rendered indented beneath this item. */
+  items?: Array<ListItem>
 }
 
 export interface List {
@@ -46,6 +48,34 @@ const ButtonDropdown = ({ list, className }: ButtonDropdownProps) => {
     setSelectedItem(item.text)
   }
 
+  const renderItems = (items: Array<ListItem>, depth = 0): React.ReactNode =>
+    items.map((item, idx) => {
+      // 2rem base inline-start padding + 1rem per nesting level. Only one
+      // sub-level is used today; the map allows two before capping.
+      const indentClass = ["ps-8", "ps-12", "ps-16"][depth] ?? "ps-16"
+      return (
+        <Fragment key={item.text}>
+          <DropdownMenuItem
+            className={cn("justify-start pe-4 text-start", indentClass)}
+            onClick={() => handleClick(item, idx)}
+            asChild={!!item.href}
+          >
+            {item.href ? (
+              <BaseLink
+                href={item.href}
+                className="text-body no-underline focus-visible:outline-0"
+              >
+                {item.text}
+              </BaseLink>
+            ) : (
+              <span>{item.text}</span>
+            )}
+          </DropdownMenuItem>
+          {item.items?.length ? renderItems(item.items, depth + 1) : null}
+        </Fragment>
+      )
+    })
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -64,25 +94,7 @@ const ButtonDropdown = ({ list, className }: ButtonDropdownProps) => {
         collisionPadding={16}
         sideOffset={8}
       >
-        {list.items.map((item, idx) => (
-          <DropdownMenuItem
-            key={item.text}
-            className="justify-center text-center"
-            onClick={() => handleClick(item, idx)}
-            asChild={!!item.href}
-          >
-            {item.href ? (
-              <BaseLink
-                href={item.href}
-                className="text-body no-underline focus-visible:outline-0"
-              >
-                {item.text}
-              </BaseLink>
-            ) : (
-              <span>{item.text}</span>
-            )}
-          </DropdownMenuItem>
-        ))}
+        {renderItems(list.items)}
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/src/data/topics/index.ts
+++ b/src/data/topics/index.ts
@@ -1,7 +1,14 @@
+import { roadmap } from "./roadmap"
+import { staking } from "./staking"
+import { upgrade } from "./upgrade"
+import { useCases } from "./use-cases"
+
 export type TopicDropdownItem = {
   textKey: string
   href: string
   matomoEvent: string
+  /** Nested sub-items rendered indented beneath this item in the dropdown. */
+  items?: TopicDropdownItem[]
 }
 
 export type TopicConfig = {
@@ -20,11 +27,6 @@ export type TopicConfig = {
    */
   showLastUpdatedInHero?: boolean
 }
-
-import { roadmap } from "./roadmap"
-import { staking } from "./staking"
-import { upgrade } from "./upgrade"
-import { useCases } from "./use-cases"
 
 export const topics: Record<string, TopicConfig> = {
   roadmap,

--- a/src/data/topics/roadmap.ts
+++ b/src/data/topics/roadmap.ts
@@ -16,62 +16,70 @@ export const roadmap: TopicConfig = {
         textKey: "nav-roadmap-security",
         href: "/roadmap/security",
         matomoEvent: "clicked roadmap security",
+        // Technical pages nested under their best-fitting parent section
+        items: [
+          {
+            textKey: "nav-roadmap-pbs",
+            href: "/roadmap/pbs/",
+            matomoEvent: "clicked roadmap pbs",
+          },
+          {
+            textKey: "nav-roadmap-secret-leader-election",
+            href: "/roadmap/secret-leader-election/",
+            matomoEvent: "clicked roadmap secret leader election",
+          },
+          {
+            textKey: "nav-roadmap-single-slot-finality",
+            href: "/roadmap/single-slot-finality/",
+            matomoEvent: "clicked roadmap single slot finality",
+          },
+        ],
       },
       {
         textKey: "nav-roadmap-scaling",
         href: "/roadmap/scaling",
         matomoEvent: "clicked roadmap scaling home",
+        items: [
+          {
+            textKey: "nav-roadmap-danksharding",
+            href: "/roadmap/danksharding/",
+            matomoEvent: "clicked roadmap danksharding",
+          },
+          {
+            textKey: "nav-roadmap-zkevm",
+            href: "/roadmap/zkevm/",
+            matomoEvent: "clicked roadmap zkevm",
+          },
+        ],
       },
       {
         textKey: "nav-roadmap-user-experience",
         href: "/roadmap/user-experience/",
         matomoEvent: "clicked roadmap user experience home",
+        items: [
+          {
+            textKey: "nav-roadmap-account-abstraction",
+            href: "/roadmap/account-abstraction/",
+            matomoEvent: "clicked roadmap account abstraction",
+          },
+        ],
       },
       {
         textKey: "nav-roadmap-future-proofing",
         href: "/roadmap/future-proofing",
         matomoEvent: "clicked roadmap future-proofing home",
-      },
-      // Additional technical pages
-      {
-        textKey: "nav-roadmap-account-abstraction",
-        href: "/roadmap/account-abstraction/",
-        matomoEvent: "clicked roadmap account abstraction",
-      },
-      {
-        textKey: "nav-roadmap-danksharding",
-        href: "/roadmap/danksharding/",
-        matomoEvent: "clicked roadmap danksharding",
-      },
-      {
-        textKey: "nav-roadmap-pbs",
-        href: "/roadmap/pbs/",
-        matomoEvent: "clicked roadmap pbs",
-      },
-      {
-        textKey: "nav-roadmap-secret-leader-election",
-        href: "/roadmap/secret-leader-election/",
-        matomoEvent: "clicked roadmap secret leader election",
-      },
-      {
-        textKey: "nav-roadmap-single-slot-finality",
-        href: "/roadmap/single-slot-finality/",
-        matomoEvent: "clicked roadmap single slot finality",
-      },
-      {
-        textKey: "nav-roadmap-statelessness",
-        href: "/roadmap/statelessness/",
-        matomoEvent: "clicked roadmap statelessness",
-      },
-      {
-        textKey: "nav-roadmap-verkle-trees",
-        href: "/roadmap/verkle-trees/",
-        matomoEvent: "clicked roadmap verkle trees",
-      },
-      {
-        textKey: "nav-roadmap-zkevm",
-        href: "/roadmap/zkevm/",
-        matomoEvent: "clicked roadmap zkevm",
+        items: [
+          {
+            textKey: "nav-roadmap-statelessness",
+            href: "/roadmap/statelessness/",
+            matomoEvent: "clicked roadmap statelessness",
+          },
+          {
+            textKey: "nav-roadmap-verkle-trees",
+            href: "/roadmap/verkle-trees/",
+            matomoEvent: "clicked roadmap verkle trees",
+          },
+        ],
       },
     ],
   },

--- a/src/layouts/Topic.tsx
+++ b/src/layouts/Topic.tsx
@@ -3,7 +3,6 @@ import { getTranslations } from "next-intl/server"
 import type { ChildOnlyProp } from "@/lib/types"
 import type { MdPageContent, TopicFrontmatter } from "@/lib/interfaces"
 
-import type { List as ButtonDropdownList } from "@/components/ButtonDropdown"
 import Emoji from "@/components/Emoji"
 import PageHero from "@/components/Hero/PageHero"
 import PageActions from "@/components/PageActions"
@@ -12,6 +11,7 @@ import InlineLink from "@/components/ui/Link"
 import { List, ListItem } from "@/components/ui/list"
 
 import { getEditPath } from "@/lib/utils/editPath"
+import { buildTopicDropdown } from "@/lib/utils/topicDropdown"
 
 import type { TopicConfig } from "@/data/topics"
 
@@ -56,19 +56,7 @@ export const TopicLayout = async ({
     ? await getTranslations("common")
     : null
 
-  const dropdownLinks: ButtonDropdownList = {
-    text: t(config.dropdown.textKey),
-    ariaLabel: t(config.dropdown.ariaLabelKey),
-    items: config.dropdown.items.map((item) => ({
-      text: t(item.textKey),
-      href: item.href,
-      matomo: {
-        eventCategory: config.dropdown.matomoCategory,
-        eventAction: "click",
-        eventName: item.matomoEvent,
-      },
-    })),
-  }
+  const dropdownLinks = buildTopicDropdown(config.dropdown, t)
 
   const baseDescription = frontmatter.summary ? (
     <p className="text-lg">{frontmatter.summary}</p>

--- a/src/lib/utils/topicDropdown.ts
+++ b/src/lib/utils/topicDropdown.ts
@@ -1,0 +1,35 @@
+import type {
+  List as ButtonDropdownList,
+  ListItem as ButtonDropdownListItem,
+} from "@/components/ButtonDropdown"
+
+import type { TopicConfig, TopicDropdownItem } from "@/data/topics"
+
+/**
+ * Maps a topic's `dropdown` config into the `ButtonDropdownList` the
+ * `ButtonDropdown` component consumes, translating `textKey`s and preserving
+ * nested `items` (rendered indented). `eventAction` is parameterized so each
+ * call site keeps its existing Matomo casing.
+ */
+export const buildTopicDropdown = (
+  dropdown: TopicConfig["dropdown"],
+  t: (key: string) => string,
+  eventAction = "click"
+): ButtonDropdownList => {
+  const mapItem = (item: TopicDropdownItem): ButtonDropdownListItem => ({
+    text: t(item.textKey),
+    href: item.href,
+    matomo: {
+      eventCategory: dropdown.matomoCategory,
+      eventAction,
+      eventName: item.matomoEvent,
+    },
+    ...(item.items ? { items: item.items.map(mapItem) } : {}),
+  })
+
+  return {
+    text: t(dropdown.textKey),
+    ariaLabel: t(dropdown.ariaLabelKey),
+    items: dropdown.items.map(mapItem),
+  }
+}


### PR DESCRIPTION
## Description

Adds nested, indented sub-items to `ButtonDropdown` and restructures the roadmap topic navigation so the technical pages sit under their parent sections instead of in one flat list.

## Changes

- **`ButtonDropdown`** renders nested `items` recursively, indented by 2rem base + 1rem per nesting level (one sub-level used today, two allowed before capping). Items are now start-justified (logical `ps`/`pe`/`text-start`, so LTR-left / RTL-right); inline-end padding is 1rem for all. Trigger button unchanged.
- **Roadmap dropdown** nests the technical pages under their best-fit parent: PBS / secret leader election / single slot finality -> **Security**; danksharding / zkEVM -> **Scaling**; account abstraction -> **User experience**; statelessness / verkle trees -> **Future-proofing**.
- **Dedup:** extracted the duplicated `TopicConfig.dropdown` -> `ButtonDropdownList` mapping (previously copied in `Topic.tsx` and the staking page) into a single nesting-aware `buildTopicDropdown` util in `src/lib/utils/`. `eventAction` is parameterized so existing Matomo casing is preserved (topics `"click"`, staking `"Clicked"`).

## Notes

- The left-justify + shared mapping also affect the **staking** dropdown (and the mobile dropdown, which reuses the component) - intentional consistency. Staking gains nesting support for free but has no nested items today, so its output is unchanged aside from left-alignment.
- No content/translation strings changed; all `textKey`s are reused.

## Preview

- `/roadmap` (+ any roadmap subpage) - desktop sidebar + mobile dropdown
- `/staking` - dropdown left-aligned, otherwise unchanged