### PR TITLE
content: add Adevar Labs to smart contract auditing services

### DIFF
--- a/public/content/developers/docs/smart-contracts/security/index.md
+++ b/public/content/developers/docs/smart-contracts/security/index.md
@@ -517,6 +517,8 @@ If you plan on querying an onchain oracle for asset prices, consider using one t
 
 - **[Inference](https://inference.ag/)** - _Security auditing company, specialized in smart contract auditing for EVM-based blockchains. Thanks to its expert auditors they identify potential issues and suggest actionable solutions to fix them before deployment._
 
+- **[Adevar Labs](https://adevarlabs.com/)** - _Blockchain security firm securing $1 billion+ on chain across smart contract, infrastructure, and operational security audits, with engineers ranked top-3 in the industry’s biggest audit competitions._
+
 ### Bug bounty platforms {#bug-bounty-platforms}
 
 - **[Immunefi](https://immunefi.com/)** - _Bug bounty platform for smart contracts and DeFi projects, where security researchers review code, disclose vulnerabilities, get paid, and make crypto safer._


### PR DESCRIPTION
## Description

Adds **Adevar Labs** to the *Smart contract auditing services* list on the [smart contract security](https://ethereum.org/developers/docs/smart-contracts/security/#smart-contract-auditing-services) page.

Appended to the end of the existing list, following the established entry format. Single-line content change, no code touched.

```markdown
- **[Adevar Labs](https://adevarlabs.com/)** - _Blockchain security firm securing $1 billion+ on chain across smart contract, infrastructure, and operational security audits, with engineers ranked top-3 in the industry's biggest audit competitions._
```

## Disclosure

I am affiliated with Adevar Labs. Happy to adjust the wording if maintainers prefer it more in line with the neutral, service-descriptive tone of the surrounding entries.

## Related Issue

N/A