### PR TITLE
fix(layer-2): sub-cent tx cost rounding

### DIFF
--- a/app/[locale]/layer-2/page.tsx
+++ b/app/[locale]/layer-2/page.tsx
@@ -19,7 +19,7 @@ import { Section } from "@/components/ui/section"
 import { getAppPageContributorInfo } from "@/lib/utils/contributors"
 import { getMetadata } from "@/lib/utils/metadata"
 import { networkMaturity } from "@/lib/utils/networkMaturity"
-import { formatPriceUSD, numberFormat } from "@/lib/utils/numbers"
+import { formatSmallUSD } from "@/lib/utils/numbers"
 
 import { layer2Data } from "@/data/networks/networks"
 
@@ -79,9 +79,12 @@ const Page = async (props: { params: Promise<PageParams> }) => {
   const t = await getTranslations("page-layer-2")
   const tCommon = await getTranslations("common")
 
+  // Both fees are formatted by significant digits, not fixed decimals: median
+  // costs are routinely sub-cent and 2-decimal rounding flattens them to $0.00
+  const ethereumTxCost = growThePieData.dailyTxCosts["ethereum"]
   const medianTxCost =
     "error" in growThePieData.txCostsMedianUsd
-      ? { error: growThePieData.txCostsMedianUsd.error }
+      ? null
       : growThePieData.txCostsMedianUsd.value
 
   const heroContent: HubHeroProps = {
@@ -166,10 +169,9 @@ const Page = async (props: { params: Promise<PageParams> }) => {
             <BigNumber
               center={false}
               className="py-0"
-              value={formatPriceUSD(
-                growThePieData.dailyTxCosts["ethereum"] || 0,
-                locale
-              )}
+              value={
+                ethereumTxCost ? formatSmallUSD(ethereumTxCost, locale) : "-"
+              }
             >
               {t("page-layer-2-blockchain-transaction-cost")}
             </BigNumber>
@@ -177,12 +179,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
             <BigNumber
               center={false}
               className="py-0"
-              value={numberFormat(locale, {
-                style: "currency",
-                currency: "USD",
-                minimumFractionDigits: 2,
-                maximumFractionDigits: 3,
-              }).format(typeof medianTxCost === "number" ? medianTxCost : 0)}
+              value={medianTxCost ? formatSmallUSD(medianTxCost, locale) : "-"}
             >
               {t("page-layer-2-networks-transaction-cost")}
             </BigNumber>


### PR DESCRIPTION
The "Average transaction cost on the Ethereum blockchain" stat on `/layer-2/` reads `$0.00` in production. This is a rounding bug, not a data-fetch failure: GrowThePie returns a valid median for `ethereum`, but `formatPriceUSD` is hard-wired to 2 fixed decimals, so anything under $0.005 rounds away. L1 median fees now routinely sit below that ($0.00372 on 2026-08-02). The sibling "Ethereum backed networks" stat had the same problem one decimal down, already pinned at its `$0.001` floor.

Both stats now use `formatSmallUSD` (2 significant digits, already used for this metric on `/resources`) -> `$0.0037` instead of `$0.00`. Missing data renders `-` rather than `$0.00`, matching `Layer2NetworksTable`; the old `|| 0` fallback made genuine data loss indistinguishable from a real sub-cent value.

## Preview link
https://deploy-preview-18966.ethereum.it/layer-2