### PR TITLE
i18n: translation pipeline, component-swiper (all languages)

### DIFF
--- a/.manifests/src/intl/ar/component-swiper.json/source.json
+++ b/.manifests/src/intl/ar/component-swiper.json/source.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "sourceFile": "src/intl/en/component-swiper.json",
+  "generatedAt": "2026-07-14T17:32:23.729Z",
+  "rootHash": "faefe793571c",
+  "tree": {
+    "contentHash": "17f5cf39183e",
+    "anchorHash": "f5818652a990",
+    "children": {
+      "swiper-next-slide": {
+        "contentHash": "cdc93d1c8fe9",
+        "anchorHash": "e3b0c44298fc"
+      },
+      "swiper-previous-slide": {
+        "contentHash": "bfb549220c60",
+        "anchorHash": "e3b0c44298fc"
+      }
+    },
+    "childrenOrder": [
+      "swiper-next-slide",
+      "swiper-previous-slide"
+    ]
+  },
+  "sourceCommitSha": "775d68671a756bcd0db81828094c44e68f18e108"
+}

--- a/.manifests/src/intl/ar/component-swiper.json/translation.json
+++ b/.manifests/src/intl/ar/component-swiper.json/translation.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "locale": "ar",
+  "translatedAt": "2026-07-14T17:32:23.729Z",
+  "englishManifestHash": "faefe793571c",
+  "placeholderOrder": [],
+  "placeholderMap": {},
+  "sections": {
+    "_all": {
+      "translatedAt": "2026-07-14T17:32:23.729Z",
+      "status": "success"
+    }
+  }
+}

--- a/.manifests/src/intl/bn/component-swiper.json/source.json
+++ b/.manifests/src/intl/bn/component-swiper.json/source.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "sourceFile": "src/intl/en/component-swiper.json",
+  "generatedAt": "2026-07-14T17:32:23.469Z",
+  "rootHash": "faefe793571c",
+  "tree": {
+    "contentHash": "17f5cf39183e",
+    "anchorHash": "f5818652a990",
+    "children": {
+      "swiper-next-slide": {
+        "contentHash": "cdc93d1c8fe9",
+        "anchorHash": "e3b0c44298fc"
+      },
+      "swiper-previous-slide": {
+        "contentHash": "bfb549220c60",
+        "anchorHash": "e3b0c44298fc"
+      }
+    },
+    "childrenOrder": [
+      "swiper-next-slide",
+      "swiper-previous-slide"
+    ]
+  },
+  "sourceCommitSha": "775d68671a756bcd0db81828094c44e68f18e108"
+}

--- a/.manifests/src/intl/bn/component-swiper.json/translation.json
+++ b/.manifests/src/intl/bn/component-swiper.json/translation.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "locale": "bn",
+  "translatedAt": "2026-07-14T17:32:23.469Z",
+  "englishManifestHash": "faefe793571c",
+  "placeholderOrder": [],
+  "placeholderMap": {},
+  "sections": {
+    "_all": {
+      "translatedAt": "2026-07-14T17:32:23.469Z",
+      "status": "success"
+    }
+  }
+}

--- a/.manifests/src/intl/cs/component-swiper.json/source.json
+++ b/.manifests/src/intl/cs/component-swiper.json/source.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "sourceFile": "src/intl/en/component-swiper.json",
+  "generatedAt": "2026-07-14T17:32:23.387Z",
+  "rootHash": "faefe793571c",
+  "tree": {
+    "contentHash": "17f5cf39183e",
+    "anchorHash": "f5818652a990",
+    "children": {
+      "swiper-next-slide": {
+        "contentHash": "cdc93d1c8fe9",
+        "anchorHash": "e3b0c44298fc"
+      },
+      "swiper-previous-slide": {
+        "contentHash": "bfb549220c60",
+        "anchorHash": "e3b0c44298fc"
+      }
+    },
+    "childrenOrder": [
+      "swiper-next-slide",
+      "swiper-previous-slide"
+    ]
+  },
+  "sourceCommitSha": "775d68671a756bcd0db81828094c44e68f18e108"
+}

--- a/.manifests/src/intl/cs/component-swiper.json/translation.json
+++ b/.manifests/src/intl/cs/component-swiper.json/translation.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "locale": "cs",
+  "translatedAt": "2026-07-14T17:32:23.387Z",
+  "englishManifestHash": "faefe793571c",
+  "placeholderOrder": [],
+  "placeholderMap": {},
+  "sections": {
+    "_all": {
+      "translatedAt": "2026-07-14T17:32:23.387Z",
+      "status": "success"
+    }
+  }
+}

--- a/.manifests/src/intl/de/component-swiper.json/source.json
+++ b/.manifests/src/intl/de/component-swiper.json/source.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "sourceFile": "src/intl/en/component-swiper.json",
+  "generatedAt": "2026-07-14T17:32:23.921Z",
+  "rootHash": "faefe793571c",
+  "tree": {
+    "contentHash": "17f5cf39183e",
+    "anchorHash": "f5818652a990",
+    "children": {
+      "swiper-next-slide": {
+        "contentHash": "cdc93d1c8fe9",
+        "anchorHash": "e3b0c44298fc"
+      },
+      "swiper-previous-slide": {
+        "contentHash": "bfb549220c60",
+        "anchorHash": "e3b0c44298fc"
+      }
+    },
+    "childrenOrder": [
+      "swiper-next-slide",
+      "swiper-previous-slide"
+    ]
+  },
+  "sourceCommitSha": "775d68671a756bcd0db81828094c44e68f18e108"
+}

