### PR TITLE
feat: add shared-component and layout stories (Storybook reorg phase 4)

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -48,6 +48,13 @@ const config: StorybookConfig = {
       config.resolve.alias = {
         ...config.resolve.alias,
         "@/storybook/*": path.resolve(process.cwd(), ".storybook"),
+        // Async server components render in the browser here, where the real
+        // helpers throw. See the shim's header for why this is a swap, not a
+        // fake. `$` keeps it an exact-request match.
+        "next-intl/server$": path.resolve(
+          process.cwd(),
+          ".storybook/next-intl-server.tsx"
+        ),
       }
     }
 

--- a/.storybook/next-intl-server.tsx
+++ b/.storybook/next-intl-server.tsx
@@ -1,0 +1,76 @@
+// Storybook stand-in for `next-intl/server`, wired up by the webpack alias in
+// `main.ts`.
+//
+// Storybook renders async server components in the browser (`experimentalRSC`),
+// but the real `next-intl/server` helpers read from a request scope that only
+// exists on the server, so they throw "not supported in Client Components" and
+// the story shows an error boundary instead. Any async component reaching for
+// `getTranslations`/`getLocale` is therefore invisible in Storybook -- which is
+// how the Footer story sat broken behind `disableSnapshot`.
+//
+// The shim resolves against the exact same `messagesByLocale` the client
+// provider uses, and against the locale currently selected in the toolbar, so a
+// server component and a client component render the same strings in the same
+// language. It is a transport swap, not a fake.
+
+import { createFormatter, createTranslator } from "next-intl"
+
+import nextIntl from "./next-intl"
+
+/**
+ * Async server helpers can't read React context, so the toolbar locale is
+ * republished here by a decorator in `preview.tsx` before each render.
+ */
+let currentLocale: string = nextIntl.defaultLocale
+
+export const setStorybookLocale = (locale: string) => {
+  currentLocale = locale
+}
+
+type TranslationsArg = string | { locale?: string; namespace?: string }
+
+const resolve = (arg?: TranslationsArg) => {
+  if (typeof arg === "string") return { locale: currentLocale, namespace: arg }
+  return {
+    locale: arg?.locale ?? currentLocale,
+    namespace: arg?.namespace,
+  }
+}
+
+const messagesFor = (locale: string) =>
+  nextIntl.messagesByLocale[locale] ??
+  nextIntl.messagesByLocale[nextIntl.defaultLocale] ??
+  {}
+
+export async function getLocale() {
+  return currentLocale
+}
+
+export async function getMessages(arg?: { locale?: string }) {
+  return messagesFor(arg?.locale ?? currentLocale)
+}
+
+export async function getTranslations(arg?: TranslationsArg) {
+  const { locale, namespace } = resolve(arg)
+  return createTranslator({
+    locale,
+    namespace,
+    messages: messagesFor(locale),
+    getMessageFallback: nextIntl.getMessageFallback,
+  })
+}
+
+export async function getFormatter(arg?: { locale?: string }) {
+  return createFormatter({ locale: arg?.locale ?? currentLocale })
+}
+
+export async function getNow() {
+  return new Date()
+}
+
+export async function getTimeZone() {
+  return "UTC"
+}
+
+/** No request scope to set in Storybook -- accepted and ignored. */
+export function setRequestLocale(_locale: string) {}

