### PR TITLE
fix: RTL support for Embla carousels (roadmap ReleaseCarousel)

### DIFF
--- a/app/[locale]/roadmap/_components/ReleaseCarousel.tsx
+++ b/app/[locale]/roadmap/_components/ReleaseCarousel.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-// TODO: Fix RTL compatibility; currently forced to LTR flow
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { useLocale } from "next-intl"
 
@@ -128,7 +127,6 @@ const ReleaseCarousel = () => {
         opts={{
           align: "center",
           containScroll: false,
-          direction: "ltr",
           loop: false,
           startIndex,
         }}
@@ -191,7 +189,7 @@ const ReleaseCarousel = () => {
                           : index < boundaryIndex
                             ? "bg-primary"
                             : index === boundaryIndex
-                              ? "bg-linear-to-r from-primary to-primary-low-contrast"
+                              ? "bg-linear-to-r from-primary to-primary-low-contrast rtl:bg-linear-to-l"
                               : "bg-primary-low-contrast"
                       )}
                     />
@@ -240,7 +238,6 @@ const ReleaseCarousel = () => {
         opts={{
           align: "center",
           containScroll: false,
-          direction: "ltr",
           loop: false,
           startIndex,
         }}

--- a/app/[locale]/roadmap/page.tsx
+++ b/app/[locale]/roadmap/page.tsx
@@ -192,11 +192,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
 
       <main className="space-y-space-3x pb-page">
         <MainArticle className="flow **:data-[label=button-link]:max-md:w-full *:[section]:px-page">
-          <Section
-            id="releases"
-            dir="ltr"
-            className="mt-space-3x overflow-hidden"
-          >
+          <Section id="releases" className="mt-space-3x overflow-hidden">
             <I18nProvider locale={locale} messages={messages}>
               <ReleaseCarousel />
             </I18nProvider>

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -1,5 +1,3 @@
-// TODO: Fix RTL compatibility
-
 import * as React from "react"
 import useEmblaCarousel, {
   type UseEmblaCarouselType,
@@ -9,6 +7,8 @@ import { ChevronLeft, ChevronRight } from "lucide-react"
 import { Button } from "@/components/ui/buttons/Button"
 
 import { cn } from "@/lib/utils/cn"
+
+import { useRtlFlip } from "@/hooks/useRtlFlip"
 
 type CarouselApi = UseEmblaCarouselType[1]
 type UseCarouselParameters = Parameters<typeof useEmblaCarousel>
@@ -59,8 +59,11 @@ const Carousel = React.forwardRef<
     },
     ref
   ) => {
+    const { isRtl, direction } = useRtlFlip()
+
     const [carouselRef, api] = useEmblaCarousel(
       {
+        direction,
         ...opts,
         axis: orientation === "horizontal" ? "x" : "y",
       },
@@ -90,13 +93,21 @@ const Carousel = React.forwardRef<
       (event: React.KeyboardEvent<HTMLDivElement>) => {
         if (event.key === "ArrowLeft") {
           event.preventDefault()
-          scrollPrev()
+          if (isRtl) {
+            scrollNext()
+          } else {
+            scrollPrev()
+          }
         } else if (event.key === "ArrowRight") {
           event.preventDefault()
-          scrollNext()
+          if (isRtl) {
+            scrollPrev()
+          } else {
+            scrollNext()
+          }
         }
       },
-      [scrollPrev, scrollNext]
+      [scrollPrev, scrollNext, isRtl]
     )
 
     React.useEffect(() => {
@@ -137,6 +148,7 @@ const Carousel = React.forwardRef<
       >
         <div
           ref={ref}
+          dir={opts?.direction ?? direction}
           onKeyDownCapture={handleKeyDown}
           className={cn("relative", className)}
           role="region"
@@ -163,7 +175,7 @@ const CarouselContent = React.forwardRef<
         ref={ref}
         className={cn(
           "flex",
-          orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
+          orientation === "horizontal" ? "-ms-4" : "-mt-4 flex-col",
           className
         )}
         {...props}
@@ -210,14 +222,14 @@ const CarouselPrevious = React.forwardRef<
         "absolute h-8 w-8 rounded-full",
         orientation === "horizontal"
           ? "start-5 top-1/2 -translate-y-1/2"
-          : "start-1/2 -top-12 -translate-x-1/2 rotate-90",
+          : "start-1/2 -top-12 -translate-x-1/2 rotate-90 rtl:translate-x-1/2",
         className
       )}
       disabled={!canScrollPrev}
       onClick={scrollPrev}
       {...props}
     >
-      <ChevronLeft className="size-6" />
+      <ChevronLeft className="size-6 rtl:-scale-x-100" />
       <span className="sr-only">Previous slide</span>
     </Button>
   )
