### PR TITLE
ci(chromatic): move the Storybook token to a secret, isolate forks

### DIFF
--- a/.github/workflows/chromatic-fork-status.yml
+++ b/.github/workflows/chromatic-fork-status.yml
@@ -1,0 +1,41 @@
+name: Chromatic fork status
+
+# Fork PRs cannot read the Chromatic token, so ci.yml skips them and the app
+# never posts the required check. This reports it so they stay mergeable.
+#
+# pull_request_target is needed for a token that can post statuses. This reads
+# only the event payload and never checks out fork code.
+
+on:
+  pull_request_target:
+    branches: [dev, master, staging, "test/**"]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  statuses: write
+
+concurrency:
+  group: chromatic-fork-status-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  report:
+    name: Report Chromatic status for fork PRs
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark the required Chromatic check as passing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+          # Must match the required check in branch protection character for
+          # character, or the PR stays blocked.
+          CONTEXT: "UI Tests: ethereum-org-website"
+        run: |
+          set -euo pipefail
+          gh api "repos/${REPO}/statuses/${SHA}" \
+            -f state=success \
+            -f context="$CONTEXT" \
+            -f description='Fork PR — visual review happens after merge'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,11 +74,16 @@ jobs:
 
   visual-tests:
     name: Visual regression (Chromatic)
-    # Runs on every non-draft PR. TurboSnap (`onlyChanged`) means PRs with no
-    # affected stories snapshot nothing, so this is cheap for content-only PRs.
-    # This job only publishes to Chromatic; the required merge gate is the
-    # Chromatic App's "UI Tests" check, so the job itself always exits 0.
-    if: github.event.pull_request.draft == false
+    # Non-draft PRs whose head is in this repo. TurboSnap (`onlyChanged`) keeps
+    # PRs with no affected stories cheap. This job only publishes; the merge gate
+    # is the Chromatic App's "UI Tests" check, so it always exits 0.
+    #
+    # Forks are excluded: they cannot read the token, and pinning to this repo
+    # also keeps a fork's own Actions off our quota. Their required check comes
+    # from chromatic-fork-status.yml.
+    if: >-
+      github.event.pull_request.draft == false
+      && github.event.pull_request.head.repo.full_name == 'ethereum/ethereum-org-website'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -90,7 +95,7 @@ jobs:
       - name: Publish to Chromatic
         uses: chromaui/action@v16
         with:
-          projectToken: fee8e66c9916
+          projectToken: ${{ secrets.CHROMATIC_STORYBOOK_TOKEN }}
           # Not named chromatic.config.json: that filename is auto-loaded by
           # both projects, and untraced without onlyChanged fails the pages job.
           configFile: chromatic.storybook.json


### PR DESCRIPTION
> Stacked on #18930 (same `with:` block). Retarget to `dev` once that merges.

The Storybook project token was hardcoded in `ci.yml`, so **any fork running our CI published builds against our quota** — about 10% of last period's snapshots. We can't switch that off from here: the dashboard has no pause, and `CHROMATIC_SKIP` is read from whichever repo runs the workflow.

## Change

| Scenario | visual-tests | reporter |
| --- | --- | --- |
| Internal PR | runs | – |
| Fork PR into this repo | skips | posts check |
| Fork running our CI | skips | – |

- Token comes from `secrets.CHROMATIC_STORYBOOK_TOKEN`; forks cannot read it.
- `visual-tests` is pinned to this repo, so forks skip the job instead of failing on an empty token.
- `chromatic-fork-status.yml` posts the required check for fork PRs, which would otherwise never see it and could never merge.

The reporter uses `pull_request_target` for a token that can post statuses. It reads only the event payload and never checks out fork code.

## Before merging

1. **Regenerate the token in Chromatic.** The current value is public, so moving it to a secret achieves nothing on its own.
2. **Add the new value as `CHROMATIC_STORYBOOK_TOKEN`** — without it, internal PRs run with an empty token and fail.
3. **Confirm `CONTEXT` matches the required check** in branch protection exactly. It's set to `UI Tests: ethereum-org-website`; if it differs, fork PRs stay blocked.

## Two caveats

- I haven't verified that a commit **status** satisfies a required check the Chromatic app posts as a **check run**. Worth testing on one fork PR first.
- Fork PRs go green without visual review, and with `autoAcceptChanges` on dev a regression then lands auto-accepted. To get coverage, push the branch to an internal branch.