### PR TITLE
Fix contradictory ToC card width caps

### DIFF
--- a/src/components/TableOfContents/index.tsx
+++ b/src/components/TableOfContents/index.tsx
@@ -40,10 +40,12 @@ const toc = tv({
         list: "list-none border-s border-s-body-medium ps-4 my-2 text-sm",
       },
       card: {
-        root: "top-28",
+        // `w-80` replaces a `min-w-80 max-w-72` pair on `container` whose max was
+        // dead (min wins), and sits on `root` per the width-caps note above.
+        root: "top-28 w-80",
         dropdown: "",
         container: [
-          "min-w-80 max-w-72 lg:p-8 px-3 py-2",
+          "lg:p-8 px-3 py-2",
           "shrink-0 gap-y-2.5 rounded-base bg-accent-a/10 text-body-medium",
         ],
         label: "text-lg text-body-medium",


### PR DESCRIPTION
## Summary

The `card` variant of `TableOfContents` set `min-w-80` and `max-w-72` on the same element, a 320px floor above a 288px ceiling — min wins in CSS, so the max was dead and the card always rendered at 320px. Both are replaced with `w-80` on `root`, where the file's own comment says width caps belong. Rendered width is unchanged at 320px, verified at 1000/1200/1536px.