### PR TITLE
Mark dropdown sub-items with dash instead of padding

### DIFF
--- a/src/components/ButtonDropdown.tsx
+++ b/src/components/ButtonDropdown.tsx
@@ -24,9 +24,13 @@ export interface ListItem {
     eventName: string
   }
   callback?: (idx: number) => void
-  /** Nested sub-items rendered indented beneath this item. */
+  /** Nested sub-items rendered beneath this item, marked with a leading dash per level. */
   items?: Array<ListItem>
 }
+
+/** Visual nesting marker; excluded from accessible names. Levels past the first indent the dash with an em space per extra level. */
+const SUB_ITEM_MARKER = "–" // en dash
+const SUB_ITEM_INDENT = " " // em space
 
 export interface List {
   text: string
@@ -50,13 +54,20 @@ const ButtonDropdown = ({ list, className }: ButtonDropdownProps) => {
 
   const renderItems = (items: Array<ListItem>, depth = 0): React.ReactNode =>
     items.map((item, idx) => {
-      // 2rem base inline-start padding + 1rem per nesting level. Only one
-      // sub-level is used today; the map allows two before capping.
-      const indentClass = ["ps-8", "ps-12", "ps-16"][depth] ?? "ps-16"
+      const label = (
+        <>
+          {depth > 0 && (
+            <span aria-hidden className="me-2">
+              {SUB_ITEM_INDENT.repeat(depth - 1) + SUB_ITEM_MARKER}
+            </span>
+          )}
+          {item.text}
+        </>
+      )
       return (
         <Fragment key={item.text}>
           <DropdownMenuItem
-            className={cn("justify-start pe-4 text-start", indentClass)}
+            className="justify-start ps-8 pe-4 text-start"
             onClick={() => handleClick(item, idx)}
             asChild={!!item.href}
           >
@@ -65,10 +76,10 @@ const ButtonDropdown = ({ list, className }: ButtonDropdownProps) => {
                 href={item.href}
                 className="text-body no-underline focus-visible:outline-0"
               >
-                {item.text}
+                {label}
               </BaseLink>
             ) : (
-              <span>{item.text}</span>
+              <span>{label}</span>
             )}
           </DropdownMenuItem>
           {item.items?.length ? renderItems(item.items, depth + 1) : null}

--- a/src/lib/utils/topicDropdown.ts
+++ b/src/lib/utils/topicDropdown.ts
@@ -8,7 +8,7 @@ import type { TopicConfig, TopicDropdownItem } from "@/data/topics"
 /**
  * Maps a topic's `dropdown` config into the `ButtonDropdownList` the
  * `ButtonDropdown` component consumes, translating `textKey`s and preserving
- * nested `items` (rendered indented). `eventAction` is parameterized so each
+ * nested `items` (rendered with a leading dash). `eventAction` is parameterized so each
  * call site keeps its existing Matomo casing.
  */
 export const buildTopicDropdown = (


### PR DESCRIPTION
## Description

Designer-requested tweak to the topic-page dropdowns (`ButtonDropdown`, used via `ContentLayout`): nested sub-items are now marked with a leading en dash (`–`) instead of extra inline-start padding.

- All depths share the base `ps-8`; the depth-based `ps-12`/`ps-16` padding map is removed
- Levels deeper than one indent the dash with an em space per extra level (only one level is used today, e.g. `/roadmap/*`)
- The marker is `aria-hidden`, so accessible names remain just the item text
- Logical margin (`me-2`) keeps RTL rendering correct with no special casing
- Marker and indent characters are single constants for easy future adjustment

## Test plan

- Open any `/roadmap/*` page and check the section dropdown: sub-items show `– ` prefix at uniform padding (mobile viewport for the sticky bottom variant)
- Verify an RTL locale (e.g. `/ar/roadmap/`): dash renders on the right of the item text

🤖 Generated with [Claude Code](https://claude.com/claude-code)