### PR TITLE
fix: include meetup groups in events search results

### DIFF
--- a/app/[locale]/community/events/search/page.tsx
+++ b/app/[locale]/community/events/search/page.tsx
@@ -15,7 +15,7 @@ import { getMetadata } from "@/lib/utils/metadata"
 import EventCard from "../_components/event-card"
 import NoResultsAlert from "../_components/no-results-alert"
 import OrganizerCTA from "../_components/organizer-cta"
-import { mapEventTranslations, sanitize } from "../utils"
+import { getMeetupGroups, mapEventTranslations, sanitize } from "../utils"
 
 import PageJsonLD from "./page-jsonld"
 
@@ -44,7 +44,9 @@ const Page = async (props: {
   const t = await getTranslations("page-community-events")
   const tCommon = await getTranslations("common")
 
-  const events = mapEventTranslations(_events, t, locale)
+  const apiEvents = mapEventTranslations(_events, t, locale)
+  const meetupGroups = getMeetupGroups(locale)
+  const events = [...apiEvents, ...meetupGroups]
 
   const filteredEvents = ((): EventItem[] => {
     if (!q) return []


### PR DESCRIPTION
## Description

The events index page and the meetups page both merge `getMeetupGroups(locale)` into their listings, but `/community/events/search` only searched API events — so meetup groups never appear in search results.

This merges meetup groups into the searchable set, same as the other two pages. Meetup `EventItem`s carry all the searched fields (`title`, `location`, `continent`, `tags`), and `pnpm type-check` passes.

## Credit

Adopts #17171 by @minimalsm, which identified and fixed this correctly but went stale after the `getMeetupGroups`/`mapEventTranslations` signatures gained a `locale` parameter. Closes #17171.