### PR TITLE
refactor(ui): bake href hover outline into Card

### DIFF
--- a/.claude/skills/design-system/SKILL.md
+++ b/.claude/skills/design-system/SKILL.md
@@ -93,7 +93,7 @@ Only **two** project shadows exist, both in `utilities.css`, for the brand-tinte
 - `shadow-primary-xl` -- `shadow-xl` tinted with `primary-low-contrast`, for large framed / window-style boxes.
 - `shadow-primary-no-blur-*` -- functional, spacing-scaled solid (no-blur) offset (`-1` = 4px, `-0.5` = 2px) in `primary-low-contrast`, for hard hover offsets.
 
-Before reaching for anything new: a default almost always fits, and a **hover lift is the `hover-lift-*` utility** (`-xs`/`-base`/`-sm`/`-md`) or `Card hoverEffect="lift"` -- not a bespoke shadow swap. If you genuinely need a custom shadow, write it as a **raw `box-shadow`** (like the two above), never an arbitrary `shadow-[...]`: arbitrary shadows route their color through `--tw-shadow-color`, which the global `* { dark:shadow-body }` rule overrides in dark mode, silently graying your color. Raw `box-shadow` utilities are immune.
+Before reaching for anything new: a default almost always fits, and a **hover lift is the `hover-lift-*` utility** (`-xs`/`-base`/`-sm`/`-md`) or `Card hoverLift` -- not a bespoke shadow swap. If you genuinely need a custom shadow, write it as a **raw `box-shadow`** (like the two above), never an arbitrary `shadow-[...]`: arbitrary shadows route their color through `--tw-shadow-color`, which the global `* { dark:shadow-body }` rule overrides in dark mode, silently graying your color. Raw `box-shadow` utilities are immune.
 
 ### One stray `toLocaleString` in `ui/chart.tsx:241`
 

