### PR TITLE
refactor: make Translation component self-contained, deprecate for new code (#18742)

### DIFF
--- a/src/components/Translation.tsx
+++ b/src/components/Translation.tsx
@@ -4,12 +4,10 @@ import parse, {
   Element,
   type HTMLReactParserOptions,
 } from "html-react-parser"
-import type { TranslationValues } from "next-intl"
+import { type TranslationValues, useTranslations } from "next-intl"
 import type { ComponentType } from "react"
 
 import TooltipLink from "./TooltipLink"
-
-import useTranslation from "@/hooks/useTranslation"
 
 type TransformMap = Record<string, ComponentType<Record<string, unknown>>>
 
@@ -20,11 +18,27 @@ type TranslationProps = {
   transform?: TransformMap
 }
 
-// Renders the translation string for the given translation key `id`. It
-// fallback to English if it doesn't find the given key in the current language
-const Translation = ({ id, ns, values, transform = {} }: TranslationProps) => {
-  const { t } = useTranslation(ns)
-  const translatedText = t(id, values)
+/**
+ * Renders the message for `id` ("key" within `ns`, or legacy "namespace:key"),
+ * falling back to English for untranslated locales. Without `values` the raw
+ * message is fetched and html-parsed so Crowdin-era embedded HTML (real tags
+ * with attributes, e.g. `<a href>`) survives; `<a>` maps to TooltipLink.
+ *
+ * @deprecated Legacy catalog messages only — do not adopt for new strings.
+ * Author new messages as plain ICU (`useTranslations`/`getTranslations`) or,
+ * when markup is needed, `t.rich` with tags supplied from code.
+ */
+const Translation = ({
+  id,
+  ns = "common",
+  values,
+  transform = {},
+}: TranslationProps) => {
+  const t = useTranslations()
+  const key = id.includes(":") ? id.replace(":", ".") : `${ns}.${id}`
+  const message = values ? t(key, values) : t.raw(key)
+  // non-string raw messages (nested objects, missing keys) fall back to the id
+  const translatedText = typeof message === "string" ? message : id
 
   // Custom components mapping used when parsing the translation text
   const defaultTransform: TransformMap = {

--- a/src/components/Translation.tsx
+++ b/src/components/Translation.tsx
@@ -26,7 +26,10 @@ type TranslationProps = {
  *
  * @deprecated Legacy catalog messages only — do not adopt for new strings.
  * Author new messages as plain ICU (`useTranslations`/`getTranslations`) or,
- * when markup is needed, `t.rich` with tags supplied from code.
+ * when markup is needed, `t.rich` with tags supplied from code. Glossary
+ * tooltips don't require this component: render `GlossaryTooltip` directly,
+ * or pass `TooltipLink` as a `t.rich` tag handler with the href in code —
+ * only messages whose href lives inside the translated string need this.
  */
 const Translation = ({
   id,


### PR DESCRIPTION
# Translation component port + deprecation (#18742)

Makes `Translation.tsx` self-contained: the legacy wrapper's dispatch moves inline — root `useTranslations()` binding, legacy `namespace:key` ids become dot paths, `values` triggers cooked ICU interpolation, and the no-values path fetches the **raw** message so Crowdin-era embedded HTML (real tags with attributes, e.g. `<a href>`) survives for `html-react-parser`. Non-string raw lookups fall back to the id, matching the wrapper's catch.

- **No rendering change**: zero of the 69 consumer files pass `values` (verified), so every live call takes the raw path exactly as before. If `values` is ever passed it now actually interpolates instead of being silently dropped.
- **Marked `@deprecated` for new code** (per review discussion): new strings should be plain ICU or `t.rich` with code-supplied tags; this component remains the designated renderer for the legacy HTML-bearing catalog corpus, and can be deleted outright if those messages are ever normalized.
- This clears the last unblocked importer of `@/hooks/useTranslation`. Still importing it: `FindWalletProductTable/**` (waits #18702), `ui/swiper.tsx` (waits #18698), `ReleaseCarousel.tsx` (waits #18734). The hook deletion + lint-rule flip to `error` lands once those are migrated.

## Test plan

- [x] `pnpm type-check`, `pnpm lint` clean locally
- [ ] Deploy-preview sweep across Translation-heavy pages (staking + roadmap/merge + docs suites, 25 locales) — posted as comment

— Fable
