### PR TITLE
fix: update CryptoSD meetup link

### DIFF
--- a/src/data/community-meetups.json
+++ b/src/data/community-meetups.json
@@ -470,7 +470,7 @@
   {
     "title": "CryptoSD",
     "location": "San Diego, USA",
-    "link": "http://cryptosandiego.org",
+    "link": "https://cryptosandiego.org",
     "logoImage": "https://secure.meetupstatic.com/photos/event/1/f/f/8/600_525848184.jpeg",
     "bannerImage": "https://secure.meetupstatic.com/photos/event/1/f/f/8/600_525848184.jpeg"
   },

--- a/src/data/community-meetups.json
+++ b/src/data/community-meetups.json
@@ -470,7 +470,7 @@
   {
     "title": "CryptoSD",
     "location": "San Diego, USA",
-    "link": "https://cryptosandiego.org",
+    "link": "https://www.meetup.com/crypto-san-diego/",
     "logoImage": "https://secure.meetupstatic.com/photos/event/1/f/f/8/600_525848184.jpeg",
     "bannerImage": "https://secure.meetupstatic.com/photos/event/1/f/f/8/600_525848184.jpeg"
   },


### PR DESCRIPTION
## Description
Updates the CryptoSD meetup link from http:// to https://.

## Related issue
Fixes #18675
