### PR TITLE
feat: add stories for ui/ primitive gaps (Storybook reorg phase 3)

### DIFF
--- a/src/components/ui/__stories__/arrow.stories.tsx
+++ b/src/components/ui/__stories__/arrow.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import { ArrowNext, ArrowPrev } from "../arrow"
+import { HStack, VStack } from "../flex"
+
+const meta = {
+  title: "UI / Arrow",
+  component: ArrowNext,
+  tags: ["autodocs"],
+  parameters: {
+    chromatic: { disableSnapshot: true },
+    docs: {
+      description: {
+        component:
+          "RTL-aware directional arrows -- Lucide `ArrowRight`/`ArrowLeft` with `rtl:-scale-x-100` baked in, so `ArrowNext` always points *forward* and `ArrowPrev` always points *back* regardless of writing direction. Use these for forward/back affordances rather than the raw Lucide icons. Chevron equivalents live in `@/components/Chevron`.",
+      },
+    },
+  },
+} satisfies Meta<typeof ArrowNext>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: () => (
+    <HStack className="gap-6">
+      <VStack className="gap-1">
+        <ArrowPrev />
+        <span className="text-xs text-body-medium">ArrowPrev</span>
+      </VStack>
+      <VStack className="gap-1">
+        <ArrowNext />
+        <span className="text-xs text-body-medium">ArrowNext</span>
+      </VStack>
+    </HStack>
+  ),
+}
+
+export const DirectionAware: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The same two components in an LTR and an RTL container. The glyphs mirror, so `ArrowNext` keeps pointing in the reading direction -- this is the whole reason to use these over `ArrowRight`/`ArrowLeft` directly.",
+      },
+    },
+  },
+  render: () => (
+    <VStack className="items-start gap-6">
+      {(["ltr", "rtl"] as const).map((dir) => (
+        <VStack key={dir} dir={dir} className="items-start gap-1">
+          <HStack className="gap-4">
+            <ArrowPrev />
+            <ArrowNext />
+          </HStack>
+          <span className="text-xs text-body-medium uppercase">{dir}</span>
+        </VStack>
+      ))}
+    </VStack>
+  ),
+}
+
+export const Sized: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Sizing and color come from `className` -- these are plain SVG icons, so Tailwind `size-*` and `text-*` apply.",
+      },
+    },
+  },
+  render: () => (
+    <HStack className="items-center gap-4">
+      <ArrowNext className="size-4" />
+      <ArrowNext className="size-6" />
+      <ArrowNext className="size-8 text-primary" />
+      <ArrowNext className="size-10 text-accent-a" />
+    </HStack>
+  ),
+}

--- a/src/components/ui/__stories__/blockquote.stories.tsx
+++ b/src/components/ui/__stories__/blockquote.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import Blockquote from "../blockquote"
+
+const meta = {
+  title: "UI / Blockquote",
+  component: Blockquote,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "padded",
+    chromatic: { disableSnapshot: true },
+    docs: {
+      description: {
+        component:
+          "Quoted passage on a tinted accent-a panel with a leading border. Wired as the `blockquote` MDX element, so markdown `>` quotes render through this -- it is rarely imported directly in app code. The leading border uses the logical `border-s` so it flips in RTL.",
+      },
+    },
+  },
+} satisfies Meta<typeof Blockquote>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    children:
+      "Ethereum is a technology that's home to digital money, global payments, and applications.",
+  },
+}
+
+export const MultipleParagraphs: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`space-y-[1lh]` puts exactly one line-height between children, so a multi-paragraph quote keeps the surrounding text rhythm.",
+      },
+    },
+  },
+  render: () => (
+    <Blockquote>
+      <p>
+        The community has built a booming digital economy, bold new ways for
+        creators to earn online, and so much more.
+      </p>
+      <p>
+        It&apos;s open to everyone, wherever you are in the world -- all you
+        need is the internet.
+      </p>
+    </Blockquote>
+  ),
+}
+
+export const WithAttribution: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Attribution is not a built-in slot -- compose it as a child, since `Blockquote` passes through to a plain `<blockquote>`.",
+      },
+    },
+  },
+  render: () => (
+    <Blockquote>
+      <p>Ethereum is whatever we want it to be.</p>
+      <footer className="text-sm text-body-medium">-- the community</footer>
+    </Blockquote>
+  ),
+}

