### PR TITLE
[recovery] fix(founders): set request locale before next-intl APIs (static→dynamic bailout on /api/founders)

### DIFF
--- a/app/[locale]/founders/page.tsx
+++ b/app/[locale]/founders/page.tsx
@@ -41,6 +41,10 @@ import heroImg from "@/public/images/upgrades/merge.png"
 const Page = async (props: { params: Promise<PageParams> }) => {
   const params = await props.params
   const { locale } = params
+
+  // Set locale before next-intl APIs so on-demand renders stay static
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-founders")
 
   const supportTags = {


### PR DESCRIPTION
## Production error

Captured from Netlify logs (`___netlify-server-handler`) via Grafana → Keep.

```
[ERROR] Error: Page changed from static to dynamic at runtime /api/founders, reason: headers
see more here https://nextjs.org/docs/messages/app-static-to-dynamic-error
    at y (.next/server/chunks/ssr/1itz_next_dist_1j1_2py._.js:2:12450)
```

- **URL / resource:** `/api/founders`
- **Occurrences:** 1 in this alert window (`hit_count: 3`), last seen 2026-08-06T19:36:45.080Z
- **Request ID:** `01KZC971DSR32TKR67WNBDMFZW`

## Root cause

`/api/founders` is not a route handler — `app/api/` only contains `gas-eth-price`, `revalidate`, `torch-webhook` and `gfi-issues-webhook`. The request therefore falls through to the `app/[locale]/…` tree with `"api"` captured as the `[locale]` param. `"api"` is not in `generateStaticParams`, so the page renders **on-demand** rather than being served from the prerender.

`app/[locale]/founders/page.tsx` called `getTranslations("page-founders")` as the first next-intl API in the page component — it never called `setRequestLocale` at all (only `generateMetadata` primed it). With the per-request locale cache unprimed, next-intl's `requestLocale` falls back to reading the request **headers**, which opts the route into dynamic rendering. Next.js aborts with `Page changed from static to dynamic at runtime` instead of rendering statically or returning a clean 404.

At build time there are no request headers, so every prerendered locale route looks fine — which is why this stayed latent and only surfaces on bot/broken-link probes to on-demand paths.

This is the documented failure mode in [`docs/solutions/architecture/setrequestlocale-static-to-dynamic-rendering.md`](../blob/dev/docs/solutions/architecture/setrequestlocale-static-to-dynamic-rendering.md), same class as #18785, #18797, #18798, #18800, #18811 and the recent recovery PRs #19003, #19005, #19006, #19007, #19008.

## Fix

One file, four added lines: call `setRequestLocale(locale)` immediately after resolving `locale` from `params`, before the `getTranslations` call.

```diff
 const Page = async (props: { params: Promise<PageParams> }) => {
   const params = await props.params
   const { locale } = params
+
+  // Set locale before next-intl APIs so on-demand renders stay static
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-founders")
```

`setRequestLocale` was already imported for `generateMetadata`, which already primes the locale first — no other change needed.

## Verification

- `pnpm type-check` → passes (`next typegen` + `tsc --noEmit` + edge-functions `tsc --noEmit`), no errors.
- `pnpm exec eslint "app/[locale]/founders/page.tsx"` → clean, no output.
- Pre-commit `lint-staged` (eslint --fix + prettier) ran clean on the staged file.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
