### PR TITLE
feat(contributing): 'Contribute with your AI agent' section (prototype)

### DIFF
--- a/public/content/contributing/index.md
+++ b/public/content/contributing/index.md
@@ -9,6 +9,16 @@ Ethereum.org is an open-source run project with **12 000+** contributors that he
 
 We are a welcoming community that will help you grow and educate in the [Ethereum](/) ecosystem while also meaningfully contribute and get relevant practical experience!
 
+## Contribute with your AI agent {#contribute-with-your-ai-agent}
+
+Already using an AI coding agent like Claude Code, Cursor, or GitHub Copilot? Let it do the heavy lifting. Point it at our guides and it can prepare a well-formed pull request for you — adding a wallet, developer tool, exchange, or layer 2, or editing content. Paste this prompt:
+
+<AgentPrompt prompt="I want to contribute to ethereum.org. Read https://ethereum.org/contributing/ and the guide for what I want to add, then help me prepare a GitHub pull request step by step." />
+
+Your agent can also read the site's machine-readable index at [ethereum.org/llms.txt](/llms.txt), and the developer-documentation index at [ethereum.org/developers/docs/llms.txt](/developers/docs/llms.txt), to understand how everything is organized before it navigates or edits.
+
+Whether a change is written by you or your agent, it still goes through the same [GitHub pull request review](#how-to-update-content) by our maintainers — so nothing skips a human.
+
 ## Ways to contribute {#ways-to-contribute}
 
 **Translations**

--- a/src/components/AgentPrompt/AgentPrompt.stories.tsx
+++ b/src/components/AgentPrompt/AgentPrompt.stories.tsx
@@ -1,0 +1,41 @@
+import { Meta, StoryObj } from "@storybook/nextjs"
+
+import AgentPrompt from "."
+
+const meta = {
+  title: "Components / Content / AgentPrompt",
+  component: AgentPrompt,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "A copy-paste prompt panel for AI coding agents, used on content pages (e.g. /contributing) to let a reader hand a ready-made instruction to their agent. Renders the prompt in a highlighted box with a prominent, always-visible copy button (reuses the `common:copy` / `common:copied` strings).",
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="max-w-3xl">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof AgentPrompt>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    prompt:
+      "I want to contribute to ethereum.org. Read https://ethereum.org/contributing/ and the guide for what I want to add, then help me prepare a GitHub pull request step by step.",
+  },
+}
+
+export const DevDocs: Story = {
+  args: {
+    prompt:
+      "Read https://ethereum.org/developers/docs/llms.txt, then help me find and understand the Ethereum developer documentation I need.",
+  },
+}

--- a/src/components/AgentPrompt/index.tsx
+++ b/src/components/AgentPrompt/index.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import { Check, Copy } from "lucide-react"
+import { useTranslations } from "next-intl"
+
+import { Button } from "@/components/ui/buttons/Button"
+
+import { cn } from "@/lib/utils/cn"
+
+import { useClipboard } from "@/hooks/useClipboard"
+
+type AgentPromptProps = {
+  prompt: string
+  className?: string
+}
+
+const AgentPrompt = ({ prompt, className }: AgentPromptProps) => {
+  const t = useTranslations("common")
+  const { onCopy, hasCopied } = useClipboard({ timeout: 1500 })
+
+  return (
+    <div
+      dir="ltr"
+      className={cn(
+        "my-8 flex flex-col gap-4 rounded-md border bg-background-highlight p-6",
+        "sm:flex-row sm:items-center sm:justify-between",
+        className
+      )}
+    >
+      <code className="font-mono text-sm text-body sm:text-base">{prompt}</code>
+      <Button
+        variant="outline"
+        onClick={() => onCopy(prompt)}
+        aria-label={hasCopied ? t("copied") : t("copy")}
+        className="shrink-0 self-start sm:self-center"
+      >
+        {hasCopied ? <Check /> : <Copy />}
+        {hasCopied ? t("copied") : t("copy")}
+      </Button>
+    </div>
+  )
+}
+
+export default AgentPrompt

--- a/src/layouts/Static.tsx
+++ b/src/layouts/Static.tsx
@@ -1,6 +1,7 @@
 import type { ChildOnlyProp } from "@/lib/types"
 import type { MdPageContent, StaticFrontmatter } from "@/lib/interfaces"
 
+import AgentPrompt from "@/components/AgentPrompt"
 import ContentFeedback from "@/components/ContentFeedback"
 import Contributors from "@/components/Contributors"
 import EnergyConsumptionChart from "@/components/EnergyConsumptionChart"
@@ -30,6 +31,7 @@ import guideHeroImg from "@/public/images/heroes/guides-hub-hero.jpg"
 
 // Static layout components
 export const staticComponents = {
+  AgentPrompt,
   Alert,
   Callout,
   Contributors,


### PR DESCRIPTION
## Summary

A **herdr.dev-style "Contribute with your AI agent"** section on the `/contributing` page — a copy-paste prompt that lets a reader hand a ready-made instruction to their AI coding agent (Claude Code, Cursor, Copilot), pointing it at our contribution guides and the machine-readable `/llms.txt` indexes.

This is a **prototype for discussion**, not a finished feature — it builds on infra the repo already has (`/llms.txt`, `/developers/docs/llms.txt`, the `contributing/adding-*` guides, and the bug-bounty agent-guide precedent).

## What's here

- **`AgentPrompt` component** (`src/components/AgentPrompt/`) — a small client component that renders a prompt in a highlighted box with a prominent, always-visible **Copy** button. Composed from existing primitives (`Button` + `useClipboard`) and reuses the `common:copy` / `common:copied` strings — no new i18n keys. Ships with a Storybook story.
- Registered in `staticComponents` (`src/layouts/Static.tsx`) so it's usable from static markdown content pages.
- A new **"Contribute with your AI agent"** section in `public/content/contributing/index.md`, placed right after the intro. Heading/description/links are plain MDX (translatable via the normal content pipeline); only the copy interaction is a component.

Framing note baked into the copy: agent-produced changes **still go through normal PR review** — nothing skips a human.

## Verification

- `pnpm type-check` ✓ · eslint ✓ · markdownlint ✓ (all via pre-commit)
- Storybook render verified in **light and dark** themes (semantic tokens adapt correctly).
- Copy click fires; the "Copied" toggle can't be shown in headless Chromium (clipboard writes are permission-blocked there) — same behavior as the existing `CopyToClipboard`.
- The `/contributing` page can't be rendered in local dev (missing `NETLIFY_BLOBS_TOKEN` for the contributor-list fetch) — confirmed environmental: an untouched sibling page 500s identically. It'll render on the Netlify preview.

## Not in this PR (possible follow-ups)

- Task-specific agent guides (`/contributing/llms.txt` or per-action `agent-guide.md`) generated from the `adding-*` content — the higher-leverage piece.
- A matching "browse these docs with your agent" affordance on `/developers/docs`.

## Screenshots

_Storybook, light & dark — see job artifacts._