--- a/src/components/ui/__stories__/button-group.stories.tsx
+++ b/src/components/ui/__stories__/button-group.stories.tsx
@@ -1,0 +1,120 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import {
+  ButtonGroup,
+  ButtonGroupSeparator,
+  ButtonGroupText,
+} from "../button-group"
+import { Button } from "../buttons/Button"
+import { VStack } from "../flex"
+
+const meta = {
+  title: "UI / ButtonGroup",
+  component: ButtonGroup,
+  tags: ["autodocs"],
+  parameters: {
+    chromatic: { disableSnapshot: true },
+    docs: {
+      description: {
+        component:
+          "Joins adjacent buttons into one segmented control by stripping the inner radii and collapsing the shared border. The seam is pure CSS on `:not(:first-child)` / `:not(:last-child)`, so it adapts to however many children you pass -- no index bookkeeping. Focus rings are lifted with `z-10` so they aren't clipped by the neighbour.\n\n`ButtonGroupText` adds a non-interactive segment (prefix, suffix, unit). Nesting a `ButtonGroup` inside another one gaps the two clusters apart instead of joining them.",
+      },
+    },
+  },
+} satisfies Meta<typeof ButtonGroup>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Horizontal: Story = {
+  render: () => (
+    <ButtonGroup>
+      <Button variant="outline">Day</Button>
+      <Button variant="outline">Week</Button>
+      <Button variant="outline">Month</Button>
+    </ButtonGroup>
+  ),
+}
+
+export const Vertical: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`orientation="vertical"` stacks the segments and moves the seam to the top/bottom edges.',
+      },
+    },
+  },
+  render: () => (
+    <ButtonGroup orientation="vertical">
+      <Button variant="outline">Top</Button>
+      <Button variant="outline">Middle</Button>
+      <Button variant="outline">Bottom</Button>
+    </ButtonGroup>
+  ),
+}
+
+export const WithText: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`ButtonGroupText` is a non-interactive segment on the highlight background -- use it for a unit or a static prefix.",
+      },
+    },
+  },
+  render: () => (
+    <ButtonGroup>
+      <ButtonGroupText>Gas</ButtonGroupText>
+      <Button variant="outline">Slow</Button>
+      <Button variant="outline">Average</Button>
+      <Button variant="outline">Fast</Button>
+      <ButtonGroupText>gwei</ButtonGroupText>
+    </ButtonGroup>
+  ),
+}
+
+export const WithSeparator: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`ButtonGroupSeparator` draws an explicit rule between segments -- useful when neighbouring buttons share a fill and the collapsed border alone doesn't read as a division.",
+      },
+    },
+  },
+  render: () => (
+    <ButtonGroup>
+      <Button variant="solid">Save</Button>
+      <ButtonGroupSeparator />
+      <Button variant="solid">Publish</Button>
+    </ButtonGroup>
+  ),
+}
+
+export const NestedGroups: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "A `ButtonGroup` whose direct children are themselves groups gets `gap-2` instead of a seam, so the clusters read as separate controls on one row.",
+      },
+    },
+  },
+  render: () => (
+    <VStack className="items-start gap-4">
+      <ButtonGroup>
+        <ButtonGroup>
+          <Button variant="outline">Bold</Button>
+          <Button variant="outline">Italic</Button>
+        </ButtonGroup>
+        <ButtonGroup>
+          <Button variant="outline">Left</Button>
+          <Button variant="outline">Center</Button>
+          <Button variant="outline">Right</Button>
+        </ButtonGroup>
+      </ButtonGroup>
+    </VStack>
+  ),
+}

