### PR TITLE
[hot-fix] feat: enable Matomo AI tracker site-wide (flag-gated)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -47,11 +47,33 @@
   included_files = ["i18n.config.json", "src/intl/**/*", "src/data-layer/mocks/**/*"]
 
 # Matomo AI tracker (see netlify/edge-functions/matomo-ai-tracker/README.md).
-# Gated by MATOMO_AI_TRACKER_ENABLED; canary scope while the Measurement
-# Protocol pipeline is verified, broaden after clean production data.
+# Gated per deploy context by MATOMO_AI_TRACKER_ENABLED. excludedPath only
+# trims edge invocation cost on asset routes; the function's own
+# URL_EXCLUDE_REGEX is the tracking-side backstop for anything that slips
+# through.
 [[edge_functions]]
   function = "matomo-ai-tracker"
-  path = "/learn/*"
+  path = "/*"
+  excludedPath = [
+    "/_next/*",
+    "/api/*",
+    "/.netlify/*",
+    "/.well-known/*",
+    "/images/*",
+    "/content/*",
+    "/videos/*",
+    "/audio/*",
+    "/code-examples/*",
+    "/reports/*",
+    "/*.css",
+    "/*.js",
+    "/*.map",
+    "/*.json",
+    "/*.ico",
+    "/*.txt",
+    "/*.xml",
+    "/*.webmanifest"
+  ]
 
 # Override SITE_URL for named branches with custom subdomains so canonical
 # URLs and OG metadata use the custom domain instead of *.netlify.app.

--- a/netlify.toml
+++ b/netlify.toml
@@ -46,6 +46,13 @@
 [functions]
   included_files = ["i18n.config.json", "src/intl/**/*", "src/data-layer/mocks/**/*"]
 
+# Matomo AI tracker (see netlify/edge-functions/matomo-ai-tracker/README.md).
+# Gated by MATOMO_AI_TRACKER_ENABLED; canary scope while the Measurement
+# Protocol pipeline is verified, broaden after clean production data.
+[[edge_functions]]
+  function = "matomo-ai-tracker"
+  path = "/learn/*"
+
 # Override SITE_URL for named branches with custom subdomains so canonical
 # URLs and OG metadata use the custom domain instead of *.netlify.app.
 [context.dev.environment]

--- a/netlify.toml
+++ b/netlify.toml
@@ -65,12 +65,12 @@
     "/audio/*",
     "/code-examples/*",
     "/reports/*",
+    "/robots.txt",
     "/*.css",
     "/*.js",
     "/*.map",
     "/*.json",
     "/*.ico",
-    "/*.txt",
     "/*.xml",
     "/*.webmanifest"
   ]

--- a/netlify/edge-functions/matomo-ai-tracker/README.md
+++ b/netlify/edge-functions/matomo-ai-tracker/README.md
@@ -10,7 +10,9 @@ Original project license: BSD-3-Clause.
 
 Tracks user-driven AI chatbot traffic (ChatGPT-User, Claude-User, Gemini-Deep-Research, Perplexity-User, Google-NotebookLM, etc.) through the Matomo Measurement Protocol so requests from AI assistants can appear in Matomo AI Chatbots reports.
 
-The function is declared in `netlify.toml` for all page routes (`/*` with asset routes excluded to save edge invocations — pages are the only thing worth tracking) and gated per deploy context by the `MATOMO_AI_TRACKER_ENABLED` env var, which is the rollout mechanism. It fails open: platform-level errors bypass the function (`onError: "bypass"`), config errors pass the request through untracked, and tracking runs after the response via `context.waitUntil()`.
+The function is declared in `netlify.toml` for all page routes (`/*` with asset routes excluded to save edge invocations — pages are the only thing worth tracking) and gated per deploy context by the `MATOMO_AI_TRACKER_ENABLED` env var, which is the rollout mechanism. It fails open: platform-level errors and origin failures bypass to origin (`onError: "bypass"`, declared inline in `index.ts` — netlify.toml has no `on_error` key), config errors pass the request through untracked, and tracking runs after the response via `context.waitUntil()`.
+
+Framework middleware runs before this function, so URLs arrive post-rewrite; tracked URLs are normalized back to their public form (default-locale `/en` prefix stripped, A/B `ab-code` variant routes mapped to the tested path). `llms.txt` fetches are deliberately tracked (flagged as document downloads); `robots.txt` is excluded.
 
 ## Environment
 

