### PR TITLE
refactor: migrate 28 misc components/hooks to useTranslations (#18742)

### DIFF
--- a/src/components/AssetDownload/AssetDownloadArtist.tsx
+++ b/src/components/AssetDownload/AssetDownloadArtist.tsx
@@ -1,11 +1,11 @@
+import { useTranslations } from "next-intl"
+
 import Emoji from "@/components/Emoji"
 
 import { cn } from "@/lib/utils/cn"
 
 import { Flex } from "../ui/flex"
 import { BaseLink } from "../ui/Link"
-
-import { useTranslation } from "@/hooks/useTranslation"
 
 type AssetDownloadArtistProps = {
   artistName: string
@@ -16,7 +16,7 @@ const AssetDownloadArtist = ({
   artistName,
   artistUrl,
 }: AssetDownloadArtistProps) => {
-  const { t } = useTranslation("page-assets")
+  const t = useTranslations("page-assets")
   return (
     <Flex className={cn("mb-4 border border-t-0", "rounded-b px-4 py-2")}>
       <Flex className="me-2">

--- a/src/components/AssetDownload/index.tsx
+++ b/src/components/AssetDownload/index.tsx
@@ -2,6 +2,7 @@ import { extname } from "path"
 
 import { BaseHTMLAttributes } from "react"
 import type { ImageProps, StaticImageData } from "next/image"
+import { useTranslations } from "next-intl"
 
 import AssetDownloadArtist from "@/components/AssetDownload/AssetDownloadArtist"
 import AssetDownloadImage from "@/components/AssetDownload/AssetDownloadImage"
@@ -10,8 +11,6 @@ import { Flex, Stack } from "@/components/ui/flex"
 
 import { cn } from "@/lib/utils/cn"
 import { trackCustomEvent } from "@/lib/utils/matomo"
-
-import { useTranslation } from "@/hooks/useTranslation"
 
 type AssetDownloadProps = {
   title: string
@@ -32,7 +31,7 @@ const AssetDownload = ({
   className,
   ...props
 }: AssetDownloadProps) => {
-  const { t } = useTranslation(["page-assets"])
+  const t = useTranslations("page-assets")
   const matomoHandler = () => {
     trackCustomEvent({
       eventCategory: "asset download button",

--- a/src/components/CentralizedExchanges/index.tsx
+++ b/src/components/CentralizedExchanges/index.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useLocale } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 
 import type { ChildOnlyProp, Lang } from "@/lib/types"
 
@@ -15,7 +15,6 @@ import { WEBSITE_EMAIL } from "@/lib/constants"
 import Select from "../Select"
 
 import { useCentralizedExchanges } from "@/hooks/useCentralizedExchanges"
-import { useTranslation } from "@/hooks/useTranslation"
 
 const ListContainer = (props: ChildOnlyProp) => (
   <div className="mt-16 flex flex-col gap-4" {...props} />
@@ -70,7 +69,7 @@ type CentralizedExchangesProps = { lastDataUpdateDate: string }
 const CentralizedExchanges = ({
   lastDataUpdateDate,
 }: CentralizedExchangesProps) => {
-  const { t } = useTranslation("page-get-eth")
+  const t = useTranslations("page-get-eth")
   const locale = useLocale()
   const {
     selectOptions,

--- a/src/components/CodeModal.tsx
+++ b/src/components/CodeModal.tsx
@@ -1,5 +1,6 @@
 import { Children, type ReactElement } from "react"
 import { Clipboard, ClipboardCheck } from "lucide-react"
+import { useTranslations } from "next-intl"
 
 import { Button } from "./ui/buttons/Button"
 import {
@@ -12,7 +13,6 @@ import {
 } from "./ui/sheet"
 
 import { useClipboard } from "@/hooks/useClipboard"
-import { useTranslation } from "@/hooks/useTranslation"
 
 type CodeModalProps = {
   title: string
@@ -22,7 +22,7 @@ type CodeModalProps = {
 }
 
 const CodeModal = ({ children, isOpen, setIsOpen, title }: CodeModalProps) => {
-  const { t } = useTranslation()
+  const t = useTranslations("common")
   const codeSnippet = (
     Children.toArray(children)[0] as ReactElement<{ children: string }>
   ).props.children

--- a/src/components/Codeblock/CodeblockClient.tsx
+++ b/src/components/Codeblock/CodeblockClient.tsx
@@ -1,15 +1,13 @@
 "use client"
-
 import { useState } from "react"
 import { Check, ChevronDown, ChevronUp, Copy } from "lucide-react"
+import { useTranslations } from "next-intl"
 
 import CopyToClipboard from "@/components/CopyToClipboard"
 
 import { cn } from "@/lib/utils/cn"
 
 import { LINES_BEFORE_COLLAPSABLE } from "@/lib/constants"
-
-import { useTranslation } from "@/hooks/useTranslation"
 
 type CodeblockClientProps = {
   html: string
@@ -32,7 +30,7 @@ const CodeblockClient = ({
   fromHomepage,
   className,
 }: CodeblockClientProps) => {
-  const { t } = useTranslation("common")
+  const t = useTranslations("common")
 
   const codeLineCount = Math.max(totalLines - 1, 1)
   const isCollapsable =

--- a/src/components/ContentFeedback.tsx
+++ b/src/components/ContentFeedback.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { type ReactNode, useState } from "react"
-import { useLocale } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 
 import type { Lang } from "@/lib/types"
 
@@ -15,7 +15,6 @@ import { Button } from "./ui/buttons/Button"
 import Translation from "./Translation"
 
 import { useSurvey } from "@/hooks/useSurvey"
-import { useTranslation } from "@/hooks/useTranslation"
 import { usePathname } from "@/i18n/navigation"
 
 type ContentFeedbackProps = {
@@ -28,7 +27,7 @@ const ContentFeedback = ({
   isArticle,
   ...props
 }: ContentFeedbackProps) => {
-  const { t } = useTranslation("common")
+  const t = useTranslations("common")
   const [feedbackSubmitted, setFeedbackSubmitted] = useState(false)
   const surveyUrl = useSurvey(feedbackSubmitted)
   const locale = useLocale()

--- a/src/components/CopyPageButton/index.tsx
+++ b/src/components/CopyPageButton/index.tsx
@@ -9,7 +9,7 @@ import {
   FileText,
   Loader2,
 } from "lucide-react"
-import { useLocale } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 
 import type { MatomoEventOptions } from "@/lib/types"
 
@@ -30,7 +30,6 @@ import { trackCustomEvent } from "@/lib/utils/matomo"
 import { DEFAULT_LOCALE, SITE_URL } from "@/lib/constants"
 
 import { useClipboard } from "@/hooks/useClipboard"
-import { useTranslation } from "@/hooks/useTranslation"
 
 type CopyPageButtonProps = {
   slug: string
@@ -98,7 +97,7 @@ const CopyPageButton = ({
   isTranslated = true,
   className,
 }: CopyPageButtonProps) => {
-  const { t } = useTranslation("common")
+  const t = useTranslations("common")
   const locale = useLocale()
   const { onCopy, hasCopied } = useClipboard({ timeout: 2000 })
   const [isLoading, setIsLoading] = useState(false)

--- a/src/components/EnergyConsumptionChart/index.tsx
+++ b/src/components/EnergyConsumptionChart/index.tsx
@@ -11,7 +11,7 @@ import {
   LinearScale,
 } from "chart.js"
 import ChartDataLabels from "chartjs-plugin-datalabels"
-import { useLocale } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import { Bar } from "react-chartjs-2"
 
 import type { Lang } from "@/lib/types"
@@ -24,7 +24,6 @@ import { isLangRightToLeft } from "@/lib/utils/translations"
 import { useBreakpointValue } from "@/hooks/useBreakpointValue"
 import useColorModeValue from "@/hooks/useColorModeValue"
 import { useIsClient } from "@/hooks/useIsClient"
-import { useTranslation } from "@/hooks/useTranslation"
 
 // ChartDataLabels required to display y-labels on top of bars
 ChartJS.register(
@@ -36,7 +35,7 @@ ChartJS.register(
 )
 
 const EnergyConsumptionChart = () => {
-  const { t } = useTranslation("page-energy-consumption")
+  const t = useTranslations("page-energy-consumption")
   const locale = useLocale()
   const isClient = useIsClient()
   const isRtl = isLangRightToLeft(locale as Lang)

--- a/src/components/EthPriceCard.tsx
+++ b/src/components/EthPriceCard.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { ArrowUpRight, Info } from "lucide-react"
-import { useLocale } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 
 import Tooltip from "@/components/Tooltip"
 import InlineLink from "@/components/ui/Link"
@@ -13,14 +13,13 @@ import { formatPriceUSD, numberToPercent } from "@/lib/utils/numbers"
 import { Flex } from "./ui/flex"
 
 import { useGasEthPrice } from "@/hooks/useGasEthPrice"
-import { useTranslation } from "@/hooks/useTranslation"
 
 const EthPriceCard = ({
   className,
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) => {
   const locale = useLocale()
-  const { t } = useTranslation()
+  const t = useTranslations("common")
   const { ethPrice, ethPercentChange24h } = useGasEthPrice()
 
   const isLoading = ethPrice === 0

--- a/src/components/ExpandableCard.tsx
+++ b/src/components/ExpandableCard.tsx
@@ -1,6 +1,6 @@
 "use client"
-
 import React, { type ReactNode, useState } from "react"
+import { useTranslations } from "next-intl"
 import type { AccordionContentProps } from "@radix-ui/react-accordion"
 
 import { HStack } from "@/components/ui/flex"
@@ -14,8 +14,6 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "./ui/accordion"
-
-import { useTranslation } from "@/hooks/useTranslation"
 
 export type ExpandableCardProps = {
   children?: ReactNode
@@ -42,7 +40,7 @@ const ExpandableCard = ({
   forceMount = true,
 }: ExpandableCardProps) => {
   const [isVisible, setIsVisible] = useState(visible)
-  const { t } = useTranslation("common")
+  const t = useTranslations("common")
   const matomo = {
     eventAction,
     eventCategory: `ExpandableCard${eventCategory}`,

--- a/src/components/FeedbackWidget/FixedDot.tsx
+++ b/src/components/FeedbackWidget/FixedDot.tsx
@@ -1,4 +1,5 @@
 import { forwardRef } from "react"
+import { useTranslations } from "next-intl"
 import type { ButtonHTMLAttributes } from "react"
 
 import { Button } from "@/components/ui/buttons/Button"
@@ -6,8 +7,6 @@ import { Button } from "@/components/ui/buttons/Button"
 import { cn } from "@/lib/utils/cn"
 
 import { FeedbackGlyphIcon } from "../icons"
-
-import { useTranslation } from "@/hooks/useTranslation"
 
 type FixedDotProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   isExpanded: boolean
@@ -17,7 +16,7 @@ type FixedDotProps = ButtonHTMLAttributes<HTMLButtonElement> & {
 
 const FixedDot = forwardRef<HTMLButtonElement, FixedDotProps>(
   ({ offsetBottom, isExpanded, suppressScale, className, ...props }, ref) => {
-    const { t } = useTranslation("common")
+    const t = useTranslations("common")
     return (
       <Button
         ref={ref}

--- a/src/components/FeedbackWidget/index.tsx
+++ b/src/components/FeedbackWidget/index.tsx
@@ -1,7 +1,7 @@
 "use client"
-
 import { useContext } from "react"
 import { X } from "lucide-react"
+import { useTranslations } from "next-intl"
 
 import { Button } from "@/components/ui/buttons/Button"
 
@@ -16,11 +16,10 @@ import FixedDot from "./FixedDot"
 import { useFeedbackWidget } from "./useFeedbackWidget"
 
 import { FeedbackWidgetContext } from "@/contexts/FeedbackWidgetContext"
-import { useTranslation } from "@/hooks/useTranslation"
 
 const FeedbackWidget = () => {
   const { showFeedbackWidget } = useContext(FeedbackWidgetContext)
-  const { t } = useTranslation("common")
+  const t = useTranslations("common")
   const {
     offsetBottom,
     cancelRef,

--- a/src/components/ListenToPlayer/index.tsx
+++ b/src/components/ListenToPlayer/index.tsx
@@ -2,7 +2,7 @@
 
 import { useContext, useEffect, useState } from "react"
 import { Howl } from "howler"
-import { useLocale } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import { Portal } from "@radix-ui/react-portal"
 
 import PlayerWidget from "@/components/ListenToPlayer/PlayerWidget"
@@ -14,7 +14,6 @@ import { trackCustomEvent } from "@/lib/utils/matomo"
 import { getPlaylistBySlug } from "@/data/listen-to-feature/playlist"
 
 import { FeedbackWidgetContext } from "@/contexts/FeedbackWidgetContext"
-import { useTranslation } from "@/hooks/useTranslation"
 
 type ListenToPlayerProps = {
   slug: string
@@ -25,7 +24,7 @@ const ListenToPlayer = ({ slug, className }: ListenToPlayerProps) => {
   const { setShowFeedbackWidget } = useContext(FeedbackWidgetContext)
   const { playlist, index } = getPlaylistBySlug(slug)
 
-  const { t } = useTranslation()
+  const t = useTranslations("common")
   const [startedPlaying, setStartedPlaying] = useState(false)
   const [isPlaying, setIsPlaying] = useState(false)
   const [showWidget, setShowWidget] = useState(false)

--- a/src/components/Logo/index.tsx
+++ b/src/components/Logo/index.tsx
@@ -1,14 +1,14 @@
 "use client"
+import { useTranslations } from "next-intl"
 
 import { Image } from "@/components/Image"
 
 import useColorModeValue from "@/hooks/useColorModeValue"
-import { useTranslation } from "@/hooks/useTranslation"
 import darkImage from "@/public/images/ef-logo.png"
 import lightImage from "@/public/images/ef-logo-white.png"
 
 const Logo = () => {
-  const { t } = useTranslation("common")
+  const t = useTranslations("common")
   const image = useColorModeValue(darkImage, lightImage)
 
   return (

--- a/src/components/NetworkMaturity.tsx
+++ b/src/components/NetworkMaturity.tsx
@@ -1,3 +1,5 @@
+import { useTranslations } from "next-intl"
+
 import { AccordionContainer } from "./ui/accordion"
 import InlineLink from "./ui/Link"
 import {
@@ -10,14 +12,13 @@ import {
 } from "./ui/table"
 import ExpandableCard from "./ExpandableCard"
 
-import useTranslation from "@/hooks/useTranslation"
 import DevelopingImage from "@/public/images/network-maturity/developing.svg"
 import EmergingImage from "@/public/images/network-maturity/emerging.svg"
 import MaturingImage from "@/public/images/network-maturity/maturing.svg"
 import RobustImage from "@/public/images/network-maturity/robust.svg"
 
 const NetworkMaturity = () => {
-  const { t } = useTranslation("page-layer-2-networks")
+  const t = useTranslations("page-layer-2-networks")
 
   return (
     <AccordionContainer className="mx-8 mt-10">

--- a/src/components/NotFoundPage/index.tsx
+++ b/src/components/NotFoundPage/index.tsx
@@ -1,12 +1,11 @@
 "use client"
+import { useTranslations } from "next-intl"
 
 import MainArticle from "../MainArticle"
 import InlineLink from "../ui/Link"
 
-import useTranslation from "@/hooks/useTranslation"
-
 function NotFoundPage() {
-  const { t } = useTranslation("common")
+  const t = useTranslations("common")
 
   return (
     <MainArticle className="mt-24 mb-32 w-full space-y-8 px-8 py-4 md:mt-32 md:mb-48">

--- a/src/components/PageActions/index.tsx
+++ b/src/components/PageActions/index.tsx
@@ -1,4 +1,5 @@
 "use client"
+import { useTranslations } from "next-intl"
 
 import CopyPageButton from "@/components/CopyPageButton"
 import Github from "@/components/icons/github.svg"
@@ -9,7 +10,6 @@ import { cn } from "@/lib/utils/cn"
 
 import { getPlaylistBySlug } from "@/data/listen-to-feature/playlist"
 
-import { useTranslation } from "@/hooks/useTranslation"
 import { usePathname } from "@/i18n/navigation"
 
 type PageActionsProps = {
@@ -27,7 +27,7 @@ const PageActions = ({
   hideEditButton,
   className,
 }: PageActionsProps) => {
-  const { t } = useTranslation("common")
+  const t = useTranslations("common")
   const pathname = usePathname()
   const hasListenToPlaylist = getPlaylistBySlug(slug).index !== -1
 

--- a/src/components/RadialChart/index.tsx
+++ b/src/components/RadialChart/index.tsx
@@ -2,7 +2,7 @@
 
 import { type ReactNode, useEffect, useState } from "react"
 import { Info } from "lucide-react"
-import { useLocale } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import { PolarAngleAxis, RadialBar, RadialBarChart } from "recharts"
 
 import { cn } from "@/lib/utils/cn"
@@ -10,8 +10,6 @@ import { dateTimeFormat, isValidDate } from "@/lib/utils/date"
 
 import Tooltip from "../Tooltip"
 import Link from "../ui/Link"
-
-import { useTranslation } from "@/hooks/useTranslation"
 
 /**
  * RadialChartProps defines the properties for the RadialChart component.
@@ -52,7 +50,7 @@ const RadialChart = ({
   className,
   displayValue,
 }: RadialChartProps) => {
-  const { t } = useTranslation("common")
+  const t = useTranslations("common")
   const locale = useLocale()
   const [isMounted, setIsMounted] = useState(false)
 

--- a/src/components/SkipLink.tsx
+++ b/src/components/SkipLink.tsx
@@ -1,15 +1,13 @@
 "use client"
-
+import { useTranslations } from "next-intl"
 import type { MouseEvent } from "react"
 
 import { scrollIntoView } from "@/lib/utils/scrollIntoView"
 
 import { MAIN_CONTENT_ID } from "@/lib/constants"
 
-import useTranslation from "@/hooks/useTranslation"
-
 const SkipLink = () => {
-  const { t } = useTranslation("common")
+  const t = useTranslations("common")
 
   const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
     const target = document.getElementById(MAIN_CONTENT_ID)

--- a/src/components/StoryCard/index.tsx
+++ b/src/components/StoryCard/index.tsx
@@ -1,6 +1,6 @@
 "use client"
-
 import { useState } from "react"
+import { useTranslations } from "next-intl"
 
 import type { Story } from "@/lib/types"
 
@@ -9,8 +9,6 @@ import { Button, ButtonLink } from "@/components/ui/buttons/Button"
 import { Card, CardContent } from "@/components/ui/card"
 
 import { cn } from "@/lib/utils/cn"
-
-import { useTranslation } from "@/hooks/useTranslation"
 
 type StoryCardProps = {
   story: Story
@@ -40,7 +38,7 @@ const StoryCard = ({
   expandable = true,
   showDate = true,
 }: StoryCardProps) => {
-  const { t } = useTranslation("common")
+  const t = useTranslations("common")
   const [isFlipped, setIsFlipped] = useState(false)
   const [isExpanded, setIsExpanded] = useState(false)
   const [isFading, setIsFading] = useState(false)

--- a/src/components/TranslationBanner/index.tsx
+++ b/src/components/TranslationBanner/index.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react"
 import { X } from "lucide-react"
-import { useLocale } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 
 import { Button } from "@/components/ui/buttons/Button"
 
@@ -10,7 +10,6 @@ import { cn } from "@/lib/utils/cn"
 
 import { DEFAULT_LOCALE } from "@/lib/constants"
 
-import useTranslation from "@/hooks/useTranslation"
 import { usePathname } from "@/i18n/navigation"
 import { DO_NOT_TRANSLATE_PATHS } from "@/scripts/intl-pipeline/constants"
 
@@ -18,7 +17,7 @@ const TranslationBanner = () => {
   const locale = useLocale()
   const pathname = usePathname()
 
-  const { t } = useTranslation()
+  const t = useTranslations("common")
 
   // Default to isOpen being false, and let the useEffect set this.
   const [isOpen, setIsOpen] = useState(false)

--- a/src/components/TutorialMetadata.tsx
+++ b/src/components/TutorialMetadata.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useLocale } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 
 import { Lang, Skill, TranslationKey } from "@/lib/types"
 import { TutorialFrontmatter } from "@/lib/interfaces"
@@ -17,8 +17,6 @@ import { Flex } from "./ui/flex"
 import InlineLink from "./ui/Link"
 import { Tag } from "./ui/tag"
 
-import { useTranslation } from "@/hooks/useTranslation"
-
 export type TutorialMetadataProps = {
   frontmatter: TutorialFrontmatter
   timeToRead: number
@@ -34,7 +32,7 @@ const TutorialMetadata = ({
   timeToRead,
 }: TutorialMetadataProps) => {
   const locale = useLocale()
-  const { t } = useTranslation("page-developers-tutorials")
+  const t = useTranslations("page-developers-tutorials")
 
   const hasSource = frontmatter.source && frontmatter.sourceUrl
   const published = frontmatter.published

--- a/src/components/ui/TruncatedText.tsx
+++ b/src/components/ui/TruncatedText.tsx
@@ -1,6 +1,6 @@
 "use client"
-
 import { useState } from "react"
+import { useTranslations } from "next-intl"
 
 import type { MatomoEventOptions } from "@/lib/types"
 
@@ -10,8 +10,6 @@ import { cn } from "@/lib/utils/cn"
 import { trackCustomEvent } from "@/lib/utils/matomo"
 
 import { LINE_CLAMP_CLASS_MAPPING } from "@/lib/constants"
-
-import useTranslation from "@/hooks/useTranslation"
 
 interface TruncatedTextProps
   extends Pick<
@@ -30,7 +28,7 @@ const TruncatedText = ({
   children,
   matomoEvent,
 }: TruncatedTextProps) => {
-  const { t } = useTranslation("common")
+  const t = useTranslations("common")
   const [isExpanded, setIsExpanded] = useState(false)
 
   return (

--- a/src/components/ui/dialog-modal.tsx
+++ b/src/components/ui/dialog-modal.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import { X } from "lucide-react"
+import { useTranslations } from "next-intl"
 import { tv, type VariantProps } from "tailwind-variants"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
 
@@ -7,8 +8,6 @@ import { cn } from "@/lib/utils/cn"
 
 import { Button } from "./buttons/Button"
 import { Center, Flex } from "./flex"
-
-import useTranslation from "@/hooks/useTranslation"
 
 const dialogVariant = tv({
   slots: {
@@ -128,7 +127,7 @@ const DialogHeader = ({
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) => {
   const { header, close } = useDialogStyles()
-  const { t } = useTranslation("common")
+  const t = useTranslations("common")
   return (
     <div className={cn(header(), className)} {...props}>
       {children}

--- a/src/components/ui/tag-filter.tsx
+++ b/src/components/ui/tag-filter.tsx
@@ -2,14 +2,12 @@
 
 import { useState } from "react"
 import { ChevronDown, ChevronUp } from "lucide-react"
-import { useLocale } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 
 import { TagButton } from "@/components/ui/tag"
 
 import { cn } from "@/lib/utils/cn"
 import { numberFormat } from "@/lib/utils/numbers"
-
-import useTranslation from "@/hooks/useTranslation"
 
 export interface TagFilterProps {
   /**
@@ -47,7 +45,7 @@ const TagFilter = ({
   showCount = true,
   className,
 }: TagFilterProps) => {
-  const { t } = useTranslation("common")
+  const t = useTranslations("common")
   const locale = useLocale()
   const [expanded, setExpanded] = useState(false)
 

--- a/src/hooks/useCentralizedExchanges.ts
+++ b/src/hooks/useCentralizedExchanges.ts
@@ -1,6 +1,6 @@
 import { useState } from "react"
 import { shuffle } from "lodash"
-import { useLocale } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 
 import type { ImageProps } from "@/components/Image"
 import { SelectOnChange } from "@/components/Select"
@@ -10,7 +10,6 @@ import { trackCustomEvent } from "@/lib/utils/matomo"
 
 import exchangeData from "@/data/exchangesByCountry"
 
-import { useTranslation } from "@/hooks/useTranslation"
 import binance from "@/public/images/exchanges/binance.png"
 import bitbuy from "@/public/images/exchanges/bitbuy.png"
 import bitfinex from "@/public/images/exchanges/bitfinex.png"
@@ -314,7 +313,8 @@ const exchanges: ExchangeDetails = {
 
 export const useCentralizedExchanges = () => {
   const locale = useLocale()
-  const { t } = useTranslation("page-get-eth")
+  const t = useTranslations("page-get-eth")
+  const tCommon = useTranslations("common")
   const [selectedCountry, setSelectedCountry] =
     useState<ExchangeByCountryOption | null>()
 
@@ -328,7 +328,7 @@ export const useCentralizedExchanges = () => {
       const countryName =
         countryCode.length === 2
           ? getCountryCodeName(countryCode, locale)
-          : t(`common:region-${countryCode.toLowerCase()}`)
+          : tCommon(`region-${countryCode.toLowerCase()}`)
 
       return {
         value: countryName,

--- a/src/hooks/useLanguagesDisplayInfo.ts
+++ b/src/hooks/useLanguagesDisplayInfo.ts
@@ -1,7 +1,7 @@
 "use client"
 
 import { useMemo } from "react"
-import { useLocale } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 
 import type { Lang, LocaleDisplayInfo } from "@/lib/types"
 
@@ -9,7 +9,6 @@ import { filterRealLocales } from "@/lib/utils/translations"
 
 import { LOCALES_CODES } from "@/lib/constants"
 
-import useTranslation from "@/hooks/useTranslation"
 import { localeToDisplayInfo } from "@/lib/nav/localeToDisplayInfo"
 
 // Pre-filtered locales
@@ -23,7 +22,7 @@ export const useLanguagesDisplayInfo = (): LocaleDisplayInfo[] => {
   const locale = useLocale()
   // Use common namespace - translations may not exist, but localeToDisplayInfo
   // has fallbacks using Intl.DisplayNames
-  const { t } = useTranslation("common")
+  const t = useTranslations("common")
 
   return useMemo(() => {
     if (!FILTERED_LOCALES?.length) return []

--- a/src/hooks/useStakingConsiderations.tsx
+++ b/src/hooks/useStakingConsiderations.tsx
@@ -1,4 +1,5 @@
 import { ElementType, useState } from "react"
+import { useTranslations } from "next-intl"
 
 import type { MatomoEventOptions, StakingPage } from "@/lib/types"
 
@@ -17,8 +18,6 @@ import {
 } from "@/components/icons/staking"
 import { StakingConsiderationsProps } from "@/components/Staking/StakingConsiderations"
 
-import { useTranslation } from "@/hooks/useTranslation"
-
 type DataType = {
   title: string
   description: string
@@ -33,7 +32,7 @@ export const useStakingConsiderations = ({
   page,
 }: StakingConsiderationsProps) => {
   const [activeIndex, setActiveIndex] = useState(0)
-  const { t } = useTranslation("page-staking")
+  const t = useTranslations("page-staking")
 
   const data: { [key in StakingPage]: DataType[] } = {
     solo: [


### PR DESCRIPTION
# Misc-components batch for #18742

Fifth batch per the #18749 recipe: 28 self-contained components and hooks across `src/components` and `src/hooks`. Namespaces: `common` (most), `page-assets`, `page-get-eth`, `page-energy-consumption`, `page-developers-tutorials`, `page-layer-2-networks`, `page-staking`.

## Notes for review

- **All literal keys pre-verified plain text** in the English catalogs (no ICU, no markup), so the wrapper's raw-return → cooked `t()` switch is behavior-identical.
- **`useCentralizedExchanges`** had the batch's one cross-namespace dynamic key — `` t(`common:region-${countryCode}`) `` — now a second binding: `` tCommon(`region-${...}`) ``.
- **`AssetDownload`** used the array namespace form `useTranslation(["page-assets"])`; the wrapper only ever read the first element, so the single binding preserves semantics.
- **Deferred**: `ui/swiper.tsx` (#18698 fixes its missing a11y keys and touches the same file — migrates after that lands) and `Translation.tsx` (the raw-message dispatch moves into it in the final hook-deletion PR, since rendering embedded-HTML messages is that component's actual job).

## Test plan

- [x] `pnpm type-check`, `pnpm lint` clean locally
- [x] Deploy-preview sweep: representative pages (`/assets/`, `/get-eth/`, `/energy-consumption/`, a tutorial page, 404) × 25 locales (posted as comment)
- [x] Playwright: feedback widget open/answer and copy-page-button menu on the preview (en, ar, zh) — the interaction-gated strings

— Fable
