### PR TITLE
Add ClearTrace to the data and analytics page

### DIFF
--- a/public/content/developers/docs/data-and-analytics/index.md
+++ b/public/content/developers/docs/data-and-analytics/index.md
@@ -78,7 +78,7 @@ To get started, follow the [HyperIndex quickstart](https://docs.envio.dev/docs/H
 
 ## ClearTrace {#cleartrace}
 
-[ClearTrace](https://cleartracedata.com) is a free, independent benchmark of DEX aggregator execution quality measured from on-chain data. It publishes realized slippage, user-only revert rates (bot retries filtered out), MEV sandwich exposure, and cross-frontend attribution of unlabeled DEX volume across Ethereum, Base, Arbitrum, and Optimism, with a published methodology. Developers can use the REST API (no key required, CORS enabled) or the open dataset (CSV, citable DOI).
+[ClearTrace](https://cleartracedata.com) is a free, independent benchmark of DEX aggregator execution quality measured from onchain data. It publishes realized slippage, user-only revert rates (bot retries filtered out), MEV sandwich exposure, and cross-frontend attribution of unlabeled DEX volume across Ethereum, Base, Arbitrum, and Optimism, with a published methodology. Developers can use the REST API (no key required, CORS enabled) or the open dataset (CSV, citable DOI).
 
 To get started, visit the [documentation](https://cleartracedata.com/docs) or explore the [live dashboard](https://cleartracedata.com/app).
 

--- a/public/content/developers/docs/data-and-analytics/index.md
+++ b/public/content/developers/docs/data-and-analytics/index.md
@@ -76,6 +76,12 @@ EVM Query Language (EQL) is an SQL-like language designed to query EVM (Ethereum
 
 To get started, follow the [HyperIndex quickstart](https://docs.envio.dev/docs/HyperIndex/quickstart) to create, deploy, and query an indexer.
 
+## ClearTrace {#cleartrace}
+
+[ClearTrace](https://cleartracedata.com) is a free, independent benchmark of DEX aggregator execution quality measured from on-chain data. It publishes realized slippage, user-only revert rates (bot retries filtered out), MEV sandwich exposure, and cross-frontend attribution of unlabeled DEX volume across Ethereum, Base, Arbitrum, and Optimism, with a published methodology. Developers can use the REST API (no key required, CORS enabled) or the open dataset (CSV, citable DOI).
+
+To get started, visit the [documentation](https://cleartracedata.com/docs) or explore the [live dashboard](https://cleartracedata.com/app).
+
 ## Further Reading {#further-reading}
 
 - [Exploring Crypto Data I: Data Flow Architectures](https://web.archive.org/web/20250125012042/https://research.2077.xyz/exploring-crypto-data-1-data-flow-architectures)


### PR DESCRIPTION
## Description
Adds a ClearTrace section to `developers/docs/data-and-analytics`, following the existing per-product section format (Codex, Mobula, Envio).

ClearTrace is a free, independent benchmark of DEX aggregator execution quality measured from on-chain data: realized slippage, user-only revert rates, MEV sandwich exposure, and cross-frontend attribution of unlabeled DEX volume across Ethereum, Base, Arbitrum, and Optimism. Methodology is published, the REST API needs no key (CORS enabled), and the dataset is open (CSV, citable DOI on Zenodo). It differs from the general-purpose platforms already listed (Dune, The Graph) by being a single-purpose, neutral execution-quality benchmark rather than a query platform.

- Site: https://cleartracedata.com
- Docs: https://cleartracedata.com/docs
- Open dataset: https://github.com/RantumBits/cleartrace-dex-execution-quality (DOI 10.5281/zenodo.21089929)