### PR TITLE
[recovery] fix(learn): set request locale before next-intl APIs (static→dynamic bailout on /api/learn)

### DIFF
--- a/app/[locale]/learn/page.tsx
+++ b/app/[locale]/learn/page.tsx
@@ -97,6 +97,9 @@ const LearnCard = ({
 export default async function Page(props: { params: Promise<PageParams> }) {
   const params = await props.params
   const { locale } = params
+
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-learn")
   const tCommon = await getTranslations("common")
 


### PR DESCRIPTION
## Production error

Captured from Netlify logs (`___netlify-server-handler`) via Grafana → Keep:

```
[ERROR] ⨯ Error: Page changed from static to dynamic at runtime /api/learn, reason: headers
see more here https://nextjs.org/docs/messages/app-static-to-dynamic-error
    at y (.next/server/chunks/ssr/1itz_next_dist_1j1_2py._.js:2:12450)
```

- **URL:** `/api/learn` — `api` is captured as `[locale]`, so this resolves to the learn hub page rendered on-demand (no `generateStaticParams` entry for `api`).
- **Occurrences:** 1 in the alert window, `hit_count: 6`; last seen 2026-08-06T19:36:16Z.
- **Request id:** `01KZC96EBBAK9P389NWKRX0SGJ`

## Root cause

next-intl resolves the request locale lazily: `requestLocale` in `src/i18n/request.ts` reads the request **headers** unless `setRequestLocale(locale)` has already primed the per-request cache. Any next-intl API called before priming forces that header read and opts the whole route into dynamic rendering.

`app/[locale]/learn/page.tsx` called `getTranslations("page-learn")` / `getTranslations("common")` in the page component without priming first. At build time there are no headers, so the prerendered locale routes are fine and the bug stays latent — but an on-demand render (a `[locale]` value outside `generateStaticParams`, such as `api`) performs the header read at request time and Next.js aborts with the static-to-dynamic error instead of rendering statically or returning a clean 404.

`generateMetadata` in this same file already had `setRequestLocale` (added by the systemic sweep in #18811, which covered `generateMetadata` only); the page component was missed.

This is the documented failure mode in `docs/solutions/architecture/setrequestlocale-static-to-dynamic-rendering.md`, and matches prior recovery PRs #18785, #18797, #18798, #18800, #18994, #19003, #19005.

## Fix

One file, three lines — call `setRequestLocale(locale)` as the first statement of the page component, before any next-intl API:

```diff
 export default async function Page(props: { params: Promise<PageParams> }) {
   const params = await props.params
   const { locale } = params
+
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-learn")
   const tCommon = await getTranslations("common")
```

`setRequestLocale` was already imported in this file. No other changes.

## Verification

- `pnpm type-check` — passed (`next typegen && tsc --noEmit && tsc --noEmit -p netlify/edge-functions`, no errors)
- `pnpm exec eslint "app/[locale]/learn/page.tsx"` — clean, no output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
