### PR TITLE
fix(ci): review release against deploy preview, not stale staging

### DIFF
--- a/.claude/commands/review-release.md
+++ b/.claude/commands/review-release.md
@@ -1,12 +1,12 @@
 ---
-description: Review a release/deploy PR by checking key changes on staging with a browser
+description: Review a release/deploy PR by checking key changes on its deploy preview with a browser
 allowed-tools: Bash, Read, Glob, Grep, Agent, Skill
 argument-hints: [<pr-number>] [--post-comment]
 ---
 
 # Review Release
 
-Review a release/deploy PR by fetching its description, identifying the most important changes, and verifying them on the staging deploy using the browser.
+Review a release/deploy PR by fetching its description, identifying the most important changes, and verifying them on the PR's deploy preview using the browser.
 
 This command NEVER approves or requests changes on the PR. By default it only prints the summary in the terminal. Pass `--post-comment` to additionally post the summary as a comment on the PR (informational, not a review).
 
@@ -36,15 +36,33 @@ From the PR description, identify the most impactful changes to verify. Prioriti
 
 Summarize the changes for the user before proceeding.
 
-### Step 3: Browser Checks
+### Step 3: Pick the Base URL
 
-Use `playwright-cli` (the `@playwright/cli` terminal client) via Bash to check each key page on the staging deploy at:
-`https://staging.ethereum.org/`
+Verify changes against the PR's **deploy preview**, not `staging.ethereum.org`:
+
+```bash
+gh pr view <PR_NUMBER> --repo ethereum/ethereum-org-website --json statusCheckRollup \
+  -q '[.statusCheckRollup[] | select(.context=="netlify/ethereumorg/deploy-preview") | .targetUrl] | first'
+```
+
+The preview is built from the PR's head commit and is guaranteed current. `staging.ethereum.org` is a separate Netlify branch deploy that finishes ~20–35 minutes **after** the PR is created, so right after CI goes green it usually still serves the *previous* release.
+
+Because of that lag, **never conclude that "the staging deploy is stale"** — that has produced repeated false alarms. If content is missing on staging but present on the deploy preview, the branch deploy simply hasn't finished; at most add an informational note ("staging branch deploy still building — expected lag"). Only fall back to `staging.ethereum.org` as the check target if no deploy preview exists.
+
+### Step 4: Browser Checks
+
+Use `playwright-cli` (the `@playwright/cli` terminal client) via Bash to check each key page on the base URL from Step 3.
 
 Workflow: `playwright-cli open` → `playwright-cli goto <url>` → `playwright-cli snapshot` (returns element refs like `e15`) → `playwright-cli click e15` / `playwright-cli fill e22 "text"`. Fall back to the `/agent-browser` skill only if `playwright-cli` is unavailable in the environment.
 
+#### URL and fetch conventions
+
+- Canonical English URLs have **no `/en/` prefix** — `/en/<path>` returns a 301 redirect to `/<path>`. Always use the un-prefixed form.
+- When fetching page source with curl, always follow redirects and record the outcome: `curl -sL -w "%{http_code} %{url_effective}" <url>`. A grep against a non-followed response is grepping an empty redirect body.
+- Zero grep matches means your fetch method is suspect **before** it means the content is missing. Re-check the final URL and status, then re-check the same URL on the deploy preview, before reporting content as absent.
+
 1. **Open each page** — verify it loads without errors (no 404s, no blank pages)
-2. **Take screenshots** — save to `/tmp/screenshots/` for reference
+2. **Take screenshots** — `playwright-cli screenshot` (files are saved under `.playwright-cli/`)
 3. **Snapshot interactive elements** — verify navigation, buttons, and links are present
 4. **Verify specific changes** — e.g., check JSON-LD in page source, confirm updated text/amounts, validate new layouts
 5. **Check homepage** — always do a quick sanity check that the homepage loads
