### PR TITLE
Docs: migrate Hello World fullstack tutorial from Goerli to Sepolia

### DIFF
--- a/public/content/developers/tutorials/hello-world-smart-contract-fullstack/index.md
+++ b/public/content/developers/tutorials/hello-world-smart-contract-fullstack/index.md
@@ -20,7 +20,7 @@ lang: en
 published: 2021-10-25
 ---
 
-This guide is for you if you are new to blockchain development and don't know where to start or how to deploy and interact with smart contracts. We will walk through creating and deploying a simple, smart contract on the Goerli test network using [MetaMask](https://metamask.io), [Solidity](https://docs.soliditylang.org/en/v0.8.0/), [Hardhat](https://hardhat.org), and [Alchemy](https://alchemy.com/eth).
+This guide is for you if you are new to blockchain development and don't know where to start or how to deploy and interact with smart contracts. We will walk through creating and deploying a simple, smart contract on the Sepolia test network using [MetaMask](https://metamask.io), [Solidity](https://docs.soliditylang.org/en/v0.8.0/), [Hardhat](https://hardhat.org), and [Alchemy](https://alchemy.com/eth).
 
 You'll need an Alchemy account to complete this tutorial. [Sign up for a free account](https://www.alchemy.com/).
 
@@ -34,17 +34,17 @@ There are many ways to make requests to the Ethereum chain. For simplicity, we'l
 
 ### Create your app and API key {#create-your-app-and-api-key}
 