--- a/.storybook/next-intl.ts
+++ b/.storybook/next-intl.ts
@@ -9,6 +9,7 @@ export const baseLocales = {
 // Only i18n files named in this array are being exposed to Storybook. Add filenames as necessary.
 export const ns = [
   "common",
+  "component-story-card",
   "component-wallet-simulator",
   "glossary",
   "glossary-tooltip",
@@ -26,6 +27,7 @@ export const ns = [
   "page-upgrades-index",
   "page-wallets-find-wallet",
   "page-developers-docs",
+  "page-developers-tutorials",
   "table",
 ] as const
 const supportedLngs = Object.keys(baseLocales)

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -7,6 +7,7 @@ import ThemeProvider from "@/components/ThemeProvider"
 import { TooltipProvider } from "@/components/ui/tooltip"
 
 import nextIntl, { baseLocales } from "./next-intl"
+import { setStorybookLocale } from "./next-intl-server"
 import { withNextThemes } from "./withNextThemes"
 
 import "../src/styles/global.css"
@@ -38,6 +39,13 @@ export const breakpointSet: [token: string, value: string][] = [
 
 const preview: Preview = {
   decorators: [
+    // Republishes the toolbar locale for the `next-intl/server` shim, which is
+    // outside React and so can't read the provider's context. Must stay ahead
+    // of the story in this list so it lands before an async component runs.
+    (Story, context) => {
+      setStorybookLocale(context.globals.locale ?? nextIntl.defaultLocale)
+      return <Story />
+    },
     withNextThemes({
       themes: {
         light: "light",

--- a/src/components/BigNumber/BigNumber.stories.tsx
+++ b/src/components/BigNumber/BigNumber.stories.tsx
@@ -1,0 +1,85 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import { HStack } from "@/components/ui/flex"
+
+import BigNumber from "."
+
+const meta = {
+  title: "Components / Data Viz / BigNumber",
+  component: BigNumber,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "padded",
+    chromatic: { disableSnapshot: true },
+    docs: {
+      description: {
+        component:
+          "A single headline statistic with its caption, and optionally its provenance. When `sourceName`/`sourceUrl`/`lastUpdated` are supplied it renders an info tooltip attributing the figure -- pass them whenever the number comes from an external feed, since an unattributed statistic is the thing readers challenge.\n\nAn async server component: it awaits the locale to format `lastUpdated`. The `default` variant flexes to fill a row of siblings; `light` is the compact treatment for denser contexts.",
+      },
+    },
+  },
+} satisfies Meta<typeof BigNumber>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    value: "1,048,576",
+    children: "Active validators securing the network",
+  },
+}
+
+export const WithSource: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "With attribution, an info icon appears next to the caption; the tooltip carries the source link and the formatted last-updated date.",
+      },
+    },
+  },
+  args: {
+    value: "1,048,576",
+    children: "Active validators securing the network",
+    sourceName: "beaconcha.in",
+    sourceUrl: "https://beaconcha.in",
+    lastUpdated: "2026-08-01T00:00:00.000Z",
+  },
+}
+
+export const LightVariant: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`variant="light"` drops the responsive size bump and mutes the caption -- for denser groupings where the figure shouldn\'t dominate.',
+      },
+    },
+  },
+  args: {
+    variant: "light",
+    value: "32 ETH",
+    children: "Required to run a solo validator",
+  },
+}
+
+export const InARow: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The `default` variant is `flex-1`, so siblings share a row evenly without width props.",
+      },
+    },
+  },
+  args: { children: "Active validators" },
+  render: () => (
+    <HStack className="w-full items-stretch gap-4">
+      <BigNumber value="1,048,576">Active validators</BigNumber>
+      <BigNumber value="32 ETH">Stake per validator</BigNumber>
+      <BigNumber value="~12s">Slot time</BigNumber>
+    </HStack>
+  ),
+}

--- a/src/components/Chevron/Chevron.stories.tsx
+++ b/src/components/Chevron/Chevron.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import { HStack, VStack } from "@/components/ui/flex"
+
+import { ChevronNext, ChevronPrev } from "."
+
+const meta = {
+  title: "Components / Chevron",
+  component: ChevronNext,
+  tags: ["autodocs"],
+  parameters: {
+    chromatic: { disableSnapshot: true },
+    docs: {
+      description: {
+        component:
+          "RTL-aware chevrons -- Lucide `ChevronRight`/`ChevronLeft` with `rtl:-scale-x-100` baked in, so `ChevronNext` always points forward. The chevron counterpart to `ArrowNext`/`ArrowPrev` (`@/components/ui/arrow`): reach for a chevron on compact affordances (carousel controls, disclosure, breadcrumb separators) and an arrow for prominent forward links.",
+      },
+    },
+  },
+} satisfies Meta<typeof ChevronNext>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: () => (
+    <HStack className="gap-6">
+      <VStack className="gap-1">
+        <ChevronPrev />
+        <span className="text-xs text-body-medium">ChevronPrev</span>
+      </VStack>
+      <VStack className="gap-1">
+        <ChevronNext />
+        <span className="text-xs text-body-medium">ChevronNext</span>
+      </VStack>
+    </HStack>
+  ),
+}
+
+export const DirectionAware: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The glyphs mirror in an RTL container, so `ChevronNext` keeps pointing in the reading direction.",
+      },
+    },
+  },
+  render: () => (
+    <VStack className="items-start gap-6">
+      {(["ltr", "rtl"] as const).map((dir) => (
+        <VStack key={dir} dir={dir} className="items-start gap-1">
+          <HStack className="gap-4">
+            <ChevronPrev />
+            <ChevronNext />
+          </HStack>
+          <span className="text-xs text-body-medium uppercase">{dir}</span>
+        </VStack>
+      ))}
+    </VStack>
+  ),
+}

