### PR TITLE
docs: standardize autodocs and sync Storybook conventions (Storybook reorg phase 5)

### DIFF
--- a/.claude/skills/design-system/references/new-component-checklist.md
+++ b/.claude/skills/design-system/references/new-component-checklist.md
@@ -4,26 +4,26 @@ Use before opening a PR that introduces a new UI component.
 
 ## Step 0: Should this even be a new component?
 
-Before writing a new file, run through `references/variant-vs-new.md`. The answer is usually "add a variant to an existing primitive." A new component file should encapsulate *fundamentally different behavior*, not just different styling.
+Before writing a new file, run through `references/variant-vs-new.md`. The answer is usually "add a variant to an existing primitive." A new component file should encapsulate _fundamentally different behavior_, not just different styling.
 
 If you've justified the new file, continue.
 
 ## Where Does It Live?
 
-| Use scope | Location |
-|---|---|
-| UI primitive, reusable anywhere on the site | `src/components/ui/` |
-| shadcn-regenerable primitive | `src/components/ui/` (mixed with custom; that's OK) |
-| Reused across many pages | `src/components/ComponentName/index.tsx` |
+| Use scope                                                                                                | Location                                                                                      |
+| -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| UI primitive, reusable anywhere on the site                                                              | `src/components/ui/`                                                                          |
+| shadcn-regenerable primitive                                                                             | `src/components/ui/` (mixed with custom; that's OK)                                           |
+| Reused across many pages                                                                                 | `src/components/ComponentName/index.tsx`                                                      |
 | Reused across a sub-tree (e.g. `/community/**`), or required as a separate file due to client-side needs | `_components/` directory inside that page folder (e.g. `app/[locale]/community/_components/`) |
-| Used only ONCE | Inline in the page file -- don't extract |
-| Markdown shortcode | Add to `src/components/MdComponents/` |
+| Used only ONCE                                                                                           | Inline in the page file -- don't extract                                                      |
+| Markdown shortcode                                                                                       | Add to `src/components/MdComponents/`                                                         |
 
-**Default to inlining single-use JSX in the page file.** A separate component file is justified by *reuse* or by a *technical need* (client-component split, hook isolation), not by length.
+**Default to inlining single-use JSX in the page file.** A separate component file is justified by _reuse_ or by a _technical need_ (client-component split, hook isolation), not by length.
 
 ## File Structure
 
-For `ui/` primitives: source co-located in `src/components/ui/`, stories under `src/components/ui/__stories__/` (NOT co-located alongside the source). Story files use PascalCase names regardless of source casing.
+For `ui/` primitives: source co-located in `src/components/ui/`, stories under `src/components/ui/__stories__/` (NOT co-located alongside the source). Story filename casing is inconsistent in-tree (roughly two-thirds PascalCase, one-third matching the kebab-case source) and has no functional effect -- titles drive everything. Match the file you're adding alongside; don't rename existing ones.
 
 ```
 src/components/ui/
@@ -63,6 +63,7 @@ interface MyFeatureProps {
 ```
 
 **Rules**:
+
 - All visible components MUST accept `className?: string`. Non-negotiable for composability.
 - Don't use `React.FC<Props>` -- function declarations are preferred.
 - Don't `Omit` from HTML attributes unless you genuinely need to.
@@ -96,12 +97,18 @@ Don't use `cva` for new components. (No bulk migration of existing `cva` compone
 ```tsx
 import { cn } from "@/lib/utils/cn"
 
-return <div className={cn(myComponentVariants({ variant, size }), className)} {...props} />
+return (
+  <div
+    className={cn(myComponentVariants({ variant, size }), className)}
+    {...props}
+  />
+)
 ```
 
 ### `forwardRef` (when applicable)
 
 Use `forwardRef` when:
+
 - The component wraps a single interactive HTML element (button, input, anchor)
 - It wraps a Radix primitive that accepts refs
 - It needs to participate in focus management
@@ -122,12 +129,14 @@ MyComponent.displayName = "MyComponent"
 ```
 
 Don't use `forwardRef` on:
+
 - Feature/business components (they aren't composed into other UI)
 - Pure layout components (Flex, Stack) unless they need DOM measurement
 
 ## Server vs Client
 
 Default to Server Component. Only mark `"use client"` if you genuinely need:
+
 - `useState` / `useReducer` / `useEffect`
 - Browser APIs (`window`, `document`, `localStorage`)
 - Inline event handlers (`onClick`, `onChange`, etc.)
@@ -165,6 +174,15 @@ import { MyComponent } from "../my-component"
 const meta = {
   title: "UI / MyComponent",
   component: MyComponent,
+  tags: ["autodocs"],
+  parameters: {
+    chromatic: { disableSnapshot: true }, // house norm for every `ui/` story
+    docs: {
+      description: {
+        component: "What it's for, and the constraint a caller needs to know.",
+      },
+    },
+  },
 } satisfies Meta<typeof MyComponent>
 
 export default meta
@@ -182,15 +200,30 @@ export const Variants: StoryObj = {
 }
 ```
 
-Title hierarchy:
-- `UI / Primitives / [Name]` -- shadcn-regenerable
-- `UI / [Name]` -- custom project primitives
-- `Components / [Name]` -- feature components
-- `Layouts / [Name]` -- layout components
+Title hierarchy (reorganized August 2026, issue #18967). The **section is derived from the file path**, so it is never a judgment call -- and `tests/unit/storybook/story-titles.spec.ts` enforces it:
+
+| Path                                  | Section         |
+| ------------------------------------- | --------------- |
+| `src/styles/**`                       | `Design System` |
+| `src/components/ui/**`                | `UI`            |
+| `src/components/**` (everything else) | `Components`    |
+| `src/layouts/**`                      | `Layouts`       |
+| `app/**`                              | `Pages`         |
+
+The `UI / Primitives /` middle tier is **gone** -- everything in `ui/` is a primitive, so the tier carried no information.
+
+The second level is a light functional group (Actions, Forms, Layout, Navigation, Overlays, Data Display for `UI /`; Cards, Heroes, Navigation, Site Chrome, Content, Data Viz, Features for `Components /`). Use one only if it already fits. **Never invent a group for a single component** -- a flat `Components / Morpher` is correct, and inventing categories is how the previous six competing schemes accumulated.
+
+The test also requires an explicit title on every story and rejects duplicates: Storybook merges two files sharing a title into one sidebar entry with no warning, which is how three separate Hero stories hid behind one entry for months.
+
+> **Deprecated components get no story.** A rendered example reads as an endorsement whatever the caption says, so a component on the way out is left out of Storybook entirely and its deprecation noted in prose (see `HR`'s `narrow` variant, and `Swiper`, which has no story). A component whose status is merely undecided keeps its story plus a blurb saying it isn't for new work (see `Carousel`).
+
+> **A green build does not prove a story renders.** `pnpm build-storybook` compiles without executing, and every `ui/` story disables Chromatic snapshots -- so neither CI signal catches a story that throws. Open it in `pnpm storybook`. Async server components rely on the `next-intl/server` shim (`.storybook/next-intl-server.tsx`); `usePathname` consumers need `parameters.nextjs.navigation.pathname`; and a new i18n namespace has to be added to `ns` in `.storybook/next-intl.ts` or its strings render as raw key tails.
 
 ## Pre-Merge Checklist
 
 ### Implementation
+
 - [ ] Component justifies its existence (not just a variant of an existing one)
 - [ ] Lives in the correct directory
 - [ ] Accepts `className?: string`
@@ -205,15 +238,18 @@ Title hierarchy:
 - [ ] No `toLocaleString()` / `Intl.*` directly -- locale wrappers
 
 ### Server / Client
+
 - [ ] Server Component unless `"use client"` is genuinely required
 - [ ] If client, the boundary is as deep as possible (not at the top of a page)
 
 ### Story
+
 - [ ] `MyComponent.stories.tsx` exists
 - [ ] Story shows all variants
 - [ ] Title follows the hierarchy convention
 
 ### Verification
+
 - [ ] Renders in light AND dark mode (check Storybook)
 - [ ] Renders in RTL (Arabic) -- spacing, icons, alignment all sensible
 - [ ] Renders in verbose-language (German/Spanish) without overflow
@@ -222,6 +258,7 @@ Title hierarchy:
 - [ ] Screen-reader announces sensibly (test with VoiceOver / NVDA / TalkBack)
 
 ### Cleanup
+
 - [ ] No commented-out code
 - [ ] No `console.log` debug statements
 - [ ] No TODO comments without an owner / issue link

--- a/.storybook/Overview.mdx
+++ b/.storybook/Overview.mdx
@@ -1,0 +1,99 @@
+import { Meta } from "@storybook/addon-docs/blocks"
+
+<Meta title="Overview" />
+
+# ethereum.org in Storybook
+
+This Storybook mirrors the repository. The top-level section a component
+appears under is derived from where its file lives -- not from a judgment call
+about how "big" or "reusable" it is.
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">Section</th>
+      <th align="left">Lives in</th>
+    </tr>
+  </thead>
+  <tbody>
+    {[
+      ["Design System", "src/styles/"],
+      ["UI", "src/components/ui/"],
+      ["Components", "src/components/ (everything else)"],
+      ["Layouts", "src/layouts/"],
+      ["Pages", "app/[locale]/**/_components/"],
+    ].map(([section, path]) => (
+      <tr key={section}>
+        <td align="left">
+          <strong>{section}</strong>
+        </td>
+        <td align="left">
+          <code>{path}</code>
+        </td>
+      </tr>
+    ))}
+  </tbody>
+</table>
+
+So a title tells you two things at once: what the thing is, and where to open
+it. `UI / Forms / Field` is `src/components/ui/field.tsx`.
+`Components / Heroes / PageHero` is `src/components/Hero/PageHero/`.
+
+## Reading the sections
+
+**Design System** is the foundation layer -- color, gradients, shadows, and
+typography. These document CSS rather than components: the typography entries
+render bare elements and utility classes so you can see what `base.css` gives
+you before any component is involved.
+
+**UI** is the primitive library: buttons, inputs, overlays, layout helpers.
+Everything here is generic and content-free. If you are building a page, this
+is your parts bin, and it is where you should look before writing anything new
+-- most "new component" needs are a variant of something already here.
+
+**Components** is the shared layer above the primitives: cards, heroes, site
+chrome, content rendering, data visualization, and the larger features (Quiz,
+Simulator, wallet finder). These know something about ethereum.org.
+
+**Layouts** are the page skeletons that markdown content is poured into.
+**Pages** holds components colocated with a single route, which exist for one
+page and are not meant to be reused.
+
+## How titles are structured
+
+`Section / Group / Name`. The group is a light functional bucket -- Actions,
+Forms, Overlays, Cards, Heroes, and so on -- and it exists purely so the
+sidebar is browsable.
+
+Not everything has a group. Where a component has no natural bucket, its title
+is just `Section / Name` (`Components / Morpher`, `UI / Alert`). That is
+deliberate: inventing a category for a single component is how the previous
+six competing schemes accumulated. A flat entry is honest about there being no
+category.
+
+A unit test enforces the section prefix, that every story is explicitly
+titled, and that no two files share a title -- Storybook silently folds
+duplicate titles into one sidebar entry, so nothing else would catch it.
+See `tests/unit/storybook/story-titles.spec.ts`.
+
+## Things worth knowing
+
+**A story here means the component is available.** Anything on the way out is
+deliberately absent, because a rendered example reads as an endorsement no
+matter what the caption says -- `Swiper` and `HR`'s `narrow` variant are both
+in the codebase and both intentionally unshown. So the absence of a component
+is information: check the `design-system` skill before assuming something is
+missing by oversight.
+
+The exception is a component whose future is undecided rather than settled.
+`UI / Carousel` is here with a blurb saying it isn't for new work and pointing
+at `EdgeScrollContainer` instead.
+
+**Not everything renders a snapshot.** Every `UI /` story sets
+`chromatic: { disableSnapshot: true }`; layouts snapshot across locale and
+viewport modes. So a green Chromatic run is not evidence that a `UI /` story
+renders -- only that nothing it snapshots changed.
+
+**Locale and theme are toolbar controls.** Both light/dark and the locale
+(including RTL via Arabic) switch from the toolbar, and are worth exercising on
+anything with text or directional layout.

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -10,6 +10,7 @@ import type { StorybookConfig } from "@storybook/nextjs"
  */
 const config: StorybookConfig = {
   stories: [
+    "./Overview.mdx",
     // Recursive everywhere: a story nested a directory deeper than expected
     // would otherwise never load, with no error to say so.
     "../src/components/**/*.stories.{ts,tsx}",

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -76,7 +76,14 @@ const preview: Preview = {
     },
     options: {
       storySort: {
-        order: ["Design System", "UI", "Components", "Layouts", "Pages"],
+        order: [
+          "Overview",
+          "Design System",
+          "UI",
+          "Components",
+          "Layouts",
+          "Pages",
+        ],
       },
     },
     layout: "centered",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,9 +177,33 @@ For pipeline mechanics, recovery, manifests, ETHGlossary integration, and the `i
    - Use `src/components/ui` for shadcn components or pure UI components
 2. Add TypeScript types and proper props interface
 3. Accept `ref` as a regular prop when needed (React 19); `forwardRef` only survives in legacy components
-4. Add Storybook story in same directory
+4. Add a Storybook story (see below)
 5. Export from appropriate index file
 6. Update documentation if adding new patterns
+
+### Storybook stories
+
+**Location**: `__stories__/` for flat directories (`ui/`, `styles/`), co-located `X.stories.tsx` for foldered components. Story globs are recursive, so nesting works, but match the neighbours.
+
+**Title**: `Section / Group / Name`. The section is derived from the file path -- not a judgment call:
+
+| Path                                  | Section         |
+| ------------------------------------- | --------------- |
+| `src/styles/**`                       | `Design System` |
+| `src/components/ui/**`                | `UI`            |
+| `src/components/**` (everything else) | `Components`    |
+| `src/layouts/**`                      | `Layouts`       |
+| `app/**`                              | `Pages`         |
+
+Use a second-level group only when an established one fits (Actions, Forms, Layout, Navigation, Overlays, Data Display, Cards, Heroes, Site Chrome, Content, Data Viz, Features). **Don't invent a group for a single component** -- a flat `Components / Morpher` is correct and preferred. `tests/unit/storybook/story-titles.spec.ts` enforces the section prefix, explicit titles, and title uniqueness (Storybook silently merges duplicate titles into one sidebar entry).
+
+**Don't add a story for a deprecated component or variant.** A rendered example reads as an endorsement whatever the caption says, so the showcase should only contain things that are available to use -- note the deprecation in prose instead (see `HR`). A component whose future is merely undecided can keep its story with a status blurb (see `Carousel`).
+
+Add `tags: ["autodocs"]`. Write the `parameters.docs.description.component` blurb for someone deciding whether to use the thing -- constraints and gotchas, not a restatement of the props table.
+
+**A green build does not mean a story renders.** `pnpm build-storybook` compiles stories without executing them, and every `UI /` story sets `chromatic: { disableSnapshot: true }`, so neither CI signal catches a story that throws. Open new stories in `pnpm storybook` before pushing.
+
+Async server components render via a `next-intl/server` shim (`.storybook/next-intl-server.tsx`). Components calling `usePathname` need `parameters.nextjs.navigation.pathname`. New i18n namespaces must be added to the `ns` array in `.storybook/next-intl.ts`, or strings render as raw key tails.
 
 ### Content Updates
 

--- a/app/[locale]/community/events/_components/event-card.stories.tsx
+++ b/app/[locale]/community/events/_components/event-card.stories.tsx
@@ -9,6 +9,7 @@ import EventCard from "./event-card"
 const meta = {
   title: "Pages / Community Events / EventCard",
   component: EventCard,
+  tags: ["autodocs"],
   decorators: [
     (Story) => (
       <div className="max-w-[720px]">

--- a/docs/applying-storybook.md
+++ b/docs/applying-storybook.md
@@ -52,15 +52,52 @@ type Story = StoryObj<typeof meta>
 export const Basic: Story = {}
 ```
 
-- With the `title` option, we write this based on the groupings set by the Design System. Groupings are declared with forward slashes. (i.e., `Atoms / Form / Input`). See the Storybook docs for details on [Naming conventions](https://storybook.js.org/docs/writing-stories/naming-components-and-hierarchy)
+- The `title` option places the story in the sidebar, and its **top-level section is derived from the file's path** -- see [Story titles](#story-titles) below. Groupings are declared with forward slashes (i.e., `UI / Forms / Input`). See the Storybook docs for details on [Naming conventions](https://storybook.js.org/docs/writing-stories/naming-components-and-hierarchy)
 - The `satisfies` TypeScript keyword is used with the `Meta` type for stricter type checking. This is particularly helpful to make sure required args are not missed. [Storybook Docs regarding `satisfies`](https://storybook.js.org/docs/writing-stories/typescript#using-satisfies-for-better-type-safety)
 - The use of `StoryObj` is to be able to typecheck the creation of a story as an object. This helps with prop inference.
 - We use `StoryObj<typeof meta>` in the event a required arg is provided in the `meta` object, to be applied to all stories in the file. This prevents type errors from being thrown at the story level for a required missing arg.
 - If the story does not need any args or any custom rendering, it should be left as an empty object. Otherwise, use the `render` option to explicitly write the rendering of the story: i.e., `render: () => <Component />`
 
-Also, please view the Figma file for the [proposed structure for the Design System](https://www.figma.com/file/Ne3iAassyfAcJ0AlgqioAP/DS-to-storybook-structure?type=design&node-id=42%3A50&mode=design&t=RGkyouvTilzF42y0-1) to provide the correct groupings.
+We maintain this structure for every story file, regardless of simplicity.
 
-We will maintain this structure for every story file, regardless of simplicity.
+## Story titles
+
+Titles read `Section / Group / Name`. The **section comes from where the file lives**, so it is never a judgment call:
+
+| Path                                  | Section         |
+| ------------------------------------- | --------------- |
+| `src/styles/**`                       | `Design System` |
+| `src/components/ui/**`                | `UI`            |
+| `src/components/**` (everything else) | `Components`    |
+| `src/layouts/**`                      | `Layouts`       |
+| `app/**`                              | `Pages`         |
+
+The second level is a light functional group for browsability -- Actions, Forms, Layout, Navigation, Overlays, Data Display under `UI /`; Cards, Heroes, Navigation, Site Chrome, Content, Data Viz, Features under `Components /`. Use one only when it already fits. **Do not invent a group for a single component**: a flat `Components / Morpher` is correct, and inventing categories is exactly how the six competing schemes this replaced accumulated.
+
+`tests/unit/storybook/story-titles.spec.ts` enforces the section prefix, requires an explicit title on every story, and rejects duplicate titles -- Storybook merges two files sharing a title into a single sidebar entry with no warning.
+
+> This taxonomy replaced the old `Atoms / Molecules / Organisms` structure (and the Figma "DS to storybook structure" file behind it) in August 2026. See issue #18967 for the rationale.
+
+### Deprecated components get no story
+
+A rendered example reads as an endorsement whatever the caption says. If a component or variant is on the way out, leave it out of Storybook and note the deprecation in prose -- `Swiper` and `HR`'s `narrow` variant are both in the codebase and both intentionally unshown. A component whose future is undecided rather than settled keeps its story plus a blurb saying it isn't for new work (`Carousel`).
+
+### Writing MDX docs pages
+
+`.storybook/Overview.mdx` is the entry-point page. Two gotchas if you add or edit one:
+
+- **No `remark-gfm`.** A markdown pipe table renders as literal pipes -- write tables as JSX.
+- **Prettier mangles MDX comments.** It rewrites `{/* … */}` to `{/_ … _/}`, which is invalid and breaks the build. Leave comments out of `.mdx`.
+
+### Verifying a story actually renders
+
+`pnpm build-storybook` compiles stories **without executing them**, and every `ui/` story sets `chromatic: { disableSnapshot: true }`. Neither CI signal catches a story that throws at render, so open new stories in `pnpm storybook` before pushing.
+
+Three things commonly break a story that compiles fine:
+
+- **Async server components** call `getTranslations`/`getLocale`, which throw in the browser. `.storybook/next-intl-server.tsx` shims `next-intl/server` against the same messages the client provider uses.
+- **`usePathname` consumers** get `null` without `parameters.nextjs.navigation.pathname`.
+- **New i18n namespaces** render as raw key tails until added to the `ns` array in `.storybook/next-intl.ts`.
 
 Should the component accept props on all or some renders, you can provide an `args` prop for each story and supply the necessary data. This can be done in place of the render if only a single instance of the given component is needed with no other components. If the `children` prop is used, it can still be used in the `args` prop.
 
@@ -74,7 +111,7 @@ import Button from "."
 type ButtonType = typeof Button
 
 const meta = {
-  title: "Atoms / Form / Button",
+  title: "UI / Actions / Button",
   component: Button,
 } satisfies Meta<ButtonType>
 
@@ -120,13 +157,13 @@ export const Variants: StoryObj = {
 
 ### Story file containing a single story
 
-If only one story is provided for a component, the name of the exported object should match the name in the `title` meta option. For example, if the title is `Atoms / Form / Button` then the story should be named `Button`. This will hoist the display name up to the parent level in the Storybook dashboard's sidebar. This will also mean you have to rename the import of the component. Call it `ButtonComponent`, say.
+If only one story is provided for a component, the name of the exported object should match the name in the `title` meta option. For example, if the title is `UI / Actions / Button` then the story should be named `Button`. This will hoist the display name up to the parent level in the Storybook dashboard's sidebar. This will also mean you have to rename the import of the component. Call it `ButtonComponent`, say.
 
 ```tsx
 import ButtonComponent from "."
 
 const meta = {
-  title: "Atoms / Form / Button",
+  title: "UI / Actions / Button",
   component: ButtonComponent,
 } satisfies Meta<typeof ButtonComponent>
 
@@ -174,10 +211,10 @@ CI publishes on every non-draft PR, so you don't normally need to run Chromatic 
 
 If you do need a local run, the repo has two Chromatic projects and each script takes its own token:
 
-| Script | Token | Project |
-| --- | --- | --- |
-| `pnpm chromatic` | `CHROMATIC_STORYBOOK_TOKEN` | Storybook components |
-| `pnpm chromatic:pages` | `CHROMATIC_PAGES_TOKEN` | Full-page visual tests |
+| Script                 | Token                       | Project                |
+| ---------------------- | --------------------------- | ---------------------- |
+| `pnpm chromatic`       | `CHROMATIC_STORYBOOK_TOKEN` | Storybook components   |
+| `pnpm chromatic:pages` | `CHROMATIC_PAGES_TOKEN`     | Full-page visual tests |
 
 Both must be exported in your shell — `.env.local` won't work, since the scripts expand them before Chromatic starts. Each script fails immediately if its token is missing, which is deliberate: a single shared token would let a page-test token publish a Storybook build into the wrong project.
 
@@ -199,7 +236,7 @@ import { langViewportModes } from "../../../../.storybook/modes"
 import ContentHeroComponent, { ContentHeroProps } from "."
 
 const meta = {
-  title: "Organisms / Layouts / Hero",
+  title: "Components / Heroes / PageHero",
   component: ContentHeroComponent,
   parameters: {
     chromatic: {

--- a/src/components/AppCard/AppCard.stories.tsx
+++ b/src/components/AppCard/AppCard.stories.tsx
@@ -12,6 +12,7 @@ import AppCard from "."
 const meta = {
   title: "Components / Cards / AppCard",
   component: AppCard,
+  tags: ["autodocs"],
   decorators: [
     (Story) => (
       <div className="max-w-md">

--- a/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -7,6 +7,7 @@ import BreadcrumbsComponent from "."
 const meta = {
   title: "Components / Navigation / Breadcrumbs",
   component: BreadcrumbsComponent,
+  tags: ["autodocs"],
 } satisfies Meta<typeof BreadcrumbsComponent>
 
 export default meta

--- a/src/components/CallToContribute/CallToContribute.stories.tsx
+++ b/src/components/CallToContribute/CallToContribute.stories.tsx
@@ -5,6 +5,7 @@ import CallToContributeComponent from "."
 const meta = {
   title: "Components / CallToContribute",
   component: CallToContributeComponent,
+  tags: ["autodocs"],
   args: {
     editPath:
       "https://github.com/ethereum/ethereum-org-website/tree/dev/public/content/developers/docs/index.md",

--- a/src/components/ChainImages/ChainImages.stories.tsx
+++ b/src/components/ChainImages/ChainImages.stories.tsx
@@ -7,6 +7,7 @@ import ChainImages from "."
 const meta = {
   title: "Components / ChainImages",
   component: ChainImages,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/ChecklistGrid/ChecklistGrid.stories.tsx
+++ b/src/components/ChecklistGrid/ChecklistGrid.stories.tsx
@@ -5,6 +5,7 @@ import ChecklistGrid from "."
 const meta = {
   title: "Components / ChecklistGrid",
   component: ChecklistGrid,
+  tags: ["autodocs"],
   parameters: {
     docs: {
       description: {

--- a/src/components/Codeblock/Codeblock.stories.tsx
+++ b/src/components/Codeblock/Codeblock.stories.tsx
@@ -5,6 +5,7 @@ import Codeblock from "."
 const meta = {
   title: "Components / Content / Codeblock",
   component: Codeblock,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/CommentCard/CommentCard.stories.tsx
+++ b/src/components/CommentCard/CommentCard.stories.tsx
@@ -7,6 +7,7 @@ import CommentCard from "."
 const meta = {
   title: "Components / Cards / CommentCard",
   component: CommentCard,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/ContentFeedback.stories.tsx
+++ b/src/components/ContentFeedback.stories.tsx
@@ -6,6 +6,7 @@ import ContentFeedback from "./ContentFeedback"
 const meta = {
   title: "Components / ContentFeedback",
   component: ContentFeedback,
+  tags: ["autodocs"],
   parameters: {
     layout: "padded",
   },

--- a/src/components/Contributors/Contributors.stories.tsx
+++ b/src/components/Contributors/Contributors.stories.tsx
@@ -5,6 +5,7 @@ import ContributorsView, { type Contributor } from "./ContributorsView"
 const meta = {
   title: "Components / Content / Contributors",
   component: ContributorsView,
+  tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
   },

--- a/src/components/CopyToClipboard/CopyToClipboard.stories.tsx
+++ b/src/components/CopyToClipboard/CopyToClipboard.stories.tsx
@@ -8,6 +8,7 @@ import CopyToClipboard, { CopyButton } from "."
 const meta = {
   title: "Components / CopyToClipboard",
   component: CopyToClipboard,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/DeveloperDocsLinks/DeveloperDocsLinks.stories.tsx
+++ b/src/components/DeveloperDocsLinks/DeveloperDocsLinks.stories.tsx
@@ -7,6 +7,7 @@ import DeveloperDocsLinksComponent from "."
 const meta = {
   title: "Components / Navigation / DeveloperDocsLinks",
   component: DeveloperDocsLinksComponent,
+  tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
     chromatic: {

--- a/src/components/DocLink/DocLink.stories.tsx
+++ b/src/components/DocLink/DocLink.stories.tsx
@@ -7,6 +7,7 @@ import DocLink from "."
 const meta = {
   title: "Components / Navigation / DocLink",
   component: DocLink,
+  tags: ["autodocs"],
 } satisfies Meta<typeof DocLink>
 
 export default meta

--- a/src/components/DocsNav/DocsNav.stories.tsx
+++ b/src/components/DocsNav/DocsNav.stories.tsx
@@ -5,6 +5,7 @@ import DocsNavComponent from "."
 const meta = {
   title: "Components / Navigation / DocsNav",
   component: DocsNavComponent,
+  tags: ["autodocs"],
   parameters: {
     nextjs: {
       appDirectory: true,

--- a/src/components/EnergyConsumptionChart/EnergyConsumptionChart.stories.tsx
+++ b/src/components/EnergyConsumptionChart/EnergyConsumptionChart.stories.tsx
@@ -5,6 +5,7 @@ import ChartComponent from "."
 const meta = {
   title: "Components / Data Viz / EnergyConsumptionChart",
   component: ChartComponent,
+  tags: ["autodocs"],
 } satisfies Meta<typeof ChartComponent>
 
 export default meta

--- a/src/components/FeedbackWidget/FeedbackWidget.stories.tsx
+++ b/src/components/FeedbackWidget/FeedbackWidget.stories.tsx
@@ -12,6 +12,7 @@ const meta = {
     layout: "fullscreen",
   },
   component: FeedbackWidget,
+  tags: ["autodocs"],
   decorators: [
     (Story) => (
       <Stack className="relative min-h-[100vh] gap-0">

--- a/src/components/FilterBar/FilterBar.stories.tsx
+++ b/src/components/FilterBar/FilterBar.stories.tsx
@@ -6,6 +6,7 @@ import FilterBar from "./"
 const meta = {
   title: "Components / Navigation / FilterBar",
   component: FilterBar,
+  tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
   },

--- a/src/components/FilterableCatalog/FilterableCatalog.stories.tsx
+++ b/src/components/FilterableCatalog/FilterableCatalog.stories.tsx
@@ -13,6 +13,7 @@ import { toggleId } from "./utils"
 const meta = {
   title: "Components / Features / FilterableCatalog",
   component: FilterableCatalog,
+  tags: ["autodocs"],
   parameters: {
     layout: "padded",
   },

--- a/src/components/FindWalletProductTable/FindWalletProductTable.stories.tsx
+++ b/src/components/FindWalletProductTable/FindWalletProductTable.stories.tsx
@@ -116,6 +116,7 @@ const walletsData = [
 const meta = {
   title: "Components / Features / FindWalletProductTable",
   component: FindWalletProductTable,
+  tags: ["autodocs"],
   decorators: [
     (Story) => (
       <div className="mx-auto max-w-screen-2xl">

--- a/src/components/Footer/Footer.stories.tsx
+++ b/src/components/Footer/Footer.stories.tsx
@@ -5,6 +5,7 @@ import Footer from "."
 const meta = {
   title: "Components / Site Chrome / Footer",
   component: Footer,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     layout: "fullscreen",

--- a/src/components/Glossary/GlossaryDefinition/GlossaryDefinition.stories.tsx
+++ b/src/components/Glossary/GlossaryDefinition/GlossaryDefinition.stories.tsx
@@ -5,6 +5,7 @@ import GlossaryDefinitionComponent from "."
 const meta = {
   title: "Components / Content / Glossary / Definition",
   component: GlossaryDefinitionComponent,
+  tags: ["autodocs"],
 } as Meta<typeof GlossaryDefinitionComponent>
 
 export default meta

--- a/src/components/Glossary/GlossaryTooltip/GlossaryTooltip.stories.tsx
+++ b/src/components/Glossary/GlossaryTooltip/GlossaryTooltip.stories.tsx
@@ -7,6 +7,7 @@ import GlossaryTooltipComponent from "."
 const meta = {
   title: "Components / Content / Glossary / Tooltip",
   component: GlossaryTooltipComponent,
+  tags: ["autodocs"],
   args: {
     termKey: "bridge",
     children: "bridge",

--- a/src/components/Hero/HomeHero/HomeHero.stories.tsx
+++ b/src/components/Hero/HomeHero/HomeHero.stories.tsx
@@ -7,6 +7,7 @@ import HomeHeroComponent from "."
 const meta = {
   title: "Components / Heroes / HomeHero",
   component: HomeHeroComponent,
+  tags: ["autodocs"],
   parameters: {
     layout: "none",
     chromatic: {

--- a/src/components/Hero/HubHero/HubHero.stories.tsx
+++ b/src/components/Hero/HubHero/HubHero.stories.tsx
@@ -10,6 +10,7 @@ import learnHubHeroImg from "@/public/images/heroes/learn-hub-hero.png"
 const meta = {
   title: "Components / Heroes / HubHero",
   component: HubHeroComponent,
+  tags: ["autodocs"],
   parameters: {
     layout: "none",
     chromatic: {

--- a/src/components/Hero/PageHero/PageHero.stories.tsx
+++ b/src/components/Hero/PageHero/PageHero.stories.tsx
@@ -10,6 +10,7 @@ import heroImg from "@/public/images/upgrades/merge.png"
 const meta = {
   title: "Components / Heroes / PageHero",
   component: PageHeroComponent,
+  tags: ["autodocs"],
   parameters: {
     layout: "none",
     // asPath lets the Breadcrumbs component resolve the "home" crumb label

--- a/src/components/HighlightCard/HighlightCard.stories.tsx
+++ b/src/components/HighlightCard/HighlightCard.stories.tsx
@@ -8,6 +8,7 @@ import { HighlightCard, HighlightCardContent, HighlightStack, IconBox } from "."
 const meta = {
   title: "Components / Cards / HighlightCard",
   component: HighlightCard,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/HorizontalCard/HorizontalCard.stories.tsx
+++ b/src/components/HorizontalCard/HorizontalCard.stories.tsx
@@ -8,6 +8,7 @@ import HorizontalCard from "."
 const meta = {
   title: "Components / Cards / HorizontalCard",
   component: HorizontalCard,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/ListenToPlayer/ListenToPlayer.stories.tsx
+++ b/src/components/ListenToPlayer/ListenToPlayer.stories.tsx
@@ -6,6 +6,7 @@ import Component from "."
 const meta = {
   title: "Components / Content / ListenToPlayer",
   component: Component,
+  tags: ["autodocs"],
   args: {
     slug: "/eth/",
   },

--- a/src/components/ListingMethodology/ListingMethodology.stories.tsx
+++ b/src/components/ListingMethodology/ListingMethodology.stories.tsx
@@ -5,6 +5,7 @@ import ListingMethodology from "."
 const meta = {
   title: "Components / ListingMethodology",
   component: ListingMethodology,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/Logo/Logo.stories.tsx
+++ b/src/components/Logo/Logo.stories.tsx
@@ -6,6 +6,7 @@ import LogoComponent from "."
 const meta = {
   title: "Components / Logo",
   component: LogoComponent,
+  tags: ["autodocs"],
 } satisfies Meta<typeof LogoComponent>
 
 export default meta

--- a/src/components/MarkdownCard/MarkdownCard.stories.tsx
+++ b/src/components/MarkdownCard/MarkdownCard.stories.tsx
@@ -10,6 +10,7 @@ import CardComponent, { MarkdownCardProps } from "."
 const meta = {
   title: "Components / Cards / MarkdownCard",
   component: CardComponent,
+  tags: ["autodocs"],
   parameters: { layout: "fullscreen" },
   decorators: [
     (Story) => (

--- a/src/components/MdComponents/MdComponents.stories.tsx
+++ b/src/components/MdComponents/MdComponents.stories.tsx
@@ -7,6 +7,7 @@ import MdComponentSet from "."
 
 const meta = {
   title: "Components / Content / MdComponents",
+  tags: ["autodocs"],
   parameters: {
     layout: "none",
     chromatic: {

--- a/src/components/MergeInfographic/MergeInfographic.stories.tsx
+++ b/src/components/MergeInfographic/MergeInfographic.stories.tsx
@@ -7,6 +7,7 @@ import MergeInfographicComponent from "."
 const meta = {
   title: "Components / MergeInfographic",
   component: MergeInfographicComponent,
+  tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
     chromatic: {

--- a/src/components/MobileButtonDropdown/MobileButtonDropdown.stories.tsx
+++ b/src/components/MobileButtonDropdown/MobileButtonDropdown.stories.tsx
@@ -7,6 +7,7 @@ import MobileButtonDropdown from "."
 const meta = {
   title: "Components / MobileButtonDropdown",
   component: MobileButtonDropdown,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/Morpher/Morpher.stories.tsx
+++ b/src/components/Morpher/Morpher.stories.tsx
@@ -5,6 +5,7 @@ import Morpher from "."
 const meta = {
   title: "Components / Morpher",
   component: Morpher,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/Nav/Nav.stories.tsx
+++ b/src/components/Nav/Nav.stories.tsx
@@ -5,6 +5,7 @@ import Nav from "."
 const meta = {
   title: "Components / Site Chrome / Nav",
   component: Nav,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     layout: "fullscreen",

--- a/src/components/PieChart/PieChart.stories.tsx
+++ b/src/components/PieChart/PieChart.stories.tsx
@@ -5,6 +5,7 @@ import { PieChart } from "."
 const meta = {
   title: "Components / Data Viz / PieChart",
   component: PieChart,
+  tags: ["autodocs"],
   parameters: {
     layout: "padded",
   },

--- a/src/components/ProductList/ProductList.stories.tsx
+++ b/src/components/ProductList/ProductList.stories.tsx
@@ -5,6 +5,7 @@ import ProductList, { type ProductListContent } from "."
 const meta = {
   title: "Components / ProductList",
   component: ProductList,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/Quiz/stories/QuizButtonGroup.stories.tsx
+++ b/src/components/Quiz/stories/QuizButtonGroup.stories.tsx
@@ -10,6 +10,7 @@ import { LAYER_2_QUIZ_TITLE_KEY, layer2Questions } from "./utils"
 const meta = {
   title: "Components / Features / Quiz / QuizWidget / ButtonGroup",
   component: QuizButtonGroup,
+  tags: ["autodocs"],
   args: {
     answerStatus: undefined,
     currentQuestionAnswerChoice: null,

--- a/src/components/Quiz/stories/QuizModal.stories.tsx
+++ b/src/components/Quiz/stories/QuizModal.stories.tsx
@@ -16,6 +16,7 @@ type ModalPropsAndWidgetArgs = ComponentProps<typeof QuizzesModal> & {
 const meta = {
   title: "Components / Features / Quiz / Modal",
   component: QuizzesModal,
+  tags: ["autodocs"],
   args: {
     isQuizModalOpen: true,
     quizStatus: "neutral",

--- a/src/components/Quiz/stories/QuizProgressBar.stories.tsx
+++ b/src/components/Quiz/stories/QuizProgressBar.stories.tsx
@@ -11,6 +11,7 @@ import { LAYER_2_QUIZ_KEY, layer2Questions } from "./utils"
 const meta = {
   title: "Components / Features / Quiz / QuizWidget / ProgressBar",
   component: QuizProgressBar,
+  tags: ["autodocs"],
   args: {
     questions: layer2Questions,
   },

--- a/src/components/Quiz/stories/QuizRadioGroup.stories.tsx
+++ b/src/components/Quiz/stories/QuizRadioGroup.stories.tsx
@@ -10,6 +10,7 @@ import { LAYER_2_QUIZ_TITLE_KEY, layer2Questions } from "./utils"
 const meta = {
   title: "Components / Features / Quiz / QuizWidget / RadioGroup",
   component: QuizRadioGroup,
+  tags: ["autodocs"],
   decorators: [
     (Story, { args }) => {
       const t = useTranslations("common")

--- a/src/components/Quiz/stories/QuizSummary.stories.tsx
+++ b/src/components/Quiz/stories/QuizSummary.stories.tsx
@@ -9,6 +9,7 @@ import { LAYER_2_QUIZ_TITLE_KEY, layer2Questions } from "./utils"
 const meta = {
   title: "Components / Features / Quiz / QuizWidget / Summary",
   component: QuizSummary,
+  tags: ["autodocs"],
   args: {
     questionsLength: layer2Questions.length,
   },

--- a/src/components/Quiz/stories/QuizWidget.stories.tsx
+++ b/src/components/Quiz/stories/QuizWidget.stories.tsx
@@ -8,6 +8,7 @@ import { LAYER_2_QUIZ_KEY, layer2Questions } from "./utils"
 const meta = {
   title: "Components / Features / Quiz / QuizWidget",
   component: StandaloneQuizClient,
+  tags: ["autodocs"],
   args: {
     quizKey: LAYER_2_QUIZ_KEY,
   },

--- a/src/components/Quiz/stories/QuizzesList.stories.tsx
+++ b/src/components/Quiz/stories/QuizzesList.stories.tsx
@@ -17,6 +17,7 @@ import QuizzesListComponent from "../QuizzesList"
 const meta = {
   title: "Components / Features / Quiz / QuizzesList",
   component: QuizzesListComponent,
+  tags: ["autodocs"],
   args: {
     content: ethereumBasicsQuizzes,
     headingId: "basics",

--- a/src/components/Quiz/stories/QuizzesStats.stories.tsx
+++ b/src/components/Quiz/stories/QuizzesStats.stories.tsx
@@ -5,6 +5,7 @@ import QuizzesStats from "../QuizzesStats"
 const meta = {
   title: "Components / Features / Quiz / QuizzesStats",
   component: QuizzesStats,
+  tags: ["autodocs"],
   args: {
     averageScoresArray: [],
     completedQuizzes: {

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -7,6 +7,7 @@ import Select from "./"
 const meta = {
   title: "Components / Forms / Select",
   component: Select,
+  tags: ["autodocs"],
   parameters: {
     // TODO: Remove this when this story file becomes the primary one
     chromatic: { disableSnapshot: true },

--- a/src/components/Simulator/WalletHome/__stories__/WalletHome.stories.tsx
+++ b/src/components/Simulator/WalletHome/__stories__/WalletHome.stories.tsx
@@ -11,6 +11,7 @@ import NFTImage from "@/public/images/deep-panic.png"
 const meta = {
   title: "Components / Features / Simulator / WalletHome",
   component: Component,
+  tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
   },

--- a/src/components/Simulator/__stories__/ClickAnimation.stories.tsx
+++ b/src/components/Simulator/__stories__/ClickAnimation.stories.tsx
@@ -8,6 +8,7 @@ import { ClickAnimation } from "../ClickAnimation"
 const meta = {
   title: "Components / Features / Simulator / ClickAnimation",
   component: ClickAnimation,
+  tags: ["autodocs"],
   decorators: [
     (Story) => (
       <div className="relative">

--- a/src/components/Simulator/__stories__/Explanation.stories.tsx
+++ b/src/components/Simulator/__stories__/Explanation.stories.tsx
@@ -17,6 +17,7 @@ SendReceiveIcon.displayName = "SendReceiveIcon"
 const meta = {
   title: "Components / Features / Simulator / Explanation",
   component: ExplanationComponent,
+  tags: ["autodocs"],
   parameters: {
     chromatic: {
       modes: pickBy(viewportModes, (arg) =>

--- a/src/components/Simulator/__stories__/MoreInfoPopover.stories.tsx
+++ b/src/components/Simulator/__stories__/MoreInfoPopover.stories.tsx
@@ -8,6 +8,7 @@ import { MoreInfoPopover as MoreInfoPopoverComponent } from "../MoreInfoPopover"
 const meta = {
   title: "Components / Features / Simulator / MoreInfoPopover",
   component: MoreInfoPopoverComponent,
+  tags: ["autodocs"],
   decorators: [
     (Story) => (
       <Flex className="h-80 w-96 items-center justify-center">

--- a/src/components/Simulator/__stories__/PathButton.stories.tsx
+++ b/src/components/Simulator/__stories__/PathButton.stories.tsx
@@ -7,6 +7,7 @@ import { PathButton as PathButtonComponent } from "../PathButton"
 const meta = {
   title: "Components / Features / Simulator / PathButton",
   component: PathButtonComponent,
+  tags: ["autodocs"],
   decorators: [
     (Story) => (
       <div className="grid w-[300px]">

--- a/src/components/Simulator/screens/ConnectWeb3/__stories__/ConnectWeb3.stories.tsx
+++ b/src/components/Simulator/screens/ConnectWeb3/__stories__/ConnectWeb3.stories.tsx
@@ -9,6 +9,7 @@ import { ConnectWeb3 as Component } from "../"
 const meta = {
   title: "Components / Features / Simulator / Screens / ConnectWeb3",
   component: Component,
+  tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
   },

--- a/src/components/Simulator/screens/CreateAccount/__stories__/GeneratingKeys.stories.tsx
+++ b/src/components/Simulator/screens/CreateAccount/__stories__/GeneratingKeys.stories.tsx
@@ -16,6 +16,7 @@ const meta = {
   title:
     "Components / Features / Simulator / Screens / CreateAccount / GeneratingKeys",
   component: GeneratingKeys,
+  tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
   },

--- a/src/components/Simulator/screens/CreateAccount/__stories__/HomeScreen.stories.tsx
+++ b/src/components/Simulator/screens/CreateAccount/__stories__/HomeScreen.stories.tsx
@@ -9,6 +9,7 @@ const meta = {
   title:
     "Components / Features / Simulator / Screens / CreateAccount / HomeScreen",
   component: Component,
+  tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
   },

--- a/src/components/Simulator/screens/CreateAccount/__stories__/InitialWordDisplay.stories.tsx
+++ b/src/components/Simulator/screens/CreateAccount/__stories__/InitialWordDisplay.stories.tsx
@@ -8,6 +8,7 @@ const meta = {
   title:
     "Components / Features / Simulator / Screens / CreateAccount / InitialWordDisplay",
   component: Component,
+  tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
   },

--- a/src/components/Simulator/screens/CreateAccount/__stories__/InteractiveWordSelector.stories.tsx
+++ b/src/components/Simulator/screens/CreateAccount/__stories__/InteractiveWordSelector.stories.tsx
@@ -16,6 +16,7 @@ const meta = {
   title:
     "Components / Features / Simulator / Screens / CreateAccount / InteractiveWordSelector",
   component: Component,
+  tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
   },

--- a/src/components/Simulator/screens/CreateAccount/__stories__/RecoveryPhraseNotice.stories.tsx
+++ b/src/components/Simulator/screens/CreateAccount/__stories__/RecoveryPhraseNotice.stories.tsx
@@ -8,6 +8,7 @@ const meta = {
   title:
     "Components / Features / Simulator / Screens / CreateAccount / RecoveryPhraseNotice",
   component: Component,
+  tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
   },

--- a/src/components/Simulator/screens/CreateAccount/__stories__/WelcomeScreen.stories.tsx
+++ b/src/components/Simulator/screens/CreateAccount/__stories__/WelcomeScreen.stories.tsx
@@ -8,6 +8,7 @@ const meta = {
   title:
     "Components / Features / Simulator / Screens / CreateAccount / WelcomeScreen",
   component: Component,
+  tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
   },

--- a/src/components/Simulator/screens/SendReceive/__stories__/SendReceive.stories.tsx
+++ b/src/components/Simulator/screens/SendReceive/__stories__/SendReceive.stories.tsx
@@ -9,6 +9,7 @@ import { SendReceive } from ".."
 const meta = {
   title: "Components / Features / Simulator / Screens / SendReceive",
   component: SendReceive,
+  tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
   },

--- a/src/components/SocialListItem/SocialListItem.stories.tsx
+++ b/src/components/SocialListItem/SocialListItem.stories.tsx
@@ -7,6 +7,7 @@ import SocialListItem from "."
 const meta = {
   title: "Components / SocialListItem",
   component: SocialListItem,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/SubpageCard/SubpageCard.stories.tsx
+++ b/src/components/SubpageCard/SubpageCard.stories.tsx
@@ -6,6 +6,7 @@ import SubpageCard from "."
 const meta = {
   title: "Components / Cards / SubpageCard",
   component: SubpageCard,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/SupportedLanguagesTooltip/SupportedLanguagesTooltip.stories.tsx
+++ b/src/components/SupportedLanguagesTooltip/SupportedLanguagesTooltip.stories.tsx
@@ -5,6 +5,7 @@ import { SupportedLanguagesTooltip } from "."
 const meta = {
   title: "Components / SupportedLanguagesTooltip",
   component: SupportedLanguagesTooltip,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/TableOfContents/TableOfContents.stories.tsx
+++ b/src/components/TableOfContents/TableOfContents.stories.tsx
@@ -75,6 +75,7 @@ const tocItems: ToCItem[] = [
 const meta = {
   title: "Components / Navigation / TableOfContents",
   component: TableOfContentsComponent,
+  tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
   },

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -18,6 +18,7 @@ const TooltipContent = () => (
 const meta = {
   title: "Components / Tooltip",
   component: TooltipComponent,
+  tags: ["autodocs"],
   args: {
     content: <TooltipContent />,
     children: (

--- a/src/components/TranslationBanner/TranslationBanner.stories.tsx
+++ b/src/components/TranslationBanner/TranslationBanner.stories.tsx
@@ -5,6 +5,7 @@ import TranslationBanner from "."
 const meta = {
   title: "Components / Site Chrome / TranslationBanner",
   component: TranslationBanner,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     layout: "fullscreen",

--- a/src/components/TranslationChartImage/TranslationChartImage.stories.tsx
+++ b/src/components/TranslationChartImage/TranslationChartImage.stories.tsx
@@ -5,6 +5,7 @@ import TranslationChartImageComponent from "."
 const meta = {
   title: "Components / TranslationChartImage",
   component: TranslationChartImageComponent,
+  tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
   },

--- a/src/components/cards/__stories__/pathway-card.stories.tsx
+++ b/src/components/cards/__stories__/pathway-card.stories.tsx
@@ -9,6 +9,7 @@ import walletCardImg from "@/public/images/homepage/features/global.png"
 const meta = {
   title: "Components / Cards / PathwayCard",
   component: PathwayCard,
+  tags: ["autodocs"],
   parameters: {
     layout: "centered",
     chromatic: { disableSnapshot: true },

--- a/src/components/icons/Icons.stories.tsx
+++ b/src/components/icons/Icons.stories.tsx
@@ -96,6 +96,7 @@ import { EthHomeIcon, FeedbackThumbsUpIcon } from "."
 
 const meta = {
   title: "Components / Icons",
+  tags: ["autodocs"],
 } satisfies Meta
 
 export default meta

--- a/src/components/ui/__stories__/Accordion.stories.tsx
+++ b/src/components/ui/__stories__/Accordion.stories.tsx
@@ -10,6 +10,7 @@ import {
 const meta = {
   title: "UI / Data Display / Accordion",
   component: Accordion,
+  tags: ["autodocs"],
   decorators: [
     (Story) => (
       <div className="w-[420px]">

--- a/src/components/ui/__stories__/Alert.stories.tsx
+++ b/src/components/ui/__stories__/Alert.stories.tsx
@@ -15,6 +15,7 @@ import { VStack } from "../flex"
 const meta = {
   title: "UI / Alert",
   component: Alert,
+  tags: ["autodocs"],
   parameters: {
     docs: {
       description: {

--- a/src/components/ui/__stories__/Avatar.stories.tsx
+++ b/src/components/ui/__stories__/Avatar.stories.tsx
@@ -18,6 +18,7 @@ const SAMPLE = {
 const meta = {
   title: "UI / Data Display / Avatar",
   component: Avatar,
+  tags: ["autodocs"],
   args: SAMPLE,
   parameters: {
     docs: {

--- a/src/components/ui/__stories__/Breadcrumb.stories.tsx
+++ b/src/components/ui/__stories__/Breadcrumb.stories.tsx
@@ -13,6 +13,7 @@ import {
 const meta = {
   title: "UI / Navigation / Breadcrumb",
   component: Breadcrumb,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/ui/__stories__/Button.stories.tsx
+++ b/src/components/ui/__stories__/Button.stories.tsx
@@ -7,6 +7,7 @@ import { HStack, VStack } from "../flex"
 const meta = {
   title: "UI / Actions / Button",
   component: Button,
+  tags: ["autodocs"],
   args: {
     children: "What is Ethereum?",
   },

--- a/src/components/ui/__stories__/ButtonLink.stories.tsx
+++ b/src/components/ui/__stories__/ButtonLink.stories.tsx
@@ -6,6 +6,7 @@ import { HStack, VStack } from "../flex"
 const meta = {
   title: "UI / Actions / ButtonLink",
   component: ButtonLink,
+  tags: ["autodocs"],
   args: {
     href: "#",
     children: "What is Ethereum?",

--- a/src/components/ui/__stories__/Chart.stories.tsx
+++ b/src/components/ui/__stories__/Chart.stories.tsx
@@ -26,6 +26,7 @@ import {
 const meta = {
   title: "UI / Data Display / Chart",
   component: ChartContainer,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/ui/__stories__/Checkbox.stories.tsx
+++ b/src/components/ui/__stories__/Checkbox.stories.tsx
@@ -6,6 +6,7 @@ import { HStack, VStack } from "../flex"
 const meta = {
   title: "UI / Forms / Checkbox",
   component: Checkbox,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/ui/__stories__/Collapsible.stories.tsx
+++ b/src/components/ui/__stories__/Collapsible.stories.tsx
@@ -12,6 +12,7 @@ import { HStack, VStack } from "../flex"
 const meta = {
   title: "UI / Collapsible",
   component: Collapsible,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/ui/__stories__/Command.stories.tsx
+++ b/src/components/ui/__stories__/Command.stories.tsx
@@ -17,6 +17,7 @@ import {
 const meta = {
   title: "UI / Overlays / Command",
   component: Command,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/ui/__stories__/Dialog.stories.tsx
+++ b/src/components/ui/__stories__/Dialog.stories.tsx
@@ -17,6 +17,7 @@ import { Flex } from "../flex"
 const meta = {
   title: "UI / Overlays / Dialog",
   component: Dialog,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/ui/__stories__/DropdownMenu.stories.tsx
+++ b/src/components/ui/__stories__/DropdownMenu.stories.tsx
@@ -21,6 +21,7 @@ import {
 const meta = {
   title: "UI / Overlays / DropdownMenu",
   component: DropdownMenu,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/ui/__stories__/EdgeScrollContainer.stories.tsx
+++ b/src/components/ui/__stories__/EdgeScrollContainer.stories.tsx
@@ -5,6 +5,7 @@ import { EdgeScrollContainer, EdgeScrollItem } from "../edge-scroll-container"
 const meta = {
   title: "UI / Layout / EdgeScrollContainer",
   component: EdgeScrollContainer,
+  tags: ["autodocs"],
   decorators: [
     (Story) => (
       <div className="mx-auto max-w-screen-2xl px-4 py-8 md:px-8">

--- a/src/components/ui/__stories__/Flex.stories.tsx
+++ b/src/components/ui/__stories__/Flex.stories.tsx
@@ -5,6 +5,7 @@ import { Center, Flex, HStack, Stack, VStack } from "../flex"
 const meta = {
   title: "UI / Layout / Flex",
   component: Flex,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/ui/__stories__/Input.stories.tsx
+++ b/src/components/ui/__stories__/Input.stories.tsx
@@ -6,6 +6,7 @@ import Input from "../input"
 const meta = {
   title: "UI / Forms / Input",
   component: Input,
+  tags: ["autodocs"],
   parameters: {
     docs: {
       description: {

--- a/src/components/ui/__stories__/Link.stories.tsx
+++ b/src/components/ui/__stories__/Link.stories.tsx
@@ -7,6 +7,7 @@ import { ListItem, UnorderedList } from "../list"
 const meta = {
   title: "UI / Navigation / Link",
   component: InlineLink,
+  tags: ["autodocs"],
   decorators: [
     (Story) => (
       <Center className="max-w-prose">

--- a/src/components/ui/__stories__/LinkBox.stories.tsx
+++ b/src/components/ui/__stories__/LinkBox.stories.tsx
@@ -6,6 +6,7 @@ import { LinkBox, LinkOverlay } from "../link-box"
 const meta = {
   title: "UI / Navigation / LinkBox",
   component: LinkBox,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/ui/__stories__/List.stories.tsx
+++ b/src/components/ui/__stories__/List.stories.tsx
@@ -5,6 +5,7 @@ import { List, ListItem, OrderedList, UnorderedList } from "../list"
 const meta = {
   title: "UI / Data Display / List",
   component: List,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/ui/__stories__/Modal.stories.tsx
+++ b/src/components/ui/__stories__/Modal.stories.tsx
@@ -6,6 +6,7 @@ import ModalComponent from "../dialog-modal"
 const meta = {
   title: "UI / Overlays / Modal",
   component: ModalComponent,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
   },

--- a/src/components/ui/__stories__/PersistentPanel.stories.tsx
+++ b/src/components/ui/__stories__/PersistentPanel.stories.tsx
@@ -7,6 +7,7 @@ import { PersistentPanel } from "../persistent-panel"
 const meta = {
   title: "UI / Data Display / PersistentPanel",
   component: PersistentPanel,
+  tags: ["autodocs"],
   args: {
     open: false,
     children: null,

--- a/src/components/ui/__stories__/Popover.stories.tsx
+++ b/src/components/ui/__stories__/Popover.stories.tsx
@@ -12,6 +12,7 @@ import {
 const meta = {
   title: "UI / Overlays / Popover",
   component: Popover,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/ui/__stories__/Progress.stories.tsx
+++ b/src/components/ui/__stories__/Progress.stories.tsx
@@ -6,6 +6,7 @@ import { Progress } from "../progress"
 const meta = {
   title: "UI / Data Display / Progress",
   component: Progress,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/ui/__stories__/ScrollArea.stories.tsx
+++ b/src/components/ui/__stories__/ScrollArea.stories.tsx
@@ -5,6 +5,7 @@ import { ScrollArea, ScrollBar } from "../scroll-area"
 const meta = {
   title: "UI / ScrollArea",
   component: ScrollArea,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/ui/__stories__/Section.stories.tsx
+++ b/src/components/ui/__stories__/Section.stories.tsx
@@ -11,6 +11,7 @@ import {
 const meta = {
   title: "UI / Layout / Section",
   component: Section,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/ui/__stories__/Select.stories.tsx
+++ b/src/components/ui/__stories__/Select.stories.tsx
@@ -15,6 +15,7 @@ import {
 const meta = {
   title: "UI / Forms / Select",
   component: Select,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/ui/__stories__/Sheet.stories.tsx
+++ b/src/components/ui/__stories__/Sheet.stories.tsx
@@ -15,6 +15,7 @@ import {
 const meta = {
   title: "UI / Overlays / Sheet",
   component: Sheet,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/ui/__stories__/Skeleton.stories.tsx
+++ b/src/components/ui/__stories__/Skeleton.stories.tsx
@@ -12,6 +12,7 @@ import {
 const meta = {
   title: "UI / Layout / Skeleton",
   component: Skeleton,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/ui/__stories__/Spinner.stories.tsx
+++ b/src/components/ui/__stories__/Spinner.stories.tsx
@@ -6,6 +6,7 @@ import { Spinner } from "../spinner"
 const meta = {
   title: "UI / Data Display / Spinner",
   component: Spinner,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/ui/__stories__/Switch.stories.tsx
+++ b/src/components/ui/__stories__/Switch.stories.tsx
@@ -6,6 +6,7 @@ import Switch from "../switch"
 const meta = {
   title: "UI / Forms / Switch",
   component: Switch,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/ui/__stories__/TabNav.stories.tsx
+++ b/src/components/ui/__stories__/TabNav.stories.tsx
@@ -9,6 +9,7 @@ import TabNav, { StickyContainer } from "../TabNav"
 const meta = {
   title: "UI / Navigation / TabNav",
   component: TabNav,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/ui/__stories__/Table/Table.stories.tsx
+++ b/src/components/ui/__stories__/Table/Table.stories.tsx
@@ -12,6 +12,7 @@ import {
 const meta = {
   title: "UI / Data Display / Table",
   component: Table,
+  tags: ["autodocs"],
   decorators: [
     (Story) => (
       <Flex className="max-w-screen-md flex-col gap-12">

--- a/src/components/ui/__stories__/Tabs.stories.tsx
+++ b/src/components/ui/__stories__/Tabs.stories.tsx
@@ -5,6 +5,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "../tabs"
 const meta = {
   title: "UI / Navigation / Tabs",
   component: Tabs,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/ui/__stories__/Tag.stories.tsx
+++ b/src/components/ui/__stories__/Tag.stories.tsx
@@ -6,6 +6,7 @@ import { Tag, TagButton, TagsInlineText } from "../tag"
 const meta = {
   title: "UI / Actions / Tag",
   component: Tag,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/ui/__stories__/TagFilter.stories.tsx
+++ b/src/components/ui/__stories__/TagFilter.stories.tsx
@@ -6,6 +6,7 @@ import TagFilter, { type TagFilterProps } from "../tag-filter"
 const meta = {
   title: "UI / Data Display / TagFilter",
   component: TagFilter,
+  tags: ["autodocs"],
   decorators: [
     (Story) => (
       <div className="w-[640px]">

--- a/src/components/ui/__stories__/TerminalTypewriter.stories.tsx
+++ b/src/components/ui/__stories__/TerminalTypewriter.stories.tsx
@@ -6,6 +6,7 @@ import { TerminalTypewriter } from "../terminal-typewriter"
 const meta = {
   title: "UI / Data Display / TerminalTypewriter",
   component: TerminalTypewriter,
+  tags: ["autodocs"],
   decorators: [
     (Story) => (
       <div className="w-[42rem]">

--- a/src/components/ui/__stories__/TruncatedText.stories.tsx
+++ b/src/components/ui/__stories__/TruncatedText.stories.tsx
@@ -6,6 +6,7 @@ import TruncatedText from "../TruncatedText"
 const meta = {
   title: "UI / Data Display / TruncatedText",
   component: TruncatedText,
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: {

--- a/src/components/ui/__stories__/callout.stories.tsx
+++ b/src/components/ui/__stories__/callout.stories.tsx
@@ -19,6 +19,7 @@ import walking from "@/public/images/walking.png"
 const meta = {
   title: "UI / Data Display / Callout",
   component: Callout,
+  tags: ["autodocs"],
   parameters: {
     // Default preview is layout: "centered" (flex-centered, content-width).
     // Callout has no intrinsic width — it relies on its parent in real pages —

--- a/src/components/ui/__stories__/grid.stories.tsx
+++ b/src/components/ui/__stories__/grid.stories.tsx
@@ -6,6 +6,7 @@ import { Grid } from "@/components/ui/grid"
 const meta = {
   title: "UI / Layout / Grid",
   component: Grid,
+  tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
     // Variant-axis reference stories; opt out of Chromatic by default.

--- a/src/layouts/stories/ContentLayout.stories.tsx
+++ b/src/layouts/stories/ContentLayout.stories.tsx
@@ -9,6 +9,7 @@ import { ContentLayout as ContentLayoutComponent } from "../ContentLayout"
 const meta = {
   title: "Layouts / ContentLayout",
   component: ContentLayoutComponent,
+  tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
     chromatic: {

--- a/src/layouts/stories/Docs.stories.tsx
+++ b/src/layouts/stories/Docs.stories.tsx
@@ -15,6 +15,7 @@ import {
 const meta = {
   title: "Layouts / Docs",
   component: DocsLayout,
+  tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
     // DocsNav does `pathname.indexOf(...)` to mark the active page; without a

--- a/src/layouts/stories/Static.stories.tsx
+++ b/src/layouts/stories/Static.stories.tsx
@@ -15,6 +15,7 @@ import {
 const meta = {
   title: "Layouts / Static",
   component: StaticLayout,
+  tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
     chromatic: { modes: { ...langViewportModes } },

--- a/src/layouts/stories/Topic.stories.tsx
+++ b/src/layouts/stories/Topic.stories.tsx
@@ -17,6 +17,7 @@ import {
 const meta = {
   title: "Layouts / Topic",
   component: TopicLayout,
+  tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
     chromatic: { modes: { ...langViewportModes } },

--- a/src/layouts/stories/Tutorial.stories.tsx
+++ b/src/layouts/stories/Tutorial.stories.tsx
@@ -15,6 +15,7 @@ import {
 const meta = {
   title: "Layouts / Tutorial",
   component: TutorialLayout,
+  tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
     chromatic: { modes: { ...langViewportModes } },

--- a/src/styles/__stories__/colors.stories.tsx
+++ b/src/styles/__stories__/colors.stories.tsx
@@ -18,6 +18,7 @@ import { cn } from "@/lib/utils/cn"
 
 const meta = {
   title: "Design System / Colors",
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     layout: "padded",

--- a/src/styles/__stories__/flow-rhythm.stories.tsx
+++ b/src/styles/__stories__/flow-rhythm.stories.tsx
@@ -21,6 +21,7 @@ import { Button } from "@/components/ui/buttons/Button"
  */
 const meta = {
   title: "Design System / Typography / FlowRhythm",
+  tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
     chromatic: {

--- a/src/styles/__stories__/gradients.stories.tsx
+++ b/src/styles/__stories__/gradients.stories.tsx
@@ -33,6 +33,7 @@ import { cn } from "@/lib/utils/cn"
 
 const meta = {
   title: "Design System / Gradients",
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     layout: "padded",

--- a/src/styles/__stories__/heading.stories.tsx
+++ b/src/styles/__stories__/heading.stories.tsx
@@ -5,6 +5,7 @@ import { Center, Stack } from "@/components/ui/flex"
 
 const meta = {
   title: "Design System / Typography / Heading",
+  tags: ["autodocs"],
   parameters: {
     layout: null,
     chromatic: {

--- a/src/styles/__stories__/shadows.stories.tsx
+++ b/src/styles/__stories__/shadows.stories.tsx
@@ -17,6 +17,7 @@ import { cn } from "@/lib/utils/cn"
 
 const meta = {
   title: "Design System / Shadows",
+  tags: ["autodocs"],
   parameters: {
     chromatic: { disableSnapshot: true },
     layout: "fullscreen",

--- a/src/styles/__stories__/text.stories.tsx
+++ b/src/styles/__stories__/text.stories.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/lib/utils/cn"
 
 const meta = {
   title: "Design System / Typography / Text",
+  tags: ["autodocs"],
   parameters: {
     layout: "none",
   },


### PR DESCRIPTION
## Summary

Phase 5 of #18967, and the last of the sequence.

Adds `tags: ["autodocs"]` to the 118 story files that lacked it -- every component now has a generated docs page (142 of 142).

Adds an **Overview** page as the entry point for designers: which section maps to which directory, how to read each section, why some titles are flat, and the two traps that make Storybook lie -- documented-but-deprecated components, and the fact that a green Chromatic run says nothing about a `UI /` story since they all disable snapshots.

Syncs the three places still documenting the old scheme:

- `AGENTS.md` gains a Storybook section under component development
- `docs/applying-storybook.md` drops its `Atoms / Molecules / Organisms` guidance and the superseded Figma structure file it pointed at
- the `design-system` skill's checklist drops the `UI / Primitives` tier

All three now carry the same rule -- section derived from the file path, second-level group only when an established one fits, never invent a group for a single component -- plus a pointer to the enforcement test and the warning that a passing build doesn't mean a story renders.

Also corrects a stale skill claim that story filenames are PascalCase; the tree is ~⅔ PascalCase, ⅓ kebab. Casing has no functional effect, so the doc now says match your neighbours rather than renaming 15 files to satisfy a rule nobody followed.

Base: `feat/storybook-component-layout-stories` (phase 4, #18987).