--- a/src/components/ui/__stories__/carousel.stories.tsx
+++ b/src/components/ui/__stories__/carousel.stories.tsx
@@ -1,0 +1,99 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from "../carousel"
+
+const meta = {
+  title: "UI / Carousel",
+  component: Carousel,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "padded",
+    chromatic: { disableSnapshot: true },
+    docs: {
+      description: {
+        component:
+          "Embla-backed carousel. Compose `CarouselContent` + `CarouselItem`, with `CarouselPrevious` / `CarouselNext` anywhere inside the `Carousel` -- they read the API off context, so placement is free. Pass Embla options through `opts`, and grab the instance with `setApi` when you need to drive it externally (the roadmap page syncs two carousels this way).\n\n**Not recommended for new work.** It has unresolved RTL issues and its status is pending team discussion. For a plain horizontal scroll list, `EdgeScrollContainer` is the preferred component.",
+      },
+    },
+  },
+} satisfies Meta<typeof Carousel>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+const Slide = ({ n }: { n: number }) => (
+  <div className="flex h-40 items-center justify-center rounded border border-border bg-background-highlight text-h3">
+    {n}
+  </div>
+)
+
+export const Default: Story = {
+  render: () => (
+    <Carousel className="w-full max-w-xl px-14">
+      <CarouselContent>
+        {[1, 2, 3, 4, 5].map((n) => (
+          <CarouselItem key={n}>
+            <Slide n={n} />
+          </CarouselItem>
+        ))}
+      </CarouselContent>
+      <CarouselPrevious />
+      <CarouselNext />
+    </Carousel>
+  ),
+}
+
+export const MultipleVisible: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Item width is set with basis utilities on `CarouselItem` -- Embla itself doesn't own the sizing.",
+      },
+    },
+  },
+  render: () => (
+    <Carousel className="w-full max-w-xl px-14">
+      <CarouselContent>
+        {[1, 2, 3, 4, 5, 6].map((n) => (
+          <CarouselItem key={n} className="basis-1/3">
+            <Slide n={n} />
+          </CarouselItem>
+        ))}
+      </CarouselContent>
+      <CarouselPrevious />
+      <CarouselNext />
+    </Carousel>
+  ),
+}
+
+export const Looping: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Embla options go through `opts`. With `loop`, the prev/next buttons never reach a disabled state.",
+      },
+    },
+  },
+  render: () => (
+    <Carousel className="w-full max-w-xl px-14" opts={{ loop: true }}>
+      <CarouselContent>
+        {[1, 2, 3, 4].map((n) => (
+          <CarouselItem key={n}>
+            <Slide n={n} />
+          </CarouselItem>
+        ))}
+      </CarouselContent>
+      <CarouselPrevious />
+      <CarouselNext />
+    </Carousel>
+  ),
+}

--- a/src/components/ui/__stories__/eyebrow.stories.tsx
+++ b/src/components/ui/__stories__/eyebrow.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import Eyebrow from "../eyebrow"
+import { VStack } from "../flex"
+
+const meta = {
+  title: "UI / Eyebrow",
+  component: Eyebrow,
+  tags: ["autodocs"],
+  parameters: {
+    chromatic: { disableSnapshot: true },
+    docs: {
+      description: {
+        component:
+          "Small uppercase kicker in the high-contrast primary color, for the label slot above a heading. Renders a `<p>` -- it is deliberately not a heading, so it never enters the document outline. `PageHero` takes an `eyebrow` prop for this slot; `HubHero` is the exception where the eyebrow is intentionally the `<h1>`.",
+      },
+    },
+  },
+} satisfies Meta<typeof Eyebrow>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: { children: "Upgrade your knowledge" },
+}
+
+export const AboveAHeading: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: "The intended shape: kicker, then the real heading below it.",
+      },
+    },
+  },
+  render: () => (
+    <VStack className="items-start gap-1">
+      <Eyebrow>Ethereum basics</Eyebrow>
+      <h2 className="text-h2">What is Ethereum?</h2>
+    </VStack>
+  ),
+}