-Once you've created an Alchemy account, you can generate an API key by creating an app. This will allow you to make requests to the Goerli testnet. If you're not familiar with testnets you can [read Alchemy's guide to choosing a network](https://www.alchemy.com/docs/choosing-a-web3-network).
+Once you've created an Alchemy account, you can generate an API key by creating an app. This will allow you to make requests to the Sepolia testnet. If you're not familiar with testnets you can [read Alchemy's guide to choosing a network](https://www.alchemy.com/docs/choosing-a-web3-network).
 
 On the Alchemy dashboard, find the **Apps** dropdown in the navigation bar and click **Create App**.
 
 ![Hello world create app](./hello-world-create-app.png)
 
-Give your app the name '_Hello World_' and write a short description. Select **Staging** as your environment and **Goerli** as your network.
+Give your app the name '_Hello World_' and write a short description. Select **Staging** as your environment and **Sepolia** as your network.
 
 ![create app view hello world](./create-app-view-hello-world.png)
 
-_Note: be sure to select **Goerli**, or this tutorial won't work._
+_Note: be sure to select **Sepolia**, or this tutorial won't work._
 
 Click **Create app**. Your app will appear in the table below.
 
@@ -52,11 +52,11 @@ Click **Create app**. Your app will appear in the table below.
 
 You need an Ethereum account to send and receive transactions. We'll use MetaMask, a virtual wallet in the browser that lets users manage their Ethereum account address.
 
-You can download and create a MetaMask account for free [here](https://metamask.io/download). When you are creating an account, or if you already have an account, make sure to switch over to the “Goerli Test Network” in the upper right (so that we’re not dealing with real money).
+You can download and create a MetaMask account for free [here](https://metamask.io/download). When you are creating an account, or if you already have an account, make sure to switch over to the “Sepolia Test Network” in the upper right (so that we’re not dealing with real money).
 
 ### Step 4: Add ether from a Faucet {#step-4-add-ether-from-a-faucet}
 
-To deploy your smart contract to the test network, you'll need some fake ETH. To get ETH on the Goerli network, go to a Goerli faucet and enter your Goerli account address. Note that Goerli faucets can be a bit unreliable recently - see the [test networks page](/developers/docs/networks/#goerli) for a list of options to try:
+To deploy your smart contract to the test network, you'll need some fake ETH. To get ETH on the Sepolia network, go to a Sepolia faucet and enter your Sepolia account address. Note that testnet faucets can be a bit unreliable at times - see the [test networks page](/developers/docs/networks/#sepolia) for a list of options to try:
 
 _Note: due to network congestion, this might take a while._
 ``
@@ -247,7 +247,7 @@ Do not name it `process.env` or `.env-custom` or anything else.
 Your `.env` should look like this:
 
 ```
-API_URL = "https://eth-goerli.alchemyapi.io/v2/your-api-key"
+API_URL = "https://eth-sepolia.g.alchemy.com/v2/your-api-key"
 PRIVATE_KEY = "your-metamask-private-key"
 ```
 
@@ -283,10 +283,10 @@ const { API_URL, PRIVATE_KEY } = process.env
 
 module.exports = {
   solidity: "0.7.3",
-  defaultNetwork: "goerli",
+  defaultNetwork: "sepolia",
   networks: {
     hardhat: {},
-    goerli: {
+    sepolia: {
       url: API_URL,
       accounts: [`0x${PRIVATE_KEY}`],
     },
@@ -348,7 +348,7 @@ Calling `deploy()` on a `ContractFactory` will start the deployment, and return 
 We’re finally ready to deploy our smart contract! Navigate to the command line and run:
 
 ```bash
-npx hardhat run scripts/deploy.js --network goerli
+npx hardhat run scripts/deploy.js --network sepolia
 ```
 
 You should then see something like:
@@ -359,7 +359,7 @@ Contract deployed to address: 0x6cd7d44516a20882cEa2DE9f205bF401c0d23570
 
 **Please save this address**. We will be using it later in the tutorial.
 
-If we go to the [Goerli etherscan](https://goerli.etherscan.io) and search for our contract address we should able to see that it has been deployed successfully. The transaction will look something like this:
+If we go to the [Sepolia etherscan](https://sepolia.etherscan.io) and search for our contract address we should able to see that it has been deployed successfully. The transaction will look something like this:
 
 ![](./etherscan-contract.png)
 
@@ -373,11 +373,11 @@ To understand what’s going on under the hood, let’s navigate to the Explorer
 
 ![](./hello-world-explorer.png)
 
-Here you’ll see a handful of JSON-RPC methods that Hardhat/Ethers made under the hood for us when we called the `.deploy()` function. Two important methods here are [`eth_sendRawTransaction`](https://www.alchemy.com/docs/chains/ethereum/ethereum-api-endpoints/eth-send-raw-transaction), which is the request to write our contract onto the Goerli chain, and [`eth_getTransactionByHash`](https://www.alchemy.com/docs/chains/ethereum/ethereum-api-endpoints/eth-get-transaction-by-hash), which is a request to read information about our transaction given the hash. To learn more about sending transactions, check out [our tutorial on sending transactions using Web3](/developers/tutorials/sending-transactions-using-web3-and-alchemy/).
+Here you’ll see a handful of JSON-RPC methods that Hardhat/Ethers made under the hood for us when we called the `.deploy()` function. Two important methods here are [`eth_sendRawTransaction`](https://www.alchemy.com/docs/chains/ethereum/ethereum-api-endpoints/eth-send-raw-transaction), which is the request to write our contract onto the Sepolia chain, and [`eth_getTransactionByHash`](https://www.alchemy.com/docs/chains/ethereum/ethereum-api-endpoints/eth-get-transaction-by-hash), which is a request to read information about our transaction given the hash. To learn more about sending transactions, check out [our tutorial on sending transactions using Web3](/developers/tutorials/sending-transactions-using-web3-and-alchemy/).
 
 ## Part 2: Interact with your Smart Contract {#part-2-interact-with-your-smart-contract}
 
-Now that we've successfully deployed a smart contract to the Goerli network let's learn how to interact with it.
+Now that we've successfully deployed a smart contract to the Sepolia network let's learn how to interact with it.
 
 ### Create a interact.js file {#create-a-interactjs-file}
 
@@ -404,7 +404,7 @@ Your `.env` file should look something like this:
 ```bash
 # .env
 
-API_URL = "https://eth-goerli.alchemyapi.io/v2/<your-api-key>"
+API_URL = "https://eth-sepolia.g.alchemy.com/v2/<your-api-key>"
 API_KEY = "<your-api-key>"
 PRIVATE_KEY = "<your-metamask-private-key>"
 CONTRACT_ADDRESS = "0x<your contract address>"
@@ -446,7 +446,7 @@ We'll use the contract ABI from the previous step to create our instance of the 
 
 // Provider
 const alchemyProvider = new ethers.providers.AlchemyProvider(
-  (network = "goerli"),
+  (network = "sepolia"),
   API_KEY
 )
 
@@ -532,7 +532,7 @@ const contract = require("../artifacts/contracts/HelloWorld.sol/HelloWorld.json"
 
 // provider - Alchemy
 const alchemyProvider = new ethers.providers.AlchemyProvider(
-  (network = "goerli"),
+  (network = "sepolia"),
   API_KEY
 )
 
@@ -563,7 +563,7 @@ main()
 
 Now just run the script and you should be able to see the old message, the updating status, and the new message printed out to your terminal!
 
-`npx hardhat run scripts/interact.js --network goerli`
+`npx hardhat run scripts/interact.js --network sepolia`
 
 ```
 The message is: Hello World!
@@ -571,7 +571,7 @@ Updating the message...
 The new message is: This is the new message.
 ```
 
-While running that script, you may notice that the `Updating the message...` step takes a while to load before the new message loads. That is due to the mining process; if you are curious about tracking transactions while they are being mined, visit the [Alchemy mempool](https://dashboard.alchemy.com/mempool) to see the status of a transaction. If the transaction is dropped, it's also helpful to check [Goerli Etherscan](https://goerli.etherscan.io) and search for your transaction hash.
+While running that script, you may notice that the `Updating the message...` step takes a while to load before the new message loads. That is due to the mining process; if you are curious about tracking transactions while they are being mined, visit the [Alchemy mempool](https://dashboard.alchemy.com/mempool) to see the status of a transaction. If the transaction is dropped, it's also helpful to check [Sepolia Etherscan](https://sepolia.etherscan.io) and search for your transaction hash.
 
 ## Part 3: Publish your Smart Contract to Etherscan {#part-3-publish-your-smart-contract-to-etherscan}
 
@@ -596,7 +596,7 @@ Next, we need to add the Etherscan API key to our `.env` file.
 After adding it, your `.env`file should look like this:
 
 ```javascript
-API_URL = "https://eth-goerli.alchemyapi.io/v2/your-api-key"
+API_URL = "https://eth-sepolia.g.alchemy.com/v2/your-api-key"
 PUBLIC_KEY = "your-public-account-address"
 PRIVATE_KEY = "your-private-account-address"
 CONTRACT_ADDRESS = "your-contract-address"
@@ -626,10 +626,10 @@ const { API_URL, PRIVATE_KEY, ETHERSCAN_API_KEY } = process.env
 
 module.exports = {
   solidity: "0.7.3",
-  defaultNetwork: "goerli",
+  defaultNetwork: "sepolia",
   networks: {
     hardhat: {},
-    goerli: {
+    sepolia: {
       url: API_URL,
       accounts: [`0x${PRIVATE_KEY}`],
     },
@@ -649,10 +649,10 @@ Ensure all files are saved and all `.env` variables are correctly configured.
 Run the `verify` task, passing the contract address, and the network to where it's deployed:
 
 ```text
-npx hardhat verify --network goerli DEPLOYED_CONTRACT_ADDRESS 'Hello World!'
+npx hardhat verify --network sepolia DEPLOYED_CONTRACT_ADDRESS 'Hello World!'
 ```
 
-Make sure that `DEPLOYED_CONTRACT_ADDRESS` is the address of your deployed smart contract on the Goerli test network. Also, the final argument (`'Hello World!'`) must be the same string value used [during the deploy step in part 1](#step-15-write-our-deploy-script).
+Make sure that `DEPLOYED_CONTRACT_ADDRESS` is the address of your deployed smart contract on the Sepolia test network. Also, the final argument (`'Hello World!'`) must be the same string value used [during the deploy step in part 1](#step-15-write-our-deploy-script).
 
 If all goes well, you will see the following message in your terminal:
 
@@ -663,7 +663,7 @@ for verification on Etherscan. Waiting for verification result...
 
 
 Successfully verified contract HelloWorld on Etherscan.
-https://goerli.etherscan.io/address/<contract-address>#contracts
+https://sepolia.etherscan.io/address/<contract-address>#contracts
 ```
 
 Congrats! Your smart contract code is on Etherscan!
@@ -921,7 +921,7 @@ For our dapp, **we'll be using our Websockets API key** instead of our HTTP API 
 Once you have your API key, create a `.env` file in your root directory and add your Alchemy Websockets url to it. Afterwards, your `.env` file should look like so:
 
 ```javascript
-REACT_APP_ALCHEMY_KEY = wss://eth-goerli.ws.alchemyapi.io/v2/<key>
+REACT_APP_ALCHEMY_KEY = wss://eth-sepolia.g.alchemy.com/v2/<key>
 ```
 
 Now, we're ready to set up our Alchemy Web3 endpoint in our dapp! Let's go back to our `interact.js`, which is nested inside our `util` folder and add the following code at the top of the file:
@@ -947,7 +947,7 @@ To load your Hello World smart contract, you'll need its contract address and AB
 
 #### How to get your contract ABI from Etherscan {#how-to-get-your-contract-abi-from-etherscan}
 
-If you skipped Part 3 of this tutorial, you can use the HelloWorld contract with address [0x6f3f635A9762B47954229Ea479b4541eAF402A6A](https://goerli.etherscan.io/address/0x6f3f635a9762b47954229ea479b4541eaf402a6a#code). Its ABI can be found [here](https://goerli.etherscan.io/address/0x6f3f635a9762b47954229ea479b4541eaf402a6a#code).
+If you skipped Part 3 of this tutorial, use the HelloWorld contract you deployed in [Step 16](#step-16-deploy-our-contract): open its address on [Sepolia Etherscan](https://sepolia.etherscan.io) and, once the source is verified, copy the ABI from the **Contract > Code** tab.
 
 A contract ABI is necessary for specifying which function a contract will invoke as well ensuring that the function will return data in the format you're expecting. Once we've copied our contract ABI, let's save it as a JSON file called `contract-abi.json` in your `src` directory.
 
@@ -1121,11 +1121,11 @@ If you want to understand more about how transactions on Ethereum work, check ou
 
 #### Download MetaMask {#download-metamask}
 
-You can download and create a MetaMask account for free [here](https://metamask.io/download). When you are creating an account, or if you already have an account, make sure to switch over to the “Goerli Test Network” in the upper right \(so that we’re not dealing with real money\).
+You can download and create a MetaMask account for free [here](https://metamask.io/download). When you are creating an account, or if you already have an account, make sure to switch over to the “Sepolia Test Network” in the upper right \(so that we’re not dealing with real money\).
 
 #### Add ether from a Faucet {#add-ether-from-a-faucet}
 
-To sign a transaction on the Ethereum blockchain, we’ll need some fake Eth. To get Eth you can go to the [FaucETH](https://fauceth.komputing.org) and enter your Goerli account address, click “Request funds”, then select “Ethereum Testnet Goerli” in the dropdown and finally click “Request funds” button again. You should see Eth in your MetaMask account soon after!
+To sign a transaction on the Ethereum blockchain, we’ll need some fake Eth. To get Eth, pick a faucet from the [test networks page](/developers/docs/networks/#sepolia) and enter your Sepolia account address to request funds. You should see Eth in your MetaMask account soon after!
 
 #### Check your Balance {#check-your-balance}
 
@@ -1430,7 +1430,7 @@ try {
     status: (
       <span>
         ✅{" "}
-        <a target="_blank" href={`https://goerli.etherscan.io/tx/${txHash}`}>
+        <a target="_blank" href={`https://sepolia.etherscan.io/tx/${txHash}`}>
           View the status of your transaction on Etherscan!
         </a>
         <br />
@@ -1496,7 +1496,7 @@ export const updateMessage = async (address, message) => {
       status: (
         <span>
           ✅{" "}
-          <a target="_blank" href={`https://goerli.etherscan.io/tx/${txHash}`}>
+          <a target="_blank" href={`https://sepolia.etherscan.io/tx/${txHash}`}>
             View the status of your transaction on Etherscan!
           </a>
           <br />


### PR DESCRIPTION
## Description

The Hello World fullstack tutorial was written for the Goerli testnet, which has been deprecated — `goerli.etherscan.io` returns HTTP 521 and its faucets/RPC endpoints no longer work, so the tutorial cannot be completed as written.

This migrates the tutorial to **Sepolia**, the recommended default testnet for application development:

- Network references throughout (intro, Alchemy app setup, MetaMask, deploy/verify steps): Goerli → Sepolia
- Alchemy RPC/WebSocket URLs updated to the current format (`eth-sepolia.g.alchemy.com`) instead of the legacy `alchemyapi.io` host
- Hardhat config (`defaultNetwork`, network key) and CLI commands (`--network sepolia`)
- Block explorer links → `sepolia.etherscan.io` (including the JSX transaction links in the frontend section)
- Faucet guidance now points to the [test networks page](/developers/docs/networks/#sepolia) faucet list; the old `#goerli` anchor no longer exists
- The pre-deployed Goerli demo contract (`0x6f3f…`) only existed on Goerli, so that "skipped Part 3" note now directs readers to the contract they deployed in Step 16 instead of a dead link

No stray `goerli` references remain in the file.

## Related Issue

Closes #18595
