### PR TITLE
ci(chromatic): add an emergency stop for snapshot spend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,10 @@ jobs:
           # Not named chromatic.config.json: that filename is auto-loaded by
           # both projects, and untraced without onlyChanged fails the pages job.
           configFile: chromatic.storybook.json
+          # Emergency stop: set repo variable CHROMATIC_SKIP to "**". Snapshots
+          # stop but the UI Tests check still passes, so PRs stay mergeable.
+          # The value is a branch glob, hence a default no branch can match.
+          skip: ${{ vars.CHROMATIC_SKIP || '__chromatic_skip_disabled__' }}
           exitZeroOnChanges: true
           onlyChanged: true
           # Release-train builds (dev/staging/master head branches) were


### PR DESCRIPTION
Gives us a way to halt snapshot spend from the GitHub UI, with no code change or deploy.

## Why not the dashboard

There's no documented way to pause or disable a project from Chromatic's web UI. The only pause is involuntary: when the monthly quota runs out, the CLI exits `11 / ACCOUNT_QUOTA_REACHED` and testing stops — which is what happened on Jul 24.

## The switch

```yaml
skip: ${{ vars.CHROMATIC_SKIP || '__chromatic_skip_disabled__' }}
```

To halt: **Settings → Variables → set `CHROMATIC_SKIP` to `**`**. Clear it to resume.

Two deliberate choices:

**`skip`, not an `if:` on the job.** The merge gate is the Chromatic app's "UI Tests" check. Skipping the job outright leaves that check unreported and blocks every PR — the exact problem the deleted `chromatic-required-status.yml` reporter existed to work around. `skip` marks the commit as passing while consuming no snapshots.

**A sentinel default rather than an empty string.** The value is a branch glob handed to picomatch, and picomatch *throws* on `""`. Verified against the bundled picomatch:

| Pattern | Result |
| --- | --- |
| `__chromatic_skip_disabled__` (default) | every branch runs |
| `**` (emergency) | every branch skipped, nested included |
| `""` | throws `Expected pattern to be a non-empty string` |

## Not included: skipping dependabot

I'd floated `skip: "dependabot/**"` as a standing saving, and I'm holding it back on reflection. Dependabot bumps `next`, `tailwindcss`, `@radix-ui/*`, `shiki` — all of which can change rendering — and with `autoAcceptChanges: "{dev,staging,master}"` a regression that first appears on dev is auto-accepted with no review. That's the same blind spot we rejected when deciding not to restore the path gate. It was only ~1,389 billed (4%) last period, so the risk/reward looks poor. Happy to add it if you'd rather take the trade.