### PR TITLE
[recovery] fix(what-is-ethereum): set request locale before next-intl APIs (static→dynamic bailout on /api/what-is-ethereum)

### DIFF
--- a/app/[locale]/what-is-ethereum/page.tsx
+++ b/app/[locale]/what-is-ethereum/page.tsx
@@ -55,6 +55,9 @@ import heroImg from "@/public/images/what-is-ethereum.png"
 const Page = async (props: { params: Promise<PageParams> }) => {
   const params = await props.params
   const { locale } = params
+
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-what-is-ethereum")
 
   const { contributors, lastEditLocaleTimestamp } =


### PR DESCRIPTION
## Production error

```
[ERROR] ⨯ Error: Page changed from static to dynamic at runtime /api/what-is-ethereum, reason: headers
see more here https://nextjs.org/docs/messages/app-static-to-dynamic-error
    at y (.next/server/chunks/ssr/1itz_next_dist_1j1_2py._.js:2:12450)
```

- **Function:** `___netlify-server-handler`
- **URL:** `/api/what-is-ethereum`
- **Occurrences:** 1 alert (hit_count `6`), last seen 2026-08-06T19:36:19Z
- **Source:** Netlify logs → Grafana → Keep

## Root cause

`/api/what-is-ethereum` is not an API route — the proxy matcher excludes `/api`, so the request falls through to the App Router and matches `app/[locale]/what-is-ethereum/page.tsx` with `[locale]` captured as `api`. That param is not in `generateStaticParams`, so the page renders on demand at request time.

The `Page` component called `getTranslations("page-what-is-ethereum")` before priming the locale cache:

```tsx
const { locale } = params
const t = await getTranslations("page-what-is-ethereum")   // reads request headers
```

next-intl's request config resolves the locale via `await requestLocale`, which reads the request **headers** unless `setRequestLocale(locale)` has already primed the per-request cache. At build time there are no headers, so the 25 prerendered locales are unaffected — but an on-demand render performs the header read at request time and Next.js aborts with the static-to-dynamic error instead of returning a clean 404.

`generateMetadata` in this file was already correct (it calls `setRequestLocale` first); only the page component was missing it. This is the same latent gap documented in `docs/solutions/architecture/setrequestlocale-static-to-dynamic-rendering.md` — the earlier systemic sweep (#18811) covered `generateMetadata`, and page bodies have been fixed route-by-route since (see #18932, #18994, #19003).

## Fix

One line in `app/[locale]/what-is-ethereum/page.tsx`: call `setRequestLocale(locale)` as the first statement after resolving `locale` from `params`, before any next-intl API. `setRequestLocale` is already imported in this file.

With the cache primed, `src/i18n/request.ts` sees `locale === "api"`, finds it invalid, and falls back to the default locale — no header read, no dynamic bailout, and the `[locale]` layout's `notFound()` produces a proper 404.

## Verification

- `pnpm type-check` — passed (`next typegen` + `tsc --noEmit` + edge-functions tsconfig, no errors)
- `pnpm exec eslint "app/[locale]/what-is-ethereum/page.tsx"` — clean, no output

Scope is intentionally minimal: no other routes or files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
