### PR TITLE
Fix find-wallet filter sidebar UI bugs

### DIFF
--- a/src/components/FindWalletProductTable/hooks/useWalletFilters.tsx
+++ b/src/components/FindWalletProductTable/hooks/useWalletFilters.tsx
@@ -512,7 +512,7 @@ export const useWalletFilters = (): FilterOption[] => {
       ],
     },
     {
-      title: "Network support",
+      title: t("page-find-wallet-network-support"),
       showFilterOption: true,
       items: [
         {

--- a/src/components/ProductTable/FilterInputs/SwitchFilterInput.tsx
+++ b/src/components/ProductTable/FilterInputs/SwitchFilterInput.tsx
@@ -40,7 +40,7 @@ const SwitchFilterInput = ({
           htmlFor={id}
           className="flex w-fit cursor-pointer flex-row items-center gap-0 text-base leading-normal font-normal"
         >
-          <span className="h-8 w-8">
+          <span className="h-8 w-8 shrink-0">
             {Icon && (
               <Icon className="mt-0.5 size-7" strokeWidth={1} aria-hidden />
             )}

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -34,7 +34,7 @@ const AccordionTrigger = React.forwardRef<
     <AccordionPrimitive.Trigger
       ref={ref}
       className={cn(
-        "flex flex-1 items-center justify-between gap-2 px-2 py-2 font-medium transition-all hover:bg-background-highlight hover:text-primary-hover focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-primary-hover md:px-4 [&[data-state=open]]:bg-background-highlight [&[data-state=open]]:text-primary-high-contrast [&[data-state=open]_[data-label=icon-container]>svg]:-rotate-90 [&[data-state=open]:dir(rtl)_[data-label=icon-container]>svg]:rotate-90",
+        "flex flex-1 items-center justify-between gap-2 px-2 py-2 text-start font-medium transition-all hover:bg-background-highlight hover:text-primary-hover focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-primary-hover md:px-4 [&[data-state=open]]:bg-background-highlight [&[data-state=open]]:text-primary-high-contrast [&[data-state=open]_[data-label=icon-container]>svg]:-rotate-90 [&[data-state=open]:dir(rtl)_[data-label=icon-container]>svg]:rotate-90",
         className
       )}
       {...props}

--- a/src/intl/en/page-wallets-find-wallet.json
+++ b/src/intl/en/page-wallets-find-wallet.json
@@ -39,6 +39,7 @@
   "page-find-wallet-buy-crypto-desc": "Buy crypto with fiat directly in the wallet \n *Note: buying crypto may be region specific",
   "page-find-wallet-sell-for-fiat": "Sell for cash",
   "page-find-wallet-sell-for-fiat-desc": "Sell crypto to fiat directly in the wallet \n *Note: withdrawing crypto may be region specific",
+  "page-find-wallet-network-support": "Network support",
   "page-find-wallet-multisig": "Multisig",
   "page-find-wallet-multisig-desc": "Wallets that require multiple signatures to authorize a transaction",
   "page-find-wallet-social-recovery": "Social recovery",


### PR DESCRIPTION
## Description

Fixes the three issues noted in [this review comment](https://github.com/ethereum/ethereum-org-website/pull/18714#pullrequestreview-4647072068) on the /wallets/find-wallet filter sidebar, one commit each:

1. **Centered title when wrapping** — buttons default to `text-align: center`, so an `AccordionTrigger` label that wraps to a second line renders centered. Added `text-start` to the trigger base classes in `ui/accordion.tsx` (logical property, RTL-safe). This also corrects the same latent wrap behavior for other accordion consumers (FAQ, expandable cards, mobile nav).

2. **Filter label losing spacing next to its icon when wrapping** — the `w-8` icon wrapper in `SwitchFilterInput` has no `shrink-0`, so a long wrapping label's min-content width squeezes it and the text lands flush against the icon glyph. Added `shrink-0`.

3. **Hard-coded "Network support"** — the filter section title was a raw English string in `useWalletFilters.tsx`. Extracted to `page-find-wallet-network-support` in the `page-wallets-find-wallet` namespace.

Related to #18714

## Test plan

- [ ] Filter section titles (e.g. "Buy crypto / Sell for cash" in Czech) stay start-aligned when they wrap
- [ ] Switch filter labels (e.g. "Connect to dapps" in Czech) keep spacing between icon and text when wrapping
- [ ] "Network support" section title renders from the intl string in English; other locales fall back to English until translations land

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Preview link
https://deploy-preview-18715.ethereum.it/cs/wallets/find-wallet