### PR TITLE
refactor: migrate Layer2NetworksTable + ProductTable to useTranslations (#18742)

### DIFF
--- a/src/components/Layer2NetworksTable/NetworkMaturityTooltip.tsx
+++ b/src/components/Layer2NetworksTable/NetworkMaturityTooltip.tsx
@@ -1,12 +1,12 @@
+import { useTranslations } from "next-intl"
+
 import { MaturityLevel } from "@/lib/types"
 
 import Tooltip from "@/components/Tooltip"
 import { Tag } from "@/components/ui/tag"
 
-import useTranslation from "@/hooks/useTranslation"
-
 const NetworkMaturityTooltip = ({ maturity }: { maturity: MaturityLevel }) => {
-  const { t } = useTranslation("page-layer-2-networks")
+  const t = useTranslations("page-layer-2-networks")
 
   const maturityDescription = {
     "n/a": {

--- a/src/components/Layer2NetworksTable/NetworksNoResults.tsx
+++ b/src/components/Layer2NetworksTable/NetworksNoResults.tsx
@@ -1,11 +1,11 @@
+import { useTranslations } from "next-intl"
+
 import { trackCustomEvent } from "@/lib/utils/matomo"
 
 import { Button } from "../ui/buttons/Button"
 
-import useTranslation from "@/hooks/useTranslation"
-
 const FindWalletsNoResults = ({ resetFilters }) => {
-  const { t } = useTranslation("page-layer-2-networks")
+  const t = useTranslations("page-layer-2-networks")
 
   // Track empty state
   trackCustomEvent({

--- a/src/components/Layer2NetworksTable/NetworksSubComponent.tsx
+++ b/src/components/Layer2NetworksTable/NetworksSubComponent.tsx
@@ -1,4 +1,5 @@
 import { Info } from "lucide-react"
+import { useTranslations } from "next-intl"
 
 import { ExtendedRollup } from "@/lib/types"
 
@@ -7,8 +8,6 @@ import Tooltip from "@/components/Tooltip"
 
 import { ButtonLink } from "../ui/buttons/Button"
 import InlineLink from "../ui/Link"
-
-import useTranslation from "@/hooks/useTranslation"
 
 const formatNumber = (num: number): string => {
   if (num >= 1e9) {
@@ -28,7 +27,7 @@ type NetworkSubComponentProps = {
 }
 
 const NetworkSubComponent = ({ network }: NetworkSubComponentProps) => {
-  const { t } = useTranslation("page-layer-2-networks")
+  const t = useTranslations("page-layer-2-networks")
 
   return (
     <div className="flex w-full flex-col gap-4 px-6 pb-4">

--- a/src/components/Layer2NetworksTable/NetworksWalletSelectInput.tsx
+++ b/src/components/Layer2NetworksTable/NetworksWalletSelectInput.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react"
+import { useTranslations } from "next-intl"
 
 import { FilterInputState } from "@/lib/types"
 
@@ -12,8 +13,6 @@ import {
 } from "@/components/ui/select"
 
 import { walletsData } from "@/data/wallets/wallet-data"
-
-import useTranslation from "@/hooks/useTranslation"
 
 interface NetworksWalletSelectInputProps {
   filterIndex: number
@@ -33,7 +32,7 @@ const NetworksWalletSelectInput = ({
   updateFilterState,
 }: NetworksWalletSelectInputProps) => {
   const [searchQuery, setSearchQuery] = useState("")
-  const { t } = useTranslation("page-layer-2-networks")
+  const t = useTranslations("page-layer-2-networks")
 
   const filteredWallets = walletsData
     .filter((wallet) =>

--- a/src/components/Layer2NetworksTable/hooks/useNetworkFilters.tsx
+++ b/src/components/Layer2NetworksTable/hooks/useNetworkFilters.tsx
@@ -1,3 +1,5 @@
+import { useTranslations } from "next-intl"
+
 import { FilterOption } from "@/lib/types"
 
 import {
@@ -11,10 +13,8 @@ import SwitchFilterInput from "@/components/ProductTable/FilterInputs/SwitchFilt
 
 import { trackCustomEvent } from "@/lib/utils/matomo"
 
-import useTranslation from "@/hooks/useTranslation"
-
 export const useNetworkFilters = (): FilterOption[] => {
-  const { t } = useTranslation("page-layer-2-networks")
+  const t = useTranslations("page-layer-2-networks")
 
   return [
     {

--- a/src/components/Layer2NetworksTable/index.tsx
+++ b/src/components/Layer2NetworksTable/index.tsx
@@ -1,4 +1,5 @@
 "use client"
+import { useTranslations } from "next-intl"
 
 import { ExtendedRollup, FilterOption, Lang } from "@/lib/types"
 
@@ -12,8 +13,6 @@ import { trackCustomEvent } from "@/lib/utils/matomo"
 
 import DataTable from "../DataTable"
 
-import useTranslation from "@/hooks/useTranslation"
-
 const Layer2NetworksTable = ({
   layer2Data,
   locale,
@@ -24,7 +23,7 @@ const Layer2NetworksTable = ({
   mainnetData: ExtendedRollup
 }) => {
   const networkFilterOptions = useNetworkFilters()
-  const { t } = useTranslation("page-layer-2-networks")
+  const t = useTranslations("page-layer-2-networks")
 
   const networks = [mainnetData, ...layer2Data].map((network) => ({
     ...network,

--- a/src/components/ProductTable/Filters.tsx
+++ b/src/components/ProductTable/Filters.tsx
@@ -1,4 +1,5 @@
 import { RotateCcw } from "lucide-react"
+import { useTranslations } from "next-intl"
 
 import { FilterOption } from "@/lib/types"
 
@@ -6,8 +7,6 @@ import { Accordion } from "@/components/ui/accordion"
 import { Button } from "@/components/ui/buttons/Button"
 
 import Filter from "./Filter"
-
-import { useTranslation } from "@/hooks/useTranslation"
 
 interface PresetFiltersProps {
   filters: FilterOption[]
@@ -22,7 +21,7 @@ const Filters = ({
   resetFilters,
   activeFiltersCount,
 }: PresetFiltersProps) => {
-  const { t } = useTranslation("table")
+  const t = useTranslations("table")
 
   return (
     <div className="w-full lg:w-80" data-testid="filters-container">

--- a/src/components/ProductTable/MobileFilters.tsx
+++ b/src/components/ProductTable/MobileFilters.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { ListFilter, RotateCcw, X } from "lucide-react"
+import { useTranslations } from "next-intl"
 
 import { FilterOption, TPresetFilters } from "@/lib/types"
 
@@ -11,8 +12,6 @@ import { Sheet, SheetTrigger } from "@/components/ui/sheet"
 import { trackCustomEvent } from "@/lib/utils/matomo"
 
 import { Button } from "../ui/buttons/Button"
-
-import { useTranslation } from "@/hooks/useTranslation"
 
 interface MobileFiltersProps {
   filters: FilterOption[]
@@ -39,7 +38,7 @@ const MobileFilters = ({
   resetFilters,
   mobileFiltersLabel,
 }: MobileFiltersProps) => {
-  const { t } = useTranslation("table")
+  const t = useTranslations("table")
   const triggerRef = React.useRef<HTMLButtonElement>(null)
 
   const handleOpenChange = (open: boolean) => {

--- a/src/components/ProductTable/PresetFilters.tsx
+++ b/src/components/ProductTable/PresetFilters.tsx
@@ -1,7 +1,7 @@
 "use client"
-
 import { useCallback, useId, useMemo } from "react"
 import { Check } from "lucide-react"
+import { useTranslations } from "next-intl"
 
 import type { FilterOption, TPresetFilters } from "@/lib/types"
 
@@ -16,7 +16,6 @@ import {
 import { cn } from "@/lib/utils/cn"
 import { trackCustomEvent } from "@/lib/utils/matomo"
 
-import { useTranslation } from "@/hooks/useTranslation"
 import { getActivePresets } from "@/lib/product-table"
 
 export interface PresetFiltersProps {
@@ -68,7 +67,7 @@ const PresetCard = ({
   showMobileSidebar,
   onSelect,
 }: PresetCardProps) => {
-  const { t } = useTranslation("page-wallets-find-wallet")
+  const t = useTranslations("page-wallets-find-wallet")
   const id = useId()
   const descriptionId = !showMobileSidebar ? `${id}-description` : undefined
   const colorIdx = colors.text[idx] ? idx : idx % colors.text.length
@@ -128,10 +127,9 @@ const PresetCard = ({
                 </span>
                 <span className="sr-only">
                   {" "}
-                  {t(
-                    "page-wallets-find-wallet:page-find-wallet-persona-count-available",
-                    { count: presetFiltersCount }
-                  )}
+                  {t("page-find-wallet-persona-count-available", {
+                    count: presetFiltersCount,
+                  })}
                 </span>
               </>
             )}
@@ -157,7 +155,7 @@ const PresetFilters = ({
   showMobileSidebar = false,
   presetFiltersCounts,
 }: PresetFiltersProps) => {
-  const { t } = useTranslation("page-wallets-find-wallet")
+  const t = useTranslations("page-wallets-find-wallet")
   const activePresets = useMemo(() => {
     return getActivePresets(presets, filters)
   }, [presets, filters])


### PR DESCRIPTION
# Tables batch for #18742

Fourth batch per the #18749 recipe: **Layer2NetworksTable** (6 files → `page-layer-2-networks`) and **ProductTable** (`Filters`/`MobileFilters` → `table`; `PresetFilters` → `page-wallets-find-wallet`).

## Scope note

**`FindWalletProductTable` is deliberately excluded**: #18702 (find-wallet INP rebuild) rewrites 10 files in that subtree and #18715 touches it as well. Migrating it now would hand both PRs conflicts; it gets its own small batch after they land.

## Notes for review

- All 60+ literal keys pre-verified plain text (no ICU, no markup) in the catalogs; the wrapper's raw-return → cooked `t()` switch is behavior-identical for them.
- `PresetFilters`'s sr-only persona count is the one ICU call: colon form with values (already interpolated pre-migration), prefix now redundant and dropped — `t("page-find-wallet-persona-count-available", { count })`.
- `NetworkMaturityTooltip`'s template key `` t(`page-layer-2-networks-${maturity}-label`) `` resolves only to the five verified maturity-label keys.
- The two client components (`Layer2NetworksTable/index`, `PresetFilters`) keep `"use client"` as the first statement (regression check after the #18753 transform bug).

## Test plan

- [x] `pnpm type-check`, `pnpm lint` clean locally
- [x] Deploy-preview sweep: `/layer-2/networks/` × 25 locales incl. filter/tooltip strings (posted as comment)
- [x] Playwright: expand a network row + open maturity tooltip + wallet filter on the preview (en, ar, zh)

— Fable
