### PR TITLE
[recovery] Disable Next image on-disk cache on read-only Netlify Lambda

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -126,6 +126,10 @@ module.exports = (phase) => {
     serverExternalPackages: ["pino-pretty", "lokijs", "encoding"],
     trailingSlash: true,
     images: {
+      // Disable Next's on-disk image LRU: its eager mkdir('.next/cache/images')
+      // crashes on Netlify's read-only Lambda FS as an unhandled rejection.
+      // Images are served via Netlify's image CDN (NEXT_FORCE_EDGE_IMAGES) anyway.
+      maximumDiskCacheSize: 0,
       qualities: [5, 10, 20, 35, 40, 75, 90, 100],
       deviceSizes: [640, 750, 828, 1080, 1200, 1504, 1920],
       remotePatterns: [


### PR DESCRIPTION
## Error

Recurring unhandled promise rejection in the `___netlify-server-handler` function (11 hits, first seen 2026-05-25):

```
[ERROR] Unhandled Promise Rejection {"errorType":"Runtime.UnhandledPromiseRejection",
"errorMessage":"Error: ENOENT: no such file or directory, mkdir '/var/task/.next/cache'",
... at .../next/dist/server/lib/disk-lru-cache.external.js:36:17}
```

## Root cause

Next.js 16's image optimizer (`ImageOptimizerCache`, `next/dist/server/image-optimizer.js:686-694`) **eagerly** initializes an on-disk LRU cache in its constructor whenever:

- no custom `cacheHandler` is set, **and**
- `images.maximumDiskCacheSize !== 0`, **and**
- `experimental.isrFlushToDisk` is truthy

All three hold by default in our config. That eager `getOrInitDiskLRU(...)` promise (`disk-lru-cache.external.js:36`) calls `fs.promises.mkdir(cacheDir, { recursive: true })` where `cacheDir = .next/cache/images`. On Netlify's **read-only** Lambda filesystem (`/var/task`), creating `.next/cache` fails with `ENOENT`.

Because the promise is created eagerly in the constructor and **not awaited or caught at that point** (only later inside `get()`/`set()`), the rejection escapes as an unhandled promise rejection and crashes/pollutes the server handler.

## Fix

Set `images.maximumDiskCacheSize: 0` in `next.config.js`. Per the constructor guard, this leaves `isDiskCacheEnabled` false so `getOrInitDiskLRU` is never called — no `mkdir`, no rejection.

`maximumDiskCacheSize` is a documented public image option (`z.number().int().min(0).optional()` in Next's config schema). The local disk image cache is useless on ephemeral, read-only Lambda anyway — optimized images are served through Netlify's image CDN (`NEXT_FORCE_EDGE_IMAGES=true`), so there is no functional regression.

## Affected files

- `next.config.js`

## Verification

- `pnpm type-check` ✅
- `pnpm exec eslint next.config.js` ✅ (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)