### PR TITLE
fix(apps): rehost app screenshots to S3

### DIFF
--- a/src/data-layer/fetchers/fetchApps.ts
+++ b/src/data-layer/fetchers/fetchApps.ts
@@ -1,6 +1,6 @@
 import { AppCategoryEnum, AppData } from "@/lib/types"
 
-import { uploadToS3 } from "@/data-layer/s3"
+import { uploadManyToS3, uploadToS3 } from "@/data-layer/s3"
 
 import { fetchRetry } from "./fetchRetry"
 
@@ -158,8 +158,13 @@ async function uploadAppImages(apps: AppData[]): Promise<AppData[]> {
       const bannerImage = app.bannerImage
         ? ((await uploadToS3(app.bannerImage, "apps/banners")) ?? "")
         : app.bannerImage
+      // Drop failed uploads: an external URL would 400 in next/image, since only
+      // the S3 host is in remotePatterns.
+      const screenshots = (
+        await uploadManyToS3(app.screenshots, "apps/screenshots")
+      ).filter((url): url is string => Boolean(url))
 
-      return { ...app, image, bannerImage }
+      return { ...app, image, bannerImage, screenshots }
     })
   )
 }

--- a/src/data-layer/s3.ts
+++ b/src/data-layer/s3.ts
@@ -127,6 +127,21 @@ function buildS3Url(bucket: string, key: string): string {
 }
 
 /**
+ * True when the URL already points at our own S3 host. Sources are often
+ * hand-uploaded to the bucket and pasted back into a sheet, so re-uploading
+ * would re-key the object under a content hash and orphan the original.
+ */
+function isAlreadyOnS3(url: string): boolean {
+  const endpoint = process.env.S3_ENDPOINT
+  if (!endpoint) return false
+  try {
+    return new URL(url).hostname === new URL(endpoint).hostname
+  } catch {
+    return false
+  }
+}
+
+/**
  * Upload an image from an external URL to S3.
  *
  * @param sourceUrl - The external image URL to fetch and upload
@@ -144,6 +159,9 @@ export async function uploadToS3(
     console.warn(`[S3] Invalid or empty URL: ${sourceUrl || "(empty)"}`)
     return null
   }
+
+  // Already hosted by us: pass through untouched
+  if (isAlreadyOnS3(sourceUrl)) return sourceUrl
 
   const bucket = getBucket()
   const s3 = getS3Client()
@@ -235,15 +253,25 @@ export async function uploadToS3(
 }
 
 /**
- * Batch upload multiple images in parallel.
+ * Batch upload multiple images, in chunks to bound peak memory: every upload
+ * buffers the whole image before the size check, so unbounded fan-out can OOM
+ * the task machine.
  *
  * @param urls - Array of external image URLs
  * @param prefix - S3 key prefix
- * @returns Array of S3 URLs (null for failed uploads)
+ * @returns Array of S3 URLs (null for failed uploads), in input order
  */
 export async function uploadManyToS3(
   urls: string[],
-  prefix: string
+  prefix: string,
+  concurrency = 5
 ): Promise<(string | null)[]> {
-  return Promise.all(urls.map((url) => uploadToS3(url, prefix)))
+  const results: (string | null)[] = []
+  for (let i = 0; i < urls.length; i += concurrency) {
+    const chunk = urls.slice(i, i + concurrency)
+    results.push(
+      ...(await Promise.all(chunk.map((u) => uploadToS3(u, prefix))))
+    )
+  }
+  return results
 }


### PR DESCRIPTION
## Summary

App screenshots were never rehosted to S3. `uploadAppImages` only covered the logo and banner, so screenshot URLs passed through from the sheet verbatim and any host outside `next.config.js` `remotePatterns` 400s in `next/image` -- which is what broke the [Session](https://ethereum.org/apps/session/) screenshot. It went unnoticed because every other app's screenshots were hand-uploaded to the bucket, with the S3 URL pasted back into the sheet.

Screenshots now go through `uploadManyToS3` under an `apps/screenshots` prefix. Two supporting changes in `s3.ts`: `uploadToS3` passes through URLs already on the `S3_ENDPOINT` host, so the existing hand-uploaded cells aren't refetched from our own bucket and re-keyed under a content hash; and `uploadManyToS3` chunks instead of fanning out unbounded, since every upload buffers the full image before the 5MB size check.

`fetch-apps` is a daily task, so this takes effect on the next run after deploy.

## Related issue
Fixes:
<img width="1576" height="981" alt="image" src="https://github.com/user-attachments/assets/45591bf8-4a49-4ad5-8b20-d898c1b7ae3b" />
(https://ethereum.org/apps/session/)