### PR TITLE
fix(homepage): show one article per source in Latest updates

### DIFF
--- a/src/components/Homepage/LatestUpdates.tsx
+++ b/src/components/Homepage/LatestUpdates.tsx
@@ -16,8 +16,9 @@ type LatestUpdatesProps = {
 }
 
 // Homepage preview of the /latest stream: the three most recent merged
-// articles, rendered with the same card as the /latest grid, plus a CTA to the
-// full page.
+// articles — capped to one per source so a single high-frequency feed (e.g. ETH
+// Daily) can't fill every slot — rendered with the same card as the /latest
+// grid, plus a CTA to the full page.
 const HOMEPAGE_LATEST_COUNT = 3
 
 const LatestUpdates = async ({
@@ -29,7 +30,19 @@ const LatestUpdates = async ({
   const tLatest = await getTranslations("page-latest")
 
   const { articles } = await getLatestArticles(locale)
-  const items = articles.slice(0, HOMEPAGE_LATEST_COUNT)
+
+  // Collapse the newest-first stream to one article per source, then take the
+  // top N. `getLatestArticles` caps each source at LATEST_MAX_PER_SOURCE for the
+  // full /latest grid, but the homepage preview only wants a single most-recent
+  // item per source.
+  const seenSources = new Set<string>()
+  const items = articles
+    .filter((article) => {
+      if (seenSources.has(article.source)) return false
+      seenSources.add(article.source)
+      return true
+    })
+    .slice(0, HOMEPAGE_LATEST_COUNT)
 
   // Nothing to show (e.g. no builder posts and RSS cache empty) — drop the
   // section rather than render an empty heading.


### PR DESCRIPTION
## Bug

The homepage **Latest updates** section was showing up to 3 articles from the *same* source (e.g. three ETH Daily items filling all three slots), instead of one article per source.

## Root cause

`LatestUpdates.tsx` reused `getLatestArticles()`, the shared data function behind the `/latest` page. That function caps each source at `LATEST_MAX_PER_SOURCE` (3) — correct for the full `/latest` grid, but the homepage preview then just sliced the top 3 of the merged, newest-first stream. A single high-frequency feed like ETH Daily could therefore occupy every slot.

## Fix

Dedup the newest-first stream to one article per source in `LatestUpdates.tsx` before taking the top 3, so the homepage preview shows three distinct sources. No change to `/latest`, which still uses the 3-per-source cap.

## Testing

- `pnpm type-check` passes.
- Since `articles` is pre-sorted newest-first and every article has a `source` (RSS `item.source`; builder posts `BUILDER_CATEGORY`), the retained item per source is the most recent one.