### PR TITLE
FeedbackWidget popup UI polish

### DIFF
--- a/src/components/FeedbackWidget/index.tsx
+++ b/src/components/FeedbackWidget/index.tsx
@@ -49,35 +49,41 @@ const FeedbackWidget = () => {
         </PopoverTrigger>
 
         <PopoverContent
-          className="mx-2 w-80 max-w-[calc(100vw_-_1rem)] rounded bg-background p-4 sm:p-8"
+          className="mx-2 w-80 max-w-[calc(100vw_-_1rem)] rounded-base bg-background p-4"
+          aria-labelledby="feedback-widget-title"
           data-testid="feedback-widget-modal"
         >
-          <div className="flex items-start gap-2">
-            <header className="me-0 flex-1 p-0 text-xl font-bold">
-              {feedbackSubmitted
-                ? t("feedback-widget-thank-you-title")
-                : t("feedback-widget-prompt")}
-            </header>
+          <div className="flex justify-end">
             <PopoverClose asChild>
               <Button
                 variant="ghost"
-                className="w-8 py-0 text-body"
+                className="w-8 py-0 text-body [&>svg]:size-6"
                 size="sm"
+                aria-label={t("close")}
                 ref={cancelRef}
               >
-                <X className="h-fit w-5" />
+                <X />
               </Button>
             </PopoverClose>
           </div>
 
+          <h2
+            id="feedback-widget-title"
+            className="text-center text-xl font-bold"
+          >
+            {feedbackSubmitted
+              ? t("feedback-widget-thank-you-title")
+              : t("feedback-widget-prompt")}
+          </h2>
+
           {feedbackSubmitted && (
             <>
-              <div className="text-center text-md leading-5 font-normal">
+              <p className="mt-space-half text-center text-md">
                 {t("feedback-widget-thank-you-subtitle")}
-              </div>
-              <div className="text-center text-xs leading-4 font-bold tracking-wide text-body-medium">
+              </p>
+              <p className="mt-space-half text-center text-xs text-body-medium">
                 {t("feedback-widget-thank-you-timing")}
-              </div>
+              </p>
             </>
           )}
 


### PR DESCRIPTION
## Description

UI adjustments to the FeedbackWidget popup (the dialog that opens from the floating dot):

- `rounded-base` border radius and halved padding (`p-4`)
- Close button moved to its own row above the title, rendering the standard 24px lucide `X`, with a translatable `aria-label`
- All popup text centered on both screens
- `mt-space-half` rhythm above the thank-you subtitle and timing lines; dropped stray `leading-`/`tracking-` overrides
- Semantic cleanup: subtext divs are now `p` elements, and the title is an `h2` referenced by `aria-labelledby` on the dialog

Note on the `h2`: it never enters a page's heading outline during normal browsing — Radix fully unmounts the portaled popover content when closed, so the heading only exists in the DOM while the popup is open. While open, a heading title referenced by `aria-labelledby` is the WAI-ARIA dialog pattern recommendation, and APG's dialog examples use `h2`.

-- Fable