### PR TITLE
docs: add OpenChainBench to nodes-as-a-service further reading

### DIFF
--- a/public/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
+++ b/public/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
@@ -415,6 +415,7 @@ Here is a list of some of the most popular Ethereum node providers, feel free to
 ## Further reading {#further-reading}
 
 - [List of Ethereum node services](https://ethereumnodes.com/)
+- [OpenChainBench](https://openchainbench.com/benchmarks/ethereum-rpc) _– Open-source, continuously updated latency and reliability benchmark of free public Ethereum RPC endpoints, measured from three regions with public methodology and CC-BY-4.0 data_
 
 ## Related topics {#related-topics}
 


### PR DESCRIPTION
## Description

Adds a single entry to the "Further reading" section of the nodes-as-a-service page: [OpenChainBench](https://openchainbench.com/benchmarks/ethereum-rpc), an open-source (MIT, https://github.com/ChainBench/OpenChainBench), continuously running benchmark of free public Ethereum RPC endpoints.

What the resource provides for readers of this page:

- Identical `eth_blockNumber` probes sent to each endpoint from three geographic regions
- Response classification (errors, stale blocks, timeouts) and per-region leaderboards
- Archive-depth audits of historical state availability
- Fully public methodology, including the exact Prometheus queries used
- Data published under CC-BY-4.0

Several providers already listed on this page (for example dRPC and PublicNode) are among the endpoints measured. The project is vendor-neutral and lists no paid placements.


The change adds one bullet to the Further reading list, formatted to match the site's existing further reading entry style. No other content on the page is modified.

## Related Issue

N/A - documentation-only addition of one further reading link.
