### PR TITLE
fix: update broken links in developer tutorials and docs

### DIFF
--- a/public/content/developers/docs/mev/index.md
+++ b/public/content/developers/docs/mev/index.md
@@ -211,7 +211,7 @@ Some projects, such as MEV Boost, use the Builder API as part of an overall stru
 
 - [What Is Miner-Extractable Value (MEV)?](https://blog.chain.link/what-is-miner-extractable-value-mev/)
 - [MEV and Me](https://www.paradigm.xyz/2021/02/mev-and-me)
-- [Ethereum is a Dark Forest](https://www.paradigm.xyz/2020/08/ethereum-is-a-dark-forest/)
+- [Ethereum is a Dark Forest](https://www.paradigm.xyz/2020/08/ethereum-is-a-dark-forest)
 - [Escaping the Dark Forest](https://samczsun.com/escaping-the-dark-forest/)
 - [Flashbots: Frontrunning the MEV Crisis](https://medium.com/flashbots/frontrunning-the-mev-crisis-40629a613752)
 - [@bertcmiller's MEV Threads](https://twitter.com/bertcmiller/status/1402665992422047747)

--- a/public/content/developers/tutorials/hello-world-smart-contract-fullstack/index.md
+++ b/public/content/developers/tutorials/hello-world-smart-contract-fullstack/index.md
@@ -329,7 +329,7 @@ main()
   })
 ```
 
-Hardhat does an amazing job of explaining what each of these lines of code does in their [Contracts tutorial](https://hardhat.org/tutorial/testing-contracts.html#writing-tests), we’ve adopted their explanations here.
+Hardhat does an amazing job of explaining what each of these lines of code does in their [Contracts tutorial](https://hardhat.org/tutorial/testing-contracts#writing-tests), we’ve adopted their explanations here.
 
 ```javascript
 const HelloWorld = await ethers.getContractFactory("HelloWorld")
@@ -1199,7 +1199,7 @@ If `window.ethereum` _is not_ present, then that means MetaMask is not installed
 
 Now if `window.ethereum` _is_ present, then that's when things get interesting.
 
-Using a try/catch loop, we'll try to connect to MetaMask by calling [`window.ethereum.request({ method: "eth_requestAccounts" });`](https://docs.metamask.io/guide/rpc-api.html#eth-requestaccounts). Calling this function will open up MetaMask in the browser, whereby the user will be prompted to connect their wallet to your dapp.
+Using a try/catch loop, we'll try to connect to MetaMask by calling [`window.ethereum.request({ method: "eth_requestAccounts" });`](https://docs.metamask.io/wallet/reference/json-rpc-methods/eth_requestaccounts). Calling this function will open up MetaMask in the browser, whereby the user will be prompted to connect their wallet to your dapp.
 
 - If the user chooses to connect, `method: "eth_requestAccounts"` will return an array that contains all of the user's account addresses that connected to the dapp. Altogether, our `connectWallet` function will return a JSON object that contains the _first_ `address` in this array \(see line 9\) and a `status` message that prompts the user to write a message to the smart contract.
 - If the user rejects the connection, then the JSON object will contain an empty string for the `address` returned and a `status` message that reflects that the user rejected the connection.

--- a/public/content/developers/tutorials/hello-world-smart-contract/index.md
+++ b/public/content/developers/tutorials/hello-world-smart-contract/index.md
@@ -312,7 +312,7 @@ main()
   });
 ```
 
-Hardhat does an amazing job of explaining what each of these lines of code does in their [Contracts tutorial](https://hardhat.org/tutorial/testing-contracts.html#writing-tests), we’ve adopted their explanations here.
+Hardhat does an amazing job of explaining what each of these lines of code does in their [Contracts tutorial](https://hardhat.org/tutorial/testing-contracts#writing-tests), we’ve adopted their explanations here.
 
 ```
 const HelloWorld = await ethers.getContractFactory("HelloWorld");

--- a/public/content/developers/tutorials/how-to-write-and-deploy-an-nft/index.md
+++ b/public/content/developers/tutorials/how-to-write-and-deploy-an-nft/index.md
@@ -312,7 +312,7 @@ main()
   })
 ```
 
-Hardhat does an amazing job of explaining what each of these lines of code does in their [Contracts tutorial](https://hardhat.org/tutorial/testing-contracts.html#writing-tests), we’ve adopted their explanations here.
+Hardhat does an amazing job of explaining what each of these lines of code does in their [Contracts tutorial](https://hardhat.org/tutorial/testing-contracts#writing-tests), we’ve adopted their explanations here.
 
     const MyNFT = await ethers.getContractFactory("MyNFT");
 

--- a/public/content/developers/tutorials/nft-minter/index.md
+++ b/public/content/developers/tutorials/nft-minter/index.md
@@ -279,7 +279,7 @@ If `window.ethereum` _is not_ present, then that means MetaMask is not installed
 
 Now if `window.ethereum` _is_ present, then that's when things get interesting.
 
-Using a try/catch loop, we'll try to connect to MetaMask by calling [`window.ethereum.request({ method: "eth_requestAccounts" });`](https://docs.metamask.io/guide/rpc-api.html#eth-requestaccounts). Calling this function will open up MetaMask in the browser, whereby the user will be prompted to connect their wallet to your dapp.
+Using a try/catch loop, we'll try to connect to MetaMask by calling [`window.ethereum.request({ method: "eth_requestAccounts" });`](https://docs.metamask.io/wallet/reference/json-rpc-methods/eth_requestaccounts). Calling this function will open up MetaMask in the browser, whereby the user will be prompted to connect their wallet to your dapp.
 
 - If the user chooses to connect, `method: "eth_requestAccounts"` will return an array that contains all of the user's account addresses that are connected to the dapp. Altogether, our `connectWallet` function will return a JSON object that contains the _first_ `address` in this array \(see line 9\) and a `status` message that prompts the user to write a message to the smart contract.
 - If the user rejects the connection, then the JSON object will contain an empty string for the `address` returned and a `status` message that reflects that the user rejected the connection.


### PR DESCRIPTION
## Description

Several external links in the developer tutorials and docs return 404 because the target pages moved. This updates each to its current location (all verified reachable on 2026-08-17). Only the URLs change; the surrounding content is untouched.

- Hardhat dropped the `.html` suffix from its tutorial URLs (the `#writing-tests` anchor still resolves).
- MetaMask restructured its JSON-RPC method reference.
- The Paradigm "Ethereum is a Dark Forest" article URL returns 404 with the trailing slash.

| Page | Old (404) | New (200) |
| --- | --- | --- |
| `developers/tutorials/hello-world-smart-contract-fullstack` | `hardhat.org/tutorial/testing-contracts.html#writing-tests` | `hardhat.org/tutorial/testing-contracts#writing-tests` |
| `developers/tutorials/hello-world-smart-contract` | `hardhat.org/tutorial/testing-contracts.html#writing-tests` | `hardhat.org/tutorial/testing-contracts#writing-tests` |
| `developers/tutorials/how-to-write-and-deploy-an-nft` | `hardhat.org/tutorial/testing-contracts.html#writing-tests` | `hardhat.org/tutorial/testing-contracts#writing-tests` |
| `developers/tutorials/hello-world-smart-contract-fullstack` | `docs.metamask.io/guide/rpc-api.html#eth-requestaccounts` | `docs.metamask.io/wallet/reference/json-rpc-methods/eth_requestaccounts` |
| `developers/tutorials/nft-minter` | `docs.metamask.io/guide/rpc-api.html#eth-requestaccounts` | `docs.metamask.io/wallet/reference/json-rpc-methods/eth_requestaccounts` |
| `developers/docs/mev` | `paradigm.xyz/2020/08/ethereum-is-a-dark-forest/` | `paradigm.xyz/2020/08/ethereum-is-a-dark-forest` |

## Related Issue

Closes #19089
