### PR TITLE
fix(simulator): modal not closing on direct load

### DIFF
--- a/src/components/Simulator/index.tsx
+++ b/src/components/Simulator/index.tsx
@@ -23,16 +23,12 @@ import { Template } from "./Template"
 import type { PathId, SimulatorData } from "./types"
 import { getValidPathId, isValidPathId } from "./utils"
 
-import { usePathname, useRouter } from "@/i18n/navigation"
-
 type SimulatorProps = {
   children: ReactNode
   data: SimulatorData
 }
 export const Simulator = ({ children, data }: SimulatorProps) => {
   const t = useTranslations("component-wallet-simulator")
-  const router = useRouter()
-  const pathname = usePathname()
   const searchParams = useSearchParams()
 
   // Track step
@@ -47,8 +43,11 @@ export const Simulator = ({ children, data }: SimulatorProps) => {
   // If pathId present, modal is open, else closed
   const isOpen = !!pathId
 
+  // Shallow history updates only: router.replace() serves same-pathname navs
+  // from the client cache, which restores the URL it was created with -- on a
+  // direct load that URL includes ?sim=, making the modal impossible to close
   const clearUrlParams = () => {
-    router.replace(pathname, { scroll: false })
+    window.history.replaceState(null, "", window.location.pathname)
   }
 
   // When simulator closed: log event, clear URL params and close modal
@@ -97,15 +96,10 @@ export const Simulator = ({ children, data }: SimulatorProps) => {
   }
 
   const openPath = (id: PathId): void => {
-    // Set new pathId in navigation
-    router.replace(
-      {
-        pathname,
-        query: {
-          [PATH_ID_QUERY_PARAM]: id,
-        },
-      },
-      { scroll: false }
+    window.history.replaceState(
+      null,
+      "",
+      `${window.location.pathname}?${PATH_ID_QUERY_PARAM}=${id}`
     )
   }
 


### PR DESCRIPTION
## Description

Loading `/wallets/?sim=<path-id>` directly (fresh page load with the query param already attached) made the wallet simulator modal impossible to close: the X button, backdrop click, and Escape all failed, and the URL kept the `?sim=` param. Opening the simulator from the page worked fine.

The close handler used `router.replace(pathname)` to drop the param, but the App Router serves same-pathname navigations from the client cache entry created at initial load and restores that entry's URL. On a direct load that URL includes `?sim=`, so the param never leaves `useSearchParams`, and the modal's `open` state (derived from it) stays true.

This switches `openPath`/`clearUrlParams` to native `window.history.replaceState`, the documented App Router pattern for shallow query-param updates (synced to `useSearchParams` since Next 14.1). Since the `sim` param is consumed only client-side, this also drops the unnecessary RSC round-trip on open/close.

Verified against the production build with Playwright: native `replaceState` closes the modal on a direct `?sim=` load, re-opening afterwards works, and the open-from-page flow is unchanged.

## Related issue

- Closes #18760