### PR TITLE
[recovery] fix(i18n): set request locale before the notFound() bail in [locale] layout (static→dynamic on /api/bug-bounty)

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -36,12 +36,13 @@ export default async function LocaleLayout(props: {
 
   const { children } = props
 
+  // Safety net only - pages must still call this themselves. Runs before the
+  // notFound() bail so invalid-locale probes can't fall back to headers().
+  setRequestLocale(locale)
+
   if (!routing.locales.includes(locale)) {
     notFound()
   }
-
-  // Enable static rendering
-  setRequestLocale(locale)
 
   const allMessages = await getMessages()
   const messages = pick(allMessages, "common")


### PR DESCRIPTION
> Filed by the automated recovery agent from a production Netlify error captured via Grafana → Keep.

## Production error

```
[ERROR] Error: Page changed from static to dynamic at runtime /api/bug-bounty, reason: headers
see more here https://nextjs.org/docs/messages/app-static-to-dynamic-error
    at y (.next/server/chunks/ssr/1itz_next_dist_1j1_2py._.js:2:12450)
```

- **Function:** `___netlify-server-handler` (SSR)
- **Fingerprint:** `grafana-fn-error-page-changed-from-static-to-dynamic-at-runtime-api-bug-bounty-reason-h`
- **URL / resource:** `/api/bug-bounty`
- **Occurrences:** 1 (`hit_count: 1`), last seen `2026-08-06T14:54:01.209Z`, request id `01KZBS2344AQ21YCAVDY5YNB8B`

## Root cause

`/api/bug-bounty` is not an API route — `app/api/` only holds `gas-eth-price`, `gfi-issues-webhook`, `revalidate` and `torch-webhook`. Because `[locale]` is a dynamic segment it acts as a catch-all for unknown top-level paths, so the request matches `app/[locale]/bug-bounty/page.tsx` with `params.locale === "api"`. `proxy.ts`'s matcher explicitly excludes `api`, so next-intl's middleware never runs and no `X-NEXT-INTL-LOCALE` header is set.

`app/[locale]/layout.tsx` guards the segment, but it called `notFound()` **before** `setRequestLocale(locale)`. The page body renders concurrently with the layout, so it ran with an empty request-locale cache, and next-intl fell back to reading headers:

```js
// next-intl/dist/esm/*/server/react-server/RequestLocale.js
async function getRequestLocale() {
  return getCachedRequestLocale() || (await getLocaleFromHeader()); // <- headers()
}
```

That `headers()` access marks the render dynamic. Since `/[locale]/bug-bounty` is prerendered (via the layout's `generateStaticParams`), Next.js throws `Page changed from static to dynamic at runtime … reason: headers` instead of serving a clean 404.

Confirmed by instrumenting `getRequestLocale` and the page body against the dev server:

| Request | Result |
| --- | --- |
| `/es/bug-bounty/` | `cached locale HIT: es (no headers access)` — layout ran `setRequestLocale` first |
| `/api/bug-bounty/` (before) | `cached locale MISS -> falling back to headers()` |
| `/api/bug-bounty/` (after) | `cached locale HIT: api (no headers access)` |

The page body was observed running with `locale = api` even though the layout calls `notFound()` — which is the part that makes the guard ordering matter.

## Fix

Move `setRequestLocale(locale)` above the validity check in `app/[locale]/layout.tsx`, so the request-scoped locale is populated for the whole subtree before the `notFound()` bail. No descendant can then fall back to `headers()`.

An unsupported value is harmless: `src/i18n/request.ts` already normalizes any locale outside `routing.locales` to `routing.defaultLocale`. The 404 is unchanged — `/api/bug-bounty/` still returns 404 after the fix.

This fixes the class at the layout level instead of per page, and so covers every page under `[locale]` that omits `setRequestLocale` in its body — not just the ones a bot has happened to probe. Two earlier recovery PRs patched individual pages for this same root cause:

- #18932 — `/.well-known/bug-bounty` → `setRequestLocale` in `app/[locale]/bug-bounty/page.tsx` (open since 2026-07-28, would already have covered this alert's page had it merged)
- #18994 — `/api/stablecoins` → `setRequestLocale` in `app/[locale]/stablecoins/page.tsx`

Both become redundant with this change. Neither conflicts with it (different files), so closing them is your call. This is also a step toward the systemic "stop relying on per-route guard ordering for unknown top-level segments" fix discussed in #18792, though it does not replace it: this makes the subtree render safely rather than rejecting the segment before page code runs.

## Verification

- `pnpm type-check` → passes (`next typegen && tsc --noEmit && tsc --noEmit -p netlify/edge-functions`; types generated successfully, no errors)
- `pnpm exec eslint "app/[locale]/layout.tsx"` → clean, no output
- Dev-server reproduction before/after as tabulated above, plus `/api/bug-bounty/` still 404 and `/es/bug-bounty/` still resolves its locale from the cache.
- All instrumentation was reverted before committing (temporary page/layout `console.log` probes and a local `node_modules/next-intl` patch); the committed diff is the single statement move plus its explanatory comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
