### PR TITLE
refactor: migrate Quiz tree to useTranslations, fix sr-only question number (#18742, fixes #18743)

### DIFF
--- a/.manifests/src/intl/ar/learn-quizzes.json/source.json
+++ b/.manifests/src/intl/ar/learn-quizzes.json/source.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
   "sourceFile": "src/intl/en/learn-quizzes.json",
-  "generatedAt": "2026-05-07T18:12:55.067Z",
-  "rootHash": "8b5e4c6a75a7",
+  "generatedAt": "2026-07-10T04:59:03.683Z",
+  "rootHash": "0561335dbe12",
   "tree": {
-    "contentHash": "6ff4d2a951e5",
+    "contentHash": "4ba0d2099539",
     "anchorHash": "5593dd9060f1",
     "children": {
       "add-quiz": {
@@ -52,11 +52,11 @@
         "anchorHash": "e3b0c44298fc"
       },
       "question-number": {
-        "contentHash": "3f0df6500564",
+        "contentHash": "11f03a62b80b",
         "anchorHash": "10d7fcd5c413",
         "children": {
           "prose:1": {
-            "contentHash": "ded4c6350fd1",
+            "contentHash": "925a785ad06a",
             "anchorHash": "e3b0c44298fc"
           },
           "icu:0": {
@@ -64,7 +64,7 @@
             "anchorHash": "ba58697be4db"
           },
           "prose:2": {
-            "contentHash": "7413958e5dc6",
+            "contentHash": "e7ac0786668e",
             "anchorHash": "e3b0c44298fc"
           }
         },
@@ -3510,5 +3510,5 @@
       "smart-contracts-4-d-explanation"
     ]
   },
-  "sourceCommitSha": "37d70722cfa869934ca70dab17c0dc37f73bf30d"
+  "sourceCommitSha": "5035db81f97e3a15f7c8b71bf91b72c02ad8a11a"
 }

--- a/.manifests/src/intl/bn/learn-quizzes.json/source.json
+++ b/.manifests/src/intl/bn/learn-quizzes.json/source.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
   "sourceFile": "src/intl/en/learn-quizzes.json",
-  "generatedAt": "2026-05-07T18:12:41.597Z",
-  "rootHash": "8b5e4c6a75a7",
+  "generatedAt": "2026-07-10T04:59:03.687Z",
+  "rootHash": "0561335dbe12",
   "tree": {
-    "contentHash": "6ff4d2a951e5",
+    "contentHash": "4ba0d2099539",
     "anchorHash": "5593dd9060f1",
     "children": {
       "add-quiz": {
@@ -52,11 +52,11 @@
         "anchorHash": "e3b0c44298fc"
       },
       "question-number": {
-        "contentHash": "3f0df6500564",
+        "contentHash": "11f03a62b80b",
         "anchorHash": "10d7fcd5c413",
         "children": {
           "prose:1": {
-            "contentHash": "ded4c6350fd1",
+            "contentHash": "925a785ad06a",
             "anchorHash": "e3b0c44298fc"
           },
           "icu:0": {
@@ -64,7 +64,7 @@
             "anchorHash": "ba58697be4db"
           },
           "prose:2": {
-            "contentHash": "7413958e5dc6",
+            "contentHash": "e7ac0786668e",
             "anchorHash": "e3b0c44298fc"
           }
         },
@@ -3510,5 +3510,5 @@
       "smart-contracts-4-d-explanation"
     ]
   },
-  "sourceCommitSha": "37d70722cfa869934ca70dab17c0dc37f73bf30d"
+  "sourceCommitSha": "5035db81f97e3a15f7c8b71bf91b72c02ad8a11a"
 }

--- a/.manifests/src/intl/cs/learn-quizzes.json/source.json
+++ b/.manifests/src/intl/cs/learn-quizzes.json/source.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
   "sourceFile": "src/intl/en/learn-quizzes.json",
-  "generatedAt": "2026-05-07T18:12:24.896Z",
-  "rootHash": "8b5e4c6a75a7",
+  "generatedAt": "2026-07-10T04:59:03.690Z",
+  "rootHash": "0561335dbe12",
   "tree": {
-    "contentHash": "6ff4d2a951e5",
+    "contentHash": "4ba0d2099539",
     "anchorHash": "5593dd9060f1",
     "children": {
       "add-quiz": {
@@ -52,11 +52,11 @@
         "anchorHash": "e3b0c44298fc"
       },
       "question-number": {
-        "contentHash": "3f0df6500564",
+        "contentHash": "11f03a62b80b",
         "anchorHash": "10d7fcd5c413",
         "children": {
           "prose:1": {
-            "contentHash": "ded4c6350fd1",
+            "contentHash": "925a785ad06a",
             "anchorHash": "e3b0c44298fc"
           },
           "icu:0": {
@@ -64,7 +64,7 @@
             "anchorHash": "ba58697be4db"
           },
           "prose:2": {
-            "contentHash": "7413958e5dc6",
+            "contentHash": "e7ac0786668e",
             "anchorHash": "e3b0c44298fc"
           }
         },
@@ -3510,5 +3510,5 @@
       "smart-contracts-4-d-explanation"
     ]
   },
-  "sourceCommitSha": "37d70722cfa869934ca70dab17c0dc37f73bf30d"
+  "sourceCommitSha": "5035db81f97e3a15f7c8b71bf91b72c02ad8a11a"
 }

--- a/.manifests/src/intl/de/learn-quizzes.json/source.json
+++ b/.manifests/src/intl/de/learn-quizzes.json/source.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
   "sourceFile": "src/intl/en/learn-quizzes.json",
-  "generatedAt": "2026-05-07T18:11:19.736Z",
-  "rootHash": "8b5e4c6a75a7",
+  "generatedAt": "2026-07-10T04:59:03.695Z",
+  "rootHash": "0561335dbe12",
   "tree": {
-    "contentHash": "6ff4d2a951e5",
+    "contentHash": "4ba0d2099539",
     "anchorHash": "5593dd9060f1",
     "children": {
       "add-quiz": {
@@ -52,11 +52,11 @@
         "anchorHash": "e3b0c44298fc"
       },
       "question-number": {
-        "contentHash": "3f0df6500564",
+        "contentHash": "11f03a62b80b",
         "anchorHash": "10d7fcd5c413",
         "children": {
           "prose:1": {
-            "contentHash": "ded4c6350fd1",
+            "contentHash": "925a785ad06a",
             "anchorHash": "e3b0c44298fc"
           },
           "icu:0": {
@@ -64,7 +64,7 @@
             "anchorHash": "ba58697be4db"
           },
           "prose:2": {
-            "contentHash": "7413958e5dc6",
+            "contentHash": "e7ac0786668e",
             "anchorHash": "e3b0c44298fc"
           }
         },
@@ -3510,5 +3510,5 @@
       "smart-contracts-4-d-explanation"
     ]
   },
-  "sourceCommitSha": "37d70722cfa869934ca70dab17c0dc37f73bf30d"
+  "sourceCommitSha": "5035db81f97e3a15f7c8b71bf91b72c02ad8a11a"
 }

--- a/.manifests/src/intl/es/learn-quizzes.json/source.json
+++ b/.manifests/src/intl/es/learn-quizzes.json/source.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
   "sourceFile": "src/intl/en/learn-quizzes.json",
-  "generatedAt": "2026-05-07T18:11:28.059Z",
-  "rootHash": "8b5e4c6a75a7",
+  "generatedAt": "2026-07-10T04:59:03.700Z",
+  "rootHash": "0561335dbe12",
   "tree": {
-    "contentHash": "6ff4d2a951e5",
+    "contentHash": "4ba0d2099539",
     "anchorHash": "5593dd9060f1",
     "children": {
       "add-quiz": {
@@ -52,11 +52,11 @@
         "anchorHash": "e3b0c44298fc"
       },
       "question-number": {
-        "contentHash": "3f0df6500564",
+        "contentHash": "11f03a62b80b",
         "anchorHash": "10d7fcd5c413",
         "children": {
           "prose:1": {
-            "contentHash": "ded4c6350fd1",
+            "contentHash": "925a785ad06a",
             "anchorHash": "e3b0c44298fc"
           },
           "icu:0": {
@@ -64,7 +64,7 @@
             "anchorHash": "ba58697be4db"
           },
           "prose:2": {
-            "contentHash": "7413958e5dc6",
+            "contentHash": "e7ac0786668e",
             "anchorHash": "e3b0c44298fc"
           }
         },
@@ -3510,5 +3510,5 @@
       "smart-contracts-4-d-explanation"
     ]
   },
-  "sourceCommitSha": "37d70722cfa869934ca70dab17c0dc37f73bf30d"
+  "sourceCommitSha": "5035db81f97e3a15f7c8b71bf91b72c02ad8a11a"
 }

--- a/.manifests/src/intl/fr/learn-quizzes.json/source.json
+++ b/.manifests/src/intl/fr/learn-quizzes.json/source.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
   "sourceFile": "src/intl/en/learn-quizzes.json",
-  "generatedAt": "2026-05-07T18:11:38.375Z",
-  "rootHash": "8b5e4c6a75a7",
+  "generatedAt": "2026-07-10T04:59:03.704Z",
+  "rootHash": "0561335dbe12",
   "tree": {
-    "contentHash": "6ff4d2a951e5",
+    "contentHash": "4ba0d2099539",
     "anchorHash": "5593dd9060f1",
     "children": {
       "add-quiz": {
@@ -52,11 +52,11 @@
         "anchorHash": "e3b0c44298fc"
       },
       "question-number": {
-        "contentHash": "3f0df6500564",
+        "contentHash": "11f03a62b80b",
         "anchorHash": "10d7fcd5c413",
         "children": {
           "prose:1": {
-            "contentHash": "ded4c6350fd1",
+            "contentHash": "925a785ad06a",
             "anchorHash": "e3b0c44298fc"
           },
           "icu:0": {
@@ -64,7 +64,7 @@
             "anchorHash": "ba58697be4db"
           },
           "prose:2": {
-            "contentHash": "7413958e5dc6",
+            "contentHash": "e7ac0786668e",
             "anchorHash": "e3b0c44298fc"
           }
         },
@@ -3510,5 +3510,5 @@
       "smart-contracts-4-d-explanation"
     ]
   },
-  "sourceCommitSha": "37d70722cfa869934ca70dab17c0dc37f73bf30d"
+  "sourceCommitSha": "5035db81f97e3a15f7c8b71bf91b72c02ad8a11a"
 }

--- a/.manifests/src/intl/hi/learn-quizzes.json/source.json
+++ b/.manifests/src/intl/hi/learn-quizzes.json/source.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
   "sourceFile": "src/intl/en/learn-quizzes.json",
-  "generatedAt": "2026-05-07T18:12:01.568Z",
-  "rootHash": "8b5e4c6a75a7",
+  "generatedAt": "2026-07-10T04:59:03.711Z",
+  "rootHash": "0561335dbe12",
   "tree": {
-    "contentHash": "6ff4d2a951e5",
+    "contentHash": "4ba0d2099539",
     "anchorHash": "5593dd9060f1",
     "children": {
       "add-quiz": {
@@ -52,11 +52,11 @@
         "anchorHash": "e3b0c44298fc"
       },
       "question-number": {
-        "contentHash": "3f0df6500564",
+        "contentHash": "11f03a62b80b",
         "anchorHash": "10d7fcd5c413",
         "children": {
           "prose:1": {
-            "contentHash": "ded4c6350fd1",
+            "contentHash": "925a785ad06a",
             "anchorHash": "e3b0c44298fc"
           },
           "icu:0": {
@@ -64,7 +64,7 @@
             "anchorHash": "ba58697be4db"
           },
           "prose:2": {
-            "contentHash": "7413958e5dc6",
+            "contentHash": "e7ac0786668e",
             "anchorHash": "e3b0c44298fc"
           }
         },
@@ -3510,5 +3510,5 @@
       "smart-contracts-4-d-explanation"
     ]
   },
-  "sourceCommitSha": "37d70722cfa869934ca70dab17c0dc37f73bf30d"
+  "sourceCommitSha": "5035db81f97e3a15f7c8b71bf91b72c02ad8a11a"
 }

--- a/.manifests/src/intl/id/learn-quizzes.json/source.json
+++ b/.manifests/src/intl/id/learn-quizzes.json/source.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
   "sourceFile": "src/intl/en/learn-quizzes.json",
-  "generatedAt": "2026-05-07T18:10:53.557Z",
-  "rootHash": "8b5e4c6a75a7",
+  "generatedAt": "2026-07-10T04:59:03.715Z",
+  "rootHash": "0561335dbe12",
   "tree": {
-    "contentHash": "6ff4d2a951e5",
+    "contentHash": "4ba0d2099539",
     "anchorHash": "5593dd9060f1",
     "children": {
       "add-quiz": {
@@ -52,11 +52,11 @@
         "anchorHash": "e3b0c44298fc"
       },
       "question-number": {
-        "contentHash": "3f0df6500564",
+        "contentHash": "11f03a62b80b",
         "anchorHash": "10d7fcd5c413",
         "children": {
           "prose:1": {
-            "contentHash": "ded4c6350fd1",
+            "contentHash": "925a785ad06a",
             "anchorHash": "e3b0c44298fc"
           },
           "icu:0": {
@@ -64,7 +64,7 @@
             "anchorHash": "ba58697be4db"
           },
           "prose:2": {
-            "contentHash": "7413958e5dc6",
+            "contentHash": "e7ac0786668e",
             "anchorHash": "e3b0c44298fc"
           }
         },
@@ -3510,5 +3510,5 @@
       "smart-contracts-4-d-explanation"
     ]
   },
-  "sourceCommitSha": "37d70722cfa869934ca70dab17c0dc37f73bf30d"
+  "sourceCommitSha": "5035db81f97e3a15f7c8b71bf91b72c02ad8a11a"
 }

--- a/.manifests/src/intl/it/learn-quizzes.json/source.json
+++ b/.manifests/src/intl/it/learn-quizzes.json/source.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
   "sourceFile": "src/intl/en/learn-quizzes.json",
-  "generatedAt": "2026-05-07T18:10:57.422Z",
-  "rootHash": "8b5e4c6a75a7",
+  "generatedAt": "2026-07-10T04:59:03.719Z",
+  "rootHash": "0561335dbe12",
   "tree": {
-    "contentHash": "6ff4d2a951e5",
+    "contentHash": "4ba0d2099539",
     "anchorHash": "5593dd9060f1",
     "children": {
       "add-quiz": {
@@ -52,11 +52,11 @@
         "anchorHash": "e3b0c44298fc"
       },
       "question-number": {
-        "contentHash": "3f0df6500564",
+        "contentHash": "11f03a62b80b",
         "anchorHash": "10d7fcd5c413",
         "children": {
           "prose:1": {
-            "contentHash": "ded4c6350fd1",
+            "contentHash": "925a785ad06a",
             "anchorHash": "e3b0c44298fc"
           },
           "icu:0": {
@@ -64,7 +64,7 @@
             "anchorHash": "ba58697be4db"
           },
           "prose:2": {
-            "contentHash": "7413958e5dc6",
+            "contentHash": "e7ac0786668e",
             "anchorHash": "e3b0c44298fc"
           }
         },
@@ -3510,5 +3510,5 @@
       "smart-contracts-4-d-explanation"
     ]
   },
-  "sourceCommitSha": "37d70722cfa869934ca70dab17c0dc37f73bf30d"
+  "sourceCommitSha": "5035db81f97e3a15f7c8b71bf91b72c02ad8a11a"
 }

--- a/.manifests/src/intl/ja/learn-quizzes.json/source.json
+++ b/.manifests/src/intl/ja/learn-quizzes.json/source.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
   "sourceFile": "src/intl/en/learn-quizzes.json",
-  "generatedAt": "2026-05-07T18:11:21.794Z",
-  "rootHash": "8b5e4c6a75a7",
+  "generatedAt": "2026-07-10T04:59:03.723Z",
+  "rootHash": "0561335dbe12",
   "tree": {
-    "contentHash": "6ff4d2a951e5",
+    "contentHash": "4ba0d2099539",
     "anchorHash": "5593dd9060f1",
     "children": {
       "add-quiz": {
@@ -52,11 +52,11 @@
         "anchorHash": "e3b0c44298fc"
       },
       "question-number": {
-        "contentHash": "3f0df6500564",
+        "contentHash": "11f03a62b80b",
         "anchorHash": "10d7fcd5c413",
         "children": {
           "prose:1": {
-            "contentHash": "ded4c6350fd1",
+            "contentHash": "925a785ad06a",
             "anchorHash": "e3b0c44298fc"
           },
           "icu:0": {
@@ -64,7 +64,7 @@
             "anchorHash": "ba58697be4db"
           },
           "prose:2": {
-            "contentHash": "7413958e5dc6",
+            "contentHash": "e7ac0786668e",
             "anchorHash": "e3b0c44298fc"
           }
         },
@@ -3510,5 +3510,5 @@
       "smart-contracts-4-d-explanation"
     ]
   },
-  "sourceCommitSha": "37d70722cfa869934ca70dab17c0dc37f73bf30d"
+  "sourceCommitSha": "5035db81f97e3a15f7c8b71bf91b72c02ad8a11a"
 }

--- a/.manifests/src/intl/ko/learn-quizzes.json/source.json
+++ b/.manifests/src/intl/ko/learn-quizzes.json/source.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
   "sourceFile": "src/intl/en/learn-quizzes.json",
-  "generatedAt": "2026-05-07T18:11:15.371Z",
-  "rootHash": "8b5e4c6a75a7",
+  "generatedAt": "2026-07-10T04:59:03.728Z",
+  "rootHash": "0561335dbe12",
   "tree": {
-    "contentHash": "6ff4d2a951e5",
+    "contentHash": "4ba0d2099539",
     "anchorHash": "5593dd9060f1",
     "children": {
       "add-quiz": {
@@ -52,11 +52,11 @@
         "anchorHash": "e3b0c44298fc"
       },
       "question-number": {
-        "contentHash": "3f0df6500564",
+        "contentHash": "11f03a62b80b",
         "anchorHash": "10d7fcd5c413",
         "children": {
           "prose:1": {
-            "contentHash": "ded4c6350fd1",
+            "contentHash": "925a785ad06a",
             "anchorHash": "e3b0c44298fc"
           },
           "icu:0": {
@@ -64,7 +64,7 @@
             "anchorHash": "ba58697be4db"
           },
           "prose:2": {
-            "contentHash": "7413958e5dc6",
+            "contentHash": "e7ac0786668e",
             "anchorHash": "e3b0c44298fc"
           }
         },
@@ -3510,5 +3510,5 @@
       "smart-contracts-4-d-explanation"
     ]
   },
-  "sourceCommitSha": "37d70722cfa869934ca70dab17c0dc37f73bf30d"
+  "sourceCommitSha": "5035db81f97e3a15f7c8b71bf91b72c02ad8a11a"
 }

--- a/.manifests/src/intl/mr/learn-quizzes.json/source.json
+++ b/.manifests/src/intl/mr/learn-quizzes.json/source.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
   "sourceFile": "src/intl/en/learn-quizzes.json",
-  "generatedAt": "2026-05-07T18:12:33.847Z",
-  "rootHash": "8b5e4c6a75a7",
+  "generatedAt": "2026-07-10T04:59:03.732Z",
+  "rootHash": "0561335dbe12",
   "tree": {
-    "contentHash": "6ff4d2a951e5",
+    "contentHash": "4ba0d2099539",
     "anchorHash": "5593dd9060f1",
     "children": {
       "add-quiz": {
@@ -52,11 +52,11 @@
         "anchorHash": "e3b0c44298fc"
       },
       "question-number": {
-        "contentHash": "3f0df6500564",
+        "contentHash": "11f03a62b80b",
         "anchorHash": "10d7fcd5c413",
         "children": {
           "prose:1": {
-            "contentHash": "ded4c6350fd1",
+            "contentHash": "925a785ad06a",
             "anchorHash": "e3b0c44298fc"
           },
           "icu:0": {
@@ -64,7 +64,7 @@
             "anchorHash": "ba58697be4db"
           },
           "prose:2": {
-            "contentHash": "7413958e5dc6",
+            "contentHash": "e7ac0786668e",
             "anchorHash": "e3b0c44298fc"
           }
         },
@@ -3510,5 +3510,5 @@
       "smart-contracts-4-d-explanation"
     ]
   },
-  "sourceCommitSha": "37d70722cfa869934ca70dab17c0dc37f73bf30d"
+  "sourceCommitSha": "5035db81f97e3a15f7c8b71bf91b72c02ad8a11a"
 }

--- a/.manifests/src/intl/pl/learn-quizzes.json/source.json
+++ b/.manifests/src/intl/pl/learn-quizzes.json/source.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
   "sourceFile": "src/intl/en/learn-quizzes.json",
-  "generatedAt": "2026-05-07T18:11:44.463Z",
-  "rootHash": "8b5e4c6a75a7",
+  "generatedAt": "2026-07-10T04:59:03.735Z",
+  "rootHash": "0561335dbe12",
   "tree": {
-    "contentHash": "6ff4d2a951e5",
+    "contentHash": "4ba0d2099539",
     "anchorHash": "5593dd9060f1",
     "children": {
       "add-quiz": {
@@ -52,11 +52,11 @@
         "anchorHash": "e3b0c44298fc"
       },
       "question-number": {
-        "contentHash": "3f0df6500564",
+        "contentHash": "11f03a62b80b",
         "anchorHash": "10d7fcd5c413",
         "children": {
           "prose:1": {
-            "contentHash": "ded4c6350fd1",
+            "contentHash": "925a785ad06a",
             "anchorHash": "e3b0c44298fc"
           },
           "icu:0": {
@@ -64,7 +64,7 @@
             "anchorHash": "ba58697be4db"
           },
           "prose:2": {
-            "contentHash": "7413958e5dc6",
+            "contentHash": "e7ac0786668e",
             "anchorHash": "e3b0c44298fc"
           }
         },
@@ -3510,5 +3510,5 @@
       "smart-contracts-4-d-explanation"
     ]
   },
-  "sourceCommitSha": "37d70722cfa869934ca70dab17c0dc37f73bf30d"
+  "sourceCommitSha": "5035db81f97e3a15f7c8b71bf91b72c02ad8a11a"
 }

--- a/.manifests/src/intl/pt-br/learn-quizzes.json/source.json
+++ b/.manifests/src/intl/pt-br/learn-quizzes.json/source.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
   "sourceFile": "src/intl/en/learn-quizzes.json",
-  "generatedAt": "2026-05-07T18:11:56.744Z",
-  "rootHash": "8b5e4c6a75a7",
+  "generatedAt": "2026-07-10T04:59:03.738Z",
+  "rootHash": "0561335dbe12",
   "tree": {
-    "contentHash": "6ff4d2a951e5",
+    "contentHash": "4ba0d2099539",
     "anchorHash": "5593dd9060f1",
     "children": {
       "add-quiz": {
@@ -52,11 +52,11 @@
         "anchorHash": "e3b0c44298fc"
       },
       "question-number": {
-        "contentHash": "3f0df6500564",
+        "contentHash": "11f03a62b80b",
         "anchorHash": "10d7fcd5c413",
         "children": {
           "prose:1": {
-            "contentHash": "ded4c6350fd1",
+            "contentHash": "925a785ad06a",
             "anchorHash": "e3b0c44298fc"
           },
           "icu:0": {
@@ -64,7 +64,7 @@
             "anchorHash": "ba58697be4db"
           },
           "prose:2": {
-            "contentHash": "7413958e5dc6",
+            "contentHash": "e7ac0786668e",
             "anchorHash": "e3b0c44298fc"
           }
         },
@@ -3510,5 +3510,5 @@
       "smart-contracts-4-d-explanation"
     ]
   },
-  "sourceCommitSha": "37d70722cfa869934ca70dab17c0dc37f73bf30d"
+  "sourceCommitSha": "5035db81f97e3a15f7c8b71bf91b72c02ad8a11a"
 }

--- a/.manifests/src/intl/ru/learn-quizzes.json/source.json
+++ b/.manifests/src/intl/ru/learn-quizzes.json/source.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
   "sourceFile": "src/intl/en/learn-quizzes.json",
-  "generatedAt": "2026-05-07T18:11:42.343Z",
-  "rootHash": "8b5e4c6a75a7",
+  "generatedAt": "2026-07-10T04:59:03.742Z",
+  "rootHash": "0561335dbe12",
   "tree": {
-    "contentHash": "6ff4d2a951e5",
+    "contentHash": "4ba0d2099539",
     "anchorHash": "5593dd9060f1",
     "children": {
       "add-quiz": {
@@ -52,11 +52,11 @@
         "anchorHash": "e3b0c44298fc"
       },
       "question-number": {
-        "contentHash": "3f0df6500564",
+        "contentHash": "11f03a62b80b",
         "anchorHash": "10d7fcd5c413",
         "children": {
           "prose:1": {
-            "contentHash": "ded4c6350fd1",
+            "contentHash": "925a785ad06a",
             "anchorHash": "e3b0c44298fc"
           },
           "icu:0": {
@@ -64,7 +64,7 @@
             "anchorHash": "ba58697be4db"
           },
           "prose:2": {
-            "contentHash": "7413958e5dc6",
+            "contentHash": "e7ac0786668e",
             "anchorHash": "e3b0c44298fc"
           }
         },
@@ -3510,5 +3510,5 @@
       "smart-contracts-4-d-explanation"
     ]
   },
-  "sourceCommitSha": "37d70722cfa869934ca70dab17c0dc37f73bf30d"
+  "sourceCommitSha": "5035db81f97e3a15f7c8b71bf91b72c02ad8a11a"
 }

--- a/.manifests/src/intl/sw/learn-quizzes.json/source.json
+++ b/.manifests/src/intl/sw/learn-quizzes.json/source.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
   "sourceFile": "src/intl/en/learn-quizzes.json",
-  "generatedAt": "2026-05-07T18:12:57.188Z",
-  "rootHash": "8b5e4c6a75a7",
+  "generatedAt": "2026-07-10T04:59:03.745Z",
+  "rootHash": "0561335dbe12",
   "tree": {
-    "contentHash": "6ff4d2a951e5",
+    "contentHash": "4ba0d2099539",
     "anchorHash": "5593dd9060f1",
     "children": {
       "add-quiz": {
@@ -52,11 +52,11 @@
         "anchorHash": "e3b0c44298fc"
       },
       "question-number": {
-        "contentHash": "3f0df6500564",
+        "contentHash": "11f03a62b80b",
         "anchorHash": "10d7fcd5c413",
         "children": {
           "prose:1": {
-            "contentHash": "ded4c6350fd1",
+            "contentHash": "925a785ad06a",
             "anchorHash": "e3b0c44298fc"
           },
           "icu:0": {
@@ -64,7 +64,7 @@
             "anchorHash": "ba58697be4db"
           },
           "prose:2": {
-            "contentHash": "7413958e5dc6",
+            "contentHash": "e7ac0786668e",
             "anchorHash": "e3b0c44298fc"
           }
         },
@@ -3510,5 +3510,5 @@
       "smart-contracts-4-d-explanation"
     ]
   },
-  "sourceCommitSha": "37d70722cfa869934ca70dab17c0dc37f73bf30d"
+  "sourceCommitSha": "5035db81f97e3a15f7c8b71bf91b72c02ad8a11a"
 }

--- a/.manifests/src/intl/ta/learn-quizzes.json/source.json
+++ b/.manifests/src/intl/ta/learn-quizzes.json/source.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
   "sourceFile": "src/intl/en/learn-quizzes.json",
-  "generatedAt": "2026-05-07T18:21:11.755Z",
-  "rootHash": "8b5e4c6a75a7",
+  "generatedAt": "2026-07-10T04:59:04.217Z",
+  "rootHash": "0561335dbe12",
   "tree": {
-    "contentHash": "6ff4d2a951e5",
+    "contentHash": "4ba0d2099539",
     "anchorHash": "5593dd9060f1",
     "children": {
       "add-quiz": {
@@ -52,11 +52,11 @@
         "anchorHash": "e3b0c44298fc"
       },
       "question-number": {
-        "contentHash": "3f0df6500564",
+        "contentHash": "11f03a62b80b",
         "anchorHash": "10d7fcd5c413",
         "children": {
           "prose:1": {
-            "contentHash": "ded4c6350fd1",
+            "contentHash": "925a785ad06a",
             "anchorHash": "e3b0c44298fc"
           },
           "icu:0": {
@@ -64,7 +64,7 @@
             "anchorHash": "ba58697be4db"
           },
           "prose:2": {
-            "contentHash": "7413958e5dc6",
+            "contentHash": "e7ac0786668e",
             "anchorHash": "e3b0c44298fc"
           }
         },
@@ -3510,5 +3510,5 @@
       "smart-contracts-4-d-explanation"
     ]
   },
-  "sourceCommitSha": "37d70722cfa869934ca70dab17c0dc37f73bf30d"
+  "sourceCommitSha": "5035db81f97e3a15f7c8b71bf91b72c02ad8a11a"
 }

--- a/.manifests/src/intl/te/learn-quizzes.json/source.json
+++ b/.manifests/src/intl/te/learn-quizzes.json/source.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
   "sourceFile": "src/intl/en/learn-quizzes.json",
-  "generatedAt": "2026-05-07T18:21:22.734Z",
-  "rootHash": "8b5e4c6a75a7",
+  "generatedAt": "2026-07-10T04:59:04.242Z",
+  "rootHash": "0561335dbe12",
   "tree": {
-    "contentHash": "6ff4d2a951e5",
+    "contentHash": "4ba0d2099539",
     "anchorHash": "5593dd9060f1",
     "children": {
       "add-quiz": {
@@ -52,11 +52,11 @@
         "anchorHash": "e3b0c44298fc"
       },
       "question-number": {
-        "contentHash": "3f0df6500564",
+        "contentHash": "11f03a62b80b",
         "anchorHash": "10d7fcd5c413",
         "children": {
           "prose:1": {
-            "contentHash": "ded4c6350fd1",
+            "contentHash": "925a785ad06a",
             "anchorHash": "e3b0c44298fc"
           },
           "icu:0": {
@@ -64,7 +64,7 @@
             "anchorHash": "ba58697be4db"
           },
           "prose:2": {
-            "contentHash": "7413958e5dc6",
+            "contentHash": "e7ac0786668e",
             "anchorHash": "e3b0c44298fc"
           }
         },
@@ -3510,5 +3510,5 @@
       "smart-contracts-4-d-explanation"
     ]
   },
-  "sourceCommitSha": "37d70722cfa869934ca70dab17c0dc37f73bf30d"
+  "sourceCommitSha": "5035db81f97e3a15f7c8b71bf91b72c02ad8a11a"
 }

--- a/.manifests/src/intl/tr/learn-quizzes.json/source.json
+++ b/.manifests/src/intl/tr/learn-quizzes.json/source.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
   "sourceFile": "src/intl/en/learn-quizzes.json",
-  "generatedAt": "2026-05-07T18:21:38.573Z",
-  "rootHash": "8b5e4c6a75a7",
+  "generatedAt": "2026-07-10T04:59:04.245Z",
+  "rootHash": "0561335dbe12",
   "tree": {
-    "contentHash": "6ff4d2a951e5",
+    "contentHash": "4ba0d2099539",
     "anchorHash": "5593dd9060f1",
     "children": {
       "add-quiz": {
@@ -52,11 +52,11 @@
         "anchorHash": "e3b0c44298fc"
       },
       "question-number": {
-        "contentHash": "3f0df6500564",
+        "contentHash": "11f03a62b80b",
         "anchorHash": "10d7fcd5c413",
         "children": {
           "prose:1": {
-            "contentHash": "ded4c6350fd1",
+            "contentHash": "925a785ad06a",
             "anchorHash": "e3b0c44298fc"
           },
           "icu:0": {
@@ -64,7 +64,7 @@
             "anchorHash": "ba58697be4db"
           },
           "prose:2": {
-            "contentHash": "7413958e5dc6",
+            "contentHash": "e7ac0786668e",
             "anchorHash": "e3b0c44298fc"
           }
         },
@@ -3510,5 +3510,5 @@
       "smart-contracts-4-d-explanation"
     ]
   },
-  "sourceCommitSha": "37d70722cfa869934ca70dab17c0dc37f73bf30d"
+  "sourceCommitSha": "5035db81f97e3a15f7c8b71bf91b72c02ad8a11a"
 }

--- a/.manifests/src/intl/uk/learn-quizzes.json/source.json
+++ b/.manifests/src/intl/uk/learn-quizzes.json/source.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
   "sourceFile": "src/intl/en/learn-quizzes.json",
-  "generatedAt": "2026-05-07T18:21:53.374Z",
-  "rootHash": "8b5e4c6a75a7",
+  "generatedAt": "2026-07-10T04:59:04.254Z",
+  "rootHash": "0561335dbe12",
   "tree": {
-    "contentHash": "6ff4d2a951e5",
+    "contentHash": "4ba0d2099539",
     "anchorHash": "5593dd9060f1",
     "children": {
       "add-quiz": {
@@ -52,11 +52,11 @@
         "anchorHash": "e3b0c44298fc"
       },
       "question-number": {
-        "contentHash": "3f0df6500564",
+        "contentHash": "11f03a62b80b",
         "anchorHash": "10d7fcd5c413",
         "children": {
           "prose:1": {
-            "contentHash": "ded4c6350fd1",
+            "contentHash": "925a785ad06a",
             "anchorHash": "e3b0c44298fc"
           },
           "icu:0": {
@@ -64,7 +64,7 @@
             "anchorHash": "ba58697be4db"
           },
           "prose:2": {
-            "contentHash": "7413958e5dc6",
+            "contentHash": "e7ac0786668e",
             "anchorHash": "e3b0c44298fc"
           }
         },
@@ -3510,5 +3510,5 @@
       "smart-contracts-4-d-explanation"
     ]
   },
-  "sourceCommitSha": "37d70722cfa869934ca70dab17c0dc37f73bf30d"
+  "sourceCommitSha": "5035db81f97e3a15f7c8b71bf91b72c02ad8a11a"
 }

--- a/.manifests/src/intl/ur/learn-quizzes.json/source.json
+++ b/.manifests/src/intl/ur/learn-quizzes.json/source.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
   "sourceFile": "src/intl/en/learn-quizzes.json",
-  "generatedAt": "2026-05-07T18:21:42.815Z",
-  "rootHash": "8b5e4c6a75a7",
+  "generatedAt": "2026-07-10T04:59:04.273Z",
+  "rootHash": "0561335dbe12",
   "tree": {
-    "contentHash": "6ff4d2a951e5",
+    "contentHash": "4ba0d2099539",
     "anchorHash": "5593dd9060f1",
     "children": {
       "add-quiz": {
@@ -52,11 +52,11 @@
         "anchorHash": "e3b0c44298fc"
       },
       "question-number": {
-        "contentHash": "3f0df6500564",
+        "contentHash": "11f03a62b80b",
         "anchorHash": "10d7fcd5c413",
         "children": {
           "prose:1": {
-            "contentHash": "ded4c6350fd1",
+            "contentHash": "925a785ad06a",
             "anchorHash": "e3b0c44298fc"
           },
           "icu:0": {
@@ -64,7 +64,7 @@
             "anchorHash": "ba58697be4db"
           },
           "prose:2": {
-            "contentHash": "7413958e5dc6",
+            "contentHash": "e7ac0786668e",
             "anchorHash": "e3b0c44298fc"
           }
         },
@@ -3510,5 +3510,5 @@
       "smart-contracts-4-d-explanation"
     ]
   },
-  "sourceCommitSha": "37d70722cfa869934ca70dab17c0dc37f73bf30d"
+  "sourceCommitSha": "5035db81f97e3a15f7c8b71bf91b72c02ad8a11a"
 }

--- a/.manifests/src/intl/vi/learn-quizzes.json/source.json
+++ b/.manifests/src/intl/vi/learn-quizzes.json/source.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
   "sourceFile": "src/intl/en/learn-quizzes.json",
-  "generatedAt": "2026-05-07T18:21:32.693Z",
-  "rootHash": "8b5e4c6a75a7",
+  "generatedAt": "2026-07-10T04:59:04.311Z",
+  "rootHash": "0561335dbe12",
   "tree": {
-    "contentHash": "6ff4d2a951e5",
+    "contentHash": "4ba0d2099539",
     "anchorHash": "5593dd9060f1",
     "children": {
       "add-quiz": {
@@ -52,11 +52,11 @@
         "anchorHash": "e3b0c44298fc"
       },
       "question-number": {
-        "contentHash": "3f0df6500564",
+        "contentHash": "11f03a62b80b",
         "anchorHash": "10d7fcd5c413",
         "children": {
           "prose:1": {
-            "contentHash": "ded4c6350fd1",
+            "contentHash": "925a785ad06a",
             "anchorHash": "e3b0c44298fc"
           },
           "icu:0": {
@@ -64,7 +64,7 @@
             "anchorHash": "ba58697be4db"
           },
           "prose:2": {
-            "contentHash": "7413958e5dc6",
+            "contentHash": "e7ac0786668e",
             "anchorHash": "e3b0c44298fc"
           }
         },
@@ -3510,5 +3510,5 @@
       "smart-contracts-4-d-explanation"
     ]
   },
-  "sourceCommitSha": "37d70722cfa869934ca70dab17c0dc37f73bf30d"
+  "sourceCommitSha": "5035db81f97e3a15f7c8b71bf91b72c02ad8a11a"
 }

--- a/.manifests/src/intl/zh-tw/learn-quizzes.json/source.json
+++ b/.manifests/src/intl/zh-tw/learn-quizzes.json/source.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
   "sourceFile": "src/intl/en/learn-quizzes.json",
-  "generatedAt": "2026-05-07T18:21:28.797Z",
-  "rootHash": "8b5e4c6a75a7",
+  "generatedAt": "2026-07-10T04:59:04.320Z",
+  "rootHash": "0561335dbe12",
   "tree": {
-    "contentHash": "6ff4d2a951e5",
+    "contentHash": "4ba0d2099539",
     "anchorHash": "5593dd9060f1",
     "children": {
       "add-quiz": {
@@ -52,11 +52,11 @@
         "anchorHash": "e3b0c44298fc"
       },
       "question-number": {
-        "contentHash": "3f0df6500564",
+        "contentHash": "11f03a62b80b",
         "anchorHash": "10d7fcd5c413",
         "children": {
           "prose:1": {
-            "contentHash": "ded4c6350fd1",
+            "contentHash": "925a785ad06a",
             "anchorHash": "e3b0c44298fc"
           },
           "icu:0": {
@@ -64,7 +64,7 @@
             "anchorHash": "ba58697be4db"
           },
           "prose:2": {
-            "contentHash": "7413958e5dc6",
+            "contentHash": "e7ac0786668e",
             "anchorHash": "e3b0c44298fc"
           }
         },
@@ -3510,5 +3510,5 @@
       "smart-contracts-4-d-explanation"
     ]
   },
-  "sourceCommitSha": "37d70722cfa869934ca70dab17c0dc37f73bf30d"
+  "sourceCommitSha": "5035db81f97e3a15f7c8b71bf91b72c02ad8a11a"
 }

--- a/.manifests/src/intl/zh/learn-quizzes.json/source.json
+++ b/.manifests/src/intl/zh/learn-quizzes.json/source.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
   "sourceFile": "src/intl/en/learn-quizzes.json",
-  "generatedAt": "2026-05-07T18:20:11.696Z",
-  "rootHash": "8b5e4c6a75a7",
+  "generatedAt": "2026-07-10T04:59:04.325Z",
+  "rootHash": "0561335dbe12",
   "tree": {
-    "contentHash": "6ff4d2a951e5",
+    "contentHash": "4ba0d2099539",
     "anchorHash": "5593dd9060f1",
     "children": {
       "add-quiz": {
@@ -52,11 +52,11 @@
         "anchorHash": "e3b0c44298fc"
       },
       "question-number": {
-        "contentHash": "3f0df6500564",
+        "contentHash": "11f03a62b80b",
         "anchorHash": "10d7fcd5c413",
         "children": {
           "prose:1": {
-            "contentHash": "ded4c6350fd1",
+            "contentHash": "925a785ad06a",
             "anchorHash": "e3b0c44298fc"
           },
           "icu:0": {
@@ -64,7 +64,7 @@
             "anchorHash": "ba58697be4db"
           },
           "prose:2": {
-            "contentHash": "7413958e5dc6",
+            "contentHash": "e7ac0786668e",
             "anchorHash": "e3b0c44298fc"
           }
         },
@@ -3510,5 +3510,5 @@
       "smart-contracts-4-d-explanation"
     ]
   },
-  "sourceCommitSha": "37d70722cfa869934ca70dab17c0dc37f73bf30d"
+  "sourceCommitSha": "5035db81f97e3a15f7c8b71bf91b72c02ad8a11a"
 }

--- a/src/components/Quiz/QuizItem.tsx
+++ b/src/components/Quiz/QuizItem.tsx
@@ -1,3 +1,5 @@
+import { useTranslations } from "next-intl"
+
 import type { QuizzesSection } from "@/lib/types"
 
 import { cn } from "@/lib/utils/cn"
@@ -8,8 +10,6 @@ import { Button } from "../ui/buttons/Button"
 import { Flex, Stack } from "../ui/flex"
 import { ListItem } from "../ui/list"
 import { Tag } from "../ui/tag"
-
-import { useTranslation } from "@/hooks/useTranslation"
 
 export type QuizzesListItemProps = Omit<QuizzesSection, "id"> & {
   isCompleted: boolean
@@ -25,7 +25,7 @@ const QuizItem = ({
   numberOfQuestions,
   handleStart,
 }: QuizzesListItemProps) => {
-  const { t } = useTranslation("learn-quizzes")
+  const t = useTranslations("learn-quizzes")
 
   return (
     <ListItem
@@ -49,7 +49,7 @@ const QuizItem = ({
           <Flex className="gap-3 font-normal">
             {/* number of questions - label */}
             <Tag className="lg:-ms-2">
-              {t(`${numberOfQuestions} ${t("questions")}`)}
+              {`${numberOfQuestions} ${t("questions")}`}
             </Tag>
 
             {/* difficulty - label */}

--- a/src/components/Quiz/QuizWidget/QuizRadioGroup.tsx
+++ b/src/components/Quiz/QuizWidget/QuizRadioGroup.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react"
+import { useTranslations } from "next-intl"
 import * as RadioGroup from "@radix-ui/react-radio-group"
 
 import type {
@@ -14,8 +15,6 @@ import { cn } from "@/lib/utils/cn"
 
 import type { AnswerStatus } from "./useQuizWidget"
 
-import useTranslation from "@/hooks/useTranslation"
-
 type QuizRadioGroupProps = {
   questions: Question[]
   currentQuestionIndex: number
@@ -29,7 +28,7 @@ export const QuizRadioGroup = ({
   answerStatus,
   setCurrentQuestionAnswerChoice,
 }: QuizRadioGroupProps) => {
-  const { t } = useTranslation("learn-quizzes")
+  const t = useTranslations("learn-quizzes")
 
   const [selectedAnswer, setSelectedAnswer] =
     useState<RadioGroup.RadioGroupProps["value"]>("")

--- a/src/components/Quiz/QuizWidget/QuizSummary.tsx
+++ b/src/components/Quiz/QuizWidget/QuizSummary.tsx
@@ -1,4 +1,4 @@
-import { useLocale } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 
 import { HStack, VStack } from "@/components/ui/flex"
 
@@ -7,7 +7,6 @@ import { numberToPercent } from "@/lib/utils/numbers"
 import { screens } from "@/lib/utils/screen"
 
 import { useMediaQuery } from "@/hooks/useMediaQuery"
-import { useTranslation } from "@/hooks/useTranslation"
 
 type QuizSummaryProps = {
   numberOfCorrectAnswers: number
@@ -23,7 +22,7 @@ export const QuizSummary = ({
   isPassingScore,
 }: QuizSummaryProps) => {
   const locale = useLocale()
-  const { t } = useTranslation("learn-quizzes")
+  const t = useTranslations("learn-quizzes")
 
   const [largerThanMobile] = useMediaQuery([`(min-width: ${screens.sm})`])
 

--- a/src/components/Quiz/QuizWidget/useQuizWidget.tsx
+++ b/src/components/Quiz/QuizWidget/useQuizWidget.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react"
 import isChromatic from "chromatic"
 import { shuffle } from "lodash"
+import { useTranslations } from "next-intl"
 
 import type {
   AnswerChoice,
@@ -20,15 +21,14 @@ import { getNextQuiz } from "../utils"
 
 import { QuizWidgetProps } from "."
 
-import useTranslation from "@/hooks/useTranslation"
-
 export type AnswerStatus = "correct" | "incorrect" | null
 
 export const useQuizWidget = ({
   quizKey,
   updateUserStats,
 }: Pick<QuizWidgetProps, "quizKey" | "updateUserStats">) => {
-  const { t } = useTranslation()
+  const tCommon = useTranslations("common")
+  const tQuizzes = useTranslations("learn-quizzes")
 
   const [quizData, setQuizData] = useState<Quiz | null>(null)
   const [nextQuiz, setNextQuiz] = useState<QuizKey | undefined>(undefined)
@@ -57,7 +57,12 @@ export const useQuizWidget = ({
     // ! Do not shuffle questions in Chromatic to keep the modal story snapshot stable
     const shuffledQuestions = isChromatic() ? questions : shuffle(questions)
     const quiz: Quiz = {
-      title: t(rawQuiz.title),
+      // Quiz titles are common-namespace keys, except one legacy
+      // "learn-quizzes:" pointer in data/quizzes; non-key titles ("DAOs",
+      // "DeFi") pass through untranslated via getMessageFallback
+      title: rawQuiz.title.startsWith("learn-quizzes:")
+        ? tQuizzes(rawQuiz.title.slice("learn-quizzes:".length))
+        : tCommon(rawQuiz.title),
       questions: shuffledQuestions,
     }
 

--- a/src/components/Quiz/QuizzesStats.tsx
+++ b/src/components/Quiz/QuizzesStats.tsx
@@ -1,4 +1,4 @@
-import { useLocale } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 
 import { CompletedQuizzes, QuizShareStats } from "@/lib/types"
 
@@ -20,8 +20,6 @@ import {
   getTotalQuizzesPoints,
   shareOnTwitter,
 } from "./utils"
-
-import { useTranslation } from "@/hooks/useTranslation"
 
 const handleShare = ({ score, total }: QuizShareStats) => {
   shareOnTwitter({
@@ -48,7 +46,7 @@ const QuizzesStats = ({
   completedQuizzes,
 }: QuizzesStatsProps) => {
   const locale = useLocale()
-  const { t } = useTranslation("learn-quizzes")
+  const t = useTranslations("learn-quizzes")
   const numberOfCompletedQuizzes = getNumberOfCompletedQuizzes(completedQuizzes)
 
   // These values are not fixed but calculated each time, can't be moved to /constants

--- a/src/components/Quiz/stories/QuizButtonGroup.stories.tsx
+++ b/src/components/Quiz/stories/QuizButtonGroup.stories.tsx
@@ -1,3 +1,4 @@
+import { useTranslations } from "next-intl"
 import { fn } from "storybook/test"
 import type { Meta, StoryObj } from "@storybook/nextjs"
 
@@ -5,8 +6,6 @@ import { QuizButtonGroup } from "../QuizWidget/QuizButtonGroup"
 import { QuizContent } from "../QuizWidget/QuizContent"
 
 import { LAYER_2_QUIZ_TITLE_KEY, layer2Questions } from "./utils"
-
-import useTranslation from "@/hooks/useTranslation"
 
 const meta = {
   title: "Molecules / Display Content / Quiz / QuizWidget / ButtonGroup",
@@ -29,7 +28,7 @@ const meta = {
   },
   decorators: [
     (Story, { args }) => {
-      const { t } = useTranslation()
+      const t = useTranslations("common")
       return (
         <QuizContent
           title={t(LAYER_2_QUIZ_TITLE_KEY)}

--- a/src/components/Quiz/stories/QuizProgressBar.stories.tsx
+++ b/src/components/Quiz/stories/QuizProgressBar.stories.tsx
@@ -1,3 +1,4 @@
+import { useTranslations } from "next-intl"
 import type { Meta, StoryObj } from "@storybook/nextjs"
 
 import allQuizzesData from "@/data/quizzes"
@@ -7,8 +8,6 @@ import { QuizProgressBar } from "../QuizWidget/QuizProgressBar"
 
 import { LAYER_2_QUIZ_KEY, layer2Questions } from "./utils"
 
-import useTranslation from "@/hooks/useTranslation"
-
 const meta = {
   title: "Molecules / Display Content / Quiz / QuizWidget / ProgressBar",
   component: QuizProgressBar,
@@ -17,7 +16,7 @@ const meta = {
   },
   decorators: [
     (Story, { args }) => {
-      const { t } = useTranslation()
+      const t = useTranslations("common")
 
       return (
         <QuizContent

--- a/src/components/Quiz/stories/QuizRadioGroup.stories.tsx
+++ b/src/components/Quiz/stories/QuizRadioGroup.stories.tsx
@@ -1,3 +1,4 @@
+import { useTranslations } from "next-intl"
 import { expect, fireEvent, fn, within } from "storybook/test"
 import type { Meta, StoryObj } from "@storybook/nextjs"
 
@@ -6,14 +7,12 @@ import { QuizRadioGroup } from "../QuizWidget/QuizRadioGroup"
 
 import { LAYER_2_QUIZ_TITLE_KEY, layer2Questions } from "./utils"
 
-import useTranslation from "@/hooks/useTranslation"
-
 const meta = {
   title: "Molecules / Display Content / Quiz / QuizWidget / RadioGroup",
   component: QuizRadioGroup,
   decorators: [
     (Story, { args }) => {
-      const { t } = useTranslation()
+      const t = useTranslations("common")
       return (
         <QuizContent
           title={t(LAYER_2_QUIZ_TITLE_KEY)}

--- a/src/components/Quiz/stories/QuizSummary.stories.tsx
+++ b/src/components/Quiz/stories/QuizSummary.stories.tsx
@@ -1,11 +1,10 @@
+import { useTranslations } from "next-intl"
 import type { Meta, StoryObj } from "@storybook/nextjs"
 
 import { QuizContent } from "../QuizWidget/QuizContent"
 import { QuizSummary } from "../QuizWidget/QuizSummary"
 
 import { LAYER_2_QUIZ_TITLE_KEY, layer2Questions } from "./utils"
-
-import useTranslation from "@/hooks/useTranslation"
 
 const meta = {
   title: "Molecules / Display Content / Quiz / QuizWidget / Summary",
@@ -15,7 +14,7 @@ const meta = {
   },
   decorators: [
     (Story) => {
-      const { t } = useTranslation()
+      const t = useTranslations("common")
       return (
         <QuizContent title={t(LAYER_2_QUIZ_TITLE_KEY)} answerStatus={null}>
           <Story />

--- a/src/components/Quiz/stories/QuizzesList.stories.tsx
+++ b/src/components/Quiz/stories/QuizzesList.stories.tsx
@@ -1,3 +1,4 @@
+import { useTranslations } from "next-intl"
 import { fn } from "storybook/test"
 import type { Meta, StoryObj } from "@storybook/nextjs"
 
@@ -6,8 +7,6 @@ import type { CompletedQuizzes } from "@/lib/types"
 import { ethereumBasicsQuizzes } from "@/data/quizzes"
 
 import QuizzesListComponent from "../QuizzesList"
-
-import useTranslation from "@/hooks/useTranslation"
 
 /**
  * This story also renders the `QuizItem` component.
@@ -36,7 +35,7 @@ export default meta
 
 export const Default: StoryObj<typeof meta> = {
   render: (args) => {
-    const { t } = useTranslation("learn-quizzes")
+    const t = useTranslations("learn-quizzes")
     return (
       <QuizzesListComponent
         {...args}
@@ -60,7 +59,7 @@ export const OneCompletedQuiz: StoryObj<typeof meta> = {
     },
   },
   render: (args) => {
-    const { t } = useTranslation("learn-quizzes")
+    const t = useTranslations("learn-quizzes")
     return (
       <QuizzesListComponent
         {...args}

--- a/src/intl/ar/learn-quizzes.json
+++ b/src/intl/ar/learn-quizzes.json
@@ -10,7 +10,7 @@
   "explanation": "الشرح",
   "next-question": "السؤال التالي",
   "next-quiz": "الاختبار التالي",
-  "question-number": "السؤال رقم {{number}}:",
+  "question-number": "السؤال رقم {number}:",
   "page-assets-merge": "الدمج",
   "passed": "لقد اجتزت الاختبار!",
   "questions": "الأسئلة",

--- a/src/intl/bn/learn-quizzes.json
+++ b/src/intl/bn/learn-quizzes.json
@@ -10,7 +10,7 @@
   "explanation": "ব্যাখ্যা",
   "next-question": "পরবর্তী প্রশ্ন",
   "next-quiz": "পরবর্তী কুইজ",
-  "question-number": "প্রশ্ন নম্বর {{number}}:",
+  "question-number": "প্রশ্ন নম্বর {number}:",
   "page-assets-merge": "দ্য মার্জ",
   "passed": "আপনি কুইজে পাস করেছেন!",
   "questions": "প্রশ্নসমূহ",

--- a/src/intl/cs/learn-quizzes.json
+++ b/src/intl/cs/learn-quizzes.json
@@ -10,7 +10,7 @@
   "explanation": "Vysvětlení",
   "next-question": "Další otázka",
   "next-quiz": "Další kvíz",
-  "question-number": "Otázka číslo {{number}}:",
+  "question-number": "Otázka číslo {number}:",
   "page-assets-merge": "Merge",
   "passed": "Úspěšně jste prošli kvízem!",
   "questions": "Otázky",

--- a/src/intl/de/learn-quizzes.json
+++ b/src/intl/de/learn-quizzes.json
@@ -10,7 +10,7 @@
   "explanation": "Erklärung",
   "next-question": "Nächste Frage",
   "next-quiz": "Nächstes Quiz",
-  "question-number": "Frage Nummer {{number}}:",
+  "question-number": "Frage Nummer {number}:",
   "page-assets-merge": "Der Merge",
   "passed": "Du hast das Quiz bestanden!",
   "questions": "Fragen",

--- a/src/intl/en/learn-quizzes.json
+++ b/src/intl/en/learn-quizzes.json
@@ -10,7 +10,7 @@
   "explanation": "Explanation",
   "next-question": "Next question",
   "next-quiz": "Next quiz",
-  "question-number": "Question number {{number}}:",
+  "question-number": "Question number {number}:",
   "page-assets-merge": "The Merge",
   "passed": "You passed the quiz!",
   "questions": "Questions",

--- a/src/intl/es/learn-quizzes.json
+++ b/src/intl/es/learn-quizzes.json
@@ -10,7 +10,7 @@
   "explanation": "Explicación",
   "next-question": "Siguiente pregunta",
   "next-quiz": "Siguiente cuestionario",
-  "question-number": "Pregunta número {{number}}:",
+  "question-number": "Pregunta número {number}:",
   "page-assets-merge": "La Fusión",
   "passed": "¡Aprobaste el cuestionario!",
   "questions": "Preguntas",

--- a/src/intl/fr/learn-quizzes.json
+++ b/src/intl/fr/learn-quizzes.json
@@ -10,7 +10,7 @@
   "explanation": "Explication",
   "next-question": "Question suivante",
   "next-quiz": "Quiz suivant",
-  "question-number": "Question numéro {{number}} :",
+  "question-number": "Question numéro {number} :",
   "page-assets-merge": "La Fusion",
   "passed": "Vous avez réussi le quiz !",
   "questions": "Questions",

--- a/src/intl/hi/learn-quizzes.json
+++ b/src/intl/hi/learn-quizzes.json
@@ -10,7 +10,7 @@
   "explanation": "स्पष्टीकरण",
   "next-question": "अगला प्रश्न",
   "next-quiz": "अगला क्विज़",
-  "question-number": "प्रश्न संख्या {{number}}:",
+  "question-number": "प्रश्न संख्या {number}:",
   "page-assets-merge": "द मर्ज",
   "passed": "आपने क्विज़ पास कर लिया!",
   "questions": "प्रश्न",

--- a/src/intl/id/learn-quizzes.json
+++ b/src/intl/id/learn-quizzes.json
@@ -10,7 +10,7 @@
   "explanation": "Penjelasan",
   "next-question": "Pertanyaan selanjutnya",
   "next-quiz": "Kuis selanjutnya",
-  "question-number": "Pertanyaan nomor {{number}}:",
+  "question-number": "Pertanyaan nomor {number}:",
   "page-assets-merge": "The Merge",
   "passed": "Anda lulus kuis!",
   "questions": "Pertanyaan",

--- a/src/intl/it/learn-quizzes.json
+++ b/src/intl/it/learn-quizzes.json
@@ -10,7 +10,7 @@
   "explanation": "Spiegazione",
   "next-question": "Prossima domanda",
   "next-quiz": "Prossimo quiz",
-  "question-number": "Domanda numero {{number}}:",
+  "question-number": "Domanda numero {number}:",
   "page-assets-merge": "The Merge",
   "passed": "Hai superato il quiz!",
   "questions": "Domande",

--- a/src/intl/ja/learn-quizzes.json
+++ b/src/intl/ja/learn-quizzes.json
@@ -10,7 +10,7 @@
   "explanation": "解説",
   "next-question": "次の質問",
   "next-quiz": "次のクイズ",
-  "question-number": "質問 {{number}}:",
+  "question-number": "質問 {number}:",
   "page-assets-merge": "マージ",
   "passed": "クイズに合格しました！",
   "questions": "質問",

--- a/src/intl/ko/learn-quizzes.json
+++ b/src/intl/ko/learn-quizzes.json
@@ -10,7 +10,7 @@
   "explanation": "설명",
   "next-question": "다음 질문",
   "next-quiz": "다음 퀴즈",
-  "question-number": "질문 번호 {{number}}:",
+  "question-number": "질문 번호 {number}:",
   "page-assets-merge": "머지",
   "passed": "퀴즈를 통과했습니다!",
   "questions": "질문",

--- a/src/intl/mr/learn-quizzes.json
+++ b/src/intl/mr/learn-quizzes.json
@@ -10,7 +10,7 @@
   "explanation": "स्पष्टीकरण",
   "next-question": "पुढचा प्रश्न",
   "next-quiz": "पुढची क्विझ",
-  "question-number": "प्रश्न क्रमांक {{number}}:",
+  "question-number": "प्रश्न क्रमांक {number}:",
   "page-assets-merge": "द मर्ज",
   "passed": "तुम्ही क्विझ उत्तीर्ण केली!",
   "questions": "प्रश्न",

--- a/src/intl/pl/learn-quizzes.json
+++ b/src/intl/pl/learn-quizzes.json
@@ -10,7 +10,7 @@
   "explanation": "Wyjaśnienie",
   "next-question": "Następne pytanie",
   "next-quiz": "Następny quiz",
-  "question-number": "Pytanie numer {{number}}:",
+  "question-number": "Pytanie numer {number}:",
   "page-assets-merge": "The Merge",
   "passed": "Zdałeś quiz!",
   "questions": "Pytania",

--- a/src/intl/pt-br/learn-quizzes.json
+++ b/src/intl/pt-br/learn-quizzes.json
@@ -10,7 +10,7 @@
   "explanation": "Explicação",
   "next-question": "Próxima pergunta",
   "next-quiz": "Próximo questionário",
-  "question-number": "Pergunta número {{number}}:",
+  "question-number": "Pergunta número {number}:",
   "page-assets-merge": "The Merge",
   "passed": "Você passou no questionário!",
   "questions": "Perguntas",

--- a/src/intl/ru/learn-quizzes.json
+++ b/src/intl/ru/learn-quizzes.json
@@ -10,7 +10,7 @@
   "explanation": "Объяснение",
   "next-question": "Следующий вопрос",
   "next-quiz": "Следующая викторина",
-  "question-number": "Вопрос номер {{number}}:",
+  "question-number": "Вопрос номер {number}:",
   "page-assets-merge": "Слияние",
   "passed": "Вы прошли викторину!",
   "questions": "Вопросы",

--- a/src/intl/sw/learn-quizzes.json
+++ b/src/intl/sw/learn-quizzes.json
@@ -10,7 +10,7 @@
   "explanation": "Maelezo",
   "next-question": "Swali linalofuata",
   "next-quiz": "Chemsha bongo inayofuata",
-  "question-number": "Nambari ya swali {{number}}:",
+  "question-number": "Nambari ya swali {number}:",
   "page-assets-merge": "Unganisho",
   "passed": "Umefaulu chemsha bongo!",
   "questions": "Maswali",

--- a/src/intl/ta/learn-quizzes.json
+++ b/src/intl/ta/learn-quizzes.json
@@ -10,7 +10,7 @@
   "explanation": "விளக்கம்",
   "next-question": "அடுத்த கேள்வி",
   "next-quiz": "அடுத்த வினாடி வினா",
-  "question-number": "கேள்வி எண் {{number}}:",
+  "question-number": "கேள்வி எண் {number}:",
   "page-assets-merge": "ஒருங்கிணைப்பு",
   "passed": "நீங்கள் வினாடி வினாவில் தேர்ச்சி பெற்றுவிட்டீர்கள்!",
   "questions": "கேள்விகள்",

--- a/src/intl/te/learn-quizzes.json
+++ b/src/intl/te/learn-quizzes.json
@@ -10,7 +10,7 @@
   "explanation": "వివరణ",
   "next-question": "తదుపరి ప్రశ్న",
   "next-quiz": "తదుపరి క్విజ్",
-  "question-number": "ప్రశ్న సంఖ్య {{number}}:",
+  "question-number": "ప్రశ్న సంఖ్య {number}:",
   "page-assets-merge": "ది మెర్జ్",
   "passed": "మీరు క్విజ్‌లో ఉత్తీర్ణులయ్యారు!",
   "questions": "ప్రశ్నలు",

--- a/src/intl/tr/learn-quizzes.json
+++ b/src/intl/tr/learn-quizzes.json
@@ -10,7 +10,7 @@
   "explanation": "Açıklama",
   "next-question": "Sonraki soru",
   "next-quiz": "Sonraki test",
-  "question-number": "Soru numarası {{number}}:",
+  "question-number": "Soru numarası {number}:",
   "page-assets-merge": "Birleşme",
   "passed": "Testi geçtiniz!",
   "questions": "Sorular",

--- a/src/intl/uk/learn-quizzes.json
+++ b/src/intl/uk/learn-quizzes.json
@@ -10,7 +10,7 @@
   "explanation": "Пояснення",
   "next-question": "Наступне запитання",
   "next-quiz": "Наступна вікторина",
-  "question-number": "Запитання номер {{number}}:",
+  "question-number": "Запитання номер {number}:",
   "page-assets-merge": "Злиття",
   "passed": "Ви пройшли вікторину!",
   "questions": "Запитання",

--- a/src/intl/ur/learn-quizzes.json
+++ b/src/intl/ur/learn-quizzes.json
@@ -10,7 +10,7 @@
   "explanation": "وضاحت",
   "next-question": "اگلا سوال",
   "next-quiz": "اگلا کوئز",
-  "question-number": "سوال نمبر {{number}}:",
+  "question-number": "سوال نمبر {number}:",
   "page-assets-merge": "دی مرج",
   "passed": "آپ نے کوئز پاس کر لیا!",
   "questions": "سوالات",

--- a/src/intl/vi/learn-quizzes.json
+++ b/src/intl/vi/learn-quizzes.json
@@ -10,7 +10,7 @@
   "explanation": "Giải thích",
   "next-question": "Câu hỏi tiếp theo",
   "next-quiz": "Bài trắc nghiệm tiếp theo",
-  "question-number": "Câu hỏi số {{number}}:",
+  "question-number": "Câu hỏi số {number}:",
   "page-assets-merge": "The Merge",
   "passed": "Bạn đã vượt qua bài trắc nghiệm!",
   "questions": "Câu hỏi",

--- a/src/intl/zh-tw/learn-quizzes.json
+++ b/src/intl/zh-tw/learn-quizzes.json
@@ -10,7 +10,7 @@
   "explanation": "解釋",
   "next-question": "下一題",
   "next-quiz": "下一個測驗",
-  "question-number": "第 {{number}} 題：",
+  "question-number": "第 {number} 題：",
   "page-assets-merge": "合併",
   "passed": "您通過了測驗！",
   "questions": "問題",

--- a/src/intl/zh/learn-quizzes.json
+++ b/src/intl/zh/learn-quizzes.json
@@ -10,7 +10,7 @@
   "explanation": "解释",
   "next-question": "下一题",
   "next-quiz": "下一个测验",
-  "question-number": "问题 {{number}}：",
+  "question-number": "问题 {number}：",
   "page-assets-merge": "合并",
   "passed": "你通过了测验！",
   "questions": "问题",


### PR DESCRIPTION
# Quiz batch for #18742 — fixes #18743

Second batch of the `useTranslation` → `useTranslations` migration, applying the recipe from #18749 to all ten Quiz files (components bind `learn-quizzes`, story decorators bind `common`).

## Ships the #18743 a11y fix

Two stacked defects made `QuizRadioGroup`'s sr-only label announce the literal string "Question number {{number}}:" in every quiz, all 25 locales:

1. The legacy wrapper's plain-key form returned `t.raw()` and silently dropped the `values` argument — fixed by this migration (cooked `t("question-number", { number })`).
2. The message itself still used next-translate-era `{{number}}` double braces, which ICU never interpolates — fixed in the first commit across en + all 24 locale files. The substitution is language-invariant and the `learn-quizzes` manifests are current, so hand-patching is safe per the verified procedure in #18743; a stamp-only intl-pipeline run on this branch records the patched state (manifests-only PR into this branch to follow).

`src/intl` now contains zero `{{...}}` placeholders.

## Non-mechanical hunks

- **`useQuizWidget` title resolution**: quiz titles in `data/quizzes` are `common`-namespace keys — except one legacy `learn-quizzes:page-assets-merge` colon pointer, plus two literal non-key titles ("DAOs", "DeFi") that render as-is via `getMessageFallback`. The migration keeps all three behaviors explicitly (small branch + comment) instead of relying on the wrapper's try/catch.
- **`QuizItem` latent bug**: `t(`${n} ${t("questions")}`)` double-translated the already-built label and only rendered via the missing-key fallback. Now plain string interpolation.
- Everything else is the mechanical hook swap; all dynamic keys (`prompt`/`label`/`explanation`, 696 `learn-quizzes` keys) were pre-verified plain text — no ICU, no markup.

## Test plan

- [x] `pnpm type-check`, `pnpm lint` clean locally
- [ ] Deploy-preview sweep: `/quizzes/` × 25 locales (posted as comment)
- [ ] Playwright: open a quiz on the preview, assert the sr-only span announces a real question number ("Question number 1:", and one non-Latin locale) — the #18743 acceptance check
- [ ] Merge the stamp-only manifests PR into this branch before merging to dev

— Fable