--- a/src/components/DataTable/DataTable.stories.tsx
+++ b/src/components/DataTable/DataTable.stories.tsx
@@ -1,0 +1,116 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+import type { ColumnDef } from "@tanstack/react-table"
+
+import DataTable from "."
+
+type Network = {
+  name: string
+  type: string
+  settlement: string
+  detail: string
+}
+
+const DATA: Network[] = [
+  {
+    name: "Arbitrum One",
+    type: "Optimistic rollup",
+    settlement: "Ethereum",
+    detail: "Fraud proofs with a seven-day challenge window.",
+  },
+  {
+    name: "Base",
+    type: "Optimistic rollup",
+    settlement: "Ethereum",
+    detail: "Built on the OP Stack.",
+  },
+  {
+    name: "Starknet",
+    type: "Validity rollup",
+    settlement: "Ethereum",
+    detail: "STARK proofs; a non-EVM execution environment.",
+  },
+]
+
+const COLUMNS: ColumnDef<Network>[] = [
+  { accessorKey: "name", header: "Network" },
+  { accessorKey: "type", header: "Type" },
+  { accessorKey: "settlement", header: "Settles to" },
+]
+
+// Instantiated up front: `satisfies Meta<typeof DataTable<Network, unknown>>`
+// alone leaves the args inferred as `ColumnDef<unknown, unknown>[]`.
+const NetworkDataTable = DataTable<Network, unknown>
+
+const meta = {
+  title: "Components / DataTable",
+  component: NetworkDataTable,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "padded",
+    chromatic: { disableSnapshot: true },
+    docs: {
+      description: {
+        component:
+          "TanStack Table bound to the `ui/table` primitives, backing the filterable product/network directories. Pass `columns` and `data`; `subComponent` adds an expandable detail row per record.\n\nThe filter-related props are reporting inputs, not behavior: `allDataLength` and `activeFiltersCount` describe the *unfiltered* set and the active filter count so the table can render an accurate empty state. Filtering itself happens upstream -- this component only receives the result. `matomoEventCategory` is required because row expansion is tracked.",
+      },
+    },
+  },
+} satisfies Meta<typeof NetworkDataTable>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    columns: COLUMNS,
+    data: DATA,
+    allDataLength: DATA.length,
+    activeFiltersCount: 0,
+    matomoEventCategory: "storybook demo table",
+  },
+}
+
+export const WithExpandableRows: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`subComponent` renders a detail panel under a row when it is expanded.",
+      },
+    },
+  },
+  args: {
+    columns: COLUMNS,
+    data: DATA,
+    allDataLength: DATA.length,
+    activeFiltersCount: 0,
+    matomoEventCategory: "storybook demo table",
+    subComponent: (row: Network) => (
+      <div className="p-4 text-sm text-body-medium">{row.detail}</div>
+    ),
+  },
+}
+
+export const NoResults: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Empty `data` with a non-zero `activeFiltersCount` -- the filtered-to-nothing state, distinct from having no data at all.",
+      },
+    },
+  },
+  args: {
+    columns: COLUMNS,
+    data: [],
+    allDataLength: DATA.length,
+    activeFiltersCount: 2,
+    matomoEventCategory: "storybook demo table",
+    noResultsComponent: () => (
+      <div className="p-8 text-center text-body-medium">
+        No networks match the current filters.
+      </div>
+    ),
+  },
+}

--- a/src/components/FeaturedText/FeaturedText.stories.tsx
+++ b/src/components/FeaturedText/FeaturedText.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import FeaturedText from "."
+
+const meta = {
+  title: "Components / FeaturedText",
+  component: FeaturedText,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "padded",
+    chromatic: { disableSnapshot: true },
+    docs: {
+      description: {
+        component:
+          "Marks a passage with a dashed primary border on the leading edge. Uses logical properties (`-ms-4` / `ps-4` / `border-s`), so the accent flips to the right edge in RTL. The negative inline-start margin pulls the border into the gutter, keeping the text itself aligned with the surrounding column.",
+      },
+    },
+  },
+} satisfies Meta<typeof FeaturedText>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: () => (
+    <div className="max-w-prose">
+      <p>
+        Ordinary paragraph above, for alignment reference against the featured
+        block below.
+      </p>
+      <FeaturedText>
+        <p>
+          Ethereum is open to everyone. All you need is a wallet to participate.
+        </p>
+      </FeaturedText>
+    </div>
+  ),
+}
+
+export const RTL: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: "The dashed accent moves to the right edge in an RTL container.",
+      },
+    },
+  },
+  render: () => (
+    <div dir="rtl" className="max-w-prose">
+      <FeaturedText>
+        <p>إيثريوم مفتوح للجميع. كل ما تحتاجه هو محفظة للمشاركة.</p>
+      </FeaturedText>
+    </div>
+  ),
+}

--- a/src/components/LanguagePicker/LanguagePicker.stories.tsx
+++ b/src/components/LanguagePicker/LanguagePicker.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import type { LocaleDisplayInfo } from "@/lib/types"
+
+import LanguagePicker from "."
+
+const LANGUAGES: LocaleDisplayInfo[] = [
+  {
+    localeOption: "en",
+    sourceName: "English",
+    targetName: "English",
+    englishName: "English",
+    isBrowserDefault: true,
+  },
+  {
+    localeOption: "es",
+    sourceName: "Spanish",
+    targetName: "Espanol",
+    englishName: "Spanish",
+  },
+  {
+    localeOption: "de",
+    sourceName: "German",
+    targetName: "Deutsch",
+    englishName: "German",
+  },
+  {
+    localeOption: "ja",
+    sourceName: "Japanese",
+    targetName: "日本語",
+    englishName: "Japanese",
+  },
+  {
+    localeOption: "ar",
+    sourceName: "Arabic",
+    targetName: "العربية",
+    englishName: "Arabic",
+  },
+  {
+    localeOption: "zh",
+    sourceName: "Chinese Simplified",
+    targetName: "简体中文",
+    englishName: "Chinese Simplified",
+  },
+]
+
+const meta = {
+  title: "Components / Site Chrome / LanguagePicker",
+  component: LanguagePicker,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "padded",
+    chromatic: { disableSnapshot: true },
+    docs: {
+      description: {
+        component:
+          "The locale switcher in the site nav. Takes a prepared `LocaleDisplayInfo[]` -- it does no locale resolution itself, so the same component serves the desktop menu and the mobile sheet.\n\nEach entry carries both a `sourceName` (the language in the *current* UI language) and a `targetName` (the language in its own script), which is what lets a reader who can't read the current UI language still find their own. `isBrowserDefault` surfaces the browser-preferred locale near the top.\n\nThe menu renders inline rather than behind a trigger -- the nav supplies its own disclosure around it. Selecting a locale performs a hard navigation by design: a soft push to an intercepting `@modal` route would re-open the modal instead of switching locale.",
+      },
+    },
+  },
+} satisfies Meta<typeof LanguagePicker>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: { languages: LANGUAGES },
+}
+
+export const SingleLanguage: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "One entry -- the search field and the no-results path still render, so the empty state stays reachable.",
+      },
+    },
+  },
+  args: { languages: [LANGUAGES[0]] },
+}

