### PR TITLE
fix: remove gasfees.io phishing link from resources page

### DIFF
--- a/app/[locale]/resources/utils.tsx
+++ b/app/[locale]/resources/utils.tsx
@@ -216,12 +216,6 @@ export const getResources = async ({
           href: "https://www.blocknative.com/gas-estimator",
           imgSrc: IconBlocknative,
         },
-        {
-          title: "GasFees.io",
-          description: t("page-resources-gas-gasfees-description"),
-          href: "https://www.gasfees.io/",
-          imgSrc: IconEthGlyphBlueCircle,
-        },
       ],
     },
   ]

--- a/src/intl/en/page-resources.json
+++ b/src/intl/en/page-resources.json
@@ -24,7 +24,6 @@
   "page-resources-gas-etherscan-description": "Track all the KPIs on gas.",
   "page-resources-gas-ethgastracker-description": "Monitor gas prices across Ethereum and L2s.",
   "page-resources-gas-blocknative-description": "Web3's most accurate gas fee prediction.",
-  "page-resources-gas-gasfees-description": "Gas costs data tracker for Ethereum networks.",
   "page-resources-defi-title": "DeFi",
   "page-resources-defi-defillama-description": "DefiLlama is the largest TVL aggregator for DeFi (Decentralized Finance).",
   "page-resources-defi-eigenphi-description": "Wanna understand DeFi transactions and trading strategies?",


### PR DESCRIPTION
Remove the GasFees[.]io link.

## Description

Removes the GasFees.io entry from the resources page and its corresponding English localization key.

The site’s owner has [stated](https://x.com/0xKofi/status/2049025760141128100) that they have lost control of the domain. `gasfees[.]io` is now a phishing site.

**Before the Attack**

Visiting `gasfees[.]io` displayed the legitimate website for checking gas fees.

**Now**

Visiting `gasfees[.]io` displays a malicious website containing an Inferno Drainer. It prompts users to approve malicious transactions that can drain their ERC-20 tokens and NFTs.