### PR TITLE
feat(quiz): per-quiz stats and popular tag on the hub

### DIFF
--- a/app/[locale]/quizzes/_components/quiz-sections.tsx
+++ b/app/[locale]/quizzes/_components/quiz-sections.tsx
@@ -8,6 +8,10 @@ import QuizWidget from "@/components/Quiz/QuizWidget/QuizWidgetClient"
 import QuizzesList from "@/components/Quiz/QuizzesList"
 import QuizzesModal from "@/components/Quiz/QuizzesModal"
 import { useLocalQuizData } from "@/components/Quiz/useLocalQuizData"
+import {
+  getPopularQuizIds,
+  type QuizStatsByQuiz,
+} from "@/components/Quiz/utils"
 
 import { quizzesSections } from "@/data/quizzes"
 
@@ -15,8 +19,13 @@ import { INITIAL_QUIZ } from "@/lib/constants"
 
 import { useDisclosure } from "@/hooks/useDisclosure"
 
+type QuizSectionsProps = {
+  /** Null until the daily Matomo fetch lands; rows then omit their figures */
+  quizStats: QuizStatsByQuiz | null
+}
+
 /** The quiz lists and the modal they open; both need the same widget state. */
-const QuizSections = () => {
+const QuizSections = ({ quizStats }: QuizSectionsProps) => {
   const t = useTranslations("learn-quizzes")
 
   const [userStats, updateUserStats] = useLocalQuizData()
@@ -29,8 +38,10 @@ const QuizSections = () => {
       userStats,
       quizHandler: setCurrentQuiz,
       modalHandler: onOpen,
+      quizStats,
+      popularQuizIds: getPopularQuizIds(quizStats),
     }),
-    [onOpen, userStats]
+    [onOpen, quizStats, userStats]
   )
 
   return (

--- a/app/[locale]/quizzes/page.tsx
+++ b/app/[locale]/quizzes/page.tsx
@@ -120,7 +120,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
               )}
             </Grid>
 
-            <QuizSections />
+            <QuizSections quizStats={communityStats?.byQuiz ?? null} />
 
             {/* Same grid as the sections above, so the callout lines up with the
                 quiz lists: it starts in track 2, leaving the header track empty. */}

--- a/src/components/Quiz/QuizItem.tsx
+++ b/src/components/Quiz/QuizItem.tsx
@@ -1,4 +1,4 @@
-import { useTranslations } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 
 import type { QuizLevel, QuizzesSection } from "@/lib/types"
 
@@ -6,11 +6,15 @@ import { LinkBox, LinkOverlay } from "@/components/ui/link-box"
 
 import { cn } from "@/lib/utils/cn"
 
+import type { QuizStatsEntry } from "@/data-layer/fetchers/fetchQuizStats"
+
 import { GreenTickIcon } from "../icons/quiz"
 import { Button } from "../ui/buttons/Button"
 import { Flex, Stack } from "../ui/flex"
 import { ListItem } from "../ui/list"
