### PR TITLE
fix: external-link arrow on card CTAs + translatable link assistive text

### DIFF
--- a/src/components/Homepage/GetStartedGrid.tsx
+++ b/src/components/Homepage/GetStartedGrid.tsx
@@ -20,8 +20,6 @@ import { numberFormat } from "@/lib/utils/numbers"
 
 import { ENTERPRISE_ETHEREUM_URL } from "@/lib/constants"
 
-import { ChevronNext } from "../Chevron"
-
 import learnImage from "@/public/images/heroes/guides-hub-hero.jpg"
 import enterpriseImage from "@/public/images/heroes/roadmap-hub-hero.jpg"
 import developersImage from "@/public/images/homepage/get-started/developers.png"
@@ -164,10 +162,7 @@ const GetStartedGrid = async ({
                 </ul>
               </CardContent>
               <CardFooter>
-                <CardButtonFake>
-                  {card.cta}
-                  <ChevronNext className="size-5" />
-                </CardButtonFake>
+                <CardButtonFake withChevron>{card.cta}</CardButtonFake>
               </CardFooter>
             </Card>
           ))}

--- a/src/components/ui/Link.tsx
+++ b/src/components/ui/Link.tsx
@@ -16,10 +16,13 @@ import { DISCORD_PATH, SITE_URL } from "@/lib/constants"
 import { Link as I18nLink } from "@/i18n/navigation"
 import { usePathname } from "@/i18n/navigation"
 
-export const ExternalLinkIcon = () => (
+export const ExternalLinkIcon = ({ className }: { className?: string }) => (
   <ExternalLink
     data-label="arrow"
-    className="ms-1 mb-0.5! inline-block size-[0.875em] max-h-4 max-w-4 shrink-0 rtl:-scale-x-100"
+    className={cn(
+"ms-1 mb-0.5! inline-block size-[0.875em] max-h-4 max-w-4 shrink-0 rtl:-scale-x-100",
+      className
+    )}
   />
 )
 

--- a/src/components/ui/Link.tsx
+++ b/src/components/ui/Link.tsx
@@ -3,6 +3,7 @@
 import { AnchorHTMLAttributes, ComponentProps, forwardRef } from "react"
 import { ArrowRight, ExternalLink, Mail } from "lucide-react"
 import NextLink from "next/link"
+import { useTranslations } from "next-intl"
 
 import { MatomoEventOptions } from "@/lib/types"
 
@@ -20,7 +21,7 @@ export const ExternalLinkIcon = ({ className }: { className?: string }) => (
   <ExternalLink
     data-label="arrow"
     className={cn(
-"ms-1 mb-0.5! inline-block size-[0.875em] max-h-4 max-w-4 shrink-0 rtl:-scale-x-100",
+      "ms-1 mb-0.5! inline-block size-[0.875em] max-h-4 max-w-4 shrink-0 rtl:-scale-x-100",
       className
     )}
   />
@@ -63,6 +64,7 @@ export const BaseLink = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
   }: LinkProps,
   ref
 ) {
+  const t = useTranslations("common")
   const pathname = usePathname()
   if (!href) {
     // If troubleshooting this warning, check for multiple h1's in markdown content—these will result in broken id hrefs
@@ -133,7 +135,9 @@ export const BaseLink = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
         )}
         <span className="sr-only select-none">
           &nbsp;
-          {isMailto ? "(opens email client)" : "(opens in a new tab)"}
+          {isMailto
+            ? t("link-mailto-assistive-text")
+            : t("link-external-assistive-text")}
         </span>
         {!hideArrow && !isMailto && <ExternalLinkIcon />}
       </a>

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -5,9 +5,10 @@ import { Slot } from "@radix-ui/react-slot"
 import Emoji from "@/components/Emoji"
 
 import { cn } from "@/lib/utils/cn"
+import { isExternal } from "@/lib/utils/url"
 
 import { Button, type ButtonProps } from "./buttons/Button"