--- a/.manifests/src/intl/de/component-swiper.json/translation.json
+++ b/.manifests/src/intl/de/component-swiper.json/translation.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "locale": "de",
+  "translatedAt": "2026-07-14T17:32:23.921Z",
+  "englishManifestHash": "faefe793571c",
+  "placeholderOrder": [],
+  "placeholderMap": {},
+  "sections": {
+    "_all": {
+      "translatedAt": "2026-07-14T17:32:23.921Z",
+      "status": "success"
+    }
+  }
+}

--- a/.manifests/src/intl/es/component-swiper.json/source.json
+++ b/.manifests/src/intl/es/component-swiper.json/source.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "sourceFile": "src/intl/en/component-swiper.json",
+  "generatedAt": "2026-07-14T17:32:26.205Z",
+  "rootHash": "faefe793571c",
+  "tree": {
+    "contentHash": "17f5cf39183e",
+    "anchorHash": "f5818652a990",
+    "children": {
+      "swiper-next-slide": {
+        "contentHash": "cdc93d1c8fe9",
+        "anchorHash": "e3b0c44298fc"
+      },
+      "swiper-previous-slide": {
+        "contentHash": "bfb549220c60",
+        "anchorHash": "e3b0c44298fc"
+      }
+    },
+    "childrenOrder": [
+      "swiper-next-slide",
+      "swiper-previous-slide"
+    ]
+  },
+  "sourceCommitSha": "775d68671a756bcd0db81828094c44e68f18e108"
+}

--- a/.manifests/src/intl/es/component-swiper.json/translation.json
+++ b/.manifests/src/intl/es/component-swiper.json/translation.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "locale": "es",
+  "translatedAt": "2026-07-14T17:32:26.205Z",
+  "englishManifestHash": "faefe793571c",
+  "placeholderOrder": [],
+  "placeholderMap": {},
+  "sections": {
+    "_all": {
+      "translatedAt": "2026-07-14T17:32:26.205Z",
+      "status": "success"
+    }
+  }
+}

--- a/.manifests/src/intl/fr/component-swiper.json/source.json
+++ b/.manifests/src/intl/fr/component-swiper.json/source.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "sourceFile": "src/intl/en/component-swiper.json",
+  "generatedAt": "2026-07-14T17:32:22.844Z",
+  "rootHash": "faefe793571c",
+  "tree": {
+    "contentHash": "17f5cf39183e",
+    "anchorHash": "f5818652a990",
+    "children": {
+      "swiper-next-slide": {
+        "contentHash": "cdc93d1c8fe9",
+        "anchorHash": "e3b0c44298fc"
+      },
+      "swiper-previous-slide": {
+        "contentHash": "bfb549220c60",
+        "anchorHash": "e3b0c44298fc"
+      }
+    },
+    "childrenOrder": [
+      "swiper-next-slide",
+      "swiper-previous-slide"
+    ]
+  },
+  "sourceCommitSha": "775d68671a756bcd0db81828094c44e68f18e108"
+}

--- a/.manifests/src/intl/fr/component-swiper.json/translation.json
+++ b/.manifests/src/intl/fr/component-swiper.json/translation.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "locale": "fr",
+  "translatedAt": "2026-07-14T17:32:22.845Z",
+  "englishManifestHash": "faefe793571c",
+  "placeholderOrder": [],
+  "placeholderMap": {},
+  "sections": {
+    "_all": {
+      "translatedAt": "2026-07-14T17:32:22.845Z",
+      "status": "success"
+    }
+  }
+}

--- a/.manifests/src/intl/hi/component-swiper.json/source.json
+++ b/.manifests/src/intl/hi/component-swiper.json/source.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "sourceFile": "src/intl/en/component-swiper.json",
+  "generatedAt": "2026-07-14T17:32:23.413Z",
+  "rootHash": "faefe793571c",
+  "tree": {
+    "contentHash": "17f5cf39183e",
+    "anchorHash": "f5818652a990",
+    "children": {
+      "swiper-next-slide": {
+        "contentHash": "cdc93d1c8fe9",
+        "anchorHash": "e3b0c44298fc"
+      },
+      "swiper-previous-slide": {
+        "contentHash": "bfb549220c60",
+        "anchorHash": "e3b0c44298fc"
+      }
+    },
+    "childrenOrder": [
+      "swiper-next-slide",
+      "swiper-previous-slide"
+    ]
+  },
+  "sourceCommitSha": "775d68671a756bcd0db81828094c44e68f18e108"
+}

--- a/.manifests/src/intl/hi/component-swiper.json/translation.json
+++ b/.manifests/src/intl/hi/component-swiper.json/translation.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "locale": "hi",
+  "translatedAt": "2026-07-14T17:32:23.413Z",
+  "englishManifestHash": "faefe793571c",
+  "placeholderOrder": [],
+  "placeholderMap": {},
+  "sections": {
+    "_all": {
+      "translatedAt": "2026-07-14T17:32:23.413Z",
+      "status": "success"
+    }
+  }
+}

