### PR TITLE
Docs: mention Vyper's module system on the languages page

### DIFF
--- a/public/content/developers/docs/smart-contracts/languages/index.md
+++ b/public/content/developers/docs/smart-contracts/languages/index.md
@@ -101,6 +101,8 @@ This example should give you a sense of what Solidity contract syntax is like. F
   - Infinite-length loops
   - Binary fixed points
 
+Since v0.4.0, Vyper supports a [module system](https://docs.vyperlang.org/en/stable/using-modules.html). Code reuse is achieved through composition, rather than class inheritance.
+
 For more information, [read the Vyper rationale](https://vyper.readthedocs.io/en/latest/index.html).
 
 ### Important links {#important-links-1}


### PR DESCRIPTION
## Description

The "Vyper does not support:" list on the smart contract languages page includes "Inheritance" as a bare bullet, which can read as if Vyper has no mechanism for code reuse at all. This adds one sentence after the list noting that, since v0.4.0, Vyper supports a module system and achieves code reuse through composition rather than class inheritance.

## Related Issue

Closes #18613