-import { Tag, type TagProps } from "../ui/tag"
+import { Tag, type TagProps, TagsInlineText } from "../ui/tag"
+
+import { getQuizStatValues } from "./utils"
 
 const LEVEL_STATUS: Record<QuizLevel, NonNullable<TagProps["status"]>> = {
   beginner: "tag-green",
@@ -27,6 +31,9 @@ export type QuizzesListItemProps = Omit<QuizzesSection, "id"> & {
   numberOfQuestions: number
   titleId: string
   handleStart: () => void
+  /** Undefined until the daily Matomo fetch has figures for this quiz */
+  stats?: QuizStatsEntry
+  isPopular?: boolean
 }
 
 const QuizItem = ({
@@ -35,13 +42,18 @@ const QuizItem = ({
   titleId,
   numberOfQuestions,
   handleStart,
+  stats,
+  isPopular = false,
 }: QuizzesListItemProps) => {
+  const locale = useLocale()
   const t = useTranslations("learn-quizzes")
   const tCommon = useTranslations("common")
 
   const title = titleId.startsWith(LEARN_QUIZZES_PREFIX)
     ? t(titleId.slice(LEARN_QUIZZES_PREFIX.length))
     : tCommon(titleId)
+
+  const statValues = stats && getQuizStatValues(locale, stats)
 
   return (
     // The whole row is clickable via LinkOverlay's ::before, the same pattern
@@ -67,13 +79,28 @@ const QuizItem = ({
           </Flex>
 
           {/* Labels */}
-          <Flex className="gap-3 font-normal">
+          <Flex className="flex-wrap gap-3 font-normal">
             {/* number of questions - label */}
             <Tag>{`${numberOfQuestions} ${t("questions")}`}</Tag>
 
             {/* difficulty - label */}
             <Tag status={LEVEL_STATUS[level]}>{level.toUpperCase()}</Tag>
+
+            {/* Top five by answers per question; see getPopularQuizIds */}
+            {isPopular && <Tag status="tag">{t("popular")}</Tag>}
           </Flex>
+
+          {/* Community figures, omitted until Matomo has data for this quiz */}
+          {statValues && (
+            <TagsInlineText
+              variant="light"
+              className="font-normal"
+              list={[
+                `${t("average-score")} ${statValues.averageScore}`,
+                `${t("questions-answered")} ${statValues.questionsAnswered}`,
+              ]}
+            />
+          )}
         </Stack>
 
         <LinkOverlay asChild>

--- a/src/components/Quiz/QuizItem.tsx
+++ b/src/components/Quiz/QuizItem.tsx
@@ -97,7 +97,7 @@ const QuizItem = ({
               className="font-normal"
               list={[
                 `${t("average-score")} ${statValues.averageScore}`,
-                `${t("questions-answered")} ${statValues.questionsAnswered}`,
+                `${t("times-taken")} ${statValues.timesTaken}`,
               ]}
             />
           )}

--- a/src/components/Quiz/QuizzesList.tsx
+++ b/src/components/Quiz/QuizzesList.tsx
@@ -11,6 +11,7 @@ import { OrderedList } from "../ui/list"
 import { Section } from "../ui/section"
 
 import QuizItem from "./QuizItem"
+import type { QuizStatsByQuiz } from "./utils"
 
 type QuizzesListProps = {
   sectionId: string
@@ -20,6 +21,8 @@ type QuizzesListProps = {
   descriptionId: string
   quizHandler: (id: QuizKey) => void
   modalHandler: (isModalOpen: boolean) => void
+  quizStats?: QuizStatsByQuiz | null
+  popularQuizIds?: QuizKey[]
 }
 
 const QuizzesList = ({
@@ -30,6 +33,8 @@ const QuizzesList = ({
   descriptionId,
   quizHandler,
   modalHandler,
+  quizStats,
+  popularQuizIds = [],
 }: QuizzesListProps) => (
   // data-flow="skip" so the flow rhythm doesn't add margins between columns.
   // Grid, not the responsiveFlex variant: `flex-basis: 0` is floored by an
@@ -69,6 +74,8 @@ const QuizzesList = ({
             numberOfQuestions={allQuizzesData[listItem.id].questions.length}
             titleId={allQuizzesData[listItem.id].title}
             handleStart={handleStart}
+            stats={quizStats?.[listItem.id]}
+            isPopular={popularQuizIds.includes(listItem.id)}
           />
         )
       })}

--- a/src/components/Quiz/stories/QuizzesList.stories.tsx
+++ b/src/components/Quiz/stories/QuizzesList.stories.tsx
@@ -5,8 +5,10 @@ import type { Meta, StoryObj } from "@storybook/nextjs"
 import type { CompletedQuizzes } from "@/lib/types"
 
 import { quizzesSections } from "@/data/quizzes"
+import quizStatsMock from "@/data-layer/mocks/fetch-quiz-stats.json"
 
 import QuizzesListComponent from "../QuizzesList"
+import { getPopularQuizIds } from "../utils"
 
 /**
  * This story also renders the `QuizItem` component.
@@ -29,6 +31,8 @@ const meta = {
     },
     quizHandler: fn(),
     modalHandler: fn(),
+    quizStats: quizStatsMock.byQuiz,
+    popularQuizIds: getPopularQuizIds(quizStatsMock.byQuiz),
   },
 } satisfies Meta<typeof QuizzesListComponent>
 

--- a/src/components/Quiz/utils.ts
+++ b/src/components/Quiz/utils.ts
@@ -1,9 +1,12 @@
-import type { CompletedQuizzes, QuizShareStats } from "@/lib/types"
+import type { CompletedQuizzes, QuizKey, QuizShareStats } from "@/lib/types"
 
 import { numberFormat, numberToPercent } from "@/lib/utils/numbers"
 
 import allQuizzesData, { allQuizzesInOrder } from "@/data/quizzes"
-import type { QuizStatsData } from "@/data-layer/fetchers/fetchQuizStats"
+import type {
+  QuizStatsData,
+  QuizStatsEntry,
+} from "@/data-layer/fetchers/fetchQuizStats"
 
 export const getTotalQuizzesPoints = () =>
   Object.values(allQuizzesData)
@@ -54,6 +57,40 @@ export const getFormattedUserAverageScore = (
   locale: string,
   valueSet: number[]
 ) => asPercent(mean(valueSet), locale)
+
+/** How many quizzes carry the "popular" tag on the hub. */
+const POPULAR_QUIZ_COUNT = 5
+
+export type QuizStatsByQuiz = QuizStatsData["byQuiz"]
+
+/**
+ * Ids of the most-answered quizzes, normalised by question count: a six-question
+ * quiz logs 50% more answers than a four-question one for the same audience, so
+ * raw event totals would just rank by length.
+ */
+export const getPopularQuizIds = (byQuiz?: QuizStatsByQuiz | null): QuizKey[] =>
+  // Keys are quiz ids, but a stale blob can name a quiz that has since been
+  // removed, so filter before treating them as QuizKeys.
+  (Object.entries(byQuiz || {}) as [QuizKey, QuizStatsEntry][])
+    .filter(([id]) => id in allQuizzesData)
+    .map(([id, { questionsAnswered }]) => ({
+      id,
+      perQuestion: questionsAnswered / allQuizzesData[id].questions.length,
+    }))
+    .sort((a, b) => b.perQuestion - a.perQuestion)
+    .slice(0, POPULAR_QUIZ_COUNT)
+    .map(({ id }) => id)
+
+/** Formatted per-quiz figures for a single row on the hub. */
+export const getQuizStatValues = (
+  locale: string,
+  { averageScore, questionsAnswered }: QuizStatsEntry
+) => ({
+  averageScore: asPercent(averageScore, locale),
+  questionsAnswered: numberFormat(locale, { style: "decimal" }).format(
+    questionsAnswered
+  ),
+})
 
 /** Label/value rows for the community stats panel, in display order. */
 export const getCommunityStatRows = (

--- a/src/components/Quiz/utils.ts
+++ b/src/components/Quiz/utils.ts
@@ -63,33 +63,23 @@ const POPULAR_QUIZ_COUNT = 5
 
 export type QuizStatsByQuiz = QuizStatsData["byQuiz"]
 
-/**
- * Ids of the most-answered quizzes, normalised by question count: a six-question
- * quiz logs 50% more answers than a four-question one for the same audience, so
- * raw event totals would just rank by length.
- */
+/** Ids of the most-taken quizzes. */
 export const getPopularQuizIds = (byQuiz?: QuizStatsByQuiz | null): QuizKey[] =>
   // Keys are quiz ids, but a stale blob can name a quiz that has since been
   // removed, so filter before treating them as QuizKeys.
   (Object.entries(byQuiz || {}) as [QuizKey, QuizStatsEntry][])
     .filter(([id]) => id in allQuizzesData)
-    .map(([id, { questionsAnswered }]) => ({
-      id,
-      perQuestion: questionsAnswered / allQuizzesData[id].questions.length,
-    }))
-    .sort((a, b) => b.perQuestion - a.perQuestion)
+    .sort(([, a], [, b]) => b.timesTaken - a.timesTaken)
     .slice(0, POPULAR_QUIZ_COUNT)
-    .map(({ id }) => id)
+    .map(([id]) => id)
 
 /** Formatted per-quiz figures for a single row on the hub. */
 export const getQuizStatValues = (
   locale: string,
-  { averageScore, questionsAnswered }: QuizStatsEntry
+  { averageScore, timesTaken }: QuizStatsEntry
 ) => ({
   averageScore: asPercent(averageScore, locale),
-  questionsAnswered: numberFormat(locale, { style: "decimal" }).format(
-    questionsAnswered
-  ),
+  timesTaken: numberFormat(locale, { style: "decimal" }).format(timesTaken),
 })
 
 /** Label/value rows for the community stats panel, in display order. */

--- a/src/data-layer/fetchers/fetchQuizStats.ts
+++ b/src/data-layer/fetchers/fetchQuizStats.ts
@@ -5,14 +5,18 @@ import { fetchRetry } from "./fetchRetry"
 export interface QuizStatsEntry {
   /** Mean of the correct/incorrect event values, as a percentage */
   averageScore: number
-  /** Total "Question answered" events */
-  questionsAnswered: number
+  /** Estimated runs over the trailing year; see PER_QUIZ_WINDOW_DAYS */
+  timesTaken: number
 }
 
-export interface QuizStatsData extends QuizStatsEntry {
+export interface QuizStatsData {
+  /** Mean of the correct/incorrect event values, as a percentage */
+  averageScore: number
+  /** Total "Question answered" events */
+  questionsAnswered: number
   /** Retries as a percentage of questions answered */
   retryRate: number
-  /** Per-quiz totals keyed by quiz id. A quiz nobody has answered is omitted. */
+  /** Per-quiz figures keyed by quiz id. A quiz nobody has taken is omitted. */
   byQuiz: Record<string, QuizStatsEntry>
   timestamp: number
 }
@@ -34,10 +38,26 @@ const ANSWERED_ACTION = "Question answered"
 const RETRY_NAME = "Retry question"
 
 // Each "Question answered" event names the question it belongs to, not the quiz
-// (QuizButtonGroup sends `QID: <question id>`), so per-quiz totals are summed
-// over each quiz's question list. Questions shared by two quizzes -- currently
+// (QuizButtonGroup sends `QID: <question id>`), so per-quiz figures are derived
+// from each quiz's question list. Questions shared by two quizzes -- currently
 // only wallets-3 -- count toward both.
 const QID_PREFIX = "QID: "
+
+// Matomo truncates the Event Names report to the top N names at archive time,
+// and the longer the window the harder it bites: over a lifetime range only the
+// busiest handful of QID rows survive, the rest fold into "Others". A trailing
+// year keeps every quiz. The site-wide figures above are unaffected -- they come
+// from Events.getAction, a small report that survives any range.
+const PER_QUIZ_WINDOW_DAYS = 365
+
+const median = (values: number[]): number => {
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+
+  return sorted.length % 2
+    ? sorted[mid]
+    : Math.round((sorted[mid - 1] + sorted[mid]) / 2)
+}
 
 export async function fetchQuizStats(): Promise<QuizStatsData> {
   const matomoUrl = process.env.MATOMO_URL
@@ -52,14 +72,25 @@ export async function fetchQuizStats(): Promise<QuizStatsData> {
 
   console.log("Starting quiz stats fetch")
 
-  const report = async (method: string): Promise<MatomoEventRow[]> => {
-    // Lifetime totals, so the figures read as "since the quizzes launched"
+  // Lifetime, so the site-wide figures read as "since the quizzes launched"
+  const LIFETIME = "2019-01-01,today"
+
+  const trailingYear = new Date(
+    Date.now() - PER_QUIZ_WINDOW_DAYS * 24 * 60 * 60 * 1000
+  )
+    .toISOString()
+    .slice(0, 10)
+
+  const report = async (
+    method: string,
+    date: string
+  ): Promise<MatomoEventRow[]> => {
     const params = new URLSearchParams({
       module: "API",
       method,
       idSite: siteId,
       period: "range",
-      date: "2019-01-01,today",
+      date,
       filter_limit: "-1",
       format: "JSON",
       token_auth: apiToken,
@@ -82,9 +113,10 @@ export async function fetchQuizStats(): Promise<QuizStatsData> {
     return rows
   }
 
-  const [actionRows, nameRows] = await Promise.all([
-    report("Events.getAction"),
-    report("Events.getName"),
+  const [actionRows, nameRows, recentNameRows] = await Promise.all([
+    report("Events.getAction", LIFETIME),
+    report("Events.getName", LIFETIME),
+    report("Events.getName", `${trailingYear},today`),
   ])
 
   const answered = actionRows.find((row) => row.label === ANSWERED_ACTION)
@@ -106,7 +138,7 @@ export async function fetchQuizStats(): Promise<QuizStatsData> {
   const retryRate = (retried.nb_events / questionsAnswered) * 100
 
   const questionRows = new Map(
-    nameRows
+    recentNameRows
       .filter((row) => row.label.startsWith(QID_PREFIX))
       .map((row) => [row.label.slice(QID_PREFIX.length), row])
   )
@@ -131,7 +163,13 @@ export async function fetchQuizStats(): Promise<QuizStatsData> {
 
     byQuiz[quizId] = {
       averageScore: (quizCorrect / quizAnswered) * 100,
-      questionsAnswered: quizAnswered,
+      // Questions are shuffled per run, so each is answered about once per run
+      // and any single question's count approximates the number of runs.
+      // Median rather than sum (which just scales with question count), max (a
+      // question borrowed by another quiz carries its traffic too -- security
+      // borrows wallets-3) or mean (dragged down by questions added part-way
+      // through the window).
+      timesTaken: median(rows.map((row) => row.nb_events)),
     }
   }
 

--- a/src/data-layer/fetchers/fetchQuizStats.ts
+++ b/src/data-layer/fetchers/fetchQuizStats.ts
@@ -1,12 +1,19 @@
+import allQuizzesData from "@/data/quizzes"
+
 import { fetchRetry } from "./fetchRetry"
 
-export interface QuizStatsData {
+export interface QuizStatsEntry {
   /** Mean of the correct/incorrect event values, as a percentage */
   averageScore: number
   /** Total "Question answered" events */
   questionsAnswered: number
+}
+
+export interface QuizStatsData extends QuizStatsEntry {
   /** Retries as a percentage of questions answered */
   retryRate: number
+  /** Per-quiz totals keyed by quiz id. A quiz nobody has answered is omitted. */
+  byQuiz: Record<string, QuizStatsEntry>
   timestamp: number
 }
 
@@ -25,6 +32,12 @@ type MatomoEventRow = {
 // name, and Events.getAction never returns a row labelled "Retry question".
 const ANSWERED_ACTION = "Question answered"
 const RETRY_NAME = "Retry question"
+
+// Each "Question answered" event names the question it belongs to, not the quiz
+// (QuizButtonGroup sends `QID: <question id>`), so per-quiz totals are summed
+// over each quiz's question list. Questions shared by two quizzes -- currently
+// only wallets-3 -- count toward both.
+const QID_PREFIX = "QID: "
 
 export async function fetchQuizStats(): Promise<QuizStatsData> {
   const matomoUrl = process.env.MATOMO_URL
@@ -92,14 +105,50 @@ export async function fetchQuizStats(): Promise<QuizStatsData> {
     ((answered.sum_event_value ?? 0) / questionsAnswered) * 100
   const retryRate = (retried.nb_events / questionsAnswered) * 100
 
+  const questionRows = new Map(
+    nameRows
+      .filter((row) => row.label.startsWith(QID_PREFIX))
+      .map((row) => [row.label.slice(QID_PREFIX.length), row])
+  )
+
+  const byQuiz: Record<string, QuizStatsEntry> = {}
+
+  for (const [quizId, quiz] of Object.entries(allQuizzesData)) {
+    const rows = quiz.questions
+      .map((questionId) => questionRows.get(questionId))
+      .filter((row) => !!row)
+
+    const quizAnswered = rows.reduce((sum, row) => sum + row.nb_events, 0)
+
+    // Omit rather than store zeros: a quiz that just shipped has no data, which
+    // is not the same as a quiz everyone got wrong.
+    if (!quizAnswered) continue
+
+    const quizCorrect = rows.reduce(
+      (sum, row) => sum + (row.sum_event_value ?? 0),
+      0
+    )
+
+    byQuiz[quizId] = {
+      averageScore: (quizCorrect / quizAnswered) * 100,
+      questionsAnswered: quizAnswered,
+    }
+  }
+
   const data: QuizStatsData = {
     averageScore,
     questionsAnswered,
     retryRate,
+    byQuiz,
     timestamp: Date.now(),
   }
 
-  console.log("Successfully fetched quiz stats", data)
+  console.log("Successfully fetched quiz stats", {
+    averageScore,
+    questionsAnswered,
+    retryRate,
+    quizzesWithData: Object.keys(byQuiz).length,
+  })
 
   return data
 }

--- a/src/data-layer/mocks/fetch-quiz-stats.json
+++ b/src/data-layer/mocks/fetch-quiz-stats.json
@@ -1,6 +1,112 @@
 {
-  "averageScore": 69.98158463195207,
+  "averageScore": 69.9816,
   "questionsAnswered": 1098539,
   "retryRate": 24.682237043928346,
+  "byQuiz": {
+    "what-is-ethereum": {
+      "averageScore": 69.2001,
+      "questionsAnswered": 136134
+    },
+    "what-is-ether": {
+      "averageScore": 64.8807,
+      "questionsAnswered": 90403
+    },
+    "wallets": {
+      "averageScore": 74.3677,
+      "questionsAnswered": 69568
+    },
+    "what-are-apps": {
+      "averageScore": 63.1781,
+      "questionsAnswered": 73896
+    },
+    "web3": {
+      "averageScore": 79.9752,
+      "questionsAnswered": 65453
+    },
+    "energy-consumption": {
+      "averageScore": 78.6255,
+      "questionsAnswered": 52794
+    },
+    "security": {
+      "averageScore": 78.762,
+      "questionsAnswered": 49372
+    },
+    "privacy": {
+      "averageScore": 75.1037,
+      "questionsAnswered": 44853
+    },
+    "zero-knowledge-proofs": {
+      "averageScore": 59.1287,
+      "questionsAnswered": 51593
+    },
+    "nfts": {
+      "averageScore": 76.9216,
+      "questionsAnswered": 86052
+    },
+    "stablecoins": {
+      "averageScore": 72.1451,
+      "questionsAnswered": 23995
+    },
+    "defi": {
+      "averageScore": 67.5842,
+      "questionsAnswered": 25269
+    },
+    "daos": {
+      "averageScore": 66.0893,
+      "questionsAnswered": 26682
+    },
+    "payments": {
+      "averageScore": 71.1046,
+      "questionsAnswered": 26948
+    },
+    "accounts": {
+      "averageScore": 80.3002,
+      "questionsAnswered": 70452
+    },
+    "smart-contracts": {
+      "averageScore": 61.3047,
+      "questionsAnswered": 19850
+    },
+    "transactions": {
+      "averageScore": 70.7822,
+      "questionsAnswered": 21804
+    },
+    "blocks": {
+      "averageScore": 68.6035,
+      "questionsAnswered": 25674
+    },
+    "gas": {
+      "averageScore": 58.2663,
+      "questionsAnswered": 17527
+    },
+    "evm": {
+      "averageScore": 59.4045,
+      "questionsAnswered": 18892
+    },
+    "bridges": {
+      "averageScore": 73.8317,
+      "questionsAnswered": 21840
+    },
+    "layer-2": {
+      "averageScore": 46.1459,
+      "questionsAnswered": 14229
+    },
+    "run-a-node": {
+      "averageScore": 55.6299,
+      "questionsAnswered": 20078
+    },
+    "merge": {
+      "averageScore": 55.7248,
+      "questionsAnswered": 13027
+    },
+    "staking-solo": {
+      "averageScore": 58.1638,
+      "questionsAnswered": 21970
+    },
+    "scaling": {
+      "averageScore": 59.5088,
+      "questionsAnswered": 10184
+    }
+  },
   "timestamp": 1786057850729
 }

--- a/src/data-layer/mocks/fetch-quiz-stats.json
+++ b/src/data-layer/mocks/fetch-quiz-stats.json
@@ -1,112 +1,112 @@
 {
-  "averageScore": 69.9816,
-  "questionsAnswered": 1098539,
-  "retryRate": 24.682237043928346,
+  "averageScore": 69.97565025808545,
+  "questionsAnswered": 1100217,
+  "retryRate": 24.691583569423123,
   "byQuiz": {
     "what-is-ethereum": {
-      "averageScore": 69.2001,
-      "questionsAnswered": 136134
+      "averageScore": 72.5007,
+      "timesTaken": 13438
     },
     "what-is-ether": {
-      "averageScore": 64.8807,
-      "questionsAnswered": 90403
+      "averageScore": 78.1314,
+      "timesTaken": 7363
     },
     "wallets": {
-      "averageScore": 74.3677,
-      "questionsAnswered": 69568
+      "averageScore": 72.7651,
+      "timesTaken": 10416
     },
     "what-are-apps": {
-      "averageScore": 63.1781,
-      "questionsAnswered": 73896
+      "averageScore": 61.3432,
+      "timesTaken": 165
     },
     "web3": {
-      "averageScore": 79.9752,
-      "questionsAnswered": 65453
+      "averageScore": 74.833,
+      "timesTaken": 8722
     },
     "energy-consumption": {
-      "averageScore": 78.6255,
-      "questionsAnswered": 52794
+      "averageScore": 76.189,
+      "timesTaken": 724
     },
     "security": {
-      "averageScore": 78.762,
-      "questionsAnswered": 49372
+      "averageScore": 77.5672,
+      "timesTaken": 3704
     },
     "privacy": {
-      "averageScore": 75.1037,
-      "questionsAnswered": 44853
+      "averageScore": 71.7565,
+      "timesTaken": 607
     },
     "zero-knowledge-proofs": {
-      "averageScore": 59.1287,
-      "questionsAnswered": 51593
+      "averageScore": 56.928,
+      "timesTaken": 590
     },
     "nfts": {
-      "averageScore": 76.9216,
-      "questionsAnswered": 86052
+      "averageScore": 82.4503,
+      "timesTaken": 2956
     },
     "stablecoins": {
-      "averageScore": 72.1451,
-      "questionsAnswered": 23995
+      "averageScore": 69.2597,
+      "timesTaken": 4194
     },
     "defi": {
-      "averageScore": 67.5842,
-      "questionsAnswered": 25269
+      "averageScore": 81.6257,
+      "timesTaken": 1715
     },
     "daos": {
-      "averageScore": 66.0893,
-      "questionsAnswered": 26682
+      "averageScore": 70.3081,
+      "timesTaken": 1633
     },
     "payments": {
-      "averageScore": 71.1046,
-      "questionsAnswered": 26948
+      "averageScore": 72.2009,
+      "timesTaken": 979
     },
     "accounts": {
-      "averageScore": 80.3002,
-      "questionsAnswered": 70452
+      "averageScore": 69.8797,
+      "timesTaken": 651
     },
     "smart-contracts": {
-      "averageScore": 61.3047,
-      "questionsAnswered": 19850
+      "averageScore": 61.2702,
+      "timesTaken": 2034
     },
     "transactions": {
-      "averageScore": 70.7822,
-      "questionsAnswered": 21804
+      "averageScore": 64.5463,
+      "timesTaken": 962
     },
     "blocks": {
-      "averageScore": 68.6035,
-      "questionsAnswered": 25674
+      "averageScore": 78.5873,
+      "timesTaken": 428
     },
     "gas": {
-      "averageScore": 58.2663,
-      "questionsAnswered": 17527
+      "averageScore": 58.8501,
+      "timesTaken": 939
     },
     "evm": {
-      "averageScore": 59.4045,
-      "questionsAnswered": 18892
+      "averageScore": 55.7895,
+      "timesTaken": 985
     },
     "bridges": {
-      "averageScore": 73.8317,
-      "questionsAnswered": 21840
+      "averageScore": 64.8568,
+      "timesTaken": 165
     },
     "layer-2": {
-      "averageScore": 46.1459,
-      "questionsAnswered": 14229
+      "averageScore": 61.8046,
+      "timesTaken": 1715
     },
     "run-a-node": {
-      "averageScore": 55.6299,
-      "questionsAnswered": 20078
+      "averageScore": 68.3845,
+      "timesTaken": 3144
     },
     "merge": {
-      "averageScore": 55.7248,
-      "questionsAnswered": 13027
+      "averageScore": 70.6717,
+      "timesTaken": 608
     },
     "staking-solo": {
-      "averageScore": 58.1638,
-      "questionsAnswered": 21970
+      "averageScore": 65.0356,
+      "timesTaken": 628
     },
     "scaling": {
-      "averageScore": 59.5088,
-      "questionsAnswered": 10184
+      "averageScore": 65.9098,
+      "timesTaken": 356
     }
   },
-  "timestamp": 1786057850729
+  "timestamp": 1786496764331
 }

--- a/src/intl/en/learn-quizzes.json
+++ b/src/intl/en/learn-quizzes.json
@@ -14,6 +14,7 @@
   "page-assets-merge": "The Merge",
   "page-privacy": "Privacy",
   "passed": "You passed the quiz!",
+  "popular": "Popular",
   "questions": "Questions",
   "questions-answered": "Questions answered:",
   "quizzes-subtitle": "Find out how well you understand Ethereum and cryptocurrencies. Are you ready to become an expert?",

--- a/src/intl/en/learn-quizzes.json
+++ b/src/intl/en/learn-quizzes.json
@@ -25,6 +25,7 @@
   "start": "Start",
   "submit-answer": "Check answer",
   "test-your-knowledge": "Test your Ethereum knowledge",
+  "times-taken": "Times taken:",
   "try-again": "Try again",
   "want-more-quizzes": "Want to see more quizzes here?",
   "your-results": "Your results",


### PR DESCRIPTION
## Summary

Adds per-quiz **average score** and **questions answered** to each row on `/quizzes`, plus a **POPULAR** tag on the five most-taken quizzes, all sourced from the daily Matomo fetch introduced in #19004.

No additional Matomo requests are needed. "Question answered" events carry the question id as the event *name* (`QID: <id>`), and the fetcher already pulls `Events.getName` for the retry count, so per-quiz totals are a regroup of a response we were already fetching. The task in `tasks.ts` needed no change either, since the stored blob is the fetcher's return value verbatim.

Popularity ranks by answers divided by question count rather than raw answers: ranking on totals would just sort by quiz length, since `zero-knowledge-proofs` has 7 questions and `wallets` has 4.

`byQuiz` is additive, so an older blob degrades to no per-quiz figures rather than breaking the page, and a quiz with no answers yet is omitted rather than stored as zero. The metric labels reuse the existing `average-score` and `questions-answered` keys from the community panel, so `popular` is the only new string owed across the other 24 locales.

Mock data regenerated to match the new shape, verified by driving the fetcher against a stubbed Matomo response and diffing its output against the mock.

Draft pending a real trigger.dev run against live Matomo.