### PR TITLE
refactor: migrate Staking i18n to next-intl useTranslations (#18742 pattern PR)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -52,6 +52,17 @@
     ],
     "simple-import-sort/exports": "error",
     "no-unused-vars": "off",
+    "no-restricted-imports": [
+      "warn",
+      {
+        "paths": [
+          {
+            "name": "@/hooks/useTranslation",
+            "message": "Deprecated (#18742): bind namespaces directly with useTranslations from next-intl (client) or getTranslations from next-intl/server (server)."
+          }
+        ]
+      }
+    ],
     "unused-imports/no-unused-vars": [
       "error",
       {

--- a/src/components/Staking/StakingComparison.tsx
+++ b/src/components/Staking/StakingComparison.tsx
@@ -1,4 +1,5 @@
 "use client"
+import { useTranslations } from "next-intl"
 import type { JSX } from "react"
 
 import type {
@@ -19,8 +20,6 @@ import { trackCustomEvent } from "@/lib/utils/matomo"
 import { Flex } from "../ui/flex"
 import InlineLink from "../ui/Link"
 
-import { useTranslation } from "@/hooks/useTranslation"
-
 interface DataType {
   title: TranslationKey
   linkText: TranslationKey
@@ -36,7 +35,7 @@ export type StakingComparisonProps = {
 }
 
 const StakingComparison = ({ page, className }: StakingComparisonProps) => {
-  const { t } = useTranslation("page-staking")
+  const t = useTranslations("page-staking")
 
   const solo: DataType = {
     title: "page-staking-dropdown-solo",

--- a/src/components/Staking/StakingHierarchy.tsx
+++ b/src/components/Staking/StakingHierarchy.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import React, { HTMLAttributes } from "react"
+import { useTranslations } from "next-intl"
 
 import { ChildOnlyProp } from "@/lib/types"
 
@@ -17,8 +18,6 @@ import {
 import Translation from "../Translation"
 import { ButtonLink } from "../ui/buttons/Button"
 import { Center, Flex, VStack } from "../ui/flex"
-
-import { useTranslation } from "@/hooks/useTranslation"
 
 type SectionGridProps = ChildOnlyProp
 
@@ -104,7 +103,7 @@ const Content = ({ children }: ChildOnlyProp) => (
 )
 
 const StakingHierarchy = () => {
-  const { t } = useTranslation("page-staking")
+  const t = useTranslations("page-staking")
 
   return (
     <VStack

--- a/src/components/Staking/StakingLaunchpadWidget.tsx
+++ b/src/components/Staking/StakingLaunchpadWidget.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import { useTranslations } from "next-intl"
 
 import Tools from "@/components/icons/tools.svg"
 import { ButtonLink } from "@/components/ui/buttons/Button"
@@ -13,12 +14,10 @@ import { Strong } from "../IntlStringElements"
 import Select, { type SelectOnChange } from "../Select"
 import InlineLink from "../ui/Link"
 
-import { useTranslation } from "@/hooks/useTranslation"
-
 type StakingDataOption = { label: string; value: string }
 
 const StakingLaunchpadWidget = () => {
-  const { t } = useTranslation("page-staking")
+  const t = useTranslations("page-staking")
   const [selection, setSelection] = useState("testnet")
 
   const handleChange: SelectOnChange<StakingDataOption> = (data) => {
@@ -35,7 +34,7 @@ const StakingLaunchpadWidget = () => {
 
   const data = {
     testnet: {
-      label: t("page-staking:page-staking-network-testnet", {
+      label: t("page-staking-network-testnet", {
         network: CANONICAL_STAKING_TESTNET,
       }),
       url: `https://${CANONICAL_STAKING_TESTNET.toLowerCase()}.launchpad.ethereum.org`,
@@ -65,7 +64,7 @@ const StakingLaunchpadWidget = () => {
         className="w-full md:max-w-md!"
       />
       <p>
-        {t.rich("page-staking.page-staking-launchpad-widget-p1", {
+        {t.rich("page-staking-launchpad-widget-p1", {
           network: CANONICAL_STAKING_TESTNET,
           strong: Strong,
           link: (chunks) => (
@@ -77,11 +76,11 @@ const StakingLaunchpadWidget = () => {
       </p>
       <p>{t("page-staking-launchpad-widget-p2")}</p>
       <ButtonLink href={data[selection].url} className="max-md:w-full">
-        {t("page-staking:page-staking-launchpad-widget-start", {
+        {t("page-staking-launchpad-widget-start", {
           network:
             selection === "mainnet"
-              ? t("page-staking:page-staking-launchpad-widget-mainnet-label")
-              : t("page-staking:page-staking-network-testnet", {
+              ? t("page-staking-launchpad-widget-mainnet-label")
+              : t("page-staking-network-testnet", {
                   network: CANONICAL_STAKING_TESTNET,
                 }),
         })}

--- a/src/components/Staking/StakingStatsBox.tsx
+++ b/src/components/Staking/StakingStatsBox.tsx
@@ -1,5 +1,5 @@
 import { Info } from "lucide-react"
-import { useLocale } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 
 import type { ChildOnlyProp, StakingStatsData } from "@/lib/types"
 
@@ -9,8 +9,6 @@ import { Flex, VStack } from "@/components/ui/flex"
 import { numberFormat } from "@/lib/utils/numbers"
 
 import InlineLink from "../ui/Link"
-
-import { useTranslation } from "@/hooks/useTranslation"
 
 const Cell = ({ children }: ChildOnlyProp) => (
   <VStack className="gap-2 px-8 py-4">{children}</VStack>
@@ -41,7 +39,8 @@ type StakingStatsBoxProps = {
 }
 const StakingStatsBox = ({ data }: StakingStatsBoxProps) => {
   const locale = useLocale()
-  const { t } = useTranslation("page-staking")
+  const t = useTranslations("page-staking")
+  const tCommon = useTranslations("common")
 
   // Helper functions
   const formatInteger = (amount: number): string =>
@@ -69,7 +68,7 @@ const StakingStatsBox = ({ data }: StakingStatsBoxProps) => {
           <DataSourceTooltip>
             <div className="normal-case">
               <p>{t("page-staking-stats-box-metric-1-tooltip")}</p>
-              {t("common:data-provided-by")}{" "}
+              {tCommon("data-provided-by")}{" "}
               <InlineLink href="https://dune.com/">Dune Analytics</InlineLink>
             </div>
           </DataSourceTooltip>
@@ -82,7 +81,7 @@ const StakingStatsBox = ({ data }: StakingStatsBoxProps) => {
           <DataSourceTooltip>
             <div className="normal-case">
               <p>{t("page-staking-stats-box-metric-2-tooltip")}</p>
-              {t("common:data-provided-by")}{" "}
+              {tCommon("data-provided-by")}{" "}
               <InlineLink href="https://dune.com/">Dune Analytics</InlineLink>
             </div>
           </DataSourceTooltip>
@@ -95,7 +94,7 @@ const StakingStatsBox = ({ data }: StakingStatsBoxProps) => {
           <DataSourceTooltip>
             <div className="normal-case">
               <p>{t("page-staking-stats-box-metric-3-tooltip")}</p>
-              {t("common:data-provided-by")}{" "}
+              {tCommon("data-provided-by")}{" "}
               <InlineLink href="https://dune.com/">Dune Analytics</InlineLink>
             </div>
           </DataSourceTooltip>

--- a/src/components/Staking/WithdrawalCredentials.tsx
+++ b/src/components/Staking/WithdrawalCredentials.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { ChangeEvent, FC, useState } from "react"
+import { useTranslations } from "next-intl"
 
 import { ButtonLink } from "@/components/ui/buttons/Button"
 
@@ -9,10 +10,8 @@ import { CANONICAL_STAKING_TESTNET } from "@/lib/constants"
 import { Flex } from "../ui/flex"
 import Input from "../ui/input"
 
-import { useTranslation } from "@/hooks/useTranslation"
-
 const WithdrawalCredentials: FC = () => {
-  const { t } = useTranslation("page-staking")
+  const t = useTranslations("page-staking")
   const [inputValue, setInputValue] = useState<string>("")
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) =>
@@ -40,7 +39,7 @@ const WithdrawalCredentials: FC = () => {
             aria-disabled={isDisabled || undefined}
             tabIndex={isDisabled ? -1 : undefined}
           >
-            {t("page-staking:comp-withdrawal-credentials-verify", {
+            {t("comp-withdrawal-credentials-verify", {
               network: "Mainnet",
             })}
           </ButtonLink>
@@ -51,7 +50,7 @@ const WithdrawalCredentials: FC = () => {
             aria-disabled={isDisabled || undefined}
             tabIndex={isDisabled ? -1 : undefined}
           >
-            {t("page-staking:comp-withdrawal-credentials-verify", {
+            {t("comp-withdrawal-credentials-verify", {
               network: CANONICAL_STAKING_TESTNET,
             })}
           </ButtonLink>

--- a/src/components/Staking/WithdrawalsTabComparison.tsx
+++ b/src/components/Staking/WithdrawalsTabComparison.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import { useTranslations } from "next-intl"
+
 import WithdrawalCredentials from "@/components/Staking/WithdrawalCredentials"
 import Translation from "@/components/Translation"
 import { ListItem, UnorderedList } from "@/components/ui/list"
@@ -11,10 +13,8 @@ import { Strong } from "../IntlStringElements"
 import { ButtonLink } from "../ui/buttons/Button"
 import InlineLink from "../ui/Link"
 
-import { useTranslation } from "@/hooks/useTranslation"
-
 const WithdrawalsTabComparison = () => {
-  const { t } = useTranslation("page-staking")
+  const t = useTranslations("page-staking")
   const handleMatomoEvent = (name: string): void => {
     trackCustomEvent({
       eventCategory: `Staker tabs`,
@@ -54,7 +54,7 @@ const WithdrawalsTabComparison = () => {
           </ListItem>
         </UnorderedList>
         <p>
-          {t.rich("page-staking.comp-withdrawal-comparison-current-p", {
+          {t.rich("comp-withdrawal-comparison-current-p", {
             strong: Strong,
             // Intentionally kept in English to match Beaconcha.in destination
             depositsTab: '"Deposits"',


### PR DESCRIPTION
# Pattern PR for #18742 — Staking directory

First batch of the `@/hooks/useTranslation` → `useTranslations` migration. Staking was chosen as the pattern batch because it contains every migration trap in the repo-wide inventory — including the **only** two root-dotted `t.rich` passthroughs and the only two embedded-HTML messages in all 103 affected files. Later batches reference this PR as the recipe.

## Migration recipe

**1. Hook swap** (every file):

```tsx
// Before
import { useTranslation } from "@/hooks/useTranslation"
const { t } = useTranslation("page-staking")
// After
import { useTranslations } from "next-intl"
const t = useTranslations("page-staking")
```

**2. Colon-form keys** → already namespace-bound, drop the prefix; a *different* namespace gets a second binding:

```tsx
// Before
t("page-staking:comp-withdrawal-credentials-verify", { network: "Mainnet" })
t("common:data-provided-by")
// After
t("comp-withdrawal-credentials-verify", { network: "Mainnet" })
const tCommon = useTranslations("common")
tCommon("data-provided-by")
```

**3. Root-dotted `t.rich`/`t.raw` passthroughs** → drop the namespace segment (the binding supplies it):

```tsx
// Before
t.rich("page-staking.page-staking-launchpad-widget-p1", { ... })
// After
t.rich("page-staking-launchpad-widget-p1", { ... })
```

**4. Plain keys** → unchanged call, but the semantics change from `t.raw()` (legacy wrapper) to cooked ICU `t()`. This is safe **only if the message contains no ICU args and no HTML** — verified per key against `src/intl/en/*.json` before the swap (see audit below). Messages with markup would instead need `t.raw`/`t.rich`; none were needed in this batch outside the existing `t.rich` sites.

## Why this is behavior-preserving

- Every plain-key message referenced by these six files (including the dynamic `t(title)`/`t(content)`/`t(linkText)` key sets in `StakingComparison`, which are statically enumerable) was classified against the English catalogs: all plain text, no ICU args, no markup, and zero ICU-quote-risk strings (`''` or `'` adjacent to `{}`) in `page-staking` or `common`.
- Missing-key behavior is unchanged: `src/i18n/request.ts` already suppresses `onError` and supplies `getMessageFallback` globally, so next-intl degrades the same way the wrapper's try/catch did.
- The wrapper itself is a thin veneer over the same `useTranslations()` instance, so locale resolution, message merging, and formats are identical.

## Lint guard

Adds `no-restricted-imports` (**warn**) on `@/hooks/useTranslation` to stop new call sites while batches land. The final cleanup PR (delete the hook) flips it to **error**.

## Repo-wide audit snapshot (script-assisted)

103 files / 932 call sites before this PR → 97 files / 871 call sites after. Remaining across the repo: 47 colon-form calls, 5 ICU-message keys, 38 dynamic keys, 1 silently-dropped `values` bug (#18743, lands with the Quiz batch), 14 missing-key call sites (pre-existing live bugs, incl. #18695 — will be verified/fixed per batch). Zero `t.rich`/`t.raw` passthroughs and zero HTML-message calls remain after this batch.

## Affected pages

`/staking/` (StakingStatsBox, StakingHierarchy) and the markdown staking topic pages `/staking/solo/`, `/staking/saas/`, `/staking/pools/`, `/staking/withdrawals/`, `/staking/dvt/` (StakingComparison, StakingLaunchpadWidget, WithdrawalCredentials, WithdrawalsTabComparison via `MdComponents/topics/staking.tsx`).

An automated rendering sweep against the Netlify deploy preview (every affected page × all 25 locales: strings render, no literal `{placeholder}`, no visible raw markup, no missing-key fallbacks; Playwright for the tab/select interactions) will be posted as a comment once the preview is live.

## Test plan

- [x] `pnpm type-check`, `pnpm lint` clean locally
- [ ] Deploy-preview sweep: affected staking pages × 25 locales (posted as comment)
- [ ] Spot-check `t.rich` sites render markup correctly in a non-English locale (launchpad widget p1, withdrawals comparison p) — covered by the sweep's raw-markup assertion

Follow-up batches (tracked in #18742): Quiz (+#18743 fix), Nav/Search/shell, product tables, `src/components` singles, `app/[locale]` page components, then hook deletion + lint error.

— Fable