--- a/src/components/ui/__stories__/field.stories.tsx
+++ b/src/components/ui/__stories__/field.stories.tsx
@@ -1,0 +1,211 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import Checkbox from "../checkbox"
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+  FieldLegend,
+  FieldSeparator,
+  FieldSet,
+  FieldTitle,
+} from "../field"
+import Input from "../input"
+import Switch from "../switch"
+
+const meta = {
+  title: "UI / Forms / Field",
+  component: Field,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "padded",
+    chromatic: { disableSnapshot: true },
+    docs: {
+      description: {
+        component:
+          "Composable form-row scaffolding: label, control, description and error in one consistently spaced unit. Nothing here owns state -- wire it to whatever form library the page uses.\n\nThe pieces: `FieldSet` + `FieldLegend` for a titled group, `FieldGroup` for the spacing container, `Field` for one row, and `FieldLabel` / `FieldTitle` / `FieldDescription` / `FieldError` for the slots. `FieldSeparator` divides groups and can carry a centered word.\n\n`Field` has three orientations. `responsive` is the notable one -- it goes horizontal at the `@md` **container** query, so a field reflows on its container's width rather than the viewport's, and the same field can sit in a wide form or a narrow sidebar without a variant change.",
+      },
+    },
+  },
+} satisfies Meta<typeof Field>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Vertical: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: "Default orientation -- label above control, description below.",
+      },
+    },
+  },
+  render: () => (
+    <FieldGroup className="max-w-md">
+      <Field>
+        <FieldLabel htmlFor="node-name">Node name</FieldLabel>
+        <Input id="node-name" placeholder="my-execution-client" />
+        <FieldDescription>
+          Shown in the client dashboard. Only you can see it.
+        </FieldDescription>
+      </Field>
+    </FieldGroup>
+  ),
+}
+
+export const Horizontal: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`orientation="horizontal"` puts the label and control on one row. With a `FieldContent` wrapper the control aligns to the top so a wrapping description doesn\'t drag it off-center.',
+      },
+    },
+  },
+  render: () => (
+    <FieldGroup className="max-w-md">
+      <Field orientation="horizontal">
+        <FieldContent>
+          <FieldTitle>Testnet mode</FieldTitle>
+          <FieldDescription>
+            Point the interface at Sepolia instead of mainnet.
+          </FieldDescription>
+        </FieldContent>
+        <Switch id="testnet" />
+      </Field>
+    </FieldGroup>
+  ),
+}
+
+export const WithError: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`data-invalid` on the `Field` recolors the row, and `FieldError` renders with `role="alert"`. Pass `errors` an array and it renders a bulleted list; a single entry renders as bare text.',
+      },
+    },
+  },
+  render: () => (
+    <FieldGroup className="max-w-md">
+      <Field data-invalid="true">
+        <FieldLabel htmlFor="address">Address</FieldLabel>
+        <Input id="address" defaultValue="0xnothex" hasError />
+        <FieldError
+          errors={[
+            { message: "Must be a 42-character hex string." },
+            { message: "Checksum does not match." },
+          ]}
+        />
+      </Field>
+    </FieldGroup>
+  ),
+}
+
+export const SelectableCards: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "A `FieldLabel` wrapping a `Field` becomes a bordered, selectable card -- `has-data-[state=checked]:` lights up the border and tint from the control's own state, with no JS.",
+      },
+    },
+  },
+  render: () => (
+    <FieldGroup className="max-w-md">
+      {[
+        {
+          id: "solo",
+          title: "Solo staking",
+          description: "Run your own validator with 32 ETH.",
+        },
+        {
+          id: "pooled",
+          title: "Pooled staking",
+          description: "Stake any amount through a pool.",
+        },
+      ].map(({ id, title, description }) => (
+        <FieldLabel key={id} htmlFor={id}>
+          <Field orientation="horizontal">
+            <FieldContent>
+              <FieldTitle>{title}</FieldTitle>
+              <FieldDescription>{description}</FieldDescription>
+            </FieldContent>
+            <Checkbox id={id} />
+          </Field>
+        </FieldLabel>
+      ))}
+    </FieldGroup>
+  ),
+}
+
+export const FieldSetWithSeparator: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`FieldSet` renders a real `<fieldset>` with `FieldLegend` as its `<legend>`. `FieldSeparator` divides groups, optionally with a centered word.",
+      },
+    },
+  },
+  render: () => (
+    <FieldSet className="max-w-md">
+      <FieldLegend>Notifications</FieldLegend>
+      <FieldGroup>
+        <Field orientation="horizontal">
+          <FieldContent>
+            <FieldTitle>Protocol upgrades</FieldTitle>
+            <FieldDescription>Network-wide changes only.</FieldDescription>
+          </FieldContent>
+          <Switch id="upgrades" defaultChecked />
+        </Field>
+        <FieldSeparator>or</FieldSeparator>
+        <Field orientation="horizontal">
+          <FieldContent>
+            <FieldTitle>Everything</FieldTitle>
+            <FieldDescription>Every release note we publish.</FieldDescription>
+          </FieldContent>
+          <Switch id="everything" />
+        </Field>
+      </FieldGroup>
+    </FieldSet>
+  ),
+}
+
+export const ResponsiveOrientation: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same `orientation="responsive"` field in a wide and a narrow container. It flips on the **container** query (`@md/field-group`), not the viewport -- resize nothing to see both states.',
+      },
+    },
+  },
+  render: () => (
+    <div className="flex flex-col gap-8">
+      {[
+        { label: "Wide container", width: "w-full max-w-2xl" },
+        { label: "Narrow container", width: "w-64" },
+      ].map(({ label, width }) => (
+        <div key={label} className="flex flex-col gap-2">
+          <span className="text-xs text-body-medium uppercase">{label}</span>
+          <FieldGroup className={width}>
+            <Field orientation="responsive">
+              <FieldContent>
+                <FieldTitle>Auto-update</FieldTitle>
+                <FieldDescription>
+                  Pull new releases as they ship.
+                </FieldDescription>
+              </FieldContent>
+              <Switch id={`auto-${label}`} />
+            </Field>
+          </FieldGroup>
+        </div>
+      ))}
+    </div>
+  ),
+}

