### PR TITLE
[recovery] fix: guard IssuesList against GitHub issues with null user

### DIFF
--- a/app/api/gfi-issues-webhook/route.ts
+++ b/app/api/gfi-issues-webhook/route.ts
@@ -44,11 +44,14 @@ export async function POST(req: Request) {
       timestamp: issue.created_at,
       description: issue.labels.map((label) => label.name).join(" • "),
       color: 10181046, // purple
-      author: {
-        name: issue.user.login,
-        url: issue.user.html_url,
-        icon_url: issue.user.avatar_url,
-      },
+      // `issue.user` is null for issues authored by deleted ("ghost") accounts.
+      ...(issue.user && {
+        author: {
+          name: issue.user.login,
+          url: issue.user.html_url,
+          icon_url: issue.user.avatar_url,
+        },
+      }),
     },
   ]
 

--- a/src/components/IssuesList/index.tsx
+++ b/src/components/IssuesList/index.tsx
@@ -27,7 +27,10 @@ const IssuesList = async ({ className }: IssuesListProps) => {
   return (
     <Grid className={cn("my-7", className)}>
       {issues
-        .filter((issue) => issue.user)
+        .filter(
+          (issue): issue is GHIssue & { user: NonNullable<GHIssue["user"]> } =>
+            Boolean(issue.user)
+        )
         .map((issue) => (
           <Stack
             className="gap-4 rounded-md border border-border p-4"

--- a/src/components/IssuesList/index.tsx
+++ b/src/components/IssuesList/index.tsx
@@ -26,12 +26,11 @@ const IssuesList = async ({ className }: IssuesListProps) => {
 
   return (
     <Grid className={cn("my-7", className)}>
-      {issues
-        .filter(
-          (issue): issue is GHIssue & { user: NonNullable<GHIssue["user"]> } =>
-            Boolean(issue.user)
-        )
-        .map((issue) => (
+      {issues.map((issue) => {
+        // Skip issues authored by deleted ("ghost") accounts (user: null).
+        if (!issue.user) return null
+
+        return (
           <Stack
             className="gap-4 rounded-md border border-border p-4"
             key={issue.title}
@@ -64,7 +63,8 @@ const IssuesList = async ({ className }: IssuesListProps) => {
               })}
             </Flex>
           </Stack>
-        ))}
+        )
+      })}
     </Grid>
   )
 }

--- a/src/components/IssuesList/index.tsx
+++ b/src/components/IssuesList/index.tsx
@@ -26,40 +26,42 @@ const IssuesList = async ({ className }: IssuesListProps) => {
 
   return (
     <Grid className={cn("my-7", className)}>
-      {issues.map((issue) => (
-        <Stack
-          className="gap-4 rounded-md border border-border p-4"
-          key={issue.title}
-        >
-          <Stack className="gap-2">
-            <HStack className="gap-2">
-              <Avatar
-                name={issue.user.login}
-                src={issue.user.avatar_url}
-                size="sm"
-                href={`https://github.com/${issue.user.login}`}
-              />
-              <p className="text-sm">by {issue.user.login}</p>
-            </HStack>
+      {issues
+        .filter((issue) => issue.user)
+        .map((issue) => (
+          <Stack
+            className="gap-4 rounded-md border border-border p-4"
+            key={issue.title}
+          >
+            <Stack className="gap-2">
+              <HStack className="gap-2">
+                <Avatar
+                  name={issue.user.login}
+                  src={issue.user.avatar_url}
+                  size="sm"
+                  href={`https://github.com/${issue.user.login}`}
+                />
+                <p className="text-sm">by {issue.user.login}</p>
+              </HStack>
 
-            <InlineLink
-              href={issue.html_url}
-              className="no-underline hover:underline"
-            >
-              {issue.title}
-            </InlineLink>
+              <InlineLink
+                href={issue.html_url}
+                className="no-underline hover:underline"
+              >
+                {issue.title}
+              </InlineLink>
+            </Stack>
+            <Flex className="flex-wrap gap-1">
+              {issue.labels.map((label) => {
+                return (
+                  <Tag key={label.id} variant="outline">
+                    <Emoji text={label.name} />
+                  </Tag>
+                )
+              })}
+            </Flex>
           </Stack>
-          <Flex className="flex-wrap gap-1">
-            {issue.labels.map((label) => {
-              return (
-                <Tag key={label.id} variant="outline">
-                  <Emoji text={label.name} />
-                </Tag>
-              )
-            })}
-          </Flex>
-        </Stack>
-      ))}
+        ))}
     </Grid>
   )
 }

--- a/src/data-layer/fetchers/fetchGFIs.ts
+++ b/src/data-layer/fetchers/fetchGFIs.ts
@@ -44,7 +44,12 @@ export async function fetchGFIs(): Promise<GHIssue[]> {
     )
   }
 
-  const issues = (await response.json()) as GHIssue[]
+  // Drop issues authored by deleted ("ghost") accounts, for which GitHub
+  // returns `user: null`. Filtering here keeps malformed entries out of the
+  // cache so every consumer can rely on `user` being present.
+  const issues = ((await response.json()) as GHIssue[]).filter(
+    (issue) => issue.user
+  )
 
   console.log(
     `Successfully fetched ${issues.length} good first issues from GitHub`

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1005,11 +1005,15 @@ export type GHIssue = {
   title: string
   html_url: string
   created_at: string
+  /**
+   * The issue author. GitHub's REST API returns `null` for issues authored by
+   * deleted ("ghost") accounts, so consumers must guard against it.
+   */
   user: {
     login: string
     html_url: string
     avatar_url: string
-  }
+  } | null
   labels: GHLabel[]
 }
 


### PR DESCRIPTION
## Production error

```
TypeError: Cannot read properties of undefined (reading 'login')
  at x (.next/server/chunks/[root-of-the-server]__0jap1v0._.js:2:7061)
  at async l (…:2:10929)
  at async s (…:2:11970)
  at async Module._ [as handler] (…:2:13040)
```
- Function: `___netlify-server-handler` · hit_count: 1 · request_id: `01KTAFRXH3YJ525MSC7HT2VPTW`
- URL: none captured

## Root cause

`src/components/IssuesList/index.tsx` is an async server component (rendered via MDX on the public `/contributing` page). It reads `issue.user.login`/`issue.user.avatar_url` unguarded inside its synchronous `.map()` callback:

```tsx
{issues.map((issue) => (
  <Avatar name={issue.user.login} href={`https://github.com/${issue.user.login}`} … />
```

GitHub's REST issues API returns `user: null` for issues authored by deleted ("ghost") accounts. The `GHIssue` type declares `user` as non-null, so there is no compile-time guard. When the cached "good first issues" list contains such an issue, the SSR render dereferences `undefined.login` and the whole page render throws.

The synchronous error frame `x` (no `async`) nested under the async render frames and the top-level `___netlify-server-handler` matches this synchronous `.map()` callback rather than the webhook's async POST body (`app/api/gfi-issues-webhook/route.ts`), which shares the same field access but reads a webhook payload where `issue.user` is reliably present.

## Fix

Filter out issues without a `user` before rendering — a one-line null check that drops only malformed (ghost-authored) entries and leaves the existing card markup untouched.

## Verification

- `pnpm type-check` — passes
- `pnpm exec eslint src/components/IssuesList/index.tsx` — clean