### PR TITLE
chore(chromatic): separate the width matrix from content variants

### DIFF
--- a/.storybook/modes.ts
+++ b/.storybook/modes.ts
@@ -56,3 +56,23 @@ export const langViewportModes = Object.entries(
     ...currLangViewObj,
   }
 }, {})
+
+// The responsive + RTL contract (langViewportModes) belongs on ONE
+// representative story per component -- on `meta` it multiplies by every
+// content variant in the file for no added signal. Content variants use
+// variantMode instead, which proves the variant renders at all.
+//
+// The key must stay "en-lg": Chromatic stacks modes across project/meta/story
+// level rather than replacing them, de-duping by key. On the representative
+// story this set unions with langViewportModes down to langViewportModes'
+// own 8 -- renaming the key would silently add a 9th.
+export const variantMode: LangViewModeObj = {
+  "en-lg": { viewport: "lg", locale: "en" },
+}
+
+// For components with no responsive classes anywhere in their subtree --
+// width isn't a variable for them, but direction still is.
+export const staticModes: LangViewModeObj = {
+  "en-lg": { viewport: "lg", locale: "en" },
+  "ar-lg": { viewport: "lg", locale: "ar" },
+}

--- a/.storybook/modes.ts
+++ b/.storybook/modes.ts
@@ -57,21 +57,12 @@ export const langViewportModes = Object.entries(
   }
 }, {})
 
-// The responsive + RTL contract (langViewportModes) belongs on ONE
-// representative story per component -- on `meta` it multiplies by every
-// content variant in the file for no added signal. Content variants use
-// variantMode instead, which proves the variant renders at all.
-//
-// The key must stay "en-lg": Chromatic stacks modes across project/meta/story
-// level rather than replacing them, de-duping by key. On the representative
-// story this set unions with langViewportModes down to langViewportModes'
-// own 8 -- renaming the key would silently add a 9th.
+// Key must stay "en-lg": Chromatic stacks modes rather than replacing them,
+// de-duping by key, so this unions with langViewportModes down to its own 8.
 export const variantMode: LangViewModeObj = {
   "en-lg": { viewport: "lg", locale: "en" },
 }
 
