### PR TITLE
fix: use console.warn instead of console.log in useLocalStorage catch block

### DIFF
--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -101,7 +101,7 @@ function parseJSON<T>(value: string | null): T | undefined {
   try {
     return value === "undefined" ? undefined : JSON.parse(value ?? "")
   } catch {
-    console.log("parsing error on", { value })
+    console.warn("parsing error on", { value })
     return undefined
   }
 }


### PR DESCRIPTION
Closes #18658

## Description

Replaces \console.log\ with \console.warn\ in the \JSON.parse\ catch block in \src/hooks/useLocalStorage.ts\. Error conditions should use \console.warn\ or \console.error\ so they are visually distinct and can be filtered properly.