--- a/src/components/ui/__stories__/hr.stories.tsx
+++ b/src/components/ui/__stories__/hr.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import HR from "../hr"
+
+const meta = {
+  title: "UI / HR",
+  component: HR,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "padded",
+    chromatic: { disableSnapshot: true },
+    docs: {
+      description: {
+        component:
+          "The canonical horizontal rule, also wired as the `hr` MDX element. Always carries `my-space-3x` vertical rhythm, so it spaces itself -- don't add margins at the call site. For dividing content inside a component (menu, button group), reach for `Separator` instead.\n\nThe `narrow` variant and the `Divider` named export are deprecated and deliberately not shown -- a rendered example reads as an endorsement. Use a plain `<HR />`.",
+      },
+    },
+  },
+} satisfies Meta<typeof HR>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "No props -- a plain full-width rule. This is the going-forward separator.",
+      },
+    },
+  },
+  render: () => (
+    <div className="w-full">
+      <p>Above the rule.</p>
+      <HR />
+      <p>Below the rule.</p>
+    </div>
+  ),
+}
+
+export const Indented: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`position="indent"` insets both ends by the responsive page gutter (`mx-page`). Only for a full-bleed rule -- inside an already-padded section it doubles the gutter. The inset uses margin, not padding: a default `HR` draws its line as the top border, which spans the full border-box and ignores padding.',
+      },
+    },
+  },
+  render: () => (
+    <div className="w-full">
+      <HR position="indent" />
+    </div>
+  ),
+}

--- a/src/components/ui/__stories__/kbd.stories.tsx
+++ b/src/components/ui/__stories__/kbd.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import { HStack } from "../flex"
+import KBD from "../kbd"
+
+const meta = {
+  title: "UI / KBD",
+  component: KBD,
+  tags: ["autodocs"],
+  parameters: {
+    chromatic: { disableSnapshot: true },
+    docs: {
+      description: {
+        component:
+          "Keyboard key. Renders a real `<kbd>` with a primary outline, and is wired as the `kbd` MDX element so markdown docs get it for free. `align-middle` keeps it on the baseline when it sits inside a sentence.",
+      },
+    },
+  },
+} satisfies Meta<typeof KBD>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: { children: "Esc" },
+}
+
+export const Combination: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "A chord is separate `KBD` elements with the joining character as plain text between them.",
+      },
+    },
+  },
+  render: () => (
+    <HStack className="items-center gap-1">
+      <KBD>Ctrl</KBD>
+      <span>+</span>
+      <KBD>K</KBD>
+    </HStack>
+  ),
+}
+
+export const Inline: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Inside running text -- the common case, since this backs the markdown `kbd` element.",
+      },
+    },
+  },
+  render: () => (
+    <p className="max-w-prose">
+      Press <KBD>/</KBD> to focus search, then <KBD>Enter</KBD> to open the
+      first result. <KBD>Esc</KBD> closes the dialog.
+    </p>
+  ),
+}

