### PR TITLE
fix(storybook): remove dead page-roadmap-vision i18n namespace

### DIFF
--- a/.storybook/next-intl.ts
+++ b/.storybook/next-intl.ts
@@ -21,7 +21,6 @@ export const ns = [
   "page-learn",
   "page-upgrades",
   "page-developers-index",
-  "page-roadmap-vision",
   "page-staking",
   "page-what-is-ethereum",
   "page-upgrades-index",


### PR DESCRIPTION
## Problem

The **Visual regression (Chromatic)** check on the v11.13.0 release PR (#18667) fails with:

```
✖ Failed to extract stories from your Storybook
  Error: Cannot find module './page-roadmap-vision.json'
```

## Root cause

`.storybook/next-intl.ts` still listed the `page-roadmap-vision` namespace, but `src/intl/en/page-roadmap-vision.json` was removed in `f5c9f112c4` ("chore: remove deprecated /roadmap/vision page"). The loader does `require('../src/intl/<lng>/page-roadmap-vision.json')`; on miss the `catch` falls back to `require('../src/intl/en/page-roadmap-vision.json')` — also gone — so it throws uncaught and crashes the whole Storybook preview module. Chromatic can then extract **zero** stories.

This is a pre-existing breakage present on both `dev` and `staging`; it was not introduced by the release.

## Fix

Remove the dead namespace entry. Nothing in `src/` or `app/` references it anymore, and all 19 remaining namespaces are backed by an English JSON, so the preview module loads cleanly.

Targets `staging` to unblock the v11.13.0 release PR.