### PR TITLE
[recovery] fix: setRequestLocale ordering in resources page (static→dynamic error)

### DIFF
--- a/app/[locale]/resources/page.tsx
+++ b/app/[locale]/resources/page.tsx
@@ -1,4 +1,4 @@
-import { getTranslations } from "next-intl/server"
+import { getTranslations, setRequestLocale } from "next-intl/server"
 
 import type { Lang, PageParams } from "@/lib/types"
 
@@ -34,6 +34,8 @@ const EVENT_CATEGORY = "dashboard"
 const Page = async (props: { params: Promise<PageParams> }) => {
   const params = await props.params
   const { locale } = params
+
+  setRequestLocale(locale)
 
   const t = await getTranslations("page-resources")
 
@@ -236,6 +238,9 @@ export async function generateMetadata(props: {
 }) {
   const params = await props.params
   const { locale } = params
+
+  // Set locale before next-intl APIs so on-demand renders stay static
+  setRequestLocale(locale)
 
   const t = await getTranslations("page-resources")
 


### PR DESCRIPTION
## Production error

```
[ERROR] Error: Page changed from static to dynamic at runtime /api/resources, reason: headers
    at get requestLocale (...)
```

- **Fingerprint:** `grafana-fn-error-page-changed-from-static-to-dynamic-at-runtime-api-resources-reason-he`
- **URL:** `/api/resources`
- **Hit count:** 1 (first seen 2026-05-29)

## Root cause

`app/[locale]/resources/page.tsx` called `getTranslations("page-resources")` **before** ever calling `setRequestLocale(locale)`, and `generateMetadata` never called it at all.

The alerted URL `/api/resources` is a bot/invalid path where `api` is captured as the `[locale]` segment. That isn't a valid locale, so it's not covered by `generateStaticParams` and the route renders on-demand. next-intl then reads the locale from request **headers**, which opts the route into dynamic rendering, and Next.js throws `Page changed from static to dynamic at runtime`.

## Fix

Call `setRequestLocale(locale)` first — before any next-intl API — in both `Page` and `generateMetadata`. This is the same fix class already applied to the wallets page (#18797) and videos `[slug]` page (#18785).

## Verification

- `pnpm type-check` ✅
- `pnpm exec eslint app/[locale]/resources/page.tsx` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)