### PR TITLE
fix(seo): drop transcript from VideoObject

### DIFF
--- a/app/[locale]/videos/[slug]/page-jsonld.tsx
+++ b/app/[locale]/videos/[slug]/page-jsonld.tsx
@@ -4,7 +4,6 @@ import type { VideoFrontmatter } from "@/lib/interfaces"
 
 import PageJsonLD from "@/components/PageJsonLD"
 
-import { stripMarkdown } from "@/lib/utils/md"
 import { toIsoDuration } from "@/lib/utils/time"
 import { normalizeUrlForJsonLd } from "@/lib/utils/url"
 
@@ -16,12 +15,10 @@ export default async function VideoPageJsonLD({
   locale,
   slug,
   frontmatter,
-  transcript,
 }: {
   locale: string
   slug: string
   frontmatter: VideoFrontmatter
-  transcript: string | null
 }) {
   const url = normalizeUrlForJsonLd(locale, `/videos/${slug}/`)
   const videoGalleryUrl = normalizeUrlForJsonLd(locale, "/videos/")
@@ -101,13 +98,6 @@ export default async function VideoPageJsonLD({
         publisher: REFERENCE.ETHEREUM_FOUNDATION,
         isAccessibleForFree: true,
         isFamilyFriendly: true,
-        // Add transcript as plain text if available
-        transcript: transcript
-          ? stripMarkdown(transcript, true)
-              // Escape < and / to prevent script injection (XSS protection)
-              .replace(/</g, "\\u003c")
-              .replace(/\//g, "\\u002f")
-          : undefined,
       },
     ],
   }

--- a/app/[locale]/videos/[slug]/page.tsx
+++ b/app/[locale]/videos/[slug]/page.tsx
@@ -49,12 +49,7 @@ const VideoLandingPage = async (props: {
 
   return (
     <>
-      <VideoPageJsonLD
-        locale={locale}
-        slug={slug}
-        frontmatter={frontmatter}
-        transcript={transcriptMdx}
-      />
+      <VideoPageJsonLD locale={locale} slug={slug} frontmatter={frontmatter} />
 
       <main className="max-w-4xl p-page pt-hero lg:pt-hero-2x">
         <MainArticle className="flow">

--- a/tests/e2e/videos-jsonld.spec.ts
+++ b/tests/e2e/videos-jsonld.spec.ts
@@ -1,0 +1,63 @@
+import { expect, Page, test } from "@playwright/test"
+
+const VIDEO_SLUG = "ethereum-privacy-stack-andy-guzman"
+
+interface JsonLdNode {
+  "@type"?: string
+  "@graph"?: JsonLdNode[]
+  [key: string]: unknown
+}
+
+const getVideoObject = async (page: Page) => {
+  const documents = await page
+    .locator('script[type="application/ld+json"]')
+    .evaluateAll((scripts) =>
+      scripts.map((script) => JSON.parse(script.textContent || "{}"))
+    )
+
+  const nodes = (documents as JsonLdNode[]).flatMap(
+    (document) => document["@graph"] || [document]
+  )
+
+  return nodes.find((node) => node["@type"] === "VideoObject")
+}
+
+test.describe("Video page structured data", () => {
+  const locales = [
+    {
+      name: "English",
+      path: `/videos/${VIDEO_SLUG}/`,
+      videoName:
+        "The Ethereum privacy stack: private reads, networking, and the hidden leak",
+      transcriptText: "A talk by Andy Guzman",
+    },
+    {
+      name: "Spanish",
+      path: `/es/videos/${VIDEO_SLUG}/`,
+      videoName:
+        "El stack de privacidad de Ethereum: lecturas privadas, redes y la fuga oculta",
+      transcriptText: "Una charla de Andy Guzman",
+    },
+  ]
+
+  for (const locale of locales) {
+    test(`${locale.name} omits the transcript from JSON-LD but renders it in the page`, async ({
+      page,
+    }) => {
+      await page.goto(locale.path)
+
+      const videoObject = await getVideoObject(page)
+
+      expect(videoObject).toBeDefined()
+      expect(videoObject).not.toHaveProperty("transcript")
+      expect(videoObject).toEqual(
+        expect.objectContaining({
+          name: locale.videoName,
+          thumbnailUrl: "https://img.youtube.com/vi/tvAqDJXCBaA/hqdefault.jpg",
+          uploadDate: "2026-02-16T00:00:00+00:00",
+        })
+      )
+      await expect(page.locator("main")).toContainText(locale.transcriptText)
+    })
+  }
+})


### PR DESCRIPTION
## Description

Closes #18996.

This PR removes the `transcript` property from the `VideoObject` JSON-LD emitted by video detail pages.

Google does not list `transcript` as a supported property for video rich results. In addition, the existing escaping converted every slash in transcript content into literal `\u002f` text after JSON serialization, corrupting URLs, dates, and fractions. On localized pages, attaching a translated transcript to a `VideoObject` whose `inLanguage` describes the original audio also made the node internally ambiguous.

The transcript remains in the server-rendered page body, where it is visible to users and available for indexing.

## Changes

- Removed `transcript` from the video detail page's `VideoObject` JSON-LD node.
- Removed the now-unused `transcript` prop from `VideoPageJsonLD`.
- Removed the now-unused `stripMarkdown` import and transcript escaping logic.
- Stopped passing transcript Markdown into the JSON-LD component.
- Added Playwright regression coverage for English and Spanish versions of the example video from the issue.

The regression test parses the emitted JSON-LD and verifies that:

- the `VideoObject` has no `transcript` property;
- `name`, `thumbnailUrl`, and `uploadDate` remain populated; and
- localized transcript text still renders in the page body.

No transcript content, translations, accordion behavior, or other `VideoObject` fields were changed.

## JSON-LD size measurements

Measured from the `application/ld+json` script containing the `VideoObject` while running the site locally:

| Page | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| `/videos/ethereum-privacy-stack-andy-guzman/` | 26,853 bytes | 3,124 bytes | 88.4% |
| `/es/videos/ethereum-privacy-stack-andy-guzman/` | 29,820 bytes | 3,258 bytes | 89.1% |

## Testing

- TDD regression check before the implementation: `corepack pnpm exec playwright test tests/e2e/videos-jsonld.spec.ts --project=e2e --workers=1` — failed in both locale cases specifically because `VideoObject.transcript` was still present.
- `corepack pnpm lint` — passed with no ESLint errors.
- `corepack pnpm type-check` — passed Next.js route type generation, application TypeScript checks, and Netlify edge-function TypeScript checks.
- `corepack pnpm test:unit` — 990 passed, 1 skipped, 0 failed.
- `corepack pnpm exec playwright test tests/e2e/videos-jsonld.spec.ts --project=e2e --workers=1` — 2 passed, 0 failed.
