### PR TITLE
[recovery] fix: setRequestLocale ordering in [...slug] generateMetadata (static→dynamic error)

### DIFF
--- a/app/[locale]/[...slug]/page.tsx
+++ b/app/[locale]/[...slug]/page.tsx
@@ -154,6 +154,9 @@ export async function generateMetadata(props: {
   const params = await props.params
   const { locale, slug } = params
 
+  // Set locale before next-intl APIs so on-demand renders stay static
+  setRequestLocale(locale)
+
   try {
     return await getMdMetadata({
       locale,


### PR DESCRIPTION
## Production error

- **Fingerprint:** `grafana-fn-error-page-changed-from-static-to-dynamic-at-runtime-images-videos-clw-qfnsu`
- **Message:** `[ERROR] ⨯ Error: Page changed from static to dynamic at runtime /images/videos/Clw-qf1sUZg.jpg, reason: headers`
- **Hit count:** 2
- Stack terminates in `get requestLocale` (next-intl).

## Root cause

`/images/videos/Clw-qf1sUZg.jpg` has no static asset and falls through to the catch-all `app/[locale]/[...slug]/page.tsx` with `locale="images"`, `slug=["videos","Clw-qf1sUZg.jpg"]` (a bot/broken-link probe against a YouTube-ID-shaped path).

`generateMetadata` in that route never called `setRequestLocale(locale)` before invoking next-intl APIs:
- the happy path `getMdMetadata` → `getMetadata` calls `getTranslations("common")` (`src/lib/utils/metadata.ts:66`);
- the `catch` block also calls `getTranslations("common")`.

Without `setRequestLocale`, next-intl falls back to reading the locale from request `headers()` for on-demand slugs (those not covered by `generateStaticParams`), which opts the route into dynamic rendering and throws *"Page changed from static to dynamic at runtime … reason: headers"*.

## Fix

Add `setRequestLocale(locale)` at the top of `generateMetadata`, before any next-intl call. Same class of fix as #18785 (videos slug), #18797 (wallets), #18798 (resources).

## Verification

- `pnpm type-check` ✅
- `pnpm exec eslint` on changed file ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)