### PR TITLE
feat: track top-level nav menu interactions

### DIFF
--- a/src/components/Nav/Menu/MenuContent.tsx
+++ b/src/components/Nav/Menu/MenuContent.tsx
@@ -1,13 +1,12 @@
-import { motion } from "motion/react"
+import { motion, type MotionProps } from "motion/react"
 import { tv } from "tailwind-variants"
 import { Content } from "@radix-ui/react-navigation-menu"
 
 import { cn } from "@/lib/utils/cn"
 
-import { NavItem, NavSections } from "../types"
+import { NavItem, NavSectionKey } from "../types"
 
 import SubMenu from "./SubMenu"
-import { useNavMenu } from "./useNavMenu"
 
 export const navMenuVariants = tv({
   slots: {
@@ -50,12 +49,21 @@ export const navMenuVariants = tv({
 type MenuContentProps = {
   items: NavItem[]
   isOpen: boolean
-  sections: NavSections
+  activeSection: NavSectionKey | null
+  containerVariants: MotionProps["variants"]
+  onClose: () => void
 }
 
 // Desktop Menu content
-const MenuContent = ({ items, isOpen, sections }: MenuContentProps) => {
-  const { activeSection, containerVariants, onClose } = useNavMenu(sections)
+// State comes from the single useNavMenu instance in the parent; calling the
+// hook here would fork it and leave activeSection permanently null
+const MenuContent = ({
+  items,
+  isOpen,
+  activeSection,
+  containerVariants,
+  onClose,
+}: MenuContentProps) => {
   const { base } = navMenuVariants()
 
   return (

--- a/src/components/Nav/Menu/index.tsx
+++ b/src/components/Nav/Menu/index.tsx
@@ -24,8 +24,14 @@ type NavMenuProps = BaseHTMLAttributes<HTMLDivElement>
 
 const Menu = ({ ...props }: NavMenuProps) => {
   const { linkSections } = useNavigation()
-  const { activeSection, direction, handleSectionChange, isOpen } =
-    useNavMenu(linkSections)
+  const {
+    activeSection,
+    containerVariants,
+    direction,
+    handleSectionChange,
+    isOpen,
+    onClose,
+  } = useNavMenu(linkSections)
 
   return (
     <div {...props}>
@@ -65,7 +71,9 @@ const Menu = ({ ...props }: NavMenuProps) => {
                 <MenuContent
                   items={items}
                   isOpen={isOpen}
-                  sections={linkSections}
+                  activeSection={activeSection}
+                  containerVariants={containerVariants}
+                  onClose={onClose}
                 />
               </Item>
             )

--- a/src/components/Nav/Menu/useNavMenu.ts
+++ b/src/components/Nav/Menu/useNavMenu.ts
@@ -1,7 +1,9 @@
-import { useState } from "react"
+import { useRef, useState } from "react"
 import type { MotionProps } from "motion/react"
+import { useLocale } from "next-intl"
 
 import { isModified } from "@/lib/utils/keyboard"
+import { trackCustomEvent } from "@/lib/utils/matomo"
 
 import { MAIN_NAV_ID, SECTION_LABELS } from "@/lib/constants"
 
@@ -12,7 +14,11 @@ import { useRtlFlip } from "@/hooks/useRtlFlip"
 
 export const useNavMenu = (sections: NavSections) => {
   const { direction } = useRtlFlip()
+  const locale = useLocale()
   const [activeSection, setActiveSection] = useState<NavSectionKey | null>(null)
+  // Sections already reported this session. Nav lives in the persistent layout,
+  // so this survives client-side navigation and resets only on a full page load
+  const trackedSections = useRef(new Set<NavSectionKey>())
 
   // Focus corresponding nav section when number keys pressed
   useEventListener("keydown", (event) => {
@@ -44,7 +50,20 @@ export const useNavMenu = (sections: NavSections) => {
   }
 
   const handleSectionChange = (activeSection: string) => {
-    setActiveSection(getEnglishSectionName(activeSection))
+    const sectionKey = getEnglishSectionName(activeSection)
+    setActiveSection(sectionKey)
+
+    // Radix clears the value on close; only opens are counted. Hover opens the
+    // menu, so a section is reported once and then muted for the rest of the
+    // session -- a mouse sweep across the bar can't inflate the count.
+    if (!sectionKey || trackedSections.current.has(sectionKey)) return
+    trackedSections.current.add(sectionKey)
+
+    trackCustomEvent({
+      eventCategory: "Desktop navigation menu",
+      eventAction: "Section changed",
+      eventName: `Open section: ${locale} - ${sectionKey}`,
+    })
   }
 
   const isOpen = activeSection !== null

--- a/src/components/Nav/Menu/useNavMenu.ts
+++ b/src/components/Nav/Menu/useNavMenu.ts
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import type { MotionProps } from "motion/react"
 import { useLocale } from "next-intl"
 
@@ -12,13 +12,23 @@ import type { NavSectionKey, NavSections } from "../types"
 import { useEventListener } from "@/hooks/useEventListener"
 import { useRtlFlip } from "@/hooks/useRtlFlip"
 
+// How long the pointer must rest on a section before the open is reported.
+// The menu opens on hover, so a sweep across the bar would otherwise report
+// every section it passed over.
+const OPEN_DWELL_MS = 300
+
 export const useNavMenu = (sections: NavSections) => {
   const { direction } = useRtlFlip()
   const locale = useLocale()
   const [activeSection, setActiveSection] = useState<NavSectionKey | null>(null)
-  // Sections already reported this session. Nav lives in the persistent layout,
-  // so this survives client-side navigation and resets only on a full page load
-  const trackedSections = useRef(new Set<NavSectionKey>())
+  const dwellTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(
+    () => () => {
+      if (dwellTimer.current) clearTimeout(dwellTimer.current)
+    },
+    []
+  )
 
   // Focus corresponding nav section when number keys pressed
   useEventListener("keydown", (event) => {
@@ -53,17 +63,18 @@ export const useNavMenu = (sections: NavSections) => {
     const sectionKey = getEnglishSectionName(activeSection)
     setActiveSection(sectionKey)
 
-    // Radix clears the value on close; only opens are counted. Hover opens the
-    // menu, so a section is reported once and then muted for the rest of the
-    // session -- a mouse sweep across the bar can't inflate the count.
-    if (!sectionKey || trackedSections.current.has(sectionKey)) return
-    trackedSections.current.add(sectionKey)
+    // Moving on cancels the pending open, so only the section the pointer
+    // settles on is reported. Radix clears the value on close.
+    if (dwellTimer.current) clearTimeout(dwellTimer.current)
+    if (!sectionKey) return
 
-    trackCustomEvent({
-      eventCategory: "Desktop navigation menu",
-      eventAction: "Section changed",
-      eventName: `Open section: ${locale} - ${sectionKey}`,
-    })
+    dwellTimer.current = setTimeout(() => {
+      trackCustomEvent({
+        eventCategory: "Desktop navigation menu",
+        eventAction: "Section changed",
+        eventName: `Open section: ${locale} - ${sectionKey}`,
+      })
+    }, OPEN_DWELL_MS)
   }
 
   const isOpen = activeSection !== null

--- a/src/components/Nav/MobileMenu/MobileMenuClient.tsx
+++ b/src/components/Nav/MobileMenu/MobileMenuClient.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { useTranslations } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 
 import { ErrorBoundary } from "@/components/ui/error-boundary"
 import { PersistentPanel } from "@/components/ui/persistent-panel"
@@ -9,6 +9,7 @@ import { Sheet, SheetTrigger } from "@/components/ui/sheet"
 import { Skeleton } from "@/components/ui/skeleton"
 
 import { cn } from "@/lib/utils/cn"
+import { trackCustomEvent } from "@/lib/utils/matomo"
 
 import { SITE_TITLE } from "@/lib/constants"
 
@@ -66,6 +67,7 @@ type MobileMenuClientProps = {
 
 const MobileMenuClient = ({ className, side }: MobileMenuClientProps) => {
   const t = useTranslations("common")
+  const locale = useLocale()
   const [open, setOpen] = useCloseOnNavigate()
   const triggerRef = React.useRef<HTMLButtonElement>(null)
   // Track if menu has ever been opened to keep content loaded after first open
@@ -86,6 +88,12 @@ const MobileMenuClient = ({ className, side }: MobileMenuClientProps) => {
       setHasBeenOpened(true)
     }
     setOpen(nextOpen)
+
+    trackCustomEvent({
+      eventCategory: "Mobile navigation menu",
+      eventAction: "Menu toggled",
+      eventName: `${nextOpen ? "Open" : "Close"} menu: ${locale}`,
+    })
   }
 
   return (

--- a/src/components/Nav/MobileMenu/MobileMenuContent.tsx
+++ b/src/components/Nav/MobileMenu/MobileMenuContent.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { useRef } from "react"
 import { Languages, Menu } from "lucide-react"
 import { useLocale, useTranslations } from "next-intl"
 import * as TabsPrimitive from "@radix-ui/react-tabs"
@@ -102,21 +101,13 @@ export default function MobileMenuContent() {
 function NavigationContent({ className }: { className?: string }) {
   const locale = useLocale()
   const { linkSections } = useNavigation()
-  // Section toggles already reported. The panel stays mounted, so this survives
-  // close/reopen and client-side navigation, resetting only on a full page load
-  const reported = useRef(new Set<string>())
 
-  const trackSectionToggle = (key: string, open: boolean) => {
-    const direction = open ? "Open" : "Close"
-    if (reported.current.has(`${key}:${direction}`)) return
-    reported.current.add(`${key}:${direction}`)
-
+  const trackSectionToggle = (key: string, open: boolean) =>
     trackCustomEvent({
       eventCategory: "Mobile navigation menu",
       eventAction: "Section changed",
-      eventName: `${direction} section: ${locale} - ${key}`,
+      eventName: `${open ? "Open" : "Close"} section: ${locale} - ${key}`,
     })
-  }
 
   return (
     <nav className={cn("p-0", className)}>

--- a/src/components/Nav/MobileMenu/MobileMenuContent.tsx
+++ b/src/components/Nav/MobileMenu/MobileMenuContent.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useRef } from "react"
 import { Languages, Menu } from "lucide-react"
 import { useLocale, useTranslations } from "next-intl"
 import * as TabsPrimitive from "@radix-ui/react-tabs"
@@ -18,6 +19,7 @@ import {
 import { SheetFooter, SheetHeader } from "@/components/ui/sheet"
 
 import { cn } from "@/lib/utils/cn"
+import { trackCustomEvent } from "@/lib/utils/matomo"
 import { isLangRightToLeft } from "@/lib/utils/translations"
 import { slugify } from "@/lib/utils/url"
 
@@ -100,6 +102,21 @@ export default function MobileMenuContent() {
 function NavigationContent({ className }: { className?: string }) {
   const locale = useLocale()
   const { linkSections } = useNavigation()
+  // Section toggles already reported. The panel stays mounted, so this survives
+  // close/reopen and client-side navigation, resetting only on a full page load
+  const reported = useRef(new Set<string>())
+
+  const trackSectionToggle = (key: string, open: boolean) => {
+    const direction = open ? "Open" : "Close"
+    if (reported.current.has(`${key}:${direction}`)) return
+    reported.current.add(`${key}:${direction}`)
+
+    trackCustomEvent({
+      eventCategory: "Mobile navigation menu",
+      eventAction: "Section changed",
+      eventName: `${direction} section: ${locale} - ${key}`,
+    })
+  }
 
   return (
     <nav className={cn("p-0", className)}>
@@ -110,6 +127,7 @@ function NavigationContent({ className }: { className?: string }) {
           <Collapsible
             key={key}
             className="border-b border-body-light first:border-t"
+            onOpenChange={(open) => trackSectionToggle(key, open)}
           >
             <CollapsibleTrigger
               data-testid={`mobile-menu-collapsible-${slugify(label)}`}


### PR DESCRIPTION
Adds Matomo events for the top-level navigation. Desktop section opens were never tracked at all; the mobile top-level sections lost their coverage in an earlier refactor when they moved to a plain `Collapsible`. This establishes a baseline for both.

## Nav menu tracking - how to read the numbers

**Where it lands in Matomo** (Behaviour -> Events)

| Category | Action | Name |
|---|---|---|
| `Desktop navigation menu` | `Section changed` | `Open section: en - learn` |
| `Mobile navigation menu` | `Section changed` | `Open/Close section: en - learn` |
| `Mobile navigation menu` | `Menu toggled` | `Open/Close menu: en` |

Section names are always English (`learn`, `use`, `build`, `participate`, `research`) regardless of the visitor's language. The locale is the `en` part of the name, so you can split by language.

**What one event means**

One event is one interaction. Every row gives you both numbers: `nb_events` is how many times the thing happened, `nb_visits` is how many distinct sessions did it at least once. So "how many people looked in Learn" and "how often did they look" are both available, and open counts divide cleanly into leaf-link clicks to give open-to-click conversion.

**Desktop opens require a 300ms pause**

The desktop menu opens on hover, so a mouse moving left to right across the bar would otherwise register an open for all five sections. An open is only recorded once the pointer has rested on a section for 300ms. A section brushed past in transit is not counted; a section someone actually stopped on is.

**Two caveats that matter for interpretation**

1. **Desktop opens on hover, mobile opens on tap.** Even with the dwell filter, a deliberate 300ms hover is a weaker signal of intent than a tap. Expect desktop numbers to run somewhat higher than mobile for the same real interest. Compare desktop-to-desktop and mobile-to-mobile.
2. **Desktop records no close event.** A desktop menu closes when the mouse leaves, which is not an interaction. Mobile records both open and close, since both are taps. Do not compare open/close ratios across the two.

**What this is good for:** relative demand between the five sections, open-to-click conversion, how both differ by device and language, and as a baseline for A/B testing a nav redesign.

**What it can't tell you:** how long someone browsed the menu, or whether a hover past 300ms was genuinely intentional.

## Bug fixed along the way

`MenuContent` called `useNavMenu` a second time, forking the hook state and leaving `activeSection` permanently `null`. Existing desktop submenu link events have therefore been reporting `Menu - null - en`. Threading the parent state down as props additionally makes `onClose` work (clicking a nav link now closes the menu) and cuts the duplicated number-key focus listener from six registrations to one.

**Continuity heads-up:** on deploy, the desktop leaf-click action changes from `Menu - null - en` to `Menu - learn - en` and so on. Every desktop section series splits at that date, and any saved segment keyed on the old string stops matching. The historical data is not lost - per @konopkja, the section is recoverable from the href in `eventName` for 98.4% of the 26,816 affected events using the current nav config, and 99.996% using the union of nav versions live during the window.

## Not included

Kept out to hold the diff scoped, all worth separate PRs:

- **Two orphaned files**, both zero references: `Nav/MobileMenu/MenuAccordion.tsx` (carries a full mobile section-tracking implementation that has never run - this is what made mobile look instrumented) and `Nav/MobileMenu/TrackedCollapsible.tsx` (a duplicate of `ui/collapsible.tsx`'s `CollapsibleTracked`).
- **Desktop leaf clicks double-fire.** `SubMenu`'s `BaseLink` passes no `customEventOptions`, so `Link.tsx` falls back to `eventCategory: "Link"` on top of the menu event, inflating `Link` by roughly 26.5k events.
- **Search** records the open but neither the query typed nor the result clicked.

## Test plan

- [ ] Desktop: resting on a section reports one open; sweeping across the bar reports only where the pointer stops
- [ ] Desktop: clicking a submenu link reports the real section name, not `null`, and closes the menu
- [ ] Mobile: every section open and close reports, including repeat toggles
- [ ] Mobile: level-2+ sub-sections still fire on every toggle (unchanged)

Events only fire when `NODE_ENV=production`, so verify on the deploy preview rather than locally.

-- Opus 5
