### PR TITLE
Add upgrade status data layer for roadmap pages

### DIFF
--- a/src/data/upgrades/README.md
+++ b/src/data/upgrades/README.md
@@ -23,6 +23,10 @@ Strongest to weakest claim: `live` running now · `confirmed` date set via ACD �
 `anticipated` expected, no date · `projected` inferred from the mainnet target ·
 `complete` finished. The UI must never render a weaker status as a settled one.
 
+An undated future fork gets **no milestone entry at all**. `UpgradePhase` already
+encodes the sequence (`devnet` → `testnet` → `scheduled`), so the phase carries
+the shape and milestones carry the facts. A missing testnet fork is not a gap.
+
 ## Status is confidence, not kind
 
 `EipStatus` answers "how firm is this", never "what kind of change is this".

--- a/src/data/upgrades/README.md
+++ b/src/data/upgrades/README.md
@@ -1,40 +1,45 @@
 # Upgrade status data
 
 Volatile facts about network upgrades: phase, dates, milestones, EIP inclusion
-status. One file per upgrade, typed by `types.ts`.
-
-**Prose stays in `public/content/`.** These files exist so that refreshing a
-date does not require a human to edit an explainer. If a value here is wrong,
-fix it here — do not paper over it in the markdown.
+status. One file per upgrade, typed by `types.ts`. **Prose stays in
+`public/content/`** — these files exist so refreshing a date does not require
+editing an explainer. If a value here is wrong, fix it here.
 
 ## Sources of truth
 
