### PR TITLE
test: verify Chromatic UI Tests on content-only PR (DO NOT MERGE)

### DIFF
--- a/public/content/community/get-involved/index.md
+++ b/public/content/community/get-involved/index.md
@@ -126,4 +126,4 @@ The Ethereum ecosystem is on a mission to fund public goods and impactful projec
 - [MetaFactory](https://metafactory.ai) [@TheMetaFactory](https://twitter.com/TheMetaFactory) - _Digiphysical Apparel Brands_
 - [Raid Guild](https://raidguild.org) [@RaidGuild](https://twitter.com/RaidGuild) - _Collective of Web3 builders_
 
-Please remember to abide by the ethereum.org [code of conduct](/community/code-of-conduct) whenever and however you contribute to ethereum.org!
+Please remember to follow the ethereum.org [code of conduct](/community/code-of-conduct) whenever and however you contribute to ethereum.org!


### PR DESCRIPTION
Throwaway PR to confirm that under the new CI config (#18809) a content-only change still gets a passing `UI Tests: ethereum-org-website` check before we make it a required status check. Will be closed once verified.