### PR TITLE
fix(apps): rebuild gallery thumbnails as buttons

### DIFF
--- a/app/[locale]/apps/[application]/_components/ScreenshotSwiper.tsx
+++ b/app/[locale]/apps/[application]/_components/ScreenshotSwiper.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import { useTranslations } from "next-intl"
 
 import { Image } from "@/components/Image"
 import Modal from "@/components/ui/dialog-modal"
@@ -21,6 +22,7 @@ interface ScreenshotSwiperProps {
 }
 
 const ScreenshotSwiper = ({ screenshots, appName }: ScreenshotSwiperProps) => {
+  const t = useTranslations("page-apps")
   const lazyPreloadPrevNext = useBreakpointValue({ base: 1, sm: 2, md: 4 })
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [currentImageIndex, setCurrentImageIndex] = useState<number | null>(
@@ -38,16 +40,21 @@ const ScreenshotSwiper = ({ screenshots, appName }: ScreenshotSwiperProps) => {
         slidesPerView="auto"
         spaceBetween={16}
         lazyPreloadPrevNext={lazyPreloadPrevNext}
+        // Swiper's `overflow: hidden` sits flush to the slides and would clip the
+        // hover/focus outline; pad the clip box, cancel with the margin.
+        className="-m-1 p-1"
       >
         {screenshots.map((screenshot, index) => (
-          <SwiperSlide key={index} className="!w-auto">
-            <Image
-              src={screenshot}
-              alt={`Screenshot ${index + 1} of ${appName} showing the application interface`}
-              width={300}
-              height={600}
-              sizes="(max-width: 640px) 150px, (max-width: 1024px) 200px, 250px"
-              className="h-[200px] w-auto cursor-pointer rounded-lg object-contain transition-transform hover:scale-105 md:h-[350px]"
+          // me-4 duplicates spaceBetween, which Swiper only applies as an inline
+          // margin once initialized -- without it the slides touch on first paint.
+          <SwiperSlide key={index} className="me-4 w-auto!">
+            {/* Accessible name comes from the sharp image's alt. overflow-hidden clips
+                both copies to the border radius; it does not clip the outline. */}
+            <button
+              type="button"
+              // --tile-h drives both the height and the 16:9 max width, so the tile
+              // never grows wider than widescreen and a pre-load box is already 16:9.
+              className="relative isolate overflow-hidden rounded-base border bg-background [--tile-h:--spacing(50)] hover:outline-2 hover:outline-primary-hover focus-visible:outline-2 focus-visible:outline-primary-hover md:[--tile-h:--spacing(87.5)]"
               onClick={() => {
                 handleImageClick(index)
                 trackCustomEvent({
@@ -56,7 +63,31 @@ const ScreenshotSwiper = ({ screenshots, appName }: ScreenshotSwiperProps) => {
                   eventName: `app name ${appName}`,
                 })
               }}
-            />
+            >
+              {/* Blurred low-res backdrop fills the letterbox left by object-contain.
+                  Decorative, so it stays out of the accessibility tree. */}
+              <Image
+                src={screenshot}
+                alt=""
+                aria-hidden
+                width={640}
+                height={360}
+                sizes="64px"
+                className="absolute inset-0 -z-10 size-full scale-110 object-cover blur-xl"
+              />
+              <Image
+                src={screenshot}
+                alt={t("page-apps-gallery-screenshot-alt", {
+                  index: index + 1,
+                  appName,
+                })}
+                // 16:9 so the loading box matches the tile it resolves into.
+                width={640}
+                height={360}
+                sizes="(max-width: 640px) 356px, 622px"
+                className="h-(--tile-h) w-auto max-w-[calc(var(--tile-h)*16/9)] object-contain"
+              />
+            </button>
           </SwiperSlide>
         ))}
         {screenshots.length > 1 && <SwiperNavigation />}
@@ -71,7 +102,7 @@ const ScreenshotSwiper = ({ screenshots, appName }: ScreenshotSwiperProps) => {
           }
         }}
         size="xl"
-        title={`${appName} Screenshots`}
+        title={t("page-apps-gallery-modal-title", { appName })}
         contentProps={{
           className: "max-w-[95vw] max-h-[95vh] p-2 md:p-8",
         }}
@@ -88,11 +119,14 @@ const ScreenshotSwiper = ({ screenshots, appName }: ScreenshotSwiperProps) => {
                   <div className="flex items-center justify-center">
                     <Image
                       src={screenshot}
-                      alt={`Screenshot ${index + 1} of ${appName}`}
+                      alt={t("page-apps-gallery-screenshot-alt", {
+                        index: index + 1,
+                        appName,
+                      })}
                       width={800}
                       height={1200}
                       sizes="(max-width: 768px) 90vw, (max-width: 1024px) 80vw, 70vw"
-                      className="max-h-[60vh] w-auto rounded-lg object-contain md:max-h-[70vh]"
+                      className="max-h-[60vh] w-auto rounded-base object-contain md:max-h-[70vh]"
                     />
                   </div>
                 </SwiperSlide>

--- a/src/intl/en/page-apps.json
+++ b/src/intl/en/page-apps.json
@@ -65,6 +65,8 @@
   "page-apps-info-creator": "Creator",
   "page-apps-info-last-updated": "Last updated",
   "page-apps-gallery-title": "Gallery",
+  "page-apps-gallery-screenshot-alt": "Screenshot {index} of {appName} showing the application interface",
+  "page-apps-gallery-modal-title": "{appName} Screenshots",
   "page-apps-more-apps-like-this": "More apps like this",
   "page-apps-by-company": "by {company}",
   "page-apps-today": "Today",


### PR DESCRIPTION
## Summary

The Gallery thumbnails on `/apps/<application>` had their `onClick` on a bare `<img>`, so the lightbox was unreachable by keyboard and the thumbnail carried no role. Each thumbnail is now a real `<button>` (accessible name from the image alt) with `rounded-base` corners, a 1px resting border, and a 2px `primary-hover` outline on hover and focus. The old hover scale is gone -- it was being clipped, because Swiper's `overflow: hidden` sits flush to the slides, so the Swiper root now takes a small padding cancelled by a negative margin to move the clip boundary clear.

Each thumbnail is capped at 16:9 via a max width derived from the tile height, so a wide banner can't hog the carousel, with a blurred low-res copy of the image behind the contained one to fill the letterbox.

Two loading glitches fixed along the way: the slides touched on first paint because Swiper only applies `spaceBetween` as an inline margin once initialized, and the pre-load box was far narrower than the image it resolved into because the declared dimensions were a 1:2 placeholder.

Hard-coded English alt text and the modal title are now in the `page-apps` namespace.