### PR TITLE
fix(get-eth): use country code for country-selector analytics event

### DIFF
--- a/src/hooks/useCentralizedExchanges.ts
+++ b/src/hooks/useCentralizedExchanges.ts
@@ -348,7 +348,8 @@ export const useCentralizedExchanges = () => {
     trackCustomEvent({
       eventCategory: `Country input`,
       eventAction: `Selected`,
-      eventName: selectedOption.value,
+      // Locale-stable code; localized names fragment analytics per language
+      eventName: selectedOption.countryCode,
     })
     setSelectedCountry(selectedOption)
   }


### PR DESCRIPTION
## Description

One-line analytics fix: the get-eth country selector's `Country input / Selected` Matomo event now sends the locale-stable `countryCode` as `eventName` instead of the localized country display name.

Since the revamped page shipped in all languages, the localized names fragment per-country data — Jul 11–Aug 9 Matomo shows Brazil split as `Brazil` (64) + `Brasil` (55), China as `China` + `中国`, with every locale adding another alias. `countryCode` has been available on the select option since #18626, so this reuses it.

The select's visible `value`/`label` are untouched — only the analytics payload changes.

Heads-up: event labels switch from display names to ISO codes (`US`, `BR`, …) at deploy — a one-time continuity break for anything keyed on the old names, in exchange for locale-independent data going forward.

Fixes #19023

🤖 Generated with [Claude Code](https://claude.com/claude-code)