-import { BaseLink, LinkProps } from "./Link"
+import { BaseLink, ExternalLinkIcon, LinkProps } from "./Link"
 
 const cardVariants = cva(
   cn(
@@ -107,6 +108,9 @@ const Card = React.forwardRef<HTMLDivElement | HTMLAnchorElement, CardProps>(
           className={classes}
           customEventOptions={customEventOptions}
           hideArrow
+          // Card hides BaseLink's trailing arrow; instead a CardButtonFake CTA
+          // surfaces it on the button via this flag (see CardButtonFake).
+          data-external={isExternal(href) || undefined}
           {...props}
         />
       )
@@ -209,6 +213,10 @@ const CardButtonFake = React.forwardRef<HTMLDivElement, CardButtonFakeProps>(
     <Button asChild variant={variant} size={size} isSecondary={isSecondary}>
       <div ref={ref} data-label="button-link" className={className} {...props}>
         {children}
+        {/* Hidden unless the enclosing link Card is external (data-external on
+            the group/link anchor). The card anchor already carries the sr-only
+            "opens in a new tab" text, so this glyph is purely visual. */}
+        <ExternalLinkIcon className="hidden group-data-external/link:inline-block" />
       </div>
     </Button>
   )

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -7,6 +7,8 @@ import Emoji from "@/components/Emoji"
 import { cn } from "@/lib/utils/cn"
 import { isExternal } from "@/lib/utils/url"
 
+import { ChevronNext } from "../Chevron"
+
 import { Button, type ButtonProps } from "./buttons/Button"
 import { BaseLink, ExternalLinkIcon, LinkProps } from "./Link"
 
@@ -206,17 +208,45 @@ CardFooter.displayName = "CardFooter"
  * identical to hovering the button itself -- no hover styles are duplicated here.
  */
 type CardButtonFakeProps = React.HTMLAttributes<HTMLDivElement> &
-  Pick<ButtonProps, "variant" | "size" | "isSecondary">
+  Pick<ButtonProps, "variant" | "size" | "isSecondary"> & {
+    withChevron?: boolean
+    hideArrow?: boolean
+  }
 
 const CardButtonFake = React.forwardRef<HTMLDivElement, CardButtonFakeProps>(
-  ({ className, variant, size, isSecondary, children, ...props }, ref) => (
+  (
+    {
+      className,
+      variant,
+      size,
+      isSecondary,
+      children,
+      withChevron,
+      hideArrow,
+      ...props
+    },
+    ref
+  ) => (
     <Button asChild variant={variant} size={size} isSecondary={isSecondary}>
       <div ref={ref} data-label="button-link" className={className} {...props}>
         {children}
         {/* Hidden unless the enclosing link Card is external (data-external on
             the group/link anchor). The card anchor already carries the sr-only
             "opens in a new tab" text, so this glyph is purely visual. */}
-        <ExternalLinkIcon className="hidden group-data-external/link:inline-block" />
+        {!hideArrow && (
+          <ExternalLinkIcon className="hidden group-data-external/link:inline-block" />
+        )}
+        {/* Optional Chevron indicator. External links hide Chevron and show
+            ExternalLinkIcon instead by deafult. If `hideArrow` also applied,
+            external link arrow hidden and replaced with chevron. */}
+        {withChevron && (
+          <ChevronNext
+            className={cn(
+              "size-5",
+              !hideArrow && "group-data-external/link:hidden"
+            )}
+          />
+        )}
       </div>
     </Button>
   )

--- a/src/intl/en/common.json
+++ b/src/intl/en/common.json
@@ -231,6 +231,8 @@
   "less": "Less",
   "light-mode": "Light",
   "light-mode-aria-label": "Switch to light mode",
+  "link-external-assistive-text": "(opens in a new tab)",
+  "link-mailto-assistive-text": "(opens email client)",
   "loading": "Loading...",
   "loading-error-refresh": "Error, please refresh.",
   "meetups": "Meetups",


### PR DESCRIPTION
## Description

Two small, related link fixes:

- **UI — external arrow on card CTAs:** A `Card` with an `href` hides `BaseLink`'s trailing external-link arrow, so any external-link card using a `CardButtonFake` CTA had no external indicator. Now handled centrally in the `ui/card` primitive: `Card` flags external hrefs with `data-external` on the `group/link` anchor, and `CardButtonFake` reveals the arrow purely via CSS. Fixes every external card CTA site-wide with no per-call-site changes.
- **intl — translatable assistive text:** The link "(opens in a new tab)" / "(opens email client)" screen-reader text was hardcoded English. Extracted into the `common` namespace via `useTranslations` so it's translatable in all locales. `common` is used deliberately: `BaseLink` is a site-wide client primitive, and `common` is the only namespace shipped to every client provider.

## Related Issue

None.