-// For components with no responsive classes anywhere in their subtree --
-// width isn't a variable for them, but direction still is.
 export const staticModes: LangViewModeObj = {
   "en-lg": { viewport: "lg", locale: "en" },
   "ar-lg": { viewport: "lg", locale: "ar" },

--- a/src/components/DeveloperDocsLinks/developer-docs-links.stories.tsx
+++ b/src/components/DeveloperDocsLinks/developer-docs-links.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from "@storybook/nextjs"
 
-import { langViewportModes } from "../../../.storybook/modes"
+import { staticModes, variantMode } from "../../../.storybook/modes"
 
 import DeveloperDocsLinksComponent from "."
 
@@ -11,9 +11,7 @@ const meta = {
   parameters: {
     layout: "fullscreen",
     chromatic: {
-      modes: {
-        ...langViewportModes,
-      },
+      modes: variantMode,
     },
   },
   decorators: [
@@ -29,7 +27,13 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
+// No component in this file's subtree declares a responsive class, so width
+// isn't a variable here -- one story still checks direction (RTL list
+// markers/indent) rather than dropping it entirely.
 export const FoundationalTopics: Story = {
+  parameters: {
+    chromatic: { modes: staticModes },
+  },
   args: {
     headerId: "foundational-topics",
   },

--- a/src/components/DeveloperDocsLinks/developer-docs-links.stories.tsx
+++ b/src/components/DeveloperDocsLinks/developer-docs-links.stories.tsx
@@ -27,9 +27,6 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
-// No component in this file's subtree declares a responsive class, so width
-// isn't a variable here -- one story still checks direction (RTL list
-// markers/indent) rather than dropping it entirely.
 export const FoundationalTopics: Story = {
   parameters: {
     chromatic: { modes: staticModes },

--- a/src/components/Hero/PageHero/page-hero.stories.tsx
+++ b/src/components/Hero/PageHero/page-hero.stories.tsx
@@ -61,9 +61,6 @@ const useBaseProps = () => {
 /**
  * The workhorse: breadcrumbs + image + two buttons, with the default bottom
  * divider. `title` is the page `<h1>`.
- *
- * Carries the full responsive + RTL contract for every PageHero variant --
- * the other stories below only need to prove their variant renders.
  */
 export const PageHeroWithImage: Story = {
   parameters: {

--- a/src/components/Hero/PageHero/page-hero.stories.tsx
+++ b/src/components/Hero/PageHero/page-hero.stories.tsx
@@ -1,7 +1,7 @@
 import { useTranslations } from "next-intl"
 import type { Meta, StoryObj } from "@storybook/nextjs"
 
-import { langViewportModes } from "@/storybook/modes"
+import { langViewportModes, variantMode } from "@/storybook/modes"
 
 import PageHeroComponent, { type PageHeroProps } from "."
 
@@ -16,9 +16,7 @@ const meta = {
     // asPath lets the Breadcrumbs component resolve the "home" crumb label
     nextjs: { router: { asPath: "/en" } },
     chromatic: {
-      modes: {
-        ...langViewportModes,
-      },
+      modes: variantMode,
     },
   },
 } satisfies Meta<typeof PageHeroComponent>
@@ -63,8 +61,14 @@ const useBaseProps = () => {
 /**
  * The workhorse: breadcrumbs + image + two buttons, with the default bottom
  * divider. `title` is the page `<h1>`.
+ *
+ * Carries the full responsive + RTL contract for every PageHero variant --
+ * the other stories below only need to prove their variant renders.
  */
 export const PageHeroWithImage: Story = {
+  parameters: {
+    chromatic: { modes: langViewportModes },
+  },
   render: () => (
     <PageHeroComponent
       breadcrumbs={{ slug: "/run-a-node/" }}

--- a/src/layouts/stories/docs.stories.tsx
+++ b/src/layouts/stories/docs.stories.tsx
@@ -59,8 +59,6 @@ const baseArgs = {
   children: <ArticleBody />,
 }
 
-// Carries the full responsive + RTL contract for the layout -- the other
-// stories below only need to prove their variant renders.
 export const Default: Story = {
   parameters: { chromatic: { modes: langViewportModes } },
   args: baseArgs,

--- a/src/layouts/stories/docs.stories.tsx
+++ b/src/layouts/stories/docs.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/nextjs"
 
-import { langViewportModes } from "@/storybook/modes"
+import { langViewportModes, variantMode } from "@/storybook/modes"
 
 import { DocsLayout } from "../Docs"
 
@@ -24,7 +24,7 @@ const meta = {
       appDirectory: true,
       navigation: { pathname: "/developers/docs/" },
     },
-    chromatic: { modes: { ...langViewportModes } },
+    chromatic: { modes: variantMode },
     docs: {
       description: {
         component:
@@ -59,7 +59,12 @@ const baseArgs = {
   children: <ArticleBody />,
 }
 
-export const Default: Story = { args: baseArgs }
+// Carries the full responsive + RTL contract for the layout -- the other
+// stories below only need to prove their variant renders.
+export const Default: Story = {
+  parameters: { chromatic: { modes: langViewportModes } },
+  args: baseArgs,
+}
 
 export const Incomplete: Story = {
   parameters: {

--- a/src/layouts/stories/static.stories.tsx
+++ b/src/layouts/stories/static.stories.tsx
@@ -53,8 +53,6 @@ const baseArgs = {
   children: <ArticleBody />,
 }
 
-// Carries the full responsive + RTL contract for the layout -- the other
-// stories below only need to prove their variant renders.
 export const Default: Story = {
   parameters: { chromatic: { modes: langViewportModes } },
   args: baseArgs,

--- a/src/layouts/stories/static.stories.tsx
+++ b/src/layouts/stories/static.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/nextjs"
 
-import { langViewportModes } from "@/storybook/modes"
+import { langViewportModes, variantMode } from "@/storybook/modes"
 
 import { StaticLayout } from "../Static"
 
@@ -18,7 +18,7 @@ const meta = {
   tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
-    chromatic: { modes: { ...langViewportModes } },
+    chromatic: { modes: variantMode },
     docs: {
       description: {
         component:
@@ -53,7 +53,12 @@ const baseArgs = {
   children: <ArticleBody />,
 }
 
-export const Default: Story = { args: baseArgs }
+// Carries the full responsive + RTL contract for the layout -- the other
+// stories below only need to prove their variant renders.
+export const Default: Story = {
+  parameters: { chromatic: { modes: langViewportModes } },
+  args: baseArgs,
+}
 
 export const EditButtonHidden: Story = {
   parameters: {

--- a/src/layouts/stories/topic.stories.tsx
+++ b/src/layouts/stories/topic.stories.tsx
@@ -64,8 +64,6 @@ const baseArgs = {
   children: <ArticleBody />,
 }
 
-// Carries the full responsive + RTL contract for the layout -- the other
-// stories below only need to prove their variant renders.
 export const Default: Story = {
   parameters: { chromatic: { modes: langViewportModes } },
   args: baseArgs,

--- a/src/layouts/stories/topic.stories.tsx
+++ b/src/layouts/stories/topic.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs"
 
 import { staking } from "@/data/topics/staking"
 
-import { langViewportModes } from "@/storybook/modes"
+import { langViewportModes, variantMode } from "@/storybook/modes"
 
 import { TopicLayout } from "../Topic"
 
@@ -20,7 +20,7 @@ const meta = {
   tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
-    chromatic: { modes: { ...langViewportModes } },
+    chromatic: { modes: variantMode },
     docs: {
       description: {
         component:
@@ -64,7 +64,12 @@ const baseArgs = {
   children: <ArticleBody />,
 }
 
-export const Default: Story = { args: baseArgs }
+// Carries the full responsive + RTL contract for the layout -- the other
+// stories below only need to prove their variant renders.
+export const Default: Story = {
+  parameters: { chromatic: { modes: langViewportModes } },
+  args: baseArgs,
+}
 
 export const WithSummaryProse: Story = {
   parameters: {

--- a/src/layouts/stories/tutorial.stories.tsx
+++ b/src/layouts/stories/tutorial.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/nextjs"
 
-import { langViewportModes } from "@/storybook/modes"
+import { langViewportModes, variantMode } from "@/storybook/modes"
 
 import { TutorialLayout } from "../Tutorial"
 
@@ -18,7 +18,7 @@ const meta = {
   tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
-    chromatic: { modes: { ...langViewportModes } },
+    chromatic: { modes: variantMode },
     docs: {
       description: {
         component:
@@ -58,7 +58,12 @@ const baseArgs = {
   children: <ArticleBody />,
 }
 
-export const Default: Story = { args: baseArgs }
+// Carries the full responsive + RTL contract for the layout -- the other
+// stories below only need to prove their variant renders.
+export const Default: Story = {
+  parameters: { chromatic: { modes: langViewportModes } },
+  args: baseArgs,
+}
 
 export const WithSourceAttribution: Story = {
   parameters: {

--- a/src/layouts/stories/tutorial.stories.tsx
+++ b/src/layouts/stories/tutorial.stories.tsx
@@ -58,8 +58,6 @@ const baseArgs = {
   children: <ArticleBody />,
 }
 
-// Carries the full responsive + RTL contract for the layout -- the other
-// stories below only need to prove their variant renders.
 export const Default: Story = {
   parameters: { chromatic: { modes: langViewportModes } },
   args: baseArgs,

--- a/tests/unit/storybook/story-titles.spec.ts
+++ b/tests/unit/storybook/story-titles.spec.ts
@@ -123,14 +123,8 @@ const storyFiles = SEARCH_ROOTS.flatMap(findStoryFiles).sort()
 const sectionFor = (relPath: string): string | null =>
   TAXONOMY.find(({ prefix }) => relPath.startsWith(prefix))?.section ?? null
 
-/**
- * `langViewportModes` referenced anywhere inside `meta` (the usual spread is
- * `chromatic: { modes: { ...langViewportModes } }`) multiplies every story
- * in the file by its full width x locale matrix. With a single story that's
- * no different from putting it on the story directly, so it's only a
- * problem once a file has more than one -- put it on ONE representative
- * story instead. See `.storybook/modes.ts`.
- */
+/** `langViewportModes` on `meta` multiplies every story in the file -- fine
+ * with one story, a problem with more than one. See `.storybook/modes.ts`. */
 const metaSpreadsLangViewportModesAcrossMultipleStories = (
   relPath: string
 ): boolean => {
@@ -233,10 +227,7 @@ test.describe("Storybook title taxonomy", () => {
     expect(
       offenders,
       "put langViewportModes on ONE representative story instead of `meta` -- " +
-        "on meta it multiplies by every story in the file. Use variantMode " +
-        "(or staticModes, for components with no responsive classes at all) " +
-        "on meta, and langViewportModes on the story that should carry the " +
-        "full responsive + RTL contract. See .storybook/modes.ts"
+        "use variantMode (or staticModes) on meta. See .storybook/modes.ts"
     ).toEqual([])
   })
 

--- a/tests/unit/storybook/story-titles.spec.ts
+++ b/tests/unit/storybook/story-titles.spec.ts
@@ -123,6 +123,49 @@ const storyFiles = SEARCH_ROOTS.flatMap(findStoryFiles).sort()
 const sectionFor = (relPath: string): string | null =>
   TAXONOMY.find(({ prefix }) => relPath.startsWith(prefix))?.section ?? null
 
+/**
+ * `langViewportModes` referenced anywhere inside `meta` (the usual spread is
+ * `chromatic: { modes: { ...langViewportModes } }`) multiplies every story
+ * in the file by its full width x locale matrix. With a single story that's
+ * no different from putting it on the story directly, so it's only a
+ * problem once a file has more than one -- put it on ONE representative
+ * story instead. See `.storybook/modes.ts`.
+ */
+const metaSpreadsLangViewportModesAcrossMultipleStories = (
+  relPath: string
+): boolean => {
+  const source = ts.createSourceFile(
+    relPath,
+    readFileSync(path.join(REPO_ROOT, relPath), "utf8"),
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ false,
+    ts.ScriptKind.TSX
+  )
+  const meta = findMetaObject(source)
+  if (!meta) return false
+
+  let found = false
+  const walk = (node: ts.Node) => {
+    if (ts.isIdentifier(node) && node.text === "langViewportModes") {
+      found = true
+      return
+    }
+    ts.forEachChild(node, walk)
+  }
+  walk(meta)
+  if (!found) return false
+
+  const storyCount = source.statements.filter(
+    (stmt) =>
+      ts.isVariableStatement(stmt) &&
+      stmt.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword) &&
+      stmt.declarationList.declarations.some(
+        (d) => ts.isIdentifier(d.name) && d.name.text !== "meta"
+      )
+  ).length
+  return storyCount > 1
+}
+
 test.describe("Storybook title taxonomy", () => {
   test("story files are discovered", () => {
     // Guards against a silently broken walker turning the rest into no-ops.
@@ -181,6 +224,20 @@ test.describe("Storybook title taxonomy", () => {
         : [`${f}: "${actual}" should be "${expected}" (title: ${title})`]
     })
     expect(mismatched).toEqual([])
+  })
+
+  test("langViewportModes is never spread onto meta in a multi-story file", () => {
+    const offenders = storyFiles.filter(
+      metaSpreadsLangViewportModesAcrossMultipleStories
+    )
+    expect(
+      offenders,
+      "put langViewportModes on ONE representative story instead of `meta` -- " +
+        "on meta it multiplies by every story in the file. Use variantMode " +
+        "(or staticModes, for components with no responsive classes at all) " +
+        "on meta, and langViewportModes on the story that should carry the " +
+        "full responsive + RTL contract. See .storybook/modes.ts"
+    ).toEqual([])
   })
 
   test("no two story files share a title", () => {


### PR DESCRIPTION
## Summary

Full Chromatic build: **348 -> 244 snapshots (-30%), no coverage loss.**

`langViewportModes` (8 modes: en x 6 breakpoints, ar x base/lg) was declared on `meta`, so every content variant in a file re-tested the same width x locale matrix. This moves it to ONE representative story per component; other variants get a single desktop snapshot (`variantMode`) instead, since their job is proving the variant renders, not re-proving a responsive contract a sibling story already covers.

| File | Stories | Before | After |
|---|---|---|---|
| `PageHero` | 5 | 40 | 12 |
| `DeveloperDocsLinks` | 3 | 24 | 4 |
| `layouts/stories/{docs,static,topic,tutorial}` | 3 each | 24 each | 10 each |

`DeveloperDocsLinks` has no responsive classes anywhere in its subtree, so its representative story uses `staticModes` (desktop + RTL, no width axis) instead of the full matrix.

`HomeHero`, `HubHero`, `MergeInfographic` and `ContentLayout` are unchanged -- one story each, so there's no duplication to remove.

Didn't touch the width count inside `langViewportModes` itself (still 6 breakpoints) -- most of these components pull in `sm`/`xl` classes through composed children even where the top-level file doesn't use them, so dropping widths there would be a real coverage loss, not a free one.

Mechanism note: Chromatic stacks modes from `meta` and the story rather than replacing them, de-duping by key. `variantMode`'s key must stay `en-lg` so it collapses into `langViewportModes`' own `en-lg` on the representative story instead of adding a 9th snapshot.

## Enforcement

Extends the Storybook title-taxonomy test with a rule that fails when `langViewportModes` is spread onto `meta` in a file with more than one story -- the exact pattern this PR fixes, which had already reappeared four times via copy-paste in #18987.

## Test plan

- [x] `pnpm type-check`, `pnpm lint`, full unit suite all pass
- [x] Verified on a real Chromatic build, not just computed: [build 5540](https://www.chromatic.com/build?appId=63b7ea99632763723c7f4d6b&number=5540) captured **244 snapshots**, matching the math exactly. Passed with 19 new baselines auto-accepted (new mode/story combinations, not regressions) and zero unexpected diffs.