--- a/.manifests/src/intl/id/component-swiper.json/source.json
+++ b/.manifests/src/intl/id/component-swiper.json/source.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "sourceFile": "src/intl/en/component-swiper.json",
+  "generatedAt": "2026-07-14T17:32:23.423Z",
+  "rootHash": "faefe793571c",
+  "tree": {
+    "contentHash": "17f5cf39183e",
+    "anchorHash": "f5818652a990",
+    "children": {
+      "swiper-next-slide": {
+        "contentHash": "cdc93d1c8fe9",
+        "anchorHash": "e3b0c44298fc"
+      },
+      "swiper-previous-slide": {
+        "contentHash": "bfb549220c60",
+        "anchorHash": "e3b0c44298fc"
+      }
+    },
+    "childrenOrder": [
+      "swiper-next-slide",
+      "swiper-previous-slide"
+    ]
+  },
+  "sourceCommitSha": "775d68671a756bcd0db81828094c44e68f18e108"
+}

--- a/.manifests/src/intl/id/component-swiper.json/translation.json
+++ b/.manifests/src/intl/id/component-swiper.json/translation.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "locale": "id",
+  "translatedAt": "2026-07-14T17:32:23.423Z",
+  "englishManifestHash": "faefe793571c",
+  "placeholderOrder": [],
+  "placeholderMap": {},
+  "sections": {
+    "_all": {
+      "translatedAt": "2026-07-14T17:32:23.423Z",
+      "status": "success"
+    }
+  }
+}

--- a/.manifests/src/intl/it/component-swiper.json/source.json
+++ b/.manifests/src/intl/it/component-swiper.json/source.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "sourceFile": "src/intl/en/component-swiper.json",
+  "generatedAt": "2026-07-14T17:32:23.635Z",
+  "rootHash": "faefe793571c",
+  "tree": {
+    "contentHash": "17f5cf39183e",
+    "anchorHash": "f5818652a990",
+    "children": {
+      "swiper-next-slide": {
+        "contentHash": "cdc93d1c8fe9",
+        "anchorHash": "e3b0c44298fc"
+      },
+      "swiper-previous-slide": {
+        "contentHash": "bfb549220c60",
+        "anchorHash": "e3b0c44298fc"
+      }
+    },
+    "childrenOrder": [
+      "swiper-next-slide",
+      "swiper-previous-slide"
+    ]
+  },
+  "sourceCommitSha": "775d68671a756bcd0db81828094c44e68f18e108"
+}

--- a/.manifests/src/intl/it/component-swiper.json/translation.json
+++ b/.manifests/src/intl/it/component-swiper.json/translation.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "locale": "it",
+  "translatedAt": "2026-07-14T17:32:23.635Z",
+  "englishManifestHash": "faefe793571c",
+  "placeholderOrder": [],
+  "placeholderMap": {},
+  "sections": {
+    "_all": {
+      "translatedAt": "2026-07-14T17:32:23.635Z",
+      "status": "success"
+    }
+  }
+}

--- a/.manifests/src/intl/ja/component-swiper.json/source.json
+++ b/.manifests/src/intl/ja/component-swiper.json/source.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "sourceFile": "src/intl/en/component-swiper.json",
+  "generatedAt": "2026-07-14T17:32:23.225Z",
+  "rootHash": "faefe793571c",
+  "tree": {
+    "contentHash": "17f5cf39183e",
+    "anchorHash": "f5818652a990",
+    "children": {
+      "swiper-next-slide": {
+        "contentHash": "cdc93d1c8fe9",
+        "anchorHash": "e3b0c44298fc"
+      },
+      "swiper-previous-slide": {
+        "contentHash": "bfb549220c60",
+        "anchorHash": "e3b0c44298fc"
+      }
+    },
+    "childrenOrder": [
+      "swiper-next-slide",
+      "swiper-previous-slide"
+    ]
+  },
+  "sourceCommitSha": "775d68671a756bcd0db81828094c44e68f18e108"
+}

--- a/.manifests/src/intl/ja/component-swiper.json/translation.json
+++ b/.manifests/src/intl/ja/component-swiper.json/translation.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "locale": "ja",
+  "translatedAt": "2026-07-14T17:32:23.225Z",
+  "englishManifestHash": "faefe793571c",
+  "placeholderOrder": [],
+  "placeholderMap": {},
+  "sections": {
+    "_all": {
+      "translatedAt": "2026-07-14T17:32:23.225Z",
+      "status": "success"
+    }
+  }
+}

--- a/.manifests/src/intl/ko/component-swiper.json/source.json
+++ b/.manifests/src/intl/ko/component-swiper.json/source.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "sourceFile": "src/intl/en/component-swiper.json",
+  "generatedAt": "2026-07-14T17:32:22.984Z",
+  "rootHash": "faefe793571c",
+  "tree": {
+    "contentHash": "17f5cf39183e",
+    "anchorHash": "f5818652a990",
+    "children": {
+      "swiper-next-slide": {
+        "contentHash": "cdc93d1c8fe9",
+        "anchorHash": "e3b0c44298fc"
+      },
+      "swiper-previous-slide": {
+        "contentHash": "bfb549220c60",
+        "anchorHash": "e3b0c44298fc"
+      }
+    },
+    "childrenOrder": [
+      "swiper-next-slide",
+      "swiper-previous-slide"
+    ]
+  },
+  "sourceCommitSha": "775d68671a756bcd0db81828094c44e68f18e108"
+}

