### PR TITLE
fix(e2e): assert the real "Similar wallets" heading on wallet detail

### DIFF
--- a/tests/e2e/find-wallet.spec.ts
+++ b/tests/e2e/find-wallet.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test"
 
+import { testData } from "./fixtures/testData"
 import { FindWalletPage } from "./pages/FindWalletPage"
 
 test.describe("Find Wallet Page", () => {
@@ -78,7 +79,9 @@ test.describe("Find Wallet Page", () => {
   test("standalone page lists related wallets", async ({ page }) => {
     await page.goto("/wallets/find-wallet/metamask/")
     const related = page.locator("section").filter({
-      has: page.getByRole("heading", { name: "Related resources" }),
+      has: page.getByRole("heading", {
+        name: testData.content.headings.findWalletRelated,
+      }),
     })
     await expect(related).toBeVisible()
     await expect(

--- a/tests/e2e/fixtures/testData.ts
+++ b/tests/e2e/fixtures/testData.ts
@@ -1,5 +1,6 @@
 import en from "@/intl/en/common.json"
 import enStart from "@/intl/en/page-start.json"
+import enFindWallet from "@/intl/en/page-wallets-find-wallet.json"
 import es from "@/intl/es/common.json"
 
 /**
@@ -39,6 +40,7 @@ export const testData = {
       homepage: en["site-title"],
       startPage: enStart["page-start-meta-title"],
       findWallet: en["nav-find-wallet-label"],
+      findWalletRelated: enFindWallet["page-find-wallet-related-title"],
       notFoundEn: en["we-couldnt-find-that-page"],
       notFoundEs: es["we-couldnt-find-that-page"],
     },


### PR DESCRIPTION
Unblocks the **v11.20.0 release PR** (#19103), whose E2E job fails on `find-wallet.spec.ts:78 › standalone page lists related wallets` across all four browser projects.

## Cause

The test looked for a heading named `"Related resources"`. That string only exists as `page-developers-tools-related-title`. The wallet detail page renders `page-find-wallet-related-title`, whose English value is **"Similar wallets"** — so the locator never resolved.

Not an A/B-test artifact: the `[wallet]` detail route is not A/B tested, and the failure was deterministic across browsers and retries rather than fingerprint-dependent.

Both the test and that intl value landed in the same commit (`b334e61471`). E2E only runs for PRs into `master`/`staging`/`test/**`, and the find-wallet revamp (#18846) and A/B PRs (#18939) both merged into `dev` — so this assertion had never executed in CI until the release PR.

## Fix

Fixing the test rather than the copy: "Similar wallets" is the reviewed string and is already propagated to the other locales, so changing the key’s value would invalidate those translations. The heading is now sourced from the intl JSON via `testData`, matching how `findWallet` and `startPage` already work, so a future copy change cannot silently break the locator again.

## Verification

Ran against the v11.20.0 deploy preview: the full `find-wallet.spec.ts` passes **8/8** on the `e2e` project (previously 1 failing). `pnpm type-check` and ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)