### PR TITLE
fix(reports): correct download size for governments/institutions report

### DIFF
--- a/app/[locale]/reports/data.ts
+++ b/app/[locale]/reports/data.ts
@@ -68,7 +68,7 @@ export const reports: Report[] = [
     category: "ef-original",
     href: "/reports/basics-for-governments-institutions.pdf",
     imgSrc: ethereumBasicsCover,
-    fileSizeBytes: 2152671,
+    fileSizeBytes: 1364988,
   },
   {
     slug: "trillion-dollar-security",


### PR DESCRIPTION
## Description

The policy report PDF added in #18650 / #18619 (`public/reports/basics-for-governments-institutions.pdf`) shipped with a placeholder `fileSizeBytes` that didn't match the actual file.

- Actual PDF size: **1364988 bytes** (~1.3 MB), verified against the committed file on `dev` (and merge commit `033a6c3`).
- Previous value in `app/[locale]/reports/data.ts`: `2152671`.

This corrects the value so the download size shown on the report card is accurate.

## Notes
Single-line data change; no logic affected.