### PR TITLE
spike(ab-testing): revive Flags SDK precompute approach (#17265 v2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,14 @@ NEXT_PUBLIC_MATOMO_SITE_ID=
 # API token for A/B testing experiments
 # MATOMO_API_TOKEN=your-matomo-api-token
 
+# Flags SDK secret (required for precomputed A/B testing)
+# Generate with: openssl rand -base64 32
+# FLAGS_SECRET=
+
+# Use mock A/B experiments instead of fetching from Matomo
+# Useful for local development without Matomo credentials
+# USE_MOCK_EXPERIMENTS=true
+
 # Used to avoid loading Matomo in our preview deploys
 NEXT_PUBLIC_IS_PREVIEW_DEPLOY=false
 

--- a/app/[locale]/ab-code/[code]/page.tsx
+++ b/app/[locale]/ab-code/[code]/page.tsx
@@ -1,0 +1,67 @@
+import { generatePermutations, getPrecomputed } from "flags/next"
+import { notFound } from "next/navigation"
+import { setRequestLocale } from "next-intl/server"
+
+import type { Lang } from "@/lib/types"
+
+import { DEFAULT_LOCALE } from "@/lib/constants"
+
+import OriginalHomePage from "../../page"
+
+import { abTestFlags, homepageHeroFlag } from "@/lib/ab-testing/flags"
+
+export { generateMetadata } from "../../page"
+
+/**
+ * Generate a static page for each possible combination of flag values.
+ * Falls back to on-demand rendering (dynamicParams) when permutations
+ * can't be generated at build time (e.g. FLAGS_SECRET missing in CI).
+ */
+export async function generateStaticParams() {
+  try {
+    const codes = await generatePermutations(abTestFlags)
+    // Only the default locale is A/B tested
+    return codes.map((code) => ({ locale: DEFAULT_LOCALE, code }))
+  } catch (error) {
+    console.warn(
+      "[A/B Testing] generatePermutations failed (missing FLAGS_SECRET?):",
+      error instanceof Error ? error.message : error
+    )
+    return []
+  }
+}
+
+interface PageProps {
+  params: Promise<{ locale: string; code: string }>
+}
+
+/**
+ * Precomputed homepage with A/B test variants.
+ * The proxy rewrites eligible requests to include the signed flags code,
+ * which is used here to retrieve the precomputed flag values.
+ * This route is internal-only: it is never linked and only reached via rewrite.
+ */
+export default async function PrecomputedHomePage({ params }: PageProps) {
+  const { locale, code } = await params
+
+  // Only the default locale is A/B tested
+  if (locale !== DEFAULT_LOCALE) notFound()
+
+  // Enable static rendering
+  setRequestLocale(locale)
+
+  let heroVariant: number
+  try {
+    ;[heroVariant] = await getPrecomputed([homepageHeroFlag], abTestFlags, code)
+  } catch {
+    // Invalid or tampered code - this route is only reachable via the proxy rewrite
+    notFound()
+  }
+
+  return (
+    <OriginalHomePage
+      params={Promise.resolve({ locale: locale as Lang })}
+      heroVariant={heroVariant}
+    />
+  )
+}

--- a/app/[locale]/ab-code/[code]/page.tsx
+++ b/app/[locale]/ab-code/[code]/page.tsx
@@ -8,6 +8,7 @@ import { DEFAULT_LOCALE } from "@/lib/constants"
 
 import OriginalHomePage from "../../page"
 
+import { decodeABCode, encodeABCode } from "@/lib/ab-testing/constants"
 import { abTestFlags, homepageHeroFlag } from "@/lib/ab-testing/flags"
 
 export { generateMetadata } from "../../page"
@@ -20,8 +21,12 @@ export { generateMetadata } from "../../page"
 export async function generateStaticParams() {
   try {
     const codes = await generatePermutations(abTestFlags)
-    // Only the default locale is A/B tested
-    return codes.map((code) => ({ locale: DEFAULT_LOCALE, code }))
+    // Only the default locale is A/B tested. Codes are dot-encoded to keep
+    // the URL segment directory-like (see encodeABCode).
+    return codes.map((code) => ({
+      locale: DEFAULT_LOCALE,
+      code: encodeABCode(code),
+    }))
   } catch (error) {
     console.warn(
       "[A/B Testing] generatePermutations failed (missing FLAGS_SECRET?):",
@@ -52,7 +57,11 @@ export default async function PrecomputedHomePage({ params }: PageProps) {
 
   let heroVariant: number
   try {
-    ;[heroVariant] = await getPrecomputed([homepageHeroFlag], abTestFlags, code)
+    ;[heroVariant] = await getPrecomputed(
+      [homepageHeroFlag],
+      abTestFlags,
+      decodeABCode(code)
+    )
   } catch {
     // Invalid or tampered code - this route is only reachable via the proxy rewrite
     notFound()

--- a/app/[locale]/ab-code/[code]/wallets/find-wallet/page.tsx
+++ b/app/[locale]/ab-code/[code]/wallets/find-wallet/page.tsx
@@ -6,12 +6,12 @@ import type { Lang } from "@/lib/types"
 
 import { DEFAULT_LOCALE } from "@/lib/constants"
 
-import OriginalHomePage from "../../page"
+import OriginalFindWalletPage from "../../../../wallets/find-wallet/page"
 
 import { decodeABCode, encodeABCode } from "@/lib/ab-testing/constants"
-import { homepageFlags, homepageHeroFlag } from "@/lib/ab-testing/flags"
+import { findWalletFlags, findWalletHeroFlag } from "@/lib/ab-testing/flags"
 
-export { generateMetadata } from "../../page"
+export { generateMetadata } from "../../../../wallets/find-wallet/page"
 
 /**
  * Generate a static page for each possible combination of flag values.
@@ -20,7 +20,7 @@ export { generateMetadata } from "../../page"
  */
 export async function generateStaticParams() {
   try {
-    const codes = await generatePermutations(homepageFlags)
+    const codes = await generatePermutations(findWalletFlags)
     // Only the default locale is A/B tested. Codes are dot-encoded to keep
     // the URL segment directory-like (see encodeABCode).
     return codes.map((code) => ({
@@ -41,12 +41,12 @@ interface PageProps {
 }
 
 /**
- * Precomputed homepage with A/B test variants.
+ * Precomputed find-wallet page with A/B test variants.
  * The proxy rewrites eligible requests to include the signed flags code,
  * which is used here to retrieve the precomputed flag values.
  * This route is internal-only: it is never linked and only reached via rewrite.
  */
-export default async function PrecomputedHomePage({ params }: PageProps) {
+export default async function PrecomputedFindWalletPage({ params }: PageProps) {
   const { locale, code } = await params
 
   // Only the default locale is A/B tested
@@ -58,8 +58,8 @@ export default async function PrecomputedHomePage({ params }: PageProps) {
   let heroVariant: number
   try {
     ;[heroVariant] = await getPrecomputed(
-      [homepageHeroFlag],
-      homepageFlags,
+      [findWalletHeroFlag],
+      findWalletFlags,
       decodeABCode(code)
     )
   } catch {
@@ -68,7 +68,7 @@ export default async function PrecomputedHomePage({ params }: PageProps) {
   }
 
   return (
-    <OriginalHomePage
+    <OriginalFindWalletPage
       params={Promise.resolve({ locale: locale as Lang })}
       heroVariant={heroVariant}
     />

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -8,6 +8,7 @@ import {
 
 import type { PageParams } from "@/lib/types"
 
+import { ABTest } from "@/components/AB"
 import HomeHero from "@/components/Hero/HomeHero"
 import FeatureCards from "@/components/Homepage/FeatureCards"
 import GetStartedGrid from "@/components/Homepage/GetStartedGrid"
@@ -32,9 +33,14 @@ import IndexPageJsonLD from "./page-jsonld"
 
 import { getAccountHolders, getGrowThePieData } from "@/lib/data"
 
-const Page = async (props: { params: Promise<PageParams> }) => {
+const Page = async (props: {
+  params: Promise<PageParams>
+  /** Precomputed A/B test variant index, passed by the ab-code route */
+  heroVariant?: number
+}) => {
   const params = await props.params
   const { locale } = params
+  const { heroVariant } = props
 
   if (!LOCALES_CODES.includes(locale)) return notFound()
 
@@ -79,7 +85,25 @@ const Page = async (props: { params: Promise<PageParams> }) => {
       <IndexPageJsonLD locale={locale} />
       <I18nProvider locale={locale} messages={messages}>
         <MainArticle className="flex w-full flex-col items-center" dir={dir}>
-          <HomeHero eventCategory={eventCategory} />
+          {heroVariant !== undefined ? (
+            <ABTest
+              testKey="HomepageHero"
+              variantIndex={heroVariant}
+              variants={[
+                <HomeHero key="original" eventCategory={eventCategory} />,
+                // Spike placeholder: visibly distinct variant to verify the
+                // preview deploy. Replace with a real variant component.
+                <div key="variant-a" className="w-full">
+                  <div className="bg-warning py-2 text-center font-bold">
+                    A/B VARIANT A (Flags SDK spike)
+                  </div>
+                  <HomeHero eventCategory={eventCategory} />
+                </div>,
+              ]}
+            />
+          ) : (
+            <HomeHero eventCategory={eventCategory} />
+          )}
 
           <div className="my-24 w-full space-y-24 px-4 md:mx-6 lg:my-32 lg:space-y-32">
             <KPISection

--- a/app/[locale]/wallets/find-wallet/page.tsx
+++ b/app/[locale]/wallets/find-wallet/page.tsx
@@ -7,6 +7,7 @@ import {
 
 import type { Lang, PageParams, WalletData } from "@/lib/types"
 
+import { ABTest } from "@/components/AB"
 import FindWalletProductTable from "@/components/FindWalletProductTable"
 import PageHero from "@/components/Hero/PageHero"
 import I18nProvider from "@/components/I18nProvider"
@@ -27,9 +28,14 @@ import {
 
 import FindWalletPageJsonLD from "./page-jsonld"
 
-const Page = async (props: { params: Promise<PageParams> }) => {
+const Page = async (props: {
+  params: Promise<PageParams>
+  /** Precomputed A/B test variant index, passed by the ab-code route */
+  heroVariant?: number
+}) => {
   const params = await props.params
   const { locale } = params
+  const { heroVariant } = props
   const t = await getTranslations("page-wallets-find-wallet")
 
   setRequestLocale(locale)
@@ -79,12 +85,41 @@ const Page = async (props: { params: Promise<PageParams> }) => {
 
       <I18nProvider locale={locale} messages={messages}>
         <MainArticle className="relative flex flex-col">
-          <PageHero
-            breadcrumbs={{ slug: "/wallets/find-wallet" }}
-            title={t("page-find-wallet-title")}
-            description={t("page-find-wallet-description")}
-            variant="no-divider"
-          />
+          {heroVariant !== undefined ? (
+            <ABTest
+              testKey="FindWalletHero"
+              variantIndex={heroVariant}
+              variants={[
+                <PageHero
+                  key="original"
+                  breadcrumbs={{ slug: "/wallets/find-wallet" }}
+                  title={t("page-find-wallet-title")}
+                  description={t("page-find-wallet-description")}
+                  variant="no-divider"
+                />,
+                // Spike placeholder: visibly distinct variant to verify the
+                // preview deploy. Replace with the redesigned hero.
+                <div key="variant-a" className="w-full">
+                  <div className="bg-warning py-2 text-center font-bold">
+                    A/B VARIANT A (FindWalletHero spike)
+                  </div>
+                  <PageHero
+                    breadcrumbs={{ slug: "/wallets/find-wallet" }}
+                    title={t("page-find-wallet-title")}
+                    description={t("page-find-wallet-description")}
+                    variant="no-divider"
+                  />
+                </div>,
+              ]}
+            />
+          ) : (
+            <PageHero
+              breadcrumbs={{ slug: "/wallets/find-wallet" }}
+              title={t("page-find-wallet-title")}
+              description={t("page-find-wallet-description")}
+              variant="no-divider"
+            />
+          )}
 
           <Section id="wallets">
             <h2 className="sr-only select-none">

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "cmdk": "^1.0.0",
     "embla-carousel-react": "^8.6.0",
     "ethereum-blockies-base64": "^1.0.2",
+    "flags": "^4.2.0",
     "gray-matter": "^4.0.3",
     "howler": "^2.2.4",
     "html-react-parser": "^5.2.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
       ethereum-blockies-base64:
         specifier: ^1.0.2
         version: 1.0.2
+      flags:
+        specifier: ^4.2.0
+        version: 4.2.0(@opentelemetry/api@1.9.0)(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.53.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
@@ -1782,6 +1785,10 @@ packages:
     engines: {bun: '>=1', deno: '>=2', node: '>=16'}
     peerDependencies:
       '@noble/ciphers': ^1.0.0
+
+  '@edge-runtime/cookies@5.0.2':
+    resolution: {integrity: sha512-Sd8LcWpZk/SWEeKGE8LT6gMm5MGfX/wm+GPnh1eBEtCpya3vYqn37wYknwAHw92ONoyyREl1hJwxV/Qx2DWNOg==}
+    engines: {node: '>=16'}
 
   '@electric-sql/client@1.0.14':
     resolution: {integrity: sha512-LtPAfeMxXRiYS0hyDQ5hue2PjljUiK9stvzsVyVb4nwxWQxfOWTSF42bHTs/o5i3x1T4kAQ7mwHpxa4A+f8X7Q==}
@@ -7354,6 +7361,26 @@ packages:
   find-up@6.3.0:
     resolution: {integrity: sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  flags@4.2.0:
+    resolution: {integrity: sha512-/ahGKxe4Q3C2pi2FS7h6cNR4HWnU7/MWAtwcrTHLBQjM9vVe5NR+uRIbL+vXYYU8PYbb8VnwnD+bdLH6l69m0g==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.7.0
+      '@sveltejs/kit': '*'
+      next: '*'
+      react: ^19.2.4
+      react-dom: ^19.2.4
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   flat-cache@3.2.0:
     resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
@@ -13852,6 +13879,8 @@ snapshots:
   '@ecies/ciphers@0.2.3(@noble/ciphers@1.3.0)':
     dependencies:
       '@noble/ciphers': 1.3.0
+
+  '@edge-runtime/cookies@5.0.2': {}
 
   '@electric-sql/client@1.0.14':
     dependencies:
@@ -20879,6 +20908,16 @@ snapshots:
     dependencies:
       locate-path: 7.2.0
       path-exists: 5.0.0
+
+  flags@4.2.0(@opentelemetry/api@1.9.0)(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.53.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@edge-runtime/cookies': 5.0.2
+      jose: 5.10.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      next: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.53.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   flat-cache@3.2.0:
     dependencies:

--- a/proxy.ts
+++ b/proxy.ts
@@ -98,7 +98,10 @@ export default async function proxy(request: NextRequest) {
     try {
       const code = await precompute(abTestFlags)
       const url = request.nextUrl.clone()
-      const suffix = pathname === "/" ? "/" : pathname
+      // No trailing slash after a bare code: the signed code contains dots,
+      // so Next.js treats it as a file path and 308-strips a trailing slash
+      // at the origin, exposing the internal URL (the #17265 failure mode).
+      const suffix = pathname === "/" ? "" : pathname
       url.pathname = `/${DEFAULT_LOCALE}/${AB_CODE_SEGMENT}/${code}${suffix}`
       return NextResponse.rewrite(url)
     } catch (error) {

--- a/proxy.ts
+++ b/proxy.ts
@@ -3,7 +3,7 @@ import { NextRequest, NextResponse } from "next/server"
 import createMiddleware from "next-intl/middleware"
 
 import { routing } from "./src/i18n/routing"
-import { AB_CODE_SEGMENT } from "./src/lib/ab-testing/constants"
+import { AB_CODE_SEGMENT, encodeABCode } from "./src/lib/ab-testing/constants"
 import { abTestFlags } from "./src/lib/ab-testing/flags"
 import { DEFAULT_LOCALE } from "./src/lib/constants"
 import { getFirstSegment } from "./src/lib/utils/url"
@@ -98,11 +98,8 @@ export default async function proxy(request: NextRequest) {
     try {
       const code = await precompute(abTestFlags)
       const url = request.nextUrl.clone()
-      // No trailing slash after a bare code: the signed code contains dots,
-      // so Next.js treats it as a file path and 308-strips a trailing slash
-      // at the origin, exposing the internal URL (the #17265 failure mode).
       const suffix = pathname === "/" ? "" : pathname
-      url.pathname = `/${DEFAULT_LOCALE}/${AB_CODE_SEGMENT}/${code}${suffix}`
+      url.pathname = `/${DEFAULT_LOCALE}/${AB_CODE_SEGMENT}/${encodeABCode(code)}${suffix}`
       return NextResponse.rewrite(url)
     } catch (error) {
       console.error("[proxy] A/B precompute failed:", error)

--- a/proxy.ts
+++ b/proxy.ts
@@ -4,7 +4,7 @@ import createMiddleware from "next-intl/middleware"
 
 import { routing } from "./src/i18n/routing"
 import { AB_CODE_SEGMENT, encodeABCode } from "./src/lib/ab-testing/constants"
-import { abTestFlags } from "./src/lib/ab-testing/flags"
+import { abTestRoutes } from "./src/lib/ab-testing/flags"
 import { DEFAULT_LOCALE } from "./src/lib/constants"
 import { getFirstSegment } from "./src/lib/utils/url"
 
@@ -63,11 +63,6 @@ const DEPRECATED_LOCALES = new Set([
   "yo",
 ])
 
-// Routes with active A/B tests. English URLs are unprefixed
-// (localePrefix: "as-needed"), so entries are locale-less paths.
-// Only the default locale is A/B tested.
-const AB_TEST_ROUTES = new Set(["/"])
-
 function redirectTo(request: NextRequest, pathname: string, status: number) {
   const url = request.nextUrl.clone()
   url.pathname = pathname
@@ -93,10 +88,14 @@ export default async function proxy(request: NextRequest) {
 
   // A/B testing: precompute flag variants and rewrite to the coded route,
   // which serves a statically generated page per variant permutation.
+  // Only exact canonical paths match (non-canonical forms fall through and
+  // get slash-normalized first). Only the default locale is A/B tested:
+  // English URLs are unprefixed, so locale-prefixed paths never match.
   // On failure, fall through to normal i18n handling (original variant).
-  if (AB_TEST_ROUTES.has(pathname) && abTestFlags.length > 0) {
+  const routeFlags = abTestRoutes[pathname]
+  if (routeFlags?.length) {
     try {
-      const code = await precompute(abTestFlags)
+      const code = await precompute(routeFlags)
       const url = request.nextUrl.clone()
       const suffix = pathname === "/" ? "" : pathname
       url.pathname = `/${DEFAULT_LOCALE}/${AB_CODE_SEGMENT}/${encodeABCode(code)}${suffix}`

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,7 +1,10 @@
+import { precompute } from "flags/next"
 import { NextRequest, NextResponse } from "next/server"
 import createMiddleware from "next-intl/middleware"
 
 import { routing } from "./src/i18n/routing"
+import { AB_CODE_SEGMENT } from "./src/lib/ab-testing/constants"
+import { abTestFlags } from "./src/lib/ab-testing/flags"
 import { DEFAULT_LOCALE } from "./src/lib/constants"
 import { getFirstSegment } from "./src/lib/utils/url"
 
@@ -60,13 +63,18 @@ const DEPRECATED_LOCALES = new Set([
   "yo",
 ])
 
+// Routes with active A/B tests. English URLs are unprefixed
+// (localePrefix: "as-needed"), so entries are locale-less paths.
+// Only the default locale is A/B tested.
+const AB_TEST_ROUTES = new Set(["/"])
+
 function redirectTo(request: NextRequest, pathname: string, status: number) {
   const url = request.nextUrl.clone()
   url.pathname = pathname
   return NextResponse.redirect(url, status)
 }
 
-export default function proxy(request: NextRequest) {
+export default async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl
 
   const lowerPath = pathname.toLowerCase()
@@ -81,6 +89,21 @@ export default function proxy(request: NextRequest) {
     const rest = lowerPath.slice(firstSegment.length + 1)
     const newPath = !rest ? "/" : rest
     return redirectTo(request, newPath, 301)
+  }
+
+  // A/B testing: precompute flag variants and rewrite to the coded route,
+  // which serves a statically generated page per variant permutation.
+  // On failure, fall through to normal i18n handling (original variant).
+  if (AB_TEST_ROUTES.has(pathname) && abTestFlags.length > 0) {
+    try {
+      const code = await precompute(abTestFlags)
+      const url = request.nextUrl.clone()
+      const suffix = pathname === "/" ? "/" : pathname
+      url.pathname = `/${DEFAULT_LOCALE}/${AB_CODE_SEGMENT}/${code}${suffix}`
+      return NextResponse.rewrite(url)
+    } catch (error) {
+      console.error("[proxy] A/B precompute failed:", error)
+    }
   }
 
   // Handle i18n routing

--- a/src/components/AB/ABTest.tsx
+++ b/src/components/AB/ABTest.tsx
@@ -1,0 +1,82 @@
+import { IS_PREVIEW_DEPLOY, IS_PROD } from "@/lib/utils/env"
+
+import { ABTestDebugPanel } from "./TestDebugPanel"
+import { ABTestTracker } from "./TestTracker"
+
+import type { ABTestVariants } from "@/lib/ab-testing/types"
+
+interface ABTestProps {
+  /** Unique key for the A/B test (must match Matomo experiment name) */
+  testKey: string
+  /** Precomputed variant index from the Flags SDK */
+  variantIndex: number
+  /** Array of variant components to render (index 0 = original) */
+  variants: ABTestVariants
+}
+
+/**
+ * A/B Test component for use with precomputed flag values.
+ *
+ * Designed for the Flags SDK precomputation pattern: it receives the variant
+ * index directly from server-side precomputation (via the middleware-rewritten
+ * coded route) rather than calling an API like the legacy ABTestWrapper.
+ *
+ * @example
+ * ```tsx
+ * // In a server component with precomputed flag value
+ * const [heroVariant] = await getPrecomputed([homepageHeroFlag], abTestFlags, code)
+ *
+ * <ABTest
+ *   testKey="HomepageHero"
+ *   variantIndex={heroVariant}
+ *   variants={[
+ *     <OriginalHero key="original" />,
+ *     <VariantAHero key="variant-a" />,
+ *   ]}
+ * />
+ * ```
+ */
+export function ABTest({ testKey, variantIndex, variants }: ABTestProps) {
+  const safeIndex = Math.max(0, Math.min(variantIndex, variants.length - 1))
+
+  // Extract labels from React element keys or fall back to defaults
+  const availableVariants = variants.map((variant, i) => {
+    if (
+      variant &&
+      typeof variant === "object" &&
+      "key" in variant &&
+      variant.key
+    ) {
+      return String(variant.key)
+        .replace(/-/g, " ")
+        .replace(/\b\w/g, (l) => l.toUpperCase())
+    }
+    return `Variant ${i}`
+  })
+
+  return (
+    <>
+      {/* Track the A/B test assignment with Matomo */}
+      <ABTestTracker
+        assignment={{
+          experimentId: testKey,
+          experimentName: testKey,
+          variant: availableVariants[safeIndex],
+          variantIndex: safeIndex,
+          assignedAt: Date.now(),
+        }}
+      />
+
+      {/* Preview panel for development and preview deploys */}
+      {(!IS_PROD || IS_PREVIEW_DEPLOY) && (
+        <ABTestDebugPanel
+          testKey={testKey}
+          availableVariants={availableVariants}
+        />
+      )}
+
+      {/* Render the selected variant */}
+      {variants[safeIndex]}
+    </>
+  )
+}

--- a/src/components/AB/TestDebugPanel.tsx
+++ b/src/components/AB/TestDebugPanel.tsx
@@ -7,12 +7,34 @@ import { cn } from "@/lib/utils/cn"
 
 import { Button } from "../ui/buttons/Button"
 
-import { useLocalStorage } from "@/hooks/useLocalStorage"
 import { useOnClickOutside } from "@/hooks/useOnClickOutside"
+import { FLAG_OVERRIDE_COOKIE_PREFIX } from "@/lib/ab-testing/constants"
 
 type ABTestDebugPanelProps = {
   testKey: string
   availableVariants: string[]
+}
+
+/** Escape regex special characters */
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+/** Read a cookie value by name */
+function getCookie(name: string): string | null {
+  const escapedName = escapeRegex(name)
+  const match = document.cookie.match(new RegExp(`(^| )${escapedName}=([^;]+)`))
+  return match ? match[2] : null
+}
+
+/** Set a cookie with path=/ and security attributes */
+function setCookie(name: string, value: string) {
+  document.cookie = `${name}=${value}; path=/; max-age=86400; Secure; SameSite=Strict`
+}
+
+/** Delete a cookie */
+function deleteCookie(name: string) {
+  document.cookie = `${name}=; path=/; max-age=0`
 }
 
 export const ABTestDebugPanel = ({
@@ -21,20 +43,36 @@ export const ABTestDebugPanel = ({
 }: ABTestDebugPanelProps) => {
   const [isOpen, setIsOpen] = useState(false)
   const [mounted, setMounted] = useState(false)
-  const [selectedVariant, setSelectedVariant] = useLocalStorage<number | null>(
-    `ab-test-${testKey}`,
-    null
-  )
+  const [selectedVariant, setSelectedVariant] = useState<number | null>(null)
   const panelRef = useRef<HTMLDivElement>(null)
 
   useOnClickOutside(panelRef, () => setIsOpen(false))
 
+  const cookieName = `${FLAG_OVERRIDE_COOKIE_PREFIX}${testKey}`
+
   useEffect(() => {
     setMounted(true)
-  }, [])
+    // Read current override from cookie
+    const cookieValue = getCookie(cookieName)
+    if (cookieValue !== null) {
+      const parsed = parseInt(cookieValue, 10)
+      if (!isNaN(parsed)) {
+        setSelectedVariant(parsed)
+      }
+    }
+  }, [cookieName])
 
-  const forceVariant = (variantIndex: number) =>
-    setSelectedVariant(variantIndex)
+  // Force variant by setting cookie and reloading (triggers middleware with new cookie)
+  const forceVariant = (variantIndex: number) => {
+    setCookie(cookieName, String(variantIndex))
+    window.location.reload()
+  }
+
+  // Clear override and reload
+  const clearOverride = () => {
+    deleteCookie(cookieName)
+    window.location.reload()
+  }
 
   const panelContent = (
     <div
@@ -45,14 +83,20 @@ export const ABTestDebugPanel = ({
         onClick={() => setIsOpen(!isOpen)}
         className="w-full cursor-pointer rounded border-none bg-accent-a px-2.5 py-1 font-semibold text-white hover:bg-accent-a-hover"
       >
-        🧪 AB Test Switcher
+        🧪{" "}
+        {selectedVariant !== null
+          ? `${testKey} - [${availableVariants[selectedVariant]}]`
+          : "AB Test Debug"}
       </Button>
 
       {isOpen && (
-        <div className="mt-2.5">
+        <div className="mt-2.5 space-y-2">
           <div>
             <strong>Experiment:</strong> {testKey}
           </div>
+          {selectedVariant !== null && (
+            <div className="text-warning">⚠️ Override active</div>
+          )}
           <div>
             <strong>Select variant:</strong>
           </div>
@@ -71,6 +115,15 @@ export const ABTestDebugPanel = ({
               {variant}
             </Button>
           ))}
+          {selectedVariant !== null && (
+            <Button
+              variant="outline"
+              onClick={clearOverride}
+              className="mt-2 w-full text-error"
+            >
+              Clear Override
+            </Button>
+          )}
         </div>
       )}
     </div>

--- a/src/components/AB/TestTracker.tsx
+++ b/src/components/AB/TestTracker.tsx
@@ -21,9 +21,16 @@ export function ABTestTracker({ assignment }: ABTestTrackerProps) {
     }
 
     // Check if user has opted out (following existing pattern)
-    const optedOutValue =
-      localStorage.getItem("ethereum-org.matomo-opt-out") || "false"
-    const isOptedOut = JSON.parse(optedOutValue)
+    let isOptedOut = false
+    try {
+      const optedOutValue = localStorage.getItem("ethereum-org.matomo-opt-out")
+      if (optedOutValue) {
+        isOptedOut = JSON.parse(optedOutValue)
+      }
+    } catch {
+      // Invalid JSON in localStorage, default to not opted out
+      isOptedOut = false
+    }
     if (isOptedOut) return
 
     // Track the A/B test variant with Matomo

--- a/src/components/AB/index.ts
+++ b/src/components/AB/index.ts
@@ -1,0 +1,3 @@
+export { ABTest } from "./ABTest"
+export { ABTestDebugPanel } from "./TestDebugPanel"
+export { ABTestTracker } from "./TestTracker"

--- a/src/lib/ab-testing/constants.ts
+++ b/src/lib/ab-testing/constants.ts
@@ -1,0 +1,5 @@
+/** Cookie prefix for debug overrides - single source of truth for server and client */
+export const FLAG_OVERRIDE_COOKIE_PREFIX = "flag_override_"
+
+/** Internal path segment the middleware rewrites A/B-tested routes to. Never linked publicly. */
+export const AB_CODE_SEGMENT = "ab-code"

--- a/src/lib/ab-testing/constants.ts
+++ b/src/lib/ab-testing/constants.ts
@@ -3,3 +3,13 @@ export const FLAG_OVERRIDE_COOKIE_PREFIX = "flag_override_"
 
 /** Internal path segment the middleware rewrites A/B-tested routes to. Never linked publicly. */
 export const AB_CODE_SEGMENT = "ab-code"
+
+/**
+ * The signed flags code contains dots, which make Next.js treat the URL as a
+ * file path: with trailingSlash: true the origin then 308-redirects to strip
+ * the slash that rewrite normalization itself re-appends, exposing the
+ * internal URL (the #17265 failure mode). Encode dots as "~" (unreserved,
+ * never in base64url) so the segment is directory-like in URLs.
+ */
+export const encodeABCode = (code: string) => code.replace(/\./g, "~")
+export const decodeABCode = (code: string) => code.replace(/~/g, ".")

--- a/src/lib/ab-testing/flags.ts
+++ b/src/lib/ab-testing/flags.ts
@@ -74,8 +74,38 @@ export const homepageHeroFlag = flag<number, MatomoEntities>({
 })
 
 /**
- * All A/B test flags for precomputation.
- * Add new flags here as experiments are created in Matomo.
- * The middleware precomputes all of these and rewrites to the coded route.
+ * Find wallet Hero A/B test flag.
+ * Spike example flag for the /wallets/find-wallet redesign test.
  */
-export const abTestFlags = [homepageHeroFlag] as const
+export const findWalletHeroFlag = flag<number, MatomoEntities>({
+  key: "FindWalletHero",
+  defaultValue: 0,
+  description: "Find wallet hero A/B test variant index",
+  options: [
+    { value: 0, label: "Original" },
+    { value: 1, label: "Variant A" },
+  ],
+  identify,
+  adapter: createMatomoAdapter("FindWalletHero"),
+})
+
+/** Flags precomputed for the homepage */
+export const homepageFlags = [homepageHeroFlag] as const
+
+/** Flags precomputed for /wallets/find-wallet */
+export const findWalletFlags = [findWalletHeroFlag] as const
+
+/**
+ * A/B-tested routes and the flags precomputed for each.
+ * Keys are locale-less canonical paths (English URLs are unprefixed, and
+ * non-root paths carry the trailing slash per trailingSlash: true).
+ * Each route gets its own flag group so permutations don't multiply
+ * across pages. Add entries as experiments are created in Matomo.
+ */
+export const abTestRoutes: Record<
+  string,
+  readonly (typeof homepageHeroFlag)[]
+> = {
+  "/": homepageFlags,
+  "/wallets/find-wallet/": findWalletFlags,
+}

--- a/src/lib/ab-testing/flags.ts
+++ b/src/lib/ab-testing/flags.ts
@@ -1,0 +1,81 @@
+import type { ReadonlyHeaders, ReadonlyRequestCookies } from "flags"
+import { dedupe, flag } from "flags/next"
+
+import { IS_PREVIEW_DEPLOY, IS_PROD } from "@/lib/utils/env"
+
+import { FLAG_OVERRIDE_COOKIE_PREFIX } from "./constants"
+import { createMatomoAdapter, type MatomoEntities } from "./matomo-adapter"
+
+/** Debug overrides are only honored in dev and preview deploys */
+const ALLOW_DEBUG_OVERRIDES = !IS_PROD || IS_PREVIEW_DEPLOY
+
+/**
+ * Deduplicated identify function - runs once per request.
+ * Creates a fingerprint from request headers for deterministic variant assignment.
+ * In dev/preview, also reads debug override cookies.
+ */
+const identify = dedupe(
+  async ({
+    headers,
+    cookies,
+  }: {
+    headers: ReadonlyHeaders
+    cookies: ReadonlyRequestCookies
+  }): Promise<MatomoEntities> => {
+    // x-forwarded-for contains "client_ip, proxy1, ..." - only the first entry
+    // is stable across requests behind Cloudflare (see #17612)
+    const forwardedFor =
+      headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+      headers.get("x-real-ip") ||
+      "unknown"
+    const userAgent = headers.get("user-agent") || ""
+    const acceptLanguage = headers.get("accept-language") || ""
+    const acceptEncoding = headers.get("accept-encoding") || ""
+
+    const fingerprint = [
+      forwardedFor,
+      userAgent,
+      acceptLanguage,
+      acceptEncoding,
+    ].join("|")
+
+    let overrides: Record<string, number> | undefined
+    if (ALLOW_DEBUG_OVERRIDES) {
+      for (const cookie of cookies.getAll()) {
+        if (cookie.name.startsWith(FLAG_OVERRIDE_COOKIE_PREFIX)) {
+          const flagKey = cookie.name.slice(FLAG_OVERRIDE_COOKIE_PREFIX.length)
+          const value = parseInt(cookie.value, 10)
+          if (!isNaN(value) && value >= 0) {
+            overrides = overrides || {}
+            overrides[flagKey] = value
+          }
+        }
+      }
+    }
+
+    return { fingerprint, overrides }
+  }
+)
+
+/**
+ * Homepage Hero A/B test flag.
+ * Spike example flag - replace with actual experiments as needed.
+ */
+export const homepageHeroFlag = flag<number, MatomoEntities>({
+  key: "HomepageHero",
+  defaultValue: 0,
+  description: "Homepage hero A/B test variant index",
+  options: [
+    { value: 0, label: "Original" },
+    { value: 1, label: "Variant A" },
+  ],
+  identify,
+  adapter: createMatomoAdapter("HomepageHero"),
+})
+
+/**
+ * All A/B test flags for precomputation.
+ * Add new flags here as experiments are created in Matomo.
+ * The middleware precomputes all of these and rewrites to the coded route.
+ */
+export const abTestFlags = [homepageHeroFlag] as const

--- a/src/lib/ab-testing/index.ts
+++ b/src/lib/ab-testing/index.ts
@@ -1,0 +1,4 @@
+export * from "./constants"
+export * from "./flags"
+export { createMatomoAdapter, type MatomoEntities } from "./matomo-adapter"
+export * from "./types"

--- a/src/lib/ab-testing/matomo-adapter.ts
+++ b/src/lib/ab-testing/matomo-adapter.ts
@@ -19,6 +19,15 @@ const MOCK_EXPERIMENTS: Record<string, ABTestConfig> = {
       { name: "VariantA", weight: 50 },
     ],
   },
+  FindWalletHero: {
+    name: "FindWalletHero",
+    id: "dev-2",
+    enabled: true,
+    variants: [
+      { name: "Original", weight: 50 },
+      { name: "VariantA", weight: 50 },
+    ],
+  },
 }
 
 function isExperimentActive(exp: MatomoExperiment): boolean {

--- a/src/lib/ab-testing/matomo-adapter.ts
+++ b/src/lib/ab-testing/matomo-adapter.ts
@@ -1,0 +1,169 @@
+import type { Adapter } from "flags"
+
+import type { ABTestConfig, MatomoExperiment } from "./types"
+
+const USE_MOCK_EXPERIMENTS = process.env.USE_MOCK_EXPERIMENTS === "true"
+
+/**
+ * Mock experiments for local development.
+ * Add experiments here to test A/B variants without Matomo.
+ * Enable with USE_MOCK_EXPERIMENTS=true
+ */
+const MOCK_EXPERIMENTS: Record<string, ABTestConfig> = {
+  HomepageHero: {
+    name: "HomepageHero",
+    id: "dev-1",
+    enabled: true,
+    variants: [
+      { name: "Original", weight: 50 },
+      { name: "VariantA", weight: 50 },
+    ],
+  },
+}
+
+function isExperimentActive(exp: MatomoExperiment): boolean {
+  const now = new Date()
+  if (exp.start_date && new Date(exp.start_date) > now) return false
+  if (exp.end_date && new Date(exp.end_date) < now) return false
+  return ["created", "running"].includes(exp.status)
+}
+
+async function fetchMatomoExperiments(): Promise<Record<string, ABTestConfig>> {
+  if (USE_MOCK_EXPERIMENTS) {
+    return MOCK_EXPERIMENTS
+  }
+
+  const matomoUrl = process.env.NEXT_PUBLIC_MATOMO_URL
+  const apiToken = process.env.MATOMO_API_TOKEN
+  const siteId = process.env.NEXT_PUBLIC_MATOMO_SITE_ID || "4"
+
+  if (!matomoUrl || !apiToken) {
+    console.error("[Matomo Adapter] Missing configuration")
+    return {}
+  }
+
+  try {
+    const response = await fetch(
+      `${matomoUrl}/index.php?module=API&method=AbTesting.getAllExperiments&idSite=${siteId}&format=json&token_auth=${apiToken}`,
+      {
+        headers: { "User-Agent": "ethereum.org-flags-adapter/1.0" },
+        cache: "force-cache",
+      }
+    )
+
+    if (!response.ok) {
+      console.error(
+        `[Matomo Adapter] HTTP ${response.status}: ${response.statusText}`
+      )
+      return {}
+    }
+
+    const data = await response.json()
+    if (data.result === "error" || !Array.isArray(data)) {
+      return {}
+    }
+
+    const config: Record<string, ABTestConfig> = {}
+    for (const exp of data as MatomoExperiment[]) {
+      if (!exp.variations?.length) continue
+
+      const variationsTotalWeight = exp.variations.reduce(
+        (sum, v) => sum + (v.percentage || 0),
+        0
+      )
+
+      // Clamp original weight to 0 if variations exceed 100%
+      const originalWeight = 100 - variationsTotalWeight
+      if (originalWeight < 0) {
+        console.warn(
+          `[Matomo Adapter] Experiment ${exp.name} variations exceed 100% (${variationsTotalWeight}%)`
+        )
+      }
+
+      config[exp.name] = {
+        name: exp.name,
+        id: exp.idexperiment,
+        enabled: isExperimentActive(exp),
+        variants: [
+          { name: "Original", weight: Math.max(0, originalWeight) },
+          ...exp.variations.map((v) => ({
+            name: v.name,
+            weight: v.percentage || 0,
+          })),
+        ],
+      }
+    }
+
+    return config
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error"
+    console.error("[Matomo Adapter] Fetch failed:", message)
+    return {}
+  }
+}
+
+// FNV-1a hash for deterministic assignment (matching legacy implementation)
+function fnv1aHash(str: string): number {
+  let hash = 2166136261
+  for (let i = 0; i < str.length; i++) {
+    hash ^= str.charCodeAt(i)
+    hash = (hash * 16777619) >>> 0
+  }
+  return hash
+}
+
+function assignVariantIndex(config: ABTestConfig, fingerprint: string): number {
+  const totalWeight = config.variants.reduce((sum, v) => sum + v.weight, 0)
+  if (totalWeight === 0) return 0
+
+  const hash = fnv1aHash(fingerprint)
+  const normalized = hash / 0x100000000
+  const weighted = normalized * totalWeight
+
+  let cumulative = 0
+  for (let i = 0; i < config.variants.length; i++) {
+    cumulative += config.variants[i].weight
+    if (weighted <= cumulative) return i
+  }
+  return 0
+}
+
+export interface MatomoEntities {
+  fingerprint: string
+  /** Debug overrides from cookies (flag key -> variant index). Only populated in dev/preview. */
+  overrides?: Record<string, number>
+}
+
+/**
+ * Creates a Matomo adapter for a specific experiment.
+ * The adapter fetches experiment config from Matomo and assigns variants deterministically.
+ */
+export function createMatomoAdapter(
+  experimentName: string
+): Adapter<number, MatomoEntities> {
+  return {
+    origin() {
+      const matomoUrl = process.env.NEXT_PUBLIC_MATOMO_URL
+      return matomoUrl ? `${matomoUrl}/index.php?module=AbTesting` : undefined
+    },
+
+    async decide({ key, entities }) {
+      // Check for debug override first (only populated in dev/preview)
+      const override = entities?.overrides?.[key]
+      if (override !== undefined) {
+        return override
+      }
+
+      const config = await fetchMatomoExperiments()
+      const experiment = config[experimentName]
+
+      if (!experiment || !experiment.enabled) {
+        return 0 // Default to original variant
+      }
+
+      const fingerprint = entities?.fingerprint || "anonymous"
+      const fullFingerprint = `${fingerprint}|${key}`
+      return assignVariantIndex(experiment, fullFingerprint)
+    },
+  }
+}

--- a/src/lib/ab-testing/types.ts
+++ b/src/lib/ab-testing/types.ts
@@ -1,4 +1,4 @@
-import type { JSX, ReactNode } from "react"
+import type { ReactNode } from "react"
 
 export type MatomoExperiment = {
   idexperiment: string
@@ -31,5 +31,4 @@ export type ABTestAssignment = {
 }
 
 // Type-safe tuple for at least 2 variants
-type Element = ReactNode | JSX.Element | string
-export type ABTestVariants = [Element, Element, ...Element[]]
+export type ABTestVariants = [ReactNode, ReactNode, ...ReactNode[]]


### PR DESCRIPTION
## Summary

Revival of #17265 on current `dev`, to verify on a deploy preview that the Netlify blocker is gone. A fresh minimal repro confirmed that middleware `NextResponse.rewrite()` + next-intl no longer gets converted to a 308 on the current Netlify Next.js runtime (v5.15.12) — in both `trailingSlash` modes — so this approach should now work without removing `trailingSlash` (#17581).

**Why:** the current `ABTestWrapper` infra reads `headers()` at render time, forcing any A/B-tested page into dynamic rendering (the homepage needed `force-dynamic` in #17294, reverted in #17742). The Flags SDK precompute pattern instead assigns the variant in the proxy and rewrites to a statically generated per-permutation route — intended for the upcoming /find-wallets redesign test without giving up static rendering.

## How it works

1. `proxy.ts` precomputes all flags for routes in `AB_TEST_ROUTES` (currently `/`) and rewrites to `/en/ab-code/<signed-code>/` — internal-only, users keep seeing `/`
2. `app/[locale]/ab-code/[code]/page.tsx` statically generates one page per variant permutation (`generatePermutations`) and renders the homepage with the precomputed variant index
3. `ABTest` renders the variant + Matomo tracking; the debug panel (dev/preview) forces variants via `flag_override_*` cookies, which the proxy honors when re-precomputing

## Changes vs #17265

- Coded route under a literal `ab-code` segment — `app/[locale]/[code]` would have shadowed every single-segment content page served by the `[...slug]` catch-all
- Adapted to `localePrefix: "as-needed"` (English URLs are unprefixed) and Next 16 `proxy.ts`
- Fingerprint takes only the client IP from `x-forwarded-for` (#17612 fix)
- `generateStaticParams` tolerates missing `FLAGS_SECRET` (CI); invalid codes 404
- Legacy `ABTestWrapper` infra untouched — consolidation after the preview verifies

## Verification

Locally verified with `USE_MOCK_EXPERIMENTS=true`:
- `/` serves the coded route silently (200, URL unchanged)
- Override cookie `0`/`1` switches original ↔ variant marker
- `/about/`, `/en/` → `/` 301, garbage codes 404, content routes unshadowed

**On this preview** (no Matomo experiment named `HomepageHero` is running, so everyone gets Original by default):
- [ ] `curl -sI <preview>/` → 200, no 308, homepage content
- [ ] Set cookie `flag_override_HomepageHero=1` → yellow *A/B VARIANT A (Flags SDK spike)* banner above the hero
- [ ] Check cache headers on `/` (does the rewritten response still hit Netlify durable cache?)
- [ ] Content pages / other locales unaffected

## Open questions before productionizing

- Cacheability of rewritten responses on Netlify (the actual TTFB win)
- Bot handling: bots currently get fingerprint-assigned like #17605 reverted state
- Remove legacy `ABTestWrapper` + `/api/ab-config` once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)