### PR TITLE
[recovery] fix(what-is-the-ethereum-network): set request locale before next-intl APIs (static→dynamic bailout on /api/what-is-the-ethereum-network)

### DIFF
--- a/app/[locale]/what-is-the-ethereum-network/page.tsx
+++ b/app/[locale]/what-is-the-ethereum-network/page.tsx
@@ -29,6 +29,8 @@ import heroImg from "@/public/images/what-is-ethereum-network/what-is-ethereum-n
 const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
   const { locale } = await params
 
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-what-is-the-ethereum-network")
 
   const { contributors, lastEditLocaleTimestamp } =


### PR DESCRIPTION
## Production error

Captured from Netlify function logs (Grafana → Keep), `___netlify-server-handler`:

```
[ERROR] Error: Page changed from static to dynamic at runtime /api/what-is-the-ethereum-network, reason: headers
see more here https://nextjs.org/docs/messages/app-static-to-dynamic-error
    at y (.next/server/chunks/ssr/1itz_next_dist_1j1_2py._.js:2:12450)
```

- **Path:** `/api/what-is-the-ethereum-network`
- **Occurrences:** 1 (last seen 2026-08-06T19:37:19Z, `request_id` `01KZC98SDPAASSJ968K2EWWNJ0`)

## Root cause

`app/[locale]/what-is-the-ethereum-network/page.tsx` awaited `getTranslations()` without ever calling `setRequestLocale()` in the page component. When next-intl has no locale set for the request, it resolves one from the request headers, which reads `headers()` and opts the route into dynamic rendering.

That stays invisible for the 25 prerendered locales, because `generateMetadata` in the same file *does* call `setRequestLocale(locale)` and primes the per-request cache. It surfaces on on-demand renders for params outside `generateStaticParams`: the proxy matcher (`proxy.ts`) excludes `/api`, so a request to `/api/what-is-the-ethereum-network` skips i18n routing entirely and matches `app/[locale]/what-is-the-ethereum-network/page.tsx` with `"api"` captured as `[locale]`. Next.js renders that path expecting a static result, hits `headers()`, and aborts with the static→dynamic bailout.

Same class of bug as #19005, #19006, #19007, #19008, #19009, #19010, #19011 — a different page each time, so this is a distinct fix rather than a duplicate.

## Fix

One line in `app/[locale]/what-is-the-ethereum-network/page.tsx` — call `setRequestLocale(locale)` before the first next-intl API, matching the ordering `generateMetadata` already uses (and the pattern next-intl documents for every locale-segment page):

```diff
   const { locale } = await params
 
+  setRequestLocale(locale)
+
   const t = await getTranslations("page-what-is-the-ethereum-network")
```

`setRequestLocale` was already imported. No other changes.

## Verification

- `pnpm type-check` — passes (`next typegen && tsc --noEmit && tsc --noEmit -p netlify/edge-functions`, no errors)
- `pnpm exec eslint "app/[locale]/what-is-the-ethereum-network/page.tsx"` — clean, no output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
