### PR TITLE
fix: stop root not-found from poisoning request locale in dev

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -1,6 +1,5 @@
 import { Suspense } from "react"
 import { pick } from "lodash"
-import { IBM_Plex_Mono, Inter } from "next/font/google"
 import { notFound } from "next/navigation"
 import { getMessages, setRequestLocale } from "next-intl/server"
 
@@ -11,6 +10,8 @@ import Matomo from "@/components/Matomo"
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
 import { getLocaleTimestamp } from "@/lib/utils/time"
 import { toLanguageTag } from "@/lib/utils/url"
+
+import { ibmPlexMono, inter } from "../fonts"
 
 import Providers from "./providers"
 
@@ -24,20 +25,6 @@ import { BaseLayout } from "@/layouts/BaseLayout"
 export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }))
 }
-
-const inter = Inter({
-  subsets: ["latin"],
-  display: "swap",
-  variable: "--font-inter",
-  preload: true,
-})
-
-const ibmPlexMono = IBM_Plex_Mono({
-  subsets: ["latin"],
-  weight: ["400"],
-  display: "swap",
-  variable: "--font-mono",
-})
 
 export default async function LocaleLayout(props: {
   children: React.ReactNode

--- a/app/fonts.ts
+++ b/app/fonts.ts
@@ -1,0 +1,15 @@
+import { IBM_Plex_Mono, Inter } from "next/font/google"
+
+export const inter = Inter({
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-inter",
+  preload: true,
+})
+
+export const ibmPlexMono = IBM_Plex_Mono({
+  subsets: ["latin"],
+  weight: ["400"],
+  display: "swap",
+  variable: "--font-mono",
+})

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,13 +1,40 @@
+import { pick } from "lodash"
+import { getMessages } from "next-intl/server"
+
 import NotFoundPage from "@/components/NotFoundPage"
+
+import { toLanguageTag } from "@/lib/utils/url"
 
 import { DEFAULT_LOCALE } from "@/lib/constants"
 
-import LocaleLayout from "./[locale]/layout"
+import Providers from "./[locale]/providers"
+import { ibmPlexMono, inter } from "./fonts"
 
+import "@/styles/global.css"
+
+// This root not-found boundary must stay self-contained and use only
+// explicit-locale next-intl APIs. In dev, Next.js renders it alongside every
+// page request within the same request-scoped cache, so calling
+// `setRequestLocale` (directly or by reusing `LocaleLayout`) or any implicit
+// API (`getTranslations()`, `getLocale()`, ...) here poisons the locale of the
+// actual page being rendered. It is only reached for locale-less paths the
+// proxy matcher excludes; localized 404s render via app/[locale]/not-found.tsx
+// with the full site chrome.
 export default async function GlobalNotFound() {
+  const allMessages = await getMessages({ locale: DEFAULT_LOCALE })
+  const messages = pick(allMessages, "common")
+
   return (
-    <LocaleLayout params={Promise.resolve({ locale: DEFAULT_LOCALE })}>
-      <NotFoundPage />
-    </LocaleLayout>
+    <html
+      lang={toLanguageTag(DEFAULT_LOCALE)}
+      className={`${inter.variable} ${ibmPlexMono.variable}`}
+      suppressHydrationWarning
+    >
+      <body>
+        <Providers locale={DEFAULT_LOCALE} messages={messages}>
+          <NotFoundPage />
+        </Providers>
+      </body>
+    </html>
   )
 }


### PR DESCRIPTION
## Description

Fixes the dev-only bug where non-English pages render with mixed languages — server components in English, client components in the page's locale (e.g. `/es/developers/tutorials` with an English hero/nav and Spanish filters).

## Root cause

In dev, Next.js renders the global `app/not-found.tsx` boundary alongside **every** full-document request, sharing the request-scoped React cache with the actual page. Because it reused `LocaleLayout` hardcoded to `DEFAULT_LOCALE`, every request fired `setRequestLocale("en")` plus an implicit `getMessages()` — resolving and caching next-intl's implicit request config as English before the real page's `setRequestLocale(locale)` could take effect (next-intl memoizes the first implicit resolution per request).

- Server components (`getTranslations()` / `getLocale()`) → poisoned English
- Client components → correct locale, because pages pass an **explicit** `getMessages({ locale })` catalog to the provider (separate cache key)

Production is unaffected: `/_not-found` is prerendered in isolation at build time. The bug surfaced when the language picker moved from soft nav to a hard refresh, since RSC-payload requests don't co-render the not-found boundary the way full document loads do.

## Fix

Make the root not-found self-contained: its own `<html>` document using only explicit-locale APIs and no `setRequestLocale`, so it can never write to or resolve the shared request-locale store. Localized 404s keep the full site chrome via `app/[locale]/not-found.tsx`; the root 404 (only reachable for extension-style paths the proxy matcher excludes) drops the nav/footer chrome, since `Nav`/`Footer` are server components with implicit i18n calls that would reintroduce the race. Fonts move to a shared `app/fonts.ts` used by both documents.

## Verified (dev server)

- `/es/developers/tutorials/`: fully Spanish server + client output (was mixed)
- `/en/developers/tutorials/`: fully English
- Root 404 path (`/foo.txt`): renders the 404 page correctly
- `tsc --noEmit` + ESLint pass