### PR TITLE
patch(ui): full width card footer alert

### DIFF
--- a/app/[locale]/10years/_components/NFTMintCard/index.tsx
+++ b/app/[locale]/10years/_components/NFTMintCard/index.tsx
@@ -63,7 +63,7 @@ const NFTMintCard = async () => {
       <CardFooter>
         <Alert
           variant="update"
-          className="rounded-(--banner-radius) border-none"
+          className="w-full rounded-(--banner-radius) border-none"
         >
           <AlertContent>
             <AlertTitle>{t("page-10-year-mint-card-ended-title")}</AlertTitle>


### PR DESCRIPTION
## Description
Make `Alert` full width in NFTMintCard footer

<img width="707" height="596" alt="image" src="https://github.com/user-attachments/assets/3edf619e-d2b1-4c76-bce4-c814f25fe4d5" />


## Related Issue
<img width="724" height="612" alt="image" src="https://github.com/user-attachments/assets/4584c041-9d19-45da-ba42-f1800455a1d3" />