@@ -239,14 +251,14 @@ const CarouselNext = React.forwardRef<
         "absolute h-8 w-8 rounded-full",
         orientation === "horizontal"
           ? "end-5 top-1/2 -translate-y-1/2"
-          : "start-1/2 -bottom-12 -translate-x-1/2 rotate-90",
+          : "start-1/2 -bottom-12 -translate-x-1/2 rotate-90 rtl:translate-x-1/2",
         className
       )}
       disabled={!canScrollNext}
       onClick={scrollNext}
       {...props}
     >
-      <ChevronRight className="size-6" />
+      <ChevronRight className="size-6 rtl:-scale-x-100" />
       <span className="sr-only">Next slide</span>
     </Button>
   )


### PR DESCRIPTION
## Description

Fixes #18580: the `ui/carousel` Embla wrapper always ran LTR physics, and the roadmap release carousel additionally hard-forced `dir="ltr"`, so RTL locales (ar/ur) got a backwards timeline with inverted keyboard arrows.

| File | Change |
|---|---|
| `src/components/ui/carousel.tsx` | Pass `direction` from `useRtlFlip()` into the Embla options (explicit `opts.direction` still wins); set `dir` on the region root so `rtl:` variants work from first paint; swap ArrowLeft/ArrowRight semantics in RTL (in Embla RTL the visually-left slide is *next*); `-ml-4` → `-ms-4`; mirror both chevrons (`rtl:-scale-x-100`); fix vertical-orientation button centering (`rtl:translate-x-1/2`). |
| `ReleaseCarousel.tsx` | Remove both hardcoded `direction: "ltr"` opts + the stale TODO; boundary gradient gets `rtl:bg-linear-to-l`. |
| `roadmap/page.tsx` | Remove the forced `dir="ltr"` on the releases `<Section>` — this was added after the earlier fix attempt branched and would have kept the bug alive. |

**Design note:** direction comes from the locale (`useRtlFlip`/`useLocale`), *not* `document.dir` — in this app `dir` is set client-side in an effect (`useLocaleDirection`), so it's empty during hydration and unusable for this.

**Verified** on a local dev server (`USE_MOCK_DATA=true`): `/ar/roadmap` renders both carousel roots with `dir="rtl"` and logical margins; `/en/roadmap` keeps `dir="ltr"`; no hydration errors. The scroll interaction itself can't be exercised locally — the nav buttons are disabled with mock data **on unmodified dev as well** (verified via stash-control), so please do the interactive check on the deploy preview: on `/ar/roadmap` the timeline should start from the right, ArrowLeft should advance, chevrons mirrored, and the shipped→upcoming gradient should fade right-to-left. Swiper-based carousels (homepage) need no change — Swiper auto-detects RTL and was verified out of scope in the investigation.

Supersedes #18637, which had the right idea (credit @alerodriargui) but was based on pre-#18468 code, relied on `document.dir` (unset at hydration), and missed the `dir="ltr"` that had moved to `roadmap/page.tsx`.

Fixes #18580