### PR TITLE
chore: remove plagiarized contributor entries

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -14425,28 +14425,10 @@
       ]
     },
     {
-      "login": "FDongFDong",
-      "name": "FDongFDong",
-      "avatar_url": "https://avatars.githubusercontent.com/u/20445415?v=4",
-      "profile": "https://velog.io/@fdongfdong",
-      "contributions": [
-        "maintenance"
-      ]
-    },
-    {
       "login": "0xDecentralizer",
       "name": "Mohammad Mahdi Keshavarz",
       "avatar_url": "https://avatars.githubusercontent.com/u/52651219?v=4",
       "profile": "https://linktr.ee/0xdecentralizer",
-      "contributions": [
-        "maintenance"
-      ]
-    },
-    {
-      "login": "Semak12345",
-      "name": "Sambyd",
-      "avatar_url": "https://avatars.githubusercontent.com/u/88731119?v=4",
-      "profile": "https://github.com/Semak12345",
       "contributions": [
         "maintenance"
       ]

--- a/README.md
+++ b/README.md
@@ -2241,9 +2241,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Equious"><img src="https://avatars.githubusercontent.com/u/76449140?v=4?s=100" width="100px;" alt="Equious"/><br /><sub><b>Equious</b></sub></a><br /><a href="#tool-Equious" title="Tools">🔧</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://0xheycat.xyz/"><img src="https://avatars.githubusercontent.com/u/81378817?v=4?s=100" width="100px;" alt="0xheycat"/><br /><sub><b>0xheycat</b></sub></a><br /><a href="#content-0xheycat" title="Content">🖋</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/jensendunamu"><img src="https://avatars.githubusercontent.com/u/233986215?v=4?s=100" width="100px;" alt="jensen"/><br /><sub><b>jensen</b></sub></a><br /><a href="#maintenance-jensendunamu" title="Maintenance">🚧</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://velog.io/@fdongfdong"><img src="https://avatars.githubusercontent.com/u/20445415?v=4?s=100" width="100px;" alt="FDongFDong"/><br /><sub><b>FDongFDong</b></sub></a><br /><a href="#maintenance-FDongFDong" title="Maintenance">🚧</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://linktr.ee/0xdecentralizer"><img src="https://avatars.githubusercontent.com/u/52651219?v=4?s=100" width="100px;" alt="Mohammad Mahdi Keshavarz"/><br /><sub><b>Mohammad Mahdi Keshavarz</b></sub></a><br /><a href="#maintenance-0xDecentralizer" title="Maintenance">🚧</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/Semak12345"><img src="https://avatars.githubusercontent.com/u/88731119?v=4?s=100" width="100px;" alt="Sambyd"/><br /><sub><b>Sambyd</b></sub></a><br /><a href="#maintenance-Semak12345" title="Maintenance">🚧</a></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
## Description

Removes two `maintenance` entries from `.all-contributorsrc` and the README contributor grid.

## Violation: plagiarism

Both credits were granted for pull requests that copied existing contributions rather than authoring original work.

- **FDongFDong** - the merged #18729 (Vyper module-system note) is a byte-identical copy of the earlier, still-open #18614 by @lufa23, who filed both the original issue (#18613) and the fix. The copy was merged over the original.
- **Semak12345** (`Sambyd`) - #18778 duplicated #18678 (CryptoSD meetup link) by @alerodriargui, and #18780 was a byte-identical copy of the already-merged Vyper note. The account's broader activity fits contribution-farming (batched PRs, a self-repo named `gh-achievements-sprint`).

## Notes

- Content is unaffected. #18614 (lufa23's original) is now merged, so the Vyper note remains live; this only corrects the misattributed credit.
- Contributor count drops 1567 -> 1565. The README badge is the dynamic shields.io `all-contributors` badge, so no hardcoded number needs updating.
