### PR TITLE
feat: add OnFinality as Node Provider

### DIFF
--- a/public/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
+++ b/public/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
@@ -290,6 +290,14 @@ Here is a list of some of the most popular Ethereum node providers, feel free to
     - Personal Account Manager
     - Shared, archive, backup and dedicated nodes
 
+- [**OnFinality**](https://onfinality.io/en/networks/eth)
+  - [Docs](https://documentation.onfinality.io/support/)
+  - Features
+    - HTTP and WebSocket endpoints
+    - Archive access and Trace API
+    - Shared RPC APIs with dedicated node options
+    - Request analytics and usage-based billing
+
 - [**Pocket Network**](https://www.pokt.network/)
   - [Docs](https://docs.pokt.network/)
   - Features


### PR DESCRIPTION
## Description

This PR adds OnFinality as an Ethereum RPC provider.

OnFinality provides public Ethereum RPC endpoints for developers and applications that need an additional infrastructure option.

Public endpoint test: https://www.comparenodes.com/library/public-endpoints/ethereum/

Changes
* Added OnFinality to the Ethereum RPC provider list.
