### PR TITLE
Consolidate roadmap status, EIP chips, and Hegota page

### DIFF
--- a/.github/workflows/sync-upgrades.yml
+++ b/.github/workflows/sync-upgrades.yml
@@ -73,12 +73,11 @@ jobs:
           pnpm type-check
           pnpm test:unit
 
-      # Empty output means nothing changed that any page can contradict, and a
-      # failure here costs a notification rather than the week's sync.
+      # Empty output means nothing changed that any page can contradict.
+      # A classifier failure stops the sync so it cannot suppress human review.
       - name: Classify the change
         id: classify
         if: steps.diff.outputs.changed == 'true'
-        continue-on-error: true
         env:
           SYNC_BASE_REF: ${{ steps.base.outputs.ref }}
         run: |
@@ -88,6 +87,42 @@ jobs:
           else
             echo "notable=false" >> "$GITHUB_OUTPUT"
             echo "Data-only change — no content review needed."
+          fi
+
+      # Report before advancing the sync branch. If issue creation fails, the
+      # old branch remains the baseline and the same report is retried.
+      - name: Open or append the content-review issue
+        if: steps.classify.outputs.notable == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          {
+            echo "### $(date -u +'%Y-%m-%d') · [data sync](https://github.com/ethereum/ethereum-org-website/compare/dev...$BRANCH)"
+            echo
+            echo '```'
+            cat notable.txt
+            echo '```'
+            echo
+            pnpm exec tsx src/scripts/sync-upgrades/coverage.ts
+            echo
+            echo "<details><summary>Store diff</summary>"
+            echo
+            echo '```diff'
+            head -c "$DIFF_LIMIT" store.diff
+            if [ "$(wc -c < store.diff)" -gt "$DIFF_LIMIT" ]; then
+              printf '\n… truncated — the data sync has the full diff\n'
+            fi
+            echo '```'
+            echo
+            echo "</details>"
+          } > issue_body.md
+          NUM=$(gh issue list --state open --limit 100 --json number,title \
+            --jq ".[] | select(.title == \"$ISSUE_TITLE\") | .number" | head -1)
+          if [ -n "$NUM" ]; then
+            gh issue comment "$NUM" --body-file issue_body.md
+          else
+            gh issue create --title "$ISSUE_TITLE" \
+              --body-file issue_body.md --label "content 🖋️"
           fi
 
       - name: Commit to the sync branch
@@ -103,7 +138,6 @@ jobs:
       # One long-lived branch and one open PR: a weekly force-push refreshes an
       # unmerged PR instead of stacking another one behind it.
       - name: Open or update the PR
-        id: pr
         if: steps.diff.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -116,45 +150,6 @@ jobs:
           if [ -n "$NUM" ]; then
             gh pr edit "$NUM" --title "$TITLE" --body-file pr_body.md
           else
-            URL=$(gh pr create --base dev --head "$BRANCH" \
-              --title "$TITLE" --body-file pr_body.md --label "update 🔄")
-            NUM="${URL##*/}"
-          fi
-          echo "number=$NUM" >> "$GITHUB_OUTPUT"
-
-      # Appended as a comment, not a body edit: comments notify subscribers and
-      # keep the history in order. Comments share the body's 65,536-char limit.
-      - name: Open or append the content-review issue
-        if: steps.classify.outputs.notable == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR: ${{ steps.pr.outputs.number }}
-        run: |
-          {
-            echo "### $(date -u +'%Y-%m-%d') · #$PR"
-            echo
-            echo '```'
-            cat notable.txt
-            echo '```'
-            echo
-            pnpm exec tsx src/scripts/sync-upgrades/coverage.ts
-            echo
-            echo "<details><summary>Store diff</summary>"
-            echo
-            echo '```diff'
-            head -c "$DIFF_LIMIT" store.diff
-            if [ "$(wc -c < store.diff)" -gt "$DIFF_LIMIT" ]; then
-              printf '\n… truncated — the PR has the full diff\n'
-            fi
-            echo '```'
-            echo
-            echo "</details>"
-          } > issue_body.md
-          NUM=$(gh issue list --state open --limit 100 --json number,title \
-            --jq ".[] | select(.title == \"$ISSUE_TITLE\") | .number" | head -1)
-          if [ -n "$NUM" ]; then
-            gh issue comment "$NUM" --body-file issue_body.md
-          else
-            gh issue create --title "$ISSUE_TITLE" \
-              --body-file issue_body.md --label "content 🖋️"
+            gh pr create --base dev --head "$BRANCH" \
+              --title "$TITLE" --body-file pr_body.md --label "update 🔄"
           fi

--- a/public/content/roadmap/glamsterdam/index.md
+++ b/public/content/roadmap/glamsterdam/index.md
@@ -5,11 +5,10 @@ lang: en
 template: upgrade
 ---
 
+<UpgradeSummary slug="glamsterdam" />
+
 <Alert variant="update">
 <AlertContent>
-<AlertTitle>
-Glamsterdam is an upcoming Ethereum upgrade planned for Q4 2026
-</AlertTitle>
 <AlertDescription>
 The Glamsterdam upgrade is only a single step in Ethereum's long-term development goals. Learn more about [the protocol roadmap](/roadmap/) and [previous upgrades](/ethereum-forks/).
 </AlertDescription>

--- a/public/content/roadmap/glamsterdam/index.md
+++ b/public/content/roadmap/glamsterdam/index.md
@@ -5,8 +5,6 @@ lang: en
 template: upgrade
 ---
 
-<UpgradeSummary slug="glamsterdam" />
-
 <Alert variant="update">
 <AlertContent>
 <AlertDescription>

--- a/public/content/roadmap/glamsterdam/index.md
+++ b/public/content/roadmap/glamsterdam/index.md
@@ -28,7 +28,7 @@ These improvements ensure Ethereum remains fast, affordable, and decentralized a
 <Alert variant="info">
 <AlertContent>
 <AlertDescription>
