### PR TITLE
[codex] Remove SendReceive Storybook debug log

### DIFF
--- a/src/components/Simulator/screens/SendReceive/__stories__/SendReceive.stories.tsx
+++ b/src/components/Simulator/screens/SendReceive/__stories__/SendReceive.stories.tsx
@@ -110,7 +110,6 @@ export const Success: Story = {
     await waitFor(
       async () => {
         const successIcon = canvas.getByTestId("success-icon")
-        console.log("🚀 ~ successIcon:", successIcon)
         await expect(successIcon).toBeInTheDocument()
         await expect(successIcon).toHaveStyle({
           transform: "none",


### PR DESCRIPTION
## What changed

Removed the leftover debug `console.log` from the `SendReceive` Storybook `Success` story interaction test.

## Why

The log was development noise and could appear during Storybook or Chromatic runs.

Closes #18659

## Validation

- Verified the fork branch diff contains one deletion in `src/components/Simulator/screens/SendReceive/__stories__/SendReceive.stories.tsx`.
- Confirmed the `Success` story still asserts `successIcon` is present and styled.

Note: local `git`, `gh`, and package scripts were unavailable in this shell, so validation was limited to static inspection and GitHub compare metadata.