### PR TITLE
style: rounded-base for tooltips & popovers

### DIFF
--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -31,7 +31,7 @@ const PopoverContent = React.forwardRef<
         sideOffset={sideOffset}
         className={cn(
           // `popover-outline` = border + lift wrapping the Arrow. See design-system skill (Floating surfaces).
-          "text-popover-foreground z-popover w-72 rounded p-4 outline-hidden popover-outline data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "text-popover-foreground z-popover w-72 rounded-base p-4 outline-hidden popover-outline data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           nested ? "bg-background" : "bg-background-highlight",
           className
         )}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -22,7 +22,7 @@ const TooltipContent = React.forwardRef<
     className={cn(
       // `popover-outline` = border + lift wrapping the Arrow; no `overflow-hidden`
       // (it would clip the Arrow). See design-system skill (Floating surfaces).
-      "z-popover animate-in rounded-md p-4 text-sm text-body popover-outline fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+      "z-popover animate-in rounded-base p-4 text-sm text-body popover-outline fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
       nested ? "bg-background" : "bg-background-highlight",
       className
     )}


### PR DESCRIPTION
Updates `TooltipContent` and `PopoverContent` to use the `rounded-base` radius token, so all floating surfaces share consistent corners.

- `ui/tooltip.tsx`: `rounded-md` -> `rounded-base`
- `ui/popover.tsx`: `rounded` -> `rounded-base`