### PR TITLE
fix: scroll to top on route navigation

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -56,6 +56,9 @@ export default async function LocaleLayout(props: {
     <html
       lang={toLanguageTag(locale)}
       className={`${inter.variable} ${ibmPlexMono.variable}`}
+      // Lets Next disable smooth scroll during route transitions so it lands
+      // at the true top instead of short (behind the sticky nav).
+      data-scroll-behavior="smooth"
       suppressHydrationWarning
     >
       <body>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -28,6 +28,7 @@ export default async function GlobalNotFound() {
     <html
       lang={toLanguageTag(DEFAULT_LOCALE)}
       className={`${inter.variable} ${ibmPlexMono.variable}`}
+      data-scroll-behavior="smooth"
       suppressHydrationWarning
     >
       <body>


### PR DESCRIPTION
## Problem

Clicking an internal link scrolled the page back up but stopped short of the top, leaving the top of the content tucked behind the sticky nav. The shortfall was inconsistent and often severe -- a navigation that needed ~2000px of upward scroll might move only ~100px before stopping.

## Root cause

Next 16 only neutralizes CSS smooth-scrolling during route transitions when the `<html>` element carries `data-scroll-behavior="smooth"` (see `disableSmoothScrollDuringRouteTransition`). Our global `* { scroll-behavior: smooth }` (`src/styles/base.css`) was left active during navigation, so Next's synchronous `htmlElement.scrollTop = 0` *animated* instead of jumping. Its follow-up in-viewport check then read the mid-animation (pre-scroll) position, judged the target "not visible," and fell through to `domNode.scrollIntoView()` -- which honors the `scroll-mt-32` (8rem) that `base.css` applies to every `<section>`/heading. Because the check races an in-flight animation, where it lands varies with scroll distance and timing, which is why the shortfall was inconsistent.

## Fix

Add `data-scroll-behavior="smooth"` to `<html>`. Next then flips `<html>` to `scroll-behavior: auto` for the duration of a navigation, so route changes land at the true top. In-page hash/anchor links still smooth-scroll (Next short-circuits on `onlyHashChange`).

## Changes

- `app/[locale]/layout.tsx` -- add the attribute to the main app shell `<html>`
- `app/not-found.tsx` -- same, for the 404 shell

## Test plan

- [ ] Navigate between internal pages while scrolled down -> page lands flush at the very top, no content hidden behind the nav
- [ ] Click an in-page `#anchor` link -> still smooth-scrolls
- [ ] No `data-scroll-behavior` dev-console warning from Next

-- Opus 4.8
