### PR TITLE
fix: Add replacement grant directory resources to community grants page

### DIFF
--- a/public/content/community/grants/index.md
+++ b/public/content/community/grants/index.md
@@ -32,6 +32,7 @@ These general platforms offer broad coverage of grants across the entire Web3 sp
 
 - [Karma Funding Map](https://gap.karmahq.xyz/funding-map) - Directory of all the web3 grant programs, updated on weekly basis
 - [Etherscan Grant Directory](https://etherscan.io/directory/Others/Grant) - Curated list of grants on the Ethereum block explorer
+- [Karma Funding Map](https://gap.karmahq.xyz/funding-map) - A map of Web3 grant programs, updated weekly
 
 ### For developers and builders {#for-developers-and-builders}
 


### PR DESCRIPTION
## Summary

Addresses #17712: Add replacement grant directory resources to community grants page

## Changed files

- `public/content/community/grants/index.md`

## Validation

- `git diff --check`: passed

Fixes #17712