--- a/.claude/skills/design-system/references/card-walkthrough.md
+++ b/.claude/skills/design-system/references/card-walkthrough.md
@@ -75,17 +75,18 @@ When you pass `href`, `Card` automatically wraps in `BaseLink` and adds a `group
 | `sm` | 10px | 10px | Compact list cards |
 | `xs` | 0 | 4px | No padding; use when the banner image needs to extend to all edges of the Card |
 
-### Interaction props: `border`, `hoverOutline`, `hoverLift`
+### Interaction props: `border`, `hoverLift` (and the automatic `href` hover ring)
 
-Three independent booleans layer edge/interaction treatment on top of `variant`/`size` -- they're additive, so combine freely:
+Two independent booleans layer edge/interaction treatment on top of `variant`/`size` -- they're additive, so combine freely:
 
 | Prop | Effect | When |
 |---|---|---|
 | `border` | Static hairline edge (`ring ring-border`). It's a `ring`, so it never shifts layout. | A resting outline on `nested`/`ghost` cards that need definition against their background. |
-| `hoverOutline` | Ring that's transparent at rest and turns `ring-primary-hover` on hover. **Auto-enabled whenever the Card has an `href`**, so clickable cards always get the affordance. | Interactive cards. Rarely set by hand -- passing `href` already turns it on. |
-| `hoverLift` | `hover:shadow-md` plus a subtle `hover:scale`. | Clickable cards that should physically lift on hover. |
+| `hoverLift` | `hover:shadow-md` plus a subtle `hover:scale`. | Cards that hold their own actions instead of being a link themselves: multiple action buttons, or text-link actions in the body/footer. The lift signals "interactive content here" without implying the whole card is clickable. |
 
-`border` and `hoverOutline` are both a `ring`, so used together they read as a resting border that brightens to primary on hover (the `ring-border` shows at rest, the `hover:ring-primary-hover` takes over on hover). These three replaced the old `hoverEffect="lift"` prop.
+**There is no `hoverOutline` prop anymore.** Every Card with an `href` gets the hover ring automatically (transparent at rest, `ring-primary-hover` on hover) -- it's baked into the link render path, not a variant you set. It also can't be applied to non-link cards by hand; if a card isn't a link, use `hoverLift` (or nothing).
+
+`border` composes with the automatic ring: on an `href` Card, the `ring-border` shows at rest and `hover:ring-primary-hover` takes over on hover, reading as a resting border that brightens to primary. These props replaced the old `hoverEffect="lift"` prop.
 
 ## Step 4: Border Radius "Just Works"
 

--- a/.claude/skills/design-system/references/cleanup-playbook.md
+++ b/.claude/skills/design-system/references/cleanup-playbook.md
@@ -401,12 +401,12 @@ The old multi-layer CSS-variable shadow set was removed in favor of the Tailwind
 | `shadow-window-box` | `shadow-primary-xl` (custom) | brand-tinted large framed boxes |
 | `shadow-[4px_4px_…primary-low-contrast]` | `shadow-primary-no-blur-1` (custom) | solid hover offset (`-1` = 4px, `-0.5` = 2px) |
 | `shadow-table-item-box` | drop it | hairline rarely read; remove unless clearly needed |
-| `shadow-table-box-hover` (hover lift) | `Card hoverEffect="lift"` / `hover-lift-*` | not a manual shadow swap |
+| `shadow-table-box-hover` (hover lift) | `Card hoverLift` / `hover-lift-*` | not a manual shadow swap |
 | `shadow-[1px_0px_0px_…]` (edge line) | a real `border` / `border-e` | shadow-as-border is a smell |
 
 Rules:
 - **Default to the Tailwind scale** (`shadow-md`/`-lg`/`-xl`). A custom shadow needs a brand-tint justification.
-- **Hover elevation is `hover-lift-*`** (`-xs`/`-base`/`-sm`/`-md`) or `Card hoverEffect="lift"`, never a per-component resting/hover shadow pair.
+- **Hover elevation is `hover-lift-*`** (`-xs`/`-base`/`-sm`/`-md`) or `Card hoverLift`, never a per-component resting/hover shadow pair.
 - **Custom shadows are raw `box-shadow`** (`@utility` writing the property directly), never arbitrary `shadow-[...]` -- arbitrary shadows route color through `--tw-shadow-color`, which `* { dark:shadow-body }` overrides to gray in dark mode.
 
 ## Inline `<div className="flex flex-col gap-2">` -> `Stack`

--- a/src/components/Homepage/GetStartedGrid.tsx
+++ b/src/components/Homepage/GetStartedGrid.tsx
@@ -110,8 +110,6 @@ const GetStartedGrid = async ({
           {cards.map((card) => (
             <Card
               key={card.title}
-              className="border transition-colors hover:border-primary-hover"
-              variant="nested"
               href={card.href}
               size="lg"
               customEventOptions={{
@@ -119,6 +117,8 @@ const GetStartedGrid = async ({
                 eventAction: "section_click",
                 eventName: `get_started/${card.id}`,
               }}
+              variant="nested"
+              border
             >
               <CardHeader>
                 <CardBanner zoom={false}>

--- a/src/components/cards/pathway-card.tsx
+++ b/src/components/cards/pathway-card.tsx
@@ -52,7 +52,6 @@ const PathwayCard = ({
       className={cn("@lg/pathway:flex-row", className)}
       border
       hoverLift
-      hoverOutline
     >
       {banner && (
         <CardBanner

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -37,7 +37,6 @@ const cardVariants = cva(
         xs: "[--card-pad:--spacing(0)] [--content-space:--spacing(1)]",
       },
       hoverLift: { true: "hover-lift-base" },
-      hoverOutline: { true: "ring ring-transparent hover:ring-primary-hover" },
       border: { true: "ring ring-border" },
     },
     defaultVariants: {
@@ -60,7 +59,6 @@ const Card = React.forwardRef<HTMLDivElement | HTMLAnchorElement, CardProps>(
       variant,
       size,
       hoverLift,
-      hoverOutline,
       border,
       ...props
     },
@@ -71,7 +69,6 @@ const Card = React.forwardRef<HTMLDivElement | HTMLAnchorElement, CardProps>(
         variant,
         size,
         hoverLift,
-        hoverOutline: !!href || hoverOutline,
         border,
       }),
       className
@@ -81,7 +78,10 @@ const Card = React.forwardRef<HTMLDivElement | HTMLAnchorElement, CardProps>(
         <BaseLink
           ref={ref as React.Ref<HTMLAnchorElement>}
           href={href}
-          className={cn(classes, "group/link")}
+          className={cn(
+            "group/link ring ring-transparent hover:ring-primary-hover",
+            classes
+          )}
           customEventOptions={customEventOptions}
           hideArrow
           {...props}


### PR DESCRIPTION
## Description

Follow-up to [this discussion on #18630](https://github.com/ethereum/ethereum-org-website/pull/18630#discussion_r3515142162): the hover outline was only ever wanted on linkable cards, and `href` already auto-enabled it, so the manual `hoverOutline` variant was redundant surface area.

- Removes the `hoverOutline` variant from `ui/card`; the ring (`ring ring-transparent hover:ring-primary-hover`) is now applied directly in the `href` render path, so every linkable Card gets the affordance and it can no longer be set on non-link cards
- `border` still composes: `ring-border` at rest, brightening to `ring-primary-hover` on hover
- `hoverLift` remains the opt-in for cards that hold their own actions (multiple buttons or text-link actions) where the card itself isn't clickable
- Drops the now-redundant `hoverOutline` from `PathwayCard` and migrates `GetStartedGrid` from a manual `border transition-colors hover:border-primary-hover` class chain to the `border` prop + automatic ring
- Updates the design-system skill docs to match (and fixes stale `hoverEffect="lift"` references)

## Test plan

- [x] `GetStartedGrid` and `PathwayCard` cards show the same rest border and primary hover ring as before
- [x] Non-link Cards render no hover ring

🤖 Generated with [Claude Code](https://claude.com/claude-code)