### PR TITLE
Update NodeFlare entry (23 chains, 5 regions)

### DIFF
--- a/public/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
+++ b/public/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
@@ -274,8 +274,8 @@ Here is a list of some of the most popular Ethereum node providers, feel free to
 - [**NodeFlare**](https://nodeflare.app/)
   - [Docs](https://nodeflare.app/docs/quick-start)
   - Features
-    - 8 EVM chains including Ethereum, Base, Arbitrum One, and Optimism
-    - 4 regions (Europe, Asia, North America) with automatic failover to nearest healthy node
+    - 23 EVM chains including Ethereum, Base, Polygon, Arbitrum One & Nova, Optimism, Linea, Unichain and Sonic
+    - 5 regions (Europe, UK, Asia, US-East, US-West) with automatic failover to nearest healthy node
     - Free public endpoint (no API key) + free plan with 3M compute units/month
     - Compute Unit billing — pay only for what you use, heavier calls cost more
     - No throttling on paid plans

--- a/public/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
+++ b/public/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
@@ -274,7 +274,7 @@ Here is a list of some of the most popular Ethereum node providers, feel free to
 - [**NodeFlare**](https://nodeflare.app/)
   - [Docs](https://nodeflare.app/docs/quick-start)
   - Features
-    - 23 EVM chains including Ethereum, Base, Polygon, Arbitrum One & Nova, Optimism, Linea, Unichain and Sonic
+    - 23 EVM chains including Ethereum, Base, Arbitrum One & Nova, Optimism, Linea, and Unichain
     - 5 regions (Europe, UK, Asia, US-East, US-West) with automatic failover to nearest healthy node
     - Free public endpoint (no API key) + free plan with 3M compute units/month
     - Compute Unit billing — pay only for what you use, heavier calls cost more


### PR DESCRIPTION
Small factual update to the existing NodeFlare entry (added in #18244): the service expanded from 8 to 23 EVM chains (July 2026) and now runs 5 regions. No other changes.

