### PR TITLE
fix(dev-tools): default missing `repos` to [] in builder-resources fetch

### DIFF
--- a/src/data-layer/fetchers/developer-tools/fetchBuilderResources.ts
+++ b/src/data-layer/fetchers/developer-tools/fetchBuilderResources.ts
@@ -30,7 +30,15 @@ export async function fetchBuilderResources(): Promise<{
   }
 
   const taxonomy = (await taxonomyResponse.json()) as BuilderResourcesTaxonomy
-  const resources =
-    (await resourcesResponse.json()) as BuilderResourcesCatalogResource[]
+  // The catalog omits `repos` for resources without a repository (MCP
+  // servers, hosted CLIs, …). Downstream enrichment iterates `repos`
+  // unconditionally, so normalize it to an array at this single entry point.
+  const rawResources = (await resourcesResponse.json()) as Array<
+    Omit<BuilderResourcesCatalogResource, "repos"> &
+      Partial<Pick<BuilderResourcesCatalogResource, "repos">>
+  >
+  const resources: BuilderResourcesCatalogResource[] = rawResources.map(
+    (resource) => ({ ...resource, repos: resource.repos ?? [] })
+  )
   return { resources, taxonomy }
 }


### PR DESCRIPTION
## Problem

Running the `fetch-developer-tools` task fails with:

```
TypeError: app.repos is not iterable
    at fetchGitHub (src/data-layer/fetchers/developer-tools/fetchGitHub.ts:168)
    at fetchDeveloperTools (src/data-layer/fetchers/developer-tools/index.ts:83)
```

The `ethereum/builder-resources` catalog **omits `repos`** for resources with no repository (MCP servers, hosted CLIs, …). `BuilderResourcesCatalogResource.repos` is typed as **required**, but the catalog is fetched raw and untyped at runtime, so those entries slip past TypeScript and blow up the enrichment steps that iterate `repos` unconditionally.

**5 live entries** currently trigger this: **Steer CLI, Morpho Agents, Fluid Skill, CoinGecko MCP, Tenderly MCP** (296 resources total).

This crashes the whole fetch — in the dev environment now, and it **would crash the prod fetch** once the new developer-tools code ships to `master`.

## Fix

Normalize `repos` to an array at the **single entry point** where the untrusted external catalog is parsed (`fetchBuilderResources`), so every downstream consumer is safe: `fetchGitHub`, `ranking` (×2), and `trimResourceForFrontend`. This mirrors the existing `packages` defaulting and keeps `BuilderResourcesCatalogResource.repos` required (all internal code already assumes an array).

## Verification

- `pnpm type-check` ✅, `eslint` ✅
- Ran the real `fetchBuilderResources()` against the **live catalog**: before → 5 non-array `repos` (the crashers); after normalization → **0 non-array**, all 462 repo entries iterate cleanly through the exact loop that threw.