### PR TITLE
Update NodeFlare entry: free plan is now 2M compute units/month

### DIFF
--- a/public/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
+++ b/public/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
@@ -276,7 +276,7 @@ Here is a list of some of the most popular Ethereum node providers, feel free to
   - Features
     - 23 EVM chains including Ethereum, Base, Arbitrum One & Nova, Optimism, Linea, and Unichain
     - 5 regions (Europe, UK, Asia, US-East, US-West) with automatic failover to nearest healthy node
-    - Free public endpoint (no API key) + free plan with 3M compute units/month
+    - Free public endpoint (no API key) + free plan with 2M compute units/month
     - Compute Unit billing — pay only for what you use, heavier calls cost more
     - No throttling on paid plans
 


### PR DESCRIPTION
One-line factual update to the NodeFlare entry in nodes-as-a-service: the free plan changed from 3M to 2M compute units/month. Keeps the listing accurate with [nodeflare.app/pricing](https://nodeflare.app/pricing).