--- a/src/components/ui/__stories__/label.stories.tsx
+++ b/src/components/ui/__stories__/label.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import Checkbox from "../checkbox"
+import { HStack, VStack } from "../flex"
+import Input from "../input"
+import { Label } from "../label"
+
+const meta = {
+  title: "UI / Forms / Label",
+  component: Label,
+  tags: ["autodocs"],
+  parameters: {
+    chromatic: { disableSnapshot: true },
+    docs: {
+      description: {
+        component:
+          "Radix Label. Associates text with a control via `htmlFor`, which also makes the label click-target activate the control. Carries `peer-disabled:` styling, so a label placed after a `peer`-marked disabled input dims automatically. `Field`/`FieldLabel` compose this -- prefer those when you need description and error slots too.",
+      },
+    },
+  },
+} satisfies Meta<typeof Label>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const WithInput: Story = {
+  render: () => (
+    <VStack className="w-72 items-start gap-2">
+      <Label htmlFor="email">Email address</Label>
+      <Input id="email" type="email" placeholder="you@example.com" />
+    </VStack>
+  ),
+}
+
+export const WithCheckbox: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Matching `htmlFor`/`id` makes the label text itself toggle the checkbox.",
+      },
+    },
+  },
+  render: () => (
+    <HStack className="items-center gap-2">
+      <Checkbox id="newsletter" />
+      <Label htmlFor="newsletter">Send me the newsletter</Label>
+    </HStack>
+  ),
+}
+
+export const DisabledPeer: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`peer-disabled:opacity-70` fires when the control is marked `peer` and disabled, so the label dims without extra wiring.",
+      },
+    },
+  },
+  render: () => (
+    <HStack className="items-center gap-2">
+      <Checkbox id="unavailable" className="peer" disabled />
+      <Label htmlFor="unavailable">Currently unavailable</Label>
+    </HStack>
+  ),
+}

--- a/src/components/ui/__stories__/separator.stories.tsx
+++ b/src/components/ui/__stories__/separator.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import { HStack, VStack } from "../flex"
+import { Separator } from "../separator"
+
+const meta = {
+  title: "UI / Separator",
+  component: Separator,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "padded",
+    chromatic: { disableSnapshot: true },
+    docs: {
+      description: {
+        component:
+          "Radix Separator -- a hairline `bg-border` rule for dividing content *within* a component (menus, button groups, inline metadata). For a page- or section-level rule with vertical rhythm, use `HR` instead. Defaults to `decorative` (aria-hidden); pass `decorative={false}` when the divide carries real meaning for assistive tech.",
+      },
+    },
+  },
+} satisfies Meta<typeof Separator>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Horizontal: Story = {
+  render: () => (
+    <VStack className="w-72 items-stretch gap-4">
+      <span>Above</span>
+      <Separator />
+      <span>Below</span>
+    </VStack>
+  ),
+}
+
+export const Vertical: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`orientation="vertical"` renders a `w-px` full-height rule. The parent must establish a height -- here `h-5` on the row.',
+      },
+    },
+  },
+  render: () => (
+    <HStack className="h-5 items-center gap-4 text-sm">
+      <span>Docs</span>
+      <Separator orientation="vertical" />
+      <span>Tutorials</span>
+      <Separator orientation="vertical" />
+      <span>Glossary</span>
+    </HStack>
+  ),
+}