-[Forkcast](https://forkcast.org) and the upgrade's meta EIP, and nothing else.
-Not recollection, not news coverage, not another page on this site. Facts move
-roughly weekly with the All Core Devs call cadence.
+[Forkcast](https://forkcast.org) and the upgrade's meta EIP, nothing else. Facts
+move roughly weekly with the All Core Devs cadence. Meta EIPs stay `Draft` until
+activation, so scope can still change — record what is true today.
 
 ## `phase`
 
-- `planning` — headliners not yet locked
-- `devnet` — client teams iterating on devnets
-- `testnet` — public testnet forks running
-- `scheduled` — mainnet epoch confirmed via ACD
-- `activated` — shipped to mainnet
+`planning` headliners not locked · `devnet` iterating on devnets · `testnet`
+public testnet forks running · `scheduled` mainnet epoch confirmed via ACD ·
+`activated` shipped to mainnet.
 
 ## Milestone `status`
 
-Ordered strongest to weakest claim. The UI must never render a weaker status as
-a settled one — a `projected` date is not a promise.
+Strongest to weakest claim: `live` running now · `confirmed` date set via ACD ·
+`anticipated` expected, no date · `projected` inferred from the mainnet target ·
+`complete` finished. The UI must never render a weaker status as a settled one.
 
-- `live` — currently running
-- `confirmed` — date set via ACD
-- `anticipated` — expected, no date set
-- `projected` — inferred from the mainnet target; the weakest claim
-- `complete` — happened and is finished
+## Status is confidence, not kind
 
-## Two date stamps, two meanings
+`EipStatus` answers "how firm is this", never "what kind of change is this".
+Networking EIPs are `sfi` like any other scheduled EIP — the meta EIP's
+"Networking" grouping is a category, and categories do not belong in a
+confidence enum. Collapsing two orthogonal dimensions is how enums rot. If a
+consumer ever needs kind, add a field. None does today.
 
-- **Page last updated** — derived from git. Implies a human reviewed the prose.
-- **`facts-verified`** — says only that someone checked these values against
-  Forkcast that day. It makes no claim about the surrounding prose. Bump it
-  whenever you check, even if nothing changed.
+## Dates
+
+`when` carries only the precision that has a source: `{ year }`,
+`{ year, month }`, or `{ year, month, day }`. Deliberately **no quarter or
+half-year** — every sourced value fits those three, and the one quarter ever
+claimed for Glamsterdam traced to a staking provider's post, not an ACD call.
+
+## Two date stamps
+
+**Page last updated** is git-derived and implies a human reviewed the prose.
+**`facts-verified`** says only that these values were checked against Forkcast
+that day. Bump it whenever you check, even if nothing changed.

--- a/src/data/upgrades/README.md
+++ b/src/data/upgrades/README.md
@@ -19,9 +19,10 @@ public testnet forks running · `scheduled` mainnet epoch confirmed via ACD ·
 
 ## Milestone `status`
 
-Strongest to weakest claim: `live` running now · `confirmed` date set via ACD ·
-`anticipated` expected, no date · `projected` inferred from the mainnet target ·
-`complete` finished. The UI must never render a weaker status as a settled one.
+`complete` is the one settled value — the milestone happened. The other four are
+claims about the future, strongest to weakest: `live` running now · `confirmed`
+date set via ACD · `anticipated` expected, no date · `projected` inferred from
+the mainnet target. The UI must never render a weaker one as a settled one.
 
 An undated future fork gets **no milestone entry at all**. `UpgradePhase` already
 encodes the sequence (`devnet` → `testnet` → `scheduled`), so the phase carries

--- a/src/data/upgrades/README.md
+++ b/src/data/upgrades/README.md
@@ -5,6 +5,11 @@ status. One file per upgrade, typed by `types.ts`. **Prose stays in
 `public/content/`** — these files exist so refreshing a date does not require
 editing an explainer. If a value here is wrong, fix it here.
 
+**Rationale belongs in this README, not in comments inside the data files.**
+These files are meant to be machine-writable, and anything that regenerates one
+from a template will silently drop inline comments. Record *why* a value is what
+it is here, where it survives.
+
 ## Sources of truth
 
 [Forkcast](https://forkcast.org) and the upgrade's meta EIP, nothing else. Facts

--- a/src/data/upgrades/README.md
+++ b/src/data/upgrades/README.md
@@ -1,0 +1,40 @@
+# Upgrade status data
+
+Volatile facts about network upgrades: phase, dates, milestones, EIP inclusion
+status. One file per upgrade, typed by `types.ts`.
+
+**Prose stays in `public/content/`.** These files exist so that refreshing a
+date does not require a human to edit an explainer. If a value here is wrong,
+fix it here — do not paper over it in the markdown.
+
+## Sources of truth
+
+[Forkcast](https://forkcast.org) and the upgrade's meta EIP, and nothing else.
+Not recollection, not news coverage, not another page on this site. Facts move
+roughly weekly with the All Core Devs call cadence.
+
+## `phase`
+
+- `planning` — headliners not yet locked
+- `devnet` — client teams iterating on devnets
+- `testnet` — public testnet forks running
+- `scheduled` — mainnet epoch confirmed via ACD
+- `activated` — shipped to mainnet
+
+## Milestone `status`
+
+Ordered strongest to weakest claim. The UI must never render a weaker status as
+a settled one — a `projected` date is not a promise.
+
+- `live` — currently running
+- `confirmed` — date set via ACD
+- `anticipated` — expected, no date set
+- `projected` — inferred from the mainnet target; the weakest claim
+- `complete` — happened and is finished
+
+## Two date stamps, two meanings
+
+- **Page last updated** — derived from git. Implies a human reviewed the prose.
+- **`facts-verified`** — says only that someone checked these values against
+  Forkcast that day. It makes no claim about the surrounding prose. Bump it
+  whenever you check, even if nothing changed.

--- a/src/data/upgrades/glamsterdam.ts
+++ b/src/data/upgrades/glamsterdam.ts
@@ -45,6 +45,6 @@ export const glamsterdam = {
     { id: 7708, status: "sfi", headliner: false },
     { id: 7975, status: "sfi", headliner: false },
   ],
-  "facts-verified": "2026-08-06",
+  "facts-verified": "2026-08-10",
   "source-url": "https://forkcast.org/upgrade/glamsterdam",
 } satisfies UpgradeData

--- a/src/data/upgrades/glamsterdam.ts
+++ b/src/data/upgrades/glamsterdam.ts
@@ -1,0 +1,39 @@
+import type { UpgradeData } from "./types"
+
+export const glamsterdam = {
+  name: "Glamsterdam",
+  slug: "glamsterdam",
+  "consensus-layer": "Gloas",
+  "execution-layer": "Amsterdam",
+  "meta-eip": 7773,
+  phase: "devnet",
+  "mainnet-target": { window: "2026", date: null, confirmed: false },
+  milestones: [
+    {
+      name: "Devnet-7",
+      window: "July 2026",
+      date: "2026-07-14",
+      status: "complete",
+    },
+    {
+      // Named devnet, not a public testnet. Forkcast has it targeting early
+      // August with the exact date deferred to ACDT #90.
+      name: "Devnet-8 (Plataberget)",
+      window: "August 2026",
+      date: null,
+      status: "anticipated",
+    },
+    {
+      name: "Mainnet activation",
+      window: "2026",
+      date: null,
+      status: "projected",
+    },
+  ],
+  eips: [
+    { id: 7732, status: "sfi", headliner: true },
+    { id: 7928, status: "sfi", headliner: true },
+  ],
+  "facts-verified": "2026-08-06",
+  "source-url": "https://forkcast.org/upgrade/glamsterdam",
+} satisfies UpgradeData

--- a/src/data/upgrades/glamsterdam.ts
+++ b/src/data/upgrades/glamsterdam.ts
@@ -7,32 +7,43 @@ export const glamsterdam = {
   "execution-layer": "Amsterdam",
   "meta-eip": 7773,
   phase: "devnet",
-  "mainnet-target": { window: "2026", date: null, confirmed: false },
+  // Forkcast records the mainnet target as the year only. No quarter has an ACD
+  // source, and the meta EIP's activation table is still empty.
+  "mainnet-target": { when: { year: 2026 }, confirmed: false },
   milestones: [
     {
       name: "Devnet-7",
-      window: "July 2026",
-      date: "2026-07-14",
+      when: { year: 2026, month: 7, day: 14 },
       status: "complete",
     },
     {
-      // Named devnet, not a public testnet. Forkcast has it targeting early
+      // A named devnet, not a public testnet. Forkcast has it targeting early
       // August with the exact date deferred to ACDT #90.
       name: "Devnet-8 (Plataberget)",
-      window: "August 2026",
-      date: null,
+      when: { year: 2026, month: 8 },
       status: "anticipated",
     },
     {
       name: "Mainnet activation",
-      window: "2026",
-      date: null,
+      when: { year: 2026 },
       status: "projected",
     },
   ],
+  // One entry per EIP the Glamsterdam page has a section for, in page order.
+  // Deliberately not the full meta EIP roster: Forkcast already publishes that,
+  // and duplicating it here would create a second source of truth.
   eips: [
     { id: 7732, status: "sfi", headliner: true },
     { id: 7928, status: "sfi", headliner: true },
+    { id: 8159, status: "sfi", headliner: false },
+    { id: 8037, status: "sfi", headliner: false },
+    { id: 8038, status: "sfi", headliner: false },
+    { id: 8045, status: "sfi", headliner: false },
+    { id: 8061, status: "sfi", headliner: false },
+    { id: 2780, status: "sfi", headliner: false },
+    { id: 7997, status: "sfi", headliner: false },
+    { id: 7708, status: "sfi", headliner: false },
+    { id: 7975, status: "sfi", headliner: false },
   ],
   "facts-verified": "2026-08-06",
   "source-url": "https://forkcast.org/upgrade/glamsterdam",

--- a/src/data/upgrades/index.ts
+++ b/src/data/upgrades/index.ts
@@ -1,0 +1,8 @@
+import { glamsterdam } from "./glamsterdam"
+import type { UpgradeData } from "./types"
+
+export * from "./types"
+
+export const upgrades: Record<string, UpgradeData> = {
+  glamsterdam,
+}

--- a/src/data/upgrades/types.ts
+++ b/src/data/upgrades/types.ts
@@ -44,7 +44,7 @@ export type MilestoneStatus =
  * other scheduled EIP — the meta EIP's "Networking" grouping is a category, and
  * categories do not belong in a confidence enum. See `README.md`.
  */
-export type EipStatus = "pfi" | "cfi" | "sfi" | "dfi" | "declined"
+export type EipStatus = "pfi" | "cfi" | "sfi" | "dfi"
 
 /**
  * A date carrying only the precision that has a source behind it: a year, a

--- a/src/data/upgrades/types.ts
+++ b/src/data/upgrades/types.ts
@@ -20,11 +20,20 @@ export type UpgradePhase =
   | "activated"
 
 /**
- * How strong a claim we are making about a milestone. Ordered from strongest
- * to weakest evidence; the UI must never render a weaker status as a settled
- * one.
+ * How strong a claim we are making about a milestone.
+ *
+ * `complete` is the one settled value: the milestone happened, so there is
+ * nothing left to qualify. The remaining four are claims about the future,
+ * listed strongest to weakest evidence, and the UI must never render a weaker
+ * one as though it were settled.
+ *
+ * The distinction consumers actually make today is `complete` vs everything
+ * else — the status block picks the first milestone that is not `complete` and
+ * calls it "next".
  */
 export type MilestoneStatus =
+  /** Happened and is finished. */
+  | "complete"
   /** Currently running. */
   | "live"
   /** Date set via ACD. */
@@ -33,8 +42,6 @@ export type MilestoneStatus =
   | "anticipated"
   /** Inferred from the mainnet target; the weakest claim. */
   | "projected"
-  /** Happened and is finished. */
-  | "complete"
 
 /**
  * EIP inclusion status, using the All Core Devs vocabulary.

--- a/src/data/upgrades/types.ts
+++ b/src/data/upgrades/types.ts
@@ -39,25 +39,36 @@ export type MilestoneStatus =
 /**
  * EIP inclusion status, using the All Core Devs vocabulary.
  * `pfi` proposed, `cfi` considered, `sfi` scheduled, `dfi` declined.
+ *
+ * This expresses *confidence*, never *kind*. Networking EIPs are `sfi` like any
+ * other scheduled EIP — the meta EIP's "Networking" grouping is a category, and
+ * categories do not belong in a confidence enum. See `README.md`.
  */
 export type EipStatus = "pfi" | "cfi" | "sfi" | "dfi" | "declined"
+
+/**
+ * A date carrying only the precision that has a source behind it: a year, a
+ * year and month, or an exact day. One field rather than a separate `window`
+ * string and `date`, so the two can never disagree.
+ *
+ * There is deliberately no quarter or half-year granularity — see `README.md`.
+ * The union shape makes a day-without-a-month a type error.
+ */
+export type PartialDate =
+  | { year: number; month?: never; day?: never }
+  | { year: number; month: number; day?: never }
+  | { year: number; month: number; day: number }
 
 /** A dated step on the way to mainnet: a devnet, a testnet fork, activation. */
 export interface Milestone {
   name: string
-  /** Human-readable period, e.g. "August 2026". Always present. */
-  window: string
-  /** ISO `YYYY-MM-DD`, or `null` when no exact date is set. */
-  date: string | null
+  when: PartialDate
   status: MilestoneStatus
 }
 
 /** When the upgrade is expected on mainnet. */
 export interface MainnetTarget {
-  /** Human-readable period, e.g. "2026". Always present. */
-  window: string
-  /** ISO `YYYY-MM-DD`, or `null` until an activation date is set. */
-  date: string | null
+  when: PartialDate
   /** True only once the mainnet epoch is confirmed via ACD. */
   confirmed: boolean
 }

--- a/src/data/upgrades/types.ts
+++ b/src/data/upgrades/types.ts
@@ -1,0 +1,91 @@
+/**
+ * Types for the upgrade status data layer.
+ *
+ * These files hold volatile facts about network upgrades (dates, phases, EIP
+ * inclusion status) so that refreshing them does not require editing prose.
+ * See `README.md` in this directory for the editing contract.
+ */
+
+/** Where an upgrade sits in the release process. */
+export type UpgradePhase =
+  /** Headliners not yet locked. */
+  | "planning"
+  /** Client teams iterating on devnets. */
+  | "devnet"
+  /** Public testnet forks running. */
+  | "testnet"
+  /** Mainnet epoch confirmed via ACD. */
+  | "scheduled"
+  /** Shipped to mainnet. */
+  | "activated"
+
+/**
+ * How strong a claim we are making about a milestone. Ordered from strongest
+ * to weakest evidence; the UI must never render a weaker status as a settled
+ * one.
+ */
+export type MilestoneStatus =
+  /** Currently running. */
+  | "live"
+  /** Date set via ACD. */
+  | "confirmed"
+  /** Expected, no date set. */
+  | "anticipated"
+  /** Inferred from the mainnet target; the weakest claim. */
+  | "projected"
+  /** Happened and is finished. */
+  | "complete"
+
+/**
+ * EIP inclusion status, using the All Core Devs vocabulary.
+ * `pfi` proposed, `cfi` considered, `sfi` scheduled, `dfi` declined.
+ */
+export type EipStatus = "pfi" | "cfi" | "sfi" | "dfi" | "declined"
+
+/** A dated step on the way to mainnet: a devnet, a testnet fork, activation. */
+export interface Milestone {
+  name: string
+  /** Human-readable period, e.g. "August 2026". Always present. */
+  window: string
+  /** ISO `YYYY-MM-DD`, or `null` when no exact date is set. */
+  date: string | null
+  status: MilestoneStatus
+}
+
+/** When the upgrade is expected on mainnet. */
+export interface MainnetTarget {
+  /** Human-readable period, e.g. "2026". Always present. */
+  window: string
+  /** ISO `YYYY-MM-DD`, or `null` until an activation date is set. */
+  date: string | null
+  /** True only once the mainnet epoch is confirmed via ACD. */
+  confirmed: boolean
+}
+
+/** An EIP and its inclusion status for one upgrade. */
+export interface UpgradeEip {
+  id: number
+  status: EipStatus
+  headliner: boolean
+}
+
+/** The full volatile-fact record for one network upgrade. */
+export interface UpgradeData {
+  name: string
+  slug: string
+  "consensus-layer": string
+  "execution-layer": string
+  "meta-eip": number
+  phase: UpgradePhase
+  "mainnet-target": MainnetTarget
+  milestones: Milestone[]
+  eips: UpgradeEip[]
+  /**
+   * ISO `YYYY-MM-DD` on which these facts were last checked against Forkcast.
+   * This is not the same as the page's git-derived "last updated" stamp; see
+   * `README.md`.
+   */
+  "facts-verified": string
+  /** Forkcast page for this upgrade. */
+  "source-url": string
+}


### PR DESCRIPTION
> **Base branch: `dev`.** This is PR 1 of a stack of four. Later PRs target each other, not `dev` — see the stack below.

## Description

### The problem

The Glamsterdam roadmap page went stale within about two weeks of its 20 July 2026 edit. Worth being precise about *what* went stale, because it points at the fix:

- **Everything stale was a volatile fact** — the mainnet target, testnet milestones, EIP inclusion status.
- **Everything correct was prose** — the ePBS and BAL explainers, the FAQ, the page structure.

Facts have a roughly weekly shelf life, set by the All Core Devs call cadence. Prose has a shelf life of months. Right now they share one markdown file, so refreshing a date means a human editing a file full of explainer text. That friction is why it drifts.

This happened again *today*, which is a decent illustration: #18990 landed a scope refresh, and getting the timeline from "H2 2026" to "Q4 2026" meant touching the page prose, `src/data/roadmap/releases.tsx`, and an intl string in three separate places.

### The proposal

Separate the two. Volatile facts move into a typed data layer; prose stays in `public/content/`. This PR adds only the data layer.

- `src/data/upgrades/types.ts` — `UpgradePhase`, `MilestoneStatus`, `EipStatus`, `PartialDate`, and the `UpgradeData` / `Milestone` / `UpgradeEip` / `MainnetTarget` shapes.
- `src/data/upgrades/glamsterdam.ts` — the first record: phase, mainnet target, 3 milestones, and the 11 EIPs the page has a section for.
- `src/data/upgrades/index.ts` — barrel, matching the `src/data/{apps,quizzes,topics}/index.ts` pattern.
- `src/data/upgrades/README.md` — the editing contract.

### There is no visual change

Nothing imports this yet. **The Netlify preview should be identical to `dev`** — that's the intended review check for this PR.

## Why `src/data`

`docs/stack.md` describes `/src/data` as "general data files importable by components", which is exactly what this is. It sits alongside `community-meetups.json`, `developer-docs-links.yaml`, and — most directly comparable — `networkUpgradeSummaryData.ts`, which already stores activation dates for shipped forks.

## Why `.ts` and not `.json`

Initially specced as JSON. That doesn't work: TypeScript widens JSON string values to `string`, so `satisfies UpgradeData` fails on *correct* data:

```
error TS1360: Type '{ phase: string; ... }' does not satisfy the expected type 'UpgradeData'.
  Types of property 'phase' are incompatible.
    Type 'string' is not assignable to type 'UpgradePhase'.
```

`declare module` would type the import as `UpgradeData`, but that asserts rather than checks — `"phase": "devnetX"` would sail through. That's the appearance of safety with none of it.

`.ts` with `satisfies` gives a real build-time guarantee, and matches how every other typed data file here is written (`developerTools.ts`, `wallet-data.ts`, `quizzes/index.ts` all use `satisfies` on an inline literal; none of the 12 JSON imports in `src/` carry a type).

Verified by breaking each enum in turn and running `pnpm type-check`:

```
src/data/upgrades/glamsterdam.ts(9,3):  error TS2820: Type '"devnets"' is not assignable to type 'UpgradePhase'. Did you mean '"devnet"'?
src/data/upgrades/glamsterdam.ts(24,7): error TS2322: Type '"probably"' is not assignable to type 'MilestoneStatus'.
src/data/upgrades/glamsterdam.ts(35,17): error TS2322: Type '"scheduled"' is not assignable to type 'EipStatus'.
```

A typo'd status now fails CI instead of quietly rendering.

## Dates carry only the precision that has a source

`when` is a single field whose precision is whatever keys are present — `{ year }`, `{ year, month }`, or `{ year, month, day }`. It replaces an earlier `window` string plus a separate ISO `date`. Two fields carrying the same information are two fields a future Forkcast sync could update independently and inconsistently; one field can't disagree with itself. It also removes an English month name (`"August 2026"`) from the data, so windows now locale-format through `dateTimeFormat()` instead of rendering as English inside a translated page.

The union shape does real work — both of these are compile errors:

```
error TS2322: Type '{ year: number; day: number; }' is not assignable to type 'PartialDate'.
error TS2353: Object literal may only specify known properties, and 'quarter' does not exist in type 'PartialDate'.
```

**There is deliberately no quarter or half-year granularity.** Every value with a real source fits year / month / day, and the only quarter ever claimed for Glamsterdam is the unsourced one discussed below. I checked whether half-year framing exists in the wild before ruling it out: there is no `H1`/`H2` string anywhere in English content or `src/intl/en/`. Quarters appear only in prose strings (`page-10-year-anniversary.json`, a Pectra video transcript) and in the three places #18990 added "Q4 2026" — never in structured data. Documented as a deliberate omission in the README so it doesn't get re-litigated.

## Why every date carries a confidence level

The July page flattened a projection into a plain statement. Once "we think Q4" is written as "planned for Q4", nothing downstream can tell the difference.

So confidence lives in the data: `MilestoneStatus` is ordered `live` → `confirmed` → `anticipated` → `projected`, and `mainnet-target` carries an explicit `confirmed` boolean. **The UI cannot overclaim, because the data won't let it** — a `projected` date has to render with a qualifier.

## Why two date stamps

- **"Page last updated"** — git-derived, already rendered in the hero for `template: upgrade` pages. Implies *a human reviewed the prose*.
- **`facts-verified`** — says only that someone checked these values against Forkcast that day. Makes no claim about the surrounding prose.

Collapsing them loses real information in both directions: a facts-only refresh shouldn't imply the explainers were re-read, and a typo fix in the FAQ shouldn't imply the dates were re-checked.

## Sources

Every value traces to [Forkcast](https://forkcast.org/upgrade/glamsterdam) (via its published structured data, since the site body is client-rendered) or meta [EIP-7773](https://eips.ethereum.org/EIPS/eip-7773). Three notes where that changed what was originally specced:

- **`mainnet-target.window` is `"2026"`, not `"Q4 2026"`.** See the section below.
- **"Plataberget" is devnet-8, not a testnet.** It's a short-lived fork-transition devnet, and as of today it hadn't launched (Forkcast targets early August, exact date deferred to ACDT call 90). Recorded as `anticipated`, not `live`.
- **No testnet milestones.** Forkcast has no scheduled Glamsterdam testnet forks, and the meta EIP's own activation table is still empty. Rather than invent a window, they're omitted until there's a date. Note the meta EIP's table lists **Holešky**, which is stale — Holešky was [shut down](https://blog.ethereum.org/2025/09/01/holesky-shutdown-announcement) after Fusaka, and this repo's own docs already name Sepolia and Hoodi as the maintained testnets. When those forks get dates they go in as Hoodi.

## Which EIPs are in `eips[]`

The 11 the Glamsterdam page has a section for, in page order — not the meta EIP's full roster. Forkcast and EIP-7773 already publish the complete list; a hand-maintained copy of 25 entries would be a second source of truth that silently rots, and it edges toward being an EIP directory.

This gives a checkable invariant: **every EIP section on the page has exactly one entry in `eips[]`.** PR 3 will add a test that parses the page for EIP references and asserts coverage, so a future twelfth section fails CI rather than silently rendering no chip.

All 11 are `sfi` per EIP-7773. Two of them — 7975 (eth/70) and 8159 (eth/71) — are filed under the meta EIP's "Other EIPs → Networking" heading rather than under SFI, but they're scheduled all the same; the page correctly describes both as required for all execution layer clients. They're recorded as `sfi` with **no** `networking` status and no `category` field, on the rule that status expresses confidence and category expresses kind: collapsing two orthogonal dimensions into one enum is how enums rot. That rule is now written into the README.

Scope can still change — EIP-7773 is still `Draft`, as meta EIPs are until activation. The README says so, and PR 3 keeps a sentence to that effect on the page.

## The mainnet target is `"2026"`, not `"Q4 2026"`

This is the one place where the data deliberately says something less specific than the page currently does, so it's worth setting out the reasoning.

- **The Q4 figure traces to an X post by SSV Network**, a staking provider. Ethereum has not confirmed a mainnet date.
- **ethereum.org's own official roadmap framing elsewhere is the broader H2 2026 window.**
- **The projections disagree with each other.** eipsinsight projects 2026-09-16 — that's Q3, not Q4 — and is explicit that only ACD-confirmed dates are marked as confirmed. Everstake still cites end of August 2026 as the internal working target. Datawallet puts the base case at September to December.
- **Forkcast's year-only value is editorial restraint, not a schema limitation.** Forkcast records exact dates when they exist (it has them for Pectra and Fusaka down to the slot). For Glamsterdam it publishes `2026` because that is the most specific defensible claim.
- **Rendering an unconfirmed quarter as settled is precisely the failure this data layer exists to prevent.** If we can't cite an ACD source, the schema should not let the UI imply one.

**This is a net gain for readers, not a regression.** The page today shows a vague quarter and no milestones at all. The component in PR 2 shows the year *plus* a concrete next milestone, a `facts-verified` date, and a link to Forkcast for live detail. Readers get more useful information and a clearer sense of how firm it is.

One honest caveat on that: because Forkcast has no Glamsterdam testnet forks scheduled, the concrete next milestone is currently **Devnet-8 ("Plataberget"), expected August 2026** — a devnet rather than a public testnet fork. Once Sepolia and Hoodi forks get dates, they land in `milestones` and become the next milestone automatically, with no prose edit.

## Follow-up stack: four PRs, not six

| PR | Branch | Base | What |
| -- | ------ | ---- | ---- |
| 1 | `roadmap-upgrade-data-layer` | `dev` | This PR — data only, no visual change |
| 2 | `roadmap-upgrade-status` | PR 1 | Status block, rendered by `TopicLayout` |
| 3 | `roadmap-eip-chips` | PR 2 | EIP inclusion chips driven by `eips[].status` |
| 4 | `roadmap-hegota-page` | PR 2 | Hegotá record + a thin planning-phase page |

**Two further PRs were planned and have been deliberately dropped**, because building them requires answering question 2 below rather than guessing at it:

- A `/roadmap/` upgrade-sequence refactor, pointing the existing release carousel at this data layer.
- Making the technical-history page read activation dates from here.

They collapse into a single piece of work about one seam, and it is the seam maintainers have not ruled on. The carousel spans both categories — Pectra and Fusaka have shipped, Glamsterdam and Hegotá have not — so "read from the data layer" would mean reading from *two* sources whose relationship is undecided. Worse, that refactor would have created Pectra and Fusaka records here, while both already exist in `networkUpgradeSummaryData.ts` (Fusaka at `2025-12-03` with block, epoch, slot, ETH price and Wayback link). That is precisely the duplication the refactor was meant to remove.

Explicitly **not** in scope for any of this: a workflow, cron, or script that writes these files, and any EIP directory, call tracker, or devnet dashboard. Forkcast does those well; duplicating them would create the second source of truth this exists to prevent. (For the avoidance of doubt, the scheduled job this schema anticipates would be a deterministic diff of structured fields against Forkcast's published data — no model involved in deciding what a value should be.)

## Open questions for maintainers

1. **Is `src/data/upgrades/` the right home?** Two reasons to doubt it, and I'd rather ask than be told:
   - **`src/data/roadmap/` already exists** (`releases.tsx`, which powers the `/roadmap/` release carousel). These files are roadmap data by any reasonable reading, so `src/data/roadmap/upgrades/` may be the more consistent home. I defaulted to the top level because `src/data/roadmap/` currently holds one presentational file rather than a general namespace — but that's a weak reason and easy to change now, much harder after five more PRs import from it.
   - **`networkUpgradeSummaryData.ts`** already holds activation facts for shipped forks, so there's a surface case for one file covering an upgrade's whole lifecycle. **I think they should stay separate, and the reason is a safety property rather than tidiness:** `src/data/upgrades` is *bot-writable by design* — the point of a typed, Forkcast-checkable file is that a future scheduled job could diff it and open a PR. `networkUpgradeSummaryData.ts` is the opposite: an immutable historical record of 26 entries with ETH prices and Wayback links going back to 2013, appended once per activation. Merging them would hand a future automated writer access to settled history. Keeping them apart bounds the blast radius of a bad automated write to facts that are still provisional.
   - The actual overlap is **one field** — the activation date. Everything else is disjoint: no confidence model, milestones, EIP statuses, or verification stamp exists on the historical side, and no ETH price or Wayback link belongs on the forward-looking side.
   - **This question gates the two dropped PRs.** If `isPending` is the intended mechanism, the answer is clean: the release carousel and the history page read from `networkUpgradeSummaryData.ts`, `src/data/upgrades` holds only forward-looking volatile facts, and the two dropped PRs become one PR about the handoff between them. If it isn't, the shape is different enough that guessing would waste the work.
2. **Any objection to a second date stamp?** Two dates on one page needs clear labelling or it's just confusing. If one stamp is preferred, I'd rather know before PR 2 renders it.
3. **i18n input wanted on the label set.** Every user-facing label is a Crowdin task across all locales and expensive to revise later, so the stack keeps the set deliberately small: **11 new strings total** — 7 in PR 2 (status block), 2 in PR 3 (EIP chips), 2 in PR 4 (planning-phase label, Hegotá nav entry). If anyone with i18n context wants to weigh in on trimming that further — or on whether hedges like "Date not yet confirmed" survive translation without losing their force — that feedback is most useful before PR 2 merges.
4. **Does `NetworkUpgradeDetails.isPending` point at a better design for the handoff?** That type has an `isPending: true` variant which forbids `ethPriceInUSD` and `waybackLink` — and **no entry currently uses it**. Read one way, someone already designed the pending-upgrade flow: a pending row exists first, and the price/Wayback fields get filled in on activation. If that's right, it is a better design than having the history page read activation dates out of `src/data/upgrades`: the upgrade would already have its row, and activation would simply populate it.

   I'm flagging rather than concluding: an unused type variant is as often abandoned intent as it is a plan, and someone here may know the history. Worth settling before the deferred handoff work is built, since the two designs are different PRs.
5. **Should `UpgradePhase` have an `activated` value at all?** It's in the union, but if shipped upgrades live in `networkUpgradeSummaryData.ts` then it may never be used — and the rest of an `UpgradeData` payload stops meaning anything once an upgrade ships. A settled activation date needs no `confirmed` flag, milestones become history rather than expectations, and `facts-verified` has nothing left to verify.

   So `activated` is either **the handoff state at which a file stops being maintained** — reached once, then frozen or deleted — or it should not exist. This is worth settling before anything writes to these files: it determines what a future scheduled sync does the day an upgrade ships, and "keep updating a file whose every field has become meaningless" is the wrong default to arrive at by accident.
6. **Is there an ACD source for "Q4 2026"?** #18990 introduced that wording to the page copy earlier today. If there's a confirmation I couldn't find, this is a one-line change to the data file. Otherwise I'd suggest the page copy follow the data rather than the other way round — which is the whole point of having the data layer.

7. **Does `facts-verified` survive contact with a scheduled sync?** Genuine uncertainty rather than a proposal — I don't have a good answer.

   Today the field means someone confirmed these values against Forkcast on that date, which works while a human maintains the file. Under a scheduled job it gets awkward. If the job checks weekly and nothing has changed, the facts genuinely *were* verified, so the stamp should move. But bumping it produces a PR every week containing nothing but a date change, which defeats the "only open a PR when something actually changed" rule that makes such a job tolerable in the first place.

   So either the stamp goes stale while verification is demonstrably happening, or it generates weekly noise. Possibly the field doesn't belong in a bot-maintained file at all and belongs in the job's own output — a run log or a status endpoint — with the page reading it from there. Raising it now because it is cheap to change before merge and awkward to change after.

   **This has already happened once, during review.** `facts-verified` was bumped from `2026-08-06` to `2026-08-10` in a commit that changed nothing else, because the values were re-checked against Forkcast and none of them had moved. That is the whole problem in miniature: the verification was real and worth recording, and the commit still contains only a date. A weekly job would produce that same commit indefinitely.

## Related Issue

N/A — follow-up to the content drift addressed in #18990.


