### PR TITLE
fix: responsive PieChart sizing

### DIFF
--- a/src/components/PieChart/PieChart.stories.tsx
+++ b/src/components/PieChart/PieChart.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import { PieChart } from "."
+
+const meta = {
+  title: "Molecules / Display Content / PieChart",
+  component: PieChart,
+  parameters: {
+    layout: "padded",
+  },
+} satisfies Meta<typeof PieChart>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+// Real client-diversity data (developers/docs/nodes-and-clients/client-diversity)
+export const ExecutionClients: Story = {
+  args: {
+    data: [
+      { name: "Geth", value: 41 },
+      { name: "Nethermind", value: 38 },
+      { name: "Besu", value: 16 },
+      { name: "Erigon", value: 3 },
+      { name: "Reth", value: 2 },
+    ],
+  },
+}
+
+export const ConsensusClients: Story = {
+  args: {
+    data: [
+      { name: "Lighthouse", value: 42.71 },
+      { name: "Prysm", value: 30.91 },
+      { name: "Teku", value: 13.86 },
+      { name: "Nimbus", value: 8.74 },
+      { name: "Lodestar", value: 2.67 },
+      { name: "Grandine", value: 1.04 },
+      { name: "Other", value: 0.07 },
+    ],
+  },
+}
+
+export const FewSlices: Story = {
+  args: {
+    data: [
+      { name: "Client A", value: 60 },
+      { name: "Client B", value: 30 },
+      { name: "Client C", value: 10 },
+    ],
+  },
+}
+
+export const LongLabels: Story = {
+  args: {
+    data: [
+      { name: "A very long client name that should truncate", value: 50 },
+      { name: "Another extremely verbose client label here", value: 30 },
+      { name: "Short", value: 20 },
+    ],
+  },
+}
+
+export const WithTitleAndDescription: Story = {
+  args: {
+    title: "Execution client diversity",
+    description: "Share of nodes by execution-layer client",
+    data: [
+      { name: "Geth", value: 41 },
+      { name: "Nethermind", value: 38 },
+      { name: "Besu", value: 16 },
+      { name: "Erigon", value: 3 },
+      { name: "Reth", value: 2 },
+    ],
+  },
+}

--- a/src/components/PieChart/index.tsx
+++ b/src/components/PieChart/index.tsx
@@ -3,13 +3,10 @@
 import { TrendingUp } from "lucide-react"
 import {
   Cell,
-  Legend,
   Pie,
   PieChart as RechartsPieChart,
-  ResponsiveContainer,
   type TooltipProps,
 } from "recharts"
