### PR TITLE
refactor: migrate colon-form call sites (SideNav/DocsNav/History/Merge) to useTranslations (#18742)

### DIFF
--- a/src/components/DocsNav/index.tsx
+++ b/src/components/DocsNav/index.tsx
@@ -1,6 +1,6 @@
 "use client"
-
 import { ChevronLeft, ChevronRight } from "lucide-react"
+import { useTranslations } from "next-intl"
 
 import { TranslationKey } from "@/lib/types"
 import type { DeveloperDocsLink } from "@/lib/interfaces"
@@ -11,7 +11,6 @@ import { cn } from "@/lib/utils/cn"
 
 import docLinks from "@/data/developer-docs-links.yaml"
 
-import { useTranslation } from "@/hooks/useTranslation"
 import { usePathname } from "@/i18n/navigation"
 
 const TextDiv = ({ children, className, ...props }) => (
@@ -38,7 +37,7 @@ type CardLinkProps = {
 }
 
 const CardLink = ({ docData, isPrev, contentNotTranslated }: CardLinkProps) => {
-  const { t } = useTranslation("page-developers-docs")
+  const t = useTranslations("page-developers-docs")
 
   if (!docData) return <div className="flex-1" />
 

--- a/src/components/History/NetworkUpgradeSummary.tsx
+++ b/src/components/History/NetworkUpgradeSummary.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import { useLocale } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 
 import { Flex, Stack } from "@/components/ui/flex"
 
@@ -13,8 +13,6 @@ import networkUpgradeSummaryData from "@/data/networkUpgradeSummaryData"
 import Emoji from "../Emoji"
 import InlineLink from "../ui/Link"
 
-import { useTranslation } from "@/hooks/useTranslation"
-
 type NetworkUpgradeSummaryProps = {
   name: string
 }
@@ -22,7 +20,7 @@ type NetworkUpgradeSummaryProps = {
 const NetworkUpgradeSummary = ({ name }: NetworkUpgradeSummaryProps) => {
   const [formattedUTC, setFormattedUTC] = useState("")
   const locale = useLocale()
-  const { t } = useTranslation("page-history")
+  const t = useTranslations("page-history")
 
   const {
     dateTimeAsString,
@@ -71,26 +69,26 @@ const NetworkUpgradeSummary = ({ name }: NetworkUpgradeSummaryProps) => {
       )}
       {blockNumber &&
         blockTypeTranslation(
-          "page-history:page-history-block-number",
+          "page-history-block-number",
           "https://eth.blockscout.com/block/",
           blockNumber
         )}
       {epochNumber &&
         blockTypeTranslation(
-          "page-history:page-history-epoch-number",
+          "page-history-epoch-number",
           "https://beaconcha.in/epoch/",
           epochNumber
         )}
       {slotNumber &&
         blockTypeTranslation(
-          "page-history:page-history-slot-number",
+          "page-history-slot-number",
           "https://beaconcha.in/slot/",
           slotNumber
         )}
       {ethPriceInUSD && (
         <Flex>
           <Emoji className="me-2 text-sm" text=":money_bag:" />
-          {t("page-history:page-history-eth-price")}:{" "}
+          {t("page-history-eth-price")}:{" "}
           {numberFormat(locale, {
             style: "currency",
             currency: "USD",
@@ -101,7 +99,7 @@ const NetworkUpgradeSummary = ({ name }: NetworkUpgradeSummaryProps) => {
         <Flex>
           <Emoji className="me-2 text-sm" text=":desktop_computer:" />
           <InlineLink href={waybackLink}>
-            {t("page-history:page-history-ethereum-org-wayback")}
+            {t("page-history-ethereum-org-wayback")}
           </InlineLink>
         </Flex>
       )}

--- a/src/components/MergeArticleList.tsx
+++ b/src/components/MergeArticleList.tsx
@@ -1,77 +1,49 @@
+import { useTranslations } from "next-intl"
+
 import CardList, { type CardProps } from "@/components/CardList"
 
-import { useTranslation } from "@/hooks/useTranslation"
-
 const MergeArticleList = () => {
-  const { t } = useTranslation(["page-upgrades", "page-upgrades-index"])
+  const t = useTranslations("page-upgrades-index")
 
   const reads: CardProps[] = [
     {
-      title: t("page-upgrades-index:page-upgrade-article-title-ethmerge"),
-      description: t(
-        "page-upgrades-index:page-upgrade-article-author-ethmerge"
-      ),
+      title: t("page-upgrade-article-title-ethmerge"),
+      description: t("page-upgrade-article-author-ethmerge"),
       link: "https://ethmerge.com/",
     },
     {
-      title: t(
-        "page-upgrades-index:page-upgrade-article-title-merge-is-coming"
-      ),
-      description: t("page-upgrades-index:page-upgrade-article-author-alchemy"),
+      title: t("page-upgrade-article-title-merge-is-coming"),
+      description: t("page-upgrade-article-author-alchemy"),
       link: "https://www.alchemy.com/the-merge",
     },
     {
-      title: t(
-        "page-upgrades-index:page-upgrade-article-title-state-of-the-merge"
-      ),
-      description: t(
-        "page-upgrades-index:page-upgrade-article-author-consensys"
-      ),
+      title: t("page-upgrade-article-title-state-of-the-merge"),
+      description: t("page-upgrade-article-author-consensys"),
       link: "https://consensys.net/blog/news/the-state-of-the-merge-an-update-on-ethereums-merge-to-proof-of-stake-in-2022/",
     },
     {
-      title: t(
-        "page-upgrades-index:page-upgrade-article-title-ropsten-merge-testnet"
-      ),
-      description: t(
-        "page-upgrades-index:page-upgrade-article-author-ethereum-foundation"
-      ),
+      title: t("page-upgrade-article-title-ropsten-merge-testnet"),
+      description: t("page-upgrade-article-author-ethereum-foundation"),
       link: "https://blog.ethereum.org/2022/05/30/ropsten-merge-announcement/",
     },
     {
-      title: t(
-        "page-upgrades-index:page-upgrade-article-title-execution-layer-specs"
-      ),
-      description: t(
-        "page-upgrades-index:page-upgrade-article-author-ethereum-foundation"
-      ),
+      title: t("page-upgrade-article-title-execution-layer-specs"),
+      description: t("page-upgrade-article-author-ethereum-foundation"),
       link: "https://github.com/ethereum/execution-specs/",
     },
     {
-      title: t(
-        "page-upgrades-index:page-upgrade-article-title-consensus-layer-specs"
-      ),
-      description: t(
-        "page-upgrades-index:page-upgrade-article-author-ethereum-foundation"
-      ),
+      title: t("page-upgrade-article-title-consensus-layer-specs"),
+      description: t("page-upgrade-article-author-ethereum-foundation"),
       link: "https://github.com/ethereum/consensus-specs/tree/master/specs/bellatrix",
     },
     {
-      title: t(
-        "page-upgrades-index:page-upgrade-article-title-engine-api-specs"
-      ),
-      description: t(
-        "page-upgrades-index:page-upgrade-article-author-ethereum-foundation"
-      ),
+      title: t("page-upgrade-article-title-engine-api-specs"),
+      description: t("page-upgrade-article-author-ethereum-foundation"),
       link: "https://github.com/ethereum/execution-apis/tree/main/src/engine",
     },
     {
-      title: t(
-        "page-upgrades-index:page-upgrade-article-title-hitchhikers-guide-to-ethereum"
-      ),
-      description: t(
-        "page-upgrades-index:page-upgrade-article-author-delphi-digital"
-      ),
+      title: t("page-upgrade-article-title-hitchhikers-guide-to-ethereum"),
+      description: t("page-upgrade-article-author-delphi-digital"),
       link: "https://members.delphidigital.io/reports/the-hitchhikers-guide-to-ethereum",
     },
   ]

--- a/src/components/MergeInfographic/index.tsx
+++ b/src/components/MergeInfographic/index.tsx
@@ -1,3 +1,4 @@
+import { useTranslations } from "next-intl"
 import type { SVGTextElementAttributes } from "react"
 
 import Translation from "@/components/Translation"
@@ -7,8 +8,6 @@ import { cn } from "@/lib/utils/cn"
 import { HStack } from "../ui/flex"
 
 import Background from "./background.svg"
-
-import { useTranslation } from "@/hooks/useTranslation"
 
 const Text = ({
   className,
@@ -21,38 +20,39 @@ const Text = ({
 )
 
 const SvgTextInternal = () => {
-  const { t } = useTranslation(["page-upgrades-index"])
+  const t = useTranslations("page-upgrades-index")
+  const tCommon = useTranslations("common")
   const [sm, lg] = ["text-[7px]", "text-[8px]"]
 
   return (
     <>
       <Text className={lg} x="2%" y="35%">
-        ⛏ {t("page-upgrades-index:docs-nav-proof-of-work")}
+        ⛏ {t("docs-nav-proof-of-work")}
       </Text>
       <Text className={lg} x="47%" y="35%">
-        🌱 {t("page-upgrades-index:docs-nav-proof-of-stake")}
+        🌱 {t("docs-nav-proof-of-stake")}
       </Text>
       <Text className={sm} x="11%" y="70%">
-        🚀 {t("common:beacon-chain")}
+        🚀 {tCommon("beacon-chain")}
       </Text>
       <Text className={sm} x="43%" y="12.5%">
-        🐼 {t("page-upgrades-index:page-upgrades-get-involved-ethresearch-2")}
+        🐼 {t("page-upgrades-get-involved-ethresearch-2")}
       </Text>
       <Text className={sm} x="63%" y="95%">
-        🌳 {t("page-upgrades-index:page-upgrades-get-involved-ethresearch-1")}
+        🌳 {t("page-upgrades-get-involved-ethresearch-1")}
       </Text>
     </>
   )
 }
 
 const MergeInfographic = () => {
-  const { t } = useTranslation()
+  const t = useTranslations("page-upgrades")
 
   return (
     <div
       className="relative isolate aspect-[25/11] w-full"
       role="img"
-      aria-label={t("page-upgrades:page-upgrades-merge-infographic-alt-text")}
+      aria-label={t("page-upgrades-merge-infographic-alt-text")}
     >
       <div>
         <HStack

--- a/src/components/SideNav.tsx
+++ b/src/components/SideNav.tsx
@@ -1,8 +1,8 @@
 "use client"
-
 import { useEffect, useState } from "react"
 import { ChevronRight } from "lucide-react"
 import { motion } from "motion/react"
+import { useTranslations } from "next-intl"
 
 import { ChildOnlyProp } from "@/lib/types"
 import { DeveloperDocsLink } from "@/lib/interfaces"
@@ -12,7 +12,6 @@ import docLinks from "../data/developer-docs-links.yaml"
 import { HStack } from "./ui/flex"
 import { BaseLink, LinkProps } from "./ui/Link"
 
-import { useTranslation } from "@/hooks/useTranslation"
 export const dropdownIconContainerVariant = {
   open: {
     rotate: 90,
@@ -60,7 +59,7 @@ export type NavLinkProps = {
 }
 
 const NavLink = ({ item, path, isTopLevel }: NavLinkProps) => {
-  const { t } = useTranslation("page-developers-docs")
+  const t = useTranslations("page-developers-docs")
   const isLinkInPath =
     isTopLevel || path.includes(item.href) || path.includes(item.path)
   const [isOpen, setIsOpen] = useState<boolean>(isLinkInPath)
@@ -133,12 +132,12 @@ export interface SideNavProps {
 // of the given parent. Currently all `path` items default to open
 // and they only collapse when clicked on.
 const SideNav = ({ path }: SideNavProps) => {
-  const { t } = useTranslation("page-developers-docs")
+  const tCommon = useTranslations("common")
 
   return (
     <nav
       className="sticky top-19 h-[calc(100vh-80px)] w-[calc((100%-1448px)/2+256px)] min-w-64 overflow-y-auto border-e-2 bg-background pt-8 pb-16 transition-transform duration-200 max-lg:hidden"
-      aria-label={t("common:nav-developers-docs")}
+      aria-label={tCommon("nav-developers-docs")}
     >
       {docLinks.map((item, idx) => (
         <NavLink item={item} path={path} key={idx} isTopLevel />

--- a/src/components/SideNavMobile.tsx
+++ b/src/components/SideNavMobile.tsx
@@ -1,8 +1,8 @@
 "use client"
-
 import { useState } from "react"
 import { ChevronRight } from "lucide-react"
 import { AnimatePresence, motion } from "motion/react"
+import { useTranslations } from "next-intl"
 
 import type { ChildOnlyProp, TranslationKey } from "@/lib/types"
 import { DeveloperDocsLink } from "@/lib/interfaces"
@@ -15,8 +15,6 @@ import {
   dropdownIconContainerVariant,
   type NavLinkProps as SideNavLinkProps,
 } from "./SideNav"
-
-import { useTranslation } from "@/hooks/useTranslation"
 
 // Traverse all links to find page id
 const getPageTitleId = (
@@ -72,7 +70,7 @@ export type NavLinkProps = SideNavLinkProps & {
 }
 
 const NavLink = ({ item, path, toggle }: NavLinkProps) => {
-  const { t } = useTranslation("page-developers-docs")
+  const t = useTranslations("page-developers-docs")
   const [isOpen, setIsOpen] = useState<boolean>(false)
 
   if (item.items) {
@@ -132,7 +130,7 @@ export type SideNavMobileProps = {
 
 // TODO consolidate into SideNav
 const SideNavMobile = ({ path }: SideNavMobileProps) => {
-  const { t } = useTranslation("page-developers-docs")
+  const t = useTranslations("page-developers-docs")
 
   const [isOpen, setIsOpen] = useState<boolean>(false)
 


### PR DESCRIPTION
# Colon-form batch for #18742

Sixth batch per the #18749 recipe — the six files the audit flagged as colon-form/dynamic-key heavy. All migrated strings pre-verified plain text in the catalogs.

## Notes for review

- **MergeArticleList**: declared `useTranslation(["page-upgrades", "page-upgrades-index"])` but all 16 calls were explicit `page-upgrades-index:` colon keys — collapses to one binding with prefixes dropped.
- **MergeInfographic**: two components, three namespaces — infographic binds `page-upgrades-index` + `tCommon` (`beacon-chain`); the aria-label wrapper binds `page-upgrades`. The `<Translation id="page-upgrades:...">` usages are untouched (that component migrates in the finale).
- **NetworkUpgradeSummary**: three colon keys are passed as data into `blockTypeTranslation` rather than called inline — prefixes stripped there too, since the binding supplies the namespace.
- **SideNav / SideNavMobile / DocsNav**: dynamic `t(item.id)` docs-nav keys unchanged (missing ids fall back to the key segment exactly as the wrapper did); SideNav's root component now binds only `common` since its only call moved to `tCommon`.

## Test plan

- [x] `pnpm type-check`, `pnpm lint` clean locally
- [x] Deploy-preview sweep: docs page (side nav labels), `/history/`, `/roadmap/merge/` × 25 locales (posted as comment)

— Fable
