### PR TITLE
fix(i18n): stamp SSF manifests for template + title fixes

### DIFF
--- a/.manifests/public/content/translations/ar/roadmap/single-slot-finality/index.md/source.json
+++ b/.manifests/public/content/translations/ar/roadmap/single-slot-finality/index.md/source.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
   "sourceFile": "public/content/roadmap/single-slot-finality/index.md",
-  "generatedAt": "2026-07-23T00:25:05.470Z",
-  "rootHash": "4bf44a7aa474",
+  "generatedAt": "2026-07-23T22:50:18.767Z",
+  "rootHash": "9bb8f5a5f505",
   "tree": {
-    "contentHash": "a283f02e2096",
-    "anchorHash": "d18cf4b46d2b",
+    "contentHash": "cd76e7c935a4",
+    "anchorHash": "725a23f7e9d8",
     "children": {
       "frontmatter:title": {
         "contentHash": "26be487ae07f",
@@ -93,8 +93,8 @@
         ]
       },
       "routes-to-ssf": {
-        "contentHash": "8f3484838172",
-        "anchorHash": "255c536ef8f9",
+        "contentHash": "6bcdb3dac733",
+        "anchorHash": "6331b9bca123",
         "labelHash": "d140fa94a9c9",
         "children": {
           "_label": {
@@ -102,9 +102,13 @@
             "anchorHash": "e3b0c44298fc"
           },
           "component:1": {
-            "contentHash": "6f7d93f7eedd",
-            "anchorHash": "6103ea1c6d76",
+            "contentHash": "b0e197cae82e",
+            "anchorHash": "cfc88a81eabd",
             "children": {
+              "attr:title": {
+                "contentHash": "bef51d6c28a1",
+                "anchorHash": "e3b0c44298fc"
+              },
               "attr:eventCategory": {
                 "contentHash": "e3b0c44298fc",
                 "anchorHash": "f1e82b456042"
@@ -127,6 +131,7 @@
               }
             },
             "childrenOrder": [
+              "attr:title",
               "attr:eventCategory",
               "attr:eventName",
               "prose:1",
@@ -295,5 +300,5 @@
       "further-reading"
     ]
   },
-  "sourceCommitSha": "5b981c8a5bf1439902c9c764add8642d7f283824"
+  "sourceCommitSha": "9fbda251935a99d698459c3ce514c22fdce5a065"
 }

--- a/.manifests/public/content/translations/bn/roadmap/single-slot-finality/index.md/source.json
+++ b/.manifests/public/content/translations/bn/roadmap/single-slot-finality/index.md/source.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
   "sourceFile": "public/content/roadmap/single-slot-finality/index.md",
-  "generatedAt": "2026-07-23T00:25:05.518Z",
-  "rootHash": "4bf44a7aa474",
+  "generatedAt": "2026-07-23T22:50:18.769Z",
+  "rootHash": "9bb8f5a5f505",
   "tree": {
-    "contentHash": "a283f02e2096",
-    "anchorHash": "d18cf4b46d2b",
+    "contentHash": "cd76e7c935a4",
+    "anchorHash": "725a23f7e9d8",
     "children": {
       "frontmatter:title": {
         "contentHash": "26be487ae07f",
@@ -93,8 +93,8 @@
         ]
       },
       "routes-to-ssf": {
-        "contentHash": "8f3484838172",
-        "anchorHash": "255c536ef8f9",
+        "contentHash": "6bcdb3dac733",
+        "anchorHash": "6331b9bca123",
         "labelHash": "d140fa94a9c9",
         "children": {
           "_label": {
@@ -102,9 +102,13 @@
             "anchorHash": "e3b0c44298fc"
           },
           "component:1": {
-            "contentHash": "6f7d93f7eedd",
-            "anchorHash": "6103ea1c6d76",
+            "contentHash": "b0e197cae82e",
+            "anchorHash": "cfc88a81eabd",
             "children": {
+              "attr:title": {
+                "contentHash": "bef51d6c28a1",
+                "anchorHash": "e3b0c44298fc"
+              },
               "attr:eventCategory": {
                 "contentHash": "e3b0c44298fc",
                 "anchorHash": "f1e82b456042"
@@ -127,6 +131,7 @@
               }
             },
             "childrenOrder": [
+              "attr:title",
               "attr:eventCategory",
               "attr:eventName",
               "prose:1",
@@ -295,5 +300,5 @@
       "further-reading"
     ]
   },
-  "sourceCommitSha": "5b981c8a5bf1439902c9c764add8642d7f283824"
+  "sourceCommitSha": "9fbda251935a99d698459c3ce514c22fdce5a065"
 }

--- a/.manifests/public/content/translations/cs/roadmap/single-slot-finality/index.md/source.json
+++ b/.manifests/public/content/translations/cs/roadmap/single-slot-finality/index.md/source.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
   "sourceFile": "public/content/roadmap/single-slot-finality/index.md",
-  "generatedAt": "2026-07-23T00:25:05.795Z",
-  "rootHash": "4bf44a7aa474",
+  "generatedAt": "2026-07-23T22:50:18.770Z",
+  "rootHash": "9bb8f5a5f505",
   "tree": {
-    "contentHash": "a283f02e2096",
-    "anchorHash": "d18cf4b46d2b",
+    "contentHash": "cd76e7c935a4",
+    "anchorHash": "725a23f7e9d8",
     "children": {
       "frontmatter:title": {
         "contentHash": "26be487ae07f",
@@ -93,8 +93,8 @@
         ]
       },
       "routes-to-ssf": {
-        "contentHash": "8f3484838172",
-        "anchorHash": "255c536ef8f9",
+        "contentHash": "6bcdb3dac733",
+        "anchorHash": "6331b9bca123",
         "labelHash": "d140fa94a9c9",
         "children": {
           "_label": {
@@ -102,9 +102,13 @@
             "anchorHash": "e3b0c44298fc"
           },
           "component:1": {
-            "contentHash": "6f7d93f7eedd",
-            "anchorHash": "6103ea1c6d76",
+            "contentHash": "b0e197cae82e",
+            "anchorHash": "cfc88a81eabd",
             "children": {
+              "attr:title": {
+                "contentHash": "bef51d6c28a1",
+                "anchorHash": "e3b0c44298fc"
+              },
               "attr:eventCategory": {
                 "contentHash": "e3b0c44298fc",
                 "anchorHash": "f1e82b456042"
@@ -127,6 +131,7 @@
               }
             },
             "childrenOrder": [
+              "attr:title",
               "attr:eventCategory",
               "attr:eventName",
               "prose:1",
@@ -295,5 +300,5 @@
       "further-reading"
     ]
   },
-  "sourceCommitSha": "5b981c8a5bf1439902c9c764add8642d7f283824"
+  "sourceCommitSha": "9fbda251935a99d698459c3ce514c22fdce5a065"
 }

--- a/.manifests/public/content/translations/de/roadmap/single-slot-finality/index.md/source.json
+++ b/.manifests/public/content/translations/de/roadmap/single-slot-finality/index.md/source.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
   "sourceFile": "public/content/roadmap/single-slot-finality/index.md",
-  "generatedAt": "2026-07-23T00:25:06.191Z",
-  "rootHash": "4bf44a7aa474",
+  "generatedAt": "2026-07-23T22:50:18.772Z",
+  "rootHash": "9bb8f5a5f505",
   "tree": {
-    "contentHash": "a283f02e2096",
-    "anchorHash": "d18cf4b46d2b",
+    "contentHash": "cd76e7c935a4",
+    "anchorHash": "725a23f7e9d8",
     "children": {
       "frontmatter:title": {
         "contentHash": "26be487ae07f",
@@ -93,8 +93,8 @@
         ]
       },
       "routes-to-ssf": {
-        "contentHash": "8f3484838172",
-        "anchorHash": "255c536ef8f9",
+        "contentHash": "6bcdb3dac733",
+        "anchorHash": "6331b9bca123",
         "labelHash": "d140fa94a9c9",
         "children": {
           "_label": {
@@ -102,9 +102,13 @@
             "anchorHash": "e3b0c44298fc"
           },
           "component:1": {
-            "contentHash": "6f7d93f7eedd",
-            "anchorHash": "6103ea1c6d76",
+            "contentHash": "b0e197cae82e",
+            "anchorHash": "cfc88a81eabd",
             "children": {
+              "attr:title": {
+                "contentHash": "bef51d6c28a1",
+                "anchorHash": "e3b0c44298fc"
+              },
               "attr:eventCategory": {
                 "contentHash": "e3b0c44298fc",
                 "anchorHash": "f1e82b456042"
@@ -127,6 +131,7 @@
               }
             },
             "childrenOrder": [
+              "attr:title",
               "attr:eventCategory",
               "attr:eventName",
               "prose:1",
@@ -295,5 +300,5 @@
       "further-reading"
     ]
   },
-  "sourceCommitSha": "5b981c8a5bf1439902c9c764add8642d7f283824"
+  "sourceCommitSha": "9fbda251935a99d698459c3ce514c22fdce5a065"
 }

--- a/.manifests/public/content/translations/es/roadmap/single-slot-finality/index.md/source.json
+++ b/.manifests/public/content/translations/es/roadmap/single-slot-finality/index.md/source.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
   "sourceFile": "public/content/roadmap/single-slot-finality/index.md",
-  "generatedAt": "2026-07-23T00:25:06.252Z",
-  "rootHash": "4bf44a7aa474",
+  "generatedAt": "2026-07-23T22:50:18.774Z",
+  "rootHash": "9bb8f5a5f505",
   "tree": {
-    "contentHash": "a283f02e2096",
-    "anchorHash": "d18cf4b46d2b",
+    "contentHash": "cd76e7c935a4",
+    "anchorHash": "725a23f7e9d8",
     "children": {
       "frontmatter:title": {
         "contentHash": "26be487ae07f",
@@ -93,8 +93,8 @@
         ]
       },
       "routes-to-ssf": {
-        "contentHash": "8f3484838172",
-        "anchorHash": "255c536ef8f9",
+        "contentHash": "6bcdb3dac733",
+        "anchorHash": "6331b9bca123",
         "labelHash": "d140fa94a9c9",
         "children": {
           "_label": {
@@ -102,9 +102,13 @@
             "anchorHash": "e3b0c44298fc"
           },
           "component:1": {
-            "contentHash": "6f7d93f7eedd",
-            "anchorHash": "6103ea1c6d76",
+            "contentHash": "b0e197cae82e",
+            "anchorHash": "cfc88a81eabd",
             "children": {
+              "attr:title": {
+                "contentHash": "bef51d6c28a1",
+                "anchorHash": "e3b0c44298fc"
+              },
               "attr:eventCategory": {
                 "contentHash": "e3b0c44298fc",
                 "anchorHash": "f1e82b456042"
@@ -127,6 +131,7 @@
               }
             },
             "childrenOrder": [
+              "attr:title",
               "attr:eventCategory",
               "attr:eventName",
               "prose:1",
@@ -295,5 +300,5 @@
       "further-reading"
     ]
   },
-  "sourceCommitSha": "5b981c8a5bf1439902c9c764add8642d7f283824"
+  "sourceCommitSha": "9fbda251935a99d698459c3ce514c22fdce5a065"
 }

--- a/.manifests/public/content/translations/fr/roadmap/single-slot-finality/index.md/source.json
+++ b/.manifests/public/content/translations/fr/roadmap/single-slot-finality/index.md/source.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
   "sourceFile": "public/content/roadmap/single-slot-finality/index.md",
-  "generatedAt": "2026-07-23T00:25:06.372Z",
-  "rootHash": "4bf44a7aa474",
+  "generatedAt": "2026-07-23T22:50:18.775Z",
+  "rootHash": "9bb8f5a5f505",
   "tree": {
-    "contentHash": "a283f02e2096",
-    "anchorHash": "d18cf4b46d2b",
+    "contentHash": "cd76e7c935a4",
+    "anchorHash": "725a23f7e9d8",
     "children": {
       "frontmatter:title": {
         "contentHash": "26be487ae07f",
@@ -93,8 +93,8 @@
         ]
       },
       "routes-to-ssf": {
-        "contentHash": "8f3484838172",
-        "anchorHash": "255c536ef8f9",
+        "contentHash": "6bcdb3dac733",
+        "anchorHash": "6331b9bca123",
         "labelHash": "d140fa94a9c9",
         "children": {
           "_label": {
@@ -102,9 +102,13 @@
             "anchorHash": "e3b0c44298fc"
           },
           "component:1": {
-            "contentHash": "6f7d93f7eedd",
-            "anchorHash": "6103ea1c6d76",
+            "contentHash": "b0e197cae82e",
+            "anchorHash": "cfc88a81eabd",
             "children": {
+              "attr:title": {
+                "contentHash": "bef51d6c28a1",
+                "anchorHash": "e3b0c44298fc"
+              },
               "attr:eventCategory": {
                 "contentHash": "e3b0c44298fc",
                 "anchorHash": "f1e82b456042"
@@ -127,6 +131,7 @@
               }
             },
             "childrenOrder": [
+              "attr:title",
               "attr:eventCategory",
               "attr:eventName",
               "prose:1",
@@ -295,5 +300,5 @@
       "further-reading"
     ]
   },
-  "sourceCommitSha": "5b981c8a5bf1439902c9c764add8642d7f283824"
+  "sourceCommitSha": "9fbda251935a99d698459c3ce514c22fdce5a065"
 }

--- a/.manifests/public/content/translations/hi/roadmap/single-slot-finality/index.md/source.json
+++ b/.manifests/public/content/translations/hi/roadmap/single-slot-finality/index.md/source.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
   "sourceFile": "public/content/roadmap/single-slot-finality/index.md",
-  "generatedAt": "2026-07-23T00:25:06.451Z",
-  "rootHash": "4bf44a7aa474",
+  "generatedAt": "2026-07-23T22:50:18.776Z",
+  "rootHash": "9bb8f5a5f505",
   "tree": {
-    "contentHash": "a283f02e2096",
-    "anchorHash": "d18cf4b46d2b",
+    "contentHash": "cd76e7c935a4",
+    "anchorHash": "725a23f7e9d8",
     "children": {
       "frontmatter:title": {
         "contentHash": "26be487ae07f",
@@ -93,8 +93,8 @@
         ]
       },
       "routes-to-ssf": {
-        "contentHash": "8f3484838172",
-        "anchorHash": "255c536ef8f9",
+        "contentHash": "6bcdb3dac733",
+        "anchorHash": "6331b9bca123",
         "labelHash": "d140fa94a9c9",
         "children": {
           "_label": {
@@ -102,9 +102,13 @@
             "anchorHash": "e3b0c44298fc"
           },
           "component:1": {
-            "contentHash": "6f7d93f7eedd",
-            "anchorHash": "6103ea1c6d76",
+            "contentHash": "b0e197cae82e",
+            "anchorHash": "cfc88a81eabd",
             "children": {
+              "attr:title": {
+                "contentHash": "bef51d6c28a1",
+                "anchorHash": "e3b0c44298fc"
+              },
               "attr:eventCategory": {
                 "contentHash": "e3b0c44298fc",
                 "anchorHash": "f1e82b456042"
@@ -127,6 +131,7 @@
               }
             },
             "childrenOrder": [
+              "attr:title",
               "attr:eventCategory",
               "attr:eventName",
               "prose:1",
@@ -295,5 +300,5 @@
       "further-reading"
     ]
   },
-  "sourceCommitSha": "5b981c8a5bf1439902c9c764add8642d7f283824"
+  "sourceCommitSha": "9fbda251935a99d698459c3ce514c22fdce5a065"
 }

--- a/.manifests/public/content/translations/id/roadmap/single-slot-finality/index.md/source.json
+++ b/.manifests/public/content/translations/id/roadmap/single-slot-finality/index.md/source.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
   "sourceFile": "public/content/roadmap/single-slot-finality/index.md",
-  "generatedAt": "2026-07-23T00:25:06.540Z",
-  "rootHash": "4bf44a7aa474",
+  "generatedAt": "2026-07-23T22:50:18.777Z",
+  "rootHash": "9bb8f5a5f505",
   "tree": {
-    "contentHash": "a283f02e2096",
-    "anchorHash": "d18cf4b46d2b",
+    "contentHash": "cd76e7c935a4",
+    "anchorHash": "725a23f7e9d8",
     "children": {
       "frontmatter:title": {
         "contentHash": "26be487ae07f",
@@ -93,8 +93,8 @@
         ]
       },
       "routes-to-ssf": {
-        "contentHash": "8f3484838172",
-        "anchorHash": "255c536ef8f9",
+        "contentHash": "6bcdb3dac733",
+        "anchorHash": "6331b9bca123",
         "labelHash": "d140fa94a9c9",
         "children": {
           "_label": {
@@ -102,9 +102,13 @@
             "anchorHash": "e3b0c44298fc"
           },
           "component:1": {
-            "contentHash": "6f7d93f7eedd",
-            "anchorHash": "6103ea1c6d76",
+            "contentHash": "b0e197cae82e",
+            "anchorHash": "cfc88a81eabd",
             "children": {
+              "attr:title": {
+                "contentHash": "bef51d6c28a1",
+                "anchorHash": "e3b0c44298fc"
+              },
               "attr:eventCategory": {
                 "contentHash": "e3b0c44298fc",
                 "anchorHash": "f1e82b456042"
@@ -127,6 +131,7 @@
               }
             },
             "childrenOrder": [
+              "attr:title",
               "attr:eventCategory",
               "attr:eventName",
               "prose:1",
@@ -295,5 +300,5 @@
       "further-reading"
     ]
   },
-  "sourceCommitSha": "5b981c8a5bf1439902c9c764add8642d7f283824"
+  "sourceCommitSha": "9fbda251935a99d698459c3ce514c22fdce5a065"
 }

--- a/.manifests/public/content/translations/it/roadmap/single-slot-finality/index.md/source.json
+++ b/.manifests/public/content/translations/it/roadmap/single-slot-finality/index.md/source.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
   "sourceFile": "public/content/roadmap/single-slot-finality/index.md",
-  "generatedAt": "2026-07-23T00:25:06.936Z",
-  "rootHash": "4bf44a7aa474",
+  "generatedAt": "2026-07-23T22:50:18.778Z",
+  "rootHash": "9bb8f5a5f505",
   "tree": {
-    "contentHash": "a283f02e2096",
-    "anchorHash": "d18cf4b46d2b",
+    "contentHash": "cd76e7c935a4",
+    "anchorHash": "725a23f7e9d8",
     "children": {
       "frontmatter:title": {
         "contentHash": "26be487ae07f",
@@ -93,8 +93,8 @@
         ]
       },
       "routes-to-ssf": {
-        "contentHash": "8f3484838172",
-        "anchorHash": "255c536ef8f9",
+        "contentHash": "6bcdb3dac733",
+        "anchorHash": "6331b9bca123",
         "labelHash": "d140fa94a9c9",
         "children": {
           "_label": {
@@ -102,9 +102,13 @@
             "anchorHash": "e3b0c44298fc"
           },
           "component:1": {
-            "contentHash": "6f7d93f7eedd",
-            "anchorHash": "6103ea1c6d76",
+            "contentHash": "b0e197cae82e",
+            "anchorHash": "cfc88a81eabd",
             "children": {
+              "attr:title": {
+                "contentHash": "bef51d6c28a1",
+                "anchorHash": "e3b0c44298fc"
+              },
               "attr:eventCategory": {
                 "contentHash": "e3b0c44298fc",
                 "anchorHash": "f1e82b456042"
@@ -127,6 +131,7 @@
               }
             },
             "childrenOrder": [
+              "attr:title",
               "attr:eventCategory",
               "attr:eventName",
               "prose:1",
@@ -295,5 +300,5 @@
       "further-reading"
     ]
   },
-  "sourceCommitSha": "5b981c8a5bf1439902c9c764add8642d7f283824"
+  "sourceCommitSha": "9fbda251935a99d698459c3ce514c22fdce5a065"
 }

--- a/.manifests/public/content/translations/ja/roadmap/single-slot-finality/index.md/source.json
+++ b/.manifests/public/content/translations/ja/roadmap/single-slot-finality/index.md/source.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
   "sourceFile": "public/content/roadmap/single-slot-finality/index.md",
-  "generatedAt": "2026-07-23T00:25:07.003Z",
-  "rootHash": "4bf44a7aa474",
+  "generatedAt": "2026-07-23T22:50:18.780Z",
+  "rootHash": "9bb8f5a5f505",
   "tree": {
-    "contentHash": "a283f02e2096",
-    "anchorHash": "d18cf4b46d2b",
+    "contentHash": "cd76e7c935a4",
+    "anchorHash": "725a23f7e9d8",
     "children": {
       "frontmatter:title": {
         "contentHash": "26be487ae07f",
@@ -93,8 +93,8 @@
         ]
       },
       "routes-to-ssf": {
-        "contentHash": "8f3484838172",
-        "anchorHash": "255c536ef8f9",
+        "contentHash": "6bcdb3dac733",
+        "anchorHash": "6331b9bca123",
         "labelHash": "d140fa94a9c9",
         "children": {
           "_label": {
@@ -102,9 +102,13 @@
             "anchorHash": "e3b0c44298fc"
           },
           "component:1": {
-            "contentHash": "6f7d93f7eedd",
-            "anchorHash": "6103ea1c6d76",
+            "contentHash": "b0e197cae82e",
+            "anchorHash": "cfc88a81eabd",
             "children": {
+              "attr:title": {
+                "contentHash": "bef51d6c28a1",
+                "anchorHash": "e3b0c44298fc"
+              },
               "attr:eventCategory": {
                 "contentHash": "e3b0c44298fc",
                 "anchorHash": "f1e82b456042"
@@ -127,6 +131,7 @@
               }
             },
             "childrenOrder": [
+              "attr:title",
               "attr:eventCategory",
               "attr:eventName",
               "prose:1",
@@ -295,5 +300,5 @@
       "further-reading"
     ]
   },
-  "sourceCommitSha": "5b981c8a5bf1439902c9c764add8642d7f283824"
+  "sourceCommitSha": "9fbda251935a99d698459c3ce514c22fdce5a065"
 }

--- a/.manifests/public/content/translations/ko/roadmap/single-slot-finality/index.md/source.json
+++ b/.manifests/public/content/translations/ko/roadmap/single-slot-finality/index.md/source.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
   "sourceFile": "public/content/roadmap/single-slot-finality/index.md",
-  "generatedAt": "2026-07-23T00:25:07.172Z",
-  "rootHash": "4bf44a7aa474",
+  "generatedAt": "2026-07-23T22:50:18.781Z",
+  "rootHash": "9bb8f5a5f505",
   "tree": {
-    "contentHash": "a283f02e2096",
-    "anchorHash": "d18cf4b46d2b",
+    "contentHash": "cd76e7c935a4",
+    "anchorHash": "725a23f7e9d8",
     "children": {
       "frontmatter:title": {
         "contentHash": "26be487ae07f",
@@ -93,8 +93,8 @@
         ]
       },
       "routes-to-ssf": {
-        "contentHash": "8f3484838172",
-        "anchorHash": "255c536ef8f9",
+        "contentHash": "6bcdb3dac733",
+        "anchorHash": "6331b9bca123",
         "labelHash": "d140fa94a9c9",
         "children": {
           "_label": {
@@ -102,9 +102,13 @@
             "anchorHash": "e3b0c44298fc"
           },
           "component:1": {
-            "contentHash": "6f7d93f7eedd",
-            "anchorHash": "6103ea1c6d76",
+            "contentHash": "b0e197cae82e",
+            "anchorHash": "cfc88a81eabd",
             "children": {
+              "attr:title": {
+                "contentHash": "bef51d6c28a1",
+                "anchorHash": "e3b0c44298fc"
+              },
               "attr:eventCategory": {
                 "contentHash": "e3b0c44298fc",
                 "anchorHash": "f1e82b456042"
@@ -127,6 +131,7 @@
               }
             },
             "childrenOrder": [
+              "attr:title",
               "attr:eventCategory",
               "attr:eventName",
               "prose:1",
@@ -295,5 +300,5 @@
       "further-reading"
     ]
   },
-  "sourceCommitSha": "5b981c8a5bf1439902c9c764add8642d7f283824"
+  "sourceCommitSha": "9fbda251935a99d698459c3ce514c22fdce5a065"
 }

--- a/.manifests/public/content/translations/mr/roadmap/single-slot-finality/index.md/source.json
+++ b/.manifests/public/content/translations/mr/roadmap/single-slot-finality/index.md/source.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
   "sourceFile": "public/content/roadmap/single-slot-finality/index.md",
-  "generatedAt": "2026-07-23T00:25:07.184Z",
-  "rootHash": "4bf44a7aa474",
+  "generatedAt": "2026-07-23T22:50:18.782Z",
+  "rootHash": "9bb8f5a5f505",
   "tree": {
-    "contentHash": "a283f02e2096",
-    "anchorHash": "d18cf4b46d2b",
+    "contentHash": "cd76e7c935a4",
+    "anchorHash": "725a23f7e9d8",
     "children": {
       "frontmatter:title": {
         "contentHash": "26be487ae07f",
@@ -93,8 +93,8 @@
         ]
       },
       "routes-to-ssf": {
-        "contentHash": "8f3484838172",
-        "anchorHash": "255c536ef8f9",
+        "contentHash": "6bcdb3dac733",
+        "anchorHash": "6331b9bca123",
         "labelHash": "d140fa94a9c9",
         "children": {
           "_label": {
@@ -102,9 +102,13 @@
             "anchorHash": "e3b0c44298fc"
           },
           "component:1": {
-            "contentHash": "6f7d93f7eedd",
-            "anchorHash": "6103ea1c6d76",
+            "contentHash": "b0e197cae82e",
+            "anchorHash": "cfc88a81eabd",
             "children": {
+              "attr:title": {
+                "contentHash": "bef51d6c28a1",
+                "anchorHash": "e3b0c44298fc"
+              },
               "attr:eventCategory": {
                 "contentHash": "e3b0c44298fc",
                 "anchorHash": "f1e82b456042"
@@ -127,6 +131,7 @@
               }
             },
             "childrenOrder": [
+              "attr:title",
               "attr:eventCategory",
               "attr:eventName",
               "prose:1",
@@ -295,5 +300,5 @@
       "further-reading"
     ]
   },
-  "sourceCommitSha": "5b981c8a5bf1439902c9c764add8642d7f283824"
+  "sourceCommitSha": "9fbda251935a99d698459c3ce514c22fdce5a065"
 }

--- a/.manifests/public/content/translations/pl/roadmap/single-slot-finality/index.md/source.json
+++ b/.manifests/public/content/translations/pl/roadmap/single-slot-finality/index.md/source.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
   "sourceFile": "public/content/roadmap/single-slot-finality/index.md",
-  "generatedAt": "2026-07-23T00:25:07.407Z",
-  "rootHash": "4bf44a7aa474",
+  "generatedAt": "2026-07-23T22:50:18.783Z",
+  "rootHash": "9bb8f5a5f505",
   "tree": {
-    "contentHash": "a283f02e2096",
-    "anchorHash": "d18cf4b46d2b",
+    "contentHash": "cd76e7c935a4",
+    "anchorHash": "725a23f7e9d8",
     "children": {
       "frontmatter:title": {
         "contentHash": "26be487ae07f",
@@ -93,8 +93,8 @@
         ]
       },
       "routes-to-ssf": {
-        "contentHash": "8f3484838172",
-        "anchorHash": "255c536ef8f9",
+        "contentHash": "6bcdb3dac733",
+        "anchorHash": "6331b9bca123",
         "labelHash": "d140fa94a9c9",
         "children": {
           "_label": {
@@ -102,9 +102,13 @@
             "anchorHash": "e3b0c44298fc"
           },
           "component:1": {
-            "contentHash": "6f7d93f7eedd",
-            "anchorHash": "6103ea1c6d76",
+            "contentHash": "b0e197cae82e",
+            "anchorHash": "cfc88a81eabd",
             "children": {
+              "attr:title": {
+                "contentHash": "bef51d6c28a1",
+                "anchorHash": "e3b0c44298fc"
+              },
               "attr:eventCategory": {
                 "contentHash": "e3b0c44298fc",
                 "anchorHash": "f1e82b456042"
@@ -127,6 +131,7 @@
               }
             },
             "childrenOrder": [
+              "attr:title",
               "attr:eventCategory",
               "attr:eventName",
               "prose:1",
@@ -295,5 +300,5 @@
       "further-reading"
     ]
   },
-  "sourceCommitSha": "5b981c8a5bf1439902c9c764add8642d7f283824"
+  "sourceCommitSha": "9fbda251935a99d698459c3ce514c22fdce5a065"
 }

--- a/.manifests/public/content/translations/pt-br/roadmap/single-slot-finality/index.md/source.json
+++ b/.manifests/public/content/translations/pt-br/roadmap/single-slot-finality/index.md/source.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
   "sourceFile": "public/content/roadmap/single-slot-finality/index.md",
-  "generatedAt": "2026-07-23T00:25:07.694Z",
-  "rootHash": "4bf44a7aa474",
+  "generatedAt": "2026-07-23T22:50:18.784Z",
+  "rootHash": "9bb8f5a5f505",
   "tree": {
-    "contentHash": "a283f02e2096",
-    "anchorHash": "d18cf4b46d2b",
+    "contentHash": "cd76e7c935a4",
+    "anchorHash": "725a23f7e9d8",
     "children": {
       "frontmatter:title": {
         "contentHash": "26be487ae07f",
@@ -93,8 +93,8 @@
         ]
       },
       "routes-to-ssf": {
-        "contentHash": "8f3484838172",
-        "anchorHash": "255c536ef8f9",
+        "contentHash": "6bcdb3dac733",
+        "anchorHash": "6331b9bca123",
         "labelHash": "d140fa94a9c9",
         "children": {
           "_label": {
@@ -102,9 +102,13 @@
             "anchorHash": "e3b0c44298fc"
           },
           "component:1": {
-            "contentHash": "6f7d93f7eedd",
-            "anchorHash": "6103ea1c6d76",
+            "contentHash": "b0e197cae82e",
+            "anchorHash": "cfc88a81eabd",
             "children": {
+              "attr:title": {
+                "contentHash": "bef51d6c28a1",
+                "anchorHash": "e3b0c44298fc"
+              },
               "attr:eventCategory": {
                 "contentHash": "e3b0c44298fc",
                 "anchorHash": "f1e82b456042"
@@ -127,6 +131,7 @@
               }
             },
             "childrenOrder": [
+              "attr:title",
               "attr:eventCategory",
               "attr:eventName",
               "prose:1",
@@ -295,5 +300,5 @@
       "further-reading"
     ]
   },
-  "sourceCommitSha": "5b981c8a5bf1439902c9c764add8642d7f283824"
+  "sourceCommitSha": "9fbda251935a99d698459c3ce514c22fdce5a065"
 }

--- a/.manifests/public/content/translations/ru/roadmap/single-slot-finality/index.md/source.json
+++ b/.manifests/public/content/translations/ru/roadmap/single-slot-finality/index.md/source.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
   "sourceFile": "public/content/roadmap/single-slot-finality/index.md",
-  "generatedAt": "2026-07-23T00:25:07.802Z",
-  "rootHash": "4bf44a7aa474",
+  "generatedAt": "2026-07-23T22:50:18.785Z",
+  "rootHash": "9bb8f5a5f505",
   "tree": {
-    "contentHash": "a283f02e2096",
-    "anchorHash": "d18cf4b46d2b",
+    "contentHash": "cd76e7c935a4",
+    "anchorHash": "725a23f7e9d8",
     "children": {
       "frontmatter:title": {
         "contentHash": "26be487ae07f",
@@ -93,8 +93,8 @@
         ]
       },
       "routes-to-ssf": {
-        "contentHash": "8f3484838172",
-        "anchorHash": "255c536ef8f9",
+        "contentHash": "6bcdb3dac733",
+        "anchorHash": "6331b9bca123",
         "labelHash": "d140fa94a9c9",
         "children": {
           "_label": {
@@ -102,9 +102,13 @@
             "anchorHash": "e3b0c44298fc"
           },
           "component:1": {
-            "contentHash": "6f7d93f7eedd",
-            "anchorHash": "6103ea1c6d76",
+            "contentHash": "b0e197cae82e",
+            "anchorHash": "cfc88a81eabd",
             "children": {
+              "attr:title": {
+                "contentHash": "bef51d6c28a1",
+                "anchorHash": "e3b0c44298fc"
+              },
               "attr:eventCategory": {
                 "contentHash": "e3b0c44298fc",
                 "anchorHash": "f1e82b456042"
@@ -127,6 +131,7 @@
               }
             },
             "childrenOrder": [
+              "attr:title",
               "attr:eventCategory",
               "attr:eventName",
               "prose:1",
@@ -295,5 +300,5 @@
       "further-reading"
     ]
   },
-  "sourceCommitSha": "5b981c8a5bf1439902c9c764add8642d7f283824"
+  "sourceCommitSha": "9fbda251935a99d698459c3ce514c22fdce5a065"
 }

--- a/.manifests/public/content/translations/sw/roadmap/single-slot-finality/index.md/source.json
+++ b/.manifests/public/content/translations/sw/roadmap/single-slot-finality/index.md/source.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
   "sourceFile": "public/content/roadmap/single-slot-finality/index.md",
-  "generatedAt": "2026-07-23T00:25:07.960Z",
-  "rootHash": "4bf44a7aa474",
+  "generatedAt": "2026-07-23T22:50:18.785Z",
+  "rootHash": "9bb8f5a5f505",
   "tree": {
-    "contentHash": "a283f02e2096",
-    "anchorHash": "d18cf4b46d2b",
+    "contentHash": "cd76e7c935a4",
+    "anchorHash": "725a23f7e9d8",
     "children": {
       "frontmatter:title": {
         "contentHash": "26be487ae07f",
@@ -93,8 +93,8 @@
         ]
       },
       "routes-to-ssf": {
-        "contentHash": "8f3484838172",
-        "anchorHash": "255c536ef8f9",
+        "contentHash": "6bcdb3dac733",
+        "anchorHash": "6331b9bca123",
         "labelHash": "d140fa94a9c9",
         "children": {
           "_label": {
@@ -102,9 +102,13 @@
             "anchorHash": "e3b0c44298fc"
           },
           "component:1": {
-            "contentHash": "6f7d93f7eedd",
-            "anchorHash": "6103ea1c6d76",
+            "contentHash": "b0e197cae82e",
+            "anchorHash": "cfc88a81eabd",
             "children": {
+              "attr:title": {
+                "contentHash": "bef51d6c28a1",
+                "anchorHash": "e3b0c44298fc"
+              },
               "attr:eventCategory": {
                 "contentHash": "e3b0c44298fc",
                 "anchorHash": "f1e82b456042"
@@ -127,6 +131,7 @@
               }
             },
             "childrenOrder": [
+              "attr:title",
               "attr:eventCategory",
               "attr:eventName",
               "prose:1",
@@ -295,5 +300,5 @@
       "further-reading"
     ]
   },
-  "sourceCommitSha": "5b981c8a5bf1439902c9c764add8642d7f283824"
+  "sourceCommitSha": "9fbda251935a99d698459c3ce514c22fdce5a065"
 }

--- a/.manifests/public/content/translations/ta/roadmap/single-slot-finality/index.md/source.json
+++ b/.manifests/public/content/translations/ta/roadmap/single-slot-finality/index.md/source.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
   "sourceFile": "public/content/roadmap/single-slot-finality/index.md",
-  "generatedAt": "2026-07-23T00:25:08.036Z",
-  "rootHash": "4bf44a7aa474",
+  "generatedAt": "2026-07-23T22:50:19.132Z",
+  "rootHash": "9bb8f5a5f505",
   "tree": {
-    "contentHash": "a283f02e2096",
-    "anchorHash": "d18cf4b46d2b",
+    "contentHash": "cd76e7c935a4",
+    "anchorHash": "725a23f7e9d8",
     "children": {
       "frontmatter:title": {
         "contentHash": "26be487ae07f",
@@ -93,8 +93,8 @@
         ]
       },
       "routes-to-ssf": {
-        "contentHash": "8f3484838172",
-        "anchorHash": "255c536ef8f9",
+        "contentHash": "6bcdb3dac733",
+        "anchorHash": "6331b9bca123",
         "labelHash": "d140fa94a9c9",
         "children": {
           "_label": {
@@ -102,9 +102,13 @@
             "anchorHash": "e3b0c44298fc"
           },
           "component:1": {
-            "contentHash": "6f7d93f7eedd",
-            "anchorHash": "6103ea1c6d76",
+            "contentHash": "b0e197cae82e",
+            "anchorHash": "cfc88a81eabd",
             "children": {
+              "attr:title": {
+                "contentHash": "bef51d6c28a1",
+                "anchorHash": "e3b0c44298fc"
+              },
               "attr:eventCategory": {
                 "contentHash": "e3b0c44298fc",
                 "anchorHash": "f1e82b456042"
@@ -127,6 +131,7 @@
               }
             },
             "childrenOrder": [
+              "attr:title",
               "attr:eventCategory",
               "attr:eventName",
               "prose:1",
@@ -295,5 +300,5 @@
       "further-reading"
     ]
   },
-  "sourceCommitSha": "5b981c8a5bf1439902c9c764add8642d7f283824"
+  "sourceCommitSha": "9fbda251935a99d698459c3ce514c22fdce5a065"
 }

--- a/.manifests/public/content/translations/te/roadmap/single-slot-finality/index.md/source.json
+++ b/.manifests/public/content/translations/te/roadmap/single-slot-finality/index.md/source.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
   "sourceFile": "public/content/roadmap/single-slot-finality/index.md",
-  "generatedAt": "2026-07-23T00:25:08.192Z",
-  "rootHash": "4bf44a7aa474",
+  "generatedAt": "2026-07-23T22:50:19.144Z",
+  "rootHash": "9bb8f5a5f505",
   "tree": {
-    "contentHash": "a283f02e2096",
-    "anchorHash": "d18cf4b46d2b",
+    "contentHash": "cd76e7c935a4",
+    "anchorHash": "725a23f7e9d8",
     "children": {
       "frontmatter:title": {
         "contentHash": "26be487ae07f",
@@ -93,8 +93,8 @@
         ]
       },
       "routes-to-ssf": {
-        "contentHash": "8f3484838172",
-        "anchorHash": "255c536ef8f9",
+        "contentHash": "6bcdb3dac733",
+        "anchorHash": "6331b9bca123",
         "labelHash": "d140fa94a9c9",
         "children": {
           "_label": {
@@ -102,9 +102,13 @@
             "anchorHash": "e3b0c44298fc"
           },
           "component:1": {
-            "contentHash": "6f7d93f7eedd",
-            "anchorHash": "6103ea1c6d76",
+            "contentHash": "b0e197cae82e",
+            "anchorHash": "cfc88a81eabd",
             "children": {
+              "attr:title": {
+                "contentHash": "bef51d6c28a1",
+                "anchorHash": "e3b0c44298fc"
+              },
               "attr:eventCategory": {
                 "contentHash": "e3b0c44298fc",
                 "anchorHash": "f1e82b456042"
@@ -127,6 +131,7 @@
               }
             },
             "childrenOrder": [
+              "attr:title",
               "attr:eventCategory",
               "attr:eventName",
               "prose:1",
@@ -295,5 +300,5 @@
       "further-reading"
     ]
   },
-  "sourceCommitSha": "5b981c8a5bf1439902c9c764add8642d7f283824"
+  "sourceCommitSha": "9fbda251935a99d698459c3ce514c22fdce5a065"
 }

--- a/.manifests/public/content/translations/tr/roadmap/single-slot-finality/index.md/source.json
+++ b/.manifests/public/content/translations/tr/roadmap/single-slot-finality/index.md/source.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
   "sourceFile": "public/content/roadmap/single-slot-finality/index.md",
-  "generatedAt": "2026-07-23T00:25:08.447Z",
-  "rootHash": "4bf44a7aa474",
+  "generatedAt": "2026-07-23T22:50:19.150Z",
+  "rootHash": "9bb8f5a5f505",
   "tree": {
-    "contentHash": "a283f02e2096",
-    "anchorHash": "d18cf4b46d2b",
+    "contentHash": "cd76e7c935a4",
+    "anchorHash": "725a23f7e9d8",
     "children": {
       "frontmatter:title": {
         "contentHash": "26be487ae07f",
@@ -93,8 +93,8 @@
         ]
       },
       "routes-to-ssf": {
-        "contentHash": "8f3484838172",
-        "anchorHash": "255c536ef8f9",
+        "contentHash": "6bcdb3dac733",
+        "anchorHash": "6331b9bca123",
         "labelHash": "d140fa94a9c9",
         "children": {
           "_label": {
@@ -102,9 +102,13 @@
             "anchorHash": "e3b0c44298fc"
           },
           "component:1": {
-            "contentHash": "6f7d93f7eedd",
-            "anchorHash": "6103ea1c6d76",
+            "contentHash": "b0e197cae82e",
+            "anchorHash": "cfc88a81eabd",
             "children": {
+              "attr:title": {
+                "contentHash": "bef51d6c28a1",
+                "anchorHash": "e3b0c44298fc"
+              },
               "attr:eventCategory": {
                 "contentHash": "e3b0c44298fc",
                 "anchorHash": "f1e82b456042"
@@ -127,6 +131,7 @@
               }
             },
             "childrenOrder": [
+              "attr:title",
               "attr:eventCategory",
               "attr:eventName",
               "prose:1",
@@ -295,5 +300,5 @@
       "further-reading"
     ]
   },
-  "sourceCommitSha": "5b981c8a5bf1439902c9c764add8642d7f283824"
+  "sourceCommitSha": "9fbda251935a99d698459c3ce514c22fdce5a065"
 }

--- a/.manifests/public/content/translations/uk/roadmap/single-slot-finality/index.md/source.json
+++ b/.manifests/public/content/translations/uk/roadmap/single-slot-finality/index.md/source.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
   "sourceFile": "public/content/roadmap/single-slot-finality/index.md",
-  "generatedAt": "2026-07-23T00:25:08.718Z",
-  "rootHash": "4bf44a7aa474",
+  "generatedAt": "2026-07-23T22:50:19.153Z",
+  "rootHash": "9bb8f5a5f505",
   "tree": {
-    "contentHash": "a283f02e2096",
-    "anchorHash": "d18cf4b46d2b",
+    "contentHash": "cd76e7c935a4",
+    "anchorHash": "725a23f7e9d8",
     "children": {
       "frontmatter:title": {
         "contentHash": "26be487ae07f",
@@ -93,8 +93,8 @@
         ]
       },
       "routes-to-ssf": {
-        "contentHash": "8f3484838172",
-        "anchorHash": "255c536ef8f9",
+        "contentHash": "6bcdb3dac733",
+        "anchorHash": "6331b9bca123",
         "labelHash": "d140fa94a9c9",
         "children": {
           "_label": {
@@ -102,9 +102,13 @@
             "anchorHash": "e3b0c44298fc"
           },
           "component:1": {
-            "contentHash": "6f7d93f7eedd",
-            "anchorHash": "6103ea1c6d76",
+            "contentHash": "b0e197cae82e",
+            "anchorHash": "cfc88a81eabd",
             "children": {
+              "attr:title": {
+                "contentHash": "bef51d6c28a1",
+                "anchorHash": "e3b0c44298fc"
+              },
               "attr:eventCategory": {
                 "contentHash": "e3b0c44298fc",
                 "anchorHash": "f1e82b456042"
@@ -127,6 +131,7 @@
               }
             },
             "childrenOrder": [
+              "attr:title",
               "attr:eventCategory",
               "attr:eventName",
               "prose:1",
@@ -295,5 +300,5 @@
       "further-reading"
     ]
   },
-  "sourceCommitSha": "5b981c8a5bf1439902c9c764add8642d7f283824"
+  "sourceCommitSha": "9fbda251935a99d698459c3ce514c22fdce5a065"
 }

--- a/.manifests/public/content/translations/ur/roadmap/single-slot-finality/index.md/source.json
+++ b/.manifests/public/content/translations/ur/roadmap/single-slot-finality/index.md/source.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
   "sourceFile": "public/content/roadmap/single-slot-finality/index.md",
-  "generatedAt": "2026-07-23T00:25:08.769Z",
-  "rootHash": "4bf44a7aa474",
+  "generatedAt": "2026-07-23T22:50:19.155Z",
+  "rootHash": "9bb8f5a5f505",
   "tree": {
-    "contentHash": "a283f02e2096",
-    "anchorHash": "d18cf4b46d2b",
+    "contentHash": "cd76e7c935a4",
+    "anchorHash": "725a23f7e9d8",
     "children": {
       "frontmatter:title": {
         "contentHash": "26be487ae07f",
@@ -93,8 +93,8 @@
         ]
       },
       "routes-to-ssf": {
-        "contentHash": "8f3484838172",
-        "anchorHash": "255c536ef8f9",
+        "contentHash": "6bcdb3dac733",
+        "anchorHash": "6331b9bca123",
         "labelHash": "d140fa94a9c9",
         "children": {
           "_label": {
@@ -102,9 +102,13 @@
             "anchorHash": "e3b0c44298fc"
           },
           "component:1": {
-            "contentHash": "6f7d93f7eedd",
-            "anchorHash": "6103ea1c6d76",
+            "contentHash": "b0e197cae82e",
+            "anchorHash": "cfc88a81eabd",
             "children": {
+              "attr:title": {
+                "contentHash": "bef51d6c28a1",
+                "anchorHash": "e3b0c44298fc"
+              },
               "attr:eventCategory": {
                 "contentHash": "e3b0c44298fc",
                 "anchorHash": "f1e82b456042"
@@ -127,6 +131,7 @@
               }
             },
             "childrenOrder": [
+              "attr:title",
               "attr:eventCategory",
               "attr:eventName",
               "prose:1",
@@ -295,5 +300,5 @@
       "further-reading"
     ]
   },
-  "sourceCommitSha": "5b981c8a5bf1439902c9c764add8642d7f283824"
+  "sourceCommitSha": "9fbda251935a99d698459c3ce514c22fdce5a065"
 }

--- a/.manifests/public/content/translations/vi/roadmap/single-slot-finality/index.md/source.json
+++ b/.manifests/public/content/translations/vi/roadmap/single-slot-finality/index.md/source.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
   "sourceFile": "public/content/roadmap/single-slot-finality/index.md",
-  "generatedAt": "2026-07-23T00:25:08.880Z",
-  "rootHash": "4bf44a7aa474",
+  "generatedAt": "2026-07-23T22:50:19.166Z",
+  "rootHash": "9bb8f5a5f505",
   "tree": {
-    "contentHash": "a283f02e2096",
-    "anchorHash": "d18cf4b46d2b",
+    "contentHash": "cd76e7c935a4",
+    "anchorHash": "725a23f7e9d8",
     "children": {
       "frontmatter:title": {
         "contentHash": "26be487ae07f",
@@ -93,8 +93,8 @@
         ]
       },
       "routes-to-ssf": {
-        "contentHash": "8f3484838172",
-        "anchorHash": "255c536ef8f9",
+        "contentHash": "6bcdb3dac733",
+        "anchorHash": "6331b9bca123",
         "labelHash": "d140fa94a9c9",
         "children": {
           "_label": {
@@ -102,9 +102,13 @@
             "anchorHash": "e3b0c44298fc"
           },
           "component:1": {
-            "contentHash": "6f7d93f7eedd",
-            "anchorHash": "6103ea1c6d76",
+            "contentHash": "b0e197cae82e",
+            "anchorHash": "cfc88a81eabd",
             "children": {
+              "attr:title": {
+                "contentHash": "bef51d6c28a1",
+                "anchorHash": "e3b0c44298fc"
+              },
               "attr:eventCategory": {
                 "contentHash": "e3b0c44298fc",
                 "anchorHash": "f1e82b456042"
@@ -127,6 +131,7 @@
               }
             },
             "childrenOrder": [
+              "attr:title",
               "attr:eventCategory",
               "attr:eventName",
               "prose:1",
@@ -295,5 +300,5 @@
       "further-reading"
     ]
   },
-  "sourceCommitSha": "5b981c8a5bf1439902c9c764add8642d7f283824"
+  "sourceCommitSha": "9fbda251935a99d698459c3ce514c22fdce5a065"
 }

--- a/.manifests/public/content/translations/zh-tw/roadmap/single-slot-finality/index.md/source.json
+++ b/.manifests/public/content/translations/zh-tw/roadmap/single-slot-finality/index.md/source.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
   "sourceFile": "public/content/roadmap/single-slot-finality/index.md",
-  "generatedAt": "2026-07-23T00:25:09.043Z",
-  "rootHash": "4bf44a7aa474",
+  "generatedAt": "2026-07-23T22:50:19.166Z",
+  "rootHash": "9bb8f5a5f505",
   "tree": {
-    "contentHash": "a283f02e2096",
-    "anchorHash": "d18cf4b46d2b",
+    "contentHash": "cd76e7c935a4",
+    "anchorHash": "725a23f7e9d8",
     "children": {
       "frontmatter:title": {
         "contentHash": "26be487ae07f",
@@ -93,8 +93,8 @@
         ]
       },
       "routes-to-ssf": {
-        "contentHash": "8f3484838172",
-        "anchorHash": "255c536ef8f9",
+        "contentHash": "6bcdb3dac733",
+        "anchorHash": "6331b9bca123",
         "labelHash": "d140fa94a9c9",
         "children": {
           "_label": {
@@ -102,9 +102,13 @@
             "anchorHash": "e3b0c44298fc"
           },
           "component:1": {
-            "contentHash": "6f7d93f7eedd",
-            "anchorHash": "6103ea1c6d76",
+            "contentHash": "b0e197cae82e",
+            "anchorHash": "cfc88a81eabd",
             "children": {
+              "attr:title": {
+                "contentHash": "bef51d6c28a1",
+                "anchorHash": "e3b0c44298fc"
+              },
               "attr:eventCategory": {
                 "contentHash": "e3b0c44298fc",
                 "anchorHash": "f1e82b456042"
@@ -127,6 +131,7 @@
               }
             },
             "childrenOrder": [
+              "attr:title",
               "attr:eventCategory",
               "attr:eventName",
               "prose:1",
@@ -295,5 +300,5 @@
       "further-reading"
     ]
   },
-  "sourceCommitSha": "5b981c8a5bf1439902c9c764add8642d7f283824"
+  "sourceCommitSha": "9fbda251935a99d698459c3ce514c22fdce5a065"
 }

--- a/.manifests/public/content/translations/zh/roadmap/single-slot-finality/index.md/source.json
+++ b/.manifests/public/content/translations/zh/roadmap/single-slot-finality/index.md/source.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
   "sourceFile": "public/content/roadmap/single-slot-finality/index.md",
-  "generatedAt": "2026-07-23T00:25:09.293Z",
-  "rootHash": "4bf44a7aa474",
+  "generatedAt": "2026-07-23T22:50:19.171Z",
+  "rootHash": "9bb8f5a5f505",
   "tree": {
-    "contentHash": "a283f02e2096",
-    "anchorHash": "d18cf4b46d2b",
+    "contentHash": "cd76e7c935a4",
+    "anchorHash": "725a23f7e9d8",
     "children": {
       "frontmatter:title": {
         "contentHash": "26be487ae07f",
@@ -93,8 +93,8 @@
         ]
       },
       "routes-to-ssf": {
-        "contentHash": "8f3484838172",
-        "anchorHash": "255c536ef8f9",
+        "contentHash": "6bcdb3dac733",
+        "anchorHash": "6331b9bca123",
         "labelHash": "d140fa94a9c9",
         "children": {
           "_label": {
@@ -102,9 +102,13 @@
             "anchorHash": "e3b0c44298fc"
           },
           "component:1": {
-            "contentHash": "6f7d93f7eedd",
-            "anchorHash": "6103ea1c6d76",
+            "contentHash": "b0e197cae82e",
+            "anchorHash": "cfc88a81eabd",
             "children": {
+              "attr:title": {
+                "contentHash": "bef51d6c28a1",
+                "anchorHash": "e3b0c44298fc"
+              },
               "attr:eventCategory": {
                 "contentHash": "e3b0c44298fc",
                 "anchorHash": "f1e82b456042"
@@ -127,6 +131,7 @@
               }
             },
             "childrenOrder": [
+              "attr:title",
               "attr:eventCategory",
               "attr:eventName",
               "prose:1",
@@ -295,5 +300,5 @@
       "further-reading"
     ]
   },
-  "sourceCommitSha": "5b981c8a5bf1439902c9c764add8642d7f283824"
+  "sourceCommitSha": "9fbda251935a99d698459c3ce514c22fdce5a065"
 }


### PR DESCRIPTION
## Summary

Manifest-only follow-up to #18890. Carries the 24 `single-slot-finality` `source.json` stamps produced by the scoped `stamp_only` pipeline run, which never got folded in before #18890 merged. Without these, the next pipeline run touching SSF sees the English `title="..."` fix (`0151a47e36`) as an unstamped change and MT-overwrites the hand-added, glossary-checked ExpandableCard titles across all 24 locales. Diff is exactly these 24 manifest files; English SSF source is unchanged on `dev`, so the stamps are valid as-is.