--- a/.manifests/src/intl/ko/component-swiper.json/translation.json
+++ b/.manifests/src/intl/ko/component-swiper.json/translation.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "locale": "ko",
+  "translatedAt": "2026-07-14T17:32:22.984Z",
+  "englishManifestHash": "faefe793571c",
+  "placeholderOrder": [],
+  "placeholderMap": {},
+  "sections": {
+    "_all": {
+      "translatedAt": "2026-07-14T17:32:22.984Z",
+      "status": "success"
+    }
+  }
+}

--- a/.manifests/src/intl/mr/component-swiper.json/source.json
+++ b/.manifests/src/intl/mr/component-swiper.json/source.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "sourceFile": "src/intl/en/component-swiper.json",
+  "generatedAt": "2026-07-14T17:32:23.516Z",
+  "rootHash": "faefe793571c",
+  "tree": {
+    "contentHash": "17f5cf39183e",
+    "anchorHash": "f5818652a990",
+    "children": {
+      "swiper-next-slide": {
+        "contentHash": "cdc93d1c8fe9",
+        "anchorHash": "e3b0c44298fc"
+      },
+      "swiper-previous-slide": {
+        "contentHash": "bfb549220c60",
+        "anchorHash": "e3b0c44298fc"
+      }
+    },
+    "childrenOrder": [
+      "swiper-next-slide",
+      "swiper-previous-slide"
+    ]
+  },
+  "sourceCommitSha": "775d68671a756bcd0db81828094c44e68f18e108"
+}

--- a/.manifests/src/intl/mr/component-swiper.json/translation.json
+++ b/.manifests/src/intl/mr/component-swiper.json/translation.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "locale": "mr",
+  "translatedAt": "2026-07-14T17:32:23.517Z",
+  "englishManifestHash": "faefe793571c",
+  "placeholderOrder": [],
+  "placeholderMap": {},
+  "sections": {
+    "_all": {
+      "translatedAt": "2026-07-14T17:32:23.517Z",
+      "status": "success"
+    }
+  }
+}

--- a/.manifests/src/intl/pl/component-swiper.json/source.json
+++ b/.manifests/src/intl/pl/component-swiper.json/source.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "sourceFile": "src/intl/en/component-swiper.json",
+  "generatedAt": "2026-07-14T17:32:23.169Z",
+  "rootHash": "faefe793571c",
+  "tree": {
+    "contentHash": "17f5cf39183e",
+    "anchorHash": "f5818652a990",
+    "children": {
+      "swiper-next-slide": {
+        "contentHash": "cdc93d1c8fe9",
+        "anchorHash": "e3b0c44298fc"
+      },
+      "swiper-previous-slide": {
+        "contentHash": "bfb549220c60",
+        "anchorHash": "e3b0c44298fc"
+      }
+    },
+    "childrenOrder": [
+      "swiper-next-slide",
+      "swiper-previous-slide"
+    ]
+  },
+  "sourceCommitSha": "775d68671a756bcd0db81828094c44e68f18e108"
+}

--- a/.manifests/src/intl/pl/component-swiper.json/translation.json
+++ b/.manifests/src/intl/pl/component-swiper.json/translation.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "locale": "pl",
+  "translatedAt": "2026-07-14T17:32:23.169Z",
+  "englishManifestHash": "faefe793571c",
+  "placeholderOrder": [],
+  "placeholderMap": {},
+  "sections": {
+    "_all": {
+      "translatedAt": "2026-07-14T17:32:23.169Z",
+      "status": "success"
+    }
+  }
+}

--- a/.manifests/src/intl/pt-br/component-swiper.json/source.json
+++ b/.manifests/src/intl/pt-br/component-swiper.json/source.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "sourceFile": "src/intl/en/component-swiper.json",
+  "generatedAt": "2026-07-14T17:32:23.821Z",
+  "rootHash": "faefe793571c",
+  "tree": {
+    "contentHash": "17f5cf39183e",
+    "anchorHash": "f5818652a990",
+    "children": {
+      "swiper-next-slide": {
+        "contentHash": "cdc93d1c8fe9",
+        "anchorHash": "e3b0c44298fc"
+      },
+      "swiper-previous-slide": {
+        "contentHash": "bfb549220c60",
+        "anchorHash": "e3b0c44298fc"
+      }
+    },
+    "childrenOrder": [
+      "swiper-next-slide",
+      "swiper-previous-slide"
+    ]
+  },
+  "sourceCommitSha": "775d68671a756bcd0db81828094c44e68f18e108"
+}

--- a/.manifests/src/intl/pt-br/component-swiper.json/translation.json
+++ b/.manifests/src/intl/pt-br/component-swiper.json/translation.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "locale": "pt-br",
+  "translatedAt": "2026-07-14T17:32:23.821Z",
+  "englishManifestHash": "faefe793571c",
+  "placeholderOrder": [],
+  "placeholderMap": {},
+  "sections": {
+    "_all": {
+      "translatedAt": "2026-07-14T17:32:23.821Z",
+      "status": "success"
+    }
+  }
+}

--- a/.manifests/src/intl/ru/component-swiper.json/source.json
+++ b/.manifests/src/intl/ru/component-swiper.json/source.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "sourceFile": "src/intl/en/component-swiper.json",
+  "generatedAt": "2026-07-14T17:32:23.148Z",
+  "rootHash": "faefe793571c",
+  "tree": {
+    "contentHash": "17f5cf39183e",
+    "anchorHash": "f5818652a990",
+    "children": {
+      "swiper-next-slide": {
+        "contentHash": "cdc93d1c8fe9",
+        "anchorHash": "e3b0c44298fc"
+      },
+      "swiper-previous-slide": {
+        "contentHash": "bfb549220c60",
+        "anchorHash": "e3b0c44298fc"
+      }
+    },
+    "childrenOrder": [
+      "swiper-next-slide",
+      "swiper-previous-slide"
+    ]
+  },
+  "sourceCommitSha": "775d68671a756bcd0db81828094c44e68f18e108"
+}

