### PR TITLE
Fix raw translation keys leaking after useTranslations migration

### DIFF
--- a/app/[locale]/developers/tutorials/_components/tutorials.tsx
+++ b/app/[locale]/developers/tutorials/_components/tutorials.tsx
@@ -353,7 +353,7 @@ const TutorialsList = ({ internalTutorials }: TutorialsListProps) => {
                         : "normal"
                 }
               >
-                <Translation id={getSkillTranslationId(tutorial.skill)} />
+                {t(getSkillTranslationId(tutorial.skill))}
               </Tag>
             )}
           </Flex>

--- a/app/[locale]/quizzes/page-jsonld.tsx
+++ b/app/[locale]/quizzes/page-jsonld.tsx
@@ -17,6 +17,7 @@ export default async function QuizzesPageJsonLD({
   contributors: FileContributor[]
 }) {
   const t = await getTranslations("page-quizzes")
+  const tCommon = await getTranslations("common")
 
   const url = normalizeUrlForJsonLd(locale, `/quizzes/`)
 
@@ -33,7 +34,7 @@ export default async function QuizzesPageJsonLD({
       {
         "@type": "WebPage",
         "@id": url,
-        name: t("common:quizzes-title"),
+        name: tCommon("quizzes-title"),
         description: t("quizzes-subtitle"),
         url,
         inLanguage: locale,
@@ -52,7 +53,7 @@ export default async function QuizzesPageJsonLD({
             {
               "@type": "ListItem",
               position: 2,
-              name: t("common:quizzes-title"),
+              name: tCommon("quizzes-title"),
               item: url,
             },
           ],

--- a/src/components/TutorialMetadata.tsx
+++ b/src/components/TutorialMetadata.tsx
@@ -22,10 +22,9 @@ export type TutorialMetadataProps = {
   timeToRead: number
 }
 
+// Key within the "page-developers-tutorials" namespace
 export const getSkillTranslationId = (skill: Skill): TranslationKey =>
-  `page-developers-tutorials:page-tutorial-${
-    Skill[skill.toUpperCase() as keyof typeof Skill]
-  }`
+  `page-tutorial-${Skill[skill.toUpperCase() as keyof typeof Skill]}`
 
 const TutorialMetadata = ({
   frontmatter,


### PR DESCRIPTION
## Description

Fixes the Chromatic page-visual-test regression on tutorial pages caught on the v11.15.0 deploy PR (#18820): the skill tag rendered the raw key `PAGE-DEVELOPERS-TUTORIALS:PAGE-TUTORIAL-BEGINNER` instead of "Beginner", breaking the tag row layout.

Root cause: 780bc22c40 migrated `TutorialMetadata` to next-intl's namespace-bound `useTranslations`, but `getSkillTranslationId` still returned the legacy `namespace:key` form, which next-intl cannot resolve.

Changes:
- `getSkillTranslationId` returns the bare key (`page-tutorial-*`); the tutorials listing uses its namespace-bound `t()` instead of the legacy `<Translation>` id form.
- Same bug class in `app/[locale]/quizzes/page-jsonld.tsx`: `t("common:quizzes-title")` on a `page-quizzes`-bound translator leaked the raw key into the JSON-LD WebPage/breadcrumb names. Now uses a `common`-bound translator.

A codebase-wide sweep found no other `namespace:key` strings passed to bound next-intl translators.

Verified locally: type-check + lint pass; tutorial page renders the BEGINNER tag with baseline layout, tutorials listing pills correct, quizzes JSON-LD emits "Quiz Hub".

Targets `staging` to unblock the v11.15.0 release.