### PR TITLE
fix: setRequestLocale before next-intl APIs in all generateMetadata

### DIFF
--- a/app/[locale]/10years/page.tsx
+++ b/app/[locale]/10years/page.tsx
@@ -375,6 +375,8 @@ export async function generateMetadata(props: {
   const params = await props.params
   const { locale } = params
 
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-10-year-anniversary")
 
   return await getMetadata({

--- a/app/[locale]/[...slug]/page.tsx
+++ b/app/[locale]/[...slug]/page.tsx
@@ -154,6 +154,8 @@ export async function generateMetadata(props: {
   const params = await props.params
   const { locale, slug } = params
 
+  setRequestLocale(locale)
+
   try {
     return await getMdMetadata({
       locale,

--- a/app/[locale]/apps/[application]/page.tsx
+++ b/app/[locale]/apps/[application]/page.tsx
@@ -435,6 +435,8 @@ export async function generateMetadata(props: {
   const params = await props.params
   const { locale, application } = params
 
+  setRequestLocale(locale)
+
   try {
     // Fetch apps data using the new data-layer function (already cached)
     const appsData = await getAppsData()

--- a/app/[locale]/apps/categories/[catetgoryName]/page.tsx
+++ b/app/[locale]/apps/categories/[catetgoryName]/page.tsx
@@ -223,6 +223,8 @@ export async function generateMetadata(props: {
   const params = await props.params
   const { locale, catetgoryName } = params
 
+  setRequestLocale(locale)
+
   try {
     const t = await getTranslations("page-apps")
 

--- a/app/[locale]/apps/page.tsx
+++ b/app/[locale]/apps/page.tsx
@@ -213,6 +213,9 @@ export async function generateMetadata(props: {
 }) {
   const params = await props.params
   const { locale } = params
+
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-apps")
 
   return await getMetadata({

--- a/app/[locale]/assets/page.tsx
+++ b/app/[locale]/assets/page.tsx
@@ -419,6 +419,8 @@ export async function generateMetadata(props: {
   const params = await props.params
   const { locale } = params
 
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-assets")
 
   return await getMetadata({

--- a/app/[locale]/bug-bounty/page.tsx
+++ b/app/[locale]/bug-bounty/page.tsx
@@ -1,4 +1,4 @@
-import { getTranslations } from "next-intl/server"
+import { getTranslations, setRequestLocale } from "next-intl/server"
 
 import type { Lang, Params } from "@/lib/types"
 
@@ -834,6 +834,8 @@ export async function generateMetadata(props: {
 }) {
   const params = await props.params
   const { locale } = params
+
+  setRequestLocale(locale)
 
   const t = await getTranslations("page-bug-bounty")
 

--- a/app/[locale]/collectibles/page.tsx
+++ b/app/[locale]/collectibles/page.tsx
@@ -159,6 +159,9 @@ export async function generateMetadata(props: {
 }) {
   const params = await props.params
   const { locale } = params
+
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-collectibles")
   return await getMetadata({
     locale,

--- a/app/[locale]/community/events/conferences/page.tsx
+++ b/app/[locale]/community/events/conferences/page.tsx
@@ -1,4 +1,4 @@
-import { getTranslations } from "next-intl/server"
+import { getTranslations, setRequestLocale } from "next-intl/server"
 
 import type { Lang, PageParams } from "@/lib/types"
 
@@ -152,6 +152,9 @@ export async function generateMetadata(props: {
 }) {
   const params = await props.params
   const { locale } = params
+
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-community-events")
 
   const year = getLocaleYear(locale)

--- a/app/[locale]/community/events/meetups/page.tsx
+++ b/app/[locale]/community/events/meetups/page.tsx
@@ -1,5 +1,9 @@
 import { pick } from "lodash"
-import { getMessages, getTranslations } from "next-intl/server"
+import {
+  getMessages,
+  getTranslations,
+  setRequestLocale,
+} from "next-intl/server"
 
 import type { Lang, PageParams } from "@/lib/types"
 
@@ -91,6 +95,9 @@ export async function generateMetadata(props: {
 }) {
   const params = await props.params
   const { locale } = params
+
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-community-events")
 
   const year = getLocaleYear(locale)

--- a/app/[locale]/community/events/page.tsx
+++ b/app/[locale]/community/events/page.tsx
@@ -6,7 +6,11 @@ import {
   Plus,
   Presentation,
 } from "lucide-react"
-import { getMessages, getTranslations } from "next-intl/server"
+import {
+  getMessages,
+  getTranslations,
+  setRequestLocale,
+} from "next-intl/server"
 
 import type { Lang, PageParams, SectionNavDetails } from "@/lib/types"
 
@@ -564,6 +568,9 @@ export async function generateMetadata(props: {
 }) {
   const params = await props.params
   const { locale } = params
+
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-community-events")
 
   const year = getLocaleYear(locale)

--- a/app/[locale]/community/events/search/page.tsx
+++ b/app/[locale]/community/events/search/page.tsx
@@ -152,6 +152,9 @@ export async function generateMetadata(props: {
 }) {
   const params = await props.params
   const { locale } = params
+
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-community-events")
 
   return await getMetadata({

--- a/app/[locale]/community/page.tsx
+++ b/app/[locale]/community/page.tsx
@@ -304,6 +304,8 @@ export async function generateMetadata(props: {
   const params = await props.params
   const { locale } = params
 
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-community")
   return await getMetadata({
     locale,

--- a/app/[locale]/community/support/page.tsx
+++ b/app/[locale]/community/support/page.tsx
@@ -192,6 +192,8 @@ export async function generateMetadata(props: {
   const params = await props.params
   const { locale } = params
 
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-community-support")
 
   return await getMetadata({

--- a/app/[locale]/contributing/translation-program/acknowledgements/page.tsx
+++ b/app/[locale]/contributing/translation-program/acknowledgements/page.tsx
@@ -240,6 +240,8 @@ export async function generateMetadata(props: {
   const params = await props.params
   const { locale } = params
 
+  setRequestLocale(locale)
+
   const t = await getTranslations(
     "page-contributing-translation-program-acknowledgements"
   )

--- a/app/[locale]/contributing/translation-program/contributors/page.tsx
+++ b/app/[locale]/contributing/translation-program/contributors/page.tsx
@@ -117,6 +117,8 @@ export async function generateMetadata(props: {
   const params = await props.params
   const { locale } = params
 
+  setRequestLocale(locale)
+
   const t = await getTranslations(NAMESPACE)
 
   return await getMetadata({

--- a/app/[locale]/contributing/translation-program/translatathon/leaderboard/page.tsx
+++ b/app/[locale]/contributing/translation-program/translatathon/leaderboard/page.tsx
@@ -60,6 +60,8 @@ export async function generateMetadata(props: {
   const params = await props.params
   const { locale } = params
 
+  setRequestLocale(locale)
+
   return await getMetadata({
     locale,
     slug: ["translatathon"],

--- a/app/[locale]/developers/page.tsx
+++ b/app/[locale]/developers/page.tsx
@@ -837,6 +837,8 @@ export async function generateMetadata(props: {
   const params = await props.params
   const { locale } = params
 
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-developers-index")
 
   return await getMetadata({

--- a/app/[locale]/developers/tools/[tool]/page.tsx
+++ b/app/[locale]/developers/tools/[tool]/page.tsx
@@ -202,6 +202,8 @@ export async function generateMetadata(props: {
 }) {
   const { locale, tool: toolKey } = await props.params
 
+  setRequestLocale(locale)
+
   const [normalized, toolDescriptions] = await Promise.all([
     normalizeDeveloperToolsData(await getDeveloperToolsData()),
     getTranslations({

--- a/app/[locale]/developers/tools/categories/[category]/page.tsx
+++ b/app/[locale]/developers/tools/categories/[category]/page.tsx
@@ -155,6 +155,8 @@ export async function generateMetadata(props: {
   const params = await props.params
   const { locale, category } = params
 
+  setRequestLocale(locale)
+
   // Guard against legacy/invalid slugs: the page itself redirects or 404s,
   // so skip building metadata from a nonexistent translation key
   const data = await getDeveloperToolsData()

--- a/app/[locale]/developers/tools/page.tsx
+++ b/app/[locale]/developers/tools/page.tsx
@@ -33,7 +33,10 @@ const Page = async (props: { params: Promise<PageParams> }) => {
     getDeveloperToolsData(),
     getAppPageContributorInfo("developers/tools", locale as Lang),
     getTranslations({ locale, namespace: "page-developers-tools" }),
-    getTranslations({ locale, namespace: "page-developers-tools-descriptions" }),
+    getTranslations({
+      locale,
+      namespace: "page-developers-tools-descriptions",
+    }),
   ])
 
   const normalized = normalizeDeveloperToolsData(data)
@@ -82,6 +85,9 @@ export async function generateMetadata(props: {
 }) {
   const params = await props.params
   const { locale } = params
+
+  setRequestLocale(locale)
+
   const t = await getTranslations({
     locale,
     namespace: "page-developers-tools",

--- a/app/[locale]/developers/tutorials/page.tsx
+++ b/app/[locale]/developers/tutorials/page.tsx
@@ -92,6 +92,8 @@ export async function generateMetadata(props: {
   const params = await props.params
   const { locale } = params
 
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-developers-tutorials")
 
   return await getMetadata({

--- a/app/[locale]/ethereum-history-founder-and-ownership/page.tsx
+++ b/app/[locale]/ethereum-history-founder-and-ownership/page.tsx
@@ -529,6 +529,8 @@ export async function generateMetadata({
 }) {
   const { locale } = await params
 
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-ethereum-history-founder-and-ownership")
 
   return await getMetadata({

--- a/app/[locale]/ethereum-vs-bitcoin/page.tsx
+++ b/app/[locale]/ethereum-vs-bitcoin/page.tsx
@@ -386,6 +386,8 @@ export async function generateMetadata({
 }) {
   const { locale } = await params
 
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-ethereum-vs-bitcoin")
 
   return await getMetadata({

--- a/app/[locale]/founders/page.tsx
+++ b/app/[locale]/founders/page.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { Banknote, ChartNoAxesCombined, Handshake } from "lucide-react"
-import { getTranslations } from "next-intl/server"
+import { getTranslations, setRequestLocale } from "next-intl/server"
 
 import type { Lang, PageParams, SectionNavDetails } from "@/lib/types"
 
@@ -445,6 +445,8 @@ export async function generateMetadata(props: {
 }) {
   const params = await props.params
   const { locale } = params
+
+  setRequestLocale(locale)
 
   const t = await getTranslations("page-founders")
 

--- a/app/[locale]/gas/page.tsx
+++ b/app/[locale]/gas/page.tsx
@@ -392,6 +392,8 @@ export async function generateMetadata(props: {
   const params = await props.params
   const { locale } = params
 
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-gas")
 
   return await getMetadata({

--- a/app/[locale]/get-eth/page.tsx
+++ b/app/[locale]/get-eth/page.tsx
@@ -383,6 +383,8 @@ export async function generateMetadata(props: {
   const params = await props.params
   const { locale } = params
 
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-get-eth")
 
   return await getMetadata({

--- a/app/[locale]/latest/page.tsx
+++ b/app/[locale]/latest/page.tsx
@@ -204,6 +204,8 @@ export async function generateMetadata(props: {
   const params = await props.params
   const { locale } = params
 
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-latest")
 
   const metadata = await getMetadata({

--- a/app/[locale]/layer-2/learn/page.tsx
+++ b/app/[locale]/layer-2/learn/page.tsx
@@ -385,6 +385,8 @@ export async function generateMetadata(props: {
   const params = await props.params
   const { locale } = params
 
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-layer-2-learn")
 
   return await getMetadata({

--- a/app/[locale]/layer-2/networks/page.tsx
+++ b/app/[locale]/layer-2/networks/page.tsx
@@ -235,6 +235,8 @@ export async function generateMetadata(props: {
   const params = await props.params
   const { locale } = params
 
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-layer-2-networks")
 
   return await getMetadata({

--- a/app/[locale]/layer-2/page.tsx
+++ b/app/[locale]/layer-2/page.tsx
@@ -550,6 +550,8 @@ export async function generateMetadata(props: {
   const params = await props.params
   const { locale } = params
 
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-layer-2")
 
   return await getMetadata({

--- a/app/[locale]/learn/page.tsx
+++ b/app/[locale]/learn/page.tsx
@@ -1,5 +1,5 @@
 import { Fragment } from "react"
-import { getTranslations } from "next-intl/server"
+import { getTranslations, setRequestLocale } from "next-intl/server"
 
 import type { PageParams, ToCItem } from "@/lib/types"
 import type { Lang } from "@/lib/types"
@@ -466,6 +466,8 @@ export async function generateMetadata(props: {
 }) {
   const params = await props.params
   const { locale } = params
+
+  setRequestLocale(locale)
 
   const t = await getTranslations("page-learn")
 

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -144,6 +144,8 @@ export async function generateMetadata(props: {
   const params = await props.params
   const { locale } = params
 
+  setRequestLocale(locale)
+
   try {
     const t = await getTranslations("page-index")
     return await getMetadata({

--- a/app/[locale]/privacy/page.tsx
+++ b/app/[locale]/privacy/page.tsx
@@ -452,6 +452,8 @@ export async function generateMetadata({
 }) {
   const { locale } = await params
 
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-privacy")
 
   return await getMetadata({

--- a/app/[locale]/quizzes/page.tsx
+++ b/app/[locale]/quizzes/page.tsx
@@ -46,6 +46,8 @@ export async function generateMetadata(props: {
   const params = await props.params
   const { locale } = params
 
+  setRequestLocale(locale)
+
   const t = await getTranslations()
 
   return await getMetadata({

--- a/app/[locale]/reports/page.tsx
+++ b/app/[locale]/reports/page.tsx
@@ -166,6 +166,8 @@ export async function generateMetadata(props: {
   const params = await props.params
   const { locale } = params
 
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-reports")
 
   return await getMetadata({

--- a/app/[locale]/reports/trillion-dollar-security/page.tsx
+++ b/app/[locale]/reports/trillion-dollar-security/page.tsx
@@ -890,6 +890,8 @@ export async function generateMetadata(props: {
   const params = await props.params
   const { locale } = params
 
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-trillion-dollar-security")
 
   return await getMetadata({

--- a/app/[locale]/resources/page.tsx
+++ b/app/[locale]/resources/page.tsx
@@ -1,4 +1,4 @@
-import { getTranslations } from "next-intl/server"
+import { getTranslations, setRequestLocale } from "next-intl/server"
 
 import type { Lang, PageParams } from "@/lib/types"
 
@@ -236,6 +236,8 @@ export async function generateMetadata(props: {
 }) {
   const params = await props.params
   const { locale } = params
+
+  setRequestLocale(locale)
 
   const t = await getTranslations("page-resources")
 

--- a/app/[locale]/roadmap/page.tsx
+++ b/app/[locale]/roadmap/page.tsx
@@ -370,6 +370,8 @@ export async function generateMetadata(props: {
   const params = await props.params
   const { locale } = params
 
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-roadmap")
 
   return await getMetadata({

--- a/app/[locale]/run-a-node/page.tsx
+++ b/app/[locale]/run-a-node/page.tsx
@@ -674,6 +674,8 @@ export async function generateMetadata(props: {
   const params = await props.params
   const { locale } = params
 
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-run-a-node")
 
   return await getMetadata({

--- a/app/[locale]/stablecoins/page.tsx
+++ b/app/[locale]/stablecoins/page.tsx
@@ -880,6 +880,8 @@ export async function generateMetadata(props: {
   const params = await props.params
   const { locale } = params
 
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-stablecoins")
 
   return await getMetadata({

--- a/app/[locale]/staking/deposit-contract/page.tsx
+++ b/app/[locale]/staking/deposit-contract/page.tsx
@@ -153,6 +153,8 @@ export async function generateMetadata(props: {
   const params = await props.params
   const { locale } = params
 
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-staking-deposit-contract")
 
   return await getMetadata({

--- a/app/[locale]/staking/page.tsx
+++ b/app/[locale]/staking/page.tsx
@@ -461,6 +461,8 @@ export async function generateMetadata(props: {
   const params = await props.params
   const { locale } = params
 
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-staking")
 
   return await getMetadata({

--- a/app/[locale]/start/page.tsx
+++ b/app/[locale]/start/page.tsx
@@ -89,6 +89,8 @@ export async function generateMetadata(props: {
   const params = await props.params
   const { locale } = params
 
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-start")
 
   return await getMetadata({

--- a/app/[locale]/stories/[slug]/page.tsx
+++ b/app/[locale]/stories/[slug]/page.tsx
@@ -89,6 +89,8 @@ export async function generateMetadata(props: {
 }): Promise<Metadata> {
   const { locale, slug } = await props.params
 
+  setRequestLocale(locale)
+
   return await getMdMetadata({
     locale,
     slug: ["stories", slug],

--- a/app/[locale]/stories/page.tsx
+++ b/app/[locale]/stories/page.tsx
@@ -217,6 +217,8 @@ export async function generateMetadata(props: {
 }): Promise<Metadata> {
   const { locale } = await props.params
 
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-stories")
 
   return await getMetadata({

--- a/app/[locale]/use-cases/page.tsx
+++ b/app/[locale]/use-cases/page.tsx
@@ -1,4 +1,4 @@
-import { getTranslations } from "next-intl/server"
+import { getTranslations, setRequestLocale } from "next-intl/server"
 
 import type { PageParams, ToCItem } from "@/lib/types"
 import type { Lang } from "@/lib/types"
@@ -306,6 +306,9 @@ export async function generateMetadata(props: {
 }) {
   const params = await props.params
   const { locale } = params
+
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-use-cases")
 
   return await getMetadata({

--- a/app/[locale]/videos/[slug]/page.tsx
+++ b/app/[locale]/videos/[slug]/page.tsx
@@ -110,6 +110,8 @@ export async function generateMetadata(props: {
 }): Promise<Metadata> {
   const { locale, slug } = await props.params
 
+  setRequestLocale(locale)
+
   let data
   try {
     data = await getVideoData(slug, locale)

--- a/app/[locale]/videos/page.tsx
+++ b/app/[locale]/videos/page.tsx
@@ -64,6 +64,8 @@ export async function generateMetadata(props: {
 }): Promise<Metadata> {
   const { locale } = await props.params
 
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-videos")
 
   return await getMetadata({

--- a/app/[locale]/wallets/find-wallet/page.tsx
+++ b/app/[locale]/wallets/find-wallet/page.tsx
@@ -138,6 +138,8 @@ export async function generateMetadata(props: {
   const params = await props.params
   const { locale } = params
 
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-wallets-find-wallet")
 
   return await getMetadata({

--- a/app/[locale]/wallets/page.tsx
+++ b/app/[locale]/wallets/page.tsx
@@ -386,6 +386,8 @@ export async function generateMetadata(props: {
   const params = await props.params
   const { locale } = params
 
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-wallets")
 
   return await getMetadata({

--- a/app/[locale]/what-is-ether/page.tsx
+++ b/app/[locale]/what-is-ether/page.tsx
@@ -635,6 +635,8 @@ export async function generateMetadata({
 }) {
   const { locale } = await params
 
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-what-is-ether")
 
   return await getMetadata({

--- a/app/[locale]/what-is-ethereum/page.tsx
+++ b/app/[locale]/what-is-ethereum/page.tsx
@@ -6,7 +6,7 @@ import {
   SquareCode,
   User,
 } from "lucide-react"
-import { getTranslations } from "next-intl/server"
+import { getTranslations, setRequestLocale } from "next-intl/server"
 
 import type { Lang, PageParams, ToCItem } from "@/lib/types"
 
@@ -919,6 +919,8 @@ export async function generateMetadata(props: {
 }) {
   const params = await props.params
   const { locale } = params
+
+  setRequestLocale(locale)
 
   const t = await getTranslations("page-what-is-ethereum")
 

--- a/app/[locale]/what-is-the-ethereum-network/page.tsx
+++ b/app/[locale]/what-is-the-ethereum-network/page.tsx
@@ -1,4 +1,4 @@
-import { getTranslations } from "next-intl/server"
+import { getTranslations, setRequestLocale } from "next-intl/server"
 
 import type { Lang, ToCItem } from "@/lib/types"
 
@@ -622,6 +622,8 @@ export async function generateMetadata({
   params: Promise<{ locale: string }>
 }) {
   const { locale } = await params
+
+  setRequestLocale(locale)
 
   const t = await getTranslations("page-what-is-the-ethereum-network")
 


### PR DESCRIPTION
## Problem

Every `generateMetadata` under `app/` calls a next-intl API — `getTranslations(...)` directly and/or the `getMetadata` / `getMdMetadata` helpers (which call `getTranslations("common")` internally) — **without first calling `setRequestLocale(locale)`**.

next-intl's request config (`src/i18n/request.ts`) resolves the locale via `requestLocale`, which reads request **headers** unless `setRequestLocale` has primed the per-request cache. So any `generateMetadata` that runs a next-intl API before `setRequestLocale` opts the route into **dynamic rendering** and, for params rendered **on-demand** (invalid-locale / unknown-slug bot probes not covered by `generateStaticParams`), Next.js throws:

```
Error: Page changed from static to dynamic at runtime /..., reason: headers
    at get requestLocale (next-intl)
```

Prerendered locales are built with no headers, so they were unaffected — which is why only a handful of routes actually alerted in production while the gap was latent across **~54 pages**.

## Why not a central fix?

There's no single choke point: `getMetadata` receives `locale` but calls `getTranslations("common")` (locale-less), and pages also call `getTranslations("page-x")` directly *before* `getMetadata` to build the title. Fixing only the helper leaves the direct call reading headers. `setRequestLocale(locale)` at the top of each `generateMetadata` neutralizes **both** paths at once, which is the pattern next-intl documents for static rendering.

## Changes

- Add `setRequestLocale(locale)` at the top of **every** `generateMetadata` in `app/` that uses a next-intl API (before the first next-intl call).

## Verification

- `pnpm type-check` ✅
- `pnpm lint` (full repo) ✅ — 0 errors

## Relationship to the recovery PRs

Overlaps recovery PRs #18785, #18797, #18798, #18800 on those 4 files (identical one-line addition in `generateMetadata`). Whichever merges first, reconciliation is trivial. Note: this PR intentionally scopes to `generateMetadata` only — the page-**body** ordering fixes for wallets/videos live in those recovery PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)