### PR TITLE
fix: mark Lido permissionless nodes as true on staking pools page

### DIFF
--- a/src/data/staking-products.json
+++ b/src/data/staking-products.json
@@ -1014,7 +1014,7 @@
       "isFoss": true,
       "hasBugBounty": true,
       "isTrustless": true,
-      "hasPermissionlessNodes": false,
+      "hasPermissionlessNodes": true,
       "pctMajorityExecutionClient": null,
       "pctMajorityConsensusClient": 42.83,
       "platforms": ["Browser", "Wallet"],


### PR DESCRIPTION
## Description

One-line data fix: flips `hasPermissionlessNodes` to `true` for Lido in `src/data/staking-products.json`.

Lido's Community Staking Module (CSM) ended its Early Adoption phase on 2025-01-31 and is [fully permissionless per Lido's operator portal](https://operatorportal.lido.fi/modules/community-staking-module) ("CSM on mainnet is live and fully permissionless"). The [staking pools page](https://ethereum.org/en/staking/pools/) still shows a red cross for Lido under **Permissionless Nodes**.

Fixes #14824

## Notes

- #14825 attempted a broader Lido data refresh but has been stale since Dec 2025 and its Q3-2024 numbers are outdated; this PR takes only the verified, still-current flag change. Audit links and client-diversity percentages for Lido could use a separate refresh.