--- a/.manifests/src/intl/ru/component-swiper.json/translation.json
+++ b/.manifests/src/intl/ru/component-swiper.json/translation.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "locale": "ru",
+  "translatedAt": "2026-07-14T17:32:23.148Z",
+  "englishManifestHash": "faefe793571c",
+  "placeholderOrder": [],
+  "placeholderMap": {},
+  "sections": {
+    "_all": {
+      "translatedAt": "2026-07-14T17:32:23.148Z",
+      "status": "success"
+    }
+  }
+}

--- a/.manifests/src/intl/sw/component-swiper.json/source.json
+++ b/.manifests/src/intl/sw/component-swiper.json/source.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "sourceFile": "src/intl/en/component-swiper.json",
+  "generatedAt": "2026-07-14T17:32:23.124Z",
+  "rootHash": "faefe793571c",
+  "tree": {
+    "contentHash": "17f5cf39183e",
+    "anchorHash": "f5818652a990",
+    "children": {
+      "swiper-next-slide": {
+        "contentHash": "cdc93d1c8fe9",
+        "anchorHash": "e3b0c44298fc"
+      },
+      "swiper-previous-slide": {
+        "contentHash": "bfb549220c60",
+        "anchorHash": "e3b0c44298fc"
+      }
+    },
+    "childrenOrder": [
+      "swiper-next-slide",
+      "swiper-previous-slide"
+    ]
+  },
+  "sourceCommitSha": "775d68671a756bcd0db81828094c44e68f18e108"
+}

--- a/.manifests/src/intl/sw/component-swiper.json/translation.json
+++ b/.manifests/src/intl/sw/component-swiper.json/translation.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "locale": "sw",
+  "translatedAt": "2026-07-14T17:32:23.124Z",
+  "englishManifestHash": "faefe793571c",
+  "placeholderOrder": [],
+  "placeholderMap": {},
+  "sections": {
+    "_all": {
+      "translatedAt": "2026-07-14T17:32:23.124Z",
+      "status": "success"
+    }
+  }
+}

--- a/.manifests/src/intl/ta/component-swiper.json/source.json
+++ b/.manifests/src/intl/ta/component-swiper.json/source.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "sourceFile": "src/intl/en/component-swiper.json",
+  "generatedAt": "2026-07-14T17:32:27.928Z",
+  "rootHash": "faefe793571c",
+  "tree": {
+    "contentHash": "17f5cf39183e",
+    "anchorHash": "f5818652a990",
+    "children": {
+      "swiper-next-slide": {
+        "contentHash": "cdc93d1c8fe9",
+        "anchorHash": "e3b0c44298fc"
+      },
+      "swiper-previous-slide": {
+        "contentHash": "bfb549220c60",
+        "anchorHash": "e3b0c44298fc"
+      }
+    },
+    "childrenOrder": [
+      "swiper-next-slide",
+      "swiper-previous-slide"
+    ]
+  },
+  "sourceCommitSha": "775d68671a756bcd0db81828094c44e68f18e108"
+}

--- a/.manifests/src/intl/ta/component-swiper.json/translation.json
+++ b/.manifests/src/intl/ta/component-swiper.json/translation.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "locale": "ta",
+  "translatedAt": "2026-07-14T17:32:27.928Z",
+  "englishManifestHash": "faefe793571c",
+  "placeholderOrder": [],
+  "placeholderMap": {},
+  "sections": {
+    "_all": {
+      "translatedAt": "2026-07-14T17:32:27.928Z",
+      "status": "success"
+    }
+  }
+}

--- a/.manifests/src/intl/te/component-swiper.json/source.json
+++ b/.manifests/src/intl/te/component-swiper.json/source.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "sourceFile": "src/intl/en/component-swiper.json",
+  "generatedAt": "2026-07-14T17:32:28.313Z",
+  "rootHash": "faefe793571c",
+  "tree": {
+    "contentHash": "17f5cf39183e",
+    "anchorHash": "f5818652a990",
+    "children": {
+      "swiper-next-slide": {
+        "contentHash": "cdc93d1c8fe9",
+        "anchorHash": "e3b0c44298fc"
+      },
+      "swiper-previous-slide": {
+        "contentHash": "bfb549220c60",
+        "anchorHash": "e3b0c44298fc"
+      }
+    },
+    "childrenOrder": [
+      "swiper-next-slide",
+      "swiper-previous-slide"
+    ]
+  },
+  "sourceCommitSha": "775d68671a756bcd0db81828094c44e68f18e108"
+}

--- a/.manifests/src/intl/te/component-swiper.json/translation.json
+++ b/.manifests/src/intl/te/component-swiper.json/translation.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "locale": "te",
+  "translatedAt": "2026-07-14T17:32:28.313Z",
+  "englishManifestHash": "faefe793571c",
+  "placeholderOrder": [],
+  "placeholderMap": {},
+  "sections": {
+    "_all": {
+      "translatedAt": "2026-07-14T17:32:28.313Z",
+      "status": "success"
+    }
+  }
+}

