### PR TITLE
chore(chromatic): cut snapshot usage to stay under quota

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,8 @@ jobs:
         uses: chromaui/action@v16
         with:
           projectToken: fee8e66c9916
+          # untraced globs live in chromatic.config.json (Storybook project only).
+          configFile: chromatic.config.json
           exitZeroOnChanges: true
           onlyChanged: true
           # Release-train builds (dev/staging/master head branches) were

--- a/.storybook/modes.ts
+++ b/.storybook/modes.ts
@@ -31,6 +31,11 @@ type LangViewModeObj = {
   [key: string]: { viewport: string; locale: string }
 }
 
+// RTL locales only get a representative subset of widths. Direction bugs
+// surface at mobile + desktop, so snapshotting Arabic at all 6 breakpoints
+// doubled the per-story count for little added signal.
+const rtlViewports = new Set(["base", "lg"])
+
 export const langViewportModes = Object.entries(
   viewportModes
 ).reduce<LangViewModeObj>((arr, curr) => {
@@ -39,6 +44,7 @@ export const langViewportModes = Object.entries(
   const currLangViewObj = {} as LangViewModeObj
 
   Object.entries(langModes).forEach(([langKey, langVal]) => {
+    if (langKey !== "en" && !rtlViewports.has(viewKey)) return
     currLangViewObj[`${langKey}-${viewKey}`] = {
       viewport: viewVal.viewport,
       locale: langVal.locale,

--- a/chromatic.config.json
+++ b/chromatic.config.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://www.chromatic.com/config-file.schema.json",
+  "zip": true,
+  "untraced": [
+    "public/content/**",
+    "src/intl/**",
+    "src/data/**"
+  ]
+}

--- a/chromatic.config.json
+++ b/chromatic.config.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://www.chromatic.com/config-file.schema.json",
-  "zip": true,
   "untraced": [
     "public/content/**",
     "src/intl/**",

--- a/src/intl/en/common.json
+++ b/src/intl/en/common.json
@@ -1,6 +1,6 @@
 {
   "about-ethereum-org": "About ethereum.org",
-  "about-us": "About us",
+  "about-us": "About us ",
   "account-abstraction": "Account abstraction",
   "acknowledgements": "Acknowledgements",
   "adding-community-stories": "Adding Community Stories",

--- a/src/intl/en/common.json
+++ b/src/intl/en/common.json
@@ -1,6 +1,6 @@
 {
   "about-ethereum-org": "About ethereum.org",
-  "about-us": "About us ",
+  "about-us": "About us",
   "account-abstraction": "Account abstraction",
   "acknowledgements": "Acknowledgements",
   "adding-community-stories": "Adding Community Stories",


### PR DESCRIPTION
We're about to blow the monthly Chromatic snapshot quota. **99.6%** of usage is the Storybook project, and **~56% of it is full rebuilds** — almost all triggered by translation edits, because `.storybook/preview.tsx` pulls ~100 `src/intl` JSONs into its bundle, so every intl-pipeline commit bails TurboSnap to a full build. This matters more now that `visual-tests` runs on every non-draft PR.

## Changes
1. **`chromatic.config.json`** with `untraced` globs (`src/intl/**`, `public/content/**`, `src/data/**`) so churny non-visual files stop forcing full rebuilds. Scoped to `untraced` only; per-project options stay inline in the CI jobs (the root config is read by both Chromatic projects).
2. **Trim the RTL mode axis** — `langViewportModes` renders `ar` at `base`+`lg` only (`en` keeps all 6). Opted-in stories drop 12→8 snapshots.

## Verified on CI
- Full build: **293 → 252** snapshots (mode trim).
- Intl-only change: **0** snapshots captured, was a full ~293 rebuild (`untraced`).

**Trade-off:** pure translation-text changes no longer re-snapshot (reviewed elsewhere).

_Squash-merge — branch has a test+revert pair that nets to zero._