### PR TITLE
Fix: RSS feed should reference post images via \<media:content>\ (#18305)

### DIFF
--- a/app/[locale]/latest/feed/route.ts
+++ b/app/[locale]/latest/feed/route.ts
@@ -1,6 +1,7 @@
 import type { NextRequest } from "next/server"
 import { getTranslations } from "next-intl/server"
 
+import { getBlogFallbackHero } from "@/lib/utils/blog"
 import { getBlogPostsData } from "@/lib/utils/md"
 import { getFullUrl } from "@/lib/utils/url"
 
@@ -16,6 +17,14 @@ const XML_ESCAPE: Record<string, string> = {
 
 const escapeXml = (value: string): string =>
   value.replace(/[&<>"']/g, (c) => XML_ESCAPE[c])
+
+const getMimeType = (url: string) => {
+  if (url.endsWith(".png")) return "image/png"
+  if (url.endsWith(".jpg") || url.endsWith(".jpeg")) return "image/jpeg"
+  if (url.endsWith(".webp")) return "image/webp"
+  if (url.endsWith(".svg")) return "image/svg+xml"
+  return "image"
+}
 
 export async function GET(
   _: NextRequest,
@@ -34,6 +43,7 @@ export async function GET(
   const channelLink = getFullUrl(locale, "/latest/")
   const channelTitle = t("page-latest-title")
   const channelDescription = t("page-latest-subtitle")
+  const SITE_URL = getFullUrl(locale, "/")
 
   const items = posts
     .map((post) => {
@@ -45,6 +55,13 @@ export async function GET(
       const categories = (post.tags ?? [])
         .map((tag) => `<category>${escapeXml(tag)}</category>`)
         .join("")
+        
+      let imageUrl = post.image || getBlogFallbackHero(post.href).src
+      const absoluteImageUrl = imageUrl.startsWith("http")
+        ? imageUrl
+        : new URL(imageUrl, SITE_URL).href
+      const mimeType = getMimeType(imageUrl)
+
       return [
         "<item>",
         `<title>${escapeXml(post.title)}</title>`,
@@ -54,6 +71,7 @@ export async function GET(
         creator,
         `<pubDate>${pubDate}</pubDate>`,
         categories,
+        `<media:content url="${absoluteImageUrl}" medium="image" type="${mimeType}" />`,
         "</item>",
       ].join("")
     })
@@ -62,7 +80,7 @@ export async function GET(
   const lastBuildDate = new Date().toUTCString()
   const xml = [
     '<?xml version="1.0" encoding="UTF-8"?>',
-    '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">',
+    '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:media="http://search.yahoo.com/mrss/">',
     "<channel>",
     `<title>${escapeXml(channelTitle)}</title>`,
     `<link>${channelLink}</link>`,


### PR DESCRIPTION
Fixes #18305. Added \<media:content>\ tags for blog post images and the fallback image when the post image is not present in the markdown. Updated the \ss\ xml namespace for media.