### PR TITLE
fix: unify modal backdrops with overlay token

### DIFF
--- a/.claude/skills/design-system/references/tokens.md
+++ b/.claude/skills/design-system/references/tokens.md
@@ -65,6 +65,7 @@ This is where you get colors for Claude-driven work. Light mode in `:root`, dark
 - `--background-low`
 - `--background-medium`
 - `--background-high`
+- `--overlay` (modal/sheet backdrop dim; the one token with alpha baked in -- use `bg-overlay` as-is, no `/opacity` modifier, no `dark:` needed)
 
 **Borders:**
 - `--border`

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -139,7 +139,7 @@ const Search = ({ asChild = false, children }: SearchProps) => {
         {isOpen && (
           <ErrorBoundary
             fallback={() => (
-              <div className="fixed inset-0 z-modal flex items-center justify-center bg-black/50">
+              <div className="fixed inset-0 z-modal flex items-center justify-center bg-overlay">
                 <div className="mx-4 flex flex-col items-center gap-4 rounded-lg bg-background p-8 text-center shadow-lg">
                   <p className="text-body-medium">{t("loading-error")}</p>
                   <div className="flex gap-3">

--- a/src/components/ui/dialog-modal.tsx
+++ b/src/components/ui/dialog-modal.tsx
@@ -15,7 +15,7 @@ const dialogVariant = tv({
     content:
       "z-modal grid w-full gap-4 rounded-md bg-background p-8 shadow-xl focus:outline-hidden data-[state=open]:animate-fade-in",
     overlay:
-      "data-[state=open]:animate-fade-in overflow-y-auto p-4 grid place-items-center fixed inset-0 bg-black/70 z-overlay",
+      "data-[state=open]:animate-fade-in overflow-y-auto p-4 grid place-items-center fixed inset-0 bg-overlay z-overlay",
     header: "relative pe-12",
     title: "text-2xl",
     body: "",

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -19,7 +19,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-modal bg-black/80 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+      "fixed inset-0 z-modal bg-overlay data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
       className
     )}
     {...props}

--- a/src/components/ui/persistent-panel.tsx
+++ b/src/components/ui/persistent-panel.tsx
@@ -134,8 +134,8 @@ const PersistentPanel = ({
   }
 
   const overlayClasses = cn(
-    "fixed inset-0 z-modal bg-gray-800 transition-opacity duration-300",
-    showContent ? "opacity-70" : "opacity-0 pointer-events-none"
+    "fixed inset-0 z-modal bg-overlay transition-opacity duration-300",
+    !showContent && "opacity-0 pointer-events-none"
   )
 
   const contentClasses = cn(

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -34,7 +34,7 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-modal bg-gray-800 opacity-70 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+      "fixed inset-0 z-modal bg-overlay data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
       className
     )}
     {...props}

--- a/src/styles/__stories__/colors.stories.tsx
+++ b/src/styles/__stories__/colors.stories.tsx
@@ -185,6 +185,12 @@ const semantic: { title: string; description?: string; classes: string[] }[] = [
     ],
   },
   {
+    title: "Overlay",
+    description:
+      "Modal/sheet backdrop dim. Translucent -- the alpha is baked into the token, so use bg-overlay as-is (no /opacity modifier).",
+    classes: ["bg-overlay"],
+  },
+  {
     title: "Border",
     description: "Border/outline hues (shown as fills here).",
     classes: [

--- a/src/styles/docsearch.css
+++ b/src/styles/docsearch.css
@@ -40,6 +40,8 @@
   --docsearch-highlight-color: hsla(var(--primary-hover));
   --docsearch-modal-width: 650px;
   --docsearch-hit-height: fit-content;
+  /* Replace vendor slate backdrop with the shared overlay token */
+  --docsearch-container-background: hsla(var(--overlay));
 }
 
 .dark {

--- a/src/styles/semantic-tokens.css
+++ b/src/styles/semantic-tokens.css
@@ -24,6 +24,9 @@
     --background-medium: var(--gray-200);
     --background-high: var(--gray-300);
 
+    /* Modal/sheet backdrop dim; only token with alpha baked in */
+    --overlay: var(--black), 0.75;
+
     --border: var(--gray-200);
     --border-high-contrast: var(--gray-400);
     --border-low-contrast: var(--gray-100);
@@ -95,6 +98,8 @@
     --background-low: var(--gray-700);
     --background-medium: var(--gray-600);
     --background-high: var(--gray-800);
+
+    --overlay: var(--black), 0.85;
 
     --border: var(--gray-600);
     --border-high-contrast: var(--gray-300);

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -158,6 +158,7 @@
   --color-background-low: hsla(var(--background-low));
   --color-background-medium: hsla(var(--background-medium));
   --color-background-high: hsla(var(--background-high));
+  --color-overlay: hsla(var(--overlay));
 
   /* Colors: border */
   --color-border: hsla(var(--border));


### PR DESCRIPTION
## Summary

Modal backdrops (wallet simulator and others) barely dimmed the page in dark mode -- overlays like `bg-black/70` do little over a near-black background, and two surfaces used `gray-800`, which *lightens* dark pages. The values had also drifted into a spread of six independent hand-rolled dims: `bg-black/70` (dialog-modal), `bg-black/80` (dialog), `gray-800` at 70% element opacity (sheet, persistent-panel), `bg-black/50` (Search error fallback), and the DocSearch vendor slate `rgba(101,108,133,0.8)`, which was leaking into dark mode since the vendor's dark theme keys off `[data-theme]` rather than our `.dark` class.

This replaces the spread with a single semantic token:

- **`--overlay`** in `semantic-tokens.css` -- black at **0.75** (light) / **0.85** (dark), registered as `bg-overlay` in `theme.css`. The one token with alpha baked in, so call sites use it as-is: no `/opacity` modifier, no `dark:` variant.
- All six backdrop surfaces now consume it, including DocSearch via `--docsearch-container-background: hsla(var(--overlay))`.
- `sheet` and `persistent-panel` previously folded their dim into element opacity (`opacity-70`); element opacity is now purely the show/hide transition (`opacity-0` <-> default), with the dim owned by the token. Fade animations behave identically.
- Adds an **Overlay** group to the `SemanticTokens` colors story and documents the token in the design-system skill catalog.

Light mode shifts are minimal (70->75 on the main modals, near-identical for the gray-800 surfaces); dark mode gets a clearly darker backdrop everywhere.

## Test plan

- [x] Open the wallet simulator (`/wallets/find-wallet` simulator) in light and dark -- backdrop noticeably darker in dark mode
- [x] Open a `ui/dialog`-based modal and a sheet -- same overlay treatment; fade in/out still animates
- [x] Open search (DocSearch) in dark mode -- backdrop is dark, not the light slate
- [ ] Storybook `Design System / Colors` -> `SemanticTokens` -- Overlay swatch flips with the theme toggle

🤖 Generated with Claude

## Preview link
https://deploy-preview-18746.ethereum.it/