### PR TITLE
fix(seo): preserve unresolved authors in JSON-LD

### DIFF
--- a/app/[locale]/[...slug]/page-jsonld.tsx
+++ b/app/[locale]/[...slug]/page-jsonld.tsx
@@ -52,7 +52,7 @@ export default async function SlugJsonLD({
     url: contributor.html_url,
   }))
 
-  const { authorGraphNodes, authorIds } = resolveAuthorsFromFrontmatter(
+  const { authorGraphNodes, authorReferences } = resolveAuthorsFromFrontmatter(
     frontmatter.authors ?? frontmatter.author
   )
 
@@ -71,7 +71,7 @@ export default async function SlugJsonLD({
         description: frontmatter.description,
         url,
         inLanguage: locale,
-        author: authorIds,
+        author: authorReferences,
         contributor: contributorList,
         isPartOf: REFERENCE.ETHEREUM_ORG_WEBSITE,
         breadcrumb: {
@@ -91,7 +91,7 @@ export default async function SlugJsonLD({
         image: frontmatter.image
           ? `https://ethereum.org${frontmatter.image}`
           : undefined,
-        author: authorIds,
+        author: authorReferences,
         contributor: contributorList,
         publisher: REFERENCE.ETHEREUM_FOUNDATION,
         dateModified: frontmatter.published,

--- a/src/lib/jsonld/types.ts
+++ b/src/lib/jsonld/types.ts
@@ -6,3 +6,7 @@ export type KnownEntity =
   | (typeof KNOWN_ORGANIZATIONS)[keyof typeof KNOWN_ORGANIZATIONS]
   | (typeof KNOWN_ORGANIZATIONS)["ethereum-foundation"]
   | (typeof KNOWN_ORGANIZATIONS)["ethereum-community"]
+
+export type AuthorReference =
+  | { "@id": string }
+  | { "@type": "Person"; name: string }

--- a/src/lib/jsonld/utils.ts
+++ b/src/lib/jsonld/utils.ts
@@ -3,7 +3,7 @@ import * as Sentry from "@sentry/nextjs"
 import { KNOWN_ORGANIZATIONS } from "./organizations"
 import { KNOWN_PERSONS } from "./persons"
 import { REFERENCE } from "./references"
-import type { KnownEntity } from "./types"
+import type { AuthorReference, KnownEntity } from "./types"
 
 /**
  * Helper to get an @id reference for a known Person
@@ -83,24 +83,35 @@ export function resolveKnownEntities(
 }
 
 /**
- * Resolve frontmatter author field(s) into JSON-LD @graph nodes and @id
- * references. Handles both the `authors` array and legacy singular
- * `author` string.
+ * Resolve frontmatter author field(s) into JSON-LD @graph nodes and author
+ * references. Known entities use their stable @id references; unresolved
+ * names are preserved as inline Person nodes. Handles both the `authors`
+ * array and legacy singular `author` string.
  *
- * Falls back to the community organization reference when nothing
- * resolves.
+ * Falls back to the community organization reference when no author is
+ * supplied.
  */
 export function resolveAuthorsFromFrontmatter(authors?: string | string[]): {
   authorGraphNodes: KnownEntity[]
-  authorIds: Array<{ "@id": string }>
+  authorReferences: AuthorReference[]
 } {
-  const entities = resolveKnownEntities(authors)
+  const values = !authors ? [] : Array.isArray(authors) ? authors : [authors]
+  const resolvedAuthors = values.map((name) => ({
+    name,
+    entity: resolveKnownEntities(name)[0],
+  }))
+  const authorGraphNodes = resolvedAuthors.flatMap(({ entity }) =>
+    entity ? [entity] : []
+  )
+  const authorReferences = resolvedAuthors.map(({ name, entity }) =>
+    entity ? { "@id": entity["@id"] } : { "@type": "Person" as const, name }
+  )
 
   return {
-    authorGraphNodes: entities,
-    authorIds: [
-      ...entities.map((e) => ({ "@id": e["@id"] })),
-      REFERENCE.ETHEREUM_COMMUNITY,
-    ],
+    authorGraphNodes,
+    authorReferences:
+      authorReferences.length > 0
+        ? authorReferences
+        : [REFERENCE.ETHEREUM_COMMUNITY],
   }
 }

--- a/tests/unit/jsonld/utils.spec.ts
+++ b/tests/unit/jsonld/utils.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "@playwright/test"
+
+import { KNOWN_PERSONS } from "@/lib/jsonld/persons"
+import { REFERENCE } from "@/lib/jsonld/references"
+import { resolveAuthorsFromFrontmatter } from "@/lib/jsonld/utils"
+
+test.describe("resolveAuthorsFromFrontmatter", () => {
+  test("uses the community reference when no author is supplied", () => {
+    expect(resolveAuthorsFromFrontmatter()).toEqual({
+      authorGraphNodes: [],
+      authorReferences: [REFERENCE.ETHEREUM_COMMUNITY],
+    })
+  })
+
+  test("preserves an unresolved author as an inline Person", () => {
+    expect(resolveAuthorsFromFrontmatter("jdourlens")).toEqual({
+      authorGraphNodes: [],
+      authorReferences: [{ "@type": "Person", name: "jdourlens" }],
+    })
+  })
+
+  test("preserves mixed known and unresolved authors in input order", () => {
+    const knownPerson = KNOWN_PERSONS["patrick-collins"]
+
+    expect(
+      resolveAuthorsFromFrontmatter(["PatrickAlphaC", "jdourlens"])
+    ).toEqual({
+      authorGraphNodes: [knownPerson],
+      authorReferences: [
+        { "@id": knownPerson["@id"] },
+        { "@type": "Person", name: "jdourlens" },
+      ],
+    })
+  })
+
+  test("resolves a known alias to its stable entity reference", () => {
+    const knownPerson = KNOWN_PERSONS["patrick-collins"]
+
+    expect(resolveAuthorsFromFrontmatter("PatrickAlphaC")).toEqual({
+      authorGraphNodes: [knownPerson],
+      authorReferences: [{ "@id": knownPerson["@id"] }],
+    })
+  })
+})


### PR DESCRIPTION
## Description

Fixes the JSON-LD author attribution mismatch described in #18995.

Markdown pages can display author names from frontmatter even when those names are not present in the curated `KNOWN_PERSONS` or `KNOWN_ORGANIZATIONS` registries. Previously, `resolveKnownEntities()` dropped those unresolved values, so the page's structured data omitted the visible author and credited only the Ethereum Community.

This PR:

- adds an `AuthorReference` type that supports both stable `@id` references and inline schema.org `Person` nodes;
- updates `resolveAuthorsFromFrontmatter()` to resolve each supplied author independently and preserve the original input order;
- keeps the existing full graph node and stable `@id` reference for known people and organizations;
- preserves unresolved names as inline `Person` nodes instead of silently dropping them;
- uses the Ethereum Community reference only when no author is supplied;
- updates both the `WebPage` and `Article` JSON-LD nodes in the Markdown route to use the complete author reference list;
- leaves the known-only `resolveKnownEntities()` contract unchanged, so report publisher resolution is unaffected.

Entity curation and Person-versus-Organization inference for unresolved names are intentionally out of scope. This implements the issue's option 1 fallback without guessing entity types.

## Related Issue

Closes #18995

## Testing

- `corepack pnpm exec playwright test tests/unit/jsonld/utils.spec.ts --project=unit`
  - **Result:** 4 passed.
  - Covers the no-author community fallback, a single unresolved author (`jdourlens`), mixed known/unresolved author arrays with input-order preservation, and a known GitHub alias resolving to its stable entity ID.
- `corepack pnpm lint`
  - **Result:** passed with exit code 0.
- `corepack pnpm type-check`
  - **Result:** passed with exit code 0; Next.js route types were generated successfully and both TypeScript projects completed without errors.
- `corepack pnpm test:unit`
  - **Result:** 994 passed, 1 skipped, 0 failed (995 total).
- `USE_MOCK_DATA=true corepack pnpm build`
  - **Result:** passed with exit code 0 using the same mock-data setting as the repository CI; all 9,963 static pages were generated.
- Inspected the generated HTML for `/en/developers/tutorials/deploying-your-first-smart-contract/`.
  - **Result:** both structured-data author arrays contain `{"@type":"Person","name":"jdourlens"}`.

### Local build environment note

A non-mock local build compiled successfully and completed TypeScript checking, then stopped during page-data collection because this environment does not have the production Netlify `SITE_ID` / `NETLIFY_BLOBS_TOKEN` credentials. The CI-equivalent build with `USE_MOCK_DATA=true` completed successfully as reported above.