--- a/src/components/LanguagePicker/NoResultsCallout.tsx
+++ b/src/components/LanguagePicker/NoResultsCallout.tsx
@@ -10,7 +10,7 @@ const NoResultsCallout = ({ onClose }: NoResultsCalloutProps) => {
     <div>
       <p className="mb-2 font-bold">{t("page-languages-want-more-header")}</p>
       <p className="text-body-medium">
-        {t.rich("common.page-languages-want-more-paragraph", {
+        {t.rich("page-languages-want-more-paragraph", {
           a: (chunks) => (
             <BaseLink
               key="item-no-results"

--- a/src/components/PageActions/PageActions.stories.tsx
+++ b/src/components/PageActions/PageActions.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import PageActions from "."
+
+const meta = {
+  title: "Components / PageActions",
+  component: PageActions,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "padded",
+    chromatic: { disableSnapshot: true },
+    docs: {
+      description: {
+        component:
+          "The row of per-page utilities that sits under an article: copy-page-as-markdown, edit-on-GitHub, and the listen-to player. Which controls appear is derived, not configured -- the player only renders when `getPlaylistBySlug(slug)` finds a playlist for the slug, so passing a slug without one is the normal case rather than an error state.",
+      },
+    },
+  },
+} satisfies Meta<typeof PageActions>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: { slug: "/developers/docs/intro-to-ethereum/" },
+}
+
+export const WithEditPath: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`editPath` points the GitHub link at a specific source file rather than the slug-derived default.",
+      },
+    },
+  },
+  args: {
+    slug: "/developers/docs/intro-to-ethereum/",
+    editPath:
+      "https://github.com/ethereum/ethereum-org-website/tree/dev/public/content/developers/docs/intro-to-ethereum/index.md",
+  },
+}
+
+export const EditButtonHidden: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`hideEditButton` drops the GitHub link -- used on pages whose source isn't editable in this repo.",
+      },
+    },
+  },
+  args: { slug: "/developers/docs/intro-to-ethereum/", hideEditButton: true },
+}
+
+export const Translated: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: "`isTranslated` marks the page as having localized content.",
+      },
+    },
+  },
+  args: { slug: "/developers/docs/intro-to-ethereum/", isTranslated: true },
+}

--- a/src/components/RadialChart/RadialChart.stories.tsx
+++ b/src/components/RadialChart/RadialChart.stories.tsx
@@ -1,0 +1,87 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import { HStack } from "@/components/ui/flex"
+
+import RadialChart from "."
+
+const meta = {
+  title: "Components / Data Viz / RadialChart",
+  component: RadialChart,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "padded",
+    chromatic: { disableSnapshot: true },
+    docs: {
+      description: {
+        component:
+          "Single-series radial gauge (Recharts `RadialBarChart`) for one proportion. With `totalValue` it renders `value / totalValue`; without it, `value` is read as a percentage. `displayValue` overrides the centered readout when the raw number isn't what you want shown.\n\nAttribution works the same as `BigNumber` -- `sourceName` / `sourceUrl` / `lastUpdated` add an info tooltip. The chart gates on a mounted flag before rendering, since Recharts needs real element dimensions.",
+      },
+    },
+  },
+} satisfies Meta<typeof RadialChart>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Percentage: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: "No `totalValue` -- `value` is treated as a percentage.",
+      },
+    },
+  },
+  args: { value: 68, label: "Stake participation" },
+}
+
+export const OutOfTotal: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: "With `totalValue`, the arc fills to `value / totalValue`.",
+      },
+    },
+  },
+  args: { value: 24, totalValue: 32, label: "ETH staked" },
+}
+
+export const CustomDisplayValue: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`displayValue` replaces the centered readout -- use it when the underlying number needs units or rounding the chart shouldn't infer.",
+      },
+    },
+  },
+  args: { value: 24, totalValue: 32, displayValue: "24 ETH", label: "Staked" },
+}
+
+export const WithSource: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: "Attribution tooltip, for figures pulled from an external feed.",
+      },
+    },
+  },
+  args: {
+    value: 68,
+    label: "Stake participation",
+    sourceName: "beaconcha.in",
+    sourceUrl: "https://beaconcha.in",
+    lastUpdated: "2026-08-01T00:00:00.000Z",
+  },
+}
+
+export const InARow: Story = {
+  args: { value: 68, label: "Participation" },
+  render: () => (
+    <HStack className="w-full items-stretch gap-4">
+      <RadialChart value={68} label="Participation" />
+      <RadialChart value={24} totalValue={32} label="ETH staked" />
+      <RadialChart value={92} label="Client diversity" />
+    </HStack>
+  ),
+}