--- a/.manifests/src/intl/tr/component-swiper.json/source.json
+++ b/.manifests/src/intl/tr/component-swiper.json/source.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "sourceFile": "src/intl/en/component-swiper.json",
+  "generatedAt": "2026-07-14T17:32:28.092Z",
+  "rootHash": "faefe793571c",
+  "tree": {
+    "contentHash": "17f5cf39183e",
+    "anchorHash": "f5818652a990",
+    "children": {
+      "swiper-next-slide": {
+        "contentHash": "cdc93d1c8fe9",
+        "anchorHash": "e3b0c44298fc"
+      },
+      "swiper-previous-slide": {
+        "contentHash": "bfb549220c60",
+        "anchorHash": "e3b0c44298fc"
+      }
+    },
+    "childrenOrder": [
+      "swiper-next-slide",
+      "swiper-previous-slide"
+    ]
+  },
+  "sourceCommitSha": "775d68671a756bcd0db81828094c44e68f18e108"
+}

--- a/.manifests/src/intl/tr/component-swiper.json/translation.json
+++ b/.manifests/src/intl/tr/component-swiper.json/translation.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "locale": "tr",
+  "translatedAt": "2026-07-14T17:32:28.092Z",
+  "englishManifestHash": "faefe793571c",
+  "placeholderOrder": [],
+  "placeholderMap": {},
+  "sections": {
+    "_all": {
+      "translatedAt": "2026-07-14T17:32:28.092Z",
+      "status": "success"
+    }
+  }
+}

--- a/.manifests/src/intl/uk/component-swiper.json/source.json
+++ b/.manifests/src/intl/uk/component-swiper.json/source.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "sourceFile": "src/intl/en/component-swiper.json",
+  "generatedAt": "2026-07-14T17:32:27.608Z",
+  "rootHash": "faefe793571c",
+  "tree": {
+    "contentHash": "17f5cf39183e",
+    "anchorHash": "f5818652a990",
+    "children": {
+      "swiper-next-slide": {
+        "contentHash": "cdc93d1c8fe9",
+        "anchorHash": "e3b0c44298fc"
+      },
+      "swiper-previous-slide": {
+        "contentHash": "bfb549220c60",
+        "anchorHash": "e3b0c44298fc"
+      }
+    },
+    "childrenOrder": [
+      "swiper-next-slide",
+      "swiper-previous-slide"
+    ]
+  },
+  "sourceCommitSha": "775d68671a756bcd0db81828094c44e68f18e108"
+}

--- a/.manifests/src/intl/uk/component-swiper.json/translation.json
+++ b/.manifests/src/intl/uk/component-swiper.json/translation.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "locale": "uk",
+  "translatedAt": "2026-07-14T17:32:27.609Z",
+  "englishManifestHash": "faefe793571c",
+  "placeholderOrder": [],
+  "placeholderMap": {},
+  "sections": {
+    "_all": {
+      "translatedAt": "2026-07-14T17:32:27.608Z",
+      "status": "success"
+    }
+  }
+}

--- a/.manifests/src/intl/ur/component-swiper.json/source.json
+++ b/.manifests/src/intl/ur/component-swiper.json/source.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "sourceFile": "src/intl/en/component-swiper.json",
+  "generatedAt": "2026-07-14T17:32:28.966Z",
+  "rootHash": "faefe793571c",
+  "tree": {
+    "contentHash": "17f5cf39183e",
+    "anchorHash": "f5818652a990",
+    "children": {
+      "swiper-next-slide": {
+        "contentHash": "cdc93d1c8fe9",
+        "anchorHash": "e3b0c44298fc"
+      },
+      "swiper-previous-slide": {
+        "contentHash": "bfb549220c60",
+        "anchorHash": "e3b0c44298fc"
+      }
+    },
+    "childrenOrder": [
+      "swiper-next-slide",
+      "swiper-previous-slide"
+    ]
+  },
+  "sourceCommitSha": "775d68671a756bcd0db81828094c44e68f18e108"
+}

--- a/.manifests/src/intl/ur/component-swiper.json/translation.json
+++ b/.manifests/src/intl/ur/component-swiper.json/translation.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "locale": "ur",
+  "translatedAt": "2026-07-14T17:32:28.966Z",
+  "englishManifestHash": "faefe793571c",
+  "placeholderOrder": [],
+  "placeholderMap": {},
+  "sections": {
+    "_all": {
+      "translatedAt": "2026-07-14T17:32:28.966Z",
+      "status": "success"
+    }
+  }
+}

--- a/.manifests/src/intl/vi/component-swiper.json/source.json
+++ b/.manifests/src/intl/vi/component-swiper.json/source.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "sourceFile": "src/intl/en/component-swiper.json",
+  "generatedAt": "2026-07-14T17:32:28.270Z",
+  "rootHash": "faefe793571c",
+  "tree": {
+    "contentHash": "17f5cf39183e",
+    "anchorHash": "f5818652a990",
+    "children": {
+      "swiper-next-slide": {
+        "contentHash": "cdc93d1c8fe9",
+        "anchorHash": "e3b0c44298fc"
+      },
+      "swiper-previous-slide": {
+        "contentHash": "bfb549220c60",
+        "anchorHash": "e3b0c44298fc"
+      }
+    },
+    "childrenOrder": [
+      "swiper-next-slide",
+      "swiper-previous-slide"
+    ]
+  },
+  "sourceCommitSha": "775d68671a756bcd0db81828094c44e68f18e108"
+}

