### PR TITLE
[recovery] fix(use-cases): set request locale before next-intl APIs (static→dynamic bailout on /api/use-cases)

### DIFF
--- a/app/[locale]/use-cases/page.tsx
+++ b/app/[locale]/use-cases/page.tsx
@@ -81,6 +81,9 @@ const UseCaseCard = ({
 export default async function Page(props: { params: Promise<PageParams> }) {
   const params = await props.params
   const { locale } = params
+
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-use-cases")
 
   const { contributors, lastEditLocaleTimestamp } =


### PR DESCRIPTION
## Production error

Captured from Netlify (`___netlify-server-handler`) via Grafana → Keep.

```
[ERROR] Error: Page changed from static to dynamic at runtime /api/use-cases, reason: headers
see more here https://nextjs.org/docs/messages/app-static-to-dynamic-error
    at y (.next/server/chunks/ssr/1itz_next_dist_1j1_2py._.js:2:12450)
```

- **URL / resource:** `/api/use-cases`
- **Occurrences:** 1 alert (`hit_count: 3`), last seen `2026-08-06T19:36:20.347Z`
- **Request id:** `01KZC97007D62AP13940YC4K3G`

## Root cause

`/api/use-cases` has no route handler (`proxy.ts`'s matcher excludes `/api`), so it falls through to the App Router and is captured by `app/[locale]/…` with `locale = "api"`, `slug = ["use-cases"]`. That param is not in `generateStaticParams`, so it renders on demand.

`app/[locale]/use-cases/page.tsx` called `getTranslations("page-use-cases")` **before** priming the next-intl locale cache. Without `setRequestLocale(locale)`, next-intl's `requestLocale` falls back to reading the request **headers** (`src/i18n/request.ts`), which opts the route into dynamic rendering. On an on-demand render Next.js aborts with the static-to-dynamic error instead of rendering statically or returning a clean 404.

`generateMetadata` in the same file already called `setRequestLocale(locale)` (from the systemic sweep in #18811); the page component was missed — the same gap fixed for `/api/learn` in #19006, `/api/get-eth` in #19003, `/api/what-is-ethereum` in #19005 and `/api/stablecoins` in #18994.

This is the documented failure mode in `docs/solutions/architecture/setrequestlocale-static-to-dynamic-rendering.md`.

## Fix

One file, three lines — call `setRequestLocale(locale)` as the first next-intl-touching statement of the page component, matching the rule in the solutions doc and the existing `generateMetadata` in the same file.

```diff
 export default async function Page(props: { params: Promise<PageParams> }) {
   const params = await props.params
   const { locale } = params
+
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-use-cases")
```

`setRequestLocale` was already imported in this file, so no import change is needed.

## Verification

- `pnpm type-check` → passes (`next typegen && tsc --noEmit && tsc --noEmit -p netlify/edge-functions`, no errors)
- `pnpm exec eslint "app/[locale]/use-cases/page.tsx"` → clean, no output

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