--- a/src/components/StoryCard/StoryCard.stories.tsx
+++ b/src/components/StoryCard/StoryCard.stories.tsx
@@ -1,0 +1,93 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import type { Story as CommunityStory } from "@/lib/types"
+
+import StoryCard from "."
+
+const SHORT: CommunityStory = {
+  storyKey: "short",
+  name: "Ama",
+  story:
+    "I sent my first transaction on a bus in Accra and it settled before my stop. That was the moment it stopped being theory.",
+  storyOriginal: null,
+  twitter: null,
+  country: "Ghana",
+  date: "2025-03-14",
+}
+
+const LONG: CommunityStory = {
+  storyKey: "long",
+  name: "Mateo",
+  story: [
+    "I found Ethereum through a game. A friend sent me a link, I made a wallet, and I spent a weekend reading about what was actually happening underneath.",
+    "Two years later I maintain a small library that other people depend on. I have never met most of them, and we have shipped together across six time zones.",
+    "What kept me here was not the price. It was that nobody had to give me permission to start.",
+  ].join("\n\n"),
+  storyOriginal: [
+    "Encontre Ethereum a traves de un juego. Un amigo me envio un enlace, cree una billetera y pase un fin de semana leyendo sobre lo que realmente pasaba por debajo.",
+    "Dos anos despues mantengo una pequena libreria de la que dependen otras personas. Nunca conoci a la mayoria, y hemos publicado juntos en seis zonas horarias.",
+    "Lo que me mantuvo aqui no fue el precio. Fue que nadie tuvo que darme permiso para empezar.",
+  ].join("\n\n"),
+  twitter: "https://twitter.com/ethereum",
+  country: "Argentina",
+  date: "2024-11-02",
+}
+
+const meta = {
+  title: "Components / StoryCard",
+  component: StoryCard,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "padded",
+    chromatic: { disableSnapshot: true },
+    docs: {
+      description: {
+        component:
+          "A single community story, used on `/stories` and `/10years`. Self-contained state, so it drops into a single-column list or a masonry grid unchanged.\n\nTwo behaviors worth knowing. The **flip toggle** swaps between the localized copy and the original-language submission, and hides itself when `storyOriginal` is absent or identical to `story` -- an English submission read in English shows no toggle. The **read-more expander** is gated behind `expandable`: pass `false` in masonry layouts, where an inline height change would reflow every column.",
+      },
+    },
+  },
+} satisfies Meta<typeof StoryCard>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: { story: LONG },
+}
+
+export const NoOriginalLanguage: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`storyOriginal: null` -- the flip toggle is hidden because there is nothing to flip to.",
+      },
+    },
+  },
+  args: { story: SHORT },
+}
+
+export const NotExpandable: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`expandable={false}` shows the copy in full and drops the read-more control. This is what `/stories` uses so its masonry columns don't reflow.",
+      },
+    },
+  },
+  args: { story: LONG, expandable: false },
+}
+
+export const WithoutDate: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: "`showDate={false}` hides the submission date.",
+      },
+    },
+  },
+  args: { story: LONG, showDate: false },
+}

--- a/src/components/WindowBox/WindowBox.stories.tsx
+++ b/src/components/WindowBox/WindowBox.stories.tsx
@@ -1,0 +1,51 @@
+import { Wallet } from "lucide-react"
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import WindowBox from "."
+
+const meta = {
+  title: "Components / WindowBox",
+  component: WindowBox,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "padded",
+    chromatic: { disableSnapshot: true },
+    docs: {
+      description: {
+        component:
+          "Framed panel with a titled header bar -- an icon in a rounded plate, a bold title, and an arbitrary body below. The header carries a subtle top-down primary wash that deepens in dark mode. Capped at `max-w-screen-md` and clips its children, so a full-bleed body image sits flush inside the rounded corners.",
+      },
+    },
+  },
+} satisfies Meta<typeof WindowBox>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    title: "Choose a wallet",
+    svg: <Wallet className="size-5 text-primary" />,
+    children: (
+      <div className="p-4 text-body-medium">
+        Body content sits below the header bar and is clipped to the rounded
+        corners.
+      </div>
+    ),
+  },
+}
+
+export const HeaderOnly: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: "`children` is optional -- the header alone is a valid shape.",
+      },
+    },
+  },
+  args: {
+    title: "Choose a wallet",
+    svg: <Wallet className="size-5 text-primary" />,
+  },
+}

