### PR TITLE
feat(ui): intrinsic sizing for markdown video via #WxH src fragment

### DIFF
--- a/.claude/skills/design-system/references/components.md
+++ b/.claude/skills/design-system/references/components.md
@@ -789,6 +789,14 @@ import { MdComponents } from "@/components/MdComponents"
 
 The shortcode registry for markdown content. To add a markdown shortcode, add the component to `MdComponents`.
 
+### `MarkdownVideo` (markdown clips)
+
+Renders `![](./x.mp4)` in markdown content (reached via `MarkdownImage`; not imported in app code) — the modern GIF replacement: silent, looping, plays only while on-screen, controls instead of autoplay under `prefers-reduced-motion`.
+
+**Sizing convention**: an optional `#WxH` fragment on the markdown src declares the clip's intrinsic dimensions — `![](./demo.mp4#800x400)` — and sizes the box to the clip's own aspect ratio (landscape fills the content width; taller-than-wide is height-capped). Without it, a fixed 16:9 box (9:16 via the `-portrait` filename suffix) letterboxes the clip with `object-contain`.
+
+Use the fragment for any off-ratio clip — screen captures usually are. It's presentation metadata only: browsers strip fragments before requesting, so the asset URL stays canonical (one CDN/browser cache entry, no file renames) and references without it — e.g. not-yet-repropagated translations — still play in the default box. **Never rename a video asset to encode metadata.** Implementation notes: `rehypeImg` and `MarkdownImage` strip the fragment before extension checks (an mp4 falling into the image path makes `image-size` throw at build); `MarkdownVideo` sets `width`/`height` attributes plus explicit CSS `aspect-ratio` because the attribute→ratio mapping is unreliable on `<video>` and `h-auto` overrides the height attribute — together they reserve the box before video metadata loads (no CLS).
+
 ## Components NOT to Use
 
 ### Legacy / deprecated

--- a/public/content/developers/tutorials/getting-started-with-ethereum-development-using-alchemy/index.md
+++ b/public/content/developers/tutorials/getting-started-with-ethereum-development-using-alchemy/index.md
@@ -37,7 +37,7 @@ Fill in the details under “Create App” to get your new key. You can also see
 
 You can also pull existing API keys by hovering over “Apps” and selecting one. You can “View Key” here, as well as “Edit App” to whitelist specific domains, see several developer tools, and view analytics.
 
