### PR TITLE
fix(seo): render all Tabs panels in server HTML

### DIFF
--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -42,11 +42,18 @@ TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
 const TabsContent = React.forwardRef<
   React.ComponentRef<typeof TabsPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
->(({ className, ...props }, ref) => (
+>(({ className, forceMount = true, ...props }, ref) => (
+  // forceMount also clears the `hidden` attribute Radix would otherwise put on
+  // inactive panels, so hiding them is CSS-only. display:none (rather than the
+  // accordion's invisible + 0fr collapse) because tab panels are siblings in
+  // normal flow: they must take up no space, stay out of the tab order despite
+  // the tabIndex=0 Radix sets on every panel, and stay out of the a11y tree.
   <TabsPrimitive.Content
     ref={ref}
+    forceMount={forceMount} // forceMount keeps content in DOM for SEO crawlers
     className={cn(
       "mt-4 rounded-lg border p-6 ring-offset-background focus-visible:outline focus-visible:outline-4 focus-visible:-outline-offset-1 focus-visible:outline-primary-hover",
+      "data-[state=inactive]:hidden",
       className
     )}
     {...props}

--- a/tests/e2e/tabs-server-html.spec.ts
+++ b/tests/e2e/tabs-server-html.spec.ts
@@ -1,0 +1,83 @@
+import { expect, request, test } from "@playwright/test"
+
+// Regression coverage for #18978: `TabsContent` rendered inactive panels as
+// empty shells, so crawlers and non-JS clients received only the default panel.
+//
+// These fetch raw HTML over HTTP and never execute JavaScript, which is exactly
+// what such a client sees. Scripts are stripped first because the RSC flight
+// payload embeds panel content inside <script>self.__next_f.push(...)> -- a
+// naive search would find the text there and pass even when the bug is present.
+
+const TAB_PAGES = [
+  "/en/10years",
+  "/en/stablecoins",
+  "/en/founders",
+  "/en/restaking",
+  "/en/staking/withdrawals",
+]
+
+const stripScripts = (html: string) =>
+  html
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, "")
+    .replace(/<template\b[^>]*>[\s\S]*?<\/template>/gi, "")
+
+/** Inner HTML of the <div> opening at `start`, matching nested divs. */
+const innerHtml = (html: string, start: number): string => {
+  const openEnd = html.indexOf(">", start)
+  if (openEnd === -1) return ""
+  if (html[openEnd - 1] === "/") return ""
+
+  const tagRe = /<(\/?)div\b[^>]*?(\/?)>/gi
+  tagRe.lastIndex = openEnd + 1
+  let depth = 1
+  let match: RegExpExecArray | null
+
+  while ((match = tagRe.exec(html))) {
+    if (match[2] === "/") continue // self-closing
+    depth += match[1] === "/" ? -1 : 1
+    if (depth === 0) return html.slice(openEnd + 1, match.index)
+  }
+  return ""
+}
+
+const tabPanels = (html: string) => {
+  const panels: { state: string; inner: string }[] = []
+  const panelRe = /<div\b[^>]*role="tabpanel"[^>]*>/gi
+  let match: RegExpExecArray | null
+
+  while ((match = panelRe.exec(html))) {
+    panels.push({
+      state: match[0].match(/data-state="([^"]*)"/)?.[1] ?? "",
+      inner: innerHtml(html, match.index),
+    })
+  }
+  return panels
+}
+
+test.describe("Tab panels in server HTML", () => {
+  for (const path of TAB_PAGES) {
+    test(`${path} ships every tab panel's content`, async ({ baseURL }) => {
+      const apiRequest = await request.newContext()
+      const response = await apiRequest.get(baseURL + path)
+      expect(response.status()).toBe(200)
+
+      const html = stripScripts(await response.text())
+      const panels = tabPanels(html)
+
+      // Guard against the assertions silently passing on a page that no longer
+      // renders tabs at all.
+      expect(panels.length).toBeGreaterThan(1)
+
+      const empty = panels.filter(({ inner }) => inner.trim().length === 0)
+      expect(
+        empty,
+        `${empty.length} of ${panels.length} tab panels are empty in server HTML`
+      ).toHaveLength(0)
+
+      // Exactly one panel is active; the rest stay inactive for CSS to hide.
+      expect(panels.filter(({ state }) => state === "active")).toHaveLength(1)
+
+      await apiRequest.dispose()
+    })
+  }
+})


### PR DESCRIPTION
## Description

`TabsContent` passed no `forceMount` to Radix `TabsPrimitive.Content`, so inactive tab panels never reached the server-rendered output. The panel *element* was emitted with the correct `id`, `role` and `aria-labelledby`, but Radix's `children: present && children` evaluated to `false`, so the element was empty in both the HTML and the RSC flight payload. Crawlers and non-JS clients only ever received the default panel.

Measured locally on `dev` before the change (raw HTTP, `<script>` stripped so the flight payload can't produce false positives):

| Page | Panels | Empty in server HTML |
|---|---|---|
| `/10years` | 7 | **6** |
| `/stablecoins` | 4 | **3** |
| `/founders` | 3 | **2** |
| `/restaking` | 2 | **1** |
| `/staking/withdrawals` | 2 | **1** |

After the change all of these are 0.

### Approach

This mirrors the decision already made in `accordion.tsx`, which defaults `forceMount` to `true` with the comment *"forceMount keeps content in DOM for SEO crawlers"*.

It deliberately does **not** mirror the accordion's hiding mechanism. `forceMount` also clears the `hidden` attribute Radix would otherwise set, so hiding becomes CSS-only — and tab panels are siblings in normal flow, so the accordion's `invisible` + `grid-rows-[0fr]` collapse would leave every panel stacked and occupying height. `display:none` is what keeps inactive panels out of layout, out of the tab order (Radix sets `tabIndex=0` on *every* panel), and out of the accessibility tree.

The `className` contract is unchanged — it still lands on the panel element, so the `border-0 p-0` / `border-none px-0 py-0` overrides on `/10years`, `/stablecoins` and `/founders` keep working.

### Verification

- `pnpm lint`, `pnpm type-check` clean; `pnpm test:unit` 997 passed
- New `tests/e2e/tabs-server-html.spec.ts` covers all five pages; confirmed failing before the change and passing after. It fetches raw HTML over HTTP and never executes JS, so it tests the actual no-JS guarantee
- In-browser: exactly one visible panel; inactive panels `display:none` at height 0; inactive panels and every link inside them unfocusable; roving tabindex intact; click and <kbd>←</kbd>/<kbd>→</kbd> switch tabs correctly; no layout shift

### Notes for reviewers

- **`/collectibles` is not affected by this change** — that page renders no `Tabs` at all, so the acceptance criterion naming it can't be met here. Its client-only text is a separate issue.
- **Two pages not listed in the issue are also fixed:** `/restaking` and `/staking/withdrawals` (both via MDX components).
- **Page weight:** all panels now ship, which is inherent to any fix for this. `/10years` is the notable one — roughly **+157kB of HTML** (141 events across 7 regions vs 19 today), with a comparable increase in the flight payload. `/founders` ~+107kB, `/stablecoins` ~+14kB, the others negligible. Happy to scope this down (e.g. opt-in per consumer) if that trade-off isn't wanted on `/10years`.
- **Minor behaviour change:** `WithdrawalCredentials` on `/staking/withdrawals` keeps its input value when switching tabs and back, instead of being unmounted and reset.
- I checked whether these tab sets would be better as URL-addressable content before patching the primitive. All five are comparison/segmentation of a single topic, and the repo already has `ui/TabNav` + route segments for the genuinely navigational case. `/founders` is arguably a candidate for that treatment, but it's a content/IA decision and out of scope here.

## Related Issue

Fixes #18978
