### PR TITLE
ci(intl): run pipeline daily via cron

### DIFF
--- a/.github/workflows/intl-pipeline.yml
+++ b/.github/workflows/intl-pipeline.yml
@@ -1,6 +1,9 @@
 name: Intl Pipeline
 
 on:
+  schedule:
+    # Daily 04:20 UTC; empty inputs fall through to pipeline defaults (dev, auto, all locales)
+    - cron: "20 4 * * *"
   workflow_dispatch:
     inputs:
       target_path:


### PR DESCRIPTION
## Summary
Adds a `schedule` trigger to `intl-pipeline.yml` so the translation pipeline runs daily at 04:20 UTC. Scheduled runs arrive with empty inputs, which fall through to the existing pipeline defaults in `config.ts` (`dev` base, `auto` mode, all locales) — identical to a manual dispatch with defaults. Runs accumulate into `intl/pending-dev` for review without re-translating pending work, and the existing `i18n-translation` concurrency group serializes any overlap. Manual `workflow_dispatch` is unchanged.