### PR TITLE
Add Hegota roadmap page in planning phase

### DIFF
--- a/public/content/roadmap/glamsterdam/index.md
+++ b/public/content/roadmap/glamsterdam/index.md
@@ -5,11 +5,10 @@ lang: en
 template: upgrade
 ---
 
+<UpgradeSummary slug="glamsterdam" />
+
 <Alert variant="update">
 <AlertContent>
-<AlertTitle>
-Glamsterdam is an upcoming Ethereum upgrade planned for Q4 2026
-</AlertTitle>
 <AlertDescription>
 The Glamsterdam upgrade is only a single step in Ethereum's long-term development goals. Learn more about [the protocol roadmap](/roadmap/) and [previous upgrades](/ethereum-forks/).
 </AlertDescription>

--- a/public/content/roadmap/glamsterdam/index.md
+++ b/public/content/roadmap/glamsterdam/index.md
@@ -5,8 +5,6 @@ lang: en
 template: upgrade
 ---
 
-<UpgradeSummary slug="glamsterdam" />
-
 <Alert variant="update">
 <AlertContent>
 <AlertDescription>

--- a/public/content/roadmap/hegota/index.md
+++ b/public/content/roadmap/hegota/index.md
@@ -1,0 +1,30 @@
+---
+title: Hegotá
+metaTitle: Heze-Bogotá (Hegotá)
+description: Learn about the Hegotá protocol upgrade
+lang: en
+template: upgrade
+---
+
+Hegotá is the [Ethereum](/) network upgrade expected to follow [Glamsterdam](/roadmap/glamsterdam/). It is named from the combination of "Bogotá" (execution layer upgrade, named after a previous Devcon location) and "Heze" (consensus layer upgrade, named after a star).
+
+Hegotá is in early planning. Its headliner has been chosen, but the rest of the scope is still being decided, and no dates have been set.
+
+## Headliner: FOCIL {#focil}
+
+Fork-choice enforced inclusion lists (FOCIL, or EIP-7805) is about [censorship resistance](/roadmap/security/#censorship-resistance): making sure that a valid transaction gets into a block even if the people building blocks would rather leave it out.
+
+Today a single [validator](/glossary/#validator) builds each block and decides which transactions it contains. Anyone who can influence enough block builders can therefore delay a transaction, and a user has no way to force the issue other than waiting and hoping.
+
+FOCIL spreads that decision across many validators. A committee each proposes a list of transactions that ought to be included, and the rules of the protocol oblige the block builder to honour those lists. Censoring a transaction stops being something one party can do alone.
+
+## What else is in Hegotá {#scope}
+
+Not decided yet. One further proposal is under consideration and around twenty more have been proposed, but only the headliner is scheduled. This page will stay short until the scope is settled — for the current state of the discussion, see the resources below.
+
+## Further reading {#further-reading}
+
+- [Forkcast: Hegotá](https://forkcast.org/upgrade/hegota) — live status of every proposal
+- [Hegotá Meta EIP (EIP-8081)](https://eips.ethereum.org/EIPS/eip-8081)
+- [EIP-7805 technical specification](https://eips.ethereum.org/EIPS/eip-7805)
+- [Ethereum roadmap](/roadmap/)

--- a/src/components/MdComponents/topics/upgrade.tsx
+++ b/src/components/MdComponents/topics/upgrade.tsx
@@ -1,6 +1,7 @@
 import MergeArticleList from "@/components/MergeArticleList"
 import MergeInfographic from "@/components/MergeInfographic"
 import UpgradeStatus from "@/components/UpgradeStatus"
+import UpgradeSummary from "@/components/UpgradeSummary"
 
 // MDX components available to upgrade markdown pages.
 // The layout itself lives in `src/layouts/Topic.tsx`; per-section config is
@@ -8,5 +9,9 @@ import UpgradeStatus from "@/components/UpgradeStatus"
 export const upgradeComponents = {
   MergeArticleList,
   MergeInfographic,
+  // `UpgradeStatus` is the "when shipping" aside on the Beacon Chain and Merge
+  // pages; `UpgradeSummary` is the data-driven status block on upcoming
+  // upgrades. Similar names, unrelated components.
   UpgradeStatus,
+  UpgradeSummary,
 }

--- a/src/components/MdComponents/topics/upgrade.tsx
+++ b/src/components/MdComponents/topics/upgrade.tsx
@@ -1,17 +1,18 @@
 import MergeArticleList from "@/components/MergeArticleList"
 import MergeInfographic from "@/components/MergeInfographic"
 import UpgradeStatus from "@/components/UpgradeStatus"
-import UpgradeSummary from "@/components/UpgradeSummary"
 
 // MDX components available to upgrade markdown pages.
 // The layout itself lives in `src/layouts/Topic.tsx`; per-section config is
 // in `src/data/topics/upgrade.ts`.
+//
+// Note: `UpgradeSummary` is deliberately absent. It is rendered by
+// `TopicLayout` for any page with a file in `src/data/upgrades`, so that it
+// reaches every locale without a tag in 25 markdown files. Not to be confused
+// with `UpgradeStatus` below, the "when shipping" aside on the Beacon Chain
+// and Merge pages.
 export const upgradeComponents = {
   MergeArticleList,
   MergeInfographic,
-  // `UpgradeStatus` is the "when shipping" aside on the Beacon Chain and Merge
-  // pages; `UpgradeSummary` is the data-driven status block on upcoming
-  // upgrades. Similar names, unrelated components.
   UpgradeStatus,
-  UpgradeSummary,
 }

--- a/src/components/UpgradeSummary.tsx
+++ b/src/components/UpgradeSummary.tsx
@@ -1,0 +1,118 @@
+import { getLocale, getTranslations } from "next-intl/server"
+
+import InlineLink from "@/components/ui/Link"
+import { Tag } from "@/components/ui/tag"
+
+import { formatPartialDate } from "@/lib/utils/date"
+
+import { type UpgradePhase, upgrades } from "@/data/upgrades"
+
+export type UpgradeSummaryProps = {
+  /** Key into `src/data/upgrades`, e.g. "glamsterdam". */
+  slug: string
+}
+
+/**
+ * Only phases an upgrade has actually reached get a label, because every label
+ * is a translation task across all locales. A phase missing from this map
+ * renders no tag rather than a raw key — add the key when an upgrade needs it.
+ */
+const PHASE_LABEL_KEYS: Partial<Record<UpgradePhase, string>> = {
+  devnet: "page-roadmap-upgrade-status-phase-devnet",
+}
+
+/**
+ * The volatile-fact block at the top of an upgrade page: phase, mainnet target,
+ * next milestone, and when the facts were last checked.
+ *
+ * Every value comes from `src/data/upgrades` — nothing here is hardcoded, so
+ * refreshing the page's facts never means editing prose. Confidence is carried
+ * by the data and rendered explicitly: an unconfirmed target is a different
+ * sentence from a confirmed one, never the same sentence with a softer word.
+ *
+ * Not to be confused with `UpgradeStatus`, the "when shipping" aside used on
+ * the Beacon Chain and Merge pages.
+ */
+const UpgradeSummary = async ({ slug }: UpgradeSummaryProps) => {
+  const upgrade = upgrades[slug]
+  if (!upgrade) return null
+
+  const t = await getTranslations("page-roadmap")
+  const locale = await getLocale()
+
+  const phaseLabelKey = PHASE_LABEL_KEYS[upgrade.phase]
+  const target = upgrade["mainnet-target"]
+  // `complete` milestones are behind us; `live` and everything weaker is not.
+  const next = upgrade.milestones.find((m) => m.status !== "complete")
+
+  return (
+    <aside className="flow w-full rounded-base bg-tint-accent-a p-6">
+      <h2 className="text-sm font-normal uppercase">
+        {t("page-roadmap-upgrade-status-heading")}
+      </h2>
+
+      {phaseLabelKey && (
+        <Tag status={upgrade.phase === "activated" ? "success" : "tag"}>
+          {t(phaseLabelKey)}
+        </Tag>
+      )}
+
+      <dl className="grid gap-x-6 gap-y-2 sm:grid-cols-[auto_1fr]">
+        <dt className="text-body-medium">
+          {t("page-roadmap-upgrade-status-target")}
+        </dt>
+        <dd>
+          {formatPartialDate(target.when, locale)}
+          {/* The qualifier is its own clause, not an adjective, so it cannot
+              be lost to word order in translation or read as settled. */}
+          {!target.confirmed && (
+            <span className="text-body-medium">
+              {" · "}
+              {t("page-roadmap-upgrade-status-not-confirmed")}
+            </span>
+          )}
+        </dd>
+
+        {next && (
+          <>
+            <dt className="text-body-medium">
+              {t("page-roadmap-upgrade-status-next")}
+            </dt>
+            <dd>
+              {/* Milestone names are proper nouns, rendered untranslated. */}
+              {next.name}
+              {", "}
+              {formatPartialDate(next.when, locale)}
+            </dd>
+          </>
+        )}
+
+        <dt className="text-body-medium">
+          {t("page-roadmap-upgrade-status-verified")}
+        </dt>
+        <dd>
+          <time dateTime={upgrade["facts-verified"]}>
+            {formatPartialDate(
+              toPartialDate(upgrade["facts-verified"]),
+              locale
+            )}
+          </time>
+        </dd>
+      </dl>
+
+      <p>
+        <InlineLink href={upgrade["source-url"]}>
+          {t("page-roadmap-upgrade-status-track")}
+        </InlineLink>
+      </p>
+    </aside>
+  )
+}
+
+/** Split an ISO `YYYY-MM-DD` stamp into the shape `formatPartialDate` takes. */
+const toPartialDate = (iso: string) => {
+  const [year, month, day] = iso.split("-").map(Number)
+  return { year, month, day }
+}
+
+export default UpgradeSummary

--- a/src/components/UpgradeSummary.tsx
+++ b/src/components/UpgradeSummary.tsx
@@ -4,8 +4,9 @@ import InlineLink from "@/components/ui/Link"
 import { Tag } from "@/components/ui/tag"
 
 import { formatPartialDate } from "@/lib/utils/date"
+import { numberFormat } from "@/lib/utils/numbers"
 
-import { type UpgradePhase, upgrades } from "@/data/upgrades"
+import { type Milestone, type MilestoneKind, upgrades } from "@/data/upgrades"
 
 export type UpgradeSummaryProps = {
   /** Key into `src/data/upgrades`, e.g. "glamsterdam". */
@@ -13,22 +14,32 @@ export type UpgradeSummaryProps = {
 }
 
 /**
- * Only phases an upgrade has actually reached get a label, because every label
- * is a translation task across all locales. A phase missing from this map
- * renders no tag rather than a raw key — add the key when an upgrade needs it.
+ * The stage an upgrade has reached, read from whichever milestone is running
+ * rather than from a field: `status` only distinguishes live from upcoming, and
+ * "testing on devnets" is the more useful thing to tell a reader.
+ *
+ * A kind missing from this map renders no tag rather than a raw key — every
+ * label is a translation task across all locales, so add one when an upgrade
+ * actually reaches that stage.
  */
-const PHASE_LABEL_KEYS: Partial<Record<UpgradePhase, string>> = {
+const STAGE_LABEL_KEYS: Partial<Record<MilestoneKind, string>> = {
   devnet: "page-roadmap-upgrade-status-phase-devnet",
 }
 
+const MILESTONE_LABEL_KEYS: Record<MilestoneKind, string> = {
+  devnet: "page-roadmap-upgrade-milestone-devnet",
+  testnet: "page-roadmap-upgrade-milestone-testnet",
+  mainnet: "page-roadmap-upgrade-milestone-mainnet",
+}
+
 /**
- * The volatile-fact block at the top of an upgrade page: phase, mainnet target,
- * next milestone, and when the facts were last checked.
+ * The volatile-fact block at the top of an upgrade page: stage, mainnet target
+ * and next milestone.
  *
  * Every value comes from `src/data/upgrades` — nothing here is hardcoded, so
  * refreshing the page's facts never means editing prose. Confidence is carried
- * by the data and rendered explicitly: an unconfirmed target is a different
- * sentence from a confirmed one, never the same sentence with a softer word.
+ * by the data and rendered explicitly: an unconfirmed target gets its own
+ * qualifying clause rather than a softer word.
  *
  * Not to be confused with `UpgradeStatus`, the "when shipping" aside used on
  * the Beacon Chain and Merge pages.
@@ -40,10 +51,32 @@ const UpgradeSummary = async ({ slug }: UpgradeSummaryProps) => {
   const t = await getTranslations("page-roadmap")
   const locale = await getLocale()
 
-  const phaseLabelKey = PHASE_LABEL_KEYS[upgrade.phase]
-  const target = upgrade["mainnet-target"]
-  // `complete` milestones are behind us; `live` and everything weaker is not.
-  const next = upgrade.milestones.find((m) => m.status !== "complete")
+  // A year is a label, not a quantity — grouping would render it "2,026".
+  const number = numberFormat(locale, { useGrouping: false })
+  const formatQuarter = (quarter: number, year: number) =>
+    t("page-roadmap-upgrade-quarter", {
+      quarter: number.format(quarter),
+      year: number.format(year),
+    })
+
+  /** Milestones carry no English name, so the label is built from `kind`. */
+  const milestoneLabel = (milestone: Milestone) =>
+    t(MILESTONE_LABEL_KEYS[milestone.kind], {
+      version: milestone.kind === "devnet" ? milestone.version : "",
+      network: milestone.kind === "testnet" ? milestone.network : "",
+    })
+
+  const target = upgrade.mainnetTarget
+  const running = upgrade.milestones.find((m) => m.status === "live")
+  const stageLabelKey = running && STAGE_LABEL_KEYS[running.kind]
+
+  // `live` is happening now rather than next, so a running devnet is not the
+  // answer to "what comes next". The mainnet row already states the target, so
+  // repeating it here as the next milestone would be noise.
+  const next = upgrade.milestones.find(
+    (m) =>
+      m.status !== "complete" && m.status !== "live" && m.kind !== "mainnet"
+  )
 
   return (
     <aside className="flow w-full rounded-base bg-tint-accent-a p-6">
@@ -51,27 +84,27 @@ const UpgradeSummary = async ({ slug }: UpgradeSummaryProps) => {
         {t("page-roadmap-upgrade-status-heading")}
       </h2>
 
-      {phaseLabelKey && (
-        <Tag status={upgrade.phase === "activated" ? "success" : "tag"}>
-          {t(phaseLabelKey)}
-        </Tag>
-      )}
+      {stageLabelKey && <Tag status="tag">{t(stageLabelKey)}</Tag>}
 
       <dl className="grid gap-x-6 gap-y-2 sm:grid-cols-[auto_1fr]">
-        <dt className="text-body-medium">
-          {t("page-roadmap-upgrade-status-target")}
-        </dt>
-        <dd>
-          {formatPartialDate(target.when, locale)}
-          {/* The qualifier is its own clause, not an adjective, so it cannot
-              be lost to word order in translation or read as settled. */}
-          {!target.confirmed && (
-            <span className="text-body-medium">
-              {" · "}
-              {t("page-roadmap-upgrade-status-not-confirmed")}
-            </span>
-          )}
-        </dd>
+        {target.when && (
+          <>
+            <dt className="text-body-medium">
+              {t("page-roadmap-upgrade-status-target")}
+            </dt>
+            <dd>
+              {formatPartialDate(target.when, locale, formatQuarter)}
+              {/* The qualifier is its own clause, not an adjective, so it cannot
+                  be lost to word order in translation or read as settled. */}
+              {!target.confirmed && (
+                <span className="text-body-medium">
+                  {" · "}
+                  {t("page-roadmap-upgrade-status-not-confirmed")}
+                </span>
+              )}
+            </dd>
+          </>
+        )}
 
         {next && (
           <>
@@ -79,40 +112,21 @@ const UpgradeSummary = async ({ slug }: UpgradeSummaryProps) => {
               {t("page-roadmap-upgrade-status-next")}
             </dt>
             <dd>
-              {/* Milestone names are proper nouns, rendered untranslated. */}
-              {next.name}
+              {milestoneLabel(next)}
               {", "}
-              {formatPartialDate(next.when, locale)}
+              {formatPartialDate(next.when, locale, formatQuarter)}
             </dd>
           </>
         )}
-
-        <dt className="text-body-medium">
-          {t("page-roadmap-upgrade-status-verified")}
-        </dt>
-        <dd>
-          <time dateTime={upgrade["facts-verified"]}>
-            {formatPartialDate(
-              toPartialDate(upgrade["facts-verified"]),
-              locale
-            )}
-          </time>
-        </dd>
       </dl>
 
       <p>
-        <InlineLink href={upgrade["source-url"]}>
+        <InlineLink href={upgrade.sourceUrl}>
           {t("page-roadmap-upgrade-status-track")}
         </InlineLink>
       </p>
     </aside>
   )
-}
-
-/** Split an ISO `YYYY-MM-DD` stamp into the shape `formatPartialDate` takes. */
-const toPartialDate = (iso: string) => {
-  const [year, month, day] = iso.split("-").map(Number)
-  return { year, month, day }
 }
 
 export default UpgradeSummary

--- a/src/components/UpgradeSummary.tsx
+++ b/src/components/UpgradeSummary.tsx
@@ -6,7 +6,12 @@ import { Tag } from "@/components/ui/tag"
 import { formatPartialDate } from "@/lib/utils/date"
 import { numberFormat } from "@/lib/utils/numbers"
 
-import { type Milestone, type MilestoneKind, upgrades } from "@/data/upgrades"
+import {
+  type Milestone,
+  type MilestoneKind,
+  upgrades,
+  type UpgradeStatus,
+} from "@/data/upgrades"
 
 export type UpgradeSummaryProps = {
   /** Key into `src/data/upgrades`, e.g. "glamsterdam". */
@@ -24,6 +29,14 @@ export type UpgradeSummaryProps = {
  */
 const STAGE_LABEL_KEYS: Partial<Record<MilestoneKind, string>> = {
   devnet: "page-roadmap-upgrade-status-phase-devnet",
+}
+
+/**
+ * Fallback for an upgrade with nothing running yet — Hegotá has only projected
+ * milestones, so there is no stage to read and its `status` is all we have.
+ */
+const STATUS_LABEL_KEYS: Partial<Record<UpgradeStatus, string>> = {
+  planning: "page-roadmap-upgrade-status-phase-planning",
 }
 
 const MILESTONE_LABEL_KEYS: Record<MilestoneKind, string> = {
@@ -68,7 +81,9 @@ const UpgradeSummary = async ({ slug }: UpgradeSummaryProps) => {
 
   const target = upgrade.mainnetTarget
   const running = upgrade.milestones.find((m) => m.status === "live")
-  const stageLabelKey = running && STAGE_LABEL_KEYS[running.kind]
+  const stageLabelKey = running
+    ? STAGE_LABEL_KEYS[running.kind]
+    : STATUS_LABEL_KEYS[upgrade.status]
 
   // `live` is happening now rather than next, so a running devnet is not the
   // answer to "what comes next". The mainnet row already states the target, so

--- a/src/data/roadmap/releases.tsx
+++ b/src/data/roadmap/releases.tsx
@@ -229,6 +229,7 @@ export const getReleasesData = (t: TranslationFunction): Release[] => [
     releaseName: "Hegotá",
     plannedReleaseYear: "2027",
     displayDate: "2027",
+    href: "/roadmap/hegota/",
     content: (
       <>
         <p>

--- a/src/data/topics/upgrade.ts
+++ b/src/data/topics/upgrade.ts
@@ -43,6 +43,11 @@ export const upgrade: TopicConfig = {
         matomoEvent: "/roadmap/glamsterdam/",
       },
       {
+        textKey: "page-upgrades-upgrades-hegota",
+        href: "/roadmap/hegota/",
+        matomoEvent: "/roadmap/hegota/",
+      },
+      {
         textKey: "page-upgrades-upgrades-forks",
         href: "/ethereum-forks/",
         matomoEvent: "/ethereum-forks/",

--- a/src/intl/en/page-roadmap.json
+++ b/src/intl/en/page-roadmap.json
@@ -120,6 +120,9 @@
   "page-roadmap-upgrade-status-target": "Expected on mainnet",
   "page-roadmap-upgrade-status-not-confirmed": "Date not yet confirmed",
   "page-roadmap-upgrade-status-next": "Next milestone",
-  "page-roadmap-upgrade-status-verified": "Status checked",
-  "page-roadmap-upgrade-status-track": "Track live progress on Forkcast"
+  "page-roadmap-upgrade-status-track": "Track live progress on Forkcast",
+  "page-roadmap-upgrade-quarter": "Q{quarter} {year}",
+  "page-roadmap-upgrade-milestone-devnet": "Devnet-{version}",
+  "page-roadmap-upgrade-milestone-testnet": "{network} fork",
+  "page-roadmap-upgrade-milestone-mainnet": "Mainnet activation"
 }

--- a/src/intl/en/page-roadmap.json
+++ b/src/intl/en/page-roadmap.json
@@ -114,5 +114,12 @@
   "page-roadmap-glamsterdam-bal-item-2": "Maps dependencies upfront for faster syncs, parallel execution, and parallel disk reads",
   "page-roadmap-glamsterdam-bal-item-3": "Lowers gas for state-heavy apps and improves gas cost predictability",
   "page-roadmap-hegota-discussed-title": "Planned for Hegotá",
-  "page-roadmap-hegota-discussed-item-1": "Proposals are currently under discussion"
+  "page-roadmap-hegota-discussed-item-1": "Proposals are currently under discussion",
+  "page-roadmap-upgrade-status-heading": "Upgrade status",
+  "page-roadmap-upgrade-status-phase-devnet": "Testing on devnets",
+  "page-roadmap-upgrade-status-target": "Expected on mainnet",
+  "page-roadmap-upgrade-status-not-confirmed": "Date not yet confirmed",
+  "page-roadmap-upgrade-status-next": "Next milestone",
+  "page-roadmap-upgrade-status-verified": "Status checked",
+  "page-roadmap-upgrade-status-track": "Track live progress on Forkcast"
 }

--- a/src/intl/en/page-roadmap.json
+++ b/src/intl/en/page-roadmap.json
@@ -121,6 +121,7 @@
   "page-roadmap-upgrade-status-not-confirmed": "Date not yet confirmed",
   "page-roadmap-upgrade-status-next": "Next milestone",
   "page-roadmap-upgrade-status-track": "Track live progress on Forkcast",
+  "page-roadmap-upgrade-status-phase-planning": "In planning",
   "page-roadmap-upgrade-quarter": "Q{quarter} {year}",
   "page-roadmap-upgrade-milestone-devnet": "Devnet-{version}",
   "page-roadmap-upgrade-milestone-testnet": "{network} fork",

--- a/src/intl/en/page-upgrades-index.json
+++ b/src/intl/en/page-upgrades-index.json
@@ -209,5 +209,6 @@
   "docs-nav-proof-of-stake": "Proof-of-stake",
   "docs-nav-proof-of-work": "Proof-of-work",
   "page-upgrades-get-involved-ethresearch-1": "Sharding",
-  "page-upgrades-get-involved-ethresearch-2": "The Merge"
+  "page-upgrades-get-involved-ethresearch-2": "The Merge",
+  "page-upgrades-upgrades-hegota": "Hegotá"
 }

--- a/src/layouts/Topic.tsx
+++ b/src/layouts/Topic.tsx
@@ -9,11 +9,13 @@ import PageActions from "@/components/PageActions"
 import { Alert } from "@/components/ui/alert"
 import InlineLink from "@/components/ui/Link"
 import { List, ListItem } from "@/components/ui/list"
+import UpgradeSummary from "@/components/UpgradeSummary"
 
 import { getEditPath } from "@/lib/utils/editPath"
 import { buildTopicDropdown } from "@/lib/utils/topicDropdown"
 
 import type { TopicConfig } from "@/data/topics"
+import { upgrades } from "@/data/upgrades"
 
 import { ContentLayout } from "./ContentLayout"
 
@@ -50,6 +52,11 @@ export const TopicLayout = async ({
         `Add an entry to src/data/topics/ and route through topics[layout].`
     )
   }
+
+  // `slug` is locale-independent ("roadmap/glamsterdam"), so its last segment
+  // is a stable key into the upgrade data on every locale.
+  const upgradeKey = slug.split("/").filter(Boolean).pop()
+  const upgradeSlug = upgradeKey && upgrades[upgradeKey] ? upgradeKey : null
 
   const t = await getTranslations(config.translationNs)
 
@@ -124,6 +131,17 @@ export const TopicLayout = async ({
         editPath={getEditPath(slug)}
         className="-ms-2 mb-8 [&+h2]:mt-0!"
       />
+      {/*
+        Rendered here rather than as an MDX tag so that every locale gets it
+        without waiting for the intl-pipeline to propagate a tag into 24
+        translated files — the facts live in one place, so they should render
+        everywhere at once.
+
+        The switch is *data presence*, not layout type: six pages use
+        `template: upgrade` (beacon-chain, dencun, fusaka, glamsterdam, merge,
+        pectra) and only those with a file in `src/data/upgrades` get a block.
+      */}
+      {upgradeSlug && <UpgradeSummary slug={upgradeSlug} />}
       {children}
     </ContentLayout>
   )

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -1,3 +1,5 @@
+import type { PartialDate } from "@/data/upgrades/types"
+
 import { DEFAULT_LOCALE } from "../constants"
 import type { Lang } from "../types"
 
@@ -69,6 +71,36 @@ export const formatDate = (
     year: "numeric",
     ...options,
   }).format(new Date(date))
+}
+
+/**
+ * Format a {@link PartialDate} at whatever precision it carries: a year, a
+ * quarter, a month and year, or a full date. Used by the upgrade data layer,
+ * where a date is only ever as precise as its source.
+ *
+ * Built through `dateTimeFormat` so Arabic and Urdu get the right numbering
+ * system, and pinned to UTC so a `{ year, month, day }` never renders as the
+ * previous day for viewers behind UTC.
+ *
+ * Quarters can't go through `Intl` — there is no quarter skeleton, and "Q4
+ * 2026" is written very differently across locales — so the caller passes a
+ * `formatQuarter` that renders a translated pattern. It is required rather than
+ * optional so a quarter date can never silently degrade to just its year.
+ */
+export const formatPartialDate = (
+  { year, quarter, month, day }: PartialDate,
+  locale: string = DEFAULT_LOCALE,
+  formatQuarter: (quarter: number, year: number) => string
+) => {
+  if (quarter) return formatQuarter(quarter, year)
+
+  const date = new Date(Date.UTC(year, (month ?? 1) - 1, day ?? 1))
+  return dateTimeFormat(locale, {
+    timeZone: "UTC",
+    year: "numeric",
+    ...(month && { month: "long" }),
+    ...(day && { day: "numeric" }),
+  }).format(date)
 }
 
 export const formatDateRange = (


### PR DESCRIPTION
> **Stacked on #18993**, and based on its branch so the diff here shows only this PR's own changes.
>
> A Netlify preview was verified while this PR briefly targeted `dev`: [deploy-preview-19000.ethereum.it](https://deploy-preview-19000.ethereum.it). Because CI and Netlify only run for PRs into `dev`/`master`/`staging`, further pushes here won't rebuild it until #18993 merges and this retargets to `dev`.

## Description

Adds a `/roadmap/hegota/` page for the upgrade after Glamsterdam, in its planning phase, and registers it in the upgrades nav.

## No hand-written data

The original version of this PR added `src/data/upgrades/hegota.ts` by hand. **That file is gone** — Hegotá is generated from Forkcast like every other upgrade, so the page needs no data of its own:

```
UPGRADE STATUS
[ IN PLANNING ]
Expected on mainnet   Q2 2027 · Date not yet confirmed
Next milestone        Sepolia fork, 2027
→ Track live progress on Forkcast
```

`Q2 2027` comes from Forkcast's phase timeline. The testnet forks are known only to the year, which is why they render as `2027` — the data carries only the precision its source has.

Hegotá has no running milestone yet, so the stage tag falls back to its `status`, giving "In planning". That fallback is added in #18993.

## Scope

A thin page by design: the upgrade has one scheduled EIP so far, and anything more would be inventing content. It grows as ACD decides.

## i18n

2 new strings (planning-phase label, nav entry).