@@ -54,7 +72,7 @@ For each page, note:
 - Any visual issues or broken elements
 - Whether the specific change from the PR is confirmed
 
-### Step 4: Report Results
+### Step 5: Report Results
 
 Present a summary table with:
 
@@ -64,7 +82,7 @@ Present a summary table with:
 
 Flag any issues found. If everything looks good, note that the deploy looks ready to ship.
 
-### Step 5: Optionally Post as PR Comment
+### Step 6: Optionally Post as PR Comment
 
 If `--post-comment` was passed in `$ARGUMENTS`, post the summary table as a PR comment:
 

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -171,27 +171,6 @@ jobs:
             ${{ steps.wait.outputs.missing_checks && format('Required checks never posted: `{0}`', steps.wait.outputs.missing_checks) || '' }}
             Handing off to a human. Skipping automated review.
 
-      - name: Run /review-release
-        if: steps.wait.outputs.outcome == 'success'
-        uses: anthropics/claude-code-action@v1
-        timeout-minutes: 20
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: |
-            --allowedTools "Read,Glob,Grep,Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr comment:*),Bash(curl:*),Skill"
-          prompt: |
-            Execute /review-release for PR #${{ needs.prepare.outputs.pr_number }}
-            with the --post-comment flag, per .claude/commands/review-release.md.
-
-            Arguments: ${{ needs.prepare.outputs.pr_number }} --post-comment
-
-            CI context rules:
-            - Do NOT prompt with AskUserQuestion — fully automated.
-            - NEVER call `gh pr review --approve` or `--request-changes`. The
-              skill already forbids this; do not work around it.
-            - The full summary goes in the PR comment (--post-comment). Do NOT
-              write it anywhere else — Discord only gets a pass/fail line.
-
       - name: Collect preview + Chromatic links
         if: steps.wait.outputs.outcome == 'success'
         id: links
@@ -209,6 +188,66 @@ jobs:
           echo "preview=$preview"       >> "$GITHUB_OUTPUT"
           echo "components=$components" >> "$GITHUB_OUTPUT"
           echo "pages=$pages"           >> "$GITHUB_OUTPUT"