-Note: This article highlights a selection of EIPs scheduled for inclusion in Glamsterdam. Additional scheduled proposals being tested in devnets include EIP-7610, EIP-7688, EIP-7778, EIP-7843, EIP-7976, EIP-7981, EIP-8024, EIP-8246, and EIP-8282. For the latest status updates, view the [Glamsterdam upgrade on Forkcast](https://forkcast.org/upgrade/glamsterdam).
+Note: This article highlights a selection of EIPs scheduled for inclusion in Glamsterdam. Additional scheduled proposals being tested in devnets include EIP-7610, EIP-7688, EIP-7778, EIP-7843, EIP-7976, EIP-7981, EIP-8024, EIP-8246, and EIP-8282. Scope is frozen but can still change before mainnet, as the meta EIP remains in draft. For the latest status updates, view the [Glamsterdam upgrade on Forkcast](https://forkcast.org/upgrade/glamsterdam).
 
 If you want to add an EIP that's under consideration for Glamsterdam, but hasn't been added to this page yet, [learn how to contribute to ethereum.org here](/contributing/).
 </AlertDescription>
@@ -47,7 +47,9 @@ In short, Glamsterdam will introduce structural changes to ensure that as the ne
 
 Meaningful L1 scaling requires moving away from off-protocol trust assumptions and serial execution constraints. Glamsterdam addresses this by enshrining separation of certain block-building duties and introducing new data structures that allow the network to prepare for parallel processing.
 
-### Headliner proposal: Enshrined Proposer-Builder Separation (ePBS) {#epbs}
+### Headliner: Enshrined Proposer-Builder Separation (ePBS) {#epbs}
+
+<EipTag upgrade="glamsterdam" id={7732} />
 
 - Removes off-protocol trust assumptions and reliance on third-party relays
 - Supports L1 scaling by allowing much larger payloads through extended propagation windows
@@ -72,7 +74,9 @@ By replacing off-protocol middleware and relays with in-protocol mechanics, ePBS
 
 **Resources**: [EIP-7732 technical specification](https://eips.ethereum.org/EIPS/eip-7732)
 
-### Headliner proposal: Block-Level Access Lists (BALs) {#bals}
+### Headliner: Block-Level Access Lists (BALs) {#bals}
+
+<EipTag upgrade="glamsterdam" id={7928} />
 
 - Eliminates sequential processing bottlenecks by providing an upfront map of all transaction dependencies, setting the stage for validators to process many transactions in parallel instead of one by one
 - Allows nodes to update their records by reading the final results without needing to replay every transaction (executionless sync), making it much faster to sync a node to the network
@@ -90,6 +94,8 @@ The parallel disk reads enabled by BALs will be a significant step toward a futu
 
 #### eth/71 Block Access List Exchange {#bale}
 
+<EipTag upgrade="glamsterdam" id={8159} />
+
 Block Access List Exchange (eth/71 or EIP-8159) is the direct networking companion to block-level access lists. While BALs unlock parallel execution, eth/71 upgrades the peer-to-peer protocol to allow nodes to actually share these lists over the network. Now required for all execution layer clients, the block access list exchange will enable faster syncing and allow nodes to perform executionless state updates.
 
 **Resources**:
@@ -102,6 +108,8 @@ Block Access List Exchange (eth/71 or EIP-8159) is the direct networking compani
 As the Ethereum network grows faster, it's important to ensure that the cost of using it matches the wear-and-tear on the hardware that runs Ethereum. The network needs to increase its overall capacity limits in order to safely scale and process more transactions.
 
 ### State creation gas cost increase {#state-creation-gas-cost-increase}
+
+<EipTag upgrade="glamsterdam" id={8037} />
 
 - Ensures that the fees to create new accounts or smart contracts accurately reflect the long-term burden they place on Ethereum's database
 - Sets a fixed **cost per state byte (CPSB)** targeting a safe and predictable growth rate of 120 GiB/year, ensuring standard physical hardware can continue running the network
@@ -125,6 +133,8 @@ Pricing data storage more accurately and predictably will help Ethereum safely i
 
 ### State-access gas cost update {#state-access-gas-cost-update}
 
+<EipTag upgrade="glamsterdam" id={8038} />
+
 - Increases the gas costs for when applications read or update information permanently stored on Ethereum (state-access opcodes) to accurately match the compute work these commands require
 - Strengthens network resilience by preventing denial-of-service attacks that exploit artificially cheap data-reading operations
 
@@ -146,6 +156,8 @@ Refinements to validator duties and exit processes ensure network stability duri
 
 ### Exclude slashed validators from proposing {#exclude-slashed-validators}
 
+<EipTag upgrade="glamsterdam" id={8045} />
+
 - Stops penalized (slashed) validators from being selected to propose future blocks, eliminating guaranteed missed slots
 - Keeps Ethereum running smoothly and dependably, preventing severe stalls in the case of a mass slashing event
 
@@ -158,6 +170,8 @@ Because blocks from slashed proposers are automatically rejected as invalid, thi
 **Resources**: [EIP-8045 technical specification](https://eips.ethereum.org/EIPS/eip-8045)
 
 ### Increase exit and consolidation churn {#increase-exit-and-consolidation-churn}
+
+<EipTag upgrade="glamsterdam" id={8061} />
 
 - Significantly reduces staking withdrawal times by letting exit capacity scale with the total amount of ETH staked, instead of being capped at a fixed rate
 - Gives validator consolidations their own dedicated queue capacity, speeding up the transition to larger, more efficient validators
@@ -183,6 +197,8 @@ Ethereum's Glamsterdam upgrade aims to improve the user experience, enhance data
 
 ### Reduce intrinsic transaction gas costs {#reduce-intrinsic-transaction-gas-costs}
 
+<EipTag upgrade="glamsterdam" id={2780} />
+
 - Lowers the base fee for transactions, reducing the overall cost of a simple native ETH payment
 - Makes smaller transfers more affordable, boosting Ethereum's viability as a routine medium of exchange
 
@@ -197,6 +213,8 @@ Together, the EIP-2780 aims to make everyday transfers between existing accounts
 **Resources**: [EIP-2780 technical specification](https://eips.ethereum.org/EIPS/eip-2780)
 
 ### Deterministic Factory Predeploy {#deterministic-factory-predeploy}
+
+<EipTag upgrade="glamsterdam" id={7997} />
 
 - Gives developers a native way to deploy applications and smart contract wallets to the exact same address across multiple chains
 - Allows users to have the same smart wallet address on multiple layer 2 (L2) networks, reducing cognitive load, reducing confusion, and reducing the risk of accidental loss of funds
@@ -214,6 +232,8 @@ This standardization simplifies building and managing cross-chain applications f
 
 ### ETH transfers and burns emit a log {#eth-transfers-and-burns-emit-a-log}
 
+<EipTag upgrade="glamsterdam" id={7708} />
+
 - Automatically generates a permanent record (log) every time ETH is transferred or burned
 - Fixes a historical blind spot that allows apps, exchanges, and bridges to dependably detect user deposits without ad-hoc tracing tools
 
@@ -226,6 +246,8 @@ This will make it much easier and more reliable for wallets, exchanges, and brid
 **Resources**: [EIP-7708 technical specification](https://eips.ethereum.org/EIPS/eip-7708)
 
 ### eth/70 partial block receipt lists {#eth-70-partial-block-receipt-lists}
+
+<EipTag upgrade="glamsterdam" id={7975} />
 
 As we increase the amount of work Ethereum can do, the lists of receipts for those actions (the data records of these transactions) are getting so large that they could potentially cause the network's nodes to fail when trying to sync data with one another.
 

--- a/public/content/roadmap/hegota/index.md
+++ b/public/content/roadmap/hegota/index.md
@@ -1,0 +1,30 @@
+---
+title: Hegotá
+metaTitle: Heze-Bogotá (Hegotá)
+description: Learn about the Hegotá protocol upgrade
+lang: en
+template: upgrade
+---
+
+Hegotá is the [Ethereum](/) network upgrade expected to follow [Glamsterdam](/roadmap/glamsterdam/). It is named from the combination of "Bogotá" (execution layer upgrade, named after a previous Devcon location) and "Heze" (consensus layer upgrade, named after a star).
+
+Hegotá is in early planning. Its headliner has been chosen, but the rest of the scope is still being decided, and no dates have been set.
+
+## Headliner: FOCIL {#focil}
+
+Fork-choice enforced inclusion lists (FOCIL, or EIP-7805) is about [censorship resistance](/roadmap/security/#censorship-resistance): making sure that a valid transaction gets into a block even if the people building blocks would rather leave it out.
+
+Today a single [validator](/glossary/#validator) builds each block and decides which transactions it contains. Anyone who can influence enough block builders can therefore delay a transaction, and a user has no way to force the issue other than waiting and hoping.
+
+FOCIL spreads that decision across many validators. A committee each proposes a list of transactions that ought to be included, and the rules of the protocol oblige the block builder to honour those lists. Censoring a transaction stops being something one party can do alone.
+
+## What else is in Hegotá {#scope}
+
+Not decided yet. One further proposal is under consideration and around twenty more have been proposed, but only the headliner is scheduled. This page will stay short until the scope is settled — for the current state of the discussion, see the resources below.
+
+## Further reading {#further-reading}
+
+- [Forkcast: Hegotá](https://forkcast.org/upgrade/hegota) — live status of every proposal
+- [Hegotá Meta EIP (EIP-8081)](https://eips.ethereum.org/EIPS/eip-8081)
+- [EIP-7805 technical specification](https://eips.ethereum.org/EIPS/eip-7805)
+- [Ethereum roadmap](/roadmap/)

--- a/public/content/roadmap/hegota/index.md
+++ b/public/content/roadmap/hegota/index.md
@@ -12,6 +12,8 @@ Hegotá is in early planning. Its headliner has been chosen, but the rest of the
 
 ## Headliner: FOCIL {#focil}
 
+<EipTag upgrade="hegota" id={7805} />
+
 Fork-choice enforced inclusion lists (FOCIL, or EIP-7805) is about [censorship resistance](/roadmap/security/#censorship-resistance): making sure that a valid transaction gets into a block even if the people building blocks would rather leave it out.
 
 Today a single [validator](/glossary/#validator) builds each block and decides which transactions it contains. Anyone who can influence enough block builders can therefore delay a transaction, and a user has no way to force the issue other than waiting and hoping.

--- a/src/components/EipTag.tsx
+++ b/src/components/EipTag.tsx
@@ -1,0 +1,55 @@
+import { getTranslations } from "next-intl/server"
+
+import { Tag } from "@/components/ui/tag"
+
+import { type EipStatus, upgrades } from "@/data/upgrades"
+
+export type EipTagProps = {
+  /** Key into `src/data/upgrades`, e.g. "glamsterdam". */
+  upgrade: string
+  /** EIP number, e.g. 7732. */
+  id: number
+}
+
+/**
+ * How firm an EIP's inclusion is, using the reader-facing wording rather than
+ * the All Core Devs acronyms. `pfi` and `cfi` collapse to one label because the
+ * distinction between "proposed" and "considered" is process detail a general
+ * reader can't act on — Forkcast has it if they want it.
+ */
+const STATUS_LABELS: Partial<
+  Record<EipStatus, { key: string; status: "success" | "normal" }>
+> = {
+  sfi: { key: "page-roadmap-eip-status-scheduled", status: "success" },
+  cfi: { key: "page-roadmap-eip-status-considered", status: "normal" },
+  pfi: { key: "page-roadmap-eip-status-considered", status: "normal" },
+}
+
+/**
+ * Inclusion-status chip for one EIP on an upgrade page.
+ *
+ * In July the page described already-scheduled EIPs as "being considered for
+ * inclusion". Driving this from `eips[].status` means that framing can't drift
+ * again: the chip is whatever the data says, and the data is checked against
+ * Forkcast rather than written by hand into prose.
+ *
+ * Declined EIPs render nothing — a declined EIP should be removed from the
+ * page, not labelled.
+ */
+const EipTag = async ({ upgrade, id }: EipTagProps) => {
+  const eip = upgrades[upgrade]?.eips.find((e) => e.id === id)
+  if (!eip) return null
+
+  const label = STATUS_LABELS[eip.status]
+  if (!label) return null
+
+  const t = await getTranslations("page-roadmap")
+
+  return (
+    <Tag status={label.status} size="small">
+      {t(label.key)}
+    </Tag>
+  )
+}
+
+export default EipTag

--- a/src/components/EipTag.tsx
+++ b/src/components/EipTag.tsx
@@ -12,17 +12,20 @@ export type EipTagProps = {
 }
 
 /**
- * How firm an EIP's inclusion is, using the reader-facing wording rather than
- * the All Core Devs acronyms. `pfi` and `cfi` collapse to one label because the
- * distinction between "proposed" and "considered" is process detail a general
- * reader can't act on — Forkcast has it if they want it.
+ * How firm an EIP's inclusion is, in reader-facing wording rather than the All
+ * Core Devs acronyms.
+ *
+ * Only the two statuses the data layer stores appear here. Everything else —
+ * proposed, considered, declined, withdrawn — is filtered out upstream of us, so
+ * an EIP that is not expected to ship has no entry at all rather than a chip
+ * saying so. A missing entry renders nothing, which is also the right answer for
+ * a descoped EIP: it should be removed from the page, not labelled.
  */
 const STATUS_LABELS: Partial<
   Record<EipStatus, { key: string; status: "success" | "normal" }>
 > = {
-  sfi: { key: "page-roadmap-eip-status-scheduled", status: "success" },
-  cfi: { key: "page-roadmap-eip-status-considered", status: "normal" },
-  pfi: { key: "page-roadmap-eip-status-considered", status: "normal" },
+  scheduled: { key: "page-roadmap-eip-status-scheduled", status: "success" },
+  included: { key: "page-roadmap-eip-status-included", status: "success" },
 }
 
 /**

--- a/src/components/EipTag.tsx
+++ b/src/components/EipTag.tsx
@@ -34,10 +34,8 @@ const STATUS_LABELS: Partial<
 /**
  * Inclusion-status chip for one EIP on an upgrade page.
  *
- * In July the page described already-scheduled EIPs as "being considered for
- * inclusion". Driving this from `eips[].status` means that framing can't drift
- * again: the chip is whatever the data says, and the data is checked against
- * Forkcast rather than written by hand into prose.
+ * Driving the chip from `eips[].status` keeps its framing aligned with
+ * Forkcast rather than hand-written prose.
  *
  * Declined EIPs render nothing — a declined EIP should be removed from the
  * page, not labelled.

--- a/src/components/EipTag.tsx
+++ b/src/components/EipTag.tsx
@@ -15,17 +15,20 @@ export type EipTagProps = {
  * How firm an EIP's inclusion is, in reader-facing wording rather than the All
  * Core Devs acronyms.
  *
- * Only the two statuses the data layer stores appear here. Everything else —
- * proposed, considered, declined, withdrawn — is filtered out upstream of us, so
- * an EIP that is not expected to ship has no entry at all rather than a chip
- * saying so. A missing entry renders nothing, which is also the right answer for
- * a descoped EIP: it should be removed from the page, not labelled.
+ * `considered` is the weaker claim and reads as neutral rather than a success:
+ * an upgrade whose scope has not frozen may still drop it. Only statuses the
+ * data layer stores appear here — proposed, declined and withdrawn entries are
+ * filtered out upstream, so an EIP that is not in the running has no entry at
+ * all rather than a chip saying so. A missing entry renders nothing, which is
+ * also the right answer for a descoped EIP: it should be removed from the page,
+ * not labelled.
  */
 const STATUS_LABELS: Partial<
   Record<EipStatus, { key: string; status: "success" | "normal" }>
 > = {
   scheduled: { key: "page-roadmap-eip-status-scheduled", status: "success" },
   included: { key: "page-roadmap-eip-status-included", status: "success" },
+  considered: { key: "page-roadmap-eip-status-considered", status: "normal" },
 }
 
 /**

--- a/src/components/MdComponents/topics/upgrade.tsx
+++ b/src/components/MdComponents/topics/upgrade.tsx
@@ -1,6 +1,7 @@
 import MergeArticleList from "@/components/MergeArticleList"
 import MergeInfographic from "@/components/MergeInfographic"
 import UpgradeStatus from "@/components/UpgradeStatus"
+import UpgradeSummary from "@/components/UpgradeSummary"
 
 // MDX components available to upgrade markdown pages.
 // The layout itself lives in `src/layouts/Topic.tsx`; per-section config is
@@ -8,5 +9,9 @@ import UpgradeStatus from "@/components/UpgradeStatus"
 export const upgradeComponents = {
   MergeArticleList,
   MergeInfographic,
+  // `UpgradeStatus` is the "when shipping" aside on the Beacon Chain and Merge
+  // pages; `UpgradeSummary` is the data-driven status block on upcoming
+  // upgrades. Similar names, unrelated components.
   UpgradeStatus,
+  UpgradeSummary,
 }

--- a/src/components/MdComponents/topics/upgrade.tsx
+++ b/src/components/MdComponents/topics/upgrade.tsx
@@ -1,3 +1,4 @@
+import EipTag from "@/components/EipTag"
 import MergeArticleList from "@/components/MergeArticleList"
 import MergeInfographic from "@/components/MergeInfographic"
 import UpgradeStatus from "@/components/UpgradeStatus"
@@ -12,6 +13,10 @@ import UpgradeStatus from "@/components/UpgradeStatus"
 // with `UpgradeStatus` below, the "when shipping" aside on the Beacon Chain
 // and Merge pages.
 export const upgradeComponents = {
+  // Unlike `UpgradeSummary`, this one has to be a tag: only the markdown knows
+  // which section documents which EIP, so there is nothing for the layout to
+  // derive it from. Coverage is enforced by tests/unit/roadmap/eip-tags.spec.ts.
+  EipTag,
   MergeArticleList,
   MergeInfographic,
   UpgradeStatus,

--- a/src/components/MdComponents/topics/upgrade.tsx
+++ b/src/components/MdComponents/topics/upgrade.tsx
@@ -1,17 +1,18 @@
 import MergeArticleList from "@/components/MergeArticleList"
 import MergeInfographic from "@/components/MergeInfographic"
 import UpgradeStatus from "@/components/UpgradeStatus"
-import UpgradeSummary from "@/components/UpgradeSummary"
 
 // MDX components available to upgrade markdown pages.
 // The layout itself lives in `src/layouts/Topic.tsx`; per-section config is
 // in `src/data/topics/upgrade.ts`.
+//
+// Note: `UpgradeSummary` is deliberately absent. It is rendered by
+// `TopicLayout` for any page with a file in `src/data/upgrades`, so that it
+// reaches every locale without a tag in 25 markdown files. Not to be confused
+// with `UpgradeStatus` below, the "when shipping" aside on the Beacon Chain
+// and Merge pages.
 export const upgradeComponents = {
   MergeArticleList,
   MergeInfographic,
-  // `UpgradeStatus` is the "when shipping" aside on the Beacon Chain and Merge
-  // pages; `UpgradeSummary` is the data-driven status block on upcoming
-  // upgrades. Similar names, unrelated components.
   UpgradeStatus,
-  UpgradeSummary,
 }

--- a/src/components/UpgradeSummary.tsx
+++ b/src/components/UpgradeSummary.tsx
@@ -113,15 +113,21 @@ const UpgradeSummary = async ({ slug }: UpgradeSummaryProps) => {
           <AlertTitle asChild className="text-2xl font-black">
             <h2>{t("page-roadmap-upgrade-status-heading")}</h2>
           </AlertTitle>
-          {stageLabelKey && <Tag status="tag">{t(stageLabelKey)}</Tag>}
+          {stageLabelKey && (
+            <Tag size="small" status="tag">
+              {t(stageLabelKey)}
+            </Tag>
+          )}
         </div>
 
         <AlertDescription className="text-base">
-          <dl className="grid gap-x-6 gap-y-2 sm:grid-cols-[auto_1fr]">
+          <dl className="grid gap-4">
             {target.when && (
-              <>
-                <dt className="text-body-medium">{t(targetLabelKey)}</dt>
-                <dd>
+              <div className="grid gap-1">
+                <dt className="text-xs font-bold text-body-medium uppercase">
+                  {t(targetLabelKey)}
+                </dt>
+                <dd className="text-base">
                   {formatPartialDate(target.when, locale, formatQuarter)}
                   {/* The qualifier is its own clause, not an adjective, so it cannot
                       be lost to word order in translation or read as settled. */}
@@ -132,20 +138,20 @@ const UpgradeSummary = async ({ slug }: UpgradeSummaryProps) => {
                     </span>
                   )}
                 </dd>
-              </>
+              </div>
             )}
 
             {next && (
-              <>
-                <dt className="text-body-medium">
+              <div className="grid gap-1">
+                <dt className="text-xs font-bold text-body-medium uppercase">
                   {t("page-roadmap-upgrade-status-next")}
                 </dt>
-                <dd>
+                <dd className="text-base">
                   {milestoneLabel(next)}
                   {", "}
                   {formatPartialDate(next.when, locale, formatQuarter)}
                 </dd>
-              </>
+              </div>
             )}
           </dl>
 

--- a/src/components/UpgradeSummary.tsx
+++ b/src/components/UpgradeSummary.tsx
@@ -93,6 +93,10 @@ const UpgradeSummary = async ({ slug }: UpgradeSummaryProps) => {
     mainnet?.status === "complete"
       ? "page-roadmap-upgrade-status-activated"
       : "page-roadmap-upgrade-status-target"
+  const trackLabelKey =
+    mainnet?.status === "complete"
+      ? "page-roadmap-upgrade-status-details"
+      : "page-roadmap-upgrade-status-track"
   const running = upgrade.milestones.find((m) => m.status === "live")
   const stageLabelKey = running
     ? STAGE_LABEL_KEYS[running.kind]
@@ -156,9 +160,7 @@ const UpgradeSummary = async ({ slug }: UpgradeSummaryProps) => {
           </dl>
 
           <p className="m-0">
-            <InlineLink href={upgrade.sourceUrl}>
-              {t("page-roadmap-upgrade-status-track")}
-            </InlineLink>
+            <InlineLink href={upgrade.sourceUrl}>{t(trackLabelKey)}</InlineLink>
           </p>
         </AlertDescription>
       </AlertContent>

--- a/src/components/UpgradeSummary.tsx
+++ b/src/components/UpgradeSummary.tsx
@@ -89,14 +89,9 @@ const UpgradeSummary = async ({ slug }: UpgradeSummaryProps) => {
   const mainnet = upgrade.milestones.find(
     (milestone) => milestone.kind === "mainnet"
   )
-  const targetLabelKey =
-    mainnet?.status === "complete"
-      ? "page-roadmap-upgrade-status-activated"
-      : "page-roadmap-upgrade-status-target"
-  const trackLabelKey =
-    mainnet?.status === "complete"
-      ? "page-roadmap-upgrade-status-details"
-      : "page-roadmap-upgrade-status-track"
+  if (mainnet?.status === "complete") return null
+
+  const targetLabelKey = "page-roadmap-upgrade-status-target"
   const running = upgrade.milestones.find((m) => m.status === "live")
   const stageLabelKey = running
     ? STAGE_LABEL_KEYS[running.kind]
@@ -159,9 +154,13 @@ const UpgradeSummary = async ({ slug }: UpgradeSummaryProps) => {
             )}
           </dl>
 
-          <p className="m-0">
-            <InlineLink href={upgrade.sourceUrl}>{t(trackLabelKey)}</InlineLink>
-          </p>
+          <div className="mt-4">
+            <p className="m-0">
+              <InlineLink href={upgrade.sourceUrl} className="text-sm">
+                {t("page-roadmap-upgrade-status-track")}
+              </InlineLink>
+            </p>
+          </div>
         </AlertDescription>
       </AlertContent>
     </Alert>

--- a/src/components/UpgradeSummary.tsx
+++ b/src/components/UpgradeSummary.tsx
@@ -1,0 +1,118 @@
+import { getLocale, getTranslations } from "next-intl/server"
+
+import InlineLink from "@/components/ui/Link"
+import { Tag } from "@/components/ui/tag"
+
+import { formatPartialDate } from "@/lib/utils/date"
+
+import { type UpgradePhase, upgrades } from "@/data/upgrades"
+
+export type UpgradeSummaryProps = {
+  /** Key into `src/data/upgrades`, e.g. "glamsterdam". */
+  slug: string
+}
+
+/**
+ * Only phases an upgrade has actually reached get a label, because every label
+ * is a translation task across all locales. A phase missing from this map
+ * renders no tag rather than a raw key — add the key when an upgrade needs it.
+ */
+const PHASE_LABEL_KEYS: Partial<Record<UpgradePhase, string>> = {
+  devnet: "page-roadmap-upgrade-status-phase-devnet",
+}
+
+/**
+ * The volatile-fact block at the top of an upgrade page: phase, mainnet target,
+ * next milestone, and when the facts were last checked.
+ *
+ * Every value comes from `src/data/upgrades` — nothing here is hardcoded, so
+ * refreshing the page's facts never means editing prose. Confidence is carried
+ * by the data and rendered explicitly: an unconfirmed target is a different
+ * sentence from a confirmed one, never the same sentence with a softer word.
+ *
+ * Not to be confused with `UpgradeStatus`, the "when shipping" aside used on
+ * the Beacon Chain and Merge pages.
+ */
+const UpgradeSummary = async ({ slug }: UpgradeSummaryProps) => {
+  const upgrade = upgrades[slug]
+  if (!upgrade) return null
+
+  const t = await getTranslations("page-roadmap")
+  const locale = await getLocale()
+
+  const phaseLabelKey = PHASE_LABEL_KEYS[upgrade.phase]
+  const target = upgrade["mainnet-target"]
+  // `complete` milestones are behind us; `live` and everything weaker is not.
+  const next = upgrade.milestones.find((m) => m.status !== "complete")
+
+  return (
+    <aside className="flow w-full rounded-base bg-tint-accent-a p-6">
+      <h2 className="text-sm font-normal uppercase">
+        {t("page-roadmap-upgrade-status-heading")}
+      </h2>
+
+      {phaseLabelKey && (
+        <Tag status={upgrade.phase === "activated" ? "success" : "tag"}>
+          {t(phaseLabelKey)}
+        </Tag>
+      )}
+
+      <dl className="grid gap-x-6 gap-y-2 sm:grid-cols-[auto_1fr]">
+        <dt className="text-body-medium">
+          {t("page-roadmap-upgrade-status-target")}
+        </dt>
+        <dd>
+          {formatPartialDate(target.when, locale)}
+          {/* The qualifier is its own clause, not an adjective, so it cannot
+              be lost to word order in translation or read as settled. */}
+          {!target.confirmed && (
+            <span className="text-body-medium">
+              {" · "}
+              {t("page-roadmap-upgrade-status-not-confirmed")}
+            </span>
+          )}
+        </dd>
+
+        {next && (
+          <>
+            <dt className="text-body-medium">
+              {t("page-roadmap-upgrade-status-next")}
+            </dt>
+            <dd>
+              {/* Milestone names are proper nouns, rendered untranslated. */}
+              {next.name}
+              {", "}
+              {formatPartialDate(next.when, locale)}
+            </dd>
+          </>
+        )}
+
+        <dt className="text-body-medium">
+          {t("page-roadmap-upgrade-status-verified")}
+        </dt>
+        <dd>
+          <time dateTime={upgrade["facts-verified"]}>
+            {formatPartialDate(
+              toPartialDate(upgrade["facts-verified"]),
+              locale
+            )}
+          </time>
+        </dd>
+      </dl>
+
+      <p>
+        <InlineLink href={upgrade["source-url"]}>
+          {t("page-roadmap-upgrade-status-track")}
+        </InlineLink>
+      </p>
+    </aside>
+  )
+}
+
+/** Split an ISO `YYYY-MM-DD` stamp into the shape `formatPartialDate` takes. */
+const toPartialDate = (iso: string) => {
+  const [year, month, day] = iso.split("-").map(Number)
+  return { year, month, day }
+}
+
+export default UpgradeSummary

--- a/src/components/UpgradeSummary.tsx
+++ b/src/components/UpgradeSummary.tsx
@@ -1,5 +1,12 @@
+import { Info } from "lucide-react"
 import { getLocale, getTranslations } from "next-intl/server"
 
+import {
+  Alert,
+  AlertContent,
+  AlertIcon,
+  AlertTitle,
+} from "@/components/ui/alert"
 import InlineLink from "@/components/ui/Link"
 import { Tag } from "@/components/ui/tag"
 
@@ -101,51 +108,57 @@ const UpgradeSummary = async ({ slug }: UpgradeSummaryProps) => {
   )
 
   return (
-    <aside className="flow w-full rounded-base bg-tint-accent-a p-6">
-      <h2 className="text-sm font-normal uppercase">
-        {t("page-roadmap-upgrade-status-heading")}
-      </h2>
+    <Alert variant="update" className="items-start p-6 md:p-8">
+      <AlertIcon>
+        <Info aria-hidden="true" />
+      </AlertIcon>
+      <AlertContent className="gap-4">
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+          <AlertTitle className="text-sm font-normal uppercase">
+            {t("page-roadmap-upgrade-status-heading")}
+          </AlertTitle>
+          {stageLabelKey && <Tag status="tag">{t(stageLabelKey)}</Tag>}
+        </div>
 
-      {stageLabelKey && <Tag status="tag">{t(stageLabelKey)}</Tag>}
+        <dl className="grid gap-x-6 gap-y-2 sm:grid-cols-[auto_1fr]">
+          {target.when && (
+            <>
+              <dt className="text-body-medium">{t(targetLabelKey)}</dt>
+              <dd>
+                {formatPartialDate(target.when, locale, formatQuarter)}
+                {/* The qualifier is its own clause, not an adjective, so it cannot
+                    be lost to word order in translation or read as settled. */}
+                {!target.confirmed && (
+                  <span className="text-body-medium">
+                    {" · "}
+                    {t("page-roadmap-upgrade-status-not-confirmed")}
+                  </span>
+                )}
+              </dd>
+            </>
+          )}
 
-      <dl className="grid gap-x-6 gap-y-2 sm:grid-cols-[auto_1fr]">
-        {target.when && (
-          <>
-            <dt className="text-body-medium">{t(targetLabelKey)}</dt>
-            <dd>
-              {formatPartialDate(target.when, locale, formatQuarter)}
-              {/* The qualifier is its own clause, not an adjective, so it cannot
-                  be lost to word order in translation or read as settled. */}
-              {!target.confirmed && (
-                <span className="text-body-medium">
-                  {" · "}
-                  {t("page-roadmap-upgrade-status-not-confirmed")}
-                </span>
-              )}
-            </dd>
-          </>
-        )}
+          {next && (
+            <>
+              <dt className="text-body-medium">
+                {t("page-roadmap-upgrade-status-next")}
+              </dt>
+              <dd>
+                {milestoneLabel(next)}
+                {", "}
+                {formatPartialDate(next.when, locale, formatQuarter)}
+              </dd>
+            </>
+          )}
+        </dl>
 
-        {next && (
-          <>
-            <dt className="text-body-medium">
-              {t("page-roadmap-upgrade-status-next")}
-            </dt>
-            <dd>
-              {milestoneLabel(next)}
-              {", "}
-              {formatPartialDate(next.when, locale, formatQuarter)}
-            </dd>
-          </>
-        )}
-      </dl>
-
-      <p>
-        <InlineLink href={upgrade.sourceUrl}>
-          {t("page-roadmap-upgrade-status-track")}
-        </InlineLink>
-      </p>
-    </aside>
+        <p className="m-0">
+          <InlineLink href={upgrade.sourceUrl}>
+            {t("page-roadmap-upgrade-status-track")}
+          </InlineLink>
+        </p>
+      </AlertContent>
+    </Alert>
   )
 }
 

--- a/src/components/UpgradeSummary.tsx
+++ b/src/components/UpgradeSummary.tsx
@@ -1,10 +1,9 @@
-import { Info } from "lucide-react"
 import { getLocale, getTranslations } from "next-intl/server"
 
 import {
   Alert,
   AlertContent,
-  AlertIcon,
+  AlertDescription,
   AlertTitle,
 } from "@/components/ui/alert"
 import InlineLink from "@/components/ui/Link"
@@ -108,55 +107,54 @@ const UpgradeSummary = async ({ slug }: UpgradeSummaryProps) => {
   )
 
   return (
-    <Alert variant="update" className="items-start p-6 md:p-8">
-      <AlertIcon>
-        <Info aria-hidden="true" />
-      </AlertIcon>
+    <Alert variant="info" className="items-start p-6 md:p-8">
       <AlertContent className="gap-4">
         <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
-          <AlertTitle className="text-sm font-normal uppercase">
-            {t("page-roadmap-upgrade-status-heading")}
+          <AlertTitle asChild className="text-2xl font-black">
+            <h2>{t("page-roadmap-upgrade-status-heading")}</h2>
           </AlertTitle>
           {stageLabelKey && <Tag status="tag">{t(stageLabelKey)}</Tag>}
         </div>
 
-        <dl className="grid gap-x-6 gap-y-2 sm:grid-cols-[auto_1fr]">
-          {target.when && (
-            <>
-              <dt className="text-body-medium">{t(targetLabelKey)}</dt>
-              <dd>
-                {formatPartialDate(target.when, locale, formatQuarter)}
-                {/* The qualifier is its own clause, not an adjective, so it cannot
-                    be lost to word order in translation or read as settled. */}
-                {!target.confirmed && (
-                  <span className="text-body-medium">
-                    {" · "}
-                    {t("page-roadmap-upgrade-status-not-confirmed")}
-                  </span>
-                )}
-              </dd>
-            </>
-          )}
+        <AlertDescription className="text-base">
+          <dl className="grid gap-x-6 gap-y-2 sm:grid-cols-[auto_1fr]">
+            {target.when && (
+              <>
+                <dt className="text-body-medium">{t(targetLabelKey)}</dt>
+                <dd>
+                  {formatPartialDate(target.when, locale, formatQuarter)}
+                  {/* The qualifier is its own clause, not an adjective, so it cannot
+                      be lost to word order in translation or read as settled. */}
+                  {!target.confirmed && (
+                    <span className="text-body-medium">
+                      {" · "}
+                      {t("page-roadmap-upgrade-status-not-confirmed")}
+                    </span>
+                  )}
+                </dd>
+              </>
+            )}
 
-          {next && (
-            <>
-              <dt className="text-body-medium">
-                {t("page-roadmap-upgrade-status-next")}
-              </dt>
-              <dd>
-                {milestoneLabel(next)}
-                {", "}
-                {formatPartialDate(next.when, locale, formatQuarter)}
-              </dd>
-            </>
-          )}
-        </dl>
+            {next && (
+              <>
+                <dt className="text-body-medium">
+                  {t("page-roadmap-upgrade-status-next")}
+                </dt>
+                <dd>
+                  {milestoneLabel(next)}
+                  {", "}
+                  {formatPartialDate(next.when, locale, formatQuarter)}
+                </dd>
+              </>
+            )}
+          </dl>
 
-        <p className="m-0">
-          <InlineLink href={upgrade.sourceUrl}>
-            {t("page-roadmap-upgrade-status-track")}
-          </InlineLink>
-        </p>
+          <p className="m-0">
+            <InlineLink href={upgrade.sourceUrl}>
+              {t("page-roadmap-upgrade-status-track")}
+            </InlineLink>
+          </p>
+        </AlertDescription>
       </AlertContent>
     </Alert>
   )

--- a/src/components/UpgradeSummary.tsx
+++ b/src/components/UpgradeSummary.tsx
@@ -4,8 +4,9 @@ import InlineLink from "@/components/ui/Link"
 import { Tag } from "@/components/ui/tag"
 
 import { formatPartialDate } from "@/lib/utils/date"
+import { numberFormat } from "@/lib/utils/numbers"
 
-import { type UpgradePhase, upgrades } from "@/data/upgrades"
+import { type Milestone, type MilestoneKind, upgrades } from "@/data/upgrades"
 
 export type UpgradeSummaryProps = {
   /** Key into `src/data/upgrades`, e.g. "glamsterdam". */
@@ -13,22 +14,32 @@ export type UpgradeSummaryProps = {
 }
 
 /**
- * Only phases an upgrade has actually reached get a label, because every label
- * is a translation task across all locales. A phase missing from this map
- * renders no tag rather than a raw key — add the key when an upgrade needs it.
+ * The stage an upgrade has reached, read from whichever milestone is running
+ * rather than from a field: `status` only distinguishes live from upcoming, and
+ * "testing on devnets" is the more useful thing to tell a reader.
+ *
+ * A kind missing from this map renders no tag rather than a raw key — every
+ * label is a translation task across all locales, so add one when an upgrade
+ * actually reaches that stage.
  */
-const PHASE_LABEL_KEYS: Partial<Record<UpgradePhase, string>> = {
+const STAGE_LABEL_KEYS: Partial<Record<MilestoneKind, string>> = {
   devnet: "page-roadmap-upgrade-status-phase-devnet",
 }
 
+const MILESTONE_LABEL_KEYS: Record<MilestoneKind, string> = {
+  devnet: "page-roadmap-upgrade-milestone-devnet",
+  testnet: "page-roadmap-upgrade-milestone-testnet",
+  mainnet: "page-roadmap-upgrade-milestone-mainnet",
+}
+
 /**
- * The volatile-fact block at the top of an upgrade page: phase, mainnet target,
- * next milestone, and when the facts were last checked.
+ * The volatile-fact block at the top of an upgrade page: stage, mainnet target
+ * and next milestone.
  *
  * Every value comes from `src/data/upgrades` — nothing here is hardcoded, so
  * refreshing the page's facts never means editing prose. Confidence is carried
- * by the data and rendered explicitly: an unconfirmed target is a different
- * sentence from a confirmed one, never the same sentence with a softer word.
+ * by the data and rendered explicitly: an unconfirmed target gets its own
+ * qualifying clause rather than a softer word.
  *
  * Not to be confused with `UpgradeStatus`, the "when shipping" aside used on
  * the Beacon Chain and Merge pages.
@@ -40,10 +51,32 @@ const UpgradeSummary = async ({ slug }: UpgradeSummaryProps) => {
   const t = await getTranslations("page-roadmap")
   const locale = await getLocale()
 
-  const phaseLabelKey = PHASE_LABEL_KEYS[upgrade.phase]
-  const target = upgrade["mainnet-target"]
-  // `complete` milestones are behind us; `live` and everything weaker is not.
-  const next = upgrade.milestones.find((m) => m.status !== "complete")
+  // A year is a label, not a quantity — grouping would render it "2,026".
+  const number = numberFormat(locale, { useGrouping: false })
+  const formatQuarter = (quarter: number, year: number) =>
+    t("page-roadmap-upgrade-quarter", {
+      quarter: number.format(quarter),
+      year: number.format(year),
+    })
+
+  /** Milestones carry no English name, so the label is built from `kind`. */
+  const milestoneLabel = (milestone: Milestone) =>
+    t(MILESTONE_LABEL_KEYS[milestone.kind], {
+      version: milestone.kind === "devnet" ? milestone.version : "",
+      network: milestone.kind === "testnet" ? milestone.network : "",
+    })
+
+  const target = upgrade.mainnetTarget
+  const running = upgrade.milestones.find((m) => m.status === "live")
+  const stageLabelKey = running && STAGE_LABEL_KEYS[running.kind]
+
+  // `live` is happening now rather than next, so a running devnet is not the
+  // answer to "what comes next". The mainnet row already states the target, so
+  // repeating it here as the next milestone would be noise.
+  const next = upgrade.milestones.find(
+    (m) =>
+      m.status !== "complete" && m.status !== "live" && m.kind !== "mainnet"
+  )
 
   return (
     <aside className="flow w-full rounded-base bg-tint-accent-a p-6">
@@ -51,27 +84,27 @@ const UpgradeSummary = async ({ slug }: UpgradeSummaryProps) => {
         {t("page-roadmap-upgrade-status-heading")}
       </h2>
 
-      {phaseLabelKey && (
-        <Tag status={upgrade.phase === "activated" ? "success" : "tag"}>
-          {t(phaseLabelKey)}
-        </Tag>
-      )}
+      {stageLabelKey && <Tag status="tag">{t(stageLabelKey)}</Tag>}
 
       <dl className="grid gap-x-6 gap-y-2 sm:grid-cols-[auto_1fr]">
-        <dt className="text-body-medium">
-          {t("page-roadmap-upgrade-status-target")}
-        </dt>
-        <dd>
-          {formatPartialDate(target.when, locale)}
-          {/* The qualifier is its own clause, not an adjective, so it cannot
-              be lost to word order in translation or read as settled. */}
-          {!target.confirmed && (
-            <span className="text-body-medium">
-              {" · "}
-              {t("page-roadmap-upgrade-status-not-confirmed")}
-            </span>
-          )}
-        </dd>
+        {target.when && (
+          <>
+            <dt className="text-body-medium">
+              {t("page-roadmap-upgrade-status-target")}
+            </dt>
+            <dd>
+              {formatPartialDate(target.when, locale, formatQuarter)}
+              {/* The qualifier is its own clause, not an adjective, so it cannot
+                  be lost to word order in translation or read as settled. */}
+              {!target.confirmed && (
+                <span className="text-body-medium">
+                  {" · "}
+                  {t("page-roadmap-upgrade-status-not-confirmed")}
+                </span>
+              )}
+            </dd>
+          </>
+        )}
 
         {next && (
           <>
@@ -79,40 +112,21 @@ const UpgradeSummary = async ({ slug }: UpgradeSummaryProps) => {
               {t("page-roadmap-upgrade-status-next")}
             </dt>
             <dd>
-              {/* Milestone names are proper nouns, rendered untranslated. */}
-              {next.name}
+              {milestoneLabel(next)}
               {", "}
-              {formatPartialDate(next.when, locale)}
+              {formatPartialDate(next.when, locale, formatQuarter)}
             </dd>
           </>
         )}
-
-        <dt className="text-body-medium">
-          {t("page-roadmap-upgrade-status-verified")}
-        </dt>
-        <dd>
-          <time dateTime={upgrade["facts-verified"]}>
-            {formatPartialDate(
-              toPartialDate(upgrade["facts-verified"]),
-              locale
-            )}
-          </time>
-        </dd>
       </dl>
 
       <p>
-        <InlineLink href={upgrade["source-url"]}>
+        <InlineLink href={upgrade.sourceUrl}>
           {t("page-roadmap-upgrade-status-track")}
         </InlineLink>
       </p>
     </aside>
   )
-}
-
-/** Split an ISO `YYYY-MM-DD` stamp into the shape `formatPartialDate` takes. */
-const toPartialDate = (iso: string) => {
-  const [year, month, day] = iso.split("-").map(Number)
-  return { year, month, day }
 }
 
 export default UpgradeSummary

--- a/src/components/UpgradeSummary.tsx
+++ b/src/components/UpgradeSummary.tsx
@@ -80,6 +80,13 @@ const UpgradeSummary = async ({ slug }: UpgradeSummaryProps) => {
     })
 
   const target = upgrade.mainnetTarget
+  const mainnet = upgrade.milestones.find(
+    (milestone) => milestone.kind === "mainnet"
+  )
+  const targetLabelKey =
+    mainnet?.status === "complete"
+      ? "page-roadmap-upgrade-status-activated"
+      : "page-roadmap-upgrade-status-target"
   const running = upgrade.milestones.find((m) => m.status === "live")
   const stageLabelKey = running
     ? STAGE_LABEL_KEYS[running.kind]
@@ -104,9 +111,7 @@ const UpgradeSummary = async ({ slug }: UpgradeSummaryProps) => {
       <dl className="grid gap-x-6 gap-y-2 sm:grid-cols-[auto_1fr]">
         {target.when && (
           <>
-            <dt className="text-body-medium">
-              {t("page-roadmap-upgrade-status-target")}
-            </dt>
+            <dt className="text-body-medium">{t(targetLabelKey)}</dt>
             <dd>
               {formatPartialDate(target.when, locale, formatQuarter)}
               {/* The qualifier is its own clause, not an adjective, so it cannot

--- a/src/components/UpgradeSummary.tsx
+++ b/src/components/UpgradeSummary.tsx
@@ -6,7 +6,12 @@ import { Tag } from "@/components/ui/tag"
 import { formatPartialDate } from "@/lib/utils/date"
 import { numberFormat } from "@/lib/utils/numbers"
 
-import { type Milestone, type MilestoneKind, upgrades } from "@/data/upgrades"
+import {
+  type Milestone,
+  type MilestoneKind,
+  upgrades,
+  type UpgradeStatus,
+} from "@/data/upgrades"
 
 export type UpgradeSummaryProps = {
   /** Key into `src/data/upgrades`, e.g. "glamsterdam". */
@@ -24,6 +29,14 @@ export type UpgradeSummaryProps = {
  */
 const STAGE_LABEL_KEYS: Partial<Record<MilestoneKind, string>> = {
   devnet: "page-roadmap-upgrade-status-phase-devnet",
+}
+
+/**
+ * Fallback for an upgrade with nothing running yet — Hegotá has only projected
+ * milestones, so there is no stage to read and its `status` is all we have.
+ */
+const STATUS_LABEL_KEYS: Partial<Record<UpgradeStatus, string>> = {
+  planning: "page-roadmap-upgrade-status-phase-planning",
 }
 
 const MILESTONE_LABEL_KEYS: Record<MilestoneKind, string> = {
@@ -68,7 +81,9 @@ const UpgradeSummary = async ({ slug }: UpgradeSummaryProps) => {
 
   const target = upgrade.mainnetTarget
   const running = upgrade.milestones.find((m) => m.status === "live")
-  const stageLabelKey = running && STAGE_LABEL_KEYS[running.kind]
+  const stageLabelKey = running
+    ? STAGE_LABEL_KEYS[running.kind]
+    : STATUS_LABEL_KEYS[upgrade.status]
 
   // `live` is happening now rather than next, so a running devnet is not the
   // answer to "what comes next". The mainnet row already states the target, so

--- a/src/data/roadmap/releases.tsx
+++ b/src/data/roadmap/releases.tsx
@@ -229,6 +229,7 @@ export const getReleasesData = (t: TranslationFunction): Release[] => [
     releaseName: "Hegotá",
     plannedReleaseYear: "2027",
     displayDate: "2027",
+    href: "/roadmap/hegota/",
     content: (
       <>
         <p>

--- a/src/data/topics/upgrade.ts
+++ b/src/data/topics/upgrade.ts
@@ -43,6 +43,11 @@ export const upgrade: TopicConfig = {
         matomoEvent: "/roadmap/glamsterdam/",
       },
       {
+        textKey: "page-upgrades-upgrades-hegota",
+        href: "/roadmap/hegota/",
+        matomoEvent: "/roadmap/hegota/",
+      },
+      {
         textKey: "page-upgrades-upgrades-forks",
         href: "/ethereum-forks/",
         matomoEvent: "/ethereum-forks/",

--- a/src/data/upgrades/generated.ts
+++ b/src/data/upgrades/generated.ts
@@ -203,6 +203,36 @@ export const generated = {
     },
     milestones: [
       {
+        kind: "testnet",
+        network: "Holešky",
+        when: {
+          year: 2025,
+          month: 10,
+          day: 1,
+        },
+        status: "complete",
+      },
+      {
+        kind: "testnet",
+        network: "Sepolia",
+        when: {
+          year: 2025,
+          month: 10,
+          day: 14,
+        },
+        status: "complete",
+      },
+      {
+        kind: "testnet",
+        network: "Hoodi",
+        when: {
+          year: 2025,
+          month: 10,
+          day: 28,
+        },
+        status: "complete",
+      },
+      {
         kind: "mainnet",
         when: {
           year: 2025,
@@ -398,21 +428,33 @@ export const generated = {
       },
       {
         kind: "testnet",
+        network: "Platåberget",
+        when: {
+          year: 2026,
+          month: 8,
+          day: 13,
+        },
+        status: "complete",
+      },
+      {
+        kind: "testnet",
         network: "Sepolia",
         when: {
           year: 2026,
-          quarter: 3,
+          month: 9,
+          day: 28,
         },
-        status: "projected",
+        status: "anticipated",
       },
       {
         kind: "testnet",
         network: "Hoodi",
         when: {
           year: 2026,
-          quarter: 3,
+          month: 10,
+          day: 26,
         },
-        status: "projected",
+        status: "anticipated",
       },
       {
         kind: "mainnet",

--- a/src/data/upgrades/types.ts
+++ b/src/data/upgrades/types.ts
@@ -14,6 +14,7 @@ export type UpgradeStatus = "live" | "upcoming" | "planning" | "research"
  *
  * `complete` is the only settled value. The rest are claims about the future,
  * strongest to weakest; the UI must never render a weaker one as settled.
+ * `anticipated` is a specific testnet date proposed upstream but not agreed.
  */
 export type MilestoneStatus =
   | "complete"
@@ -67,8 +68,8 @@ export interface UpgradeEip {
   id: number
   /**
    * The full upstream vocabulary is modelled so the mapping stays exhaustive,
-   * but only `scheduled` and `included` are stored — an EIP that is not
-   * expected to ship simply has no entry.
+   * but only `considered`, `scheduled` and `included` are stored. Everything
+   * else, whether never weighed or weighed and descoped, has no entry.
    */
   status: EipStatus
   networking: boolean

--- a/src/intl/en/page-roadmap.json
+++ b/src/intl/en/page-roadmap.json
@@ -122,7 +122,6 @@
   "page-roadmap-upgrade-status-not-confirmed": "Date not yet confirmed",
   "page-roadmap-upgrade-status-next": "Next milestone",
   "page-roadmap-upgrade-status-track": "Track live progress on Forkcast",
-  "page-roadmap-upgrade-status-details": "See technical details on Forkcast",
   "page-roadmap-upgrade-status-phase-planning": "In planning",
   "page-roadmap-upgrade-quarter": "Q{quarter} {year}",
   "page-roadmap-upgrade-milestone-devnet": "Devnet-{version}",

--- a/src/intl/en/page-roadmap.json
+++ b/src/intl/en/page-roadmap.json
@@ -120,6 +120,9 @@
   "page-roadmap-upgrade-status-target": "Expected on mainnet",
   "page-roadmap-upgrade-status-not-confirmed": "Date not yet confirmed",
   "page-roadmap-upgrade-status-next": "Next milestone",
-  "page-roadmap-upgrade-status-verified": "Status checked",
-  "page-roadmap-upgrade-status-track": "Track live progress on Forkcast"
+  "page-roadmap-upgrade-status-track": "Track live progress on Forkcast",
+  "page-roadmap-upgrade-quarter": "Q{quarter} {year}",
+  "page-roadmap-upgrade-milestone-devnet": "Devnet-{version}",
+  "page-roadmap-upgrade-milestone-testnet": "{network} fork",
+  "page-roadmap-upgrade-milestone-mainnet": "Mainnet activation"
 }

--- a/src/intl/en/page-roadmap.json
+++ b/src/intl/en/page-roadmap.json
@@ -114,5 +114,12 @@
   "page-roadmap-glamsterdam-bal-item-2": "Maps dependencies upfront for faster syncs, parallel execution, and parallel disk reads",
   "page-roadmap-glamsterdam-bal-item-3": "Lowers gas for state-heavy apps and improves gas cost predictability",
   "page-roadmap-hegota-discussed-title": "Planned for Hegotá",
-  "page-roadmap-hegota-discussed-item-1": "Proposals are currently under discussion"
+  "page-roadmap-hegota-discussed-item-1": "Proposals are currently under discussion",
+  "page-roadmap-upgrade-status-heading": "Upgrade status",
+  "page-roadmap-upgrade-status-phase-devnet": "Testing on devnets",
+  "page-roadmap-upgrade-status-target": "Expected on mainnet",
+  "page-roadmap-upgrade-status-not-confirmed": "Date not yet confirmed",
+  "page-roadmap-upgrade-status-next": "Next milestone",
+  "page-roadmap-upgrade-status-verified": "Status checked",
+  "page-roadmap-upgrade-status-track": "Track live progress on Forkcast"
 }

--- a/src/intl/en/page-roadmap.json
+++ b/src/intl/en/page-roadmap.json
@@ -126,5 +126,6 @@
   "page-roadmap-upgrade-milestone-testnet": "{network} fork",
   "page-roadmap-upgrade-milestone-mainnet": "Mainnet activation",
   "page-roadmap-eip-status-scheduled": "Scheduled for inclusion",
-  "page-roadmap-eip-status-included": "Included"
+  "page-roadmap-eip-status-included": "Included",
+  "page-roadmap-eip-status-considered": "Considered for inclusion"
 }

--- a/src/intl/en/page-roadmap.json
+++ b/src/intl/en/page-roadmap.json
@@ -124,5 +124,7 @@
   "page-roadmap-upgrade-quarter": "Q{quarter} {year}",
   "page-roadmap-upgrade-milestone-devnet": "Devnet-{version}",
   "page-roadmap-upgrade-milestone-testnet": "{network} fork",
-  "page-roadmap-upgrade-milestone-mainnet": "Mainnet activation"
+  "page-roadmap-upgrade-milestone-mainnet": "Mainnet activation",
+  "page-roadmap-eip-status-scheduled": "Scheduled for inclusion",
+  "page-roadmap-eip-status-included": "Included"
 }

--- a/src/intl/en/page-roadmap.json
+++ b/src/intl/en/page-roadmap.json
@@ -122,6 +122,7 @@
   "page-roadmap-upgrade-status-not-confirmed": "Date not yet confirmed",
   "page-roadmap-upgrade-status-next": "Next milestone",
   "page-roadmap-upgrade-status-track": "Track live progress on Forkcast",
+  "page-roadmap-upgrade-status-details": "See technical details on Forkcast",
   "page-roadmap-upgrade-status-phase-planning": "In planning",
   "page-roadmap-upgrade-quarter": "Q{quarter} {year}",
   "page-roadmap-upgrade-milestone-devnet": "Devnet-{version}",

--- a/src/intl/en/page-roadmap.json
+++ b/src/intl/en/page-roadmap.json
@@ -118,6 +118,7 @@
   "page-roadmap-upgrade-status-heading": "Upgrade status",
   "page-roadmap-upgrade-status-phase-devnet": "Testing on devnets",
   "page-roadmap-upgrade-status-target": "Expected on mainnet",
+  "page-roadmap-upgrade-status-activated": "Activated on mainnet",
   "page-roadmap-upgrade-status-not-confirmed": "Date not yet confirmed",
   "page-roadmap-upgrade-status-next": "Next milestone",
   "page-roadmap-upgrade-status-track": "Track live progress on Forkcast",

--- a/src/intl/en/page-roadmap.json
+++ b/src/intl/en/page-roadmap.json
@@ -121,6 +121,7 @@
   "page-roadmap-upgrade-status-not-confirmed": "Date not yet confirmed",
   "page-roadmap-upgrade-status-next": "Next milestone",
   "page-roadmap-upgrade-status-track": "Track live progress on Forkcast",
+  "page-roadmap-upgrade-status-phase-planning": "In planning",
   "page-roadmap-upgrade-quarter": "Q{quarter} {year}",
   "page-roadmap-upgrade-milestone-devnet": "Devnet-{version}",
   "page-roadmap-upgrade-milestone-testnet": "{network} fork",

--- a/src/intl/en/page-upgrades-index.json
+++ b/src/intl/en/page-upgrades-index.json
@@ -209,5 +209,6 @@
   "docs-nav-proof-of-stake": "Proof-of-stake",
   "docs-nav-proof-of-work": "Proof-of-work",
   "page-upgrades-get-involved-ethresearch-1": "Sharding",
-  "page-upgrades-get-involved-ethresearch-2": "The Merge"
+  "page-upgrades-get-involved-ethresearch-2": "The Merge",
+  "page-upgrades-upgrades-hegota": "Hegotá"
 }

--- a/src/layouts/ContentLayout.tsx
+++ b/src/layouts/ContentLayout.tsx
@@ -27,6 +27,7 @@ const variants = cva("flow flex-1", {
 type ContentLayoutProps = HTMLAttributes<HTMLDivElement> &
   Pick<TableOfContentsProps, "dropdownLinks" | "showDropdown"> & {
     children: React.ReactNode
+    articleHeader?: React.ReactNode
     tocItems: TableOfContentsProps["items"]
     heroSection: React.ReactNode
     contributors: FileContributor[]
@@ -40,6 +41,7 @@ export const ContentLayout = ({
   tocItems,
   showDropdown = true,
   heroSection,
+  articleHeader,
   contributors,
   lastEditLocaleTimestamp,
   listenSlug,
@@ -52,6 +54,7 @@ export const ContentLayout = ({
     <main className="p-page">
       <div className="flex justify-between gap-x-space-3x max-lg:flex-col-reverse">
         <MainArticle className={variants({ variant })}>
+          {articleHeader}
           <FileContributors
             contributors={contributors}
             lastEditLocaleTimestamp={lastEditLocaleTimestamp}

--- a/src/layouts/Topic.tsx
+++ b/src/layouts/Topic.tsx
@@ -9,11 +9,13 @@ import PageActions from "@/components/PageActions"
 import { Alert } from "@/components/ui/alert"
 import InlineLink from "@/components/ui/Link"
 import { List, ListItem } from "@/components/ui/list"
+import UpgradeSummary from "@/components/UpgradeSummary"
 
 import { getEditPath } from "@/lib/utils/editPath"
 import { buildTopicDropdown } from "@/lib/utils/topicDropdown"
 
 import type { TopicConfig } from "@/data/topics"
+import { upgrades } from "@/data/upgrades"
 
 import { ContentLayout } from "./ContentLayout"
 
@@ -50,6 +52,11 @@ export const TopicLayout = async ({
         `Add an entry to src/data/topics/ and route through topics[layout].`
     )
   }
+
+  // `slug` is locale-independent ("roadmap/glamsterdam"), so its last segment
+  // is a stable key into the upgrade data on every locale.
+  const upgradeKey = slug.split("/").filter(Boolean).pop()
+  const upgradeSlug = upgradeKey && upgrades[upgradeKey] ? upgradeKey : null
 
   const t = await getTranslations(config.translationNs)
 
@@ -124,6 +131,17 @@ export const TopicLayout = async ({
         editPath={getEditPath(slug)}
         className="-ms-2 mb-8 [&+h2]:mt-0!"
       />
+      {/*
+        Rendered here rather than as an MDX tag so that every locale gets it
+        without waiting for the intl-pipeline to propagate a tag into 24
+        translated files — the facts live in one place, so they should render
+        everywhere at once.
+
+        The switch is *data presence*, not layout type: six pages use
+        `template: upgrade` (beacon-chain, dencun, fusaka, glamsterdam, merge,
+        pectra) and only those with a file in `src/data/upgrades` get a block.
+      */}
+      {upgradeSlug && <UpgradeSummary slug={upgradeSlug} />}
       {children}
     </ContentLayout>
   )

--- a/src/layouts/Topic.tsx
+++ b/src/layouts/Topic.tsx
@@ -109,6 +109,10 @@ export const TopicLayout = async ({
     </>
   )
 
+  // Rendered through ContentLayout's article-header slot so the upgrade card
+  // appears before contributors and page actions without changing other
+  // layouts.
+
   return (
     <ContentLayout
       dir={contentNotTranslated ? "ltr" : "unset"}
@@ -117,6 +121,7 @@ export const TopicLayout = async ({
       contributors={contributors}
       lastEditLocaleTimestamp={lastEditLocaleTimestamp}
       heroSection={heroSection}
+      articleHeader={upgradeSlug ? <UpgradeSummary slug={upgradeSlug} /> : null}
       showDropdown={frontmatter.showDropdown ?? true}
     >
       {/*
@@ -131,17 +136,6 @@ export const TopicLayout = async ({
         editPath={getEditPath(slug)}
         className="-ms-2 mb-8 [&+h2]:mt-0!"
       />
-      {/*
-        Rendered here rather than as an MDX tag so that every locale gets it
-        without waiting for the intl-pipeline to propagate a tag into 24
-        translated files — the facts live in one place, so they should render
-        everywhere at once.
-
-        The switch is *data presence*, not layout type: six pages use
-        `template: upgrade` (beacon-chain, dencun, fusaka, glamsterdam, merge,
-        pectra) and only those with a file in `src/data/upgrades` get a block.
-      */}
-      {upgradeSlug && <UpgradeSummary slug={upgradeSlug} />}
       {children}
     </ContentLayout>
   )

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -1,3 +1,5 @@
+import type { PartialDate } from "@/data/upgrades/types"
+
 import { DEFAULT_LOCALE } from "../constants"
 import type { Lang } from "../types"
 
@@ -69,6 +71,36 @@ export const formatDate = (
     year: "numeric",
     ...options,
   }).format(new Date(date))
+}
+
+/**
+ * Format a {@link PartialDate} at whatever precision it carries: a year, a
+ * quarter, a month and year, or a full date. Used by the upgrade data layer,
+ * where a date is only ever as precise as its source.
+ *
+ * Built through `dateTimeFormat` so Arabic and Urdu get the right numbering
+ * system, and pinned to UTC so a `{ year, month, day }` never renders as the
+ * previous day for viewers behind UTC.
+ *
+ * Quarters can't go through `Intl` — there is no quarter skeleton, and "Q4
+ * 2026" is written very differently across locales — so the caller passes a
+ * `formatQuarter` that renders a translated pattern. It is required rather than
+ * optional so a quarter date can never silently degrade to just its year.
+ */
+export const formatPartialDate = (
+  { year, quarter, month, day }: PartialDate,
+  locale: string = DEFAULT_LOCALE,
+  formatQuarter: (quarter: number, year: number) => string
+) => {
+  if (quarter) return formatQuarter(quarter, year)
+
+  const date = new Date(Date.UTC(year, (month ?? 1) - 1, day ?? 1))
+  return dateTimeFormat(locale, {
+    timeZone: "UTC",
+    year: "numeric",
+    ...(month && { month: "long" }),
+    ...(day && { day: "numeric" }),
+  }).format(date)
 }
 
 export const formatDateRange = (

--- a/src/scripts/sync-upgrades/forkcast.ts
+++ b/src/scripts/sync-upgrades/forkcast.ts
@@ -54,10 +54,17 @@ export interface ForkcastDevnetLaunch {
   dateISO: string
 }
 
+export type ForkcastDateClaim = "actual" | "proposed" | "projected"
+
+export interface ForkcastStatedDate {
+  claim: ForkcastDateClaim
+  value: string
+}
+
 export interface ForkcastTestnet {
   name: string
   status: string
-  projectedDate: string | null
+  stated: ForkcastStatedDate | null
 }
 
 /**
@@ -82,6 +89,44 @@ export interface ForkcastSource {
 }
 
 export class ForkcastSyncError extends Error {}
+
+const TESTNET_DATE_KEYS = [
+  ["date", "actual"],
+  ["proposedDate", "proposed"],
+  ["projectedDate", "projected"],
+] as const satisfies readonly (readonly [string, ForkcastDateClaim])[]
+
+const parseTestnetDate = (
+  entry: string,
+  context: string
+): ForkcastStatedDate | null => {
+  const dateKeys = [
+    ...entry.matchAll(/\b(date|[A-Za-z][A-Za-z0-9]*Date)\s*:/g),
+  ].map((match) => match[1])
+  const knownKeys = new Map<string, ForkcastDateClaim>(TESTNET_DATE_KEYS)
+  const unknown = dateKeys.find((key) => !knownKeys.has(key))
+  if (unknown) {
+    throw new ForkcastSyncError(
+      `Unknown testnet date key "${unknown}" on ${context}`
+    )
+  }
+  if (dateKeys.length > 1) {
+    throw new ForkcastSyncError(
+      `Conflicting testnet date keys ${dateKeys.join("+")} on ${context}`
+    )
+  }
+  if (dateKeys.length === 0) return null
+
+  const key = dateKeys[0]
+  const claim = knownKeys.get(key)
+  const value = entry.match(new RegExp(`\\b${key}:\\s*'([^']*)'`))?.[1]
+  if (!claim || value === undefined) {
+    throw new ForkcastSyncError(
+      `Testnet date key "${key}" has no string value on ${context}`
+    )
+  }
+  return { claim, value }
+}
 
 const download = async (): Promise<{ root: string; cleanup: () => void }> => {
   const dir = mkdtempSync(join(tmpdir(), "forkcast-"))
@@ -269,8 +314,7 @@ export const parsePhases = (
           testnets.push({
             name,
             status,
-            projectedDate:
-              entry.match(/projectedDate:\s*'([^']+)'/)?.[1] ?? null,
+            stated: parseTestnetDate(entry, `${phaseMatch[1]} (${name})`),
           })
         }
       }

--- a/src/scripts/sync-upgrades/normalize.ts
+++ b/src/scripts/sync-upgrades/normalize.ts
@@ -10,6 +10,7 @@ import type {
   EipStatus,
   Milestone,
   MilestoneKind,
+  MilestoneStatus,
   PartialDate,
   Quarter,
   UpgradeData,
@@ -18,7 +19,11 @@ import type {
   UpgradeStore,
 } from "@/data/upgrades/types"
 
-import type { ForkcastSource, ForkcastUpgrade } from "./forkcast"
+import type {
+  ForkcastDateClaim,
+  ForkcastSource,
+  ForkcastUpgrade,
+} from "./forkcast"
 import { ForkcastSyncError } from "./forkcast"
 
 const UPGRADE_STATUS: Record<string, UpgradeStatus> = {
@@ -110,6 +115,12 @@ const KIND_ORDER: Record<MilestoneKind, number> = {
   mainnet: 2,
 }
 
+const TESTNET_STATUS = {
+  actual: "complete",
+  proposed: "anticipated",
+  projected: "projected",
+} as const satisfies Record<ForkcastDateClaim, MilestoneStatus>
+
 /**
  * Missing precision sorts late, not early: "sometime in 2026" belongs after
  * every dated milestone in 2026. A quarter sorts at its closing month.
@@ -178,7 +189,8 @@ const resolveMainnetTarget = (
 
 /**
  * Public testnet forks, from the phase timeline. Deprecated networks are
- * skipped — Holešky was shut down after Fusaka and is listed only as history.
+ * skipped, and status must agree with the date claim: completed forks have
+ * actual dates while upcoming forks can only have proposed or projected dates.
  */
 const normalizeTestnets = (
   source: ForkcastSource,
@@ -190,23 +202,38 @@ const normalizeTestnets = (
   if (!phase) return []
 
   return phase.testnets.flatMap((testnet) => {
-    if (testnet.status === "deprecated") return []
-    const when = parsePartialDate(testnet.projectedDate)
-    if (!when) {
-      // No date upstream is legitimate; a date we cannot read is drift.
-      if (testnet.projectedDate) {
+    if (testnet.status === "deprecated") {
+      if (testnet.stated?.claim === "actual") {
         throw new ForkcastSyncError(
-          `Unparseable testnet date "${testnet.projectedDate}" on ${upgradeId} (${testnet.name})`
+          `Deprecated testnet "${testnet.name}" on ${upgradeId} states an actual date`
         )
       }
       return []
+    }
+    if (testnet.status === "completed" && testnet.stated?.claim !== "actual") {
+      throw new ForkcastSyncError(
+        `Completed testnet "${testnet.name}" on ${upgradeId} does not state an actual date`
+      )
+    }
+    if (testnet.status === "upcoming" && testnet.stated?.claim === "actual") {
+      throw new ForkcastSyncError(
+        `Upcoming testnet "${testnet.name}" on ${upgradeId} states an actual date`
+      )
+    }
+    if (!testnet.stated) return []
+
+    const when = parsePartialDate(testnet.stated.value)
+    if (!when) {
+      throw new ForkcastSyncError(
+        `Unparseable testnet date "${testnet.stated.value}" (${testnet.stated.claim}) on ${upgradeId} (${testnet.name})`
+      )
     }
     return [
       {
         kind: "testnet",
         network: testnet.name,
         when,
-        status: testnet.status === "completed" ? "complete" : "projected",
+        status: TESTNET_STATUS[testnet.stated.claim],
       } satisfies Milestone,
     ]
   })
@@ -224,9 +251,7 @@ const normalizeTestnets = (
  *
  * `considered` is kept despite looking similar. It means ACD has formally
  * considered the EIP, which is exactly the signal a planning-phase page wants
- * before scope freezes, and it costs one row today. An earlier version excluded
- * it on the grounds that nothing consumed it — circular, since the consumer
- * (`EipTag`) was only dropped because the data lacked it.
+ * before scope freezes, and it costs one row today.
  *
  * Descoping stays visible either way: a declined EIP leaves the store, and a
  * deletion in the diff reads more clearly than a status field flipping.

--- a/src/scripts/sync-upgrades/normalize.ts
+++ b/src/scripts/sync-upgrades/normalize.ts
@@ -213,19 +213,26 @@ const normalizeTestnets = (
 }
 
 /**
- * Only EIPs expected to ship are stored. The rest of Forkcast's vocabulary is
- * still mapped below so an unknown value fails loudly, but proposed, considered,
- * declined, withdrawn and informational entries are dropped:
+ * EIPs an upgrade has formally weighed are stored; the rest of Forkcast's
+ * vocabulary is still mapped below so an unknown value fails loudly, but
+ * `proposed`, `declined`, `withdrawn` and `informational` entries are dropped.
  *
- * - nothing consumes them — a declined EIP should be removed from a page, not
- *   labelled, and listing proposals would make this an EIP directory
- * - they churn every ACD call during EIP selection (Hegotá alone has 55
- *   proposals), which would produce weekly diffs against data nobody reads
+ * `proposed` is the noisy bucket — Hegotá alone carries 64 proposals and they
+ * churn at every ACD call during EIP selection, which would mean weekly diffs
+ * against data no page reads. Listing them would also make this an EIP
+ * directory, which Forkcast already is.
  *
- * Descoping stays visible: a declined EIP leaves the store, and a deletion in
- * the diff reads more clearly than a status field flipping.
+ * `considered` is kept despite looking similar. It means ACD has formally
+ * considered the EIP, which is exactly the signal a planning-phase page wants
+ * before scope freezes, and it costs one row today. An earlier version excluded
+ * it on the grounds that nothing consumed it — circular, since the consumer
+ * (`EipTag`) was only dropped because the data lacked it.
+ *
+ * Descoping stays visible either way: a declined EIP leaves the store, and a
+ * deletion in the diff reads more clearly than a status field flipping.
  */
 const STORED_STATUSES: ReadonlySet<EipStatus> = new Set([
+  "considered",
   "scheduled",
   "included",
 ])

--- a/tests/unit/roadmap/eip-tags.spec.ts
+++ b/tests/unit/roadmap/eip-tags.spec.ts
@@ -2,15 +2,23 @@
  * Every EIP documented on an upgrade page must have exactly one entry in that
  * upgrade's `eips[]`, and exactly one `<EipTag />` rendering it.
  *
- * Without this, adding a twelfth EIP section to the page renders no chip and
- * nothing complains — which is the silent-drift failure the data layer exists
- * to prevent, reintroduced one level down.
+ * The failure this catches is mechanical: `<EipTag id={7955} />` with a typo, or
+ * a section added without a chip, renders nothing at all. The component has no
+ * way to complain, and a missing chip looks identical to a page that never had
+ * one.
  *
  * "Documented" means linked from a `**Resources**` block. That is the marker
  * the page already uses to say "this section specifies this EIP", so a new
  * section written to the existing pattern is caught automatically. EIPs merely
  * name-checked in prose (the devnet list, the FAQ, the meta EIP under Further
  * reading) are deliberately out of scope — they have no section and no chip.
+ *
+ * Deliberately **not** asserted: that every scheduled EIP has a section. The
+ * page covers 11 of the 23 Forkcast schedules for Glamsterdam, and that gap is
+ * an editorial call, not a defect. Gating CI on it would only teach people to
+ * add exemptions — leaving a suite that reports green while coverage quietly
+ * falls further behind. Compare `eips[]` against the page's `**Resources**`
+ * links when someone wants the current number.
  */
 
 import fs from "fs"
@@ -19,23 +27,6 @@ import path from "path"
 import { expect, test } from "@playwright/test"
 
 import { upgrades } from "../../../src/data/upgrades"
-
-/**
- * EIPs upstream schedules that the page does not document yet.
- *
- * This is a backlog, not a config: each entry is a section someone still has to
- * write. Listing them keeps the coverage assertion below meaningful — a *new*
- * scheduled EIP fails the build instead of being quietly absent — while not
- * failing it for gaps that already exist.
- *
- * Shrink this list by writing the section. Do not grow it to make CI pass
- * without a deliberate decision that the EIP does not warrant one.
- */
-const UNDOCUMENTED: Record<string, number[]> = {
-  glamsterdam: [
-    7610, 7688, 7778, 7843, 7954, 7976, 7981, 8024, 8070, 8136, 8246, 8282,
-  ],
-}
 
 const PAGES = [
   { slug: "glamsterdam", file: "public/content/roadmap/glamsterdam/index.md" },
@@ -86,23 +77,6 @@ for (const { slug, file } of PAGES) {
 
     test("every documented EIP has a chip", () => {
       expect(documented.filter((id) => !tagged.includes(id))).toEqual([])
-    })
-
-    test("every scheduled EIP is documented, or listed as a known gap", () => {
-      const known = UNDOCUMENTED[slug] ?? []
-      const missing = inData.filter(
-        (id) => !documented.includes(id) && !known.includes(id)
-      )
-      expect(missing).toEqual([])
-    })
-
-    test("the known-gap list has no stale entries", () => {
-      // A gap that got documented, or an EIP upstream dropped, should leave the
-      // list — otherwise it silently stops guarding anything.
-      const known = UNDOCUMENTED[slug] ?? []
-      expect(
-        known.filter((id) => documented.includes(id) || !inData.includes(id))
-      ).toEqual([])
     })
 
     test("no EIP is tagged twice", () => {

--- a/tests/unit/roadmap/eip-tags.spec.ts
+++ b/tests/unit/roadmap/eip-tags.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * Every EIP documented on an upgrade page must have exactly one entry in that
+ * upgrade's `eips[]`, and exactly one `<EipTag />` rendering it.
+ *
+ * Without this, adding a twelfth EIP section to the page renders no chip and
+ * nothing complains — which is the silent-drift failure the data layer exists
+ * to prevent, reintroduced one level down.
+ *
+ * "Documented" means linked from a `**Resources**` block. That is the marker
+ * the page already uses to say "this section specifies this EIP", so a new
+ * section written to the existing pattern is caught automatically. EIPs merely
+ * name-checked in prose (the devnet list, the FAQ, the meta EIP under Further
+ * reading) are deliberately out of scope — they have no section and no chip.
+ */
+
+import fs from "fs"
+import path from "path"
+
+import { expect, test } from "@playwright/test"
+
+import { upgrades } from "../../../src/data/upgrades"
+
+const PAGES = [
+  { slug: "glamsterdam", file: "public/content/roadmap/glamsterdam/index.md" },
+]
+
+/** EIP ids linked from a `**Resources**` block, i.e. the page's EIP sections. */
+const documentedEips = (markdown: string): number[] => {
+  const ids = new Set<number>()
+  const lines = markdown.split("\n")
+
+  lines.forEach((line, i) => {
+    if (!line.includes("**Resources**")) return
+    // A Resources block runs until the next heading.
+    for (let j = i; j < lines.length && !lines[j].startsWith("#"); j++) {
+      for (const m of lines[j].matchAll(
+        /eips\.ethereum\.org\/EIPS\/eip-(\d+)/g
+      ))
+        ids.add(Number(m[1]))
+    }
+  })
+
+  return [...ids].sort((a, b) => a - b)
+}
+
+/** EIP ids passed to `<EipTag upgrade="..." id={N} />` on the page. */
+const taggedEips = (markdown: string, slug: string): number[] =>
+  [...markdown.matchAll(/<EipTag\s+upgrade="([^"]+)"\s+id=\{(\d+)\}\s*\/>/g)]
+    .filter(([, upgrade]) => upgrade === slug)
+    .map(([, , id]) => Number(id))
+    .sort((a, b) => a - b)
+
+for (const { slug, file } of PAGES) {
+  test.describe(`${slug} EIP chip coverage`, () => {
+    const markdown = fs.readFileSync(path.join(process.cwd(), file), "utf-8")
+    const documented = documentedEips(markdown)
+    const tagged = taggedEips(markdown, slug)
+    const inData = upgrades[slug].eips.map((e) => e.id).sort((a, b) => a - b)
+
+    test("the page documents at least one EIP", () => {
+      // Guards against the parser silently matching nothing and every
+      // comparison below trivially passing.
+      expect(documented.length).toBeGreaterThan(0)
+    })
+
+    test("every documented EIP has a data entry", () => {
+      expect(documented.filter((id) => !inData.includes(id))).toEqual([])
+    })
+
+    test("every documented EIP has a chip", () => {
+      expect(documented.filter((id) => !tagged.includes(id))).toEqual([])
+    })
+
+    test("every data entry is documented on the page", () => {
+      expect(inData.filter((id) => !documented.includes(id))).toEqual([])
+    })
+
+    test("no EIP is tagged twice", () => {
+      expect(tagged).toEqual([...new Set(tagged)])
+    })
+
+    test("every chip refers to a real data entry", () => {
+      expect(tagged.filter((id) => !inData.includes(id))).toEqual([])
+    })
+  })
+}

--- a/tests/unit/roadmap/eip-tags.spec.ts
+++ b/tests/unit/roadmap/eip-tags.spec.ts
@@ -20,6 +20,23 @@ import { expect, test } from "@playwright/test"
 
 import { upgrades } from "../../../src/data/upgrades"
 
+/**
+ * EIPs upstream schedules that the page does not document yet.
+ *
+ * This is a backlog, not a config: each entry is a section someone still has to
+ * write. Listing them keeps the coverage assertion below meaningful — a *new*
+ * scheduled EIP fails the build instead of being quietly absent — while not
+ * failing it for gaps that already exist.
+ *
+ * Shrink this list by writing the section. Do not grow it to make CI pass
+ * without a deliberate decision that the EIP does not warrant one.
+ */
+const UNDOCUMENTED: Record<string, number[]> = {
+  glamsterdam: [
+    7610, 7688, 7778, 7843, 7954, 7976, 7981, 8024, 8070, 8136, 8246, 8282,
+  ],
+}
+
 const PAGES = [
   { slug: "glamsterdam", file: "public/content/roadmap/glamsterdam/index.md" },
 ]
@@ -71,8 +88,21 @@ for (const { slug, file } of PAGES) {
       expect(documented.filter((id) => !tagged.includes(id))).toEqual([])
     })
 
-    test("every data entry is documented on the page", () => {
-      expect(inData.filter((id) => !documented.includes(id))).toEqual([])
+    test("every scheduled EIP is documented, or listed as a known gap", () => {
+      const known = UNDOCUMENTED[slug] ?? []
+      const missing = inData.filter(
+        (id) => !documented.includes(id) && !known.includes(id)
+      )
+      expect(missing).toEqual([])
+    })
+
+    test("the known-gap list has no stale entries", () => {
+      // A gap that got documented, or an EIP upstream dropped, should leave the
+      // list — otherwise it silently stops guarding anything.
+      const known = UNDOCUMENTED[slug] ?? []
+      expect(
+        known.filter((id) => documented.includes(id) || !inData.includes(id))
+      ).toEqual([])
     })
 
     test("no EIP is tagged twice", () => {

--- a/tests/unit/upgrades/sync.spec.ts
+++ b/tests/unit/upgrades/sync.spec.ts
@@ -87,9 +87,17 @@ const source: ForkcastSource = {
         projectedDate: "Q3 2026",
         actualEndDate: null,
         testnets: [
-          { name: "Holešky", status: "deprecated", projectedDate: null },
-          { name: "Sepolia", status: "upcoming", projectedDate: "Q3 2026" },
-          { name: "Hoodi", status: "upcoming", projectedDate: "Q3 2026" },
+          { name: "Holešky", status: "deprecated", stated: null },
+          {
+            name: "Sepolia",
+            status: "upcoming",
+            stated: { claim: "projected", value: "Q3 2026" },
+          },
+          {
+            name: "Hoodi",
+            status: "upcoming",
+            stated: { claim: "projected", value: "Q3 2026" },
+          },
         ],
       },
       {
@@ -143,6 +151,7 @@ test("public testnet forks become milestones, skipping deprecated networks", () 
   const testnets = milestones.filter((m) => m.kind === "testnet")
   expect(testnets.map((m) => m.network)).toEqual(["Sepolia", "Hoodi"])
   expect(testnets[0].when).toEqual({ year: 2026, quarter: 3 })
+  expect(testnets[0].status).toBe("projected")
   expect(testnets.some((m) => m.network === "Holešky")).toBe(false)
 })
 
@@ -407,7 +416,11 @@ test("release stage outranks the date when precision degrades", () => {
           projectedDate: "2027",
           actualEndDate: null,
           testnets: [
-            { name: "Sepolia", status: "upcoming", projectedDate: "2027" },
+            {
+              name: "Sepolia",
+              status: "upcoming",
+              stated: { claim: "projected", value: "2027" },
+            },
           ],
         },
         {
@@ -444,7 +457,11 @@ test("an unreadable date fails loudly rather than dropping a milestone", () => {
           ? {
               ...p,
               testnets: [
-                { name: "Sepolia", status: "upcoming", projectedDate: "soon" },
+                {
+                  name: "Sepolia",
+                  status: "upcoming",
+                  stated: { claim: "projected", value: "soon" },
+                },
               ],
             }
           : p
@@ -551,7 +568,7 @@ export const forkProgress = [
       {
         phaseId: 'public-testnets',
         testnets: [
-          { name: 'Sepolia', status: 'completed', projectedDate: 'Q1 2026' },
+          { name: 'Sepolia', status: 'completed', date: 'Jan 20, 2026' },
         ],
         status: 'upcoming',
         projectedDate: 'Q3 2026',
@@ -564,6 +581,134 @@ export const forkProgress = [
   expect(phase.status).toBe("upcoming")
   expect(phase.projectedDate).toBe("Q3 2026")
   expect(phase.testnets).toEqual([
-    { name: "Sepolia", status: "completed", projectedDate: "Q1 2026" },
+    {
+      name: "Sepolia",
+      status: "completed",
+      stated: { claim: "actual", value: "Jan 20, 2026" },
+    },
   ])
+})
+
+const liveTestnetShape = `
+export const forkProgress = [
+  {
+    forkName: 'Glamsterdam',
+    phases: [
+      {
+        phaseId: 'public-testnets',
+        status: 'in-progress',
+        testnets: [
+          { name: 'Platåberget', status: 'completed', date: 'Aug 13, 2026' },
+          { name: 'Sepolia', status: 'upcoming', proposedDate: 'Sep 28, 2026' },
+          { name: 'Hoodi', status: 'upcoming', projectedDate: 'Q4 2026' },
+        ],
+      },
+    ],
+  },
+]
+`
+
+test("parses every testnet date claim Forkcast writes", () => {
+  expect(parsePhases(liveTestnetShape).glamsterdam[0].testnets).toEqual([
+    {
+      name: "Platåberget",
+      status: "completed",
+      stated: { claim: "actual", value: "Aug 13, 2026" },
+    },
+    {
+      name: "Sepolia",
+      status: "upcoming",
+      stated: { claim: "proposed", value: "Sep 28, 2026" },
+    },
+    {
+      name: "Hoodi",
+      status: "upcoming",
+      stated: { claim: "projected", value: "Q4 2026" },
+    },
+  ])
+})
+
+test("testnet date claims preserve their confidence", () => {
+  const phases = parsePhases(liveTestnetShape).glamsterdam
+  const withLiveTestnets: ForkcastSource = {
+    ...source,
+    phases: {
+      ...source.phases,
+      glamsterdam: [
+        ...phases,
+        ...source.phases.glamsterdam.filter(
+          (phase) => phase.phaseId === "mainnet-deployment"
+        ),
+      ],
+    },
+  }
+
+  const milestones = normalize(withLiveTestnets).glamsterdam.milestones.filter(
+    (milestone) => milestone.kind === "testnet"
+  )
+  expect(milestones).toEqual([
+    {
+      kind: "testnet",
+      network: "Platåberget",
+      when: { year: 2026, month: 8, day: 13 },
+      status: "complete",
+    },
+    {
+      kind: "testnet",
+      network: "Sepolia",
+      when: { year: 2026, month: 9, day: 28 },
+      status: "anticipated",
+    },
+    {
+      kind: "testnet",
+      network: "Hoodi",
+      when: { year: 2026, quarter: 4 },
+      status: "projected",
+    },
+  ])
+})
+
+test("conflicting or unknown testnet date keys fail loudly", () => {
+  const conflicting = liveTestnetShape.replace(
+    "proposedDate: 'Sep 28, 2026'",
+    "proposedDate: 'Sep 28, 2026', projectedDate: 'Q3 2026'"
+  )
+  expect(() => parsePhases(conflicting)).toThrow(
+    /Conflicting testnet date keys proposedDate\+projectedDate/
+  )
+
+  const unknown = liveTestnetShape.replace(
+    "proposedDate: 'Sep 28, 2026'",
+    "estimatedDate: 'Sep 28, 2026'"
+  )
+  expect(() => parsePhases(unknown)).toThrow(
+    /Unknown testnet date key "estimatedDate"/
+  )
+})
+
+test("completed testnets require an actual date claim", () => {
+  const badStatus: ForkcastSource = {
+    ...source,
+    phases: {
+      ...source.phases,
+      glamsterdam: source.phases.glamsterdam.map((phase) =>
+        phase.phaseId === "public-testnets"
+          ? {
+              ...phase,
+              testnets: [
+                {
+                  name: "Sepolia",
+                  status: "completed",
+                  stated: { claim: "projected", value: "Q3 2026" },
+                },
+              ],
+            }
+          : phase
+      ),
+    },
+  }
+
+  expect(() => normalize(badStatus)).toThrow(
+    /Completed testnet "Sepolia".*does not state an actual date/
+  )
 })

--- a/tests/unit/upgrades/sync.spec.ts
+++ b/tests/unit/upgrades/sync.spec.ts
@@ -269,6 +269,33 @@ test("stores only EIPs expected to ship", () => {
   expect(eips.map((e) => e.id)).toEqual([7732, 8159])
 })
 
+test("considered survives the filter but proposed does not", () => {
+  // `considered` means ACD formally weighed the EIP, which a planning-phase page
+  // wants to show. `proposed` is the churn bucket and stays out.
+  const withBoth: ForkcastSource = {
+    ...source,
+    relationships: [
+      ...source.relationships,
+      {
+        eipId: 8141,
+        forkName: "Glamsterdam",
+        statusHistory: [
+          { status: "Considered", call: "acde/233", date: "2026-03-26" },
+        ],
+      },
+      {
+        eipId: 8888,
+        forkName: "Glamsterdam",
+        statusHistory: [{ status: "Proposed", call: null, date: null }],
+      },
+    ],
+  }
+
+  const { eips } = normalize(withBoth).glamsterdam
+  expect(eips.find((e) => e.id === 8141)?.status).toBe("considered")
+  expect(eips.find((e) => e.id === 8888)).toBeUndefined()
+})
+
 test("latest devnet is live while the fork is unshipped", () => {
   const { milestones } = normalize(source).glamsterdam
   expect(


### PR DESCRIPTION
## Summary

- render Forkcast-backed upgrade status, mainnet targets, milestones, and EIP confidence on roadmap pages
- preserve actual, proposed, and projected testnet dates from Forkcast and fail loudly on date-schema drift
- make content-review reporting retryable by classifying and opening the human-review issue before advancing the sync branch
- add the Hegotá roadmap page and navigation entry

## Test plan

- `pnpm test:unit`
- `pnpm type-check`
- `pnpm lint`
- `pnpm lint:md`
- `USE_MOCK_DATA=true NEXT_PUBLIC_BUILD_LOCALES=en pnpm build`
- regenerated the store against live `ethereum/forkcast` and verified Glamsterdam/Hegotá roadmap pages render successfully