--- a/src/components/ui/__stories__/wide-table.stories.tsx
+++ b/src/components/ui/__stories__/wide-table.stories.tsx
@@ -1,0 +1,114 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "../table"
+import WideTable from "../wide-table"
+
+const meta = {
+  title: "UI / WideTable",
+  component: WideTable,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "padded",
+    chromatic: { disableSnapshot: true },
+    docs: {
+      description: {
+        component:
+          "Wrapper that forces a contained `<table>` to `min-w-5xl table-fixed`, so a table with many columns keeps readable column widths and overflows instead of crushing. It only sets those two rules -- pair it with a scrolling ancestor (`EdgeScrollContainer`, or a plain `overflow-x-auto`) or the overflow will push the page sideways.",
+      },
+    },
+  },
+} satisfies Meta<typeof WideTable>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+const COLUMNS = [
+  "Network",
+  "Type",
+  "Consensus",
+  "Settlement",
+  "Data availability",
+  "Sequencer",
+  "Proof system",
+]
+
+const ROWS = [
+  ["Ethereum", "L1", "Proof-of-stake", "--", "On-chain", "--", "--"],
+  [
+    "Optimistic L2",
+    "L2",
+    "Inherited",
+    "Ethereum",
+    "Ethereum",
+    "Centralized",
+    "Fraud proofs",
+  ],
+  [
+    "Validity L2",
+    "L2",
+    "Inherited",
+    "Ethereum",
+    "Ethereum",
+    "Centralized",
+    "Validity proofs",
+  ],
+]
+
+const SevenColumnTable = () => (
+  <Table variant="simple">
+    <TableHeader>
+      <TableRow>
+        {COLUMNS.map((c) => (
+          <TableHead key={c}>{c}</TableHead>
+        ))}
+      </TableRow>
+    </TableHeader>
+    <TableBody>
+      {ROWS.map((row) => (
+        <TableRow key={row[0]}>
+          {row.map((cell, i) => (
+            <TableCell key={i}>{cell}</TableCell>
+          ))}
+        </TableRow>
+      ))}
+    </TableBody>
+  </Table>
+)
+
+export const Wrapped: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Seven columns inside `WideTable`, with `overflow-x-auto` on the ancestor supplying the scroll. Columns stay legible and the table scrolls horizontally.",
+      },
+    },
+  },
+  render: () => (
+    <div className="overflow-x-auto">
+      <WideTable>
+        <SevenColumnTable />
+      </WideTable>
+    </div>
+  ),
+}
+
+export const Unwrapped: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The same seven columns with no wrapper, for comparison -- the table shrinks to the container and the cells wrap.",
+      },
+    },
+  },
+  render: () => <SevenColumnTable />,
+}


### PR DESCRIPTION
## Summary

Phase 3 of #18967. Covers the remaining `ui/` primitives so the UI section isn't missing a quarter of what it documents: `Arrow`, `Blockquote`, `ButtonGroup`, `Carousel`, `Eyebrow`, `Field`, `HR`, `KBD`, `Label`, `Separator`, `WideTable`. `Field` and `Label` sit under `UI / Forms` because the issue's table names them there; the rest are unlisted and stay flat, per the convention Phase 1 settled on.

**Deprecated things get no story.** A rendered example reads as an endorsement whatever the caption says, so `Swiper` -- on the issue's list, but on the path to removal in favor of `EdgeScrollContainer` -- is left uncovered, and the `HR` story documents the deprecated `narrow` variant and `Divider` export in prose without rendering them. `Carousel` keeps its story: it isn't deprecated, its status is pending team discussion, and its blurb says it isn't for new work.

Two departures from the issue's Phase 3 list:

- **`dialog-modal` dropped** -- it already has a story. `UI / Overlays / Modal` imports `../dialog-modal`, so the gap audit's filename matching missed it.
- **`ui/tooltip` deliberately left uncovered.** Not on the issue's list, and the `design-system` skill says not to import it directly -- it exists only inside `@/components/Tooltip`, which has its own story. A showcase entry would advertise the wrong import.

Verified: `pnpm build-storybook` clean, Phase 2's taxonomy test passes. Every `ui/` story disables Chromatic snapshots, so **this adds no snapshot cost**.

Base: `test/storybook-title-taxonomy` (phase 2, #18971).