### PR TITLE
chore: retitle stories to repo-mirrored taxonomy (Storybook reorg phase 1)

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -10,9 +10,11 @@ import type { StorybookConfig } from "@storybook/nextjs"
  */
 const config: StorybookConfig = {
   stories: [
+    // Recursive everywhere: a story nested a directory deeper than expected
+    // would otherwise never load, with no error to say so.
     "../src/components/**/*.stories.{ts,tsx}",
-    "../src/layouts/stories/*.stories.tsx",
-    "../src/styles/__stories__/*.stories.tsx",
+    "../src/layouts/**/*.stories.{ts,tsx}",
+    "../src/styles/**/*.stories.{ts,tsx}",
     "../app/**/*.stories.{ts,tsx}",
   ],
 

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -68,7 +68,7 @@ const preview: Preview = {
     },
     options: {
       storySort: {
-        order: ["Atoms", "Molecules", "Organisms", "Templates", "Pages"],
+        order: ["Design System", "UI", "Components", "Layouts", "Pages"],
       },
     },
     layout: "centered",

--- a/app/[locale]/community/events/_components/event-card.stories.tsx
+++ b/app/[locale]/community/events/_components/event-card.stories.tsx
@@ -7,7 +7,7 @@ import { VStack } from "@/components/ui/flex"
 import EventCard from "./event-card"
 
 const meta = {
-  title: "Molecules / Community / EventCard",
+  title: "Pages / Community Events / EventCard",
   component: EventCard,
   decorators: [
     (Story) => (

--- a/src/components/AppCard/AppCard.stories.tsx
+++ b/src/components/AppCard/AppCard.stories.tsx
@@ -10,7 +10,7 @@ import TruncatedText from "@/components/ui/TruncatedText"
 import AppCard from "."
 
 const meta = {
-  title: "Molecules / Display Content / AppCard",
+  title: "Components / Cards / AppCard",
   component: AppCard,
   decorators: [
     (Story) => (

--- a/src/components/AssetDownload/AssetDownload.stories.tsx
+++ b/src/components/AssetDownload/AssetDownload.stories.tsx
@@ -6,7 +6,7 @@ import ethDiamondBlack from "@/public/images/assets/eth-diamond-black.png"
 import hero from "@/public/images/home/hero.png"
 
 const meta = {
-  title: "Molecules / Display Content / AssetDownload",
+  title: "Components / AssetDownload",
   component: AssetDownload,
   parameters: {
     layout: "centered",

--- a/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -5,7 +5,7 @@ import { Stack } from "../ui/flex"
 import BreadcrumbsComponent from "."
 
 const meta = {
-  title: "Molecules / Navigation / Breadcrumbs",
+  title: "Components / Navigation / Breadcrumbs",
   component: BreadcrumbsComponent,
 } satisfies Meta<typeof BreadcrumbsComponent>
 

--- a/src/components/CallToContribute/CallToContribute.stories.tsx
+++ b/src/components/CallToContribute/CallToContribute.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from "@storybook/nextjs"
 import CallToContributeComponent from "."
 
 const meta = {
-  title: "Molecules / Navigation / CallToContribute",
+  title: "Components / CallToContribute",
   component: CallToContributeComponent,
   args: {
     editPath:

--- a/src/components/ChainImages/ChainImages.stories.tsx
+++ b/src/components/ChainImages/ChainImages.stories.tsx
@@ -5,7 +5,7 @@ import { VStack } from "@/components/ui/flex"
 import ChainImages from "."
 
 const meta = {
-  title: "Components / Widgets / ChainImages",
+  title: "Components / ChainImages",
   component: ChainImages,
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/src/components/Contributors/Contributors.stories.tsx
+++ b/src/components/Contributors/Contributors.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from "@storybook/nextjs"
 import ContributorsView, { type Contributor } from "./ContributorsView"
 
 const meta = {
-  title: "Molecules / Display Content / Contributors",
+  title: "Components / Content / Contributors",
   component: ContributorsView,
   parameters: {
     layout: "fullscreen",

--- a/src/components/CopyPageButton/CopyPageButton.stories.tsx
+++ b/src/components/CopyPageButton/CopyPageButton.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs"
 import CopyPageButton from "."
 
 const meta = {
-  title: "Molecules / Actions / CopyPageButton",
+  title: "Components / Site Chrome / CopyPageButton",
   component: CopyPageButton,
   parameters: {
     layout: "centered",

--- a/src/components/CopyToClipboard/CopyToClipboard.stories.tsx
+++ b/src/components/CopyToClipboard/CopyToClipboard.stories.tsx
@@ -6,7 +6,7 @@ import { VStack } from "@/components/ui/flex"
 import CopyToClipboard, { CopyButton } from "."
 
 const meta = {
-  title: "Components / Content / CopyToClipboard",
+  title: "Components / CopyToClipboard",
   component: CopyToClipboard,
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/src/components/DeveloperDocsLinks/DeveloperDocsLinks.stories.tsx
+++ b/src/components/DeveloperDocsLinks/DeveloperDocsLinks.stories.tsx
@@ -5,7 +5,7 @@ import { langViewportModes } from "../../../.storybook/modes"
 import DeveloperDocsLinksComponent from "."
 
 const meta = {
-  title: "Molecules / Navigation / DeveloperDocsLinks",
+  title: "Components / Navigation / DeveloperDocsLinks",
   component: DeveloperDocsLinksComponent,
   parameters: {
     layout: "fullscreen",

--- a/src/components/DocLink/DocLink.stories.tsx
+++ b/src/components/DocLink/DocLink.stories.tsx
@@ -5,7 +5,7 @@ import { VStack } from "../ui/flex"
 import DocLink from "."
 
 const meta = {
-  title: "Molecules / Navigation / DocLink",
+  title: "Components / Navigation / DocLink",
   component: DocLink,
 } satisfies Meta<typeof DocLink>
 

--- a/src/components/DocsNav/DocsNav.stories.tsx
+++ b/src/components/DocsNav/DocsNav.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from "@storybook/nextjs"
 import DocsNavComponent from "."
 
 const meta = {
-  title: "Molecules / Navigation / DocsNav",
+  title: "Components / Navigation / DocsNav",
   component: DocsNavComponent,
   parameters: {
     nextjs: {

--- a/src/components/EnergyConsumptionChart/EnergyConsumptionChart.stories.tsx
+++ b/src/components/EnergyConsumptionChart/EnergyConsumptionChart.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from "@storybook/nextjs"
 import ChartComponent from "."
 
 const meta = {
-  title: "Molecules / Display Content / Charts / Energy Consumption",
+  title: "Components / Data Viz / EnergyConsumptionChart",
   component: ChartComponent,
 } satisfies Meta<typeof ChartComponent>
 

--- a/src/components/FeedbackWidget/FeedbackWidget.stories.tsx
+++ b/src/components/FeedbackWidget/FeedbackWidget.stories.tsx
@@ -7,7 +7,7 @@ import { Stack } from "../ui/flex"
 import FeedbackWidget from "./"
 
 const meta = {
-  title: "FeedbackWidget",
+  title: "Components / Site Chrome / FeedbackWidget",
   parameters: {
     layout: "fullscreen",
   },

--- a/src/components/FilterBar/FilterBar.stories.tsx
+++ b/src/components/FilterBar/FilterBar.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta } from "@storybook/nextjs"
 import FilterBar from "./"
 
 const meta = {
-  title: "Molecules / Navigation / FilterBar",
+  title: "Components / Navigation / FilterBar",
   component: FilterBar,
   parameters: {
     layout: "fullscreen",

--- a/src/components/FilterableCatalog/FilterableCatalog.stories.tsx
+++ b/src/components/FilterableCatalog/FilterableCatalog.stories.tsx
@@ -11,7 +11,7 @@ import type {
 import { toggleId } from "./utils"
 
 const meta = {
-  title: "Components / FilterableCatalog",
+  title: "Components / Features / FilterableCatalog",
   component: FilterableCatalog,
   parameters: {
     layout: "padded",

--- a/src/components/FindWalletProductTable/FindWalletProductTable.stories.tsx
+++ b/src/components/FindWalletProductTable/FindWalletProductTable.stories.tsx
@@ -114,7 +114,7 @@ const walletsData = [
 ]
 
 const meta = {
-  title: "Pages / Special cases / Find Wallet Product Table",
+  title: "Components / Features / FindWalletProductTable",
   component: FindWalletProductTable,
   decorators: [
     (Story) => (

--- a/src/components/Footer/Footer.stories.tsx
+++ b/src/components/Footer/Footer.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from "@storybook/nextjs"
 import Footer from "."
 
 const meta = {
-  title: "Components / Layout / Footer",
+  title: "Components / Site Chrome / Footer",
   component: Footer,
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/src/components/Glossary/GlossaryDefinition/GlossaryDefinition.stories.tsx
+++ b/src/components/Glossary/GlossaryDefinition/GlossaryDefinition.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from "@storybook/nextjs"
 import GlossaryDefinitionComponent from "."
 
 const meta = {
-  title: "GlossaryDefinition",
+  title: "Components / Content / Glossary / Definition",
   component: GlossaryDefinitionComponent,
 } as Meta<typeof GlossaryDefinitionComponent>
 

--- a/src/components/Glossary/GlossaryTooltip/GlossaryTooltip.stories.tsx
+++ b/src/components/Glossary/GlossaryTooltip/GlossaryTooltip.stories.tsx
@@ -5,7 +5,7 @@ import { Center } from "@/components/ui/flex"
 import GlossaryTooltipComponent from "."
 
 const meta = {
-  title: "Molecules / Overlay Content / Glossary Tooltip",
+  title: "Components / Content / Glossary / Tooltip",
   component: GlossaryTooltipComponent,
   args: {
     termKey: "bridge",

--- a/src/components/Hero/HomeHero/HomeHero.stories.tsx
+++ b/src/components/Hero/HomeHero/HomeHero.stories.tsx
@@ -5,7 +5,7 @@ import { langViewportModes } from "@/storybook/modes"
 import HomeHeroComponent from "."
 
 const meta = {
-  title: "Organisms / Layouts / Hero",
+  title: "Components / Heroes / HomeHero",
   component: HomeHeroComponent,
   parameters: {
     layout: "none",

--- a/src/components/Hero/HubHero/HubHero.stories.tsx
+++ b/src/components/Hero/HubHero/HubHero.stories.tsx
@@ -8,7 +8,7 @@ import HubHeroComponent, { type HubHeroProps } from "./"
 import learnHubHeroImg from "@/public/images/heroes/learn-hub-hero.png"
 
 const meta = {
-  title: "Organisms / Layouts / Hero",
+  title: "Components / Heroes / HubHero",
   component: HubHeroComponent,
   parameters: {
     layout: "none",

--- a/src/components/Hero/PageHero/PageHero.stories.tsx
+++ b/src/components/Hero/PageHero/PageHero.stories.tsx
@@ -8,7 +8,7 @@ import PageHeroComponent, { type PageHeroProps } from "."
 import heroImg from "@/public/images/upgrades/merge.png"
 
 const meta = {
-  title: "Organisms / Layouts / Hero",
+  title: "Components / Heroes / PageHero",
   component: PageHeroComponent,
   parameters: {
     layout: "none",

--- a/src/components/ListenToPlayer/ListenToPlayer.stories.tsx
+++ b/src/components/ListenToPlayer/ListenToPlayer.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs"
 import Component from "."
 
 const meta = {
-  title: "Atoms / Media & Icons / ListenToPlayer",
+  title: "Components / Content / ListenToPlayer",
   component: Component,
   args: {
     slug: "/eth/",

--- a/src/components/ListingMethodology/ListingMethodology.stories.tsx
+++ b/src/components/ListingMethodology/ListingMethodology.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from "@storybook/nextjs"
 import ListingMethodology from "."
 
 const meta = {
-  title: "Components / Widgets / ListingMethodology",
+  title: "Components / ListingMethodology",
   component: ListingMethodology,
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/src/components/Logo/Logo.stories.tsx
+++ b/src/components/Logo/Logo.stories.tsx
@@ -4,7 +4,7 @@ import { Meta, StoryObj } from "@storybook/nextjs"
 import LogoComponent from "."
 
 const meta = {
-  title: "Atoms / Media & Icons / Logo",
+  title: "Components / Logo",
   component: LogoComponent,
 } satisfies Meta<typeof LogoComponent>
 

--- a/src/components/MarkdownCard/MarkdownCard.stories.tsx
+++ b/src/components/MarkdownCard/MarkdownCard.stories.tsx
@@ -8,7 +8,7 @@ import { Grid } from "../ui/grid"
 import CardComponent, { MarkdownCardProps } from "."
 
 const meta = {
-  title: "UI / Cards / MarkdownCard",
+  title: "Components / Cards / MarkdownCard",
   component: CardComponent,
   parameters: { layout: "fullscreen" },
   decorators: [

--- a/src/components/MdComponents/MdComponents.stories.tsx
+++ b/src/components/MdComponents/MdComponents.stories.tsx
@@ -6,7 +6,7 @@ import { viewportModes } from "@/storybook/modes"
 import MdComponentSet from "."
 
 const meta = {
-  title: "Molecules / Display Content / MdComponents",
+  title: "Components / Content / MdComponents",
   parameters: {
     layout: "none",
     chromatic: {

--- a/src/components/MergeInfographic/MergeInfographic.stories.tsx
+++ b/src/components/MergeInfographic/MergeInfographic.stories.tsx
@@ -5,7 +5,7 @@ import { langViewportModes } from "@/storybook/modes"
 import MergeInfographicComponent from "."
 
 const meta = {
-  title: "Atoms / Media & Icons / MergeInfographic",
+  title: "Components / MergeInfographic",
   component: MergeInfographicComponent,
   parameters: {
     layout: "fullscreen",

--- a/src/components/MobileButtonDropdown/MobileButtonDropdown.stories.tsx
+++ b/src/components/MobileButtonDropdown/MobileButtonDropdown.stories.tsx
@@ -5,7 +5,7 @@ import type { List } from "@/components/ButtonDropdown"
 import MobileButtonDropdown from "."
 
 const meta = {
-  title: "Components / Widgets / MobileButtonDropdown",
+  title: "Components / MobileButtonDropdown",
   component: MobileButtonDropdown,
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/src/components/Morpher/Morpher.stories.tsx
+++ b/src/components/Morpher/Morpher.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from "@storybook/nextjs"
 import Morpher from "."
 
 const meta = {
-  title: "Components / Widgets / Morpher",
+  title: "Components / Morpher",
   component: Morpher,
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/src/components/Nav/Nav.stories.tsx
+++ b/src/components/Nav/Nav.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from "@storybook/nextjs"
 import Nav from "."
 
 const meta = {
-  title: "Components / Layout / Nav",
+  title: "Components / Site Chrome / Nav",
   component: Nav,
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/src/components/PieChart/PieChart.stories.tsx
+++ b/src/components/PieChart/PieChart.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs"
 import { PieChart } from "."
 
 const meta = {
-  title: "Molecules / Display Content / PieChart",
+  title: "Components / Data Viz / PieChart",
   component: PieChart,
   parameters: {
     layout: "padded",

--- a/src/components/ProductList/ProductList.stories.tsx
+++ b/src/components/ProductList/ProductList.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from "@storybook/nextjs"
 import ProductList, { type ProductListContent } from "."
 
 const meta = {
-  title: "Components / Content / ProductList",
+  title: "Components / ProductList",
   component: ProductList,
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/src/components/Quiz/stories/QuizButtonGroup.stories.tsx
+++ b/src/components/Quiz/stories/QuizButtonGroup.stories.tsx
@@ -8,7 +8,7 @@ import { QuizContent } from "../QuizWidget/QuizContent"
 import { LAYER_2_QUIZ_TITLE_KEY, layer2Questions } from "./utils"
 
 const meta = {
-  title: "Molecules / Display Content / Quiz / QuizWidget / ButtonGroup",
+  title: "Components / Features / Quiz / QuizWidget / ButtonGroup",
   component: QuizButtonGroup,
   args: {
     answerStatus: undefined,

--- a/src/components/Quiz/stories/QuizModal.stories.tsx
+++ b/src/components/Quiz/stories/QuizModal.stories.tsx
@@ -14,7 +14,7 @@ type ModalPropsAndWidgetArgs = ComponentProps<typeof QuizzesModal> & {
 }
 
 const meta = {
-  title: "Molecules / Display Content / Quiz / Modal",
+  title: "Components / Features / Quiz / Modal",
   component: QuizzesModal,
   args: {
     isQuizModalOpen: true,

--- a/src/components/Quiz/stories/QuizProgressBar.stories.tsx
+++ b/src/components/Quiz/stories/QuizProgressBar.stories.tsx
@@ -9,7 +9,7 @@ import { QuizProgressBar } from "../QuizWidget/QuizProgressBar"
 import { LAYER_2_QUIZ_KEY, layer2Questions } from "./utils"
 
 const meta = {
-  title: "Molecules / Display Content / Quiz / QuizWidget / ProgressBar",
+  title: "Components / Features / Quiz / QuizWidget / ProgressBar",
   component: QuizProgressBar,
   args: {
     questions: layer2Questions,

--- a/src/components/Quiz/stories/QuizRadioGroup.stories.tsx
+++ b/src/components/Quiz/stories/QuizRadioGroup.stories.tsx
@@ -8,7 +8,7 @@ import { QuizRadioGroup } from "../QuizWidget/QuizRadioGroup"
 import { LAYER_2_QUIZ_TITLE_KEY, layer2Questions } from "./utils"
 
 const meta = {
-  title: "Molecules / Display Content / Quiz / QuizWidget / RadioGroup",
+  title: "Components / Features / Quiz / QuizWidget / RadioGroup",
   component: QuizRadioGroup,
   decorators: [
     (Story, { args }) => {

--- a/src/components/Quiz/stories/QuizSummary.stories.tsx
+++ b/src/components/Quiz/stories/QuizSummary.stories.tsx
@@ -7,7 +7,7 @@ import { QuizSummary } from "../QuizWidget/QuizSummary"
 import { LAYER_2_QUIZ_TITLE_KEY, layer2Questions } from "./utils"
 
 const meta = {
-  title: "Molecules / Display Content / Quiz / QuizWidget / Summary",
+  title: "Components / Features / Quiz / QuizWidget / Summary",
   component: QuizSummary,
   args: {
     questionsLength: layer2Questions.length,

--- a/src/components/Quiz/stories/QuizWidget.stories.tsx
+++ b/src/components/Quiz/stories/QuizWidget.stories.tsx
@@ -6,7 +6,7 @@ import { StandaloneQuizClient } from "../QuizWidget/QuizWidgetClient"
 import { LAYER_2_QUIZ_KEY, layer2Questions } from "./utils"
 
 const meta = {
-  title: "Molecules / Display Content / Quiz / QuizWidget",
+  title: "Components / Features / Quiz / QuizWidget",
   component: StandaloneQuizClient,
   args: {
     quizKey: LAYER_2_QUIZ_KEY,

--- a/src/components/Quiz/stories/QuizzesList.stories.tsx
+++ b/src/components/Quiz/stories/QuizzesList.stories.tsx
@@ -15,7 +15,7 @@ import QuizzesListComponent from "../QuizzesList"
  */
 
 const meta = {
-  title: "Molecules / Display Content / Quiz / QuizzesList",
+  title: "Components / Features / Quiz / QuizzesList",
   component: QuizzesListComponent,
   args: {
     content: ethereumBasicsQuizzes,

--- a/src/components/Quiz/stories/QuizzesStats.stories.tsx
+++ b/src/components/Quiz/stories/QuizzesStats.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs"
 import QuizzesStats from "../QuizzesStats"
 
 const meta = {
-  title: "Molecules / Display Content / Quiz / QuizzesStats",
+  title: "Components / Features / Quiz / QuizzesStats",
   component: QuizzesStats,
   args: {
     averageScoresArray: [],

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -5,7 +5,7 @@ import { HStack } from "../ui/flex"
 import Select from "./"
 
 const meta = {
-  title: "Atoms / Form / Dropdown",
+  title: "Components / Forms / Select",
   component: Select,
   parameters: {
     // TODO: Remove this when this story file becomes the primary one

--- a/src/components/Simulator/WalletHome/__stories__/WalletHome.stories.tsx
+++ b/src/components/Simulator/WalletHome/__stories__/WalletHome.stories.tsx
@@ -9,7 +9,7 @@ import { WalletHome as Component } from ".."
 import NFTImage from "@/public/images/deep-panic.png"
 
 const meta = {
-  title: "Molecules / Display Content / Simulator / WalletHome",
+  title: "Components / Features / Simulator / WalletHome",
   component: Component,
   parameters: {
     layout: "fullscreen",

--- a/src/components/Simulator/__stories__/ClickAnimation.stories.tsx
+++ b/src/components/Simulator/__stories__/ClickAnimation.stories.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/buttons/Button"
 import { ClickAnimation } from "../ClickAnimation"
 
 const meta = {
-  title: "Molecules / Display Content / Simulator / ClickAnimation",
+  title: "Components / Features / Simulator / ClickAnimation",
   component: ClickAnimation,
   decorators: [
     (Story) => (

--- a/src/components/Simulator/__stories__/Explanation.stories.tsx
+++ b/src/components/Simulator/__stories__/Explanation.stories.tsx
@@ -15,7 +15,7 @@ const SendReceiveIcon = (props: SVGProps<SVGElement>) => (
 SendReceiveIcon.displayName = "SendReceiveIcon"
 
 const meta = {
-  title: "Molecules / Display Content / Simulator / Explanation",
+  title: "Components / Features / Simulator / Explanation",
   component: ExplanationComponent,
   parameters: {
     chromatic: {

--- a/src/components/Simulator/__stories__/MoreInfoPopover.stories.tsx
+++ b/src/components/Simulator/__stories__/MoreInfoPopover.stories.tsx
@@ -6,7 +6,7 @@ import { Flex } from "@/components/ui/flex"
 import { MoreInfoPopover as MoreInfoPopoverComponent } from "../MoreInfoPopover"
 
 const meta = {
-  title: "Molecules / Display Content / Simulator / MoreInfoPopover",
+  title: "Components / Features / Simulator / MoreInfoPopover",
   component: MoreInfoPopoverComponent,
   decorators: [
     (Story) => (

--- a/src/components/Simulator/__stories__/PathButton.stories.tsx
+++ b/src/components/Simulator/__stories__/PathButton.stories.tsx
@@ -5,7 +5,7 @@ import { CreateAccountIcon } from "../icons"
 import { PathButton as PathButtonComponent } from "../PathButton"
 
 const meta = {
-  title: "Molecules / Display Content / Simulator / PathButton",
+  title: "Components / Features / Simulator / PathButton",
   component: PathButtonComponent,
   decorators: [
     (Story) => (

--- a/src/components/Simulator/screens/ConnectWeb3/__stories__/ConnectWeb3.stories.tsx
+++ b/src/components/Simulator/screens/ConnectWeb3/__stories__/ConnectWeb3.stories.tsx
@@ -7,7 +7,7 @@ import { Template } from "@/components/Simulator/Template"
 import { ConnectWeb3 as Component } from "../"
 
 const meta = {
-  title: "Molecules / Display Content / Simulator / ConnectWeb3 Screen",
+  title: "Components / Features / Simulator / Screens / ConnectWeb3",
   component: Component,
   parameters: {
     layout: "fullscreen",

--- a/src/components/Simulator/screens/CreateAccount/__stories__/GeneratingKeys.stories.tsx
+++ b/src/components/Simulator/screens/CreateAccount/__stories__/GeneratingKeys.stories.tsx
@@ -14,7 +14,7 @@ import { GeneratingKeys } from "../GeneratingKeys"
 
 const meta = {
   title:
-    "Molecules / Display Content / Simulator / CreateAccount Screen / GeneratingKeys",
+    "Components / Features / Simulator / Screens / CreateAccount / GeneratingKeys",
   component: GeneratingKeys,
   parameters: {
     layout: "fullscreen",

--- a/src/components/Simulator/screens/CreateAccount/__stories__/HomeScreen.stories.tsx
+++ b/src/components/Simulator/screens/CreateAccount/__stories__/HomeScreen.stories.tsx
@@ -7,7 +7,7 @@ import { HomeScreen as Component } from "../HomeScreen"
 
 const meta = {
   title:
-    "Molecules / Display Content / Simulator / CreateAccount Screen / HomeScreen",
+    "Components / Features / Simulator / Screens / CreateAccount / HomeScreen",
   component: Component,
   parameters: {
     layout: "fullscreen",

--- a/src/components/Simulator/screens/CreateAccount/__stories__/InitialWordDisplay.stories.tsx
+++ b/src/components/Simulator/screens/CreateAccount/__stories__/InitialWordDisplay.stories.tsx
@@ -6,7 +6,7 @@ import { InitialWordDisplay as Component } from "../InitialWordDisplay"
 
 const meta = {
   title:
-    "Molecules / Display Content / Simulator / CreateAccount Screen / InitialWordDisplay",
+    "Components / Features / Simulator / Screens / CreateAccount / InitialWordDisplay",
   component: Component,
   parameters: {
     layout: "fullscreen",

--- a/src/components/Simulator/screens/CreateAccount/__stories__/InteractiveWordSelector.stories.tsx
+++ b/src/components/Simulator/screens/CreateAccount/__stories__/InteractiveWordSelector.stories.tsx
@@ -14,7 +14,7 @@ import { InteractiveWordSelector as Component } from "../InteractiveWordSelector
 
 const meta = {
   title:
-    "Molecules / Display Content / Simulator / CreateAccount Screen / InteractiveWordSelector",
+    "Components / Features / Simulator / Screens / CreateAccount / InteractiveWordSelector",
   component: Component,
   parameters: {
     layout: "fullscreen",

--- a/src/components/Simulator/screens/CreateAccount/__stories__/RecoveryPhraseNotice.stories.tsx
+++ b/src/components/Simulator/screens/CreateAccount/__stories__/RecoveryPhraseNotice.stories.tsx
@@ -6,7 +6,7 @@ import { RecoveryPhraseNotice as Component } from "../RecoveryPhraseNotice"
 
 const meta = {
   title:
-    "Molecules / Display Content / Simulator / CreateAccount Screen / RecoveryPhraseNotice",
+    "Components / Features / Simulator / Screens / CreateAccount / RecoveryPhraseNotice",
   component: Component,
   parameters: {
     layout: "fullscreen",

--- a/src/components/Simulator/screens/CreateAccount/__stories__/WelcomeScreen.stories.tsx
+++ b/src/components/Simulator/screens/CreateAccount/__stories__/WelcomeScreen.stories.tsx
@@ -6,7 +6,7 @@ import { WelcomeScreen as Component } from "../WelcomeScreen"
 
 const meta = {
   title:
-    "Molecules / Display Content / Simulator / CreateAccount Screen / WelcomeScreen",
+    "Components / Features / Simulator / Screens / CreateAccount / WelcomeScreen",
   component: Component,
   parameters: {
     layout: "fullscreen",

--- a/src/components/Simulator/screens/SendReceive/__stories__/SendReceive.stories.tsx
+++ b/src/components/Simulator/screens/SendReceive/__stories__/SendReceive.stories.tsx
@@ -7,7 +7,7 @@ import { Template } from "@/components/Simulator/Template"
 import { SendReceive } from ".."
 
 const meta = {
-  title: "Molecules / Display Content / Simulator / SendReceive Screen",
+  title: "Components / Features / Simulator / Screens / SendReceive",
   component: SendReceive,
   parameters: {
     layout: "fullscreen",

--- a/src/components/SocialListItem/SocialListItem.stories.tsx
+++ b/src/components/SocialListItem/SocialListItem.stories.tsx
@@ -5,7 +5,7 @@ import { VStack } from "@/components/ui/flex"
 import SocialListItem from "."
 
 const meta = {
-  title: "Components / Widgets / SocialListItem",
+  title: "Components / SocialListItem",
   component: SocialListItem,
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/src/components/SupportedLanguagesTooltip/SupportedLanguagesTooltip.stories.tsx
+++ b/src/components/SupportedLanguagesTooltip/SupportedLanguagesTooltip.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from "@storybook/nextjs"
 import { SupportedLanguagesTooltip } from "."
 
 const meta = {
-  title: "Components / Widgets / SupportedLanguagesTooltip",
+  title: "Components / SupportedLanguagesTooltip",
   component: SupportedLanguagesTooltip,
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/src/components/TableOfContents/TableOfContents.stories.tsx
+++ b/src/components/TableOfContents/TableOfContents.stories.tsx
@@ -73,7 +73,7 @@ const tocItems: ToCItem[] = [
 ]
 
 const meta = {
-  title: "Molecules / Navigation / TableOfContents",
+  title: "Components / Navigation / TableOfContents",
   component: TableOfContentsComponent,
   parameters: {
     layout: "fullscreen",

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -16,7 +16,7 @@ const TooltipContent = () => (
 )
 
 const meta = {
-  title: "Molecules / Overlay Content / Tooltip",
+  title: "Components / Tooltip",
   component: TooltipComponent,
   args: {
     content: <TooltipContent />,

--- a/src/components/TranslationBanner/TranslationBanner.stories.tsx
+++ b/src/components/TranslationBanner/TranslationBanner.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from "@storybook/nextjs"
 import TranslationBanner from "."
 
 const meta = {
-  title: "Components / Callouts / TranslationBanner",
+  title: "Components / Site Chrome / TranslationBanner",
   component: TranslationBanner,
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/src/components/TranslationChartImage/TranslationChartImage.stories.tsx
+++ b/src/components/TranslationChartImage/TranslationChartImage.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from "@storybook/nextjs"
 import TranslationChartImageComponent from "."
 
 const meta = {
-  title: "Atoms / Media & Icons / TranslationChartImage",
+  title: "Components / TranslationChartImage",
   component: TranslationChartImageComponent,
   parameters: {
     layout: "fullscreen",

--- a/src/components/cards/__stories__/pathway-card.stories.tsx
+++ b/src/components/cards/__stories__/pathway-card.stories.tsx
@@ -7,7 +7,7 @@ import PathwayCard from "@/components/cards/pathway-card"
 import walletCardImg from "@/public/images/homepage/features/global.png"
 
 const meta = {
-  title: "Cards / PathwayCard",
+  title: "Components / Cards / PathwayCard",
   component: PathwayCard,
   parameters: {
     layout: "centered",

--- a/src/components/icons/Icons.stories.tsx
+++ b/src/components/icons/Icons.stories.tsx
@@ -95,7 +95,7 @@ import {
 import { EthHomeIcon, FeedbackThumbsUpIcon } from "."
 
 const meta = {
-  title: "Atoms / Media & Icons / Icons",
+  title: "Components / Icons",
 } satisfies Meta
 
 export default meta

--- a/src/components/ui/__stories__/Accordion.stories.tsx
+++ b/src/components/ui/__stories__/Accordion.stories.tsx
@@ -8,7 +8,7 @@ import {
 } from "../accordion"
 
 const meta = {
-  title: "UI / Accordion",
+  title: "UI / Data Display / Accordion",
   component: Accordion,
   decorators: [
     (Story) => (

--- a/src/components/ui/__stories__/Alert.stories.tsx
+++ b/src/components/ui/__stories__/Alert.stories.tsx
@@ -13,7 +13,7 @@ import {
 import { VStack } from "../flex"
 
 const meta = {
-  title: "Molecules / Action Feedback / Alerts",
+  title: "UI / Alert",
   component: Alert,
   parameters: {
     docs: {

--- a/src/components/ui/__stories__/Avatar.stories.tsx
+++ b/src/components/ui/__stories__/Avatar.stories.tsx
@@ -16,7 +16,7 @@ const SAMPLE = {
 }
 
 const meta = {
-  title: "UI / Avatar",
+  title: "UI / Data Display / Avatar",
   component: Avatar,
   args: SAMPLE,
   parameters: {

--- a/src/components/ui/__stories__/Breadcrumb.stories.tsx
+++ b/src/components/ui/__stories__/Breadcrumb.stories.tsx
@@ -11,7 +11,7 @@ import {
 } from "../breadcrumb"
 
 const meta = {
-  title: "UI / Primitives / Breadcrumb",
+  title: "UI / Navigation / Breadcrumb",
   component: Breadcrumb,
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/src/components/ui/__stories__/Button.stories.tsx
+++ b/src/components/ui/__stories__/Button.stories.tsx
@@ -5,7 +5,7 @@ import { Button, type ButtonVariantProps } from "../buttons/Button"
 import { HStack, VStack } from "../flex"
 
 const meta = {
-  title: "UI / Button",
+  title: "UI / Actions / Button",
   component: Button,
   args: {
     children: "What is Ethereum?",

--- a/src/components/ui/__stories__/ButtonLink.stories.tsx
+++ b/src/components/ui/__stories__/ButtonLink.stories.tsx
@@ -4,7 +4,7 @@ import { ButtonLink, type ButtonVariantProps } from "../buttons/Button"
 import { HStack, VStack } from "../flex"
 
 const meta = {
-  title: "UI / ButtonLink",
+  title: "UI / Actions / ButtonLink",
   component: ButtonLink,
   args: {
     href: "#",

--- a/src/components/ui/__stories__/Chart.stories.tsx
+++ b/src/components/ui/__stories__/Chart.stories.tsx
@@ -24,7 +24,7 @@ import {
 } from "../chart"
 
 const meta = {
-  title: "UI / Chart",
+  title: "UI / Data Display / Chart",
   component: ChartContainer,
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/src/components/ui/__stories__/Checkbox.stories.tsx
+++ b/src/components/ui/__stories__/Checkbox.stories.tsx
@@ -4,7 +4,7 @@ import Checkbox, { type CheckboxProps } from "../checkbox"
 import { HStack, VStack } from "../flex"
 
 const meta = {
-  title: "UI / Primitives / Checkbox",
+  title: "UI / Forms / Checkbox",
   component: Checkbox,
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/src/components/ui/__stories__/Collapsible.stories.tsx
+++ b/src/components/ui/__stories__/Collapsible.stories.tsx
@@ -10,7 +10,7 @@ import {
 import { HStack, VStack } from "../flex"
 
 const meta = {
-  title: "UI / Primitives / Collapsible",
+  title: "UI / Collapsible",
   component: Collapsible,
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/src/components/ui/__stories__/Command.stories.tsx
+++ b/src/components/ui/__stories__/Command.stories.tsx
@@ -15,7 +15,7 @@ import {
 } from "../command"
 
 const meta = {
-  title: "UI / Primitives / Command",
+  title: "UI / Overlays / Command",
   component: Command,
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/src/components/ui/__stories__/Dialog.stories.tsx
+++ b/src/components/ui/__stories__/Dialog.stories.tsx
@@ -15,7 +15,7 @@ import {
 import { Flex } from "../flex"
 
 const meta = {
-  title: "UI / Primitives / Dialog",
+  title: "UI / Overlays / Dialog",
   component: Dialog,
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/src/components/ui/__stories__/DropdownMenu.stories.tsx
+++ b/src/components/ui/__stories__/DropdownMenu.stories.tsx
@@ -19,7 +19,7 @@ import {
 } from "../dropdown-menu"
 
 const meta = {
-  title: "UI / Primitives / DropdownMenu",
+  title: "UI / Overlays / DropdownMenu",
   component: DropdownMenu,
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/src/components/ui/__stories__/EdgeScrollContainer.stories.tsx
+++ b/src/components/ui/__stories__/EdgeScrollContainer.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs"
 import { EdgeScrollContainer, EdgeScrollItem } from "../edge-scroll-container"
 
 const meta = {
-  title: "UI / EdgeScrollContainer",
+  title: "UI / Layout / EdgeScrollContainer",
   component: EdgeScrollContainer,
   decorators: [
     (Story) => (

--- a/src/components/ui/__stories__/Flex.stories.tsx
+++ b/src/components/ui/__stories__/Flex.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs"
 import { Center, Flex, HStack, Stack, VStack } from "../flex"
 
 const meta = {
-  title: "UI / Flex",
+  title: "UI / Layout / Flex",
   component: Flex,
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/src/components/ui/__stories__/Input.stories.tsx
+++ b/src/components/ui/__stories__/Input.stories.tsx
@@ -4,7 +4,7 @@ import { VStack } from "../flex"
 import Input from "../input"
 
 const meta = {
-  title: "UI / Primitives / Input",
+  title: "UI / Forms / Input",
   component: Input,
   parameters: {
     docs: {

--- a/src/components/ui/__stories__/Link.stories.tsx
+++ b/src/components/ui/__stories__/Link.stories.tsx
@@ -5,7 +5,7 @@ import InlineLink, { BaseLink, LinkWithArrow } from "../Link"
 import { ListItem, UnorderedList } from "../list"
 
 const meta = {
-  title: "UI / Link",
+  title: "UI / Navigation / Link",
   component: InlineLink,
   decorators: [
     (Story) => (

--- a/src/components/ui/__stories__/LinkBox.stories.tsx
+++ b/src/components/ui/__stories__/LinkBox.stories.tsx
@@ -4,7 +4,7 @@ import { BaseLink } from "../Link"
 import { LinkBox, LinkOverlay } from "../link-box"
 
 const meta = {
-  title: "UI / LinkBox",
+  title: "UI / Navigation / LinkBox",
   component: LinkBox,
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/src/components/ui/__stories__/List.stories.tsx
+++ b/src/components/ui/__stories__/List.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs"
 import { List, ListItem, OrderedList, UnorderedList } from "../list"
 
 const meta = {
-  title: "UI / List",
+  title: "UI / Data Display / List",
   component: List,
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/src/components/ui/__stories__/Modal.stories.tsx
+++ b/src/components/ui/__stories__/Modal.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs"
 import ModalComponent from "../dialog-modal"
 
 const meta = {
-  title: "UI / Modal",
+  title: "UI / Overlays / Modal",
   component: ModalComponent,
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/src/components/ui/__stories__/PersistentPanel.stories.tsx
+++ b/src/components/ui/__stories__/PersistentPanel.stories.tsx
@@ -5,7 +5,7 @@ import { Button } from "../buttons/Button"
 import { PersistentPanel } from "../persistent-panel"
 
 const meta = {
-  title: "UI / PersistentPanel",
+  title: "UI / Data Display / PersistentPanel",
   component: PersistentPanel,
   args: {
     open: false,

--- a/src/components/ui/__stories__/Popover.stories.tsx
+++ b/src/components/ui/__stories__/Popover.stories.tsx
@@ -10,7 +10,7 @@ import {
 } from "../popover"
 
 const meta = {
-  title: "UI / Primitives / Popover",
+  title: "UI / Overlays / Popover",
   component: Popover,
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/src/components/ui/__stories__/Progress.stories.tsx
+++ b/src/components/ui/__stories__/Progress.stories.tsx
@@ -4,7 +4,7 @@ import { VStack } from "../flex"
 import { Progress } from "../progress"
 
 const meta = {
-  title: "UI / Primitives / Progress",
+  title: "UI / Data Display / Progress",
   component: Progress,
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/src/components/ui/__stories__/ScrollArea.stories.tsx
+++ b/src/components/ui/__stories__/ScrollArea.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs"
 import { ScrollArea, ScrollBar } from "../scroll-area"
 
 const meta = {
-  title: "UI / Primitives / ScrollArea",
+  title: "UI / ScrollArea",
   component: ScrollArea,
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/src/components/ui/__stories__/Section.stories.tsx
+++ b/src/components/ui/__stories__/Section.stories.tsx
@@ -9,7 +9,7 @@ import {
 } from "../section"
 
 const meta = {
-  title: "UI / Section",
+  title: "UI / Layout / Section",
   component: Section,
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/src/components/ui/__stories__/Select.stories.tsx
+++ b/src/components/ui/__stories__/Select.stories.tsx
@@ -13,7 +13,7 @@ import {
 } from "../select"
 
 const meta = {
-  title: "UI / Primitives / Select",
+  title: "UI / Forms / Select",
   component: Select,
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/src/components/ui/__stories__/Sheet.stories.tsx
+++ b/src/components/ui/__stories__/Sheet.stories.tsx
@@ -13,7 +13,7 @@ import {
 } from "../sheet"
 
 const meta = {
-  title: "UI / Primitives / Sheet",
+  title: "UI / Overlays / Sheet",
   component: Sheet,
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/src/components/ui/__stories__/Skeleton.stories.tsx
+++ b/src/components/ui/__stories__/Skeleton.stories.tsx
@@ -10,7 +10,7 @@ import {
 } from "../skeleton"
 
 const meta = {
-  title: "UI / Skeleton",
+  title: "UI / Layout / Skeleton",
   component: Skeleton,
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/src/components/ui/__stories__/Spinner.stories.tsx
+++ b/src/components/ui/__stories__/Spinner.stories.tsx
@@ -4,7 +4,7 @@ import { HStack, VStack } from "../flex"
 import { Spinner } from "../spinner"
 
 const meta = {
-  title: "UI / Spinner",
+  title: "UI / Data Display / Spinner",
   component: Spinner,
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/src/components/ui/__stories__/Switch.stories.tsx
+++ b/src/components/ui/__stories__/Switch.stories.tsx
@@ -4,7 +4,7 @@ import { HStack, VStack } from "../flex"
 import Switch from "../switch"
 
 const meta = {
-  title: "UI / Primitives / Switch",
+  title: "UI / Forms / Switch",
   component: Switch,
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/src/components/ui/__stories__/TabNav.stories.tsx
+++ b/src/components/ui/__stories__/TabNav.stories.tsx
@@ -7,7 +7,7 @@ import type { SectionNavDetails } from "@/lib/types"
 import TabNav, { StickyContainer } from "../TabNav"
 
 const meta = {
-  title: "UI / TabNav",
+  title: "UI / Navigation / TabNav",
   component: TabNav,
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/src/components/ui/__stories__/Table/Table.stories.tsx
+++ b/src/components/ui/__stories__/Table/Table.stories.tsx
@@ -10,7 +10,7 @@ import {
 } from "./mockMdxData"
 
 const meta = {
-  title: "UI / Table",
+  title: "UI / Data Display / Table",
   component: Table,
   decorators: [
     (Story) => (

--- a/src/components/ui/__stories__/Tabs.stories.tsx
+++ b/src/components/ui/__stories__/Tabs.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../tabs"
 
 const meta = {
-  title: "UI / Primitives / Tabs",
+  title: "UI / Navigation / Tabs",
   component: Tabs,
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/src/components/ui/__stories__/Tag.stories.tsx
+++ b/src/components/ui/__stories__/Tag.stories.tsx
@@ -4,7 +4,7 @@ import { HStack, VStack } from "../flex"
 import { Tag, TagButton, TagsInlineText } from "../tag"
 
 const meta = {
-  title: "UI / Tag",
+  title: "UI / Actions / Tag",
   component: Tag,
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/src/components/ui/__stories__/TagFilter.stories.tsx
+++ b/src/components/ui/__stories__/TagFilter.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs"
 import TagFilter, { type TagFilterProps } from "../tag-filter"
 
 const meta = {
-  title: "UI / TagFilter",
+  title: "UI / Data Display / TagFilter",
   component: TagFilter,
   decorators: [
     (Story) => (

--- a/src/components/ui/__stories__/TerminalTypewriter.stories.tsx
+++ b/src/components/ui/__stories__/TerminalTypewriter.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs"
 import { TerminalTypewriter } from "../terminal-typewriter"
 
 const meta = {
-  title: "UI / TerminalTypewriter",
+  title: "UI / Data Display / TerminalTypewriter",
   component: TerminalTypewriter,
   decorators: [
     (Story) => (

--- a/src/components/ui/__stories__/TruncatedText.stories.tsx
+++ b/src/components/ui/__stories__/TruncatedText.stories.tsx
@@ -4,7 +4,7 @@ import { VStack } from "../flex"
 import TruncatedText from "../TruncatedText"
 
 const meta = {
-  title: "UI / TruncatedText",
+  title: "UI / Data Display / TruncatedText",
   component: TruncatedText,
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/src/components/ui/__stories__/callout.stories.tsx
+++ b/src/components/ui/__stories__/callout.stories.tsx
@@ -17,7 +17,7 @@ import manAndDog from "@/public/images/man-and-dog-playing.png"
 import walking from "@/public/images/walking.png"
 
 const meta = {
-  title: "UI / Primitives / Callout",
+  title: "UI / Data Display / Callout",
   component: Callout,
   parameters: {
     // Default preview is layout: "centered" (flex-centered, content-width).

--- a/src/components/ui/__stories__/card.stories.tsx
+++ b/src/components/ui/__stories__/card.stories.tsx
@@ -24,7 +24,7 @@ import { Tag } from "@/components/ui/tag"
 import heroLandscape from "@/public/images/heroes/guides-hub-hero.jpg"
 
 const meta = {
-  title: "UI / Primitives / Card",
+  title: "UI / Data Display / Card",
   component: Card,
   tags: ["autodocs"],
   parameters: {

--- a/src/components/ui/__stories__/grid.stories.tsx
+++ b/src/components/ui/__stories__/grid.stories.tsx
@@ -4,7 +4,7 @@ import { Meta, StoryObj } from "@storybook/nextjs"
 import { Grid } from "@/components/ui/grid"
 
 const meta = {
-  title: "UI / Primitives / Grid",
+  title: "UI / Layout / Grid",
   component: Grid,
   parameters: {
     layout: "fullscreen",

--- a/src/layouts/stories/ContentLayout.stories.tsx
+++ b/src/layouts/stories/ContentLayout.stories.tsx
@@ -7,7 +7,7 @@ import { langViewportModes } from "@/storybook/modes"
 import { ContentLayout as ContentLayoutComponent } from "../ContentLayout"
 
 const meta = {
-  title: "Templates / ContentLayout",
+  title: "Layouts / ContentLayout",
   component: ContentLayoutComponent,
   parameters: {
     layout: "fullscreen",

--- a/src/styles/__stories__/flow-rhythm.stories.tsx
+++ b/src/styles/__stories__/flow-rhythm.stories.tsx
@@ -20,7 +20,7 @@ import { Button } from "@/components/ui/buttons/Button"
  * Spec: .claude/skills/design-system/references/typography-spacing-flow-spec.md
  */
 const meta = {
-  title: "Atoms / Typography / Flow Rhythm",
+  title: "Design System / Typography / FlowRhythm",
   parameters: {
     layout: "fullscreen",
     chromatic: {

--- a/src/styles/__stories__/heading.stories.tsx
+++ b/src/styles/__stories__/heading.stories.tsx
@@ -1,10 +1,10 @@
 import * as React from "react"
 import { Meta, StoryObj } from "@storybook/nextjs"
 
-import { Center, Stack } from "../flex"
+import { Center, Stack } from "@/components/ui/flex"
 
 const meta = {
-  title: "Atoms / Typography / Heading",
+  title: "Design System / Typography / Heading",
   parameters: {
     layout: null,
     chromatic: {

--- a/src/styles/__stories__/text.stories.tsx
+++ b/src/styles/__stories__/text.stories.tsx
@@ -1,14 +1,14 @@
 import * as React from "react"
 import { Meta, StoryObj } from "@storybook/nextjs"
 
+import Translation from "@/components/Translation"
+import { Center, Flex, Stack, VStack } from "@/components/ui/flex"
+import LinkComponent from "@/components/ui/Link"
+
 import { cn } from "@/lib/utils/cn"
 
-import Translation from "../../Translation"
-import { Center, Flex, Stack, VStack } from "../flex"
-import LinkComponent from "../Link"
-
 const meta = {
-  title: "Atoms / Typography / Text",
+  title: "Design System / Typography / Text",
   parameters: {
     layout: "none",
   },


### PR DESCRIPTION
## Summary

Phase 1 of #18967. Retitles all 117 stories so the top level is derived from the file path (`src/styles/**` -> `Design System /`, `src/components/ui/**` -> `UI /`, `src/components/**` -> `Components /`, `src/layouts/**` -> `Layouts /`, `app/**` -> `Pages /`). Drops the `UI / Primitives` middle tier and updates `storySort.order`. Fixes the collision where `HomeHero`/`HubHero`/`PageHero` all shared `Organisms / Layouts / Hero` and folded into one sidebar entry, plus the bare `FeedbackWidget` and `GlossaryDefinition` titles.

The second level is used **only where the issue's table names a group**; anything unlisted stays flat (`Components / Morpher`, `UI / Alert`) rather than going into an invented bucket. 20 stories are flat for that reason. Picking a group for an unlisted component is exactly the judgment call the repo-mirror decision exists to remove, and it would drift again with the next component added.

Two changes beyond retitling:

- **`Heading`, `Text` and `FlowRhythm` move to `src/styles/__stories__/`.** None has a backing component -- there is no `ui/heading.tsx`, `ui/text.tsx` or `ui/flow-rhythm.tsx`. They document element defaults, `text-*` size utilities and the `.flow` rhythm, all defined in `src/styles/base.css`. They belong under `Design System` and were only reachable from `UI /` because the files sat in the wrong `__stories__` directory.
- **The layouts and styles story globs become recursive.** They matched direct children only, so a story nested one directory deeper would never load and nothing would report it -- a trap for the layout stories Phase 4 adds.

**Chromatic will show all 438 snapshots as new.** That is the expected one-shot re-baseline -- retitling changes every story ID. Nothing to fix; baseline acceptance is manual.

Two defects the issue lists don't exist: `TableOfContents` was correctly titled (`The early Web` is a fixture string), and the six `CreateAccount` stories all have explicit titles. Details in [this comment](https://github.com/ethereum/ethereum-org-website/issues/18967#issuecomment-5185652061).

Base: `chore/storybook-cleanup-dead-components` (phase 0, #18969). Phase 2 targets this branch.