### PR TITLE
Update CryptoSD meetup link to HTTPS

### DIFF
--- a/src/data/community-meetups.json
+++ b/src/data/community-meetups.json
@@ -470,7 +470,7 @@
   {
     "title": "CryptoSD",
     "location": "San Diego, USA",
-    "link": "http://cryptosandiego.org",
+    "link": "https://cryptosandiego.org",
     "logoImage": "https://secure.meetupstatic.com/photos/event/1/f/f/8/600_525848184.jpeg",
     "bannerImage": "https://secure.meetupstatic.com/photos/event/1/f/f/8/600_525848184.jpeg"
   },


### PR DESCRIPTION
## Description

Updates the CryptoSD meetup link from `http://cryptosandiego.org` to `https://cryptosandiego.org` in the community meetups data.

Closes #18675

## Validation

- Compared the branch against `ethereum:dev`; the PR contains one commit and only changes `src/data/community-meetups.json`.
- Attempted to verify `https://cryptosandiego.org` from the local shell, but the request timed out after 10 seconds in this environment.