### PR TITLE
fix: align navbar SaaS label with the page title

### DIFF
--- a/src/intl/en/common.json
+++ b/src/intl/en/common.json
@@ -426,7 +426,7 @@
   "nav-staking-pool-description": "Stake and earn rewards with any amount of ETH by joining with others",
   "nav-staking-pool-label": "Pooled staking",
   "nav-staking-saas-description": "Third-party node operators handle the operation of your validator client",
-  "nav-staking-saas-label": "Staking with a service",
+  "nav-staking-saas-label": "Staking as a service",
   "nav-staking-solo-description": "Run home hardware and personally add to the security and decentralization of the Ethereum network",
   "nav-support-description": "Get help with Ethereum questions and issues",
   "nav-staking-solo-label": "Solo staking",


### PR DESCRIPTION
## Description

One-string fix for #18332: the navbar (Use → Staking & nodes) says **"Staking with a service"**, while the page it links to is titled **"Staking as a service"** in its h1, the hamburger menu, and the URL slug (`/staking/saas/`). This aligns the navbar label to the page's canonical term.

Note for review: @wackerow mused in the issue that *"with a service"* reads more naturally as an action — if the team prefers that direction, the right change is the inverse (page title + menu instead of navbar), which is a bigger diff touching page content and more translations. This PR takes the smaller, consistent option; happy to flip it if the preference is the other way.

Fixes #18332