### PR TITLE
ci(release): make the automated release review diagnosable and non-fatal

### DIFF
--- a/.claude/commands/review-release.md
+++ b/.claude/commands/review-release.md
@@ -55,6 +55,26 @@ Use `playwright-cli` (the `@playwright/cli` terminal client) via Bash to check e
 
 Workflow: `playwright-cli open` → `playwright-cli goto <url>` → `playwright-cli snapshot` (returns element refs like `e15`) → `playwright-cli click e15` / `playwright-cli fill e22 "text"`. Fall back to the `/agent-browser` skill only if `playwright-cli` is unavailable in the environment.
 
+#### Context budget
+
+The CI run of this review has a hard dollar ceiling (`--max-budget-usd`), and a
+runaway loses the entire review — a $7 run that verified everything and then
+died reported nothing. Spend context deliberately:
+
+- **Never read a full snapshot.** `playwright-cli snapshot` is 350–1000 lines
+  per page, almost all of it nav and footer chrome. It writes to
+  `.playwright-cli/page-<timestamp>.yml` — `grep` that file for the specific
+  headings, buttons, or aria labels you need.
+- **Prefer `curl` + `grep`** for text, JSON-LD, status-code and redirect
+  assertions. Reach for the browser only when the check needs a real DOM or an
+  interaction.
+- **Screenshot only new or redesigned pages**, not every page. Note that
+  `playwright-cli screenshot --filename=NAME.png` saves to the current working
+  directory, not `.playwright-cli/`.
+- **Budget ~40–60 tool calls.** If the release touches more surfaces than that
+  covers, verify the highest-risk ones and list the rest as unverified in the
+  summary (see Step 5). Never let an unchecked change read as passing.
+
 #### URL and fetch conventions
 
 - Canonical English URLs have **no `/en/` prefix** — `/en/<path>` returns a 301 redirect to `/<path>`. Always use the un-prefixed form.
@@ -81,6 +101,10 @@ Present a summary table with:
 | Page name | Pass/Fail | What was checked and confirmed |
 
 Flag any issues found. If everything looks good, note that the deploy looks ready to ship.
+
+If you ran out of budget before covering every change from Step 2, add a
+**Not verified** list naming those changes. An omission that isn't stated reads
+as a pass.
 
 ### Step 6: Optionally Post as PR Comment
 

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -87,6 +87,18 @@ jobs:
             - On any error, print the error and exit non-zero so the workflow
               fails and the team is notified.
 
+      # Upload the raw path rather than the action's `execution_file` output:
+      # a failed composite step doesn't reliably export its outputs, and this
+      # log is only interesting when the step failed.
+      - name: Upload prepare execution log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: prepare-release-execution-log
+          path: ${{ runner.temp }}/claude-execution-output*.json
+          retention-days: 30
+          if-no-files-found: ignore
+
       - name: Capture PR number / URL / version
         if: steps.skip_check.outputs.skip == 'false'
         id: capture_pr
@@ -215,14 +227,19 @@ jobs:
           node "$(npm root -g)/@playwright/cli/node_modules/playwright-core/cli.js" \
             install --with-deps chromium
 
+      # continue-on-error: a crashed review means the release is unreviewed, not
+      # broken. The job stays green and "Announce review incomplete" hands off
+      # to a human instead of paging them with a release-failure alarm.
       - name: Run /review-release
+        id: review
         if: steps.wait.outputs.outcome == 'success'
+        continue-on-error: true
         uses: anthropics/claude-code-action@v1
         timeout-minutes: 20
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
-            --allowedTools "Read,Glob,Grep,Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr comment:*),Bash(curl:*),Bash(playwright-cli:*),Skill"
+            --allowedTools "Read,Glob,Grep,Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr comment:*),Bash(curl:*),Bash(playwright-cli:*),Skill" --max-budget-usd 4
           prompt: |
             Execute /review-release for PR #${{ needs.prepare.outputs.pr_number }}
             with the --post-comment flag, per .claude/commands/review-release.md.
@@ -249,8 +266,17 @@ jobs:
             - The full summary goes in the PR comment (--post-comment). Do NOT
               write it anywhere else — Discord only gets a pass/fail line.
 
+      - name: Upload review execution log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: review-release-execution-log
+          path: ${{ runner.temp }}/claude-execution-output*.json
+          retention-days: 30
+          if-no-files-found: ignore
+
       - name: Announce ready for human