+
+      # Informational only: staging.ethereum.org lags the PR by a full Netlify
+      # branch-deploy build, so the review must know whether it's live yet.
+      - name: Check staging branch deploy state
+        if: steps.wait.outputs.outcome == 'success'
+        id: staging_deploy
+        env:
+          NETLIFY_TOKEN: ${{ secrets.NETLIFY_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        run: |
+          sha=$(gh pr view "${{ needs.prepare.outputs.pr_number }}" \
+            --repo "${{ github.repository }}" --json headRefOid -q .headRefOid)
+          state=$(curl -sf -H "Authorization: Bearer $NETLIFY_TOKEN" \
+            "https://api.netlify.com/api/v1/sites/$NETLIFY_SITE_ID/deploys?branch=staging&per_page=20" \
+            | jq -r --arg sha "$sha" \
+              '[.[] | select(.context=="branch-deploy" and .commit_ref==$sha)][0].state // "not_found"' \
+            || echo "unknown")
+          echo "state=$state" >> "$GITHUB_OUTPUT"
+          echo "Staging branch deploy for $sha: $state"
+
+      - name: Install playwright-cli
+        if: steps.wait.outputs.outcome == 'success'
+        run: |
+          npm install -g @playwright/cli
+          node "$(npm root -g)/@playwright/cli/node_modules/playwright-core/cli.js" \
+            install --with-deps chromium
+
+      - name: Run /review-release
+        if: steps.wait.outputs.outcome == 'success'
+        uses: anthropics/claude-code-action@v1
+        timeout-minutes: 20
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: |
+            --allowedTools "Read,Glob,Grep,Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr comment:*),Bash(curl:*),Bash(playwright-cli:*),Skill"
+          prompt: |
+            Execute /review-release for PR #${{ needs.prepare.outputs.pr_number }}
+            with the --post-comment flag, per .claude/commands/review-release.md.
+
+            Arguments: ${{ needs.prepare.outputs.pr_number }} --post-comment
+
+            Environment facts:
+            - The deploy preview for this PR is ready at:
+              ${{ steps.links.outputs.preview }}
+              Verify all changes against THIS URL — it is built from the PR's
+              head commit and is guaranteed to be current.
+            - The staging.ethereum.org branch deploy for the head commit is in
+              state: "${{ steps.staging_deploy.outputs.state }}". Unless that
+              state is "ready", staging still serves the PREVIOUS release.
+              That is expected lag, not a release defect — never report it as
+              a stale/broken deploy; at most note it as informational.
+            - playwright-cli is installed — use it for the browser checks per
+              the skill. curl is also available for raw source checks.
+
+            CI context rules:
+            - Do NOT prompt with AskUserQuestion — fully automated.
+            - NEVER call `gh pr review --approve` or `--request-changes`. The
+              skill already forbids this; do not work around it.
+            - The full summary goes in the PR comment (--post-comment). Do NOT
+              write it anywhere else — Discord only gets a pass/fail line.
 
       - name: Announce ready for human
         if: steps.wait.outputs.outcome == 'success'


### PR DESCRIPTION
## Problem

The automated `/review-release` job (`weekly-release.yml` → `wait_and_review`) repeatedly reports the release content as **missing/stale on `staging.ethereum.org`** (false alarms on v11.12.0, v11.14.0, v11.15.0, and again on v11.16.0).

Root cause is a **build race**:
- `staging.ethereum.org` is a Netlify **branch deploy** of the `staging` branch, which starts on the release push and finishes **~20–35 min later**.
- The review gate (`wait-for-pr-checks`) only waits on the **PR's** checks — `Build website`, `Lint`, `netlify/ethereumorg/deploy-preview` — a *different, faster* build.
- So the review fires while `staging.ethereum.org` is still serving the **previous** release. The reviewer isn't wrong — staging genuinely is stale at that moment.

Compounded by a curl methodology bug: the CI reviewer (only `curl` allowed) hits `/en/…` URLs that 301 to the un-prefixed canonical path; without `-L` the body is empty → grep finds nothing → "content missing".

## Fix

Verify against the PR's **deploy preview** instead of `staging.ethereum.org`. The two builds are the same head commit and produce byte-identical HTML, but the preview is current *by construction* and can't serve a stale release — no polling, no extra latency.

**`.claude/commands/review-release.md`**
- New "Pick the Base URL" step: extract the `netlify/ethereumorg/deploy-preview` `targetUrl` and verify against it.
- Hard rule: **never conclude "staging is stale"** — at most an informational note that the branch deploy is still building.
- URL/fetch conventions: no `/en/` prefix (301s), always `curl -sL` with `url_effective`, treat zero grep matches as a method bug before reporting content absent.

**`.github/workflows/weekly-release.yml`**
- Reorder so the deploy-preview URL is collected *before* the review and injected into the prompt.
- New **non-blocking** "Check staging branch deploy state" step (Netlify API via existing `NETLIFY_TOKEN` / `NETLIFY_SITE_ID`, falls back to `unknown`) — informational context so lag is never read as staleness.
- Install `playwright-cli` and allow `Bash(playwright-cli:*)`, so the skill runs its browser checks as written instead of improvising curls.
- Inject environment facts into the prompt (preview URL is authoritative; staging lag is expected, never a defect).

## Notes

- This fix was written and validated during the v11.15.0 post-mortem but never shipped. Re-verified against current `dev`: applies with zero drift, and all referenced check contexts / secrets / the deploy-preview `targetUrl` still exist on the latest Deploy PR.
- The `weekly-release.yml` diff looks large because the "Collect preview links" step is *moved* earlier — it's a relocation, not new logic.