-![Gif showing a user how to pull API keys](./pull-api-keys.mp4)
+![Gif showing a user how to pull API keys](./pull-api-keys.mp4#600x340)
 
 ## 3. Make a Request from the Command Line {#make-a-request-from-the-command-line}
 

--- a/public/content/developers/tutorials/hello-world-smart-contract-fullstack/index.md
+++ b/public/content/developers/tutorials/hello-world-smart-contract-fullstack/index.md
@@ -242,7 +242,7 @@ Do not name it `process.env` or `.env-custom` or anything else.
 - Follow [these instructions](https://metamask.zendesk.com/hc/en-us/articles/360015289632-How-to-Export-an-Account-Private-Key) to export your private key
 - See below to get HTTP Alchemy API URL
 
-![Animated walkthrough of getting an Alchemy API key](./get-alchemy-api-key.mp4)
+![Animated walkthrough of getting an Alchemy API key](./get-alchemy-api-key.mp4#1280x696)
 
 Your `.env` should look like this:
 

--- a/public/content/developers/tutorials/how-to-mint-an-nft/index.md
+++ b/public/content/developers/tutorials/how-to-mint-an-nft/index.md
@@ -78,7 +78,7 @@ Once you’ve created an account:
 
 For the more visual learners, the steps above are summarized here:
 
-![How to upload your image to Pinata](./instructionsPinata.mp4)
+![How to upload your image to Pinata](./instructionsPinata.mp4#712x376)
 
 Now, we’re going to want to upload one more document to Pinata. But before we do that, we need to create it!
 
@@ -106,7 +106,7 @@ Feel free to change the data in the json. You can remove or add to the attribute
 
 Once you’re done editing the JSON file, save it and upload it to Pinata, following the same steps we did for uploading the image.
 
-![How to upload your nft-metadata.json to Pinata](./uploadPinata.mp4)
+![How to upload your nft-metadata.json to Pinata](./uploadPinata.mp4#1280x676)
 
 ## Step 5: Create an instance of your contract {#instance-contract}
 
@@ -249,7 +249,7 @@ Remember the `metadata.json` you uploaded to Pinata? Get its hashcode from Pinat
 
 Here’s how to get the hashcode:
 
-![How to get your nft metadata hashcode on Pinata](./metadataPinata.mp4)_How to get your nft metadata hashcode on Pinata_
+![How to get your nft metadata hashcode on Pinata](./metadataPinata.mp4#1280x676)_How to get your nft metadata hashcode on Pinata_
 
 > Double check that the hashcode you copied links to your **metadata.json** by loading `https://gateway.pinata.cloud/ipfs/<metadata-hash-code>` into a separate window. The page should look similar to the screenshot below:
 

--- a/public/content/developers/tutorials/how-to-view-nft-in-metamask/index.md
+++ b/public/content/developers/tutorials/how-to-view-nft-in-metamask/index.md
@@ -19,7 +19,7 @@ As a prerequisite, you should already have MetaMask on mobile installed, and it 
 
 At the top of the app, press the “Wallet” button, after which you’ll be prompted to select a network. As our NFT was minted on the Sepolia network, you’ll want to select Sepolia as your network.
 
-![How to set Sepolia as your network on MetaMask Mobile](./goerliMetamask-portrait.mp4)
+![How to set Sepolia as your network on MetaMask Mobile](./goerliMetamask-portrait.mp4#304x672)
 
 ## Step 2: Add your collectable to MetaMask {#add-nft-to-metamask}
 
@@ -29,6 +29,6 @@ Once you’re on the Sepolia network, select the “Collectibles” tab on the r
 
 You may need to refresh a couple times to view your NFT — but it will be there <Emoji text="😄" size={1} />!
 
-![How to upload your NFT to MetaMask](./findNFTMetamask-portrait.mp4)
+![How to upload your NFT to MetaMask](./findNFTMetamask-portrait.mp4#304x672)
 
 Congrats! You have successfully minted an NFT, and you can now view it! We can’t wait to see how you’ll take the NFT world by storm!

--- a/public/content/developers/tutorials/how-to-write-and-deploy-an-nft/index.md
+++ b/public/content/developers/tutorials/how-to-write-and-deploy-an-nft/index.md
@@ -229,7 +229,7 @@ Then, create a `.env` file in the root directory of our project, and add your Me
 
 - See below to get HTTP Alchemy API URL and copy it to your clipboard
 
-![Copy your Alchemy API URL](./copy-alchemy-api-url.mp4)
+![Copy your Alchemy API URL](./copy-alchemy-api-url.mp4#842x480)
 
 Your `.env` should now look like this:
 

--- a/public/content/developers/tutorials/the-graph-fixing-web3-data-querying/index.md
+++ b/public/content/developers/tutorials/the-graph-fixing-web3-data-querying/index.md
@@ -84,7 +84,7 @@ First let's talk about GraphQL, originally designed and implemented by Facebook.
 
 ![GraphQL API vs. REST API](./graphql.jpg)
 
-![Animated demonstration of a GraphQL query in The Graph playground](./graphql-query.mp4)
+![Animated demonstration of a GraphQL query in The Graph playground](./graphql-query.mp4#910x692)
 
 The two images pretty much capture the essence of GraphQL. With the query on the right we can define exactly what data we want, so there we get everything in one request and nothing more than exactly what we need. A GraphQL server handles the fetching of all data required, so it is incredibly easy for the frontend consumer side to use. [This is a nice explanation](https://www.apollographql.com/blog/graphql-explained) of how exactly the server handles a query if you're interested.
 

--- a/public/content/developers/tutorials/using-websockets/index.md
+++ b/public/content/developers/tutorials/using-websockets/index.md
@@ -40,7 +40,7 @@ wscat -c wss://eth-mainnet.ws.alchemyapi.io/ws/demo
 
 To begin, open a WebSocket using the WebSocket URL for your app. You can find your app's WebSocket URL by opening the app's page in [your dashboard](https://dashboard.alchemy.com/) and clicking "View Key". Note that your app's URL for WebSockets is different from its URL for HTTP requests, but both can be found by clicking "View Key".
 
-![Where to find your WebSocket URL in your Alchemy dashboard](./use-websockets.mp4)
+![Where to find your WebSocket URL in your Alchemy dashboard](./use-websockets.mp4#602x280)
 
 Any of the APIs listed in the [Alchemy API Reference](https://www.alchemy.com/docs/reference/api-overview) can be used via WebSocket. To do so, use the same payload that would be sent as the body of a HTTP POST request, but instead send that payload through the WebSocket.
 

--- a/public/content/stories/funding-culture/index.md
+++ b/public/content/stories/funding-culture/index.md
@@ -64,7 +64,7 @@ Our first experiment was an anime series called [White Rabbit](https://www.shibu
 - Staked to vote on plot decisions directly in player
 - Earned an ERC20 (our attention token) 
 
-![White Rabbit choose-your-own-adventure anime demo](./white-rabbit.mp4)
+![White Rabbit choose-your-own-adventure anime demo](./white-rabbit.mp4#800x400)
 
 The ERC20 was issued on a bonding curve. The earlier and more engaged you were, the more you earned. Votes (like naming the main character Mirai) happened via Snapshot. 
 

--- a/src/components/Image/MarkdownImage.tsx
+++ b/src/components/Image/MarkdownImage.tsx
@@ -36,14 +36,19 @@ const MarkdownImage = ({
     imageHeight = CONTENT_IMAGES_MAX_WIDTH / imageAspectRatio
   }
 
-  const fileExt = extname(transformedSrc).toLowerCase()
+  // A clip src may carry a `#WxH` dimensions fragment (see `MarkdownVideo`);
+  // it's presentation metadata, not part of the file path, so drop it before
+  // deriving the extension.
+  const srcFilePath = transformedSrc.split("#")[0]
+  const fileExt = extname(srcFilePath).toLowerCase()
   const isAnimated = [".gif", ".apng", ".webp"].includes(fileExt)
   const isVideo = [".mp4", ".webm", ".mov"].includes(fileExt)
 
   if (isVideo) {
     // Orientation opt-in: a `-portrait` filename suffix (e.g. `clip-portrait.mp4`)
-    // selects the portrait ratio; everything else is landscape.
-    const orientation = /-portrait\.[^.]+$/.test(transformedSrc)
+    // selects the portrait ratio; everything else is landscape. Only consulted
+    // when the src declares no dimensions — see `MarkdownVideo`.
+    const orientation = /-portrait\.[^.]+$/.test(srcFilePath)
       ? "portrait"
       : "landscape"
     return (

--- a/src/components/Image/MarkdownImage.tsx
+++ b/src/components/Image/MarkdownImage.tsx
@@ -36,9 +36,8 @@ const MarkdownImage = ({
     imageHeight = CONTENT_IMAGES_MAX_WIDTH / imageAspectRatio
   }
 
-  // A clip src may carry a `#WxH` dimensions fragment (see `MarkdownVideo`);
-  // it's presentation metadata, not part of the file path, so drop it before
-  // deriving the extension.
+  // Strip any `#WxH` dimensions fragment (see `MarkdownVideo`) before
+  // deriving the extension
   const srcFilePath = transformedSrc.split("#")[0]
   const fileExt = extname(srcFilePath).toLowerCase()
   const isAnimated = [".gif", ".apng", ".webp"].includes(fileExt)
@@ -46,8 +45,7 @@ const MarkdownImage = ({
 
   if (isVideo) {
     // Orientation opt-in: a `-portrait` filename suffix (e.g. `clip-portrait.mp4`)
-    // selects the portrait ratio; everything else is landscape. Only consulted
-    // when the src declares no dimensions — see `MarkdownVideo`.
+    // selects the portrait ratio; everything else is landscape.
     const orientation = /-portrait\.[^.]+$/.test(srcFilePath)
       ? "portrait"
       : "landscape"

--- a/src/components/Image/MarkdownVideo.tsx
+++ b/src/components/Image/MarkdownVideo.tsx
@@ -17,16 +17,33 @@ type MarkdownVideoProps = {
   orientation?: VideoOrientation
 }
 
+// An optional `#WxH` fragment on the src declares the clip's intrinsic pixel
+// dimensions, e.g. `![](./demo.mp4#800x400)`. The fragment is presentation
+// metadata only: browsers strip it before requesting, so the asset URL stays
+// canonical (one CDN/browser cache entry), and references without it — e.g.
+// not-yet-repropagated translations — still play in the default box.
+const parseDimensionsFragment = (src: string) => {
+  const match = src.match(/#(\d+)x(\d+)$/)
+  if (!match) return undefined
+  return { width: Number(match[1]), height: Number(match[2]) }
+}
+
 /**
  * Renders a short, silent, looping clip authored in markdown as `![](./x.mp4)`.
  *
- * The modern GIF replacement: a `<video>` sized by a fixed CSS aspect ratio (no
- * CLS, no `next/image` — that pipeline can't optimize video anyway), that only
- * plays while on-screen (battery/bandwidth) and never autoplays under
- * `prefers-reduced-motion` (where it shows controls instead). Clips are
- * standardized to one of two ratios at authoring time; orientation is chosen
- * from the markdown via a `-portrait` filename suffix. Mirrors the orientation
- * handling of the `YouTube` embed (`aspect-9/16 max-h-105`).
+ * The modern GIF replacement: a `<video>` (no `next/image` — that pipeline
+ * can't optimize video anyway) that only plays while on-screen
+ * (battery/bandwidth) and never autoplays under `prefers-reduced-motion`
+ * (where it shows controls instead).
+ *
+ * Sizing: when the src declares the clip's dimensions via a `#WxH` fragment,
+ * the box takes the clip's own aspect ratio so it hugs the video (rounded
+ * corners land on the clip, no letterbox): landscape fills the content width,
+ * taller-than-wide is height-capped for inline tutorial screen-captures.
+ * Without declared dimensions the box falls back to a fixed standard ratio —
+ * 16:9, or 9:16 via the `-portrait` filename suffix (mirroring the `YouTube`
+ * embed's `aspect-9/16 max-h-105`) — with `object-contain` letterboxing
+ * off-ratio clips rather than shifting layout or distorting.
  */
 const MarkdownVideo = ({
   src,
@@ -34,7 +51,10 @@ const MarkdownVideo = ({
   poster,
   orientation = "landscape",
 }: MarkdownVideoProps) => {
-  const isPortrait = orientation === "portrait"
+  const dimensions = parseDimensionsFragment(src)
+  const isPortrait = dimensions
+    ? dimensions.height > dimensions.width
+    : orientation === "portrait"
 
   const ref = useRef<HTMLVideoElement>(null)
   const inView = useInView(ref, { margin: "200px 0px" })
@@ -69,14 +89,33 @@ const MarkdownVideo = ({
         controls={showControls}
         aria-label={alt || undefined}
         src={src}
-        // `object-contain` is a safety net: a clip that isn't exactly the
-        // standard ratio letterboxes inside the fixed box rather than shifting
-        // layout or distorting.
+        // The attributes give the element its intrinsic size before video
+        // metadata loads; the explicit CSS `aspect-ratio` reserves the box up
+        // front (no CLS) — the spec's attribute→aspect-ratio mapping is
+        // unreliable on `<video>`, and `h-auto` overrides the height attribute.
+        width={dimensions?.width}
+        height={dimensions?.height}
+        style={
+          dimensions
+            ? { aspectRatio: `${dimensions.width} / ${dimensions.height}` }
+            : undefined
+        }
         className={cn(
-          "h-auto rounded-base object-contain",
-          isPortrait
-            ? "aspect-9/16 max-h-105 w-auto"
-            : "aspect-video w-full max-w-full"
+          "h-auto rounded-base",
+          dimensions
+            ? // Box hugs the clip's own ratio; cap tall clips by height.
+              isPortrait
+              ? "max-h-160 w-auto"
+              : "w-full max-w-full"
+            : [
+                // No declared dimensions: fixed standard box; `object-contain`
+                // letterboxes off-ratio clips rather than shifting layout or
+                // distorting.
+                "object-contain",
+                isPortrait
+                  ? "aspect-9/16 max-h-105 w-auto"
+                  : "aspect-video w-full max-w-full",
+              ]
         )}
       />
     </span>

--- a/src/components/Image/MarkdownVideo.tsx
+++ b/src/components/Image/MarkdownVideo.tsx
@@ -17,11 +17,8 @@ type MarkdownVideoProps = {
   orientation?: VideoOrientation
 }
 
-// An optional `#WxH` fragment on the src declares the clip's intrinsic pixel
-// dimensions, e.g. `![](./demo.mp4#800x400)`. The fragment is presentation
-// metadata only: browsers strip it before requesting, so the asset URL stays
-// canonical (one CDN/browser cache entry), and references without it — e.g.
-// not-yet-repropagated translations — still play in the default box.
+// `#WxH` src fragment = the clip's intrinsic dimensions (`./demo.mp4#800x400`).
+// Browsers strip fragments before requesting, so the asset URL stays canonical.
 const parseDimensionsFragment = (src: string) => {
   const match = src.match(/#(\d+)x(\d+)$/)
   if (!match) return undefined
@@ -29,21 +26,11 @@ const parseDimensionsFragment = (src: string) => {
 }
 
 /**
- * Renders a short, silent, looping clip authored in markdown as `![](./x.mp4)`.
- *
- * The modern GIF replacement: a `<video>` (no `next/image` — that pipeline
- * can't optimize video anyway) that only plays while on-screen
- * (battery/bandwidth) and never autoplays under `prefers-reduced-motion`
- * (where it shows controls instead).
- *
- * Sizing: when the src declares the clip's dimensions via a `#WxH` fragment,
- * the box takes the clip's own aspect ratio so it hugs the video (rounded
- * corners land on the clip, no letterbox): landscape fills the content width,
- * taller-than-wide is height-capped for inline tutorial screen-captures.
- * Without declared dimensions the box falls back to a fixed standard ratio —
- * 16:9, or 9:16 via the `-portrait` filename suffix (mirroring the `YouTube`
- * embed's `aspect-9/16 max-h-105`) — with `object-contain` letterboxing
- * off-ratio clips rather than shifting layout or distorting.
+ * Short, silent, looping clip authored in markdown as `![](./x.mp4)` — the
+ * modern GIF replacement. Plays only while on-screen; shows controls instead
+ * of autoplaying under `prefers-reduced-motion`. A `#WxH` src fragment sizes
+ * the box to the clip's own ratio; without one, a fixed 16:9 / 9:16
+ * (`-portrait`) box letterboxes the clip. Details: design-system skill.
  */
 const MarkdownVideo = ({
   src,
@@ -89,10 +76,8 @@ const MarkdownVideo = ({
         controls={showControls}
         aria-label={alt || undefined}
         src={src}
-        // The attributes give the element its intrinsic size before video
-        // metadata loads; the explicit CSS `aspect-ratio` reserves the box up
-        // front (no CLS) — the spec's attribute→aspect-ratio mapping is
-        // unreliable on `<video>`, and `h-auto` overrides the height attribute.
+        // Attributes size the element before metadata loads; explicit
+        // aspect-ratio reserves the box (attr mapping is unreliable on video).
         width={dimensions?.width}
         height={dimensions?.height}
         style={
@@ -103,14 +88,10 @@ const MarkdownVideo = ({
         className={cn(
           "h-auto rounded-base",
           dimensions
-            ? // Box hugs the clip's own ratio; cap tall clips by height.
-              isPortrait
+            ? isPortrait
               ? "max-h-160 w-auto"
               : "w-full max-w-full"
             : [
-                // No declared dimensions: fixed standard box; `object-contain`
-                // letterboxes off-ratio clips rather than shifting layout or
-                // distorting.
                 "object-contain",
                 isPortrait
                   ? "aspect-9/16 max-h-105 w-auto"

--- a/src/lib/md/rehypeImg.ts
+++ b/src/lib/md/rehypeImg.ts
@@ -52,10 +52,8 @@ type PlaceholderData = Record<Path, Placeholder>
  */
 const absolutePathRegex = /^(?:[a-z]+:)?\/\//
 
-// Video clips authored as `![](./x.mp4)` declare their intrinsic dimensions
-// via an optional `#WxH` src fragment (see `MarkdownVideo`), so the pipeline
-// doesn't measure them. We only need to recognize video here to skip
-// image-only steps (dimension probing, blur placeholders).
+// Videos are sized by the renderer (see `MarkdownVideo`); recognized here only
+// to skip image-only steps (dimension probing, blur placeholders)
 const VIDEO_EXTENSIONS = [".mp4", ".webm", ".mov"]
 
 const getImageSize = (src: string, dir: string) => {
@@ -169,14 +167,11 @@ const rehypeImg = (options: Options) => {
     visit(tree, "element", (node) => {
       if (node.tagName === "img" && node.properties) {
         const src = node.properties.src as string
-        // A clip src may carry a `#WxH` dimensions fragment; it's presentation
-        // metadata, not part of the file path, so drop it before deriving the
-        // extension.
+        // Strip any `#WxH` dimensions fragment before deriving the extension
         const ext = path.extname(src.split("#")[0]).toLowerCase()
         const isVideo = VIDEO_EXTENSIONS.includes(ext)
 
-        // Videos are sized by the renderer (from the src fragment), so they're
-        // not probed here; they still flow through for src rewriting.
+        // Videos still flow through (for src rewriting); only images are probed
         const dimensions = isVideo ? undefined : getImageSize(src, dir)
 
         // Skip non-video files that have no detectable dimensions

--- a/src/lib/md/rehypeImg.ts
+++ b/src/lib/md/rehypeImg.ts
@@ -52,11 +52,10 @@ type PlaceholderData = Record<Path, Placeholder>
  */
 const absolutePathRegex = /^(?:[a-z]+:)?\/\//
 
-// Video clips authored as `![](./x.mp4)` are standardized to fixed aspect
-// ratios at authoring time, so the pipeline doesn't measure them — orientation
-// is chosen by the renderer from a `-portrait` filename suffix. We only need to
-// recognize video here to skip image-only steps (dimension probing, blur
-// placeholders).
+// Video clips authored as `![](./x.mp4)` declare their intrinsic dimensions
+// via an optional `#WxH` src fragment (see `MarkdownVideo`), so the pipeline
+// doesn't measure them. We only need to recognize video here to skip
+// image-only steps (dimension probing, blur placeholders).
 const VIDEO_EXTENSIONS = [".mp4", ".webm", ".mov"]
 
 const getImageSize = (src: string, dir: string) => {
@@ -170,11 +169,14 @@ const rehypeImg = (options: Options) => {
     visit(tree, "element", (node) => {
       if (node.tagName === "img" && node.properties) {
         const src = node.properties.src as string
-        const ext = path.extname(src).toLowerCase()
+        // A clip src may carry a `#WxH` dimensions fragment; it's presentation
+        // metadata, not part of the file path, so drop it before deriving the
+        // extension.
+        const ext = path.extname(src.split("#")[0]).toLowerCase()
         const isVideo = VIDEO_EXTENSIONS.includes(ext)
 
-        // Videos are sized by the renderer (fixed aspect ratio), so they're not
-        // probed here; they still flow through for src rewriting.
+        // Videos are sized by the renderer (from the src fragment), so they're
+        // not probed here; they still flow through for src rewriting.
         const dimensions = isVideo ? undefined : getImageSize(src, dir)
 
         // Skip non-video files that have no detectable dimensions


### PR DESCRIPTION
## Description

Supersedes #18672, taking @pettinarip's [suggestion](https://github.com/ethereum/ethereum-org-website/pull/18672#pullrequestreview-4625273495) that a lightweight authoring convention beats build-time probing — with one adjustment: the dimensions live in a URL fragment on the markdown reference rather than the filename, so asset files never need renaming.

**The convention:** `![](./demo.mp4#800x400)` — an optional `#WxH` fragment declares the clip's intrinsic dimensions. The `<video>` box then takes the clip's own aspect ratio (rounded corners land on the clip, no letterbox; landscape fills the content width, taller-than-wide is height-capped), with layout reserved up front via CSS `aspect-ratio` (no CLS). Without a fragment, behavior is unchanged: fixed 16:9 / 9:16 (`-portrait`) box with `object-contain`.

**Why a fragment instead of a filename suffix:** browsers strip fragments before requesting, so the asset URL stays canonical — one file, one CDN/browser cache entry, zero renames. That matters at our actual scale: 11 of the 12 content clips are off-ratio (screen captures — odd ratios are the norm), and `white-rabbit.mp4` is already referenced by all 24 translated copies of its page. Translations that haven't repropagated yet keep playing the same asset in the default box — no broken-video window, no duplicate files to clean up later.

All 11 off-ratio English references adopt the fragment here; translations pick it up as the intl-pipeline propagates. `pplpleasr-intro.mp4` is exactly 16:9 and needs nothing.

## Related Issue

Supersedes #18672 (follow-up to #18501).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
