### PR TITLE
content: shorten homepage and apps meta descriptions [Fixes #18856]

### DIFF
--- a/src/intl/en/page-apps.json
+++ b/src/intl/en/page-apps.json
@@ -18,7 +18,7 @@
   "page-apps-categories-title": "Application categories",
   "page-apps-community-picks-title": "Community picks",
   "page-apps-meta-title": "Top crypto apps on Ethereum",
-  "page-apps-meta-description": "Discover crypto apps on Ethereum: DeFi, NFTs, social, gaming, bridges, privacy, and DAOs. Find trusted onchain apps to trade, earn, and interact.",
+  "page-apps-meta-description": "Discover apps on Ethereum: DeFi, NFTs, social, gaming, bridges, privacy, and DAOs. Find trusted onchain apps to trade crypto, earn, and interact.",
   "page-apps-category-defi-name": "DeFi",
   "page-apps-category-defi-description": "DeFi is a category of decentralized applications that allow users to lend, borrow, trade, and earn interest on their crypto assets.",
   "page-apps-category-defi-meta-title": "List of Ethereum DeFi apps — Lending, Borrowing & Yield",

--- a/src/intl/en/page-apps.json
+++ b/src/intl/en/page-apps.json
@@ -18,7 +18,7 @@
   "page-apps-categories-title": "Application categories",
   "page-apps-community-picks-title": "Community picks",
   "page-apps-meta-title": "Top crypto apps on Ethereum",
-  "page-apps-meta-description": "Discover  crypto apps on Ethereum: explore DeFi, NFTs, Social, Gaming, Bridges, Privacy, Productivity & DAO dApps. Find trusted onchain apps to trade, earn, and interact.",
+  "page-apps-meta-description": "Discover crypto apps on Ethereum: DeFi, NFTs, social, gaming, bridges, privacy, and DAOs. Find trusted onchain apps to trade, earn, and interact.",
   "page-apps-category-defi-name": "DeFi",
   "page-apps-category-defi-description": "DeFi is a category of decentralized applications that allow users to lend, borrow, trade, and earn interest on their crypto assets.",
   "page-apps-category-defi-meta-title": "List of Ethereum DeFi apps — Lending, Borrowing & Yield",

--- a/src/intl/en/page-index.json
+++ b/src/intl/en/page-index.json
@@ -1,6 +1,6 @@
 {
   "page-index-meta-title": "Ethereum - The complete guide from ethereum.org",
-  "page-index-meta-description": "Ethereum is a global, decentralized platform for money and new kinds of applications. On Ethereum, you control your own money, data, and identity. No bank, no middleman, no permission needed.",
+  "page-index-meta-description": "Ethereum is a decentralized platform for money and new kinds of apps. Control your own money, data, and identity, with no bank or middleman needed.",
   "page-index-description": "The leading platform for innovative apps and blockchain networks",
   "page-index-title": "Welcome to Ethereum",
   "page-index-hero-image-alt": "An illustration of a futuristic city, representing the Ethereum ecosystem.",

--- a/src/intl/en/page-index.json
+++ b/src/intl/en/page-index.json
@@ -1,6 +1,6 @@
 {
   "page-index-meta-title": "Ethereum - The complete guide from ethereum.org",
-  "page-index-meta-description": "Ethereum is a decentralized platform for money and new kinds of apps. Control your own money, data, and identity, with no bank or middleman needed.",
+  "page-index-meta-description": "Ethereum is a decentralized platform for resilient apps and infrastructure. Control your money, data, and identity, with no bank or middleman needed.",
   "page-index-description": "The leading platform for innovative apps and blockchain networks",
   "page-index-title": "Welcome to Ethereum",
   "page-index-hero-image-alt": "An illustration of a futuristic city, representing the Ethereum ecosystem.",


### PR DESCRIPTION
## Description
Shortened meta descriptions for the homepage (`page-index.json`) and dapps page (`page-apps.json`) to prevent truncation in search results and fix double-spacing.

## Related Issue
Closes #18856