### PR TITLE
fix: remove production console.log in Matomo component

### DIFF
--- a/src/components/Matomo.tsx
+++ b/src/components/Matomo.tsx
@@ -26,11 +26,6 @@ export default function Matomo() {
       // conditions with Next.js client-side routing
       // See: https://matomo.org/faq/how-to/faq_33087/
       push(["alwaysUseSendBeacon"])
-
-      console.log(
-        "[Matomo] initialized with URL:",
-        process.env.NEXT_PUBLIC_MATOMO_URL
-      )
       matomoInitialized = true
     }
   }, [])

--- a/src/hooks/useCentralizedExchanges.ts
+++ b/src/hooks/useCentralizedExchanges.ts
@@ -2,14 +2,6 @@ import { useState } from "react"
 import { shuffle } from "lodash"
 import { useLocale } from "next-intl"
 
-// TODO: Remove unused?
-// import argent from "@/public/images/wallets/argent.png"
-// import binanceus from "@/public/images/exchanges/binance.png"
-// import imtoken from "@/public/images/wallets/imtoken.png"
-// import mycrypto from "@/public/images/wallets/mycrypto.png"
-// import myetherwallet from "@/public/images/wallets/myetherwallet.png"
-// import squarelink from "@/public/images/wallets/squarelink.png"
-// import trust from "@/public/images/wallets/trust.png"
 import type { ImageProps } from "@/components/Image"
 import { SelectOnChange } from "@/components/Select"
 


### PR DESCRIPTION
Closes #18657 
Closes #18656

## Description

Removes the \console.log\ call in \src/components/Matomo.tsx\ that logs the Matomo server URL on every page load in production. This eliminates noisy logs and avoids exposing internal infrastructure URLs to end users.

Also removes the unused imports in useCentralizedExchanges.ts