### PR TITLE
fix(visual-tests): pin footer deploy date in IS_VISUAL_TEST builds

### DIFF
--- a/src/lib/utils/getLastDeployDate.ts
+++ b/src/lib/utils/getLastDeployDate.ts
@@ -1,3 +1,8 @@
 import published from "@/data/published.json"
 
-export const getLastDeployDate = () => new Date(published.date).toISOString()
+// Pinned in visual-test builds: a changing date reflows the footer and flakes
+// every Chromatic snapshot (data-chromatic="ignore" can't mask the reflow).
+export const getLastDeployDate = () =>
+  process.env.IS_VISUAL_TEST === "true"
+    ? "2024-01-01T00:00:00.000Z"
+    : new Date(published.date).toISOString()


### PR DESCRIPTION
## Problem

The footer's "Website last updated: {date}" line (from `published.date`) changes every release, producing a false-positive diff in the full-page Chromatic project on **every** release.

The existing `data-chromatic="ignore"` on the date span masks the date *pixels*, but the date **string's width changes** between releases (e.g. "May 5, 2026" vs "December 12, 2026") and the line sits in a `justify-center md:justify-between` flex row — so the whole line reflows and a real pixel diff appears *outside* the ignored region. Region-masking can't fix a reflow.

## Fix

Pin the deploy date to a constant when `IS_VISUAL_TEST=true`, at the source (`getLastDeployDate`), mirroring the repo's existing `safeShuffle` pattern. The date becomes byte-identical across releases → no reflow, no diff. Production builds are untouched.

CI's shared visual build already sets `IS_VISUAL_TEST: "true"` (ci.yml) and the `page-visual-tests` job runs off it.

## Note

The next Chromatic run will show this footer line change **once** (to the pinned date) — accept that as the new baseline, and it stops flaking from then on.