### PR TITLE
fix(seo): add accurate sitemap modification dates

### DIFF
--- a/app/[locale]/ethereum-history-founder-and-ownership/page-jsonld.tsx
+++ b/app/[locale]/ethereum-history-founder-and-ownership/page-jsonld.tsx
@@ -11,11 +11,11 @@ import { REFERENCE } from "@/lib/jsonld/references"
 
 export default async function EthereumHistoryFounderAndOwnershipPageJsonLD({
   locale,
-  lastEditLocaleTimestamp,
+  latestCommitDate,
   contributors,
 }: {
   locale: Lang | undefined
-  lastEditLocaleTimestamp: string
+  latestCommitDate: string
   contributors: FileContributor[]
 }) {
   const t = await getTranslations("page-ethereum-history-founder-and-ownership")
@@ -104,7 +104,7 @@ export default async function EthereumHistoryFounderAndOwnershipPageJsonLD({
               "The historical development and launch of the Ethereum blockchain network",
           },
         ],
-        dateModified: lastEditLocaleTimestamp,
+        dateModified: latestCommitDate,
       },
     ],
   }

--- a/app/[locale]/ethereum-history-founder-and-ownership/page.tsx
+++ b/app/[locale]/ethereum-history-founder-and-ownership/page.tsx
@@ -27,7 +27,7 @@ const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
 
   const t = await getTranslations("page-ethereum-history-founder-and-ownership")
 
-  const { contributors, lastEditLocaleTimestamp } =
+  const { contributors, lastEditLocaleTimestamp, latestCommitDate } =
     await getAppPageContributorInfo(
       "ethereum-history-founder-and-ownership",
       locale as Lang
@@ -66,7 +66,7 @@ const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
     <>
       <PageJsonLD
         locale={locale}
-        lastEditLocaleTimestamp={lastEditLocaleTimestamp}
+        latestCommitDate={latestCommitDate}
         contributors={contributors}
       />
 

--- a/app/[locale]/ethereum-vs-bitcoin/page-jsonld.tsx
+++ b/app/[locale]/ethereum-vs-bitcoin/page-jsonld.tsx
@@ -11,11 +11,11 @@ import { REFERENCE } from "@/lib/jsonld/references"
 
 export default async function EthereumVsBitcoinPageJsonLD({
   locale,
-  lastEditLocaleTimestamp,
+  latestCommitDate,
   contributors,
 }: {
   locale: Lang | undefined
-  lastEditLocaleTimestamp: string
+  latestCommitDate: string
   contributors: FileContributor[]
 }) {
   const t = await getTranslations("page-ethereum-vs-bitcoin")
@@ -91,7 +91,7 @@ export default async function EthereumVsBitcoinPageJsonLD({
               "A peer-to-peer digital currency system and the first decentralized cryptocurrency",
           },
         ],
-        dateModified: lastEditLocaleTimestamp,
+        dateModified: latestCommitDate,
       },
     ],
   }

--- a/app/[locale]/ethereum-vs-bitcoin/page.tsx
+++ b/app/[locale]/ethereum-vs-bitcoin/page.tsx
@@ -31,7 +31,7 @@ const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
 
   const t = await getTranslations("page-ethereum-vs-bitcoin")
 
