### PR TITLE
feat(apps): add subcategory prop to CategoryAppsGrid

### DIFF
--- a/src/components/Content/apps/CategoryAppsGrid.tsx
+++ b/src/components/Content/apps/CategoryAppsGrid.tsx
@@ -39,6 +39,12 @@ interface CategoryAppsGridProps {
   /** The app category slug (e.g. "defi", "gaming"). Derived from AppCategoryEnum values. */
   category: Lowercase<AppCategory>
   /**
+   * Optional subcategory to narrow the grid (e.g. "identity", "liquid-staking").
+   * Matched by slug against the category's subcategory tags. When provided,
+   * the grid is pre-filtered to that subcategory and the filter UI is hidden.
+   */
+  subcategory?: string
+  /**
    * Maximum number of apps to display. Defaults to 9.
    * Pass `Infinity` (or `"Infinity"`) to show all apps without a limit.
    * Accepts a number or a numeric string (e.g. from MDX props).
@@ -51,6 +57,7 @@ interface CategoryAppsGridProps {
 
 const CategoryAppsGrid = async ({
   category,
+  subcategory,
   limit = 9,
   hideFilter,
   className,
@@ -72,6 +79,20 @@ const CategoryAppsGrid = async ({
 
   if (!apps || apps.length === 0) return null
 
+  // Filter against raw (untranslated) tags so MDX authors pass English slugs
+  if (subcategory) {
+    const subcategorySlug = slugify(subcategory)
+    apps = apps.filter((app) =>
+      app.subCategory.some((tag) => slugify(tag) === subcategorySlug)
+    )
+    if (apps.length === 0) {
+      console.warn(
+        `No apps in category "${category}" match subcategory: ${subcategory}`
+      )
+      return null
+    }
+  }
+
   // Translate subcategory tags, falling back to the raw string
   let translatedApps = apps
   try {
@@ -89,7 +110,7 @@ const CategoryAppsGrid = async ({
 
   const sortedApps = getDailySortedApps(translatedApps)
 
-  if (hideFilter) {
+  if (hideFilter || subcategory) {
     return (
       <Grid className={className}>
         {sortedApps.slice(0, +limit).map((app) => (


### PR DESCRIPTION
## Description

Adds an optional `subcategory` prop to `CategoryAppsGrid` so content pages can embed a grid narrowed to a single subcategory, e.g. `<CategoryAppsGrid category="privacy" subcategory="identity" />`. When set, the grid is pre-filtered server-side and rendered static: no filter bar, no client component in the RSC payload.

- Matching is slug-based (`slugify`) against the raw English tags before translation, so it behaves identically across all 25 locales and accepts `"identity"`, `"Identity"`, or `"liquid-staking"`. Valid slugs are the same set as the `app-subcategories` intl keys.
- Unknown or empty-result subcategories log a warning and render nothing, mirroring the existing unknown-category behavior.
- The prop is typed `string` rather than the per-category `subCategory` unions in `types.ts` -- those unions are stale relative to the live data (e.g. `PrivacyApp` lists only `Pools | Payments | RPC`), and MDX passes strings anyway.
- `limit` and `hideFilter` behavior unchanged; `FilterableCategoryAppsGrid` untouched.

## Test plan

- [x] Manually verified against mock data with privacy apps across `identity`, `payments`, `pools`, `rpc`, and `stealth-address` filters, plus the unknown-subcategory path
- [x] `pnpm type-check`, ESLint, and Prettier pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)