### PR TITLE
[recovery] fix(collectibles): set request locale before next-intl APIs (static→dynamic bailout on /api/collectibles)

### DIFF
--- a/app/[locale]/collectibles/page.tsx
+++ b/app/[locale]/collectibles/page.tsx
@@ -44,8 +44,11 @@ async function fetchStats() {
 export default async function Page(props: { params: Promise<PageParams> }) {
   const params = await props.params
   const { locale } = params
-  const t = await getTranslations("page-collectibles")
+
+  // Set locale before next-intl APIs so on-demand renders stay static
   setRequestLocale(locale)
+
+  const t = await getTranslations("page-collectibles")
 
   // Fetch data
   const [badges, stats]: [Badge[], Stats] = await Promise.all([


### PR DESCRIPTION
## Production error

```
[ERROR] Error: Page changed from static to dynamic at runtime /api/collectibles, reason: headers
see more here https://nextjs.org/docs/messages/app-static-to-dynamic-error
    at y (.next/server/chunks/ssr/1itz_next_dist_1j1_2py._.js:2:12450)
```

- **Function:** `___netlify-server-handler`
- **URL / resource:** `/api/collectibles`
- **Occurrences:** 1 (`hit_count: 4`), last seen `2026-08-06T19:42:38.315Z`
- **Request id:** `01KZC9772XP8DGGDNJ06FQZQXG`

## Root cause

`proxy.ts` excludes `api` from its matcher (`"/((?!api|_next|_vercel|.well-known|.*\\.[^/]*$).*)"`), so a probe for `/api/collectibles` never gets locale-normalized. There is no `app/api/collectibles` route handler, so Next.js matches the `[locale]` segment instead, with `locale = "api"` and the static segment `collectibles` — i.e. it renders `app/[locale]/collectibles/page.tsx`.

In that page, `getTranslations()` ran **before** `setRequestLocale(locale)`:

```ts
const { locale } = params
const t = await getTranslations("page-collectibles")
setRequestLocale(locale)
```

With no cached request locale yet, next-intl's `getRequestLocale()` falls back to `getLocaleFromHeader()`, which calls `headers()` from `next/headers` (`next-intl/dist/.../server/react-server/RequestLocale.js`). Reading `headers()` marks the render dynamic, so the prerendered page reports `revalidate: 0` and Next.js throws the static→dynamic bailout from `next/dist/build/templates/app-page.js`.

`generateMetadata` in the same file already ordered these calls correctly; only the page component was affected.

This is the same defect already fixed for sibling pages in #18994 (stablecoins), #19003 (get-eth), #19005 (what-is-ethereum), #19006 (learn), #19007 (use-cases), #19008 (start) and #19009 (founders). `/api/collectibles` is a distinct route not covered by any of those.

## Fix

Move `setRequestLocale(locale)` above the first next-intl call in `app/[locale]/collectibles/page.tsx`, matching the ordering used by the sibling fixes and by this file's own `generateMetadata`.

## Verification

- `pnpm type-check` — passed (`next typegen && tsc --noEmit && tsc --noEmit -p netlify/edge-functions`, no errors)
- `pnpm exec eslint "app/[locale]/collectibles/page.tsx"` — clean, no output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
