### PR TITLE
Avoid optimizing volatile remote images

### DIFF
--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -5,17 +5,58 @@ import NextImage, {
 
 export type ImageProps = NextImageProps
 
+/**
+ * These third-party hosts serve user-managed images that can expire or be
+ * removed independently of ethereum.org. Sending them through `/_next/image`
+ * turns a stale upstream response into a 400 from the image optimizer. Loading
+ * them directly lets the browser's error event reach the contextual fallback
+ * used by components such as event cards and avatars.
+ */
+const VOLATILE_REMOTE_IMAGE_HOSTS = new Set([
+  "avatars.githubusercontent.com",
+  "avatars0.githubusercontent.com",
+  "avatars1.githubusercontent.com",
+  "avatars2.githubusercontent.com",
+  "avatars3.githubusercontent.com",
+  "avatars4.githubusercontent.com",
+  "coin-images.coingecko.com",
+  "i.imgur.com",
+  "images.lumacdn.com",
+  "img.evbuc.com",
+  "pbs.twimg.com",
+  "secure.meetupstatic.com",
+  "unavatar.io",
+])
+
+export const isVolatileRemoteImage = (src: ImageProps["src"]): boolean => {
+  if (typeof src !== "string" || !src.startsWith("https://")) return false
+
+  try {
+    return VOLATILE_REMOTE_IMAGE_HOSTS.has(new URL(src).hostname)
+  } catch {
+    return false
+  }
+}
+
 const isStaticImageData = (src: ImageProps["src"]): src is StaticImageData => {
   return typeof src === "object" && "blurDataURL" in src
 }
 
 const DefaultNextImage = (props: ImageProps) => {
+  const unoptimized = props.unoptimized || isVolatileRemoteImage(props.src)
+
   if (isStaticImageData(props.src)) {
-    return <NextImage placeholder="blur" {...props} />
+    return <NextImage placeholder="blur" {...props} unoptimized={unoptimized} />
   }
 
   const hasBlurData = !!props.blurDataURL
-  return <NextImage placeholder={hasBlurData ? "blur" : "empty"} {...props} />
+  return (
+    <NextImage
+      placeholder={hasBlurData ? "blur" : "empty"}
+      {...props}
+      unoptimized={unoptimized}
+    />
+  )
 }
 
 export const Image = (props: NextImageProps) => <DefaultNextImage {...props} />

--- a/tests/unit/image.spec.ts
+++ b/tests/unit/image.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "@playwright/test"
+
+import { isVolatileRemoteImage } from "@/components/Image"
+
+test.describe("isVolatileRemoteImage", () => {
+  test("identifies third-party user-managed image hosts", () => {
+    const volatileSources = [
+      "https://img.evbuc.com/event.jpg",
+      "https://images.lumacdn.com/banner.png?width=800",
+      "https://secure.meetupstatic.com/photo.webp",
+      "https://avatars3.githubusercontent.com/u/123?v=4",
+      "https://unavatar.io/github/example",
+      "https://coin-images.coingecko.com/coins/images/1/large/token.png",
+    ]
+
+    for (const src of volatileSources) {
+      expect(isVolatileRemoteImage(src)).toBe(true)
+    }
+  })
+
+  test("keeps local and stable remote images optimized", () => {
+    const optimizedSources = [
+      "/images/ethereum.png",
+      "https://s3-dcl1.ethquokkaops.io/app.png",
+      "https://storage.googleapis.com/ethereum/image.png",
+      "not a URL",
+    ]
+
+    for (const src of optimizedSources) {
+      expect(isVolatileRemoteImage(src)).toBe(false)
+    }
+  })
+})


### PR DESCRIPTION
## Description
Avoids routing volatile third-party images through the Next.js image optimizer. Images from event, avatar, and user-managed asset hosts are now loaded directly, preventing stale or invalid upstream responses from producing /_next/image 400 errors.
Existing client-side fallbacks can still handle failed images, while local and stable remote images remain optimized. Unit tests cover 
both volatile and stable image sources.

## Related Issue
Closes #18796