### PR TITLE
Remove localStorage parse debug log

### DIFF
--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -96,12 +96,11 @@ export function useLocalStorage<T>(
   return [storedValue, setValue]
 }
 
-// A wrapper for "JSON.parse()"" to support "undefined" value
+// A wrapper for "JSON.parse()" to support "undefined" value
 function parseJSON<T>(value: string | null): T | undefined {
   try {
     return value === "undefined" ? undefined : JSON.parse(value ?? "")
   } catch {
-    console.log("parsing error on", { value })
     return undefined
   }
 }


### PR DESCRIPTION
## Description

Removes the debug `console.log` from the shared `useLocalStorage` JSON parsing helper. Malformed localStorage values still fall back to `undefined`, but the raw stored value is no longer printed to the browser console.

Also fixes the nearby helper comment typo while touching the same small block.

Closes #18674

## Validation

- Compared the branch against `ethereum:dev`; the PR contains one commit and only changes `src/hooks/useLocalStorage.ts`.
- No local test run: `git`/`gh` are not available in this shell, and this is a small console cleanup.