### PR TITLE
refactor: migrate site shell (Nav/Search/LanguagePicker/TOC/Breadcrumbs) to useTranslations (#18742)

### DIFF
--- a/src/components/Breadcrumbs/index.tsx
+++ b/src/components/Breadcrumbs/index.tsx
@@ -1,5 +1,5 @@
 import { Fragment } from "react"
-import { useLocale } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 
 import type { Lang } from "@/lib/types"
 
@@ -15,8 +15,6 @@ import {
   BreadcrumbProps,
   BreadcrumbSeparator,
 } from "../ui/breadcrumb"
-
-import { useTranslation } from "@/hooks/useTranslation"
 
 export type BreadcrumbsProps = BreadcrumbProps & {
   slug: string
@@ -44,7 +42,7 @@ type Crumb = {
 //   { fullPath: "/eth2/proof-of-stake/", text: "PROOF OF STAKE" },
 // ]
 const Breadcrumbs = ({ slug, startDepth = 0, ...props }: BreadcrumbsProps) => {
-  const { t } = useTranslation("common")
+  const t = useTranslations("common")
   const locale = useLocale()
   const dir = isLangRightToLeft(locale! as Lang) ? "rtl" : "ltr"
   const normalizedSlug = normalizeSlug(slug)

--- a/src/components/LanguagePicker/LanguagePickerMenu.tsx
+++ b/src/components/LanguagePicker/LanguagePickerMenu.tsx
@@ -1,3 +1,5 @@
+import { useTranslations } from "next-intl"
+
 import type { LocaleDisplayInfo } from "@/lib/types"
 
 import {
@@ -10,8 +12,6 @@ import {
 
 import MenuItem from "./MenuItem"
 import NoResultsCallout from "./NoResultsCallout"
-
-import { useTranslation } from "@/hooks/useTranslation"
 
 type LanguagePickerMenuProps = {
   className?: string
@@ -26,7 +26,7 @@ const LanguagePickerMenu = ({
   onClose,
   onSelect,
 }: LanguagePickerMenuProps) => {
-  const { t } = useTranslation("common")
+  const t = useTranslations("common")
 
   return (
     <Command
@@ -52,7 +52,7 @@ const LanguagePickerMenu = ({
       <div className="text-xs text-body-medium">
         {t("page-languages-filter-label")}{" "}
         <span className="lowercase">
-          ({languages.length} {t("common:languages")})
+          ({languages.length} {t("languages")})
         </span>
       </div>
 

--- a/src/components/LanguagePicker/NoResultsCallout.tsx
+++ b/src/components/LanguagePicker/NoResultsCallout.tsx
@@ -1,11 +1,11 @@
-import { BaseLink } from "../ui/Link"
+import { useTranslations } from "next-intl"
 
-import { useTranslation } from "@/hooks/useTranslation"
+import { BaseLink } from "../ui/Link"
 
 type NoResultsCalloutProps = { onClose: () => void }
 
 const NoResultsCallout = ({ onClose }: NoResultsCalloutProps) => {
-  const { t } = useTranslation("common")
+  const t = useTranslations("common")
   return (
     <div>
       <p className="mb-2 font-bold">{t("page-languages-want-more-header")}</p>

--- a/src/components/Nav/MobileMenu/HamburgerButton.tsx
+++ b/src/components/Nav/MobileMenu/HamburgerButton.tsx
@@ -1,4 +1,5 @@
-"use client"
+import { useTranslations } from "next-intl"
+;("use client")
 
 import { forwardRef } from "react"
 import { motion } from "motion/react"
@@ -8,8 +9,6 @@ import { cn } from "@/lib/utils/cn"
 import { HAMBURGER_BUTTON_ID } from "@/lib/constants"
 
 import { Button, type ButtonProps } from "../../ui/buttons/Button"
-
-import { useTranslation } from "@/hooks/useTranslation"
 
 const hamburgerSvg =
   "M 2 13 l 10 0 l 0 0 l 10 0 M 4 19 l 8 0 M 12 19 l 8 0 M 2 25 l 10 0 l 0 0 l 10 0"
@@ -27,7 +26,7 @@ type HamburgerProps = ButtonProps & {
 
 const HamburgerButton = forwardRef<HTMLButtonElement, HamburgerProps>(
   ({ isMenuOpen, className, ...props }, ref) => {
-    const { t } = useTranslation("common")
+    const t = useTranslations("common")
 
     return (
       <Button

--- a/src/components/Nav/MobileMenu/HamburgerButton.tsx
+++ b/src/components/Nav/MobileMenu/HamburgerButton.tsx
@@ -1,8 +1,8 @@
-import { useTranslations } from "next-intl"
-;("use client")
+"use client"
 
 import { forwardRef } from "react"
 import { motion } from "motion/react"
+import { useTranslations } from "next-intl"
 
 import { cn } from "@/lib/utils/cn"
 

--- a/src/components/Nav/MobileMenu/MenuHeader.tsx
+++ b/src/components/Nav/MobileMenu/MenuHeader.tsx
@@ -1,11 +1,11 @@
+import { useTranslations } from "next-intl"
+
 import { SheetClose, SheetTitle } from "@/components/ui/sheet"
 
 import { SITE_TITLE } from "@/lib/constants"
 
-import { useTranslation } from "@/hooks/useTranslation"
-
 const MenuHeader = () => {
-  const { t } = useTranslation("common")
+  const t = useTranslations("common")
 
   return (
     <div className="flex items-center justify-between p-6">

--- a/src/components/Nav/MobileMenu/MobileMenuClient.tsx
+++ b/src/components/Nav/MobileMenu/MobileMenuClient.tsx
@@ -1,4 +1,5 @@
-"use client"
+import { useTranslations } from "next-intl"
+;("use client")
 
 import * as React from "react"
 
@@ -14,7 +15,6 @@ import { SITE_TITLE } from "@/lib/constants"
 import HamburgerButton from "./HamburgerButton"
 
 import { useCloseOnNavigate } from "@/hooks/useCloseOnNavigate"
-import { useTranslation } from "@/hooks/useTranslation"
 
 // Lazy-load the menu content to avoid including it in initial RSC payload
 // This saves ~82KB by not SSR'ing navigation data that's hidden behind a click
@@ -65,7 +65,7 @@ type MobileMenuClientProps = {
 }
 
 const MobileMenuClient = ({ className, side }: MobileMenuClientProps) => {
-  const { t } = useTranslation("common")
+  const t = useTranslations("common")
   const [open, setOpen] = useCloseOnNavigate()
   const triggerRef = React.useRef<HTMLButtonElement>(null)
   // Track if menu has ever been opened to keep content loaded after first open
@@ -111,7 +111,7 @@ const MobileMenuClient = ({ className, side }: MobileMenuClientProps) => {
           <ErrorBoundary
             fallback={() => (
               <div className="flex flex-1 flex-col items-center justify-center gap-4 p-8 text-center">
-                <p className="text-body-medium">{t("loading-error")}</p>
+                <p className="text-body-medium">{t("loading-error-refresh")}</p>
                 <div className="flex gap-3">
                   <button
                     className="rounded-md bg-primary px-4 py-2 text-sm text-white hover:bg-primary-hover"

--- a/src/components/Nav/MobileMenu/MobileMenuClient.tsx
+++ b/src/components/Nav/MobileMenu/MobileMenuClient.tsx
@@ -1,7 +1,7 @@
-import { useTranslations } from "next-intl"
-;("use client")
+"use client"
 
 import * as React from "react"
+import { useTranslations } from "next-intl"
 
 import { ErrorBoundary } from "@/components/ui/error-boundary"
 import { PersistentPanel } from "@/components/ui/persistent-panel"

--- a/src/components/Nav/MobileMenu/MobileMenuContent.tsx
+++ b/src/components/Nav/MobileMenu/MobileMenuContent.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { Languages, Menu } from "lucide-react"
-import { useLocale } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import * as TabsPrimitive from "@radix-ui/react-tabs"
 
 import type { Lang } from "@/lib/types"
@@ -29,14 +29,13 @@ import MenuHeader from "./MenuHeader"
 import ThemeToggleFooterButton from "./ThemeToggleFooterButton"
 
 import { useLanguagesDisplayInfo } from "@/hooks/useLanguagesDisplayInfo"
-import useTranslation from "@/hooks/useTranslation"
 
 /**
  * Client-side mobile menu content
  * Fetches navigation and language data on the client to avoid RSC payload bloat
  */
 export default function MobileMenuContent() {
-  const { t } = useTranslation("common")
+  const t = useTranslations("common")
   const locale = useLocale()
   const isRtl = isLangRightToLeft(locale as Lang)
   const dir = isRtl ? "rtl" : "ltr"

--- a/src/components/Nav/MobileMenu/ThemeToggleFooterButton.tsx
+++ b/src/components/Nav/MobileMenu/ThemeToggleFooterButton.tsx
@@ -1,4 +1,5 @@
-"use client"
+import { useTranslations } from "next-intl"
+;("use client")
 
 import { Moon, Sun } from "lucide-react"
 
@@ -8,10 +9,9 @@ import FooterButton from "./FooterButton"
 import FooterItemText from "./FooterItemText"
 
 import useColorModeValue from "@/hooks/useColorModeValue"
-import { useTranslation } from "@/hooks/useTranslation"
 
 const ThemeToggleFooterButton = () => {
-  const { t } = useTranslation("common")
+  const t = useTranslations("common")
   const ThemeIcon = useColorModeValue(Moon, Sun)
   const themeLabelKey = useColorModeValue("dark-mode", "light-mode")
   const { toggleColorMode } = useThemeToggle()

--- a/src/components/Nav/MobileMenu/ThemeToggleFooterButton.tsx
+++ b/src/components/Nav/MobileMenu/ThemeToggleFooterButton.tsx
@@ -1,7 +1,7 @@
-import { useTranslations } from "next-intl"
-;("use client")
+"use client"
 
 import { Moon, Sun } from "lucide-react"
+import { useTranslations } from "next-intl"
 
 import { useThemeToggle } from "../useThemeToggle"
 

--- a/src/components/Nav/useNavigation.ts
+++ b/src/components/Nav/useNavigation.ts
@@ -1,10 +1,11 @@
+import { useTranslations } from "next-intl"
+
 import type { NavSections } from "./types"
 
-import useTranslation from "@/hooks/useTranslation"
 import { buildNavigation } from "@/lib/nav/buildNavigation"
 
 export const useNavigation = () => {
-  const { t } = useTranslation("common")
+  const t = useTranslations("common")
 
   const linkSections: NavSections = buildNavigation(t)
 

--- a/src/components/Nav/useThemeToggle.ts
+++ b/src/components/Nav/useThemeToggle.ts
@@ -1,14 +1,14 @@
 import { Moon, Sun } from "lucide-react"
+import { useTranslations } from "next-intl"
 import { useTheme } from "next-themes"
 
 import { trackCustomEvent } from "@/lib/utils/matomo"
 
 import useColorModeValue from "@/hooks/useColorModeValue"
 import { useEventListener } from "@/hooks/useEventListener"
-import useTranslation from "@/hooks/useTranslation"
 
 export const useThemeToggle = () => {
-  const { t } = useTranslation("common")
+  const t = useTranslations("common")
   const { setTheme, resolvedTheme } = useTheme()
   const ThemeIcon = useColorModeValue(Moon, Sun)
 

--- a/src/components/Search/SearchButton.tsx
+++ b/src/components/Search/SearchButton.tsx
@@ -1,15 +1,14 @@
 import { forwardRef } from "react"
 import { Search } from "lucide-react"
+import { useTranslations } from "next-intl"
 
 import { cn } from "@/lib/utils/cn"
 
 import { Button, type ButtonProps } from "../ui/buttons/Button"
 
-import { useTranslation } from "@/hooks/useTranslation"
-
 const SearchButton = forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, ...props }, ref) => {
-    const { t } = useTranslation("common")
+    const t = useTranslations("common")
 
     return (
       <Button

--- a/src/components/Search/SearchInputButton.tsx
+++ b/src/components/Search/SearchInputButton.tsx
@@ -1,15 +1,14 @@
 import * as React from "react"
+import { useTranslations } from "next-intl"
 import { DocSearchButton } from "@docsearch/react"
 
 import { cn } from "@/lib/utils/cn"
 
 import { Button, type ButtonProps } from "../ui/buttons/Button"
 
-import { useTranslation } from "@/hooks/useTranslation"
-
 const SearchInputButton = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, ...props }, ref) => {
-    const { t } = useTranslation("common")
+    const t = useTranslations("common")
 
     return (
       <Button

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -2,7 +2,7 @@
 
 import { useRef } from "react"
 import dynamic from "next/dynamic"
-import { useLocale } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import { type DocSearchHit, useDocSearchKeyboardEvents } from "@docsearch/react"
 import * as Portal from "@radix-ui/react-portal"
 import { Slot } from "@radix-ui/react-slot"
@@ -17,7 +17,6 @@ import SearchButton from "./SearchButton"
 import SearchInputButton from "./SearchInputButton"
 
 import { useDisclosure } from "@/hooks/useDisclosure"
-import { useTranslation } from "@/hooks/useTranslation"
 
 const SearchModal = dynamic(() => import("./SearchModal"))
 
@@ -32,7 +31,7 @@ const Search = ({ asChild = false, children }: SearchProps) => {
 
   const locale = useLocale()
   const searchButtonRef = useRef<HTMLButtonElement>(null)
-  const { t } = useTranslation("common")
+  const t = useTranslations("common")
 
   const handleOpen = () => {
     onOpen()
@@ -141,7 +140,9 @@ const Search = ({ asChild = false, children }: SearchProps) => {
             fallback={() => (
               <div className="fixed inset-0 z-modal flex items-center justify-center bg-black/50">
                 <div className="mx-4 flex flex-col items-center gap-4 rounded-lg bg-background p-8 text-center shadow-lg">
-                  <p className="text-body-medium">{t("loading-error")}</p>
+                  <p className="text-body-medium">
+                    {t("loading-error-refresh")}
+                  </p>
                   <div className="flex gap-3">
                     <button
                       className="rounded-md bg-primary px-4 py-2 text-sm text-white hover:bg-primary-hover"

--- a/src/components/TableOfContents/TableOfContentsMobile.tsx
+++ b/src/components/TableOfContents/TableOfContentsMobile.tsx
@@ -1,8 +1,8 @@
-import { useTranslations } from "next-intl"
-;("use client")
+"use client"
 
 import { cva, type VariantProps } from "class-variance-authority"
 import { ChevronDown } from "lucide-react"
+import { useTranslations } from "next-intl"
 
 import type { ToCItem } from "@/lib/types"
 

--- a/src/components/TableOfContents/TableOfContentsMobile.tsx
+++ b/src/components/TableOfContents/TableOfContentsMobile.tsx
@@ -1,4 +1,5 @@
-"use client"
+import { useTranslations } from "next-intl"
+;("use client")
 
 import { cva, type VariantProps } from "class-variance-authority"
 import { ChevronDown } from "lucide-react"
@@ -13,8 +14,6 @@ import {
 } from "../ui/dropdown-menu"
 
 import ItemsListMobile from "./ItemsListMobile"
-
-import { useTranslation } from "@/hooks/useTranslation"
 
 const variants = cva("flex w-full justify-between lg:hidden", {
   variants: {
@@ -34,7 +33,7 @@ export type TableOfContentsMobileProps = {
 } & VariantProps<typeof variants>
 
 const Mobile = ({ items, maxDepth, variant }: TableOfContentsMobileProps) => {
-  const { t } = useTranslation("common")
+  const t = useTranslations("common")
 
   if (!items) {
     return null

--- a/src/components/TableOfContents/index.tsx
+++ b/src/components/TableOfContents/index.tsx
@@ -1,6 +1,6 @@
-import { useTranslations } from "next-intl"
-;("use client")
+"use client"
 
+import { useTranslations } from "next-intl"
 import { tv, type VariantProps } from "tailwind-variants"
 
 import type { ToCItem } from "@/lib/types"

--- a/src/components/TableOfContents/index.tsx
+++ b/src/components/TableOfContents/index.tsx
@@ -1,4 +1,5 @@
-"use client"
+import { useTranslations } from "next-intl"
+;("use client")
 
 import { tv, type VariantProps } from "tailwind-variants"
 
@@ -11,7 +12,6 @@ import ItemsList from "@/components/TableOfContents/ItemsList"
 import Mobile from "@/components/TableOfContents/TableOfContentsMobile"
 
 import { useActiveHash } from "@/hooks/useActiveHash"
-import { useTranslation } from "@/hooks/useTranslation"
 
 const toc = tv({
   slots: {
@@ -77,7 +77,7 @@ const TableOfContents = ({
   showDropdown,
   ...rest
 }: TableOfContentsProps) => {
-  const { t } = useTranslation("common")
+  const t = useTranslations("common")
   const titleIds: Array<string> = []
   if (!isMobile) {
     const getTitleIds = (items: Array<ToCItem>, depth: number): void => {


### PR DESCRIPTION
# Site-shell batch for #18742

Third batch, applying the #18749 recipe to the navigation chrome: **Nav** (mobile menu ×5, `useNavigation`, `useThemeToggle`), **Search** ×3, **LanguagePicker** ×2, **TableOfContents** ×2, **Breadcrumbs** — 15 files, every binding `common`.

## Notes for review

- **Nav label paths unified**: `CrawlableNav` (server) already called `buildNavigation` with a namespace-bound `getTranslations("common")`, while `useNavigation` (client) passed the legacy wrapper's raw-returning `t`. Both sides now have identical semantics; `buildNavigation`'s 190 keys are all plain text (pre-verified — no ICU, no markup).
- **Fixes a live missing-key bug**: the search modal and mobile menu lazy-load error states called `t("loading-error")` — a key that exists in **no** catalog, so prod renders the literal string `loading-error` when those chunks fail to load. Both now use the existing `loading-error-refresh` key ("Error, please refresh."), already translated in all 25 locales. (One of the 14 missing-key call sites flagged in the #18749 audit.)
- **Dynamic keys**: Breadcrumbs' `t(path)` translates URL segments and falls back to the raw segment for unknown ones — behavior identical post-migration (`getMessageFallback` returns the key, same as the wrapper's catch). `ThemeToggleFooterButton`'s `t(themeLabelKey)` takes only `dark-mode-aria-label` / `light-mode-aria-label`, both verified plain.
- One colon-form call (`common:languages` in LanguagePickerMenu) was already namespace-local — prefix dropped.

## Test plan

- [x] `pnpm type-check`, `pnpm lint` clean locally
- [ ] Deploy-preview sweep: shell strings on `/` + a docs page (breadcrumbs, TOC) × 25 locales (posted as comment)
- [ ] Playwright: open search modal, mobile menu, and language picker on the preview (en, ar, zh) — covers the lazy-loaded/interaction-gated strings incl. the `loading-error-refresh` path components

— Fable
