### PR TITLE
refactor: extract config-driven FilterableCatalog from ToolsCatalog (find-wallet revamp PR 1)

### DIFF
--- a/app/[locale]/developers/tools/_components/ToolsCatalog.tsx
+++ b/app/[locale]/developers/tools/_components/ToolsCatalog.tsx
@@ -3,9 +3,10 @@
 import { memo, useMemo } from "react"
 
 import FilterableCatalog from "@/components/FilterableCatalog"
+import CatalogNavGroup from "@/components/FilterableCatalog/CatalogNavGroup"
 import type {
   CatalogFilterState,
-  CatalogNavGroup,
+  CatalogNavGroupConfig,
 } from "@/components/FilterableCatalog/types"
 
 import type {
@@ -18,6 +19,12 @@ import { numberFormat } from "@/lib/utils/numbers"
 import ToolCard from "./ToolCard"
 
 const SUBCATEGORY_FILTER_KEY = "subcategory"
+
+const PATH_SEPARATOR = "\u00A0\u00A0/\u00A0\u00A0"
+
+function formatPathSegment(value: string): string {
+  return value.toLocaleUpperCase()
+}
 
 type ToolsCatalogProps = {
   locale: string
@@ -204,9 +211,7 @@ export default function ToolsCatalog({
     return result
   }, [tools])
 
-  const navGroup: CatalogNavGroup = {
-    type: "nav",
-    key: SUBCATEGORY_FILTER_KEY,
+  const navConfig: CatalogNavGroupConfig = {
     allLabel: labels.allCategories,
     allHref: "/developers/tools/",
     allCount: totalCount,
@@ -252,17 +257,48 @@ export default function ToolsCatalog({
     return searchableText.includes(normalizedQuery)
   }
 
+  const renderResultsHeader = (state: CatalogFilterState) => {
+    const raw = state[SUBCATEGORY_FILTER_KEY]
+    const selectedSubcategoryId = typeof raw === "string" ? raw : undefined
+    if (!currentCategoryId && !selectedSubcategoryId) return null
+    return (
+      <p className="text-sm text-body-medium">
+        {currentCategoryId &&
+          formatPathSegment(
+            getCategoryLabel(currentCategoryId, categoryLabels)
+          )}
+        {selectedSubcategoryId &&
+          `${PATH_SEPARATOR}${formatPathSegment(
+            getSubcategoryLabel(selectedSubcategoryId, subcategoryLabels)
+          )}`}
+      </p>
+    )
+  }
+
   return (
     <FilterableCatalog
       locale={locale}
       items={tools}
-      filterGroups={[navGroup]}
       filterFn={filterTool}
       labels={{
         searchPlaceholder: labels.searchPlaceholder,
         resultsLabel: labels.resultsLabel,
         noResults: labels.noResults,
       }}
+      renderSidebar={({ state, setFilter }) => {
+        const raw = state[SUBCATEGORY_FILTER_KEY]
+        return (
+          <CatalogNavGroup
+            locale={locale}
+            config={navConfig}
+            selectedChildId={typeof raw === "string" ? raw : undefined}
+            onSelectChild={(childId) =>
+              setFilter(SUBCATEGORY_FILTER_KEY, childId)
+            }
+          />
+        )
+      }}
+      renderResultsHeader={renderResultsHeader}
       renderResults={(filteredTools) => (
         <ToolsResults
           locale={locale}

--- a/app/[locale]/developers/tools/_components/ToolsCatalog.tsx
+++ b/app/[locale]/developers/tools/_components/ToolsCatalog.tsx
@@ -1,14 +1,13 @@
 "use client"
 
-import { useDeferredValue, useMemo, useRef, useState } from "react"
-import { ChevronRight } from "lucide-react"
+import { memo, useMemo } from "react"
 
-import { Button } from "@/components/ui/buttons/Button"
-import Input from "@/components/ui/input"
-import { BaseLink } from "@/components/ui/Link"
-import { Section } from "@/components/ui/section"
+import FilterableCatalog from "@/components/FilterableCatalog"
+import type {
+  CatalogFilterState,
+  CatalogNavGroup,
+} from "@/components/FilterableCatalog/types"
 
-import { cn } from "@/lib/utils/cn"
 import type {
   DeveloperToolsCategory,
   DeveloperToolWithCategory,
@@ -17,6 +16,8 @@ import { getToolKey } from "@/lib/utils/getToolKey"
 import { numberFormat } from "@/lib/utils/numbers"
 
 import ToolCard from "./ToolCard"
+
+const SUBCATEGORY_FILTER_KEY = "subcategory"
 
 type ToolsCatalogProps = {
   locale: string
@@ -53,12 +54,6 @@ function getSubcategoryLabel(
   return subcategoryLabels[subcategoryId] || subcategoryId
 }
 
-function formatPathSegment(value: string): string {
-  return value.toLocaleUpperCase()
-}
-
-const PATH_SEPARATOR = "\u00A0\u00A0/\u00A0\u00A0"
-
 function getToolStars(tool: DeveloperToolWithCategory): number {
   let maxStars = 0
   for (const repo of tool.repos) {
@@ -77,189 +72,26 @@ function getToolSortScore(tool: DeveloperToolWithCategory): number {
   return getToolStars(tool)
 }
 
-type CategorySidebarProps = {
+type ToolsResultsProps = {
   locale: string
+  tools: DeveloperToolWithCategory[]
   categories: DeveloperToolsCategory[]
   categoryLabels: Record<string, string>
   subcategoryLabels: Record<string, string>
-  countByCategory: Record<string, number>
-  countBySubcategory: Record<string, number>
-  totalCount: number
-  allCategoriesLabel: string
-  currentCategoryId?: string
-  selectedSubcategoryId?: string
-  onSelectSubcategory: (subcategoryId?: string) => void
 }
 
-function CategorySidebar({
-  locale,
-  categories,
-  categoryLabels,
-  subcategoryLabels,
-  countByCategory,
-  countBySubcategory,
-  totalCount,
-  allCategoriesLabel,
-  currentCategoryId,
-  selectedSubcategoryId,
-  onSelectSubcategory,
-}: CategorySidebarProps) {
-  const nf = numberFormat(locale)
-  return (
-    <div className="space-y-1">
-      <BaseLink
-        href="/developers/tools/"
-        className={cn(
-          "flex w-full items-center justify-between rounded-md px-3 py-2 text-start text-sm no-underline hover:bg-background-highlight",
-          !currentCategoryId && "bg-background-highlight text-primary"
-        )}
-      >
-        <span>{allCategoriesLabel}</span>
-        <span className="text-xs text-body-medium">
-          {nf.format(totalCount)}
-        </span>
-      </BaseLink>
-
-      {categories.map((category) => {
-        const isCurrent = currentCategoryId === category.id
-        const isCategoryActive = isCurrent && !selectedSubcategoryId
-
-        return (
-          <div key={category.id} className="space-y-1">
-            <BaseLink
-              href={`/developers/tools/categories/${category.id}/`}
-              className={cn(
-                "flex w-full items-center gap-2 rounded-md px-3 py-2 text-start text-sm no-underline hover:bg-background-highlight",
-                isCategoryActive && "bg-background-highlight text-primary"
-              )}
-              onClick={() => {
-                if (isCurrent) onSelectSubcategory(undefined)
-              }}
-            >
-              <ChevronRight
-                className={cn(
-                  "size-4 text-body-medium transition-transform",
-                  isCurrent && "rotate-90"
-                )}
-              />
-              <span className="flex-1">
-                {getCategoryLabel(category.id, categoryLabels)}
-              </span>
-              <span className="text-xs text-body-medium">
-                {nf.format(countByCategory[category.id] || 0)}
-              </span>
-            </BaseLink>
-            {isCurrent && (
-              <div className="ms-5 space-y-1 border-s ps-2">
-                {category.subcategories.map((subcategory) => (
-                  <Button
-                    key={subcategory.id}
-                    variant="ghost"
-                    isSecondary
-                    className={cn(
-                      "flex min-h-0 w-full items-center justify-between rounded-md px-3 py-1.5 text-start text-xs font-normal hover:bg-background-highlight",
-                      selectedSubcategoryId === subcategory.id &&
-                        "bg-background-highlight"
-                    )}
-                    onClick={() => {
-                      onSelectSubcategory(
-                        selectedSubcategoryId === subcategory.id
-                          ? undefined
-                          : subcategory.id
-                      )
-                    }}
-                  >
-                    <span>
-                      {getSubcategoryLabel(subcategory.id, subcategoryLabels)}
-                    </span>
-                    <span className="text-2xs text-body-medium">
-                      {nf.format(countBySubcategory[subcategory.id] || 0)}
-                    </span>
-                  </Button>
-                ))}
-              </div>
-            )}
-          </div>
-        )
-      })}
-    </div>
-  )
-}
-
-export default function ToolsCatalog({
+const ToolsResults = memo(function ToolsResults({
   locale,
   tools,
   categories,
   categoryLabels,
   subcategoryLabels,
-  countByCategory,
-  totalCount,
-  labels,
-  currentCategoryId,
-}: ToolsCatalogProps) {
+}: ToolsResultsProps) {
   const nf = numberFormat(locale)
-  const [search, setSearch] = useState("")
-  const [selectedSubcategoryId, setSelectedSubcategoryId] = useState<
-    string | undefined
-  >()
-  const resultsTopRef = useRef<HTMLDivElement | null>(null)
 
-  // Defer the heavy filter + grid render so typing and filtering stay responsive
-  const deferredSearch = useDeferredValue(search)
-  const deferredSubcategoryId = useDeferredValue(selectedSubcategoryId)
-  const isStale =
-    search !== deferredSearch || selectedSubcategoryId !== deferredSubcategoryId
-
-  const handleSelectSubcategory = (subcategoryId?: string) => {
-    setSelectedSubcategoryId(subcategoryId)
-    resultsTopRef.current?.scrollIntoView({
-      behavior: "smooth",
-      block: "start",
-    })
-  }
-
-  const countBySubcategory = useMemo(() => {
-    const result: Record<string, number> = {}
-    for (const tool of tools) {
-      result[tool.subcategory_id] = (result[tool.subcategory_id] || 0) + 1
-    }
-    return result
-  }, [tools])
-
-  const filteredTools = useMemo(() => {
-    const query = normalize(deferredSearch)
-    return tools.filter((tool) => {
-      if (
-        deferredSubcategoryId &&
-        tool.subcategory_id !== deferredSubcategoryId
-      ) {
-        return false
-      }
-
-      if (!query) return true
-
-      const searchableText = [
-        tool.name,
-        tool.description,
-        getCategoryLabel(tool.categoryId, categoryLabels),
-        getSubcategoryLabel(tool.subcategory_id, subcategoryLabels),
-        ...tool.tags,
-      ]
-        .join(" ")
-        .toLowerCase()
-      return searchableText.includes(query)
-    })
-  }, [
-    categoryLabels,
-    deferredSearch,
-    deferredSubcategoryId,
-    subcategoryLabels,
-    tools,
-  ])
-
-  const groupedFilteredTools = useMemo(() => {
+  const groupedTools = useMemo(() => {
     const toolsByCategory = new Map<string, DeveloperToolWithCategory[]>()
-    for (const tool of filteredTools) {
+    for (const tool of tools) {
       const existing = toolsByCategory.get(tool.categoryId)
       if (existing) {
         existing.push(tool)
@@ -311,124 +143,135 @@ export default function ToolsCatalog({
         }
       })
       .filter((group) => group.count > 0)
-  }, [categories, filteredTools])
-
-  const sidebar = (
-    <CategorySidebar
-      locale={locale}
-      categories={categories}
-      categoryLabels={categoryLabels}
-      subcategoryLabels={subcategoryLabels}
-      countByCategory={countByCategory}
-      countBySubcategory={countBySubcategory}
-      totalCount={totalCount}
-      allCategoriesLabel={labels.allCategories}
-      currentCategoryId={currentCategoryId}
-      selectedSubcategoryId={selectedSubcategoryId}
-      onSelectSubcategory={handleSelectSubcategory}
-    />
-  )
+  }, [categories, tools])
 
   return (
-    <Section id="catalog" className="space-y-5">
-      <div className="grid grid-cols-1 gap-8 lg:grid-cols-[280px_1fr]">
-        <aside className="hidden lg:block">
-          <div className="sticky top-24 space-y-4">
-            <Input
-              value={search}
-              onChange={(event) => setSearch(event.target.value)}
-              placeholder={labels.searchPlaceholder}
-              className="w-full"
-            />
-            <div className="max-h-[calc(100vh-11rem)] overflow-y-auto rounded-xl border p-2">
-              {sidebar}
-            </div>
+    <>
+      {groupedTools.map(({ category, subcategoryGroups, count }) => (
+        <div key={category.id} className="space-y-4">
+          <div className="flex items-baseline gap-2 border-b pb-2">
+            <h2 className="text-h4">
+              {getCategoryLabel(category.id, categoryLabels)}
+            </h2>
+            <span className="text-xs text-body-medium">
+              ({nf.format(count)})
+            </span>
           </div>
-        </aside>
 
-        <div className="space-y-4 lg:-mt-5">
-          <div className="space-y-3 lg:hidden">
-            <Input
-              value={search}
-              onChange={(event) => setSearch(event.target.value)}
-              placeholder={labels.searchPlaceholder}
-              className="w-full"
-            />
-            <div className="rounded-xl border p-2">{sidebar}</div>
-          </div>
-          <div ref={resultsTopRef} className="scroll-mt-24" />
-          {(currentCategoryId || selectedSubcategoryId) && (
-            <p className="text-sm text-body-medium">
-              {currentCategoryId &&
-                formatPathSegment(
-                  getCategoryLabel(currentCategoryId, categoryLabels)
-                )}
-              {selectedSubcategoryId &&
-                `${PATH_SEPARATOR}${formatPathSegment(
-                  getSubcategoryLabel(selectedSubcategoryId, subcategoryLabels)
-                )}`}
-            </p>
-          )}
-
-          <p className="text-sm text-body-medium">
-            {labels.resultsLabel}:{" "}
-            <strong>{nf.format(filteredTools.length)}</strong> /{" "}
-            {nf.format(tools.length)}
-          </p>
-
-          <div
-            className={cn(
-              "space-y-8 transition-opacity",
-              isStale && "opacity-60"
-            )}
-          >
-            {groupedFilteredTools.map(
-              ({ category, subcategoryGroups, count }) => (
-                <div key={category.id} className="space-y-4">
-                  <div className="flex items-baseline gap-2 border-b pb-2">
-                    <h2 className="text-h4">
-                      {getCategoryLabel(category.id, categoryLabels)}
-                    </h2>
+          <div className="space-y-6">
+            {subcategoryGroups.map(
+              ({ subcategory, tools: subcategoryTools }) => (
+                <div key={subcategory.id} className="space-y-2">
+                  <div className="flex items-baseline gap-2">
+                    <h3 className="text-sm font-normal text-body-medium">
+                      {getSubcategoryLabel(subcategory.id, subcategoryLabels)}
+                    </h3>
                     <span className="text-xs text-body-medium">
-                      ({nf.format(count)})
+                      ({nf.format(subcategoryTools.length)})
                     </span>
                   </div>
-
-                  <div className="space-y-6">
-                    {subcategoryGroups.map(
-                      ({ subcategory, tools: subcategoryTools }) => (
-                        <div key={subcategory.id} className="space-y-2">
-                          <div className="flex items-baseline gap-2">
-                            <h3 className="text-sm font-normal text-body-medium">
-                              {getSubcategoryLabel(
-                                subcategory.id,
-                                subcategoryLabels
-                              )}
-                            </h3>
-                            <span className="text-xs text-body-medium">
-                              ({nf.format(subcategoryTools.length)})
-                            </span>
-                          </div>
-                          <div className="grid grid-cols-auto-3 gap-x-8">
-                            {subcategoryTools.map((tool) => (
-                              <ToolCard key={getToolKey(tool)} tool={tool} />
-                            ))}
-                          </div>
-                        </div>
-                      )
-                    )}
+                  <div className="grid grid-cols-auto-3 gap-x-8">
+                    {subcategoryTools.map((tool) => (
+                      <ToolCard key={getToolKey(tool)} tool={tool} />
+                    ))}
                   </div>
                 </div>
               )
             )}
           </div>
-          {filteredTools.length === 0 && (
-            <div className="rounded-xl border p-8 text-center text-body-medium">
-              {labels.noResults}
-            </div>
-          )}
         </div>
-      </div>
-    </Section>
+      ))}
+    </>
+  )
+})
+
+export default function ToolsCatalog({
+  locale,
+  tools,
+  categories,
+  categoryLabels,
+  subcategoryLabels,
+  countByCategory,
+  totalCount,
+  labels,
+  currentCategoryId,
+}: ToolsCatalogProps) {
+  const countBySubcategory = useMemo(() => {
+    const result: Record<string, number> = {}
+    for (const tool of tools) {
+      result[tool.subcategory_id] = (result[tool.subcategory_id] || 0) + 1
+    }
+    return result
+  }, [tools])
+
+  const navGroup: CatalogNavGroup = {
+    type: "nav",
+    key: SUBCATEGORY_FILTER_KEY,
+    allLabel: labels.allCategories,
+    allHref: "/developers/tools/",
+    allCount: totalCount,
+    items: categories.map((category) => ({
+      id: category.id,
+      label: getCategoryLabel(category.id, categoryLabels),
+      href: `/developers/tools/categories/${category.id}/`,
+      count: countByCategory[category.id] || 0,
+      isCurrent: currentCategoryId === category.id,
+      children: category.subcategories.map((subcategory) => ({
+        id: subcategory.id,
+        label: getSubcategoryLabel(subcategory.id, subcategoryLabels),
+        count: countBySubcategory[subcategory.id] || 0,
+      })),
+    })),
+  }
+
+  const filterTool = (
+    tool: DeveloperToolWithCategory,
+    state: CatalogFilterState,
+    query: string
+  ) => {
+    const subcategoryId = state[SUBCATEGORY_FILTER_KEY]
+    if (
+      typeof subcategoryId === "string" &&
+      tool.subcategory_id !== subcategoryId
+    ) {
+      return false
+    }
+
+    const normalizedQuery = normalize(query)
+    if (!normalizedQuery) return true
+
+    const searchableText = [
+      tool.name,
+      tool.description,
+      getCategoryLabel(tool.categoryId, categoryLabels),
+      getSubcategoryLabel(tool.subcategory_id, subcategoryLabels),
+      ...tool.tags,
+    ]
+      .join(" ")
+      .toLowerCase()
+    return searchableText.includes(normalizedQuery)
+  }
+
+  return (
+    <FilterableCatalog
+      locale={locale}
+      items={tools}
+      filterGroups={[navGroup]}
+      filterFn={filterTool}
+      labels={{
+        searchPlaceholder: labels.searchPlaceholder,
+        resultsLabel: labels.resultsLabel,
+        noResults: labels.noResults,
+      }}
+      renderResults={(filteredTools) => (
+        <ToolsResults
+          locale={locale}
+          tools={filteredTools}
+          categories={categories}
+          categoryLabels={categoryLabels}
+          subcategoryLabels={subcategoryLabels}
+        />
+      )}
+    />
   )
 }

--- a/src/components/FilterableCatalog/CatalogCheckboxGroup.tsx
+++ b/src/components/FilterableCatalog/CatalogCheckboxGroup.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import { useId } from "react"
+
 import Checkbox from "@/components/ui/checkbox"
 
 import { numberFormat } from "@/lib/utils/numbers"
@@ -27,10 +29,13 @@ export default function CatalogCheckboxGroup({
   onToggle,
 }: CatalogCheckboxGroupProps) {
   const nf = numberFormat(locale)
+  const labelId = useId()
 
   return (
-    <div className="space-y-1">
-      <p className="px-3 py-2 text-sm font-bold">{config.label}</p>
+    <div role="group" aria-labelledby={labelId} className="space-y-1">
+      <p id={labelId} className="px-3 py-2 text-sm font-bold">
+        {config.label}
+      </p>
       {config.options.map((option) => (
         <label
           key={option.id}

--- a/src/components/FilterableCatalog/CatalogCheckboxGroup.tsx
+++ b/src/components/FilterableCatalog/CatalogCheckboxGroup.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import Checkbox from "@/components/ui/checkbox"
+
+import { numberFormat } from "@/lib/utils/numbers"
+
+import type { CatalogCheckboxGroupConfig } from "./types"
+
+type CatalogCheckboxGroupProps = {
+  locale: string
+  config: CatalogCheckboxGroupConfig
+  /** Currently selected option ids */
+  selectedIds: string[]
+  onToggle: (optionId: string) => void
+}
+
+/**
+ * Controlled sidebar building block: a labelled group of independent checkboxes.
+ * Purely presentational — value in (`selectedIds`), event out (`onToggle`); it
+ * holds no filter state of its own and doesn't know how selections are stored or
+ * how the group combines with others (that's the consumer's `filterFn`).
+ */
+export default function CatalogCheckboxGroup({
+  locale,
+  config,
+  selectedIds,
+  onToggle,
+}: CatalogCheckboxGroupProps) {
+  const nf = numberFormat(locale)
+
+  return (
+    <div className="space-y-1">
+      <p className="px-3 py-2 text-sm font-bold">{config.label}</p>
+      {config.options.map((option) => (
+        <label
+          key={option.id}
+          className="flex cursor-pointer items-center gap-2 rounded-md px-3 py-1.5 text-sm hover:bg-background-highlight"
+        >
+          <Checkbox
+            checked={selectedIds.includes(option.id)}
+            onCheckedChange={() => onToggle(option.id)}
+          />
+          <span className="flex-1 select-none">{option.label}</span>
+          {typeof option.count === "number" && (
+            <span className="text-xs text-body-medium">
+              {nf.format(option.count)}
+            </span>
+          )}
+        </label>
+      ))}
+    </div>
+  )
+}

--- a/src/components/FilterableCatalog/CatalogNavGroup.tsx
+++ b/src/components/FilterableCatalog/CatalogNavGroup.tsx
@@ -1,0 +1,109 @@
+"use client"
+
+import { ChevronRight } from "lucide-react"
+
+import { Button } from "@/components/ui/buttons/Button"
+import { BaseLink } from "@/components/ui/Link"
+
+import { cn } from "@/lib/utils/cn"
+import { numberFormat } from "@/lib/utils/numbers"
+
+import type { CatalogNavGroupConfig } from "./types"
+
+type CatalogNavGroupProps = {
+  locale: string
+  config: CatalogNavGroupConfig
+  /** Currently selected child id (single-select), or undefined for none */
+  selectedChildId?: string
+  onSelectChild: (childId?: string) => void
+}
+
+/**
+ * Controlled sidebar building block: top-level entries are route links to
+ * server-rendered listing pages; the children of the current entry are a
+ * single-select filter. Purely presentational — value in (`selectedChildId`),
+ * event out (`onSelectChild`); it holds no filter state of its own.
+ */
+export default function CatalogNavGroup({
+  locale,
+  config,
+  selectedChildId,
+  onSelectChild,
+}: CatalogNavGroupProps) {
+  const nf = numberFormat(locale)
+  const hasCurrentItem = config.items.some((item) => item.isCurrent)
+
+  return (
+    <div className="space-y-1">
+      <BaseLink
+        href={config.allHref}
+        className={cn(
+          "flex w-full items-center justify-between rounded-md px-3 py-2 text-start text-sm no-underline hover:bg-background-highlight",
+          !hasCurrentItem && "bg-background-highlight text-primary"
+        )}
+      >
+        <span>{config.allLabel}</span>
+        <span className="text-xs text-body-medium">
+          {nf.format(config.allCount)}
+        </span>
+      </BaseLink>
+
+      {config.items.map((item) => {
+        const isItemActive = item.isCurrent && !selectedChildId
+
+        return (
+          <div key={item.id} className="space-y-1">
+            <BaseLink
+              href={item.href}
+              className={cn(
+                "flex w-full items-center gap-2 rounded-md px-3 py-2 text-start text-sm no-underline hover:bg-background-highlight",
+                isItemActive && "bg-background-highlight text-primary"
+              )}
+              onClick={() => {
+                if (item.isCurrent) onSelectChild(undefined)
+              }}
+            >
+              <ChevronRight
+                className={cn(
+                  "size-4 text-body-medium transition-transform",
+                  item.isCurrent && "rotate-90"
+                )}
+              />
+              <span className="flex-1">{item.label}</span>
+              <span className="text-xs text-body-medium">
+                {nf.format(item.count)}
+              </span>
+            </BaseLink>
+            {item.isCurrent && item.children && (
+              <div className="ms-5 space-y-1 border-s ps-2">
+                {item.children.map((child) => (
+                  <Button
+                    key={child.id}
+                    variant="ghost"
+                    isSecondary
+                    className={cn(
+                      "flex min-h-0 w-full items-center justify-between rounded-md px-3 py-1.5 text-start text-xs font-normal hover:bg-background-highlight",
+                      selectedChildId === child.id && "bg-background-highlight"
+                    )}
+                    onClick={() => {
+                      onSelectChild(
+                        selectedChildId === child.id ? undefined : child.id
+                      )
+                    }}
+                  >
+                    <span>{child.label}</span>
+                    {typeof child.count === "number" && (
+                      <span className="text-2xs text-body-medium">
+                        {nf.format(child.count)}
+                      </span>
+                    )}
+                  </Button>
+                ))}
+              </div>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/FilterableCatalog/FilterableCatalog.stories.tsx
+++ b/src/components/FilterableCatalog/FilterableCatalog.stories.tsx
@@ -156,7 +156,9 @@ export const CheckboxFilters: StoryObj = {
               config={config}
               selectedIds={selectedIds}
               onToggle={(optionId) =>
-                setFilter(key, toggleId(selectedIds, optionId))
+                setFilter(key, toggleId(selectedIds, optionId), {
+                  scroll: false,
+                })
               }
             />
           )

--- a/src/components/FilterableCatalog/FilterableCatalog.stories.tsx
+++ b/src/components/FilterableCatalog/FilterableCatalog.stories.tsx
@@ -1,0 +1,203 @@
+import { Meta, StoryObj } from "@storybook/nextjs"
+
+import FilterableCatalog from "./index"
+import type { CatalogFilterGroup, CatalogFilterState } from "./types"
+
+const meta = {
+  title: "Components / FilterableCatalog",
+  component: FilterableCatalog,
+  parameters: {
+    layout: "padded",
+  },
+} satisfies Meta<typeof FilterableCatalog>
+
+export default meta
+
+type DemoWallet = {
+  name: string
+  devices: string[]
+  networks: string[]
+  purchases: string[]
+}
+
+const demoWallets: DemoWallet[] = [
+  {
+    name: "Alpha Wallet",
+    devices: ["mobile", "browser"],
+    networks: ["ethereum", "op-mainnet", "arbitrum-one"],
+    purchases: ["buy"],
+  },
+  {
+    name: "Beacon Vault",
+    devices: ["hardware", "desktop"],
+    networks: ["ethereum"],
+    purchases: [],
+  },
+  {
+    name: "Cursive",
+    devices: ["mobile"],
+    networks: ["ethereum", "base"],
+    purchases: ["buy", "sell"],
+  },
+  {
+    name: "Denominator",
+    devices: ["desktop", "browser"],
+    networks: ["ethereum", "op-mainnet", "base"],
+    purchases: ["sell"],
+  },
+  {
+    name: "Ellipsis",
+    devices: ["mobile", "desktop"],
+    networks: ["arbitrum-one"],
+    purchases: ["buy"],
+  },
+]
+
+const walletAttributes = (wallet: DemoWallet) => [
+  ...wallet.devices,
+  ...wallet.networks,
+  ...wallet.purchases,
+]
+
+// The find-wallet filter sidebar shape planned for PR 2: independent checkbox
+// groups combined with AND semantics by the consumer's filterFn
+const walletFilterGroups: CatalogFilterGroup[] = [
+  {
+    type: "checkbox",
+    key: "devices",
+    label: "Devices",
+    options: [
+      { id: "desktop", label: "Desktop" },
+      { id: "mobile", label: "Mobile" },
+      { id: "browser", label: "Browser" },
+      { id: "hardware", label: "Hardware" },
+    ],
+  },
+  {
+    type: "checkbox",
+    key: "networks",
+    label: "Networks",
+    options: [
+      { id: "ethereum", label: "Ethereum Mainnet" },
+      { id: "op-mainnet", label: "OP Mainnet" },
+      { id: "arbitrum-one", label: "Arbitrum One" },
+      { id: "base", label: "Base" },
+    ],
+  },
+  {
+    type: "checkbox",
+    key: "purchases",
+    label: "Buy / sell crypto",
+    options: [
+      { id: "buy", label: "Buy crypto" },
+      { id: "sell", label: "Sell crypto" },
+    ],
+  },
+]
+
+const andFilterWallet = (
+  wallet: DemoWallet,
+  state: CatalogFilterState,
+  query: string
+) => {
+  const attributes = walletAttributes(wallet)
+  const selectedIds = Object.values(state)
+    .filter(Array.isArray)
+    .flat() as string[]
+  if (!selectedIds.every((id) => attributes.includes(id))) return false
+
+  const normalizedQuery = query.toLowerCase().trim()
+  if (!normalizedQuery) return true
+  return wallet.name.toLowerCase().includes(normalizedQuery)
+}
+
+const renderWalletResults = (wallets: DemoWallet[]) => (
+  <div className="grid grid-cols-auto-3 gap-4">
+    {wallets.map((wallet) => (
+      <div key={wallet.name} className="space-y-1 rounded-xl border p-4">
+        <p className="font-bold">{wallet.name}</p>
+        <p className="text-sm text-body-medium">
+          {walletAttributes(wallet).join(" · ")}
+        </p>
+      </div>
+    ))}
+  </div>
+)
+
+/**
+ * Checkbox filter groups with AND semantics in the consumer's filterFn --
+ * the shape the find-wallet revamp consumes.
+ */
+export const CheckboxFilters: StoryObj = {
+  render: () => (
+    <FilterableCatalog
+      locale="en"
+      items={demoWallets}
+      filterGroups={walletFilterGroups}
+      filterFn={andFilterWallet}
+      labels={{
+        searchPlaceholder: "Search wallets",
+        resultsLabel: "Results",
+        noResults: "No results",
+      }}
+      renderResults={renderWalletResults}
+    />
+  ),
+}
+
+/**
+ * Nav-tree sidebar as used by /developers/tools: top-level entries are route
+ * links; children of the current entry are a single-select client filter.
+ */
+export const NavigationSidebar: StoryObj = {
+  render: () => (
+    <FilterableCatalog
+      locale="en"
+      items={demoWallets}
+      filterGroups={[
+        {
+          type: "nav",
+          key: "device",
+          allLabel: "All categories",
+          allHref: "#all",
+          allCount: demoWallets.length,
+          items: [
+            {
+              id: "software",
+              label: "Software",
+              href: "#software",
+              count: 4,
+              isCurrent: true,
+              children: [
+                { id: "mobile", label: "Mobile", count: 3 },
+                { id: "desktop", label: "Desktop", count: 3 },
+                { id: "browser", label: "Browser", count: 2 },
+              ],
+            },
+            {
+              id: "hardware",
+              label: "Hardware",
+              href: "#hardware",
+              count: 1,
+            },
+          ],
+        },
+      ]}
+      filterFn={(wallet, state, query) => {
+        const device = state["device"]
+        if (typeof device === "string" && !wallet.devices.includes(device)) {
+          return false
+        }
+        const normalizedQuery = query.toLowerCase().trim()
+        if (!normalizedQuery) return true
+        return wallet.name.toLowerCase().includes(normalizedQuery)
+      }}
+      labels={{
+        searchPlaceholder: "Search wallets",
+        resultsLabel: "Results",
+        noResults: "No results",
+      }}
+      renderResults={renderWalletResults}
+    />
+  ),
+}

--- a/src/components/FilterableCatalog/FilterableCatalog.stories.tsx
+++ b/src/components/FilterableCatalog/FilterableCatalog.stories.tsx
@@ -1,7 +1,14 @@
 import { Meta, StoryObj } from "@storybook/nextjs"
 
+import CatalogCheckboxGroup from "./CatalogCheckboxGroup"
+import CatalogNavGroup from "./CatalogNavGroup"
 import FilterableCatalog from "./index"
-import type { CatalogFilterGroup, CatalogFilterState } from "./types"
+import type {
+  CatalogCheckboxGroupConfig,
+  CatalogFilterState,
+  CatalogNavGroupConfig,
+} from "./types"
+import { toggleId } from "./utils"
 
 const meta = {
   title: "Components / FilterableCatalog",
@@ -60,40 +67,39 @@ const walletAttributes = (wallet: DemoWallet) => [
 ]
 
 // The find-wallet filter sidebar shape planned for PR 2: independent checkbox
-// groups combined with AND semantics by the consumer's filterFn
-const walletFilterGroups: CatalogFilterGroup[] = [
-  {
-    type: "checkbox",
-    key: "devices",
-    label: "Devices",
-    options: [
-      { id: "desktop", label: "Desktop" },
-      { id: "mobile", label: "Mobile" },
-      { id: "browser", label: "Browser" },
-      { id: "hardware", label: "Hardware" },
-    ],
-  },
-  {
-    type: "checkbox",
-    key: "networks",
-    label: "Networks",
-    options: [
-      { id: "ethereum", label: "Ethereum Mainnet" },
-      { id: "op-mainnet", label: "OP Mainnet" },
-      { id: "arbitrum-one", label: "Arbitrum One" },
-      { id: "base", label: "Base" },
-    ],
-  },
-  {
-    type: "checkbox",
-    key: "purchases",
-    label: "Buy / sell crypto",
-    options: [
-      { id: "buy", label: "Buy crypto" },
-      { id: "sell", label: "Sell crypto" },
-    ],
-  },
-]
+// groups combined with AND semantics by the consumer's filterFn. The consumer
+// owns the state key; the block config is presentational only.
+const walletFilterGroups: Array<{ key: string } & CatalogCheckboxGroupConfig> =
+  [
+    {
+      key: "devices",
+      label: "Devices",
+      options: [
+        { id: "desktop", label: "Desktop" },
+        { id: "mobile", label: "Mobile" },
+        { id: "browser", label: "Browser" },
+        { id: "hardware", label: "Hardware" },
+      ],
+    },
+    {
+      key: "networks",
+      label: "Networks",
+      options: [
+        { id: "ethereum", label: "Ethereum Mainnet" },
+        { id: "op-mainnet", label: "OP Mainnet" },
+        { id: "arbitrum-one", label: "Arbitrum One" },
+        { id: "base", label: "Base" },
+      ],
+    },
+    {
+      key: "purchases",
+      label: "Buy / sell crypto",
+      options: [
+        { id: "buy", label: "Buy crypto" },
+        { id: "sell", label: "Sell crypto" },
+      ],
+    },
+  ]
 
 const andFilterWallet = (
   wallet: DemoWallet,
@@ -133,16 +139,60 @@ export const CheckboxFilters: StoryObj = {
     <FilterableCatalog
       locale="en"
       items={demoWallets}
-      filterGroups={walletFilterGroups}
       filterFn={andFilterWallet}
       labels={{
         searchPlaceholder: "Search wallets",
         resultsLabel: "Results",
         noResults: "No results",
       }}
+      renderSidebar={({ state, setFilter }) =>
+        walletFilterGroups.map(({ key, ...config }) => {
+          const raw = state[key]
+          const selectedIds = Array.isArray(raw) ? raw : []
+          return (
+            <CatalogCheckboxGroup
+              key={key}
+              locale="en"
+              config={config}
+              selectedIds={selectedIds}
+              onToggle={(optionId) =>
+                setFilter(key, toggleId(selectedIds, optionId))
+              }
+            />
+          )
+        })
+      }
       renderResults={renderWalletResults}
     />
   ),
+}
+
+const NAV_KEY = "device"
+
+const navConfig: CatalogNavGroupConfig = {
+  allLabel: "All categories",
+  allHref: "#all",
+  allCount: demoWallets.length,
+  items: [
+    {
+      id: "software",
+      label: "Software",
+      href: "#software",
+      count: 4,
+      isCurrent: true,
+      children: [
+        { id: "mobile", label: "Mobile", count: 3 },
+        { id: "desktop", label: "Desktop", count: 3 },
+        { id: "browser", label: "Browser", count: 2 },
+      ],
+    },
+    {
+      id: "hardware",
+      label: "Hardware",
+      href: "#hardware",
+      count: 1,
+    },
+  ],
 }
 
 /**
@@ -154,37 +204,8 @@ export const NavigationSidebar: StoryObj = {
     <FilterableCatalog
       locale="en"
       items={demoWallets}
-      filterGroups={[
-        {
-          type: "nav",
-          key: "device",
-          allLabel: "All categories",
-          allHref: "#all",
-          allCount: demoWallets.length,
-          items: [
-            {
-              id: "software",
-              label: "Software",
-              href: "#software",
-              count: 4,
-              isCurrent: true,
-              children: [
-                { id: "mobile", label: "Mobile", count: 3 },
-                { id: "desktop", label: "Desktop", count: 3 },
-                { id: "browser", label: "Browser", count: 2 },
-              ],
-            },
-            {
-              id: "hardware",
-              label: "Hardware",
-              href: "#hardware",
-              count: 1,
-            },
-          ],
-        },
-      ]}
       filterFn={(wallet, state, query) => {
-        const device = state["device"]
+        const device = state[NAV_KEY]
         if (typeof device === "string" && !wallet.devices.includes(device)) {
           return false
         }
@@ -196,6 +217,17 @@ export const NavigationSidebar: StoryObj = {
         searchPlaceholder: "Search wallets",
         resultsLabel: "Results",
         noResults: "No results",
+      }}
+      renderSidebar={({ state, setFilter }) => {
+        const raw = state[NAV_KEY]
+        return (
+          <CatalogNavGroup
+            locale="en"
+            config={navConfig}
+            selectedChildId={typeof raw === "string" ? raw : undefined}
+            onSelectChild={(childId) => setFilter(NAV_KEY, childId)}
+          />
+        )
       }}
       renderResults={renderWalletResults}
     />

--- a/src/components/FilterableCatalog/index.tsx
+++ b/src/components/FilterableCatalog/index.tsx
@@ -7,160 +7,18 @@ import {
   useRef,
   useState,
 } from "react"
-import { ChevronRight } from "lucide-react"
 
-import { Button } from "@/components/ui/buttons/Button"
-import Checkbox from "@/components/ui/checkbox"
 import Input from "@/components/ui/input"
-import { BaseLink } from "@/components/ui/Link"
 import { Section } from "@/components/ui/section"
 
 import { cn } from "@/lib/utils/cn"
 import { numberFormat } from "@/lib/utils/numbers"
 
 import type {
-  CatalogCheckboxGroup,
   CatalogFilterFn,
-  CatalogFilterGroup,
   CatalogFilterState,
-  CatalogNavGroup,
+  CatalogSetFilter,
 } from "./types"
-
-const PATH_SEPARATOR = "\u00A0\u00A0/\u00A0\u00A0"
-
-function formatPathSegment(value: string): string {
-  return value.toLocaleUpperCase()
-}
-
-type NavGroupProps = {
-  locale: string
-  group: CatalogNavGroup
-  selectedChildId?: string
-  onSelectChild: (childId?: string) => void
-}
-
-function NavGroup({
-  locale,
-  group,
-  selectedChildId,
-  onSelectChild,
-}: NavGroupProps) {
-  const nf = numberFormat(locale)
-  const hasCurrentItem = group.items.some((item) => item.isCurrent)
-
-  return (
-    <div className="space-y-1">
-      <BaseLink
-        href={group.allHref}
-        className={cn(
-          "flex w-full items-center justify-between rounded-md px-3 py-2 text-start text-sm no-underline hover:bg-background-highlight",
-          !hasCurrentItem && "bg-background-highlight text-primary"
-        )}
-      >
-        <span>{group.allLabel}</span>
-        <span className="text-xs text-body-medium">
-          {nf.format(group.allCount)}
-        </span>
-      </BaseLink>
-
-      {group.items.map((item) => {
-        const isItemActive = item.isCurrent && !selectedChildId
-
-        return (
-          <div key={item.id} className="space-y-1">
-            <BaseLink
-              href={item.href}
-              className={cn(
-                "flex w-full items-center gap-2 rounded-md px-3 py-2 text-start text-sm no-underline hover:bg-background-highlight",
-                isItemActive && "bg-background-highlight text-primary"
-              )}
-              onClick={() => {
-                if (item.isCurrent) onSelectChild(undefined)
-              }}
-            >
-              <ChevronRight
-                className={cn(
-                  "size-4 text-body-medium transition-transform",
-                  item.isCurrent && "rotate-90"
-                )}
-              />
-              <span className="flex-1">{item.label}</span>
-              <span className="text-xs text-body-medium">
-                {nf.format(item.count)}
-              </span>
-            </BaseLink>
-            {item.isCurrent && item.children && (
-              <div className="ms-5 space-y-1 border-s ps-2">
-                {item.children.map((child) => (
-                  <Button
-                    key={child.id}
-                    variant="ghost"
-                    isSecondary
-                    className={cn(
-                      "flex min-h-0 w-full items-center justify-between rounded-md px-3 py-1.5 text-start text-xs font-normal hover:bg-background-highlight",
-                      selectedChildId === child.id && "bg-background-highlight"
-                    )}
-                    onClick={() => {
-                      onSelectChild(
-                        selectedChildId === child.id ? undefined : child.id
-                      )
-                    }}
-                  >
-                    <span>{child.label}</span>
-                    {typeof child.count === "number" && (
-                      <span className="text-2xs text-body-medium">
-                        {nf.format(child.count)}
-                      </span>
-                    )}
-                  </Button>
-                ))}
-              </div>
-            )}
-          </div>
-        )
-      })}
-    </div>
-  )
-}
-
-type CheckboxGroupProps = {
-  locale: string
-  group: CatalogCheckboxGroup
-  selectedIds: string[]
-  onToggle: (optionId: string) => void
-}
-
-function CheckboxGroup({
-  locale,
-  group,
-  selectedIds,
-  onToggle,
-}: CheckboxGroupProps) {
-  const nf = numberFormat(locale)
-
-  return (
-    <div className="space-y-1">
-      <p className="px-3 py-2 text-sm font-bold">{group.label}</p>
-      {group.options.map((option) => (
-        <label
-          key={option.id}
-          className="flex cursor-pointer items-center gap-2 rounded-md px-3 py-1.5 text-sm hover:bg-background-highlight"
-        >
-          <Checkbox
-            checked={selectedIds.includes(option.id)}
-            onCheckedChange={() => onToggle(option.id)}
-          />
-          <span className="flex-1 select-none">{option.label}</span>
-          {typeof option.count === "number" && (
-            <span className="text-xs text-body-medium">
-              {nf.format(option.count)}
-            </span>
-          )}
-        </label>
-      ))}
-    </div>
-  )
-}
 
 export type FilterableCatalogLabels = {
   searchPlaceholder: string
@@ -168,30 +26,45 @@ export type FilterableCatalogLabels = {
   noResults: string
 }
 
+export type CatalogSidebarHelpers = {
+  state: CatalogFilterState
+  setFilter: CatalogSetFilter
+}
+
 export type FilterableCatalogProps<TItem> = {
   locale: string
   items: TItem[]
-  filterGroups: CatalogFilterGroup[]
   filterFn: CatalogFilterFn<TItem>
   labels: FilterableCatalogLabels
+  /**
+   * Filter UI, composed by the consumer from building blocks (CatalogNavGroup,
+   * CatalogCheckboxGroup, …) or bespoke controls. Receives the shared filter
+   * `state` and a `setFilter` writer keyed however the consumer likes.
+   */
+  renderSidebar: (helpers: CatalogSidebarHelpers) => ReactNode
   renderResults: (items: TItem[]) => ReactNode
+  /** Optional line rendered above the results count (e.g. an active-path breadcrumb) */
+  renderResultsHeader?: (state: CatalogFilterState) => ReactNode
   className?: string
 }
 
 /**
- * Client island for filterable listing pages: sidebar filter groups + search
- * input + count header + results area, with `useDeferredValue` so typing and
- * filtering stay responsive on large catalogs. Consumers describe the sidebar
- * via `filterGroups` config, decide membership via `filterFn` (including how
- * search matches an item), and own the results markup via `renderResults`.
+ * Client island for filterable listing pages: it owns the layout shell, the
+ * search input, the filter `state` bag, and the `useDeferredValue` pipeline
+ * that keeps typing/filtering responsive on large catalogs — then renders the
+ * count header and no-results state. Everything divergent between pages is
+ * composed in: the consumer draws its own filters (`renderSidebar`), decides
+ * membership (`filterFn`, including how search matches), and owns the results
+ * markup (`renderResults`).
  */
 export default function FilterableCatalog<TItem>({
   locale,
   items,
-  filterGroups,
   filterFn,
   labels,
+  renderSidebar,
   renderResults,
+  renderResultsHeader,
   className,
 }: FilterableCatalogProps<TItem>) {
   const nf = numberFormat(locale)
@@ -204,7 +77,7 @@ export default function FilterableCatalog<TItem>({
   const deferredSelection = useDeferredValue(selection)
   const isStale = search !== deferredSearch || selection !== deferredSelection
 
-  const handleSelect = (key: string, value: string | string[] | undefined) => {
+  const setFilter: CatalogSetFilter = (key, value) => {
     setSelection((prev) => ({ ...prev, [key]: value }))
     resultsTopRef.current?.scrollIntoView({
       behavior: "smooth",
@@ -218,55 +91,9 @@ export default function FilterableCatalog<TItem>({
     [items, filterFn, deferredSelection, deferredSearch]
   )
 
-  // Uppercased breadcrumb of the current nav item (and its selected child)
-  // shown above the results count
-  const activePath = filterGroups.flatMap((group) => {
-    if (group.type !== "nav") return []
-    const currentItem = group.items.find((item) => item.isCurrent)
-    const selectedChild = currentItem?.children?.find(
-      (child) => child.id === selection[group.key]
-    )
-    const segments: string[] = []
-    if (currentItem) segments.push(currentItem.label)
-    if (selectedChild) segments.push(selectedChild.label)
-    return segments
-  })
-
-  const sidebar = filterGroups.map((group) => {
-    if (group.type === "nav") {
-      const selectedChildId = selection[group.key]
-      return (
-        <NavGroup
-          key={group.key}
-          locale={locale}
-          group={group}
-          selectedChildId={
-            typeof selectedChildId === "string" ? selectedChildId : undefined
-          }
-          onSelectChild={(childId) => handleSelect(group.key, childId)}
-        />
-      )
-    }
-
-    const selectedIds = selection[group.key]
-    const selectedArray = Array.isArray(selectedIds) ? selectedIds : []
-    return (
-      <CheckboxGroup
-        key={group.key}
-        locale={locale}
-        group={group}
-        selectedIds={selectedArray}
-        onToggle={(optionId) => {
-          handleSelect(
-            group.key,
-            selectedArray.includes(optionId)
-              ? selectedArray.filter((id) => id !== optionId)
-              : [...selectedArray, optionId]
-          )
-        }}
-      />
-    )
-  })
+  // Filter UI reads live selection (not deferred) so controls reflect input
+  // immediately; only the results below deferred-render.
+  const sidebar = renderSidebar({ state: selection, setFilter })
 
   return (
     <Section id="catalog" className={cn("space-y-5", className)}>
@@ -296,11 +123,7 @@ export default function FilterableCatalog<TItem>({
             <div className="space-y-4 rounded-xl border p-2">{sidebar}</div>
           </div>
           <div ref={resultsTopRef} className="scroll-mt-24" />
-          {activePath.length > 0 && (
-            <p className="text-sm text-body-medium">
-              {activePath.map(formatPathSegment).join(PATH_SEPARATOR)}
-            </p>
-          )}
+          {renderResultsHeader?.(selection)}
 
           <p className="text-sm text-body-medium">
             {labels.resultsLabel}:{" "}

--- a/src/components/FilterableCatalog/index.tsx
+++ b/src/components/FilterableCatalog/index.tsx
@@ -34,6 +34,12 @@ export type CatalogSidebarHelpers = {
 export type FilterableCatalogProps<TItem> = {
   locale: string
   items: TItem[]
+  /**
+   * Decides item membership from the deferred filter `state` and search `query`.
+   * Pass a stable reference (defined outside render, or memoized) — it's a
+   * dependency of the internal filtering memo, so a fresh function each render
+   * re-runs the filter over every item on every render.
+   */
   filterFn: CatalogFilterFn<TItem>
   labels: FilterableCatalogLabels
   /**
@@ -77,12 +83,14 @@ export default function FilterableCatalog<TItem>({
   const deferredSelection = useDeferredValue(selection)
   const isStale = search !== deferredSearch || selection !== deferredSelection
 
-  const setFilter: CatalogSetFilter = (key, value) => {
+  const setFilter: CatalogSetFilter = (key, value, options) => {
     setSelection((prev) => ({ ...prev, [key]: value }))
-    resultsTopRef.current?.scrollIntoView({
-      behavior: "smooth",
-      block: "start",
-    })
+    if (options?.scroll ?? true) {
+      resultsTopRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      })
+    }
   }
 
   const filteredItems = useMemo(

--- a/src/components/FilterableCatalog/index.tsx
+++ b/src/components/FilterableCatalog/index.tsx
@@ -1,0 +1,328 @@
+"use client"
+
+import {
+  type ReactNode,
+  useDeferredValue,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
+import { ChevronRight } from "lucide-react"
+
+import { Button } from "@/components/ui/buttons/Button"
+import Checkbox from "@/components/ui/checkbox"
+import Input from "@/components/ui/input"
+import { BaseLink } from "@/components/ui/Link"
+import { Section } from "@/components/ui/section"
+
+import { cn } from "@/lib/utils/cn"
+import { numberFormat } from "@/lib/utils/numbers"
+
+import type {
+  CatalogCheckboxGroup,
+  CatalogFilterFn,
+  CatalogFilterGroup,
+  CatalogFilterState,
+  CatalogNavGroup,
+} from "./types"
+
+const PATH_SEPARATOR = "\u00A0\u00A0/\u00A0\u00A0"
+
+function formatPathSegment(value: string): string {
+  return value.toLocaleUpperCase()
+}
+
+type NavGroupProps = {
+  locale: string
+  group: CatalogNavGroup
+  selectedChildId?: string
+  onSelectChild: (childId?: string) => void
+}
+
+function NavGroup({
+  locale,
+  group,
+  selectedChildId,
+  onSelectChild,
+}: NavGroupProps) {
+  const nf = numberFormat(locale)
+  const hasCurrentItem = group.items.some((item) => item.isCurrent)
+
+  return (
+    <div className="space-y-1">
+      <BaseLink
+        href={group.allHref}
+        className={cn(
+          "flex w-full items-center justify-between rounded-md px-3 py-2 text-start text-sm no-underline hover:bg-background-highlight",
+          !hasCurrentItem && "bg-background-highlight text-primary"
+        )}
+      >
+        <span>{group.allLabel}</span>
+        <span className="text-xs text-body-medium">
+          {nf.format(group.allCount)}
+        </span>
+      </BaseLink>
+
+      {group.items.map((item) => {
+        const isItemActive = item.isCurrent && !selectedChildId
+
+        return (
+          <div key={item.id} className="space-y-1">
+            <BaseLink
+              href={item.href}
+              className={cn(
+                "flex w-full items-center gap-2 rounded-md px-3 py-2 text-start text-sm no-underline hover:bg-background-highlight",
+                isItemActive && "bg-background-highlight text-primary"
+              )}
+              onClick={() => {
+                if (item.isCurrent) onSelectChild(undefined)
+              }}
+            >
+              <ChevronRight
+                className={cn(
+                  "size-4 text-body-medium transition-transform",
+                  item.isCurrent && "rotate-90"
+                )}
+              />
+              <span className="flex-1">{item.label}</span>
+              <span className="text-xs text-body-medium">
+                {nf.format(item.count)}
+              </span>
+            </BaseLink>
+            {item.isCurrent && item.children && (
+              <div className="ms-5 space-y-1 border-s ps-2">
+                {item.children.map((child) => (
+                  <Button
+                    key={child.id}
+                    variant="ghost"
+                    isSecondary
+                    className={cn(
+                      "flex min-h-0 w-full items-center justify-between rounded-md px-3 py-1.5 text-start text-xs font-normal hover:bg-background-highlight",
+                      selectedChildId === child.id && "bg-background-highlight"
+                    )}
+                    onClick={() => {
+                      onSelectChild(
+                        selectedChildId === child.id ? undefined : child.id
+                      )
+                    }}
+                  >
+                    <span>{child.label}</span>
+                    {typeof child.count === "number" && (
+                      <span className="text-2xs text-body-medium">
+                        {nf.format(child.count)}
+                      </span>
+                    )}
+                  </Button>
+                ))}
+              </div>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+type CheckboxGroupProps = {
+  locale: string
+  group: CatalogCheckboxGroup
+  selectedIds: string[]
+  onToggle: (optionId: string) => void
+}
+
+function CheckboxGroup({
+  locale,
+  group,
+  selectedIds,
+  onToggle,
+}: CheckboxGroupProps) {
+  const nf = numberFormat(locale)
+
+  return (
+    <div className="space-y-1">
+      <p className="px-3 py-2 text-sm font-bold">{group.label}</p>
+      {group.options.map((option) => (
+        <label
+          key={option.id}
+          className="flex cursor-pointer items-center gap-2 rounded-md px-3 py-1.5 text-sm hover:bg-background-highlight"
+        >
+          <Checkbox
+            checked={selectedIds.includes(option.id)}
+            onCheckedChange={() => onToggle(option.id)}
+          />
+          <span className="flex-1 select-none">{option.label}</span>
+          {typeof option.count === "number" && (
+            <span className="text-xs text-body-medium">
+              {nf.format(option.count)}
+            </span>
+          )}
+        </label>
+      ))}
+    </div>
+  )
+}
+
+export type FilterableCatalogLabels = {
+  searchPlaceholder: string
+  resultsLabel: string
+  noResults: string
+}
+
+export type FilterableCatalogProps<TItem> = {
+  locale: string
+  items: TItem[]
+  filterGroups: CatalogFilterGroup[]
+  filterFn: CatalogFilterFn<TItem>
+  labels: FilterableCatalogLabels
+  renderResults: (items: TItem[]) => ReactNode
+  className?: string
+}
+
+/**
+ * Client island for filterable listing pages: sidebar filter groups + search
+ * input + count header + results area, with `useDeferredValue` so typing and
+ * filtering stay responsive on large catalogs. Consumers describe the sidebar
+ * via `filterGroups` config, decide membership via `filterFn` (including how
+ * search matches an item), and own the results markup via `renderResults`.
+ */
+export default function FilterableCatalog<TItem>({
+  locale,
+  items,
+  filterGroups,
+  filterFn,
+  labels,
+  renderResults,
+  className,
+}: FilterableCatalogProps<TItem>) {
+  const nf = numberFormat(locale)
+  const [search, setSearch] = useState("")
+  const [selection, setSelection] = useState<CatalogFilterState>({})
+  const resultsTopRef = useRef<HTMLDivElement | null>(null)
+
+  // Defer the heavy filter + grid render so typing and filtering stay responsive
+  const deferredSearch = useDeferredValue(search)
+  const deferredSelection = useDeferredValue(selection)
+  const isStale = search !== deferredSearch || selection !== deferredSelection
+
+  const handleSelect = (key: string, value: string | string[] | undefined) => {
+    setSelection((prev) => ({ ...prev, [key]: value }))
+    resultsTopRef.current?.scrollIntoView({
+      behavior: "smooth",
+      block: "start",
+    })
+  }
+
+  const filteredItems = useMemo(
+    () =>
+      items.filter((item) => filterFn(item, deferredSelection, deferredSearch)),
+    [items, filterFn, deferredSelection, deferredSearch]
+  )
+
+  // Uppercased breadcrumb of the current nav item (and its selected child)
+  // shown above the results count
+  const activePath = filterGroups.flatMap((group) => {
+    if (group.type !== "nav") return []
+    const currentItem = group.items.find((item) => item.isCurrent)
+    const selectedChild = currentItem?.children?.find(
+      (child) => child.id === selection[group.key]
+    )
+    const segments: string[] = []
+    if (currentItem) segments.push(currentItem.label)
+    if (selectedChild) segments.push(selectedChild.label)
+    return segments
+  })
+
+  const sidebar = filterGroups.map((group) => {
+    if (group.type === "nav") {
+      const selectedChildId = selection[group.key]
+      return (
+        <NavGroup
+          key={group.key}
+          locale={locale}
+          group={group}
+          selectedChildId={
+            typeof selectedChildId === "string" ? selectedChildId : undefined
+          }
+          onSelectChild={(childId) => handleSelect(group.key, childId)}
+        />
+      )
+    }
+
+    const selectedIds = selection[group.key]
+    const selectedArray = Array.isArray(selectedIds) ? selectedIds : []
+    return (
+      <CheckboxGroup
+        key={group.key}
+        locale={locale}
+        group={group}
+        selectedIds={selectedArray}
+        onToggle={(optionId) => {
+          handleSelect(
+            group.key,
+            selectedArray.includes(optionId)
+              ? selectedArray.filter((id) => id !== optionId)
+              : [...selectedArray, optionId]
+          )
+        }}
+      />
+    )
+  })
+
+  return (
+    <Section id="catalog" className={cn("space-y-5", className)}>
+      <div className="grid grid-cols-1 gap-8 lg:grid-cols-[280px_1fr]">
+        <aside className="hidden lg:block">
+          <div className="sticky top-24 space-y-4">
+            <Input
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder={labels.searchPlaceholder}
+              className="w-full"
+            />
+            <div className="max-h-[calc(100vh-11rem)] space-y-4 overflow-y-auto rounded-xl border p-2">
+              {sidebar}
+            </div>
+          </div>
+        </aside>
+
+        <div className="space-y-4 lg:-mt-5">
+          <div className="space-y-3 lg:hidden">
+            <Input
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder={labels.searchPlaceholder}
+              className="w-full"
+            />
+            <div className="space-y-4 rounded-xl border p-2">{sidebar}</div>
+          </div>
+          <div ref={resultsTopRef} className="scroll-mt-24" />
+          {activePath.length > 0 && (
+            <p className="text-sm text-body-medium">
+              {activePath.map(formatPathSegment).join(PATH_SEPARATOR)}
+            </p>
+          )}
+
+          <p className="text-sm text-body-medium">
+            {labels.resultsLabel}:{" "}
+            <strong>{nf.format(filteredItems.length)}</strong> /{" "}
+            {nf.format(items.length)}
+          </p>
+
+          <div
+            className={cn(
+              "space-y-8 transition-opacity",
+              isStale && "opacity-60"
+            )}
+          >
+            {renderResults(filteredItems)}
+          </div>
+          {filteredItems.length === 0 && (
+            <div className="rounded-xl border p-8 text-center text-body-medium">
+              {labels.noResults}
+            </div>
+          )}
+        </div>
+      </div>
+    </Section>
+  )
+}

--- a/src/components/FilterableCatalog/types.ts
+++ b/src/components/FilterableCatalog/types.ts
@@ -41,9 +41,19 @@ export type CatalogCheckboxGroupConfig = {
 /** Selected filter values keyed by an arbitrary consumer-chosen key */
 export type CatalogFilterState = Record<string, string | string[] | undefined>
 
+export type CatalogSetFilterOptions = {
+  /**
+   * Scroll the results region into view after the change. Defaults to `true`
+   * (right for single-select nav); pass `false` for multi-select toggles like
+   * checkboxes, where scrolling on every tick is jarring.
+   */
+  scroll?: boolean
+}
+
 export type CatalogSetFilter = (
   key: string,
-  value: string | string[] | undefined
+  value: string | string[] | undefined,
+  options?: CatalogSetFilterOptions
 ) => void
 
 export type CatalogFilterFn<TItem> = (

--- a/src/components/FilterableCatalog/types.ts
+++ b/src/components/FilterableCatalog/types.ts
@@ -16,14 +16,12 @@ export type CatalogNavItem = {
 }
 
 /**
- * Sidebar group whose top-level entries are real route links (server-rendered
- * listing pages), while children of the current entry act as a single-select
- * client-side filter stored under `key`.
+ * Presentational data for the `CatalogNavGroup` building block: top-level
+ * entries are real route links (server-rendered listing pages); the children of
+ * the current entry are the single-select options. The block is controlled —
+ * the consumer owns where the selected child id lives.
  */
-export type CatalogNavGroup = {
-  type: "nav"
-  /** Filter-state key the selected child id is stored under */
-  key: string
+export type CatalogNavGroupConfig = {
   allLabel: string
   allHref: string
   allCount: number
@@ -31,21 +29,22 @@ export type CatalogNavGroup = {
 }
 
 /**
- * Sidebar group of independent checkboxes. Selected option ids are stored
- * under `key` as an array; combining semantics (AND/OR) are up to the
- * consumer's `filterFn`.
+ * Presentational data for the `CatalogCheckboxGroup` building block: a labelled
+ * set of independent checkboxes. The block is controlled — the consumer owns
+ * the selected ids and how the group combines with others (AND/OR) in `filterFn`.
  */
-export type CatalogCheckboxGroup = {
-  type: "checkbox"
-  key: string
+export type CatalogCheckboxGroupConfig = {
   label: string
   options: CatalogSelectOption[]
 }
 
-export type CatalogFilterGroup = CatalogNavGroup | CatalogCheckboxGroup
-
-/** Selected filter values keyed by group `key` */
+/** Selected filter values keyed by an arbitrary consumer-chosen key */
 export type CatalogFilterState = Record<string, string | string[] | undefined>
+
+export type CatalogSetFilter = (
+  key: string,
+  value: string | string[] | undefined
+) => void
 
 export type CatalogFilterFn<TItem> = (
   item: TItem,

--- a/src/components/FilterableCatalog/types.ts
+++ b/src/components/FilterableCatalog/types.ts
@@ -1,0 +1,54 @@
+export type CatalogSelectOption = {
+  id: string
+  label: string
+  count?: number
+}
+
+export type CatalogNavItem = {
+  id: string
+  label: string
+  href: string
+  count: number
+  /** Marks the item matching the current route; its children render as filters */
+  isCurrent?: boolean
+  /** Single-select filter options shown while this item is current */
+  children?: CatalogSelectOption[]
+}
+
+/**
+ * Sidebar group whose top-level entries are real route links (server-rendered
+ * listing pages), while children of the current entry act as a single-select
+ * client-side filter stored under `key`.
+ */
+export type CatalogNavGroup = {
+  type: "nav"
+  /** Filter-state key the selected child id is stored under */
+  key: string
+  allLabel: string
+  allHref: string
+  allCount: number
+  items: CatalogNavItem[]
+}
+
+/**
+ * Sidebar group of independent checkboxes. Selected option ids are stored
+ * under `key` as an array; combining semantics (AND/OR) are up to the
+ * consumer's `filterFn`.
+ */
+export type CatalogCheckboxGroup = {
+  type: "checkbox"
+  key: string
+  label: string
+  options: CatalogSelectOption[]
+}
+
+export type CatalogFilterGroup = CatalogNavGroup | CatalogCheckboxGroup
+
+/** Selected filter values keyed by group `key` */
+export type CatalogFilterState = Record<string, string | string[] | undefined>
+
+export type CatalogFilterFn<TItem> = (
+  item: TItem,
+  state: CatalogFilterState,
+  query: string
+) => boolean

--- a/src/components/FilterableCatalog/utils.ts
+++ b/src/components/FilterableCatalog/utils.ts
@@ -1,0 +1,6 @@
+/** Add/remove an id from a multi-select array — for wiring CatalogCheckboxGroup */
+export function toggleId(ids: string[], id: string): string[] {
+  return ids.includes(id)
+    ? ids.filter((existing) => existing !== id)
+    : [...ids, id]
+}

--- a/tests/visual/pages.spec.ts
+++ b/tests/visual/pages.spec.ts
@@ -13,6 +13,11 @@ const pages: Array<{ name: string; path: string }> = [
   { name: "History", path: "/history/" },
   { name: "Get ETH", path: "/get-eth/" },
   { name: "Find Wallet", path: "/wallets/find-wallet/" },
+  { name: "Developer Tools", path: "/developers/tools/" },
+  {
+    name: "Developer Tools - Category",
+    path: "/developers/tools/categories/contract-tooling/",
+  },
 
   // One representative per src/layouts/ layout — keeps coverage without per-page duplication.
   { name: "Bridges", path: "/bridges/" }, // StaticLayout


### PR DESCRIPTION
**PR 1 of the find-wallet revamp.** Extracts a reusable catalog component from `ToolsCatalog` and migrates `/developers/tools` onto it with zero behavior change. PR 2 rebuilds `/wallets/find-wallet` on top of it.

## What

- `src/components/FilterableCatalog/` — the core owns the shared machinery (layout shell, search, filter state, the `useDeferredValue` pipeline, count header, no-results). Everything page-specific is composed in: consumers draw filters (`renderSidebar`), decide membership (`filterFn`), and own results markup (`renderResults`).
- Filters ship as presentational, controlled building blocks — `CatalogNavGroup` and `CatalogCheckboxGroup` (value in, event out; no knowledge of how state is stored). Consumers compose them or drop in bespoke controls; a new filter UI needs no core change.
- `ToolsCatalog` shrinks from a 435-line monolith to a thin consumer.

## Why composition over a config union

An earlier revision drove filters from a discriminated union the core interpreted via a `switch`. The two members had disjoint shapes and each consumer used exactly one — every new affordance would have meant growing the union *and* the core. Composition keeps the core small and closed over what's genuinely shared, and leaves filter UI open-ended for PR 2.

## Verification

- Catalog DOM for both dev-tools pages is **byte-identical** to before the refactor.
- Visual-test coverage for `/developers/tools` added in a **separate first commit** so Chromatic's baseline predates the change.
- `type-check` / lint / Prettier clean; both building blocks covered by a Storybook story.

## Notes

- Matomo event-naming-via-config is deferred to PR 2 (dev tools emits no events today — it would be a dark code path here).
