### PR TITLE
[recovery] fix: setRequestLocale ordering in wallets page (static→dynamic error)

### DIFF
--- a/app/[locale]/wallets/page.tsx
+++ b/app/[locale]/wallets/page.tsx
@@ -41,9 +41,11 @@ import heroImg from "@/public/images/wallets/wallet-hero.png"
 const Page = async (props: { params: Promise<PageParams> }) => {
   const params = await props.params
   const { locale } = params
-  const t = await getTranslations("page-wallets")
 
+  // Set locale before next-intl APIs so on-demand renders stay static
   setRequestLocale(locale)
+
+  const t = await getTranslations("page-wallets")
 
   // Get i18n messages
   const allMessages = await getMessages({ locale })
@@ -385,6 +387,9 @@ export async function generateMetadata(props: {
 }) {
   const params = await props.params
   const { locale } = params
+
+  // Set locale before next-intl APIs so on-demand renders stay static
+  setRequestLocale(locale)
 
   const t = await getTranslations("page-wallets")
 


### PR DESCRIPTION
## Error

```
[ERROR] Error: Page changed from static to dynamic at runtime /api/wallets, reason: headers
    ... at get requestLocale ...
```

- **URL:** `/api/wallets`
- **Hit count:** 1 (first seen 2026-06-02)
- **Function:** `___netlify-server-handler`

## Root cause

`/api/wallets` is matched by `app/[locale]/wallets/page.tsx` with `locale="api"` — a bot/invalid path where `api` is captured as the `[locale]` dynamic segment. `api` is not a valid locale, so it is **not** produced by `generateStaticParams` and the route renders on-demand.

The page called `getTranslations("page-wallets")` **before** `setRequestLocale(locale)`, and `generateMetadata` never called `setRequestLocale` at all. With no locale set, next-intl falls back to reading the locale from request **headers**, which opts the route into dynamic rendering. Next.js then throws `Page changed from static to dynamic at runtime, reason: headers` (stack shows `get requestLocale`) instead of rendering statically / returning a clean response.

This is the same bug class as the videos `[slug]` page fixed in #18785 — a distinct route/URL, so a distinct fix.

## Fix

Call `setRequestLocale(locale)` first (before any other next-intl API) in both the page component and `generateMetadata`, mirroring #18785.

## Affected files

- `app/[locale]/wallets/page.tsx`

## Verification

- `pnpm type-check` — passes
- `pnpm exec eslint app/[locale]/wallets/page.tsx` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)