--- a/.manifests/src/intl/vi/component-swiper.json/translation.json
+++ b/.manifests/src/intl/vi/component-swiper.json/translation.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "locale": "vi",
+  "translatedAt": "2026-07-14T17:32:28.270Z",
+  "englishManifestHash": "faefe793571c",
+  "placeholderOrder": [],
+  "placeholderMap": {},
+  "sections": {
+    "_all": {
+      "translatedAt": "2026-07-14T17:32:28.270Z",
+      "status": "success"
+    }
+  }
+}

--- a/.manifests/src/intl/zh-tw/component-swiper.json/source.json
+++ b/.manifests/src/intl/zh-tw/component-swiper.json/source.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "sourceFile": "src/intl/en/component-swiper.json",
+  "generatedAt": "2026-07-14T17:32:29.583Z",
+  "rootHash": "faefe793571c",
+  "tree": {
+    "contentHash": "17f5cf39183e",
+    "anchorHash": "f5818652a990",
+    "children": {
+      "swiper-next-slide": {
+        "contentHash": "cdc93d1c8fe9",
+        "anchorHash": "e3b0c44298fc"
+      },
+      "swiper-previous-slide": {
+        "contentHash": "bfb549220c60",
+        "anchorHash": "e3b0c44298fc"
+      }
+    },
+    "childrenOrder": [
+      "swiper-next-slide",
+      "swiper-previous-slide"
+    ]
+  },
+  "sourceCommitSha": "775d68671a756bcd0db81828094c44e68f18e108"
+}

--- a/.manifests/src/intl/zh-tw/component-swiper.json/translation.json
+++ b/.manifests/src/intl/zh-tw/component-swiper.json/translation.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "locale": "zh-tw",
+  "translatedAt": "2026-07-14T17:32:29.584Z",
+  "englishManifestHash": "faefe793571c",
+  "placeholderOrder": [],
+  "placeholderMap": {},
+  "sections": {
+    "_all": {
+      "translatedAt": "2026-07-14T17:32:29.584Z",
+      "status": "success"
+    }
+  }
+}

--- a/.manifests/src/intl/zh/component-swiper.json/source.json
+++ b/.manifests/src/intl/zh/component-swiper.json/source.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "sourceFile": "src/intl/en/component-swiper.json",
+  "generatedAt": "2026-07-14T17:32:30.693Z",
+  "rootHash": "faefe793571c",
+  "tree": {
+    "contentHash": "17f5cf39183e",
+    "anchorHash": "f5818652a990",
+    "children": {
+      "swiper-next-slide": {
+        "contentHash": "cdc93d1c8fe9",
+        "anchorHash": "e3b0c44298fc"
+      },
+      "swiper-previous-slide": {
+        "contentHash": "bfb549220c60",
+        "anchorHash": "e3b0c44298fc"
+      }
+    },
+    "childrenOrder": [
+      "swiper-next-slide",
+      "swiper-previous-slide"
+    ]
+  },
+  "sourceCommitSha": "775d68671a756bcd0db81828094c44e68f18e108"
+}

--- a/.manifests/src/intl/zh/component-swiper.json/translation.json
+++ b/.manifests/src/intl/zh/component-swiper.json/translation.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "locale": "zh",
+  "translatedAt": "2026-07-14T17:32:30.693Z",
+  "englishManifestHash": "faefe793571c",
+  "placeholderOrder": [],
+  "placeholderMap": {},
+  "sections": {
+    "_all": {
+      "translatedAt": "2026-07-14T17:32:30.693Z",
+      "status": "success"
+    }
+  }
+}

--- a/src/intl/ar/component-swiper.json
+++ b/src/intl/ar/component-swiper.json
@@ -1,0 +1,4 @@
+{
+  "swiper-next-slide": "الشريحة التالية",
+  "swiper-previous-slide": "الشريحة السابقة"
+}

--- a/src/intl/bn/component-swiper.json
+++ b/src/intl/bn/component-swiper.json
@@ -1,0 +1,4 @@
+{
+  "swiper-next-slide": "পরবর্তী স্লাইড",
+  "swiper-previous-slide": "পূর্ববর্তী স্লাইড"
+}

--- a/src/intl/cs/component-swiper.json
+++ b/src/intl/cs/component-swiper.json
@@ -1,0 +1,4 @@
+{
+  "swiper-next-slide": "Další snímek",
+  "swiper-previous-slide": "Předchozí snímek"
+}

--- a/src/intl/de/component-swiper.json
+++ b/src/intl/de/component-swiper.json
@@ -1,0 +1,4 @@
+{
+  "swiper-next-slide": "Nächste Folie",
+  "swiper-previous-slide": "Vorherige Folie"
+}

--- a/src/intl/es/component-swiper.json
+++ b/src/intl/es/component-swiper.json
@@ -1,0 +1,4 @@
+{
+  "swiper-next-slide": "Siguiente diapositiva",
+  "swiper-previous-slide": "Diapositiva anterior"
+}

--- a/src/intl/fr/component-swiper.json
+++ b/src/intl/fr/component-swiper.json
@@ -1,0 +1,4 @@
+{
+  "swiper-next-slide": "Diapositive suivante",
+  "swiper-previous-slide": "Diapositive précédente"
+}

--- a/src/intl/hi/component-swiper.json
+++ b/src/intl/hi/component-swiper.json
@@ -1,0 +1,4 @@
+{
+  "swiper-next-slide": "अगली स्लाइड",
+  "swiper-previous-slide": "पिछली स्लाइड"
+}

