### PR TITLE
chore: disable blank issues and fix bug-report required-field bypass

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -15,7 +15,7 @@ body:
     attributes:
       label: To reproduce
       description: Steps to reproduce the behavior
-      value: |
+      placeholder: |
         1. Go to '...'
         2. Click on '...'
         3. Scroll down to '...'

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions and discussion
+    url: https://discord.gg/ethereum-org
+    about: Join the ethereum.org Discord to ask questions or discuss ideas with the community.
+  - name: Report a security vulnerability
+    url: https://ethereum.org/en/security/
+    about: Please do not report security vulnerabilities in public issues — see our security page for how to reach us.
+  - name: How to contribute
+    url: https://ethereum.org/en/contributing/
+    about: Read the contributing guide, including listing policies for wallets, exchanges, dapps and other products.


### PR DESCRIPTION
## Description

The 2026-07-06 backlog sweep closed ~15 issues that were empty or boilerplate-only submissions. Two template gaps let them through:

1. **No `ISSUE_TEMPLATE/config.yml` existed**, so `blank_issues_enabled` defaulted to `true` — completely blank issues bypassed every form (e.g. #18603, #18610, #17584 were single-word/empty issues with no template). This adds the config with `blank_issues_enabled: false` and three contact links: Discord for questions, the security page for vulnerability reports, and the contributing guide (which covers listing policies).

2. **`bug_report.yaml` pre-filled the required "To reproduce" field via `value:`**, so the required-field check passed with the boilerplate untouched (e.g. #18522 shipped the literal `1. Go to '...'` steps). Switched to `placeholder:` — same visual hint, but submitters must actually type steps.

Notes for review:
- `blank_issues_enabled: false` only hides the blank-issue UI option; API-created issues can still be blank, but that's a small minority of the junk.
- The Discord invite (`discord.gg/ethereum-org`) matches the canonical invite used 481× in the site content.

Part of the backlog-hygiene follow-ups from the 2026-07-06 triage (companion to #18696).