### PR TITLE
[recovery] fix: make image placeholder cache I/O best-effort on read-only runtime FS

### DIFF
--- a/src/lib/md/rehypeImg.ts
+++ b/src/lib/md/rehypeImg.ts
@@ -85,9 +85,19 @@ const setImagePlaceholders = async (
     .replaceAll("/", "-")
     .slice(1)
 
+  // The on-disk placeholder cache is a build-time optimization. When MDX is
+  // compiled on-demand in the serverless runtime the filesystem is read-only
+  // (and this dir isn't bundled), so treat cache I/O as best-effort and fall
+  // back to generating placeholders in memory.
+  let canWriteCache = true
+
   // Make directory for current page if none exists
-  if (!fs.existsSync(PLACEHOLDER_IMAGE_DIR))
-    fs.mkdirSync(PLACEHOLDER_IMAGE_DIR, { recursive: true })
+  try {
+    if (!fs.existsSync(PLACEHOLDER_IMAGE_DIR))
+      fs.mkdirSync(PLACEHOLDER_IMAGE_DIR, { recursive: true })
+  } catch {
+    canWriteCache = false
+  }
 
   const DATA_PATH = path.join(PLACEHOLDER_IMAGE_DIR, FILENAME)
   const existsCache = fs.existsSync(DATA_PATH)
@@ -133,15 +143,16 @@ const setImagePlaceholders = async (
 
   // If cache is still empty, delete JSON file and return
   if (Object.keys(placeholdersCached).length === 0) {
-    fs.rmSync(DATA_PATH, { recursive: true, force: true })
+    if (canWriteCache) fs.rmSync(DATA_PATH, { recursive: true, force: true })
     return
   }
 
   // If cached value has not changed, return without writing to file system
   if (!isChanged) return
 
-  // Write results to cache file
-  fs.writeFileSync(DATA_PATH, JSON.stringify(placeholdersCached, null, 2))
+  // Write results to cache file (skipped when the FS is read-only at runtime)
+  if (canWriteCache)
+    fs.writeFileSync(DATA_PATH, JSON.stringify(placeholdersCached, null, 2))
 }
 
 /**


### PR DESCRIPTION
## Production error

```
[ERROR] ⨯ [Error: [next-mdx-remote] error compiling MDX:
ENOENT: no such file or directory, mkdir 'src/data/placeholders'

More information: https://mdxjs.com/docs/troubleshooting-mdx] { digest: '2728894750' }
```

- Function: `___netlify-server-handler` · 106 hits since 2026-06-01
- Surfaces as a 500 on content pages whose MDX gets compiled on-demand

## Root cause

`setImagePlaceholders()` in `src/lib/md/rehypeImg.ts` unconditionally does `fs.mkdirSync('src/data/placeholders')` (plus `writeFileSync`/`rmSync`) to maintain a build-time blur-placeholder cache. When MDX is compiled on-demand in Netlify's serverless runtime, the filesystem is read-only and that directory isn't bundled (the path is an imported string constant, not folded in by the file tracer) — so the `mkdir` throws `ENOENT`, which surfaces as a next-mdx-remote compile error and crashes the render.

## Fix

Treat the on-disk cache as best-effort: wrap the directory creation in try/catch and gate the cache writes (`rmSync`/`writeFileSync`) on it succeeding. Placeholders still generate in memory, so rendering degrades gracefully instead of 500ing. Build-time behavior is unchanged — the cache directory is writable there.

## Verification

- `pnpm type-check` — passes
- `pnpm exec eslint src/lib/md/rehypeImg.ts` — clean

---

*Note: this description was reconstructed on 2026-07-20 from the agent's analysis stored in Keep — the original PR body was lost to an agent slip that pasted a stray URL from the `git push` output.*