--- a/netlify/edge-functions/matomo-ai-tracker/README.md
+++ b/netlify/edge-functions/matomo-ai-tracker/README.md
@@ -10,7 +10,7 @@ Original project license: BSD-3-Clause.
 
 Tracks user-driven AI chatbot traffic (ChatGPT-User, Claude-User, Gemini-Deep-Research, Perplexity-User, Google-NotebookLM, etc.) through the Matomo Measurement Protocol so requests from AI assistants can appear in Matomo AI Chatbots reports.
 
-The function is declared in `netlify.toml` (canary scope: `/learn/*` — English canonical URLs carry no locale prefix) and gated per deploy context by the `MATOMO_AI_TRACKER_ENABLED` env var. It fails open: platform-level errors bypass the function (`onError: "bypass"`), config errors pass the request through untracked, and tracking runs after the response via `context.waitUntil()`.
+The function is declared in `netlify.toml` for all page routes (`/*` with asset routes excluded to save edge invocations — pages are the only thing worth tracking) and gated per deploy context by the `MATOMO_AI_TRACKER_ENABLED` env var, which is the rollout mechanism. It fails open: platform-level errors bypass the function (`onError: "bypass"`), config errors pass the request through untracked, and tracking runs after the response via `context.waitUntil()`.
 
 ## Environment
 

