### PR TITLE
feat(find-wallet): add fees tooltip to standalone wallet page

### DIFF
--- a/app/[locale]/wallets/find-wallet/[wallet]/page.tsx
+++ b/app/[locale]/wallets/find-wallet/[wallet]/page.tsx
@@ -139,8 +139,18 @@ const Page = async (props: { params: Promise<WalletPageParams> }) => {
                   )}
 
                   {wallet.fees?.length ? (
-                    <p className="text-sm text-body-medium">
+                    <p className="flex items-center gap-1.5 text-sm text-body-medium">
                       {formatWalletFees(wallet.fees, locale, t)}
+                      <Tooltip
+                        nested
+                        content={
+                          <p className="text-body">
+                            {t("page-find-wallet-fee-row-tooltip")}
+                          </p>
+                        }
+                      >
+                        <Info className="size-4 shrink-0" />
+                      </Tooltip>
                     </p>
                   ) : null}
                 </div>


### PR DESCRIPTION
## Description

The wallet detail **modal** explains its fee row with a tooltip — clarifying that these are fees the wallet provider charges for its own services, as distinct from network transaction fees set by Ethereum. The **standalone** wallet page rendered the same fee string with no such context.

This adds that tooltip to the standalone page, reusing the modal's existing `page-find-wallet-fee-row-tooltip` key. No new i18n string, so translated locales pick it up automatically.

Follow-up to the find-wallet revamp, per review feedback on the fees discussion.

### Implementation notes

- The fees line uses `flex items-center gap-1.5` with a `size-4 shrink-0` icon — the same label+icon treatment as the modal's `DetailRow`, so the two pages match. Flex centering is used rather than a baseline nudge because `Tooltip` hardcodes its trigger's className, leaving no way to align the trigger button itself.
- Unlike the modal, the standalone page has no "What you pay for" label, so the tooltip attaches directly to the formatted fee string.

## Testing

- Icon center measured 0.01px from the text line's center; verified optically at 4x zoom.
- Hover confirmed the tooltip opens with the expected copy.
- MetaMask (two fees, longest string) at 375px: stays on one line, icon aligned and not squeezed.
- `pnpm type-check` and ESLint clean.

## Preview

Any wallet with fees, e.g. `/en/wallets/find-wallet/keystone/` (Device: $149) or `/en/wallets/find-wallet/metamask/`.