### PR TITLE
fix: build sitemap.xml statically

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -6,6 +6,13 @@ import { DEFAULT_LOCALE } from "@/lib/constants"
 
 import { getAllPagesWithTranslations } from "@/lib/i18n/translationRegistry"
 
+// Generate at build time only. Without this the route's transitive data-layer
+// dependency (finite-revalidate getters) opts it into ISR, so Netlify re-renders
+// it in the serverless function where public/content is excluded from the bundle
+// -- yielding empty markdown slugs and a truncated sitemap. No `revalidate`: ISR
+// re-enters that broken path; freshness rides the deploy cadence instead.
+export const dynamic = "force-static"
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const pages = await getAllPagesWithTranslations()
 

--- a/src/lib/data/index.ts
+++ b/src/lib/data/index.ts
@@ -181,6 +181,19 @@ export const getDeveloperToolsData = createCachedGetter(
   CACHE_REVALIDATE_DAY
 )
 
+/**
+ * Static-cached version of getDeveloperToolsData -- no revalidation.
+ * Used by the force-static sitemap: a finite revalidate opts the route into
+ * ISR, whose serverless re-render can't read public/content (excluded from the
+ * function bundle), yielding a truncated/empty sitemap. Refreshes on deploy.
+ * See: docs/solutions/integration-issues/netlify-isr-404-async-server-components.md
+ */
+export const getStaticDeveloperToolsData = createCachedGetter(
+  dataLayer.getDeveloperToolsData,
+  ["developer-tools-data-static"],
+  false
+)
+
 export const getAccountHolders = createCachedGetter(
   dataLayer.getAccountHolders,
   ["account-holders"],

--- a/src/lib/i18n/translationRegistry.ts
+++ b/src/lib/i18n/translationRegistry.ts
@@ -99,7 +99,7 @@ async function getDynamicIntlPagePaths(): Promise<string[]> {
   // Next.js-only modules can still load this file to test getTranslatedLocales.
   const [
     { appsCategories },
-    { getAppsData, getDeveloperToolsData },
+    { getStaticAppsData, getStaticDeveloperToolsData },
     { getToolKey, normalizeDeveloperToolsData, withCategories },
     { slugify },
   ] = await Promise.all([
@@ -111,7 +111,9 @@ async function getDynamicIntlPagePaths(): Promise<string[]> {
 
   // discoverStaticPages() excludes dynamic segments, so add known
   // generateStaticParams() routes that should be present in sitemap output.
-  const toolsData = normalizeDeveloperToolsData(await getDeveloperToolsData())
+  const toolsData = normalizeDeveloperToolsData(
+    await getStaticDeveloperToolsData()
+  )
   const devToolPaths =
     toolsData?.taxonomy.categories.definitions.map(
       (category) => `/developers/tools/categories/${category.id}/`
@@ -130,7 +132,7 @@ async function getDynamicIntlPagePaths(): Promise<string[]> {
   )
 
   // Individual app pages
-  const appsData = await getAppsData()
+  const appsData = await getStaticAppsData()
   const appPaths = appsData
     ? Object.values(appsData)
         .flat()

--- a/src/lib/utils/videos.ts
+++ b/src/lib/utils/videos.ts
@@ -123,8 +123,21 @@ export async function getVideoSlugs(): Promise<string[]> {
   if (slugsCache) return slugsCache
 
   const videosDir = join(process.cwd(), CONTENT_DIR, "videos")
-  const entries = await readdir(videosDir, { withFileTypes: true })
-  slugsCache = entries.filter((e) => e.isDirectory()).map((e) => e.name)
+  try {
+    const entries = await readdir(videosDir, { withFileTypes: true })
+    slugsCache = entries.filter((e) => e.isDirectory()).map((e) => e.name)
+  } catch (error) {
+    // Directory absent in the serverless runtime (public/content excluded from
+    // the function bundle). Match getPostSlugs: warn and return an empty list.
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      console.warn(
+        `Content directory ${videosDir} not found, returning empty slug list`
+      )
+      slugsCache = []
+    } else {
+      throw error
+    }
+  }
   return slugsCache
 }
 


### PR DESCRIPTION
## Summary

Part 1 of #18014. Makes `/sitemap.xml` build statically so it stops rendering in the Netlify serverless function, where `public/content/` is excluded from the bundle.

## Root cause

`app/sitemap.ts` -> `getAllPagesWithTranslations()` -> `getDynamicIntlPagePaths()` calls `getAppsData()` and `getDeveloperToolsData()`. Both are `createCachedGetter` wrappers with a finite `revalidate` (`CACHE_REVALIDATE_DAY`), which opts the route into ISR. Netlify then re-renders the sitemap in the serverless function, where `public/content/` is stripped from the bundle via `outputFileTracingExcludes` (`next.config.js`). `getPostSlugs("/")` hits `ENOENT`, returns `[]`, and the sitemap silently drops every markdown-driven page and truncates nondeterministically.

This is the same failure class already documented in [`docs/solutions/integration-issues/netlify-isr-404-async-server-components.md`](../blob/dev/docs/solutions/integration-issues/netlify-isr-404-async-server-components.md); the repo already ships `getStaticAppsData` (`revalidate: false`) as the sanctioned escape hatch for exactly this.

## Changes

- Add `getStaticDeveloperToolsData` (`revalidate: false`) mirroring the existing `getStaticAppsData`.
- Point the sitemap's data reads at the static getters (`getStaticAppsData` / `getStaticDeveloperToolsData`), removing the ISR trigger.
- `export const dynamic = "force-static"` on `app/sitemap.ts`, deliberately **without** `revalidate` (ISR would re-enter the broken lambda path; freshness rides the deploy cadence).
- Guard `getVideoSlugs()` against `ENOENT` to match `getPostSlugs`, silencing the companion Grafana error.

## Scope / what this does NOT fix

The sitemap is now **complete** but is still a **single ~51 MB file** (17.5k URLs x ~26 hreflang alternates), which is over Google's 50 MB per-file limit and rejected on size. Per-locale sharding via `generateSitemaps()` lands in a **stacked follow-up PR** and is required before the file is accepted. A CI regression guard (parse each shard, assert closing `</urlset>`, URL-count floor, sentinel late-alphabet URL) follows that.

## Verification

- `pnpm type-check` and `pnpm lint` pass.
- The empty-slug failure is Netlify-lambda-only and does not reproduce locally (`public/content/` is always present in dev), so the deploy preview is the real verification surface.

-- Opus 4.8
