### PR TITLE
fix: hide misleading epoch date when contributor data is missing

### DIFF
--- a/src/lib/utils/contributors.ts
+++ b/src/lib/utils/contributors.ts
@@ -63,7 +63,11 @@ export const getAppPageContributorInfo = async (
   )
 
   const latestCommitDate = getAppPageLastCommitDate(gitHubContributors)
-  const lastEditLocaleTimestamp = getLocaleTimestamp(locale, latestCommitDate)
+  // Guard the empty sentinel: getLocaleTimestamp(locale, "") would format an
+  // Invalid Date, so keep the timestamp empty when there is no commit date.
+  const lastEditLocaleTimestamp = latestCommitDate
+    ? getLocaleTimestamp(locale, latestCommitDate)
+    : ""
 
   // if (
   //   (!uniqueGitHubContributors.length || !lastEditLocaleTimestamp) &&

--- a/src/lib/utils/gh.ts
+++ b/src/lib/utils/gh.ts
@@ -1,14 +1,19 @@
 import type { FileContributor } from "../types"
 
+// Returns "" (not the Unix epoch) for an empty array, so callers can hide
+// the "last update" line instead of formatting "January 1, 1970".
 export const getAppPageLastCommitDate = (
   gitHubContributors: FileContributor[]
-) =>
-  gitHubContributors
+): string => {
+  if (!gitHubContributors.length) return ""
+
+  return gitHubContributors
     .reduce((latest, contributor) => {
       const commitDate = new Date(contributor.date)
       return commitDate > latest ? commitDate : latest
     }, new Date(0))
     .toString()
+}
 
 const LABELS_TO_SEARCH = [
   "content",


### PR DESCRIPTION
## Description

App Router pages with no contributor data (empty `appPages[pagePath]` in the GitHub-contributors blob) rendered **"Page last update: January 1, 1970"** -- the Unix epoch. `getAppPageLastCommitDate` reduced an empty array starting from `new Date(0)` and `.toString()`'d the result, producing a real, formattable epoch string that flowed through to the UI and to structured data.

This makes the date honest when the data is missing: no more fake epoch.

## Changes

- **`src/lib/utils/gh.ts`** -- `getAppPageLastCommitDate` returns `""` for an empty contributors array instead of the `new Date(0)` epoch.
- **`src/lib/utils/contributors.ts`** -- `getAppPageContributorInfo` guards the format call, so `getLocaleTimestamp(locale, "")` (which would format an Invalid Date) is never hit; the timestamp stays empty.

## Behavior when contributor data is missing

- The **"Page last update" line is hidden** -- `FileContributors` already wraps it in `{lastEditLocaleTimestamp && (...)}`, and `""` is falsy.
- The page **JSON-LD emits an empty `dateModified`** rather than the epoch.

When data is present, the UI is unchanged.

### Why `""` and not `null`

`null` is semantically cleaner and would let the JSON-LD omit `dateModified` entirely, but every consumer types the field as `string` (`?: string` in `ContentLayout` / `types.ts` / `FileContributors`, required `string` across the 12 `page-jsonld.tsx` files). Returning `null` would cascade a type change through all ~15 of them. Returning `""` keeps the type `string` and the fix at 2 files. The only cost is an empty `dateModified` in structured data in the (now rare) missing-data case -- SEO-only, invisible to users, and strictly better than advertising a wrong epoch date.

## Relationship to other PRs

- The **data-side root cause** -- the `fetch-github-contributors` task writing empty arrays when it hit GitHub's secondary rate limit -- was fixed in #18073 (merged). With that in place, contributor data populates normally and this path is only reached in degraded cases (stale cache, fetch failure, a new page not yet fetched).
- This PR is the **UI-side defensive complement** that #18073 explicitly deferred to "a separate, smaller PR", and it **supersedes #18071** (now stale/conflicting, and its broader per-page-jsonld surface has since grown from 11 to 52 files). #18071 can be closed in favor of this.

## Verification

- `tsc --noEmit` -- clean on the touched files and all consumers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
