### PR TITLE
[recovery] fix(stablecoins): set request locale before next-intl APIs (static→dynamic bailout on /api/stablecoins)

### DIFF
--- a/app/[locale]/stablecoins/page.tsx
+++ b/app/[locale]/stablecoins/page.tsx
@@ -97,10 +97,11 @@ const MIN_MARKET_CAP_USD = 500_000
 async function Page(props: { params: Promise<PageParams> }) {
   const params = await props.params
   const { locale } = params
-  const t = await getTranslations("page-stablecoins")
-  const tCommon = await getTranslations("common")
 
   setRequestLocale(locale)
+
+  const t = await getTranslations("page-stablecoins")
+  const tCommon = await getTranslations("common")
 
   // Get i18n messages
   const allMessages = await getMessages({ locale })


### PR DESCRIPTION
## Production error

Captured from Netlify logs (`___netlify-server-handler`) via Grafana → Keep.

```
[ERROR] Error: Page changed from static to dynamic at runtime /api/stablecoins, reason: headers
see more here https://nextjs.org/docs/messages/app-static-to-dynamic-error
    at y (.next/server/chunks/ssr/1itz_next_dist_1j1_2py._.js:2:12450)
```

- **URL / resource:** `/api/stablecoins`
- **Occurrences:** 1 alert event, `hit_count: 3` (last seen `2026-08-06T14:53:50.441Z`)
- **Request id:** `01KZBS1R5C64CVVMZ75JZTACMW`

## Root cause

`/api/stablecoins` is not a real route. `proxy.ts`'s matcher excludes `/api`, so the request reaches Next's router unprocessed; no static `app/api/stablecoins` segment exists, so it falls through to the dynamic route `app/[locale]/stablecoins/page.tsx` with `locale = "api"`. That param is outside `generateStaticParams()`, so the page renders on demand instead of being served from the prerender.

During that on-demand render, `Page` called next-intl APIs *before* priming the locale cache:

```ts
const { locale } = params
const t = await getTranslations("page-stablecoins")   // ← reads headers()
const tCommon = await getTranslations("common")

setRequestLocale(locale)                              // ← too late
```

With the cache unprimed, `getTranslations()` resolves the locale through next-intl's lazy `requestLocale` getter, which falls back to `headers()` (`RequestLocale.js` → `getCachedRequestLocale() || headers().get(HEADER_LOCALE_NAME)`). Reading headers opts the route into dynamic rendering, and because Next.js considers the route SSG it aborts with the static-to-dynamic error (`E132`) rather than rendering or returning a clean 404.

This is the exact failure mode already documented in `docs/solutions/architecture/setrequestlocale-static-to-dynamic-rendering.md` (prior recovery PRs #18785, #18797, #18798, #18800; systemic sweep #18811) — this page's `Page` component was missed by that sweep. Its `generateMetadata` was already correct.

Related but distinct: #18932 fixes the same class of bug on `app/[locale]/bug-bounty/page.tsx`. Different route, no overlap.

## Fix

One file, three lines: move `setRequestLocale(locale)` above the two `getTranslations` calls in `app/[locale]/stablecoins/page.tsx`, so the locale cache is primed before any next-intl API runs. No behavioural change for valid locales; invalid-locale requests now render statically and fall through to the 404 handled by `app/[locale]/layout.tsx`.

## Verification

- `pnpm type-check` → passes (`next typegen && tsc --noEmit && tsc --noEmit -p netlify/edge-functions`; types generated successfully, no errors)
- `pnpm exec eslint "app/[locale]/stablecoins/page.tsx"` → clean, no output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
