### PR TITLE
[recovery] fix(get-eth): set request locale before next-intl APIs (static→dynamic bailout on /api/get-eth)

### DIFF
--- a/app/[locale]/get-eth/page.tsx
+++ b/app/[locale]/get-eth/page.tsx
@@ -72,6 +72,10 @@ type WayToGetEth = {
 export default async function Page(props: { params: Promise<PageParams> }) {
   const params = await props.params
   const { locale } = params
+
+  // Set locale before next-intl APIs so on-demand renders stay static
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-get-eth")
 
   const waysToGetEth: WayToGetEth[] = [
@@ -131,8 +135,6 @@ export default async function Page(props: { params: Promise<PageParams> }) {
       description: t("page-get-eth-article-keeping-crypto-safe-desc"),
     },
   ]
-
-  setRequestLocale(locale)
 
   // Get i18n messages
   const allMessages = await getMessages({ locale })


### PR DESCRIPTION
> Filed by the automated recovery agent from a production Netlify error captured via Grafana → Keep.

## Production error

```
[ERROR] Error: Page changed from static to dynamic at runtime /api/get-eth, reason: headers
see more here https://nextjs.org/docs/messages/app-static-to-dynamic-error
    at y (.next/server/chunks/ssr/1itz_next_dist_1j1_2py._.js:2:12450)
```

- **Function:** `___netlify-server-handler` (SSR)
- **Fingerprint:** `grafana-fn-error-page-changed-from-static-to-dynamic-at-runtime-api-get-eth-reason-head`
- **URL / resource:** `/api/get-eth`
- **Occurrences:** 1 (`hit_count: 4`), last seen `2026-08-06T19:36:24.455Z`, request id `01KZC975CJZTES0Z14TQ96KTWJ`

## Root cause

`/api/get-eth` is not an API route — `app/api/` only holds `gas-eth-price`, `gfi-issues-webhook`, `revalidate` and `torch-webhook` (and never held a `get-eth` route in the repo's history). Because `[locale]` is a plain dynamic segment it acts as a catch-all for unknown top-level paths, so the request matches `app/[locale]/get-eth/page.tsx` with `params.locale === "api"`. `proxy.ts`'s matcher explicitly excludes `api`, so next-intl's middleware never runs and no `X-NEXT-INTL-LOCALE` header is set.

The page then called `getTranslations("page-get-eth")` at the top of `Page` (line 75) while `setRequestLocale(locale)` sat ~60 lines further down (line 135), after the `waysToGetEth` / `safetyArticles` arrays that consume `t`. With an empty request-locale cache, next-intl falls back to reading headers:

```js
// next-intl/dist/esm/*/server/react-server/RequestLocale.js
async function getRequestLocale() {
  return getCachedRequestLocale() || (await getLocaleFromHeader()); // <- headers()
}
```

That `headers()` access marks the render dynamic. Since `/[locale]/get-eth` is prerendered (the layout's `generateStaticParams` enumerates the locales), Next.js throws `Page changed from static to dynamic at runtime … reason: headers` from `next/dist/build/templates/app-page.js` instead of serving a clean 404.

## Fix

Move the existing `setRequestLocale(locale)` call above the first next-intl API call in `Page`. One statement moved; no behaviour change for real locales, and the 404 for `/api/get-eth` is unaffected. An unsupported locale value is harmless — `src/i18n/request.ts` already normalizes anything outside `routing.locales` to `routing.defaultLocale`.

`generateMetadata` in this file already ordered the two calls correctly, so it needed no change.

## Related open PRs

This is the same root cause as three other open recovery PRs, each triggered by a different probed path:

- #18932 — `/.well-known/bug-bounty` → `setRequestLocale` in `app/[locale]/bug-bounty/page.tsx`
- #18994 — `/api/stablecoins` → `setRequestLocale` in `app/[locale]/stablecoins/page.tsx`
- #18999 — `/api/bug-bounty` → moves `setRequestLocale` above the `notFound()` bail in `app/[locale]/layout.tsx`, fixing the class at the layout level

**#18999 supersedes this PR**: with the layout populating the request-locale cache before it bails, this page's ordering no longer matters. This PR is offered as the narrow, page-local fix for the specific path that alerted — it touches a different file, so it doesn't conflict with any of the above. Feel free to close it as redundant if #18999 lands. It does still fix a genuine ordering bug on `dev` independently of that decision: the convention documented elsewhere in the codebase (see the comment in `app/[locale]/[...slug]/page.tsx`) is "set locale before next-intl APIs so on-demand renders stay static", and this page violated it.

See also #18792 for the broader "reject unknown top-level segments" discussion.

## Verification

- `pnpm type-check` → passes (`next typegen && tsc --noEmit && tsc --noEmit -p netlify/edge-functions`; types generated successfully, no errors)
- `pnpm exec eslint "app/[locale]/get-eth/page.tsx"` → clean, no output
- No production build or dev-server reproduction was run for this PR; the mechanism was traced statically through `next-intl`'s `getRequestLocale` and Next.js's `app-page.js` bailout, and is the same one reproduced and tabulated against the dev server in #18999.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
