### PR TITLE
chore(chromatic): one width per device class in langViewportModes

### DIFF
--- a/.storybook/modes.ts
+++ b/.storybook/modes.ts
@@ -31,10 +31,12 @@ type LangViewModeObj = {
   [key: string]: { viewport: string; locale: string }
 }
 
-// RTL locales only get a representative subset of widths. Direction bugs
-// surface at mobile + desktop, so snapshotting Arabic at all 6 breakpoints
-// doubled the per-story count for little added signal.
-const rtlViewports = new Set(["base", "lg"])
+// One width per device class, not per breakpoint token: the six tokens include
+// near-neighbours that never disagreed. RTL adds only the narrowest, since what
+// it proves is that direction flips. Every story spreading these pays the full
+// matrix, so widths here are the largest single lever on snapshot usage.
+const ltrViewports = new Set(["base", "md", "xl"])
+const rtlViewports = new Set(["base"])
 
 export const langViewportModes = Object.entries(
   viewportModes
@@ -44,7 +46,8 @@ export const langViewportModes = Object.entries(
   const currLangViewObj = {} as LangViewModeObj
 
   Object.entries(langModes).forEach(([langKey, langVal]) => {
-    if (langKey !== "en" && !rtlViewports.has(viewKey)) return
+    const widths = langKey === "en" ? ltrViewports : rtlViewports
+    if (!widths.has(viewKey)) return
     currLangViewObj[`${langKey}-${viewKey}`] = {
       viewport: viewVal.viewport,
       locale: langVal.locale,


### PR DESCRIPTION
Cuts a full Chromatic build from **252 → 204 snapshots (-19%)**.

## Why here

96 of the 252 snapshots in a full build come from just **12 story instances** across 6 files — the ones spreading `langViewportModes` (PageHero ×5, DeveloperDocsLinks ×3, HomeHero, HubHero, MergeInfographic, ContentLayout). Everything else accounts for 156. So the width matrix is the largest single lever on the cost of any build that misses TurboSnap.

## Change

`langViewportModes` goes from 8 modes to 4 — `en` at `base`/`md`/`xl`, `ar` at `base`:

```
before: en-base en-sm en-md en-lg en-xl en-2xl  ar-base ar-lg   (8)
after:  en-base en-md en-xl  ar-base                            (4)
```

One width per device class rather than one per breakpoint token: `sm` sits beside `base`, `lg` beside `md`, `2xl` beside `xl`, and those neighbours haven't disagreed. RTL only has to prove direction flips.

## Trade-off

Real coverage loss: a responsive regression isolated to a dropped width on a hero, `ContentLayout`, `DeveloperDocsLinks` or `MergeInfographic` would no longer be caught. Those are the most breakpoint-sensitive components in the suite, which is why they carried the full matrix.

Worth it because it's the only lever that doesn't depend on anyone's behaviour: it lowers the cost of *every* bailing build. It relaxes the TurboSnap bail rate we need in order to fit the monthly cap from **≤34% to ≤50%** — measured at **73%** in the current period.

## Note

This edits `.storybook/modes.ts`, so open branches pay one full rebuild the next time they build, then return to normal. Unavoidable for any Storybook config change; branches already stale on the #18898 wall pay it either way.

Arithmetic verified against a real build: #18898 dropped 4 modes from these same 12 instances and the build went 300 → 252, exactly the 48 predicted. `pnpm type-check` passes.