--- a/src/layouts/stories/Docs.stories.tsx
+++ b/src/layouts/stories/Docs.stories.tsx
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import { langViewportModes } from "@/storybook/modes"
+
+import { DocsLayout } from "../Docs"
+
+import {
+  ArticleBody,
+  CONTRIBUTORS,
+  LANG,
+  LAST_EDIT,
+  TOC_ITEMS,
+} from "./fixtures"
+
+const meta = {
+  title: "Layouts / Docs",
+  component: DocsLayout,
+  parameters: {
+    layout: "fullscreen",
+    // DocsNav does `pathname.indexOf(...)` to mark the active page; without a
+    // router pathname that read is null and the layout throws.
+    nextjs: {
+      appDirectory: true,
+      navigation: { pathname: "/developers/docs/" },
+    },
+    chromatic: { modes: { ...langViewportModes } },
+    docs: {
+      description: {
+        component:
+          "The developer-docs layout (`/developers/docs/**`). Adds the docs side navigation and the previous/next pager to the article column, and owns the `docsComponents` MDX registry.\n\nThe distinguishing behavior is `frontmatter.incomplete`, which raises a banner warning readers the page is unfinished -- worth seeing, because it is the only layout that self-labels its own content as untrustworthy.",
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-screen-2xl">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof DocsLayout>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+const baseArgs = {
+  slug: "/developers/docs/",
+  tocItems: TOC_ITEMS,
+  lastEditLocaleTimestamp: LAST_EDIT,
+  contributors: CONTRIBUTORS,
+  contentNotTranslated: false,
+  frontmatter: {
+    title: "Ethereum developer resources",
+    description: "A developer's starting point.",
+    lang: LANG,
+  },
+  children: <ArticleBody />,
+}
+
+export const Default: Story = { args: baseArgs }
+
+export const Incomplete: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`frontmatter.incomplete` raises the page-incomplete banner above the article.",
+      },
+    },
+  },
+  args: {
+    ...baseArgs,
+    frontmatter: { ...baseArgs.frontmatter, incomplete: true },
+  },
+}
+
+export const NotTranslated: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`contentNotTranslated` pins the article to `dir="ltr"` while the surrounding chrome follows the locale.',
+      },
+    },
+  },
+  args: { ...baseArgs, contentNotTranslated: true },
+}

--- a/src/layouts/stories/Static.stories.tsx
+++ b/src/layouts/stories/Static.stories.tsx
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import { langViewportModes } from "@/storybook/modes"
+
+import { StaticLayout } from "../Static"
+
+import {
+  ArticleBody,
+  CONTRIBUTORS,
+  LANG,
+  LAST_EDIT,
+  TOC_ITEMS,
+} from "./fixtures"
+
+const meta = {
+  title: "Layouts / Static",
+  component: StaticLayout,
+  parameters: {
+    layout: "fullscreen",
+    chromatic: { modes: { ...langViewportModes } },
+    docs: {
+      description: {
+        component:
+          'The layout behind most standalone markdown pages (`/about/`, `/community/*`, and similar). Renders a breadcrumb + h1 hero from `frontmatter.title`, the article column with its table of contents, and the contributor/edit footer.\n\nIt also owns the `staticComponents` MDX registry -- the set of components a static markdown page may reference by name. `contentNotTranslated` forces `dir="ltr"` on the body, so an untranslated English page embedded in an RTL locale still reads correctly.',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-screen-2xl">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof StaticLayout>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+const baseArgs = {
+  slug: "/community/",
+  tocItems: TOC_ITEMS,
+  lastEditLocaleTimestamp: LAST_EDIT,
+  contributors: CONTRIBUTORS,
+  contentNotTranslated: false,
+  frontmatter: {
+    title: "Ethereum community",
+    description: "Meet the people building and using Ethereum.",
+    lang: LANG,
+  },
+  children: <ArticleBody />,
+}
+
+export const Default: Story = { args: baseArgs }
+
+export const EditButtonHidden: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`frontmatter.hideEditButton` drops the edit-on-GitHub affordance, for pages whose source isn't editable here.",
+      },
+    },
+  },
+  args: {
+    ...baseArgs,
+    frontmatter: { ...baseArgs.frontmatter, hideEditButton: true },
+  },
+}
+
+export const NotTranslated: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`contentNotTranslated` pins the body to `dir="ltr"`. Switch the story to the `ar` locale to see the chrome flip to RTL while the untranslated article stays left-to-right.',
+      },
+    },
+  },
+  args: { ...baseArgs, contentNotTranslated: true },
+}

