### PR TITLE
Release twice a week (Tuesday + Thursday)

### DIFF
--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -1,9 +1,9 @@
-name: Weekly Release
+name: Release
 
 on:
   schedule:
-    # Thursday 14:00 UTC year-round (11:00 ART; US/EU offsets shift with DST).
-    - cron: "0 14 * * 4"
+    # Tue + Thu 14:00 UTC year-round (11:00 ART; US/EU offsets shift with DST).
+    - cron: "0 14 * * 2,4"
   workflow_dispatch:
 
 permissions:
@@ -58,7 +58,7 @@ jobs:
         uses: ./.github/actions/discord-notify
         with:
           webhook: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
-          message: ":pause_button: Weekly release skipped — ${{ steps.skip_check.outputs.reason }}  •  <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>"
+          message: ":pause_button: Release skipped — ${{ steps.skip_check.outputs.reason }}  •  <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>"
 
       - name: Setup pnpm + node
         if: steps.skip_check.outputs.skip == 'false'
@@ -81,9 +81,11 @@ jobs:
             - No version flag is provided — analyze the draft release and
               pick a version type yourself (the skill's Step 2 "If no flag
               provided" path). DO NOT prompt; just decide and log your
-              reasoning. Bias toward --minor for substantive weeks and
-              --patch for low-activity weeks; never pick --major without a
-              clear stack/framework change.
+              reasoning. Judge the cycle since the last published release,
+              which is now half a week — bias toward --minor for a
+              substantive cycle and --patch for a light one; expect --patch
+              to be the common case. Never pick --major without a clear
+              stack/framework change.
             - On any error, print the error and exit non-zero so the workflow
               fails and the team is notified.
 
@@ -112,7 +114,7 @@ jobs:
         with:
           webhook: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
           message: |
-            :rocket: **Weekly release prepared: ${{ steps.capture_pr.outputs.version }}**  •  ${{ steps.capture_pr.outputs.url }}
+            :rocket: **Release prepared: ${{ steps.capture_pr.outputs.version }}**  •  ${{ steps.capture_pr.outputs.url }}
             Waiting for preview deploy + CI before review…
 
       - name: Announce prepare failure
@@ -121,7 +123,7 @@ jobs:
         with:
           webhook: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
           message: |
-            :rotating_light: **Weekly release failed during `prepare`**  •  <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>
+            :rotating_light: **Release failed during `prepare`**  •  <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>
             No deploy PR was created. Needs a human to look.
 
   wait_and_review:
@@ -270,6 +272,6 @@ jobs:
           webhook: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
           message_id: ${{ needs.prepare.outputs.discord_message_id }}
           message: |
-            :rotating_light: **Weekly release failed during `wait_and_review`**  •  ${{ needs.prepare.outputs.pr_url }}
+            :rotating_light: **Release failed during `wait_and_review`**  •  ${{ needs.prepare.outputs.pr_url }}
             Run: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>
             PR is open but automation couldn't finish reviewing it. Needs a human.

--- a/docs/deploy-process.md
+++ b/docs/deploy-process.md
@@ -8,7 +8,7 @@ We release twice a week, on **Tuesday and Thursday at 14:00 UTC**. Each release 
 
 Releases are driven by the `Release` GitHub Actions workflow (`.github/workflows/weekly-release.yml`), which can also be triggered manually via `workflow_dispatch` if a release needs to go out off-schedule.
 
-If a deploy PR from a previous run is still open when the next run fires, the new run **skips itself** and posts a note to Discord rather than stacking a second release on top. In practice that means an unmerged Tuesday release pushes its contents into the Thursday one.
+If a deploy PR from a previous run is still open when the next run fires, the new run **skips itself** and posts a note to Discord rather than stacking a second release on top. For example, if Tuesday's deploy PR is still open on Thursday, the Tuesday release remains pending and no Thursday release is prepared; the next release is deferred until that PR is closed.
 
 ## Deploy process
 
@@ -32,7 +32,7 @@ The typical workflow is as follows:
 Note that the `vX.Y.Z` tag is cut on `dev` during step 3, and the GitHub Release is published before the deploy PR merges. Merging into `master` is what puts the release live.
 
 ```
-master  O (tag) - - - - - - - - - - - - O (tag)
+master  O - - - - - - - - - - - - - - - O
 
         |                             /
 
@@ -40,7 +40,7 @@ staging O - - - - - - - - - O - - - O
 
         |                 /          \
 
-dev     O - - - - O - - - - O - - O - O
+dev     O (tag) - O - - - - O - - O - O (tag)
 
           \       \        /      /
 

--- a/docs/deploy-process.md
+++ b/docs/deploy-process.md
@@ -2,24 +2,34 @@
 
 Ethereum.org follows a [Gitflow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow) workflow for managing and deploying the codebase.
 
-## Deploy process
+## Release cadence
 
-The current process for deployment involves a 2-day QA cycle to test a release candidate. A release candidate is created on Tuesday, will have 2 days of testing, and then released to production on Thursday assuming no blocking bugs are found.
+We release twice a week, on **Tuesday and Thursday at 14:00 UTC**. Each release is prepared, reviewed and shipped on the same day — a release is normally live within a couple of hours of being cut.
+
+Releases are driven by the `Release` GitHub Actions workflow (`.github/workflows/weekly-release.yml`), which can also be triggered manually via `workflow_dispatch` if a release needs to go out off-schedule.
+
+If a deploy PR from a previous run is still open when the next run fires, the new run **skips itself** and posts a note to Discord rather than stacking a second release on top. In practice that means an unmerged Tuesday release pushes its contents into the Thursday one.
+
+## Deploy process
 
 The typical workflow is as follows:
 
 1. A branch is created off of the `dev` branch, and pull requests for the branch are created into `dev`
 2. Pull requests are reviewed and merged into `dev`
-3. On Tuesday, a pull request is created into the `staging` branch
-   - At this point, the `staging` branch will be the release candidate. At this point, no new features are added into staging for the release, only release blocking bugfixes.
-4. During the next 2 days (Tuesday - Thursday) QA testing on the release candidate takes place
-   - During QA testing, any bugs found will be filed under two categories:
-     - Release blocking: if a bug is considered blocking for the release, create an issue and triage for a pull request to fix before release
-     - Non-release blocking: if a bug is not blocking a release, create an issue and triage normally
-5. If any release blocking bugfixes are merged into `staging`, bring those changes into `dev`
-6. When a release candidate is ready for release, merge into `master` and deploy to production on Thursday
-7. Create a tag for the new version in master
-8. Merge the tag into `staging` and `dev`
+3. On Tuesday and Thursday, the release workflow runs and:
+   - Back-merges `master` → `staging` → `dev` so all three branches are in sync before anything is cut
+   - Bumps the version on `dev` (`pnpm version`), creating the version commit and the `vX.Y.Z` tag
+   - Merges `dev` into `staging` directly — at this point `staging` is the release candidate, and only release-blocking bugfixes should land on it
+   - Publishes the [GitHub Release](https://github.com/ethereum/ethereum-org-website/releases) from the Release Drafter draft, after stripping automated/bot noise from the notes
+   - Opens a `Deploy vX.Y.Z` pull request from `staging` into `master`
+4. CI runs the extended suite on the deploy PR (build, e2e, Lighthouse, and Chromatic visual snapshots for both components and full pages), and an automated review checks the changes against the deploy preview and posts its summary as a PR comment
+5. A maintainer then completes the remaining manual steps:
+   - Accept or reject the Chromatic visual changes on both projects
+   - Review the automated summary and the deploy preview
+   - Approve and merge the deploy PR into `master`, which deploys to production
+6. Progress and outcomes are posted to the release channel in Discord at each stage
+
+Note that the `vX.Y.Z` tag is cut on `dev` during step 3, and the GitHub Release is published before the deploy PR merges. Merging into `master` is what puts the release live.
 
 ```
 master  O (tag) - - - - - - - - - - - - O (tag)
@@ -41,7 +51,7 @@ feature 2             \ _ _  O
 
 ## Release blocking bugfix process
 
-In the event that a bug was found in `staging` during the QA cycle that blocks a release, the following steps will take place to address the bug:
+Because a release ships the same day it is cut, the window for catching problems is the time between the deploy PR opening and it being merged. Anything found in that window that is serious enough to block the release is handled as follows:
 
 1. Create an issue in GitHub documenting the bug
 2. Triage the issue to a developer
@@ -50,6 +60,8 @@ In the event that a bug was found in `staging` during the QA cycle that blocks a
 5. Create a pull request into `staging`
 6. Merge into `staging` after review
 7. Merge `staging` back into `dev` after the bugfix has been merged
+
+Holding the deploy PR while a blocking fix lands is always an option — the next scheduled release is only a couple of days away, so letting a non-blocking bug ride to Tuesday or Thursday is usually cheaper than rushing a fix or a hotfix.
 
 ```
 master O (tag) - - - - - - - - - - - - - - - - - - - O (tag)
@@ -79,6 +91,8 @@ In the event that a hotfix is found in production and needs to be addressed befo
 6. After review, merge the hotfix pull request into `master` and release into production
 7. Merge `master` into `staging` and `dev` branches
 
+Step 7 also happens automatically as part of the next scheduled release's back-merge, but doing it promptly keeps `dev` from drifting.
+
 ```
     hotfix O - - - O
 
@@ -95,8 +109,10 @@ staging O - - - - - - - O
 dev     O - - O - - - - O
 ```
 
-## More about the Release Candidate QA process
+## More about the QA process
 
-The main idea behind the community QA process is to focus on the [current release changelog](https://github.com/ethereum/ethereum-org-website/releases) and check that new features or fixes applied are working as expected. During QA sessions, some notes could also be shared if we're looking for specific things to be tested.
+The main idea behind the community QA process is to focus on the [current release changelog](https://github.com/ethereum/ethereum-org-website/releases) and check that new features or fixes applied are working as expected. The deploy preview linked from the deploy PR is the right place to check — it is always built from the PR's head commit. Note that `staging.ethereum.org` lags the deploy PR by a full Netlify branch-deploy build, so shortly after a release is cut it still serves the previous one.
+
+QA is not limited to the release window. Because releases go out twice a week, anything reported against `dev` or a deploy preview at any point in the week will typically ship within a few days.
 
 If you find any bug, please report it on the [#website-bugs](https://discord.com/channels/714888181740339261/727898649006309377) Discord channel.


### PR DESCRIPTION
Moves the release cadence from once a week to twice a week: **Tuesday and Thursday at 14:00 UTC**.

## Cadence

`.github/workflows/weekly-release.yml`:

- Cron `0 14 * * 4` → `0 14 * * 2,4`
- `name: Weekly Release` → `Release`, and the four Discord messages that said "Weekly release" now say "Release"
- The version-type prompt reasoned in units of "substantive weeks" / "low-activity weeks", which is wrong at two releases per week. It now judges the cycle since the last published release and expects `--patch` to be the common case.

The filename and the `weekly-release` concurrency group are kept on purpose — renaming the file would reset the workflow's run history in the Actions UI, and the group is just an opaque lock key. Nothing else in the repo references either.

Everything downstream is already day-agnostic: `prepare-release.sh`, `/prepare-release`, `/review-release` and Release Drafter contain no weekday logic, and the drafter computes changes since the last published tag, so it produces a correct Tue→Thu draft with no config change.

## Docs

`docs/deploy-process.md` is rewritten for the new cadence. It had also drifted from the automation, so this corrects four things that were already wrong:

- There is no `dev` → `staging` pull request; the script merges `dev` into `staging` directly
- The version tag is cut on `dev`, not on `master`
- The GitHub Release is published *before* the deploy PR merges
- The described "2-day QA cycle, RC on Tuesday, release on Thursday" had already been replaced by same-day prepare-and-merge releases (the last 10 deploy PRs were created and merged the same Thursday, 1–4h apart)

It also documents pieces that weren't written down at all: the back-merge step, the skip-if-a-deploy-PR-is-open interlock, the automated review, the manual Chromatic/approve/merge tail, and the `staging.ethereum.org` branch-deploy lag.

## Verification

- Workflow YAML parses; schedule reads back as `0 14 * * 2,4`; both jobs intact
- `2,4` is Tue/Thu in cron's 0=Sunday numbering
- Prettier clean on both files
- No stray "weekly" copy left outside the two intentional identifiers

## Before merging, note

**This can fire the same day it lands.** `dev` is the default branch, so merging here arms the cron.

Three follow-ups are deliberately **not** in this PR:

1. **No-op release guard.** The only skip check is "is a deploy PR already open?". A quiet Tue→Thu gap won't fail loudly — the version-bump push to `dev` re-triggers Release Drafter, so `fetch-draft` still succeeds — but it yields a release whose notes are entirely filtered out by the cleanup rules, a deploy PR containing only the version commit, and a full extended CI + Chromatic + production build for nothing. Worth adding a `origin/staging..origin/dev` content check.
2. **Chromatic headroom.** `page-visual-tests` runs Playwright→Chromatic with no TurboSnap: 12 pages × 3 viewports = 36 snapshots per deploy PR, unconditional. That figure doubles. The Storybook job does use `onlyChanged` and is roughly cost-neutral, since a week's changes just split across two builds.
3. **A named owner for the Tuesday 14:00–16:00 UTC window.** Automation stops before the finish line — Chromatic acceptance, PR approval and merge are still manual, and this doubles that obligation.