### PR TITLE
fix(roadmap): make SSF card title translatable

### DIFF
--- a/public/content/roadmap/single-slot-finality/index.md
+++ b/public/content/roadmap/single-slot-finality/index.md
@@ -32,7 +32,7 @@ With the current mechanism design, in order to reduce the time to finality, it i
 
 ## Routes to SSF {#routes-to-ssf}
 
-<ExpandableCard title= "Why can't we have SSF today?" eventCategory="/roadmap/single-slot-finality" eventName="clicked Why can't we hear SSF today?">
+<ExpandableCard title="Why can't we have SSF today?" eventCategory="/roadmap/single-slot-finality" eventName="clicked Why can't we hear SSF today?">
 
 The current consensus mechanism combines attestations from multiple validators, known as committees, to reduce the number of messages each validator has to process to validate a block. Every validator has an opportunity to attest in each epoch (32 slots) but in each slot, only a subset of validators, known as a 'committee' attest. They do so by dividing up into subnets in which a few validators are selected to be 'aggregators'. Those aggregators each combine all the signatures they see from other validators in their subnet into a single aggregate signature. The aggregator that includes the greatest number of individual contributions passes their aggregate signature to the block proposer, who includes it in the block along with the aggregate signature from the other committees.
 


### PR DESCRIPTION
## Summary

The `single-slot-finality` `ExpandableCard` used `title= "..."` with a space between `=` and the opening quote. The intl-pipeline's JSX attribute-value extractor doesn't match that form, so the card title (`"Why can't we have SSF today?"`) was never sent for translation and shipped verbatim in English across **all 24 locales** (the card body translated fine). Removing the space lets the next pipeline run translate the title.

Surfaced during the PR #18868 translation review.

Note: the same line's `eventName` reads `"clicked Why can't we hear SSF today?"` ("hear" vs "have") -- a pre-existing analytics-label typo left untouched here, since renaming a Matomo event affects tracking continuity. Flagging for a separate decision.