-  const { contributors, lastEditLocaleTimestamp } =
+  const { contributors, lastEditLocaleTimestamp, latestCommitDate } =
     await getAppPageContributorInfo("ethereum-vs-bitcoin", locale as Lang)
 
   const tocItems: ToCItem[] = [
@@ -93,7 +93,7 @@ const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
     <>
       <PageJsonLD
         locale={locale}
-        lastEditLocaleTimestamp={lastEditLocaleTimestamp}
+        latestCommitDate={latestCommitDate}
         contributors={contributors}
       />
 

--- a/app/[locale]/gas/page-jsonld.tsx
+++ b/app/[locale]/gas/page-jsonld.tsx
@@ -11,11 +11,11 @@ import { REFERENCE } from "@/lib/jsonld/references"
 
 export default async function GasPageJsonLD({
   locale,
-  lastEditLocaleTimestamp,
+  latestCommitDate,
   contributors,
 }: {
   locale: Lang | undefined
-  lastEditLocaleTimestamp: string
+  latestCommitDate: string
   contributors: FileContributor[]
 }) {
   const t = await getTranslations("page-gas")
@@ -75,7 +75,7 @@ export default async function GasPageJsonLD({
         contributor: contributorList,
         author: [REFERENCE.ETHEREUM_COMMUNITY],
         publisher: REFERENCE.ETHEREUM_FOUNDATION,
-        dateModified: lastEditLocaleTimestamp,
+        dateModified: latestCommitDate,
       },
     ],
   }

--- a/app/[locale]/gas/page.tsx
+++ b/app/[locale]/gas/page.tsx
@@ -60,7 +60,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
   const requiredNamespaces = getRequiredNamespacesForPage("/gas")
   const messages = pick(allMessages, requiredNamespaces)
 
-  const { contributors, lastEditLocaleTimestamp } =
+  const { contributors, lastEditLocaleTimestamp, latestCommitDate } =
     await getAppPageContributorInfo("gas", locale as Lang)
 
   const t = await getTranslations("page-gas")
@@ -87,7 +87,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
     <>
       <PageJsonLD
         locale={locale}
-        lastEditLocaleTimestamp={lastEditLocaleTimestamp}
+        latestCommitDate={latestCommitDate}
         contributors={contributors}
       />
 

--- a/app/[locale]/get-eth/page-jsonld.tsx
+++ b/app/[locale]/get-eth/page-jsonld.tsx
@@ -11,11 +11,11 @@ import { REFERENCE } from "@/lib/jsonld/references"
 
 export default async function GetEthPageJsonLD({
   locale,
-  lastEditLocaleTimestamp,
+  latestCommitDate,
   contributors,
 }: {
   locale: Lang | undefined
-  lastEditLocaleTimestamp: string
+  latestCommitDate: string
   contributors: FileContributor[]
 }) {
   const t = await getTranslations("page-get-eth")
@@ -76,7 +76,7 @@ export default async function GetEthPageJsonLD({
         contributor: contributorList,
         author: [REFERENCE.ETHEREUM_COMMUNITY],
         publisher: REFERENCE.ETHEREUM_FOUNDATION,
-        dateModified: lastEditLocaleTimestamp,
+        dateModified: latestCommitDate,
       },
     ],
   }

--- a/app/[locale]/get-eth/page.tsx
+++ b/app/[locale]/get-eth/page.tsx
@@ -139,14 +139,14 @@ export default async function Page(props: { params: Promise<PageParams> }) {
   const requiredNamespaces = getRequiredNamespacesForPage("/get-eth")
   const messages = pick(allMessages, requiredNamespaces)
 
-  const { contributors, lastEditLocaleTimestamp } =
+  const { contributors, lastEditLocaleTimestamp, latestCommitDate } =
     await getAppPageContributorInfo("get-eth", locale as Lang)
 
   return (
     <>
       <GetEthPageJsonLD
         locale={locale}
-        lastEditLocaleTimestamp={lastEditLocaleTimestamp}
+        latestCommitDate={latestCommitDate}
         contributors={contributors}
       />
 

--- a/app/[locale]/layer-2/learn/page-jsonld.tsx
+++ b/app/[locale]/layer-2/learn/page-jsonld.tsx
@@ -11,11 +11,11 @@ import { REFERENCE } from "@/lib/jsonld/references"
 
 export default async function Layer2LearnPageJsonLD({
   locale,
-  lastEditLocaleTimestamp,
+  latestCommitDate,
   contributors,
 }: {
   locale: Lang | undefined
-  lastEditLocaleTimestamp: string
+  latestCommitDate: string
   contributors: FileContributor[]
 }) {
   const t = await getTranslations("page-layer-2-learn")
@@ -82,7 +82,7 @@ export default async function Layer2LearnPageJsonLD({
         author: [REFERENCE.ETHEREUM_COMMUNITY],
         publisher: REFERENCE.ETHEREUM_FOUNDATION,
         contributor: contributorList,
-        dateModified: lastEditLocaleTimestamp,
+        dateModified: latestCommitDate,
       },
     ],
   }

--- a/app/[locale]/layer-2/learn/page.tsx
+++ b/app/[locale]/layer-2/learn/page.tsx
@@ -57,7 +57,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
   const requiredNamespaces = getRequiredNamespacesForPage(SLUG)
   const messages = pick(allMessages, requiredNamespaces)
 
-  const { contributors, lastEditLocaleTimestamp } =
+  const { contributors, lastEditLocaleTimestamp, latestCommitDate } =
     await getAppPageContributorInfo("layer-2/learn", locale as Lang)
 
   const t = await getTranslations("page-layer-2-learn")
@@ -103,7 +103,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
     <>
       <PageJsonLD
         locale={locale}
-        lastEditLocaleTimestamp={lastEditLocaleTimestamp}
+        latestCommitDate={latestCommitDate}
         contributors={contributors}
       />
 

--- a/app/[locale]/privacy/ethereum/page-jsonld.tsx
+++ b/app/[locale]/privacy/ethereum/page-jsonld.tsx
@@ -11,11 +11,11 @@ import { REFERENCE } from "@/lib/jsonld/references"
 
 export default async function PrivacyEthereumPageJsonLD({
   locale,
-  lastEditLocaleTimestamp,
+  latestCommitDate,
   contributors,
 }: {
   locale: Lang | undefined
-  lastEditLocaleTimestamp: string
+  latestCommitDate: string
   contributors: FileContributor[]
 }) {
   const t = await getTranslations("page-privacy-ethereum")
@@ -97,7 +97,7 @@ export default async function PrivacyEthereumPageJsonLD({
               "A decentralized platform for applications and digital economies powered by smart contracts",
           },
         ],
-        dateModified: lastEditLocaleTimestamp,
+        dateModified: latestCommitDate,
       },
     ],
   }

--- a/app/[locale]/privacy/ethereum/page.tsx
+++ b/app/[locale]/privacy/ethereum/page.tsx
@@ -108,7 +108,7 @@ const Page = async (props: { params: Promise<{ locale: Lang }> }) => {
 
   const t = await getTranslations("page-privacy-ethereum")
 
-  const { contributors, lastEditLocaleTimestamp } =
+  const { contributors, lastEditLocaleTimestamp, latestCommitDate } =
     await getAppPageContributorInfo("privacy/ethereum", locale)
 
   const tocItems: ToCItem[] = [
@@ -142,7 +142,7 @@ const Page = async (props: { params: Promise<{ locale: Lang }> }) => {
     <>
       <PageJsonLD
         locale={locale}
-        lastEditLocaleTimestamp={lastEditLocaleTimestamp}
+        latestCommitDate={latestCommitDate}
         contributors={contributors}
       />
 

--- a/app/[locale]/privacy/page-jsonld.tsx
+++ b/app/[locale]/privacy/page-jsonld.tsx
@@ -11,11 +11,11 @@ import { REFERENCE } from "@/lib/jsonld/references"
 
 export default async function PrivacyPageJsonLD({
   locale,
-  lastEditLocaleTimestamp,
+  latestCommitDate,
   contributors,
 }: {
   locale: Lang | undefined
-  lastEditLocaleTimestamp: string
+  latestCommitDate: string
   contributors: FileContributor[]
 }) {
   const t = await getTranslations("page-privacy")
@@ -91,7 +91,7 @@ export default async function PrivacyPageJsonLD({
               "A decentralized platform for applications and digital economies powered by smart contracts",
           },
         ],
-        dateModified: lastEditLocaleTimestamp,
+        dateModified: latestCommitDate,
       },
     ],
   }

--- a/app/[locale]/privacy/page.tsx
+++ b/app/[locale]/privacy/page.tsx
@@ -53,7 +53,7 @@ const Page = async (props: { params: Promise<{ locale: Lang }> }) => {
 
   const t = await getTranslations("page-privacy")
 
-  const { contributors, lastEditLocaleTimestamp } =
+  const { contributors, lastEditLocaleTimestamp, latestCommitDate } =
     await getAppPageContributorInfo("privacy", locale)
 
   const tocItems: ToCItem[] = [
@@ -91,7 +91,7 @@ const Page = async (props: { params: Promise<{ locale: Lang }> }) => {
     <>
       <PageJsonLD
         locale={locale}
-        lastEditLocaleTimestamp={lastEditLocaleTimestamp}
+        latestCommitDate={latestCommitDate}
         contributors={contributors}
       />
 

--- a/app/[locale]/run-a-node/page-jsonld.tsx
+++ b/app/[locale]/run-a-node/page-jsonld.tsx
@@ -11,11 +11,11 @@ import { REFERENCE } from "@/lib/jsonld/references"
 
 export default async function RunANodePageJsonLD({
   locale,
-  lastEditLocaleTimestamp,
+  latestCommitDate,
   contributors,
 }: {
   locale: Lang | undefined
-  lastEditLocaleTimestamp: string
+  latestCommitDate: string
   contributors: FileContributor[]
 }) {
   const t = await getTranslations("page-run-a-node")
@@ -82,7 +82,7 @@ export default async function RunANodePageJsonLD({
           description:
             "Guide to running your own Ethereum node, benefits, and requirements",
         },
-        dateModified: lastEditLocaleTimestamp,
+        dateModified: latestCommitDate,
       },
     ],
   }

--- a/app/[locale]/run-a-node/page.tsx
+++ b/app/[locale]/run-a-node/page.tsx
@@ -83,7 +83,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
   const requiredNamespaces = getRequiredNamespacesForPage("/run-a-node")
   const messages = pick(allMessages, requiredNamespaces)
 
-  const { contributors, lastEditLocaleTimestamp } =
+  const { contributors, lastEditLocaleTimestamp, latestCommitDate } =
     await getAppPageContributorInfo("run-a-node", locale as Lang)
 
   const t = await getTranslations("page-run-a-node")
@@ -158,7 +158,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
     <>
       <RunANodePageJsonLD
         locale={locale}
-        lastEditLocaleTimestamp={lastEditLocaleTimestamp}
+        latestCommitDate={latestCommitDate}
         contributors={contributors}
       />
 

--- a/app/[locale]/staking/page-jsonld.tsx
+++ b/app/[locale]/staking/page-jsonld.tsx
@@ -11,11 +11,11 @@ import { REFERENCE } from "@/lib/jsonld/references"
 
 export default async function StakingPageJsonLD({
   locale,
-  lastEditLocaleTimestamp,
+  latestCommitDate,
   contributors,
 }: {
   locale: Lang | undefined
-  lastEditLocaleTimestamp: string
+  latestCommitDate: string
   contributors: FileContributor[]
 }) {
   const t = await getTranslations("page-staking")
@@ -82,7 +82,7 @@ export default async function StakingPageJsonLD({
           description:
             "Guide to staking ETH, earning rewards, and securing the Ethereum network",
         },
-        dateModified: lastEditLocaleTimestamp,
+        dateModified: latestCommitDate,
       },
       {
         "@type": "FAQPage",

--- a/app/[locale]/staking/page.tsx
+++ b/app/[locale]/staking/page.tsx
@@ -70,7 +70,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
   const requiredNamespaces = getRequiredNamespacesForPage("/staking")
   const messages = pick(allMessages, requiredNamespaces)
 
-  const { contributors, lastEditLocaleTimestamp } =
+  const { contributors, lastEditLocaleTimestamp, latestCommitDate } =
     await getAppPageContributorInfo("staking", locale as Lang)
 
   const t = await getTranslations("page-staking")
@@ -139,7 +139,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
     <>
       <StakingPageJsonLD
         locale={locale}
-        lastEditLocaleTimestamp={lastEditLocaleTimestamp}
+        latestCommitDate={latestCommitDate}
         contributors={contributors}
       />
 

--- a/app/[locale]/wallets/page-jsonld.tsx
+++ b/app/[locale]/wallets/page-jsonld.tsx
@@ -9,7 +9,7 @@ import { REFERENCE } from "@/lib/jsonld/references"
 
 export default async function WalletsPageJsonLD({
   locale,
-  lastEditLocaleTimestamp,
+  latestCommitDate,
   contributors,
 }) {
   const t = await getTranslations("page-find-wallet")
@@ -76,7 +76,7 @@ export default async function WalletsPageJsonLD({
           description:
             "Complete guide to Ethereum wallets, types, features, and how to use them safely",
         },
-        dateModified: lastEditLocaleTimestamp,
+        dateModified: latestCommitDate,
       },
     ],
   }

--- a/app/[locale]/wallets/page.tsx
+++ b/app/[locale]/wallets/page.tsx
@@ -52,7 +52,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
   const requiredNamespaces = getRequiredNamespacesForPage("/wallets")
   const messages = pick(allMessages, requiredNamespaces)
 
-  const { contributors, lastEditLocaleTimestamp } =
+  const { contributors, lastEditLocaleTimestamp, latestCommitDate } =
     await getAppPageContributorInfo("wallets", locale as Lang)
 
   const cards = [
@@ -152,7 +152,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
     <>
       <WalletsPageJsonLD
         locale={locale}
-        lastEditLocaleTimestamp={lastEditLocaleTimestamp}
+        latestCommitDate={latestCommitDate}
         contributors={contributors}
       />
 

--- a/app/[locale]/what-is-ether/page-jsonld.tsx
+++ b/app/[locale]/what-is-ether/page-jsonld.tsx
@@ -11,11 +11,11 @@ import { REFERENCE } from "@/lib/jsonld/references"
 
 export default async function WhatIsEtherPageJsonLD({
   locale,
-  lastEditLocaleTimestamp,
+  latestCommitDate,
   contributors,
 }: {
   locale: Lang | undefined
-  lastEditLocaleTimestamp: string
+  latestCommitDate: string
   contributors: FileContributor[]
 }) {
   const t = await getTranslations("page-what-is-ether")
@@ -90,7 +90,7 @@ export default async function WhatIsEtherPageJsonLD({
               "A decentralized platform for applications and digital economies powered by smart contracts",
           },
         ],
-        dateModified: lastEditLocaleTimestamp,
+        dateModified: latestCommitDate,
       },
     ],
   }

--- a/app/[locale]/what-is-ether/page.tsx
+++ b/app/[locale]/what-is-ether/page.tsx
@@ -46,7 +46,7 @@ const Page = async (props: { params: Promise<{ locale: Lang }> }) => {
   const t = await getTranslations("page-what-is-ether")
 
   const [
-    { contributors, lastEditLocaleTimestamp },
+    { contributors, lastEditLocaleTimestamp, latestCommitDate },
     gasPriceData,
     ethPriceData,
   ] = await Promise.all([
@@ -97,7 +97,7 @@ const Page = async (props: { params: Promise<{ locale: Lang }> }) => {
     <>
       <PageJsonLD
         locale={locale}
-        lastEditLocaleTimestamp={lastEditLocaleTimestamp}
+        latestCommitDate={latestCommitDate}
         contributors={contributors}
       />
 

--- a/app/[locale]/what-is-ethereum/page-jsonld.tsx
+++ b/app/[locale]/what-is-ethereum/page-jsonld.tsx
@@ -11,11 +11,11 @@ import { REFERENCE } from "@/lib/jsonld/references"
 
 export default async function WhatIsEthereumPageJsonLD({
   locale,
-  lastEditLocaleTimestamp,
+  latestCommitDate,
   contributors,
 }: {
   locale: Lang | undefined
-  lastEditLocaleTimestamp: string
+  latestCommitDate: string
   contributors: FileContributor[]
 }) {
   const t = await getTranslations("page-what-is-ethereum")
@@ -88,7 +88,7 @@ export default async function WhatIsEthereumPageJsonLD({
           description:
             "Comprehensive guide to Ethereum, its network, capabilities, and how it works",
         },
-        dateModified: lastEditLocaleTimestamp,
+        dateModified: latestCommitDate,
       },
       {
         "@type": "FAQPage",

--- a/app/[locale]/what-is-ethereum/page.tsx
+++ b/app/[locale]/what-is-ethereum/page.tsx
@@ -57,7 +57,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
   const { locale } = params
   const t = await getTranslations("page-what-is-ethereum")
 
-  const { contributors, lastEditLocaleTimestamp } =
+  const { contributors, lastEditLocaleTimestamp, latestCommitDate } =
     await getAppPageContributorInfo("what-is-ethereum", locale as Lang)
 
   const tocItems: ToCItem[] = [
@@ -82,7 +82,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
     <>
       <PageJsonLD
         locale={locale}
-        lastEditLocaleTimestamp={lastEditLocaleTimestamp}
+        latestCommitDate={latestCommitDate}
         contributors={contributors}
       />
 

--- a/app/[locale]/what-is-the-ethereum-network/page-jsonld.tsx
+++ b/app/[locale]/what-is-the-ethereum-network/page-jsonld.tsx
@@ -11,11 +11,11 @@ import { REFERENCE } from "@/lib/jsonld/references"
 
 export default async function WhatIsTheEthereumNetworkPageJsonLD({
   locale,
-  lastEditLocaleTimestamp,
+  latestCommitDate,
   contributors,
 }: {
   locale: Lang | undefined
-  lastEditLocaleTimestamp: string
+  latestCommitDate: string
   contributors: FileContributor[]
 }) {
   const t = await getTranslations("page-what-is-the-ethereum-network")
@@ -88,7 +88,7 @@ export default async function WhatIsTheEthereumNetworkPageJsonLD({
           description:
             "Comprehensive guide to the Ethereum network, including fees, staking, layer 2 solutions, and live network data",
         },
-        dateModified: lastEditLocaleTimestamp,
+        dateModified: latestCommitDate,
       },
     ],
   }

--- a/app/[locale]/what-is-the-ethereum-network/page.tsx
+++ b/app/[locale]/what-is-the-ethereum-network/page.tsx
@@ -31,7 +31,7 @@ const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
 
   const t = await getTranslations("page-what-is-the-ethereum-network")
 
-  const { contributors, lastEditLocaleTimestamp } =
+  const { contributors, lastEditLocaleTimestamp, latestCommitDate } =
     await getAppPageContributorInfo(
       "what-is-the-ethereum-network",
       locale as Lang
@@ -64,7 +64,7 @@ const Page = async ({ params }: { params: Promise<{ locale: Lang }> }) => {
     <>
       <PageJsonLD
         locale={locale}
-        lastEditLocaleTimestamp={lastEditLocaleTimestamp}
+        latestCommitDate={latestCommitDate}
         contributors={contributors}
       />
 

--- a/app/sitemaps/sitemap.ts
+++ b/app/sitemaps/sitemap.ts
@@ -38,7 +38,7 @@ export default async function sitemap({
   const entries: MetadataRoute.Sitemap = []
   const seenUrls = new Set<string>()
 
-  for (const { slug, translatedLocales } of pages) {
+  for (const { slug, translatedLocales, lastModified } of pages) {
     // This shard only carries URLs for its own locale; the full hreflang
     // alternates block is still emitted so each URL cross-references every
     // translated version.
@@ -64,7 +64,7 @@ export default async function sitemap({
     if (seenUrls.has(url)) continue
     seenUrls.add(url)
 
-    entries.push({ url, alternates })
+    entries.push({ url, alternates, lastModified })
   }
 
   return entries

--- a/src/lib/i18n/translationRegistry.ts
+++ b/src/lib/i18n/translationRegistry.ts
@@ -3,6 +3,7 @@ import { join } from "path"
 
 import { DEFAULT_LOCALE, LOCALES_CODES } from "@/lib/constants"
 
+import { getAppPageLastCommitDate } from "../utils/gh"
 import { getPostSlugs } from "../utils/md"
 import { getStaticPagePaths } from "../utils/staticPages"
 import { getPrimaryNamespaceForPath } from "../utils/translations"
@@ -10,6 +11,8 @@ import { addSlashes } from "../utils/url"
 import { getVideoSlugs } from "../utils/videos"
 
 import { areNamespacesTranslated } from "./translationStatus"
+
+import { getStaticGitHubContributors } from "@/lib/data"
 
 const CONTENT_ROOT = "public/content"
 const TRANSLATIONS_ROOT = "public/content/translations"
@@ -92,6 +95,17 @@ export async function getTranslatedLocales(slug: string): Promise<string[]> {
 type PageWithTranslations = {
   slug: string
   translatedLocales: string[]
+  lastModified?: string
+}
+
+const getAppPageContributorKey = (slug: string): string => {
+  const normalized = normalizeContentSlug(slug)
+  if (normalized.startsWith("apps/categories/")) {
+    return "apps/categories/[catetgoryName]"
+  }
+  if (normalized.startsWith("apps/")) return "apps/[application]"
+  if (normalized.startsWith("developers/tools/")) return "developers/tools"
+  return normalized
 }
 
 async function getDynamicIntlPagePaths(): Promise<string[]> {
@@ -136,6 +150,7 @@ async function getDynamicIntlPagePaths(): Promise<string[]> {
   const appPaths = appsData
     ? Object.values(appsData)
         .flat()
+        .filter((app) => slugify(app.name) !== "scout-game")
         .map((app) => `/apps/${slugify(app.name)}/`)
     : []
 
@@ -151,6 +166,7 @@ export async function getAllPagesWithTranslations(): Promise<
   PageWithTranslations[]
 > {
   const pages: PageWithTranslations[] = []
+  const contributorsData = await getStaticGitHubContributors()
 
   const mdSlugs = await getPostSlugs("/")
 
@@ -167,12 +183,23 @@ export async function getAllPagesWithTranslations(): Promise<
 
   for (const slug of [...mdSlugs, ...videoSlugs]) {
     const translatedLocales = await getTranslatedLocales(slug)
-    pages.push({ slug, translatedLocales })
+    const lastModified =
+      getAppPageLastCommitDate(contributorsData?.content[slug] ?? []) ||
+      undefined
+    pages.push({ slug, translatedLocales, lastModified })
   }
 
   for (const path of uniqueIntlPaths) {
     const translatedLocales = await getTranslatedLocales(path)
-    pages.push({ slug: path, translatedLocales })
+    const contributorKey = getAppPageContributorKey(path)
+    const lastModified = getAppPageLastCommitDate(
+      contributorsData?.appPages[contributorKey] ?? []
+    )
+    pages.push({
+      slug: path,
+      translatedLocales,
+      lastModified: lastModified || undefined,
+    })
   }
 
   return pages

--- a/src/lib/utils/contributors.ts
+++ b/src/lib/utils/contributors.ts
@@ -80,6 +80,7 @@ export const getAppPageContributorInfo = async (
 
   return {
     contributors: sortTeamToEnd(uniqueGitHubContributors),
+    latestCommitDate,
     lastEditLocaleTimestamp,
   }
 }

--- a/src/lib/utils/gh.ts
+++ b/src/lib/utils/gh.ts
@@ -12,7 +12,7 @@ export const getAppPageLastCommitDate = (
       const commitDate = new Date(contributor.date)
       return commitDate > latest ? commitDate : latest
     }, new Date(0))
-    .toString()
+    .toISOString()
 }
 
 const LABELS_TO_SEARCH = [

--- a/src/lib/utils/staticPages.ts
+++ b/src/lib/utils/staticPages.ts
@@ -22,11 +22,13 @@ export function discoverStaticPages(
 
   for (const entry of entries) {
     if (entry.isDirectory()) {
-      // Skip dynamic routes (names starting with '[')
-      if (entry.name.startsWith("[")) continue
-
-      // Skip private folders starting with '_' (Next.js convention - not routable)
-      if (entry.name.startsWith("_")) continue
+      // Skip non-public Next.js route segments: dynamic routes, private
+      // folders, parallel-route slots, and route groups/interceptors.
+      if (
+        ["[", "_", "@", "("].some((prefix) => entry.name.startsWith(prefix))
+      ) {
+        continue
+      }
 
       const newBasePath = `${basePath}/${entry.name}`
       pages.push(...discoverStaticPages(join(dir, entry.name), newBasePath))

--- a/tests/unit/utils/gh.spec.ts
+++ b/tests/unit/utils/gh.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "@playwright/test"
+
+import type { FileContributor } from "@/lib/types"
+
+import { getAppPageLastCommitDate } from "@/lib/utils/gh"
+
+test("getAppPageLastCommitDate returns the latest date in ISO 8601", () => {
+  const contributors = [
+    {
+      login: "earlier",
+      avatar_url: "https://example.com/earlier.png",
+      html_url: "https://example.com/earlier",
+      date: "2025-01-02T03:04:05Z",
+    },
+    {
+      login: "later",
+      avatar_url: "https://example.com/later.png",
+      html_url: "https://example.com/later",
+      date: "2026-07-08T09:10:11Z",
+    },
+  ] satisfies FileContributor[]
+
+  expect(getAppPageLastCommitDate(contributors)).toBe(
+    "2026-07-08T09:10:11.000Z"
+  )
+})
+
+test("getAppPageLastCommitDate keeps the empty sentinel", () => {
+  expect(getAppPageLastCommitDate([])).toBe("")
+})

--- a/tests/unit/utils/static-pages.spec.ts
+++ b/tests/unit/utils/static-pages.spec.ts
@@ -1,0 +1,22 @@
+import { mkdirSync, writeFileSync } from "fs"
+import { join } from "path"
+
+import { expect, test } from "@playwright/test"
+
+import { discoverStaticPages } from "@/lib/utils/staticPages"
+
+test("discoverStaticPages excludes non-public Next.js route segments", (_, testInfo) => {
+  const root = testInfo.outputPath("routes")
+  const publicPage = join(root, "public")
+  const excluded = ["[slug]", "_private", "@modal", "(.)intercept"]
+
+  mkdirSync(publicPage, { recursive: true })
+  writeFileSync(join(publicPage, "page.tsx"), "")
+  for (const segment of excluded) {
+    const dir = join(root, segment)
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, "page.tsx"), "")
+  }
+
+  expect(discoverStaticPages(root)).toEqual(["/public"])
+})


### PR DESCRIPTION
## Description

Fixes #18982.

This adds accurate ISO 8601 `lastModified` values to sitemap entries using the existing GitHub contributor data, removes internal Next.js route segments and the dead Scout Game app URL from sitemap discovery, and passes the ISO commit date—not the localized display date—to the 13 affected Article JSON-LD components.

## Changes

- add commit-derived `lastModified` to content and app-page sitemap records
- exclude `[`, `_`, `@`, and `(` route segments from static route discovery
- exclude `/apps/scout-game/` from dynamic app routes
- expose `latestCommitDate` alongside the localized visible timestamp
- use ISO dates for Article `dateModified`
- add unit coverage for route exclusion and latest-date selection

## Validation

- `USE_MOCK_DATA=true pnpm playwright test --project=unit tests/unit/utils/static-pages.spec.ts tests/unit/utils/gh.spec.ts` (3 passed)
- ESLint on all changed TypeScript files
- Prettier on all changed TypeScript files

The full workspace typecheck was not usable in the local partial clone because unrelated modules and image assets are intentionally absent; CI has the complete tree.