-        if: steps.wait.outputs.outcome == 'success'
+        if: steps.wait.outputs.outcome == 'success' && steps.review.outcome == 'success'
         uses: ./.github/actions/discord-notify
         with:
           webhook: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
@@ -262,6 +288,20 @@ jobs:
             ${{ steps.links.outputs.components && format(':art: Chromatic (components): <{0}>', steps.links.outputs.components) || '' }}
             ${{ steps.links.outputs.pages && format(':framed_picture: Chromatic (pages): <{0}>', steps.links.outputs.pages) || '' }}
             Remaining manual steps: approve Chromatic, approve PR, merge.
+
+      - name: Announce review incomplete
+        if: steps.wait.outputs.outcome == 'success' && steps.review.outcome == 'failure'
+        uses: ./.github/actions/discord-notify
+        with:
+          webhook: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
+          message_id: ${{ needs.prepare.outputs.discord_message_id }}
+          message: |
+            :warning: **Release ${{ needs.prepare.outputs.version }} — CI green, but the automated review didn't finish**  •  ${{ needs.prepare.outputs.pr_url }}
+            The release itself is not known to be broken — the review agent errored out. Needs manual eyes on the preview before merge.
+            Run (see the `review-release-execution-log` artifact for why): <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>
+            ${{ steps.links.outputs.preview && format(':eyes: Preview: <{0}>', steps.links.outputs.preview) || '' }}
+            ${{ steps.links.outputs.components && format(':art: Chromatic (components): <{0}>', steps.links.outputs.components) || '' }}
+            ${{ steps.links.outputs.pages && format(':framed_picture: Chromatic (pages): <{0}>', steps.links.outputs.pages) || '' }}
 
       - name: Announce wait-and-review failure
         if: failure()


### PR DESCRIPTION
## Context

The v11.17.0 weekly release ([run](https://github.com/ethereum/ethereum-org-website/actions/runs/30553278979)) failed during `wait_and_review`. The `/review-release` step ended with `subtype: "success"` + `is_error: true` — the CLI's "final API call returned an error" branch — after **181 turns / 927s / $7.43**, against 57 turns / $1.45 and 65 turns / $2.09 the two prior weeks. It posted no summary, and Discord announced it as `Weekly release failed`, which reads as a broken release. The release was fine; CI was green (E2E isn't in the required-checks gate).

Three separate gaps made that worse than it needed to be.

### 1. The failure wasn't diagnosable

The result JSON carrying `api_error_status` and the error text is written to `${RUNNER_TEMP}/claude-execution-output.json`. The workflow never uploaded or read it, and `show_full_output` is false, so everything died with the runner — the exact API status is unrecoverable.

Both Claude steps now upload it as an artifact (`if: always()`, `if-no-files-found: ignore`). It uploads the raw path rather than the action's `execution_file` output, because a failed composite step doesn't reliably export outputs — and a failed step is exactly when this log matters.

### 2. Nothing bounded the runaway

- `--max-budget-usd 4` on the review step (~2x the normal spend). An overrun now ends as a clean `error_max_budget_usd` instead of a 15-minute burn.
- `.claude/commands/review-release.md` gets a **Context budget** section. The root cause of the turn explosion is that Step 4's browser loop reads full `playwright-cli snapshot` output — 350–1000 lines per page, almost entirely nav and footer chrome — and this release added five brand-new pages. The skill now says: grep the saved `.playwright-cli/page-*.yml` instead of reading it, prefer `curl` + `grep` for text/JSON-LD/redirect assertions, screenshot only new or redesigned pages, budget ~40–60 tool calls, and list anything left unverified.
- Step 5 now requires a **Not verified** list when the budget runs out, so an omission can't read as a pass.

### 3. A crashed review paged the team as a release failure

The review step is `continue-on-error: true` with `id: review`. A new **Announce review incomplete** step fires on `steps.review.outcome == 'failure'` and says CI is green but the review didn't finish, keeping the preview and Chromatic links plus a pointer to the new artifact. `Announce ready for human` is now gated on the review actually succeeding, and the `failure()` alarm stays for genuine job failures.

## Testing

`weekly-release.yml` parses and the step graph is as intended (ids, `continue-on-error`, and the mutually exclusive `outcome == 'success'` / `== 'failure'` announce conditions). The behavioural paths only exercise on a real scheduled run — worth a `workflow_dispatch` sanity run if you want it verified before next Thursday, though that would open a deploy PR.

The v11.17.0 review itself was re-run manually and posted to #18943.