### PR TITLE
refactor(date): centralize hydration-safe whitespace normalization

### DIFF
--- a/app/[locale]/10years/_components/torchHoldersData.ts
+++ b/app/[locale]/10years/_components/torchHoldersData.ts
@@ -1,4 +1,4 @@
-import { dateTimeFormat } from "@/lib/utils/date"
+import { formatDateTime } from "@/lib/utils/date"
 
 /**
  * Pre-computed static torch holders data
@@ -231,13 +231,13 @@ export const extractTwitterHandle = (twitterUrl: string): string | null => {
 
 export const formatTorchDate = (timestamp: number): string => {
   const date = new Date(timestamp * 1000)
-  const month = dateTimeFormat("en-US", { month: "long" }).format(date)
+  const month = formatDateTime("en-US", date, { month: "long" })
   const day = date.getDate().toString().padStart(2, "0")
-  const time = dateTimeFormat("en-US", {
+  const time = formatDateTime("en-US", date, {
     hour: "numeric",
     minute: "2-digit",
     hour12: true,
-  }).format(date)
+  })
 
   return `${month} ${day}, ${time}`
 }

--- a/app/[locale]/collectibles/_components/CollectiblesProgress/index.tsx
+++ b/app/[locale]/collectibles/_components/CollectiblesProgress/index.tsx
@@ -5,7 +5,7 @@ import { useLocale, useTranslations } from "next-intl"
 
 import { Progress } from "@/components/ui/progress"
 
-import { dateTimeFormat } from "@/lib/utils/date"
+import { formatDateTime } from "@/lib/utils/date"
 
 import { type BadgeWithOwned } from "../CollectiblesContent"
 
@@ -38,9 +38,11 @@ const CollectiblesProgress = ({ badges }: CollectiblesProgressProps) => {
       {contributorSinceYear < Infinity && (
         <p className="text-body-medium">
           {t("page-collectibles-contributing-since")}:{" "}
-          {dateTimeFormat(locale, {
-            year: "numeric",
-          }).format(new Date().setFullYear(contributorSinceYear))}
+          {formatDateTime(
+            locale,
+            new Date().setFullYear(contributorSinceYear),
+            { year: "numeric" }
+          )}
         </p>
       )}
       <div className="space-y-1">

--- a/app/[locale]/resources/_components/UpgradeCountdown.tsx
+++ b/app/[locale]/resources/_components/UpgradeCountdown.tsx
@@ -7,7 +7,7 @@ import type { NetworkUpgradeDetails } from "@/lib/types"
 
 import { BaseLink } from "@/components/ui/Link"
 
-import { dateTimeFormat } from "@/lib/utils/date"
+import { formatDateTime } from "@/lib/utils/date"
 import { formatDuration } from "@/lib/utils/time"
 
 import networkUpgradeSummaryData from "@/data/networkUpgradeSummaryData"
@@ -99,9 +99,9 @@ const UpgradeCountdown = () => {
         ) : (
           <div className="rounded-full bg-success px-2 py-1 text-xs font-normal text-success-light uppercase">
             Live Since{" "}
-            {dateTimeFormat(locale, { timeZone: "UTC" }).format(
-              new Date(upgradeDate)
-            )}
+            {formatDateTime(locale, new Date(upgradeDate), {
+              timeZone: "UTC",
+            })}
           </div>
         )}
       </div>

--- a/app/[locale]/roadmap/_components/ReleaseCarousel.tsx
+++ b/app/[locale]/roadmap/_components/ReleaseCarousel.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/components/ui/carousel"
 
 import { cn } from "@/lib/utils/cn"
-import { dateTimeFormat, formatDate } from "@/lib/utils/date"
+import { formatDate, formatDateTime } from "@/lib/utils/date"
 
 import { getReleasesData, Release } from "@/data/roadmap/releases"
 
@@ -106,9 +106,13 @@ const ReleaseCarousel = () => {
       return ""
 
     if ("plannedReleaseYear" in release && release.plannedReleaseYear)
-      return dateTimeFormat(locale, {
-        year: "numeric",
-      }).format(new Date(Number(release.plannedReleaseYear), 0, 1))
+      return formatDateTime(
+        locale,
+        new Date(Number(release.plannedReleaseYear), 0, 1),
+        {
+          year: "numeric",
+        }
+      )
 
     if ("releaseDate" in release && release.releaseDate)
       return formatDate(release.releaseDate, locale, { timeZone: "UTC" })

--- a/src/components/BigNumber/index.tsx
+++ b/src/components/BigNumber/index.tsx
@@ -4,7 +4,7 @@ import { Info } from "lucide-react"
 import { getLocale, getTranslations } from "next-intl/server"
 
 import { cn } from "@/lib/utils/cn"
-import { dateTimeFormat, isValidDate } from "@/lib/utils/date"
+import { formatDateTime, isValidDate } from "@/lib/utils/date"
 
 import Tooltip from "../Tooltip"
 import Link from "../ui/Link"
@@ -71,9 +71,9 @@ const BigNumber = async ({
 
   const lastUpdatedDisplay =
     lastUpdated && isValidDate(lastUpdated)
-      ? dateTimeFormat(locale, {
+      ? formatDateTime(locale, new Date(lastUpdated), {
           dateStyle: "medium",
-        }).format(new Date(lastUpdated))
+        })
       : ""
   return (
     <div

--- a/src/components/History/NetworkUpgradeSummary.tsx
+++ b/src/components/History/NetworkUpgradeSummary.tsx
@@ -4,7 +4,7 @@ import { useLocale, useTranslations } from "next-intl"
 
 import { Flex, Stack } from "@/components/ui/flex"
 
-import { dateTimeFormat, getValidDate } from "@/lib/utils/date"
+import { formatDateTime, getValidDate } from "@/lib/utils/date"
 import { numberFormat } from "@/lib/utils/numbers"
 
 import networkUpgradeSummaryData from "@/data/networkUpgradeSummaryData"
@@ -31,7 +31,7 @@ const NetworkUpgradeSummary = ({ name }: NetworkUpgradeSummaryProps) => {
 
   const upgradeDate = getValidDate(dateTimeAsString)
   const formattedUTC = upgradeDate
-    ? dateTimeFormat(locale, {
+    ? formatDateTime(locale, upgradeDate, {
         timeZone: "UTC",
         month: "short",
         day: "numeric",
@@ -40,7 +40,7 @@ const NetworkUpgradeSummary = ({ name }: NetworkUpgradeSummaryProps) => {
         minute: "numeric",
         second: "numeric",
         timeZoneName: "short",
-      }).format(upgradeDate)
+      })
     : null
 
   const blockTypeTranslation = (translationKey, explorerUrl, number) => {

--- a/src/components/LocaleDateTime.tsx
+++ b/src/components/LocaleDateTime.tsx
@@ -1,6 +1,6 @@
 import { useLocale } from "next-intl"
 
-import { dateTimeFormat } from "@/lib/utils/date"
+import { formatDateTime } from "@/lib/utils/date"
 
 type LocaleDateTimeProps = {
   utcDateTime: string
@@ -47,7 +47,7 @@ const LocaleDateTime = ({
   }
   return (
     <time dateTime={utcDateTime}>
-      {dateTimeFormat(locale, dateTimeOptions).format(date)}
+      {formatDateTime(locale, date, dateTimeOptions)}
     </time>
   )
 }

--- a/src/components/RadialChart/index.tsx
+++ b/src/components/RadialChart/index.tsx
@@ -6,7 +6,7 @@ import { useLocale, useTranslations } from "next-intl"
 import { PolarAngleAxis, RadialBar, RadialBarChart } from "recharts"
 
 import { cn } from "@/lib/utils/cn"
-import { dateTimeFormat, isValidDate } from "@/lib/utils/date"
+import { formatDateTime, isValidDate } from "@/lib/utils/date"
 
 import Tooltip from "../Tooltip"
 import Link from "../ui/Link"
@@ -60,9 +60,9 @@ const RadialChart = ({
 
   const lastUpdatedDisplay =
     lastUpdated && isValidDate(lastUpdated)
-      ? dateTimeFormat(locale, {
+      ? formatDateTime(locale, new Date(lastUpdated), {
           dateStyle: "medium",
-        }).format(new Date(lastUpdated))
+        })
       : ""
 
   const data = [{ value }]

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -31,6 +31,20 @@ export function dateTimeFormat(
   return new Intl.DateTimeFormat(locale, finalOptions)
 }
 
+const normalizeDateTimeWhitespace = (value: string): string =>
+  value.replace(/\s+/g, " ")
+
+/**
+ * Format a date with deterministic whitespace across server and browser ICU
+ * implementations, preventing byte-level React hydration mismatches.
+ */
+export const formatDateTime = (
+  locale: string,
+  date: Date | number,
+  options?: Intl.DateTimeFormatOptions
+): string =>
+  normalizeDateTimeWhitespace(dateTimeFormat(locale, options).format(date))
+
 export const dateToString = (published: Date | string) =>
   new globalThis.Date(published).toISOString().split("T")[0]
 
