### PR TITLE
Remove Torch webhook payload log

### DIFF
--- a/app/api/torch-webhook/route.ts
+++ b/app/api/torch-webhook/route.ts
@@ -3,9 +3,6 @@ import { NextRequest, NextResponse } from "next/server"
 
 export async function POST(req: NextRequest) {
   const body = await req.json()
-
-  console.log("Torch webhook", body)
-
   const webhookId = body.webhookId
 
   if (webhookId !== process.env.TORCH_WEBHOOK_ID) {


### PR DESCRIPTION
## Description

Removes the full request body log from the Torch webhook route. The route now parses the payload and validates the webhook ID without writing the untrusted webhook body to server logs.

Closes #18673

## Validation

- Compared the branch against `ethereum:dev`; the PR contains one commit and only changes `app/api/torch-webhook/route.ts`.
- No local test run: `git`/`gh` are not available in this shell, and this is a small logging-only route change.