--- a/src/layouts/stories/Topic.stories.tsx
+++ b/src/layouts/stories/Topic.stories.tsx
@@ -1,0 +1,101 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import { staking } from "@/data/topics/staking"
+
+import { langViewportModes } from "@/storybook/modes"
+
+import { TopicLayout } from "../Topic"
+
+import {
+  ArticleBody,
+  CONTRIBUTORS,
+  LANG,
+  LAST_EDIT,
+  TOC_ITEMS,
+} from "./fixtures"
+
+const meta = {
+  title: "Layouts / Topic",
+  component: TopicLayout,
+  parameters: {
+    layout: "fullscreen",
+    chromatic: { modes: { ...langViewportModes } },
+    docs: {
+      description: {
+        component:
+          "The hub layout shared by the multi-page topic sections -- staking, use-cases, roadmap, upgrade, ai-agents. On top of `ContentLayout` it adds a hero built from frontmatter (`image`, `summaryPoints`, `buttons`) and a section dropdown for moving between sibling pages.\n\n`config` is a `TopicConfig` from `src/data/topics/` -- it supplies the dropdown items and the translation namespace, and the layout throws without it. The type marks it optional only so `TopicLayout` can sit in `layoutMapping` beside layouts that don't take one; the slug router never renders it without a successful config lookup. These stories use the real `staking` config rather than a hand-rolled fixture, so the dropdown keys resolve against the shipped `page-staking` namespace.",
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-screen-2xl">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof TopicLayout>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+const baseArgs = {
+  slug: "/staking/",
+  tocItems: TOC_ITEMS,
+  lastEditLocaleTimestamp: LAST_EDIT,
+  contributors: CONTRIBUTORS,
+  contentNotTranslated: false,
+  config: staking,
+  frontmatter: {
+    title: "Stake your ETH",
+    description: "Earn rewards for helping secure Ethereum.",
+    lang: LANG,
+    image: "/images/staking/leslie-solo.png",
+    alt: "",
+    blurDataURL: "",
+    summaryPoints: [
+      "Staking secures the network and earns rewards.",
+      "You can stake alone, through a pool, or with a service.",
+      "Solo staking needs 32 ETH; pooled staking needs far less.",
+    ],
+  },
+  children: <ArticleBody />,
+}
+
+export const Default: Story = { args: baseArgs }
+
+export const WithSummaryProse: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`summary` replaces the bulleted `summaryPoints` with a single paragraph in the hero.",
+      },
+    },
+  },
+  args: {
+    ...baseArgs,
+    frontmatter: {
+      ...baseArgs.frontmatter,
+      summaryPoints: undefined,
+      summary:
+        "Staking is how Ethereum stays secure. Lock ETH, run or delegate a validator, and earn rewards for honest participation.",
+    },
+  },
+}
+
+export const WithoutDropdown: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`showDropdown: false` hides the sibling-page selector, for a topic rendered as a single page.",
+      },
+    },
+  },
+  args: {
+    ...baseArgs,
+    frontmatter: { ...baseArgs.frontmatter, showDropdown: false },
+  },
+}

--- a/src/layouts/stories/Tutorial.stories.tsx
+++ b/src/layouts/stories/Tutorial.stories.tsx
@@ -1,0 +1,99 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+
+import { langViewportModes } from "@/storybook/modes"
+
+import { TutorialLayout } from "../Tutorial"
+
+import {
+  ArticleBody,
+  CONTRIBUTORS,
+  LANG,
+  LAST_EDIT,
+  TOC_ITEMS,
+} from "./fixtures"
+
+const meta = {
+  title: "Layouts / Tutorial",
+  component: TutorialLayout,
+  parameters: {
+    layout: "fullscreen",
+    chromatic: { modes: { ...langViewportModes } },
+    docs: {
+      description: {
+        component:
+          "The community-tutorial layout (`/developers/tutorials/**`). Its header carries the things a tutorial needs and an article doesn't: author attribution, skill level, tags, and `timeToRead`.\n\n`timeToRead` is a required prop rather than frontmatter -- it's computed from the source at build time, not authored. The edit button is suppressed automatically for `latest/` slugs, since those are mirrored from external sources.",
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-screen-2xl">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof TutorialLayout>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+const baseArgs = {
+  slug: "/developers/tutorials/",
+  tocItems: TOC_ITEMS,
+  lastEditLocaleTimestamp: LAST_EDIT,
+  contributors: CONTRIBUTORS,
+  contentNotTranslated: false,
+  timeToRead: 8,
+  frontmatter: {
+    title: "Sign and verify a message",
+    description: "Prove control of an address without spending anything.",
+    lang: LANG,
+    author: "Ethereum community",
+    published: "2025-04-20",
+    skill: "beginner",
+    tags: ["wallets", "signatures", "javascript"],
+  },
+  children: <ArticleBody />,
+}
+
+export const Default: Story = { args: baseArgs }
+
+export const WithSourceAttribution: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`source` and `sourceUrl` credit a tutorial republished from elsewhere.",
+      },
+    },
+  },
+  args: {
+    ...baseArgs,
+    frontmatter: {
+      ...baseArgs.frontmatter,
+      source: "Ethereum Foundation blog",
+      sourceUrl: "https://blog.ethereum.org",
+    },
+  },
+}
+
+export const LongRead: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "A larger `timeToRead` and an advanced skill tag -- checks that the header metadata row holds its shape as values grow.",
+      },
+    },
+  },
+  args: {
+    ...baseArgs,
+    timeToRead: 45,
+    frontmatter: {
+      ...baseArgs.frontmatter,
+      skill: "advanced",
+      tags: ["solidity", "testing", "foundry", "gas optimization", "security"],
+    },
+  },
+}

