### PR TITLE
update hegotá release year to 2027

### DIFF
--- a/src/data/roadmap/releases.tsx
+++ b/src/data/roadmap/releases.tsx
@@ -227,8 +227,8 @@ export const getReleasesData = (t: TranslationFunction): Release[] => [
   {
     image: GuidesHubHeroImage,
     releaseName: "Hegotá",
-    plannedReleaseYear: "2026",
-    displayDate: "H2 2026",
+    plannedReleaseYear: "2027",
+    displayDate: "2027",
     content: (
       <>
         <p>


### PR DESCRIPTION
hegotá will not ship in 2026, 2027 is most likely