--- a/netlify/edge-functions/matomo-ai-tracker/README.md
+++ b/netlify/edge-functions/matomo-ai-tracker/README.md
@@ -12,7 +12,7 @@ Tracks user-driven AI chatbot traffic (ChatGPT-User, Claude-User, Gemini-Deep-Re
 
 The function is declared in `netlify.toml` for all page routes (`/*` with asset routes excluded to save edge invocations — pages are the only thing worth tracking) and gated per deploy context by the `MATOMO_AI_TRACKER_ENABLED` env var, which is the rollout mechanism. It fails open: platform-level errors and origin failures bypass to origin (`onError: "bypass"`, declared inline in `index.ts` — netlify.toml has no `on_error` key), config errors pass the request through untracked, and tracking runs after the response via `context.waitUntil()`.
 
-Framework middleware runs before this function, so URLs arrive post-rewrite; tracked URLs are normalized back to their public form (default-locale `/en` prefix stripped, A/B `ab-code` variant routes mapped to the tested path). `llms.txt` fetches are deliberately tracked (flagged as document downloads); `robots.txt` is excluded.
+Framework middleware runs before this function, so URLs arrive post-rewrite; tracked URLs are normalized back to their public form (default-locale `/en` prefix stripped, A/B `ab-code` variant routes mapped to the tested path). `llms.txt` fetches are deliberately tracked as plain pageviews — Matomo's bot telemetry drops download-flagged hits from the AI Chatbots report, so `txt` is removed from both default regexes; `robots.txt` is excluded.
 
 ## Environment
 

--- a/netlify/edge-functions/matomo-ai-tracker/README.md
+++ b/netlify/edge-functions/matomo-ai-tracker/README.md
@@ -10,14 +10,15 @@ Original project license: BSD-3-Clause.
 
 Tracks user-driven AI chatbot traffic (ChatGPT-User, Claude-User, Gemini-Deep-Research, Perplexity-User, Google-NotebookLM, etc.) through the Matomo Measurement Protocol so requests from AI assistants can appear in Matomo AI Chatbots reports.
 
-This implementation is intentionally dormant and is not yet wired into `netlify.toml`.
+The function is declared in `netlify.toml` (canary scope: `/learn/*` — English canonical URLs carry no locale prefix) and gated per deploy context by the `MATOMO_AI_TRACKER_ENABLED` env var. It fails open: platform-level errors bypass the function (`onError: "bypass"`), config errors pass the request through untracked, and tracking runs after the response via `context.waitUntil()`.
 
 ## Environment
 
 The edge function reads server-side environment variables via `Netlify.env`:
 
-- `MATOMO_URL` - Matomo base URL, with or without `/matomo.php`
-- `MATOMO_SITE_ID` - numeric Matomo site ID
+- `MATOMO_AI_TRACKER_ENABLED` - kill switch; tracking only runs when set to exactly `true`. Rollout: `true` on non-production contexts first (deploy previews report to the non-production Matomo site via the scoped `NEXT_PUBLIC_MATOMO_SITE_ID`), production flipped to `true` after verification. Flipping it is an env change plus a redeploy (no code change); instant rollback to a flag-off deploy also disables it immediately.
+- `MATOMO_URL` - optional override for the Matomo base URL, with or without `/matomo.php`; defaults to `NEXT_PUBLIC_MATOMO_URL`
+- `MATOMO_SITE_ID` - optional override for the numeric Matomo site ID; defaults to `NEXT_PUBLIC_MATOMO_SITE_ID`
 - `MATOMO_TIMEOUT_MS` - optional request timeout in milliseconds, defaults to `5000`
 - `LOG_LEVEL` - optional `silent`, `error`, `warn`, `info`, or `debug`
 - `HTTP_METHOD_ALLOWLIST` - optional comma-separated methods, defaults to `GET`
@@ -25,27 +26,12 @@ The edge function reads server-side environment variables via `Netlify.env`:
 - `URL_EXCLUDE_REGEX` - optional static asset exclusion override
 - `DOCUMENT_REGEX` - optional download/document URL detection override
 
-These are intentionally separate from the existing public `NEXT_PUBLIC_MATOMO_*`
-browser analytics variables.
-
 ## Local development
 
-Because this function is dormant, local requests will only route through it if
-you temporarily add an edge function declaration. Do not commit this wiring until
-the staged rollout is ready.
-
-Temporary local-only `netlify.toml` snippet:
-
-```toml
-[[edge_functions]]
-  function = "matomo-ai-tracker"
-  path = "/*"
-```
-
-Then run locally with the required env vars:
+Run locally with the required env vars:
 
 ```bash
-MATOMO_URL="https://example.matomo.cloud" MATOMO_SITE_ID="1" netlify dev
+MATOMO_AI_TRACKER_ENABLED="true" MATOMO_URL="https://example.matomo.cloud" MATOMO_SITE_ID="1" netlify dev
 ```
 
 Example request:

--- a/netlify/edge-functions/matomo-ai-tracker/config.ts
+++ b/netlify/edge-functions/matomo-ai-tracker/config.ts
@@ -31,14 +31,20 @@ const defaultUrlExcludePattern =
 export function getConfig(
   env: Partial<Env> & Record<string, string | undefined>
 ): MatomoConfig {
-  const matomoUrl = env.MATOMO_URL
+  // Unprefixed vars act as overrides; default to the site-wide NEXT_PUBLIC_*
+  // vars already scoped per deploy context in Netlify
+  const matomoUrl = env.MATOMO_URL || env.NEXT_PUBLIC_MATOMO_URL
   if (!matomoUrl) {
-    throw new Error("MATOMO_URL is required")
+    throw new Error(
+      "MATOMO_URL is required (MATOMO_URL or NEXT_PUBLIC_MATOMO_URL)"
+    )
   }
 
-  const siteIdRaw = env.MATOMO_SITE_ID
+  const siteIdRaw = env.MATOMO_SITE_ID || env.NEXT_PUBLIC_MATOMO_SITE_ID
   if (!siteIdRaw) {
-    throw new Error("MATOMO_SITE_ID is required")
+    throw new Error(
+      "MATOMO_SITE_ID is required (MATOMO_SITE_ID or NEXT_PUBLIC_MATOMO_SITE_ID)"
+    )
   }
   const matomoSiteId = toInt(siteIdRaw)
   if (matomoSiteId === undefined) {

--- a/netlify/edge-functions/matomo-ai-tracker/config.ts
+++ b/netlify/edge-functions/matomo-ai-tracker/config.ts
@@ -25,8 +25,10 @@ const defaultAllowlistPattern = `(?:${defaultUserAgentPatterns
 const defaultHttpMethodAllowlist = ["GET"]
 const defaultDocumentPattern =
   "^[^?]+\\.(?:pdf|docx?|xlsx?|pptx?|csv|json|txt|xml|epub|mobi|azw3|mp3|mp4|mpe?g|webm|mov|avi|ogg|wav|flac|zip|gz|gzip|tgz|tar|bz2|tbz|7z|rar|dmg|exe|msi|apk|jar|md5|sig)(?:\\?|$)"
+// Deviates from upstream: "txt" removed from the exclude list so llms.txt
+// fetches are tracked (robots.txt is excluded at the netlify.toml layer)
 const defaultUrlExcludePattern =
-  "^[^?]+\\.(?:css|js|mjs|map|json|xml|webmanifest|manifest|png|jpe?g|gif|webp|avif|svg|ico|bmp|tiff?|woff2?|ttf|otf|eot|rss|atom|wasm|txt)(?:\\?|$)"
+  "^[^?]+\\.(?:css|js|mjs|map|json|xml|webmanifest|manifest|png|jpe?g|gif|webp|avif|svg|ico|bmp|tiff?|woff2?|ttf|otf|eot|rss|atom|wasm)(?:\\?|$)"
 
 export function getConfig(
   env: Partial<Env> & Record<string, string | undefined>

--- a/netlify/edge-functions/matomo-ai-tracker/config.ts
+++ b/netlify/edge-functions/matomo-ai-tracker/config.ts
@@ -23,8 +23,11 @@ const defaultAllowlistPattern = `(?:${defaultUserAgentPatterns
   .map(escapeRegex)
   .join("|")})`
 const defaultHttpMethodAllowlist = ["GET"]
+// Deviates from upstream: "txt" removed so llms.txt hits stay pageviews --
+// Matomo's bot telemetry does not surface download-flagged hits in the AI
+// Chatbots report (verified empirically on site 43)
 const defaultDocumentPattern =
-  "^[^?]+\\.(?:pdf|docx?|xlsx?|pptx?|csv|json|txt|xml|epub|mobi|azw3|mp3|mp4|mpe?g|webm|mov|avi|ogg|wav|flac|zip|gz|gzip|tgz|tar|bz2|tbz|7z|rar|dmg|exe|msi|apk|jar|md5|sig)(?:\\?|$)"
+  "^[^?]+\\.(?:pdf|docx?|xlsx?|pptx?|csv|json|xml|epub|mobi|azw3|mp3|mp4|mpe?g|webm|mov|avi|ogg|wav|flac|zip|gz|gzip|tgz|tar|bz2|tbz|7z|rar|dmg|exe|msi|apk|jar|md5|sig)(?:\\?|$)"
 // Deviates from upstream: "txt" removed from the exclude list so llms.txt
 // fetches are tracked (robots.txt is excluded at the netlify.toml layer)
 const defaultUrlExcludePattern =

--- a/netlify/edge-functions/matomo-ai-tracker/index.ts
+++ b/netlify/edge-functions/matomo-ai-tracker/index.ts
@@ -10,6 +10,10 @@ declare const Netlify: {
   }
 }
 
+// If the function itself errors at the platform level, skip it and continue
+// to origin rather than failing the user request
+export const config = { onError: "bypass" }
+
 const trackRequest = async (
   request: Request,
   response: Response,
@@ -51,10 +55,17 @@ export default async function handler(
   request: Request,
   context: NetlifyEdgeContext
 ) {
+  const env = Netlify.env.toObject()
+
+  // Kill switch: tracking must be explicitly enabled per deploy context
+  if (env.MATOMO_AI_TRACKER_ENABLED !== "true") {
+    return context.next()
+  }
+
   let config: MatomoConfig | null = null
 
   try {
-    config = getConfig(Netlify.env.toObject())
+    config = getConfig(env)
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
 

--- a/netlify/edge-functions/matomo-ai-tracker/index.ts
+++ b/netlify/edge-functions/matomo-ai-tracker/index.ts
@@ -95,14 +95,19 @@ export default async function handler(
       error: message,
     })
 
-    const fallback = new Response("Bad Gateway", {
-      status: 502,
-    })
-
     const durationMs = Date.now() - start
 
-    context.waitUntil(trackRequest(request, fallback, durationMs, config))
+    // Record the failure for the report's 5xx column, then rethrow so
+    // onError: "bypass" serves origin instead of a hand-rolled error page
+    context.waitUntil(
+      trackRequest(
+        request,
+        new Response(null, { status: 502 }),
+        durationMs,
+        config
+      )
+    )
 
-    return fallback
+    throw err
   }
 }

--- a/netlify/edge-functions/matomo-ai-tracker/matomo.ts
+++ b/netlify/edge-functions/matomo-ai-tracker/matomo.ts
@@ -3,6 +3,7 @@ import {
   formatMatomoDateTime,
   getContentLength,
   isUserAgentAllowed,
+  normalizeTrackedUrl,
 } from "./utils.ts"
 
 export function buildMatomoPayload(
@@ -25,7 +26,7 @@ export function buildMatomoPayload(
     return null
   }
 
-  const url = request.url
+  const url = normalizeTrackedUrl(request.url)
   if (config.urlExcludeRegex && config.urlExcludeRegex.test(url)) {
     return null
   }

--- a/netlify/edge-functions/matomo-ai-tracker/types.ts
+++ b/netlify/edge-functions/matomo-ai-tracker/types.ts
@@ -8,8 +8,11 @@ export interface Logger {
 }
 
 export interface Env {
-  MATOMO_URL: string
-  MATOMO_SITE_ID: string
+  MATOMO_AI_TRACKER_ENABLED?: string
+  MATOMO_URL?: string
+  MATOMO_SITE_ID?: string
+  NEXT_PUBLIC_MATOMO_URL?: string
+  NEXT_PUBLIC_MATOMO_SITE_ID?: string
   MATOMO_TIMEOUT_MS?: string
   LOG_LEVEL?: LogLevel
   HTTP_METHOD_ALLOWLIST?: string

--- a/netlify/edge-functions/matomo-ai-tracker/utils.ts
+++ b/netlify/edge-functions/matomo-ai-tracker/utils.ts
@@ -18,6 +18,27 @@ export const formatMatomoDateTime = (date: Date): string => {
   return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`
 }
 
+// Netlify runs framework middleware (tier 1) ahead of toml-declared edge
+// functions, so request.url arrives post-rewrite. Map internal rewrite shapes
+// back to the public URL: the "as-needed" default-locale prefix
+// (/en/learn -> /learn) and A/B variant routes
+// (/en/ab-code/<code>/<path> -> /<path>).
+export const normalizeTrackedUrl = (rawUrl: string): string => {
+  const url = new URL(rawUrl)
+  let pathname = url.pathname
+  if (pathname === "/en" || pathname.startsWith("/en/")) {
+    pathname = pathname.slice(3) || "/"
+  }
+  const abMatch = pathname.match(/^\/ab-code\/[^/]+(\/.*)?$/)
+  if (abMatch) {
+    pathname = abMatch[1] || "/"
+  }
+  if (pathname !== url.pathname) {
+    url.pathname = pathname
+  }
+  return url.toString()
+}
+
 export const getContentLength = (response: Response): number | undefined => {
   const header = response.headers.get("content-length")
   if (!header) return undefined

--- a/tests/unit/matomo-ai-tracker/config.spec.ts
+++ b/tests/unit/matomo-ai-tracker/config.spec.ts
@@ -83,6 +83,25 @@ test.describe("getConfig", () => {
     )
   })
 
+  test("falls back to NEXT_PUBLIC_* vars when unprefixed are absent", () => {
+    const config = getConfig({
+      NEXT_PUBLIC_MATOMO_URL: "https://public.example.com",
+      NEXT_PUBLIC_MATOMO_SITE_ID: "5",
+    })
+    expect(config.matomoUrl).toBe("https://public.example.com")
+    expect(config.matomoSiteId).toBe(5)
+  })
+
+  test("unprefixed vars override NEXT_PUBLIC_* vars", () => {
+    const config = getConfig({
+      ...baseEnv,
+      NEXT_PUBLIC_MATOMO_URL: "https://public.example.com",
+      NEXT_PUBLIC_MATOMO_SITE_ID: "5",
+    })
+    expect(config.matomoUrl).toBe(baseEnv.MATOMO_URL)
+    expect(config.matomoSiteId).toBe(42)
+  })
+
   test("throws when MATOMO_URL is missing", () => {
     expect(() => getConfig({ MATOMO_SITE_ID: "1" })).toThrow(
       /MATOMO_URL is required/

--- a/tests/unit/matomo-ai-tracker/config.spec.ts
+++ b/tests/unit/matomo-ai-tracker/config.spec.ts
@@ -23,7 +23,7 @@ test.describe("getConfig", () => {
       /(?:ChatGPT-User|MistralAI-User|Gemini-Deep-Research|Claude-User|Perplexity-User|Google-NotebookLM)/i
     )
     expect(config.urlExcludeRegex).toEqual(
-      /^[^?]+\.(?:css|js|mjs|map|json|xml|webmanifest|manifest|png|jpe?g|gif|webp|avif|svg|ico|bmp|tiff?|woff2?|ttf|otf|eot|rss|atom|wasm|txt)(?:\?|$)/i
+      /^[^?]+\.(?:css|js|mjs|map|json|xml|webmanifest|manifest|png|jpe?g|gif|webp|avif|svg|ico|bmp|tiff?|woff2?|ttf|otf|eot|rss|atom|wasm)(?:\?|$)/i
     )
     expect(config.documentRegex).toEqual(
       /^[^?]+\.(?:pdf|docx?|xlsx?|pptx?|csv|json|txt|xml|epub|mobi|azw3|mp3|mp4|mpe?g|webm|mov|avi|ogg|wav|flac|zip|gz|gzip|tgz|tar|bz2|tbz|7z|rar|dmg|exe|msi|apk|jar|md5|sig)(?:\?|$)/i

--- a/tests/unit/matomo-ai-tracker/config.spec.ts
+++ b/tests/unit/matomo-ai-tracker/config.spec.ts
@@ -26,7 +26,7 @@ test.describe("getConfig", () => {
       /^[^?]+\.(?:css|js|mjs|map|json|xml|webmanifest|manifest|png|jpe?g|gif|webp|avif|svg|ico|bmp|tiff?|woff2?|ttf|otf|eot|rss|atom|wasm)(?:\?|$)/i
     )
     expect(config.documentRegex).toEqual(
-      /^[^?]+\.(?:pdf|docx?|xlsx?|pptx?|csv|json|txt|xml|epub|mobi|azw3|mp3|mp4|mpe?g|webm|mov|avi|ogg|wav|flac|zip|gz|gzip|tgz|tar|bz2|tbz|7z|rar|dmg|exe|msi|apk|jar|md5|sig)(?:\?|$)/i
+      /^[^?]+\.(?:pdf|docx?|xlsx?|pptx?|csv|json|xml|epub|mobi|azw3|mp3|mp4|mpe?g|webm|mov|avi|ogg|wav|flac|zip|gz|gzip|tgz|tar|bz2|tbz|7z|rar|dmg|exe|msi|apk|jar|md5|sig)(?:\?|$)/i
     )
   })
 

--- a/tests/unit/matomo-ai-tracker/index.spec.ts
+++ b/tests/unit/matomo-ai-tracker/index.spec.ts
@@ -16,6 +16,7 @@ import {
 } from "./helpers"
 
 const env = {
+  MATOMO_AI_TRACKER_ENABLED: "true",
   MATOMO_URL: "https://analytics.example.com",
   MATOMO_SITE_ID: "7",
   USER_AGENT_ALLOWLIST_REGEX: ".*",
@@ -155,8 +156,36 @@ test.describe("Edge function handler", () => {
     ])
   })
 
+  for (const disabledEnv of [
+    { ...env, MATOMO_AI_TRACKER_ENABLED: undefined },
+    { ...env, MATOMO_AI_TRACKER_ENABLED: "false" },
+  ]) {
+    test(`passes through silently when kill switch is ${disabledEnv.MATOMO_AI_TRACKER_ENABLED ?? "unset"}`, async () => {
+      setNetlifyEnv(disabledEnv)
+      fetchStub = stubGlobalFetch(() =>
+        Promise.resolve(new Response(null, { status: 204 }))
+      )
+      const { context, tracked } = createContext(() =>
+        Promise.resolve(new Response("origin", { status: 200 }))
+      )
+
+      const response = await handler(
+        new Request("https://example.com/path", {
+          headers: { "user-agent": "AgentX" },
+        }),
+        context
+      )
+
+      expect(response.status).toBe(200)
+      expect(tracked).toHaveLength(0)
+      expect(fetchStub.calls).toHaveLength(0)
+      expect(consoleSpies.calls.error).toHaveLength(0)
+      expect(consoleSpies.calls.warn).toHaveLength(0)
+    })
+  }
+
   test("returns origin response when config is invalid and skips tracking", async () => {
-    setNetlifyEnv({ MATOMO_SITE_ID: "7" })
+    setNetlifyEnv({ MATOMO_AI_TRACKER_ENABLED: "true", MATOMO_SITE_ID: "7" })
     fetchStub = stubGlobalFetch(() =>
       Promise.resolve(new Response(null, { status: 204 }))
     )
@@ -174,7 +203,9 @@ test.describe("Edge function handler", () => {
     expect(fetchStub.calls).toHaveLength(0)
     expect(consoleSpies.calls.error).toContainEqual([
       "Configuration error",
-      { error: "MATOMO_URL is required" },
+      {
+        error: "MATOMO_URL is required (MATOMO_URL or NEXT_PUBLIC_MATOMO_URL)",
+      },
     ])
   })
 })

--- a/tests/unit/matomo-ai-tracker/index.spec.ts
+++ b/tests/unit/matomo-ai-tracker/index.spec.ts
@@ -85,7 +85,7 @@ test.describe("Edge function handler", () => {
     )
   })
 
-  test("returns fallback when origin fails but still tracks", async () => {
+  test("rethrows when origin fails (platform bypass) but still tracks", async () => {
     setNetlifyEnv(env)
     fetchStub = stubGlobalFetch(() =>
       Promise.resolve(new Response(null, { status: 204 }))
@@ -94,17 +94,19 @@ test.describe("Edge function handler", () => {
       Promise.reject(new Error("boom"))
     )
 
-    const response = await handler(
-      new Request("https://example.com/path", {
-        headers: { "user-agent": "AgentX" },
-      }),
-      context
-    )
+    await expect(
+      handler(
+        new Request("https://example.com/path", {
+          headers: { "user-agent": "AgentX" },
+        }),
+        context
+      )
+    ).rejects.toThrow("boom")
 
-    expect(response.status).toBe(502)
     expect(tracked).toHaveLength(1)
     await tracked[0]
     expect(fetchStub.calls).toHaveLength(1)
+    expect(String(fetchStub.calls[0][0])).toContain("http_status=502")
     expect(consoleSpies.calls.error).toContainEqual([
       "Origin request failed",
       { error: "boom" },

--- a/tests/unit/matomo-ai-tracker/matomo.spec.ts
+++ b/tests/unit/matomo-ai-tracker/matomo.spec.ts
@@ -62,6 +62,34 @@ test.describe("buildMatomoPayload", () => {
     expect(payload?.cdt).toBe("2025-02-18 12:00:01")
   })
 
+  test("records the normalized public URL for internal rewrites", () => {
+    const response = new Response(null, { status: 200 })
+    const payload = buildMatomoPayload(
+      new Request("https://example.com/en/ab-code/abc123/learn/", {
+        headers: { "user-agent": "AgentX" },
+      }),
+      response,
+      10,
+      config
+    )
+    expect(payload?.url).toBe("https://example.com/learn/")
+  })
+
+  test("tracks llms.txt and flags it as a document", () => {
+    const response = new Response(null, { status: 200 })
+    const payload = buildMatomoPayload(
+      new Request("https://example.com/llms.txt", {
+        headers: { "user-agent": "AgentX" },
+      }),
+      response,
+      10,
+      config
+    )
+    expect(payload).not.toBeNull()
+    expect(payload?.url).toBe("https://example.com/llms.txt")
+    expect(payload?.download).toBe("https://example.com/llms.txt")
+  })
+
   test("returns null when user agent is not allowlisted", () => {
     const cfg = getConfig({
       MATOMO_URL: "https://analytics.example.com",

--- a/tests/unit/matomo-ai-tracker/matomo.spec.ts
+++ b/tests/unit/matomo-ai-tracker/matomo.spec.ts
@@ -75,7 +75,7 @@ test.describe("buildMatomoPayload", () => {
     expect(payload?.url).toBe("https://example.com/learn/")
   })
 
-  test("tracks llms.txt and flags it as a document", () => {
+  test("tracks llms.txt as a plain pageview (no download flag)", () => {
     const response = new Response(null, { status: 200 })
     const payload = buildMatomoPayload(
       new Request("https://example.com/llms.txt", {
@@ -87,7 +87,7 @@ test.describe("buildMatomoPayload", () => {
     )
     expect(payload).not.toBeNull()
     expect(payload?.url).toBe("https://example.com/llms.txt")
-    expect(payload?.download).toBe("https://example.com/llms.txt")
+    expect(payload).not.toHaveProperty("download")
   })
 
   test("returns null when user agent is not allowlisted", () => {

--- a/tests/unit/matomo-ai-tracker/utils.spec.ts
+++ b/tests/unit/matomo-ai-tracker/utils.spec.ts
@@ -6,6 +6,7 @@ import {
   formatMatomoDateTime,
   getContentLength,
   isUserAgentAllowed,
+  normalizeTrackedUrl,
 } from "../../../netlify/edge-functions/matomo-ai-tracker/utils"
 
 test.describe("utils", () => {
@@ -20,6 +21,32 @@ test.describe("utils", () => {
   test("formats date with zero padding", () => {
     const dt = new Date(Date.UTC(2025, 0, 2, 3, 4, 5))
     expect(formatMatomoDateTime(dt)).toBe("2025-01-02 03:04:05")
+  })
+
+  test("normalizes internal rewrite URLs back to public URLs", () => {
+    // default-locale prefix from the as-needed i18n rewrite
+    expect(normalizeTrackedUrl("https://x.org/en/learn/")).toBe(
+      "https://x.org/learn/"
+    )
+    expect(normalizeTrackedUrl("https://x.org/en")).toBe("https://x.org/")
+    expect(normalizeTrackedUrl("https://x.org/en/")).toBe("https://x.org/")
+    // A/B variant rewrite
+    expect(normalizeTrackedUrl("https://x.org/en/ab-code/abc123/learn/")).toBe(
+      "https://x.org/learn/"
+    )
+    expect(normalizeTrackedUrl("https://x.org/en/ab-code/abc123")).toBe(
+      "https://x.org/"
+    )
+    // untouched: non-default locales, lookalike paths, query strings
+    expect(normalizeTrackedUrl("https://x.org/de/learn/")).toBe(
+      "https://x.org/de/learn/"
+    )
+    expect(normalizeTrackedUrl("https://x.org/energy/")).toBe(
+      "https://x.org/energy/"
+    )
+    expect(normalizeTrackedUrl("https://x.org/en/learn/?a=1#b")).toBe(
+      "https://x.org/learn/?a=1#b"
+    )
   })
 
   test("parses content length safely", () => {


### PR DESCRIPTION
## Summary

PR 2 of the staged rollout from #18219, on top of the merged #18284. Wires the Matomo AI tracker edge function into `netlify.toml` for all page routes (`/*` with an `excludedPath` list so asset requests never invoke the function), gated per deploy context by a `MATOMO_AI_TRACKER_ENABLED` kill switch (default off, silent pass-through). Matomo URL/site ID fall back to the existing context-scoped `NEXT_PUBLIC_MATOMO_*` vars, so non-production deploys report to the non-production Matomo site; `onError: bypass` ensures a function failure never breaks the page. Kill switch and env fallback covered in the unit suite.

Verified end-to-end on this PR's deploy preview: requests with allowlisted chatbot UAs landed in the non-production Matomo site's AI Assistants > AI Chatbots report (server-side Measurement Protocol hits, no JS). Production stays inert until its `MATOMO_AI_TRACKER_ENABLED` is flipped to `true` -- planned after the currently-launching A/B test completes.