--- a/src/layouts/stories/fixtures.tsx
+++ b/src/layouts/stories/fixtures.tsx
@@ -1,0 +1,109 @@
+// Shared fixture content for the layout stories. Layouts are mostly chrome --
+// TOC, contributor footer, edit banner, nav rails -- so the body has to be
+// long and varied enough that the chrome has something real to sit against.
+
+import type { Lang, ToCItem } from "@/lib/types"
+
+export const LANG: Lang = "en"
+
+export const TOC_ITEMS: ToCItem[] = [
+  {
+    title: "What you'll learn",
+    url: "#what-youll-learn",
+    items: [],
+  },
+  {
+    title: "Prerequisites",
+    url: "#prerequisites",
+    items: [
+      { title: "A wallet", url: "#a-wallet" },
+      { title: "Test ETH", url: "#test-eth" },
+    ],
+  },
+  {
+    title: "Walkthrough",
+    url: "#walkthrough",
+    items: [
+      { title: "Connect", url: "#connect" },
+      { title: "Sign", url: "#sign" },
+      { title: "Verify", url: "#verify" },
+    ],
+  },
+  { title: "Next steps", url: "#next-steps", items: [] },
+]
+
+export const CONTRIBUTORS = [
+  {
+    login: "samajammin",
+    avatar_url: "https://avatars.githubusercontent.com/u/8097623?v=4",
+    html_url: "https://github.com/samajammin",
+    date: "2025-04-20T12:00:00.000Z",
+  },
+  {
+    login: "wackerow",
+    avatar_url: "https://avatars.githubusercontent.com/u/54227730?v=4",
+    html_url: "https://github.com/wackerow",
+    date: "2025-05-02T12:00:00.000Z",
+  },
+]
+
+export const LAST_EDIT = "April 20, 2025"
+
+const Paragraph = ({ children }: { children: React.ReactNode }) => (
+  <p className="mb-4">{children}</p>
+)
+
+/**
+ * Article body with real headings, so the TOC anchors in `TOC_ITEMS` resolve
+ * and the scroll-spy behavior is exercisable.
+ */
+export const ArticleBody = () => (
+  <>
+    <Paragraph>
+      Every layout on this site wraps the same shape: a heading, a run of prose
+      and headings deep enough to scroll, and a footer of provenance. This
+      fixture supplies that so the surrounding chrome can be judged.
+    </Paragraph>
+
+    <h2 id="what-youll-learn">What you&apos;ll learn</h2>
+    <Paragraph>
+      How the layout allocates space between the article column and its rails,
+      and where the table of contents docks as the viewport narrows.
+    </Paragraph>
+
+    <h2 id="prerequisites">Prerequisites</h2>
+    <h3 id="a-wallet">A wallet</h3>
+    <Paragraph>
+      A wallet is the account you use to interact with Ethereum applications. It
+      holds your keys, not your funds -- the funds live on the network.
+    </Paragraph>
+    <h3 id="test-eth">Test ETH</h3>
+    <Paragraph>
+      Testnet ETH has no market value and is handed out by faucets, so you can
+      practice a transaction before spending anything real.
+    </Paragraph>
+
+    <h2 id="walkthrough">Walkthrough</h2>
+    <h3 id="connect">Connect</h3>
+    <Paragraph>
+      Connecting shares your public address with the application. It does not
+      grant permission to move anything.
+    </Paragraph>
+    <h3 id="sign">Sign</h3>
+    <Paragraph>
+      Signing proves the request came from your key. Read what you are signing:
+      a signature can authorize a transfer as easily as it can prove identity.
+    </Paragraph>
+    <h3 id="verify">Verify</h3>
+    <Paragraph>
+      Once included in a block, the transaction is public. Any block explorer
+      will show it, and so will your wallet.
+    </Paragraph>
+
+    <h2 id="next-steps">Next steps</h2>
+    <Paragraph>
+      Repeat the same flow on mainnet with a small amount, then read about how
+      fees are set so the cost stops being a surprise.
+    </Paragraph>
+  </>
+)


### PR DESCRIPTION
## Summary

Phase 4 of #18967. Nine shared components (`BigNumber`, `Chevron`, `FeaturedText`, `WindowBox`, `StoryCard`, `PageActions`, `LanguagePicker`, `DataTable`, `RadialChart`) plus the four remaining layouts (`Static`, `Docs`, `Tutorial`, `Topic`), which share a fixture module so the layout chrome has a real article to sit against.

**Adds a Storybook stand-in for `next-intl/server`.** Storybook renders async server components in the browser, where the real helpers throw "not supported in Client Components" -- so any async component reaching for `getTranslations`/`getLocale` showed an error boundary instead of a story. That blocked `BigNumber` and `TopicLayout` here, and had already silently broken the shipped **`Footer`** story: invisible because it sets `disableSnapshot`, so nothing ever rendered it. The shim resolves against the same `messagesByLocale` the client provider uses, at the locale a preview decorator republishes from the toolbar, so server and client components render the same strings in the same language. `Footer` and `Nav` render again as a result.

**Fixes a real translation bug** found while writing the LanguagePicker story: `NoResultsCallout` bound `t` to the `common` namespace and then asked for `"common.page-languages-want-more-paragraph"`, doubling the prefix -- that paragraph has been rendering as its key tail in every locale.

Verified by rendering every story in a headless browser rather than trusting the build. A Storybook build compiles stories without executing them, which is exactly how the Footer breakage survived. 40 new stories render clean, plus 56 existing ones checked for regressions.

**One known miss, left deliberately:** `SideNavMobile` falls back to the literal `"Change page"` cast as a `TranslationKey`, so the Docs stories log a missing message. It reads correctly in English only by accident and is never localized. Fixing it needs a new intl key, which belongs with the translation pipeline rather than here -- worth its own issue.

Base: `feat/storybook-ui-primitive-stories` (phase 3, #18985).