@@ -63,12 +77,12 @@ export const formatDate = (
   if (!isValidDate(date)) {
     return ""
   }
-  return dateTimeFormat(locale, {
+  return formatDateTime(locale, new Date(date), {
     month: "long",
     day: "numeric",
     year: "numeric",
     ...options,
-  }).format(new Date(date))
+  })
 }
 
 export const isDateReached = (date: string) => {
@@ -83,30 +97,25 @@ export const formatDateRange = (
   locale: string = DEFAULT_LOCALE,
   options?: Intl.DateTimeFormatOptions
 ) =>
-  dateTimeFormat(locale, {
-    month: "short",
-    day: "numeric",
-    ...options,
-  })
-    .formatRange(new Date(start), new Date(end || start))
-    // Normalize whitespace to avoid SSR/client hydration mismatches: Node's ICU
-    // and the browser's ICU can emit different space characters (e.g. U+202F
-    // narrow no-break space vs a regular U+0020) around the range en-dash. The
-    // two render identically but differ byte-for-byte, tripping React's
-    // hydration check. Collapsing whitespace makes the output deterministic.
-    .replace(/\s+/g, " ")
+  normalizeDateTimeWhitespace(
+    dateTimeFormat(locale, {
+      month: "short",
+      day: "numeric",
+      ...options,
+    }).formatRange(new Date(start), new Date(end || start))
+  )
 
 export const getLocaleYear = (
   locale: string = "en-US",
   date?: ConstructorParameters<DateConstructor>[0]
 ) =>
-  dateTimeFormat(locale, { year: "numeric" }).format(
-    date ? new Date(date) : new Date()
-  )
+  formatDateTime(locale, date ? new Date(date) : new Date(), {
+    year: "numeric",
+  })
 
 export const getLocaleFormattedDate = (locale: Lang, date: string) => {
   const walletLastUpdatedDate = new Date(date)
-  return dateTimeFormat(locale).format(walletLastUpdatedDate)
+  return formatDateTime(locale, walletLastUpdatedDate)
 }
 
 /**

--- a/src/lib/utils/time.ts
+++ b/src/lib/utils/time.ts
@@ -2,7 +2,7 @@ import humanizeDuration from "humanize-duration"
 
 import { Lang } from "../types"
 
-import { dateTimeFormat } from "./date"
+import { formatDateTime } from "./date"
 import { numberFormat } from "./numbers"
 
 export const getLocaleTimestamp = (
@@ -18,7 +18,7 @@ export const getLocaleTimestamp = (
       day: "numeric",
     } as Intl.DateTimeFormatOptions)
   const date = new Date(timestamp)
-  return dateTimeFormat(locale, opts).format(date)
+  return formatDateTime(locale, date, opts)
 }
 
 /**

--- a/tests/unit/date.spec.ts
+++ b/tests/unit/date.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "@playwright/test"
+
+import {
+  formatDate,
+  formatDateRange,
+  formatDateTime,
+  getLocaleFormattedDate,
+  getLocaleYear,
+} from "@/lib/utils/date"
+
+test("date helpers normalize ICU whitespace", () => {
+  const originalDateTimeFormat = Intl.DateTimeFormat
+
+  class MockDateTimeFormat {
+    format() {
+      return "Jan\u202f 1,\u00a0 2026"
+    }
+
+    formatRange() {
+      return "Jan\u202f1 \u00a0–\u202f Jan  2"
+    }
+  }
+
+  Object.defineProperty(Intl, "DateTimeFormat", {
+    configurable: true,
+    value: MockDateTimeFormat,
+  })
+
+  try {
+    const date = new Date("2026-01-01T00:00:00Z")
+
+    expect(formatDateTime("en-US", date)).toBe("Jan 1, 2026")
+    expect(formatDate("2026-01-01", "en-US")).toBe("Jan 1, 2026")
+    expect(getLocaleFormattedDate("en", "2026-01-01")).toBe("Jan 1, 2026")
+    expect(getLocaleYear("en-US", date)).toBe("Jan 1, 2026")
+    expect(formatDateRange("2026-01-01", "2026-01-02")).toBe("Jan 1 – Jan 2")
+  } finally {
+    Object.defineProperty(Intl, "DateTimeFormat", {
+      configurable: true,
+      value: originalDateTimeFormat,
+    })
+  }
+})


### PR DESCRIPTION
## Description

Centralize hydration-safe whitespace normalization for localized date and time formatting.

- Add `formatDateTime` as the normalized string-returning formatter.
- Route existing single-date helpers through the centralized formatter.
- Reuse the same normalization for date ranges.
- Migrate direct `dateTimeFormat(...).format(...)` consumers.
- Add regression coverage for ICU whitespace differences such as U+202F and U+00A0.

Displayed dates remain unchanged apart from equivalent whitespace being collapsed to regular spaces.

## Related Issue

Closes #18828