### PR TITLE
fix(release): give /review-release headroom and surface a killed review

### DIFF
--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -217,10 +217,15 @@ jobs:
           node "$(npm root -g)/@playwright/cli/node_modules/playwright-core/cli.js" \
             install --with-deps chromium
 
+      # Sized off observed runtimes, not a guess: v11.19.1 finished in 11m52s,
+      # but v11.20.0 (find-wallet revamp + A/B infrastructure) blew past 20m and
+      # was killed mid-run, so no summary was ever posted. The review's cost
+      # scales with how much of the site the release touches, and a slow runner
+      # adds to it, so keep real headroom above the typical run.
       - name: Run /review-release
         if: steps.wait.outputs.outcome == 'success'
         uses: anthropics/claude-code-action@v1
-        timeout-minutes: 20
+        timeout-minutes: 35
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
@@ -264,6 +269,30 @@ jobs:
             ${{ steps.links.outputs.components && format(':art: Chromatic (components): <{0}>', steps.links.outputs.components) || '' }}
             ${{ steps.links.outputs.pages && format(':framed_picture: Chromatic (pages): <{0}>', steps.links.outputs.pages) || '' }}
             Remaining manual steps: approve Chromatic, approve PR, merge.
+
+      # A killed review is otherwise invisible on the PR itself: the Discord
+      # notice below EDITS the existing release message, so the earlier
+      # "prepared" text is overwritten and easy to miss entirely.
+      - name: Note review gap on the PR
+        if: failure() && steps.wait.outputs.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ needs.prepare.outputs.pr_number }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh pr comment "$PR" --repo "$REPO" --body "$(cat <<EOF
+          ## Automated release review did not complete
+
+          The **wait_and_review** job failed before it could post a /review-release
+          summary — see the [run log]($RUN_URL).
+
+          This release has **not** been automatically reviewed. Re-run the failed
+          job, or run **/review-release $PR --post-comment** locally.
+
+          _Posted automatically so this gap is visible on the PR, not only in Discord._
+          EOF
+          )"
 
       - name: Announce wait-and-review failure
         if: failure()


### PR DESCRIPTION
The v11.20.0 release (#19103) shipped with **no automated review**, and nothing on the PR explained why.

## What happened

`wait_and_review` reached the `/review-release` step and ran it for the full 20 minutes, then GitHub killed it:

```
14:51:43  Run /review-release   started
15:11:56  ##[error]The action has timed out.       ← timeout-minutes: 20
          Terminate orphan process: pid (3696) (claude)
```

The agent was killed mid-run, so it never reached its `gh pr comment` call. From the outside that is indistinguishable from the step never having run.

## Why the cap was too small

It was marginal rather than wrong. Same step, previous release:

| | v11.19.1 | v11.20.0 |
|---|---|---|
| Install playwright-cli | 27s | **11m 27s** |
| Run /review-release | **11m 52s** ✅ | **20m 13s** ❌ killed |

v11.19.1 used 60% of the budget. v11.20.0 carried the find-wallet revamp plus the A/B infrastructure, so there was materially more to open in a browser and verify — the review’s cost scales with how much of the site a release touches. The runner was also slow that day (see the install column), which slows the browser checks inside the step too.

35 minutes leaves real headroom over a typical run while still being well under the job’s own 75-minute limit, so a genuinely wedged agent can’t sit there indefinitely.

## Second change: make a killed review visible on the PR

The existing Discord notice is easy to miss, because `discord-notify` reuses `message_id` — the failure text **edits over** the earlier "release prepared" message instead of arriving as a new one. Meanwhile the PR showed nothing at all.

This adds a step that comments on the PR when the review does not finish, gated on the same wait-succeeded condition as the review itself, so it only fires when a review was actually attempted. Happy to drop this half if you would rather keep the change to the timeout alone.

## Verification

- `weekly-release.yml` parses; the `wait_and_review` step list, `if:` conditions and the new `timeout-minutes: 35` all resolve as intended.
- The new step’s heredoc was dry-run with a stubbed `gh`: variables expand and the comment body renders correctly.

v11.20.0 was reviewed by hand in the meantime — summary posted at #19103 (comment 5331363978).

🤖 Generated with [Claude Code](https://claude.com/claude-code)