### PR TITLE
[recovery] fix(i18n): don't throw ENOENT loading messages for an unknown locale (/api/… catch-all)

### DIFF
--- a/src/lib/i18n/loadMessages.ts
+++ b/src/lib/i18n/loadMessages.ts
@@ -29,7 +29,11 @@ export async function loadMessages(locale: string) {
   const localePath = path.join(intlPath, locale)
   const messages: Record<string, IntlMessages> = {}
 
-  if (fs.statSync(localePath).isDirectory()) {
+  // `throwIfNoEntry: false` returns undefined instead of throwing ENOENT: the
+  // `[locale]` segment acts as a catch-all, so bot probes like `/api/...` reach
+  // here with an unknown locale and must fall through to an empty message set
+  // (letting the layout's `notFound()` win) rather than crashing the render.
+  if (fs.statSync(localePath, { throwIfNoEntry: false })?.isDirectory()) {
     const namespaces = getNamespaces(localePath)
 
     await Promise.all(


### PR DESCRIPTION
> Filed by the automated recovery agent from a production Netlify error captured via Grafana → Keep.

## Production error

```
[ERROR] Error: ENOENT: no such file or directory, stat '/var/task/src/intl/api'
    at i (.next/server/chunks/ssr/_19pzzqm._.js:2:17200)
    at async k (.next/server/chunks/ssr/_19pzzqm._.js:2:17826)
    at async Y (.next/server/chunks/ssr/_1x2rh9o._.js:2:8748) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'stat',
  path: '/var/task/src/intl/api',
  digest: '3211470254'
}
```

- **Function:** `___netlify-server-handler` (SSR)
- **Digest:** `3211470254`
- **Fingerprint:** `grafana-fn-error-enoent-no-such-file-or-directory-stat-x-at-i-next-server-chunks`
- **URL / resource:** not captured in the alert — the stat path pins the locale segment to `api`
- **Occurrences:** 1 (`hit_count: 1`), last seen `2026-08-06T14:54:01.806Z`, request id `01KZBS25NQVRZ90NJAN7ZKH4M2`

## Root cause

`src/lib/i18n/loadMessages.ts` builds `src/intl/<locale>` and gates its work on:

```ts
if (fs.statSync(localePath).isDirectory()) {
```

The shape of that guard reads as "only load if the directory exists", but `fs.statSync` **throws** `ENOENT` when the path is missing — it never returns a falsy value. The guard is therefore dead code for the exact case it was written for, and an unknown locale crashes the render instead of being skipped.

The unknown locale here is `api`. With `localePrefix: "as-needed"` (`src/i18n/routing.ts`), the `app/[locale]/…` segment acts as a catch-all for unknown top-level paths, and `proxy.ts`'s matcher explicitly excludes `api`, so a request under `/api/…` with no matching segment in `app/api/` falls through to `app/[locale]/…` with `params.locale === "api"`. Same "bot hits the `[locale]` catch-all" wave as the sibling `/api/stablecoins` alert in #18994 (request id `01KZBS1R5C…`, 11 seconds earlier) — but a different error on a different code path.

`app/[locale]/layout.tsx` does guard the segment with `if (!routing.locales.includes(locale)) notFound()`, but the page body renders concurrently with the layout, so page-level work reaches `loadMessages` before that `notFound()` can win. The two callers differ:

- `src/i18n/request.ts:15` normalizes an invalid locale to `routing.defaultLocale` before calling — safe.
- `src/lib/utils/stories.ts:43` (`resolveStories`, reached from `/community`, `/stories`, `/10years`, and `WhatAreAppsStories`) passes the **raw** route locale straight through — the unguarded path. This matches the minified frame order: `i` = `loadMessages` and `k` = `resolveStories` in the same chunk (`stories.ts` imports `loadMessages`), `Y` = the page in a separate chunk.

Net effect: a bot-shaped URL returns an uncaught 500 instead of a clean 404.

## Fix

One line in `src/lib/i18n/loadMessages.ts` — pass Node's `throwIfNoEntry: false` so `statSync` returns `undefined` instead of throwing, making the existing guard behave the way it always read:

```ts
if (fs.statSync(localePath, { throwIfNoEntry: false })?.isDirectory()) {
```

An unknown locale now yields an empty message set and the render falls through to the layout's `notFound()` → clean 404. Behaviour for every real locale is unchanged.

Downstream is already safe with empty messages: `getTranslations` resolves through `src/i18n/request.ts`, which falls back to the default locale, and `resolveStories`'s `hasTranslation()` simply reports `false`, selecting the verbatim original story text.

Deliberately scoped to the crash. The broader systemic fix suggested in #18792 — rejecting unknown top-level segments once, before any page code runs, instead of relying on per-route guard ordering — is still worth doing and would cover #18013 / #17967 / #18792 as well.

## Verification

- `pnpm type-check` → passes (`next typegen && tsc --noEmit && tsc --noEmit -p netlify/edge-functions`; types generated successfully, no errors)
- `pnpm exec eslint src/lib/i18n/loadMessages.ts` → clean, no output
- Runtime check of the changed expression against this checkout:
  - `fs.statSync("src/intl/api", { throwIfNoEntry: false })?.isDirectory()` → `undefined` (falsy, no throw — previously threw the ENOENT above)
  - `fs.statSync("src/intl/en", { throwIfNoEntry: false })?.isDirectory()` → `true` (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
