### PR TITLE
fix(ui): migrate stray hoverEffect to hoverLift

### DIFF
--- a/app/[locale]/community/events/page.tsx
+++ b/app/[locale]/community/events/page.tsx
@@ -413,7 +413,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
 
             <Grid columns={2} size="wide">
               {/* Ethereum Everywhere Card */}
-              <Card size="lg" hoverEffect="lift" className="bg-tint-accent-a">
+              <Card size="lg" hoverLift className="bg-tint-accent-a">
                 <CardHeader className="flex items-center gap-3">
                   <div className="size-16 overflow-hidden rounded-full">
                     <Image src={ethereumEverywhereLogo} alt="" sizes="4rem" />
@@ -479,7 +479,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
               </Card>
 
               {/* Geode Labs Card */}
-              <Card size="lg" hoverEffect="lift" className="bg-tint-accent-c">
+              <Card size="lg" hoverLift className="bg-tint-accent-c">
                 <CardHeader className="flex items-center gap-3">
                   <div className="size-16 overflow-hidden rounded-full">
                     <Image src={geodeLabsLogo} alt="" sizes="4rem" />

--- a/app/[locale]/roadmap/page.tsx
+++ b/app/[locale]/roadmap/page.tsx
@@ -210,7 +210,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
             </p>
             <Grid balanced={4}>
               {changesComingItems.map((item) => (
-                <Card key={item.title} hoverEffect="lift">
+                <Card key={item.title} hoverLift>
                   <CardHeader className="flex items-center justify-between gap-4">
                     <CardTitle>{item.title}</CardTitle>
                     <div className="shrink-0 text-primary-action">
@@ -282,7 +282,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
                 <Card
                   key={item.title}
                   href={item.href}
-                  hoverEffect="lift"
+                  hoverLift
                   className="bg-linear-primary"
                 >
                   <CardContent>

--- a/src/components/BugBountyCards.tsx
+++ b/src/components/BugBountyCards.tsx
@@ -103,7 +103,7 @@ const BugBountyCards = async () => {
           key={`bug-bounty-card-${idx}`}
           variant="nested"
           className="overflow-hidden border"
-          hoverEffect="lift"
+          hoverLift
         >
           <Banner card={card} />
 


### PR DESCRIPTION
## Description

Fixes the type-check failure currently breaking `dev` builds.

PR #18630 replaced the Card `hoverEffect` prop with `hoverLift`/`hoverOutline`/`border`, but PR #18519 (merged minutes earlier) carried call sites its branch never saw. Five `hoverEffect="lift"` usages now fail type-check on `dev` (TS2322):

- `app/[locale]/community/events/page.tsx:416,482`
- `app/[locale]/roadmap/page.tsx:213,285`
- `src/components/BugBountyCards.tsx:106`

Old `hoverEffect="lift"` and new `hoverLift` both map to `hover-lift-base`, so this is a 1:1 rename with no visual change.

## Test plan

- [x] `pnpm type-check` passes locally
- [x] `grep -rn hoverEffect src app` returns no remaining usages

🤖 Generated with [Claude Code](https://claude.com/claude-code)