### PR TITLE
style: antialias body font globally

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -8,7 +8,7 @@
   }
 
   body {
-    @apply bg-background font-body leading-base text-body;
+    @apply bg-background font-body leading-base text-body antialiased;
   }
 
   a {


### PR DESCRIPTION
## Summary

Adds `antialiased` to the base `body` selector in `src/styles/base.css`. Because `-webkit-font-smoothing`/`-moz-osx-font-smoothing` are inherited properties, one declaration cascades to the whole document, giving smoother, lighter-weight glyph rendering across the site. It lives in `@layer base` alongside the other body typography defaults, so it costs nothing at runtime (static CSS, no JS/hydration) and any Tailwind utility can still override it per-element.