### PR TITLE
fix(upgrade): remove duplicate "page last updated" line from the hero

### DIFF
--- a/src/data/topics/index.ts
+++ b/src/data/topics/index.ts
@@ -20,12 +20,6 @@ export type TopicConfig = {
     items: TopicDropdownItem[]
   }
   editBanner?: { textKey: string; linkKey: string }
-  /**
-   * When true, the hero description gets an appended "page last updated"
-   * timestamp line. Used by the Upgrade topic to surface freshness on its
-   * historical event pages.
-   */
-  showLastUpdatedInHero?: boolean
 }
 
 export const topics: Record<string, TopicConfig> = {

--- a/src/data/topics/upgrade.ts
+++ b/src/data/topics/upgrade.ts
@@ -49,5 +49,4 @@ export const upgrade: TopicConfig = {
       },
     ],
   },
-  showLastUpdatedInHero: true,
 }

--- a/src/layouts/Topic.tsx
+++ b/src/layouts/Topic.tsx
@@ -52,13 +52,10 @@ export const TopicLayout = async ({
   }
 
   const t = await getTranslations(config.translationNs)
-  const tCommon = config.showLastUpdatedInHero
-    ? await getTranslations("common")
-    : null
 
   const dropdownLinks = buildTopicDropdown(config.dropdown, t)
 
-  const baseDescription = frontmatter.summary ? (
+  const heroDescription = frontmatter.summary ? (
     <p className="text-lg">{frontmatter.summary}</p>
   ) : frontmatter.summaryPoints && frontmatter.summaryPoints.length > 0 ? (
     <List>
@@ -69,18 +66,6 @@ export const TopicLayout = async ({
   ) : frontmatter.description ? (
     <p className="text-lg">{frontmatter.description}</p>
   ) : undefined
-
-  const heroDescription =
-    tCommon && lastEditLocaleTimestamp ? (
-      <>
-        {baseDescription}
-        <p className="border-t pt-4 italic">
-          {tCommon("page-last-updated")}: {lastEditLocaleTimestamp}
-        </p>
-      </>
-    ) : (
-      baseDescription
-    )
 
   const editBanner =
     config.editBanner && frontmatter.hideEditBanner !== true ? (


### PR DESCRIPTION
## Description

Fixes #19025.

On every `template: upgrade` page the last-edit date renders **twice** in the header region: once in the hero, preceded by a partial-width `border-t` rule that stops mid-page, and again about 150px below in `FileContributors`. The two lines even use different translation keys for the same string (`common:page-last-updated` in the hero, `page-last-update` in `FileContributors`).

On https://ethereum.org/roadmap/glamsterdam/ that reads, top to bottom: h1 → description → stray 768px rule → *"Page last updated: July 20, 2026"* → hero's full-width bottom border → *"Page last update: July 20, 2026"* → contributor avatars.

### Why it started

The collision is a regression from 49d6425024 (*migrate/refactor(ui): ContentLayout, TableOfContents*), which made the compact `FileContributors` unconditional at the top of the article. It was previously gated on `asidePosition === "right-top"`, and the default `left-bottom` placed contributors at the **bottom of the page** — so the hero timestamp used to be the only date in the header.

The hero rule itself is older, carried verbatim from `src/layouts/md/Upgrade.tsx` into the `showLastUpdatedInHero` flag in cba15c3405. In the old design the hero held a bulleted `summaryPoints` list, so the rule read as a footer under a block of bullets. Pages with a one-line `description` (Glamsterdam, Dencun) leave it floating under a single sentence.

### Approach

Drop `showLastUpdatedInHero` rather than suppressing the lower line, so upgrade pages surface freshness the same way every other content page on the site does. The flag had exactly one consumer, so the config field and the now-dead branch in `TopicLayout` go with it.

The `baseDescription` → `heroDescription` rename is just the collapse of the two-step derivation back into one; the expression is byte-identical.

## Affected pages

All `template: upgrade` pages, in every locale: `/roadmap/beacon-chain/`, `/roadmap/dencun/`, `/roadmap/fusaka/`, `/roadmap/glamsterdam/`, `/roadmap/merge/`, `/roadmap/pectra/`.

## Testing

Driven locally with a headless browser against `next dev`:

- `/roadmap/glamsterdam/` — hero description block now contains only the description `<p>`; `.border-t.pt-4.italic` count is `0` (was `1`)
- `/roadmap/beacon-chain/` — `summaryPoints` still render as the `<ul>` in the hero, no stray rule
- `/staking/` and `/roadmap/` — non-upgrade topics unchanged, no stray rule, no console errors

One thing I could **not** verify locally: that the remaining `FileContributors` date still renders. `next dev` leaves `lastEditLocaleTimestamp` empty (no git-history lookup), so neither date appears locally. It is already rendering on production today and this PR touches nothing in that path — but worth a glance on the deploy preview.

`tsc --noEmit`, `eslint` and `prettier --check` all clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
