### PR TITLE
[recovery] fix(start): set request locale before next-intl APIs (static→dynamic bailout on /api/start)

### DIFF
--- a/app/[locale]/start/page.tsx
+++ b/app/[locale]/start/page.tsx
@@ -28,9 +28,11 @@ import ManDogeImage from "@/public/images/start-with-ethereum/man-doge-playing.p
 const Page = async (props: { params: Promise<PageParams> }) => {
   const params = await props.params
   const { locale } = params
-  const t = await getTranslations("page-start")
 
+  // Set locale before next-intl APIs so on-demand renders stay static
   setRequestLocale(locale)
+
+  const t = await getTranslations("page-start")
 
   // Get i18n messages
   const allMessages = await getMessages({ locale })


### PR DESCRIPTION
## Production error

```
[ERROR] Error: Page changed from static to dynamic at runtime /api/start, reason: headers
see more here https://nextjs.org/docs/messages/app-static-to-dynamic-error
    at y (.next/server/chunks/ssr/1itz_next_dist_1j1_2py._.js:2:12450)
```

- **URL / resource:** `/api/start`
- **Function:** `___netlify-server-handler`
- **Occurrences:** 1 (last seen 2026-08-06T19:36:23Z, `hit_count: 4`)
- **Fingerprint:** `grafana-fn-error-page-changed-from-static-to-dynamic-at-runtime-api-start-reason-header`

## Root cause

`app/[locale]/start/page.tsx` called `getTranslations("page-start")` **before** `setRequestLocale(locale)`.

`proxy.ts`'s matcher excludes `/api`, so a request to `/api/start` reaches the App Router without i18n rewriting and matches `app/[locale]/start/page.tsx` with `locale = "api"`. That param is not in `generateStaticParams`, so Next.js renders it on-demand. Because `setRequestLocale` had not yet primed the per-request cache, next-intl's `requestLocale` (`src/i18n/request.ts`) fell back to reading the request **headers**, which opts the route into dynamic rendering — and Next.js aborts the on-demand static render with the error above instead of rendering statically or returning a clean 404.

This is the same class of bug documented in `docs/solutions/architecture/setrequestlocale-static-to-dynamic-rendering.md` and previously fixed for `/videos/[slug]` (#18785), `/wallets` (#18797), `/resources` (#18798), the `[...slug]` catch-all (#18800), and the systemic `generateMetadata` sweep (#18811). The `/start` page's `generateMetadata` was already correct; only the page component had the wrong ordering.

## Fix

One file, three lines: hoist `setRequestLocale(locale)` above the `getTranslations` call in the page component.

```diff
   const { locale } = params
-  const t = await getTranslations("page-start")
 
+  // Set locale before next-intl APIs so on-demand renders stay static
   setRequestLocale(locale)
 
+  const t = await getTranslations("page-start")
```

No behavior change for prerendered locales (build-time renders have no headers to read); on-demand renders of `/api/start` and friends now stay static and fall through to the normal 404 path.

## Verification

- `pnpm type-check` — passed (`next typegen && tsc --noEmit && tsc --noEmit -p netlify/edge-functions`, no errors)
- `pnpm exec eslint "app/[locale]/start/page.tsx"` — clean, no output
- Pre-commit `lint-staged` (eslint --fix + prettier) ran clean on the changed file

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
