### PR TITLE
[recovery] fix: setRequestLocale ordering in video slug page (static→dynamic error)

### DIFF
--- a/app/[locale]/videos/[slug]/page.tsx
+++ b/app/[locale]/videos/[slug]/page.tsx
@@ -29,8 +29,10 @@ const VideoLandingPage = async (props: {
 }) => {
   const { locale, slug } = await props.params
 
-  const t = await getTranslations("page-videos")
+  // Set locale before next-intl APIs so on-demand renders stay static
   setRequestLocale(locale)
+
+  const t = await getTranslations("page-videos")
 
   let data: VideoData | undefined
   try {
@@ -109,6 +111,9 @@ export async function generateMetadata(props: {
   params: Promise<{ locale: string; slug: string }>
 }): Promise<Metadata> {
   const { locale, slug } = await props.params
+
+  // Set locale before next-intl APIs so on-demand renders stay static
+  setRequestLocale(locale)
 
   let data
   try {


### PR DESCRIPTION
## Alert

- **Message:** `[ERROR] Error: Page changed from static to dynamic at runtime /:locale/videos/.DS_Store, reason: headers`
- **Function:** `___netlify-server-handler`
- **Hit count:** 2 (first seen 2026-05-29)
- Ref: https://nextjs.org/docs/messages/app-static-to-dynamic-error

## Root cause

`app/[locale]/videos/[slug]/page.tsx` called `getTranslations("page-videos")` **before** `setRequestLocale(locale)`, and `generateMetadata()` never called `setRequestLocale()` at all (it reaches `getTranslations` via `getMetadata`).

When a next-intl API runs before the request locale is set, next-intl reads the locale from request **headers**, which opts the route into dynamic rendering. Slugs covered by `generateStaticParams` are prerendered at build (no headers), so they were unaffected. But any slug rendered **on-demand** — a stale/removed video URL, a typo, or a bot probe like `/videos/.DS_Store` — hits the header read at request time and Next.js throws *"Page changed from static to dynamic at runtime, reason: headers"* instead of returning a clean 404.

## Fix

Call `setRequestLocale(locale)` first — before any next-intl API — in both the page component and `generateMetadata`, matching the pattern already used by the sibling videos index page (`app/[locale]/videos/page.tsx`). Unknown slugs now fall through to `notFound()` cleanly.

## Verification

- `pnpm type-check` ✅
- `pnpm exec eslint app/[locale]/videos/[slug]/page.tsx` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)