--- a/src/intl/id/component-swiper.json
+++ b/src/intl/id/component-swiper.json
@@ -1,0 +1,4 @@
+{
+  "swiper-next-slide": "Slide selanjutnya",
+  "swiper-previous-slide": "Slide sebelumnya"
+}

--- a/src/intl/it/component-swiper.json
+++ b/src/intl/it/component-swiper.json
@@ -1,0 +1,4 @@
+{
+  "swiper-next-slide": "Slide successiva",
+  "swiper-previous-slide": "Slide precedente"
+}

--- a/src/intl/ja/component-swiper.json
+++ b/src/intl/ja/component-swiper.json
@@ -1,0 +1,4 @@
+{
+  "swiper-next-slide": "次のスライド",
+  "swiper-previous-slide": "前のスライド"
+}

--- a/src/intl/ko/component-swiper.json
+++ b/src/intl/ko/component-swiper.json
@@ -1,0 +1,4 @@
+{
+  "swiper-next-slide": "다음 슬라이드",
+  "swiper-previous-slide": "이전 슬라이드"
+}

--- a/src/intl/mr/component-swiper.json
+++ b/src/intl/mr/component-swiper.json
@@ -1,0 +1,4 @@
+{
+  "swiper-next-slide": "पुढील स्लाईड",
+  "swiper-previous-slide": "मागील स्लाईड"
+}

--- a/src/intl/pl/component-swiper.json
+++ b/src/intl/pl/component-swiper.json
@@ -1,0 +1,4 @@
+{
+  "swiper-next-slide": "Następny slajd",
+  "swiper-previous-slide": "Poprzedni slajd"
+}

--- a/src/intl/pt-br/component-swiper.json
+++ b/src/intl/pt-br/component-swiper.json
@@ -1,0 +1,4 @@
+{
+  "swiper-next-slide": "Próximo slide",
+  "swiper-previous-slide": "Slide anterior"
+}

--- a/src/intl/ru/component-swiper.json
+++ b/src/intl/ru/component-swiper.json
@@ -1,0 +1,4 @@
+{
+  "swiper-next-slide": "Следующий слайд",
+  "swiper-previous-slide": "Предыдущий слайд"
+}

--- a/src/intl/sw/component-swiper.json
+++ b/src/intl/sw/component-swiper.json
@@ -1,0 +1,4 @@
+{
+  "swiper-next-slide": "Slaidi inayofuata",
+  "swiper-previous-slide": "Slaidi iliyopita"
+}

--- a/src/intl/ta/component-swiper.json
+++ b/src/intl/ta/component-swiper.json
@@ -1,0 +1,4 @@
+{
+  "swiper-next-slide": "அடுத்த ஸ்லைடு",
+  "swiper-previous-slide": "முந்தைய ஸ்லைடு"
+}

--- a/src/intl/te/component-swiper.json
+++ b/src/intl/te/component-swiper.json
@@ -1,0 +1,4 @@
+{
+  "swiper-next-slide": "తదుపరి స్లయిడ్",
+  "swiper-previous-slide": "మునుపటి స్లయిడ్"
+}

--- a/src/intl/tr/component-swiper.json
+++ b/src/intl/tr/component-swiper.json
@@ -1,0 +1,4 @@
+{
+  "swiper-next-slide": "Sonraki slayt",
+  "swiper-previous-slide": "Önceki slayt"
+}

--- a/src/intl/uk/component-swiper.json
+++ b/src/intl/uk/component-swiper.json
@@ -1,0 +1,4 @@
+{
+  "swiper-next-slide": "Наступний слайд",
+  "swiper-previous-slide": "Попередній слайд"
+}

--- a/src/intl/ur/component-swiper.json
+++ b/src/intl/ur/component-swiper.json
@@ -1,0 +1,4 @@
+{
+  "swiper-next-slide": "اگلی سلائیڈ",
+  "swiper-previous-slide": "پچھلی سلائیڈ"
+}

--- a/src/intl/vi/component-swiper.json
+++ b/src/intl/vi/component-swiper.json
@@ -1,0 +1,4 @@
+{
+  "swiper-next-slide": "Slide tiếp theo",
+  "swiper-previous-slide": "Slide trước"
+}

--- a/src/intl/zh-tw/component-swiper.json
+++ b/src/intl/zh-tw/component-swiper.json
@@ -1,0 +1,4 @@
+{
+  "swiper-next-slide": "下一張幻燈片",
+  "swiper-previous-slide": "上一張幻燈片"
+}

--- a/src/intl/zh/component-swiper.json
+++ b/src/intl/zh/component-swiper.json
@@ -1,0 +1,4 @@
+{
+  "swiper-next-slide": "下一张幻灯片",
+  "swiper-previous-slide": "上一张幻灯片"
+}


### PR DESCRIPTION
## Automated Translations

This PR contains translations managed by the intl pipeline.
Each run appends a summary below.

---
### Run: 2026-07-14 17:33:11 UTC
- Languages: ar, bn, cs, de, es, fr, hi, id, it, ja, ko, mr, pl, pt-br, ru, sw, ta, te, tr, uk, ur, vi, zh-tw, zh
- Files: 24 (0 MD, 24 JSON)
- Mode: auto
- [View workflow run](https://github.com/ethereum/ethereum-org-website/actions/runs/29354079190)
