### PR TITLE
Add SolidRPC to infrastructure services

### DIFF
--- a/public/content/developers/docs/apis/backend/index.md
+++ b/public/content/developers/docs/apis/backend/index.md
@@ -91,6 +91,12 @@ These libraries abstract away much of the complexity of interacting directly wit
 - [Documentation](https://rivet.cloud/docs/)
 - [GitHub](https://github.com/openrelayxyz/ethercattle-deployment)
 
+**SolidRPC -** **_EVM JSON-RPC infrastructure with full, archive, and keyless public access._**
+
+- [solidrpc.io](https://solidrpc.io/)
+- [Documentation](https://solidrpc.io/docs)
+- [GitHub](https://github.com/DamianFigiel/SolidRPC)
+
 **Zmok -** **_Speed-oriented Ethereum nodes as JSON-RPC/WebSockets API._**
 
 - [zmok.io](https://zmok.io/)

--- a/public/content/developers/docs/apis/backend/index.md
+++ b/public/content/developers/docs/apis/backend/index.md
@@ -95,7 +95,7 @@ These libraries abstract away much of the complexity of interacting directly wit
 
 - [solidrpc.io](https://solidrpc.io/)
 - [Documentation](https://solidrpc.io/docs)
-- [GitHub](https://github.com/DamianFigiel/SolidRPC)
+- [GitHub](https://github.com/SolidRPC)
 
 **Zmok -** **_Speed-oriented Ethereum nodes as JSON-RPC/WebSockets API._**
 


### PR DESCRIPTION
## Description

Adds SolidRPC to the “Infrastructure and node services” section of the Backend API libraries documentation.

The new entry provides links to:

- SolidRPC website: [https://solidrpc.io](https://solidrpc.io)
- Documentation: [https://solidrpc.io/docs](https://solidrpc.io/docs)
- GitHub organization: [https://github.com/SolidRPC](https://github.com/SolidRPC)

SolidRPC provides EVM JSON-RPC infrastructure over HTTPS, including authenticated full and archive access and keyless public endpoints for selected mainnets.

The change is limited to the English infrastructure-provider directory and does not modify application code or translated content.

## Related Issue

N/A — this is a documentation directory addition.