-import type { Formatter } from "recharts/types/component/DefaultLegendContent"
 
 import {
   Card,
@@ -135,38 +132,6 @@ export function PieChart({
   // Calculate total for percentage display
   const total = processedData.reduce((sum, item) => sum + item.value, 0)
 
-  // Function to calculate optimal chart dimensions based on data size and screen
-  const getChartDimensions = () => {
-    const dataCount = processedData.length
-    const baseHeight =
-      dataCount <= 4 ? 320 : Math.min(380, 280 + dataCount * 15)
-
-    return {
-      height: baseHeight,
-      outerRadius: Math.max(50, Math.min(80, 400 / Math.max(6, dataCount))),
-      cx: dataCount <= 3 ? "40%" : dataCount <= 5 ? "35%" : "30%",
-    }
-  }
-
-  const dimensions = getChartDimensions()
-
-  const legendFormatter: Formatter = (label: string, { payload }) => {
-    const numeric = typeof payload?.value === "number" ? payload.value : 0
-    const percentage = ((numeric / total) * 100).toFixed(1)
-
-    const isSmallScreen =
-      typeof window !== "undefined" ? window.innerWidth < 640 : false
-    const maxLength = isSmallScreen ? 10 : 15
-    const displayName =
-      label.length > maxLength ? `${label.substring(0, maxLength)}...` : label
-
-    return (
-      <span className="text-xs sm:text-sm" title={label}>
-        {displayName} {showPercentage && `(${percentage}%)`}
-      </span>
-    )
-  }
-
   // Custom tooltip content
   const customTooltipContent = ({
     active,
@@ -202,37 +167,60 @@ export function PieChart({
       </CardHeader>
 
       <CardContent>
-        <ChartContainer config={defaultChartConfig}>
-          <ResponsiveContainer width="100%" height={dimensions.height}>
-            <RechartsPieChart className="ms-4 -me-12">
+        {/* Stack the pie above the legend on mobile; centered side-by-side from `sm` up. */}
+        <div className="flex flex-col items-center gap-6 sm:flex-row sm:justify-center sm:gap-10">
+          <ChartContainer
+            config={defaultChartConfig}
+            // Square, fluid pie that scales with the container instead of a
+            // fixed pixel radius (overrides ChartContainer's default aspect-video).
+            className="aspect-square w-full max-w-[280px] shrink-0"
+          >
+            <RechartsPieChart>
               <ChartTooltip cursor={false} content={customTooltipContent} />
-
-              <Legend
-                layout="vertical"
-                verticalAlign="middle"
-                align="right"
-                className="max-w-1/2 text-sm/snug break-all"
-                formatter={legendFormatter}
-              />
-
               <Pie
                 data={processedData}
                 dataKey="value"
                 nameKey="name"
-                cx={dimensions.cx}
+                cx="50%"
                 cy="50%"
-                outerRadius={dimensions.outerRadius}
+                outerRadius="90%"
                 label={false}
-                stroke="#ffffff"
-                strokeWidth={1}
+                stroke="hsla(var(--background-highlight))"
+                strokeWidth={2}
               >
                 {processedData.map((_, i) => (
                   <Cell key={`cell-${i}`} fill={generateColor(i)} />
                 ))}
               </Pie>
             </RechartsPieChart>
-          </ResponsiveContainer>
-        </ChartContainer>
+          </ChartContainer>
+
+          <ul className="flex w-full max-w-[320px] flex-col gap-2.5">
+            {processedData.map((item, i) => {
+              const percentage = ((item.value / total) * 100).toFixed(1)
+              return (
+                <li
+                  key={item.name}
+                  className="flex items-center gap-2 text-sm/snug"
+                >
+                  <span
+                    aria-hidden
+                    className="size-3 shrink-0 rounded-xs"
+                    style={{ backgroundColor: generateColor(i) }}
+                  />
+                  <span className="min-w-0 flex-1 truncate" title={item.name}>
+                    {item.name}
+                  </span>
+                  {showPercentage && (
+                    <span className="shrink-0 text-body-medium tabular-nums">
+                      {percentage}%
+                    </span>
+                  )}
+                </li>
+              )
+            })}
+          </ul>
+        </div>
       </CardContent>
 
       {(footerText || footerSubText) && (


### PR DESCRIPTION
The `PieChart` used a fixed pixel radius (capped at 80px), so the pie never scaled with its container and rendered tiny on desktop (visible on `developers/docs/nodes-and-clients/client-diversity/`).

- Fluid square chart (`aspect-square`, `outerRadius="90%"`) that scales at any width
- Pie + legend centered as a unit; stacked on mobile, side-by-side from `sm`
- Custom HTML legend (color swatch + truncated name + right-aligned percentage) replacing the in-SVG recharts legend and its `window.innerWidth` render-time read
- Removed the nested `ResponsiveContainer` and the `-me-12`/`break-all` overflow hacks
- Theme-aware slice separators (`background-highlight` token instead of hardcoded white)
- Added `PieChart.stories.tsx` (execution/consensus datasets + long-label and few-slice cases)

Verified in Storybook across desktop/mobile x light/dark.

## Screenshot
<img width="1103" height="940" alt="image" src="https://github.com/user-attachments/assets/650aba2e-fae2-4a57-9d6a-33124ce571df" />
<img width="746" height="711" alt="image" src="https://github.com/user-attachments/assets/0a321985-cc63-42ec-b135-a578bfe95aca" />
<img width="404" height="697" alt="image" src="https://github.com/user-attachments/assets/4637f576-f820-445d-8912-132a3be84385" />

## Related issue
<img width="1167" height="1115" alt="image" src="https://github.com/user-attachments/assets/88bce390-e2bf-4e95-ac9b-f0b428da4fbf" />
<img width="397" height="691" alt="image" src="https://github.com/user-attachments/assets/daac8c7d-4bd9-4197-9d36-f38cd7e4dab5" />
