### PR TITLE
[recovery] fix(bug-bounty): set request locale before next-intl APIs (static→dynamic bailout on /.well-known/bug-bounty)

### DIFF
--- a/app/[locale]/bug-bounty/page.tsx
+++ b/app/[locale]/bug-bounty/page.tsx
@@ -77,6 +77,9 @@ export default async function Page(props: { params: Promise<Params> }) {
   const params = await props.params
   const { locale } = params
 
+  // Set locale before next-intl APIs so on-demand renders stay static
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-bug-bounty")
   const tCommon = await getTranslations("common")
 


### PR DESCRIPTION
> Opened by the automated recovery agent from a production Netlify error captured via Grafana → Keep.

## Production error

- **Message:**

  ```
  [ERROR] ⨯ Error: Page changed from static to dynamic at runtime /.well-known/bug-bounty, reason: headers
  see more here https://nextjs.org/docs/messages/app-static-to-dynamic-error
      at y (.next/server/chunks/ssr/0cdz_next_dist_0dhscug._.js:2:12452)
  ```

- **Function:** `___netlify-server-handler` (SSR)
- **URL / resource:** `/.well-known/bug-bounty`
- **Occurrences:** 1 in this alert window, `hit_count: 4` cumulative; last seen `2026-07-28T15:43:02.421Z`
- **Request ID:** `01KYMP9BWX1A3DNT23QXVDV1C4`

## Root cause

`/.well-known/bug-bounty` is matched by `app/[locale]/bug-bounty/page.tsx` with `params.locale === ".well-known"`. The proxy matcher excludes `.well-known` (`proxy.ts:128`), so next-intl's routing never normalizes the path, and the invalid locale segment reaches the route directly — the same `[locale]`-acts-as-a-catch-all class of bug as #18013 / #18792.

`app/[locale]/bug-bounty/page.tsx` was the only page that called next-intl's *implicit* server APIs without first pinning the request locale:

```ts
const { locale } = params

const t = await getTranslations("page-bug-bounty")   // implicit — no locale
const tCommon = await getTranslations("common")
```

With no `setRequestLocale(locale)`, next-intl falls back to `getRequestLocale()`, which reads the `X-NEXT-INTL-LOCALE` request header via `next/headers` (`next-intl/dist/.../server/react-server/RequestLocale.js`). Calling `headers()` inside a prerendered route is exactly what trips Next.js' static→dynamic bailout, producing `reason: headers`. next-intl is the only dependency in the render path that imports `next/headers`, and there are no direct `next/headers` calls anywhere in the repo — so this is the only possible source of that reason string.

Normally `app/[locale]/layout.tsx:42` populates the request-locale cache before the page renders, which is why valid locales don't log this. For `.well-known` the layout hits `notFound()` on line 39 *before* `setRequestLocale`, leaving the cache empty; page-level code runs concurrently with the layout guard (documented in #18792 and relied on by #18733), so the page's `getTranslations` calls hit `headers()` and the prerendered route bails to dynamic.

The page's own `generateMetadata` already does this correctly (`setRequestLocale(locale)` at line 838) — only the page component was missing it. 49 of the 58 pages under `app/[locale]/**` already call `setRequestLocale(locale)` in the page body, and `app/[locale]/[...slug]/page.tsx:40` carries the comment this fix reuses verbatim.

## Fix

One line in `app/[locale]/bug-bounty/page.tsx`, matching the existing repo pattern:

```ts
const { locale } = params

// Set locale before next-intl APIs so on-demand renders stay static
setRequestLocale(locale)

const t = await getTranslations("page-bug-bounty")
```

`setRequestLocale` performs no validation, so `.well-known` is simply cached as the request locale; `src/i18n/request.ts` already falls back to `routing.defaultLocale` for any value not in `routing.locales`. Behaviour for real locales is unchanged, and the 404 render no longer touches request headers.

No refactoring or drive-by cleanup — `setRequestLocale` was already imported.

## Verification

```
$ pnpm type-check
> next typegen && tsc --noEmit && tsc --noEmit -p netlify/edge-functions
Generating route types...
✓ Types generated successfully
```

```
$ pnpm exec eslint 'app/[locale]/bug-bounty/page.tsx'
(no output — clean)
```

## Follow-up (not in this PR)

Eight other pages under `app/[locale]/**` still call implicit next-intl APIs in the page body without `setRequestLocale`, so they can bail to dynamic the same way when hit with a non-locale first segment:

- `app/[locale]/learn/page.tsx`
- `app/[locale]/use-cases/page.tsx`
- `app/[locale]/what-is-ethereum/page.tsx`
- `app/[locale]/what-is-the-ethereum-network/page.tsx`
- `app/[locale]/founders/page.tsx`
- `app/[locale]/community/events/page.tsx`
- `app/[locale]/community/events/meetups/page.tsx`
- `app/[locale]/community/events/conferences/page.tsx`

Kept out of scope to keep this PR to the one alerting route. The systemic fix suggested in #18792 (reject unknown top-level segments once, before any page or metadata code runs) would cover all of them plus #18013 and #17967.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
