### PR TITLE
content: update CryptoSD meetup link to the canonical HTTPS URL

### DIFF
--- a/src/data/community-meetups.json
+++ b/src/data/community-meetups.json
@@ -470,7 +470,7 @@
   {
     "title": "CryptoSD",
     "location": "San Diego, USA",
-    "link": "http://cryptosandiego.org",
+    "link": "https://www.meetup.com/crypto-san-diego/",
     "logoImage": "https://secure.meetupstatic.com/photos/event/1/f/f/8/600_525848184.jpeg",
     "bannerImage": "https://secure.meetupstatic.com/photos/event/1/f/f/8/600_525848184.jpeg"
   },


### PR DESCRIPTION
## Description
Updated the CryptoSD meetup entry in `src/data/community-meetups.json` to the current canonical HTTPS meetup page instead of the old `http://cryptosandiego.org` URL, which now redirects there.

## Related Issue
Fixes #18675