### PR TITLE
[recovery] fix(find-wallet): set request locale before next-intl APIs (static→dynamic bailout on /api/wallets/find-wallet)

### DIFF
--- a/app/[locale]/wallets/find-wallet/page.tsx
+++ b/app/[locale]/wallets/find-wallet/page.tsx
@@ -30,9 +30,10 @@ import FindWalletPageJsonLD from "./page-jsonld"
 const Page = async (props: { params: Promise<PageParams> }) => {
   const params = await props.params
   const { locale } = params
-  const t = await getTranslations("page-wallets-find-wallet")
 
   setRequestLocale(locale)
+
+  const t = await getTranslations("page-wallets-find-wallet")
 
   const supportedLocaleWallets = getSupportedLocaleWallets(locale!)
   const noSupportedLocaleWallets = getNonSupportedLocaleWallets(locale!)


### PR DESCRIPTION
## Production error

Captured from Netlify (`___netlify-server-handler`) via Grafana → Keep.

```
[ERROR] Error: Page changed from static to dynamic at runtime /api/wallets/find-wallet, reason: headers
see more here https://nextjs.org/docs/messages/app-static-to-dynamic-error
    at y (.next/server/chunks/ssr/1itz_next_dist_1j1_2py._.js:2:12450)
```

- **URL:** `/api/wallets/find-wallet` — a probe where `api` is captured as `[locale]`, so it falls through to `app/[locale]/wallets/find-wallet/page.tsx`
- **Occurrences:** 1 in this alert window (`hit_count: 3`), last seen 2026-08-06T19:37:17.695Z
- **Request ID:** `01KZC98R19MBTMS7AKQK48V82G`

## Root cause

Another instance of the documented `setRequestLocale` ordering bug — see `docs/solutions/architecture/setrequestlocale-static-to-dynamic-rendering.md`.

In `app/[locale]/wallets/find-wallet/page.tsx`, the page component called `getTranslations("page-wallets-find-wallet")` **before** `setRequestLocale(locale)`:

```ts
const { locale } = params
const t = await getTranslations("page-wallets-find-wallet")

setRequestLocale(locale)   // too late — the cache was already missed
```

next-intl's request config resolves `requestLocale` lazily by reading the request **headers** unless `setRequestLocale(locale)` has primed the per-request cache first. The early `getTranslations` call forces that header read, which opts the whole route into dynamic rendering.

Prerendered locales are unaffected (no headers exist at build time), so the bug stays latent. It only surfaces on an on-demand render — a param outside `generateStaticParams`, such as this `/api/...` probe — where Next.js aborts with the static-to-dynamic error instead of rendering statically or returning a clean 404.

`generateMetadata` in the same file already had the correct ordering; only the page component was affected.

## Fix

Move `setRequestLocale(locale)` above the `getTranslations` call so it is the first next-intl API touched:

```ts
const { locale } = params

setRequestLocale(locale)

const t = await getTranslations("page-wallets-find-wallet")
```

One file, two lines, no behavior change for prerendered routes.

## Verification

- `pnpm type-check` — passed (`next typegen` + `tsc --noEmit` + edge-functions project, no errors)
- `pnpm exec eslint "app/[locale]/wallets/find-wallet/page.tsx"` — clean, no output

## Notes

- Same class as the sibling recovery PRs #18994, #19003, #19005, #19006, #19007, #19008, #19009, #19010 and the earlier #18785 / #18797 / #18798 / #18800 / #18811. No open PR or issue covered `/api/wallets/find-wallet` specifically.
- The open feature PR #18846 (find-wallet catalog rebuild) incidentally lands the same ordering as part of a larger rewrite, but it has been unmerged since 2026-07-20 and `dev` is still affected, so this minimal fix stands on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
