### PR TITLE
content(research): refresh active areas of Ethereum research

### DIFF
--- a/public/content/community/research/index.md
+++ b/public/content/community/research/index.md
@@ -91,7 +91,7 @@ Most Ethereum blocks are currently assembled by a small number of specialised bu
 
 ### State growth and statelessness {#state-growth-and-statelessness}
 
-Every full node stores Ethereum's state, so the rate at which that state grows sets a floor on the cost of running one. In the short term, research focuses on repricing the operations that create state and on expiring history that nodes no longer need to keep. In the longer term, the plan is to replace Ethereum's hexary Merkle-Patricia trie with a binary tree that produces much smaller proofs, and to move towards statelessness, so that a node can verify blocks without holding the entire state. Earlier work in this area assumed Verkle trees; the current proposal is a unified binary tree.
+Every full node stores Ethereum's state, so the rate at which that state grows sets a floor on the cost of running one. In the short term, research focuses on repricing the operations that create state and on expiring history that nodes no longer need to keep. In the longer term, the plan is to replace Ethereum's hexary Merkle-Patricia trie with a binary tree that produces much smaller proofs, and to move towards statelessness, so that a node can verify blocks without holding the entire state. Earlier work in this area assumed Verkle trees; the current proposal is a unified binary tree, which carries over the witness gas schedule specified for that earlier line of work.
 
 #### Background reading {#background-reading-22}
 
@@ -195,6 +195,7 @@ Rollups post their data to Ethereum in blobs, and scaling that data layer is a r
 - [Fusaka upgrade](/roadmap/fusaka/)
 - [Danksharding](/roadmap/danksharding/)
 - [Data availability](/developers/docs/data-availability/)
+- [EIP-4844: Shard blob transactions](https://eips.ethereum.org/EIPS/eip-4844)
 - [Proto-Danksharding notes](https://notes.ethereum.org/@vbuterin/proto_danksharding_faq)
 
 #### Recent research {#recent-research-4}

--- a/public/content/community/research/index.md
+++ b/public/content/community/research/index.md
@@ -8,69 +8,116 @@ One of the primary strengths of Ethereum is that an active research and engineer
 
 ## How Ethereum research works {#how-ethereum-research-works}
 
-Ethereum research is open and transparent, embodying principles of [Decentralized Science (DeSci)](https://hackernoon.com/desci-decentralized-science-as-our-chance-to-recover-the-real-science). The culture is to make research tools and outputs as open and interactive as possible, for example, through executable notebooks. Ethereum research moves quickly, with new findings posted and discussed in the open on forums such as [ethresear.ch](https://ethresear.ch/) rather than reaching the community through traditional publications after rounds of peer review.
+Ethereum research is open and transparent. The culture is to make research tools and outputs as open and interactive as possible, for example through executable notebooks. Ethereum research moves quickly, with new findings posted and discussed in the open on forums such as [ethresear.ch](https://ethresear.ch/) rather than reaching the community through traditional publications after rounds of peer review. The Ethereum Foundation also publishes what it is prioritising and why, so anyone can see which problems are currently considered urgent.
 
 ## General research resources {#general-research-resources}
 
 Regardless of the specific topic, there is a wealth of information on Ethereum research to be found at [ethresear.ch](https://ethresear.ch) and the [Eth R&D Discord channel](https://discord.gg/qGpsxSA). These are the primary places where Ethereum researchers discuss the latest ideas and development opportunities.
 
-This report published in May 2022 by [DelphiDigital](https://members.delphidigital.io/reports/the-hitchhikers-guide-to-ethereum) provides a good overview of the Ethereum roadmap.
+For an overview of where the protocol is heading, start with the [Ethereum roadmap](/roadmap/), then read the Ethereum Foundation's [Protocol Priorities Update for 2026](https://blog.ethereum.org/2026/02/18/protocol-priorities-update-2026) and the [protocol cluster updates](https://blog.ethereum.org/2026/05/11/protocol-update-may-26) that report progress against it. [Ethereum Protocol Studies](https://blog.ethereum.org/2026/02/17/ethereum-protocol-studies-26) is a structured entry point for people who want to work on the protocol itself.
 
 ## Sources of Funding {#sources-of-funding}
 
-You can get involved with Ethereum research and get paid for it! For example, [the Ethereum Foundation](/foundation/) recently ran an [Academic Grants funding round](https://esp.ethereum.foundation/academic-grants). You can find information on active and upcoming funding opportunities on [the Ethereum grants page](/community/grants/).
+You can get involved with Ethereum research and get paid for it. [The Ethereum Foundation](/foundation/) funds research and public goods through its [Ecosystem Support Program](https://esp.ethereum.foundation/applicants), which posts wishlist items and requests for proposals describing problems it would like to see solved. You can find information on active and upcoming funding opportunities on [the Ethereum grants page](/community/grants/).
 
 ## Protocol research {#protocol-research}
 
-Protocol research is concerned with Ethereum's base layer - the set of rules defining how nodes connect, communicate, exchange and store Ethereum data and come to consensus about the state of the blockchain. Protocol research gets divided into two top-level categories: consensus and execution.
+Protocol research is concerned with Ethereum's base layer: the set of rules defining how nodes connect, communicate, exchange and store Ethereum data and come to consensus about the state of the blockchain. Its two long-standing categories are consensus and execution, and several research topics now cut across both.
 
 ### Consensus {#consensus}
 
-Consensus research is concerned with [Ethereum's proof-of-stake mechanism](/developers/docs/consensus-mechanisms/pos/). Some example consensus research topics are:
+Consensus research is concerned with [Ethereum's proof-of-stake mechanism](/developers/docs/consensus-mechanisms/pos/): the security of the fork choice rule and the finality gadget, the cryptoeconomics of staking, the peer-to-peer network that carries blocks, attestations and blob data, and the cryptography that validators sign with. Some example consensus research topics are:
 
 - identifying and patching vulnerabilities;
 - quantifying cryptoeconomic security;
-- increasing the security or performance of client implementations;
-- and developing light clients.
+- reducing the time it takes for a block to become final;
+- and improving the efficiency, safety and monitoring of peer-to-peer networking between consensus clients.
 
-As well as forward-looking research, some fundamental redesigns of the protocol, such as single slot finality, are being researched to allow for significant improvements to Ethereum. Furthermore, the efficiency, safety, and monitoring of peer-to-peer networking between consensus clients are also important research topics.
+Much of this work has moved from paper to specification. Data availability sampling shipped in the [Fusaka](/roadmap/fusaka/) upgrade, changes to how blocks are built and how transactions are guaranteed inclusion are specified for upcoming upgrades, and a longer-horizon redesign known as lean consensus is exploring faster finality together with post-quantum signatures.
 
 #### Background reading {#background-reading}
 
 - [Introduction to proof-of-stake](/developers/docs/consensus-mechanisms/pos/)
+- [Single slot finality](/roadmap/single-slot-finality/)
 - [Casper-FFG paper](https://arxiv.org/abs/1710.09437)
-- [Casper-FFG explainer](https://medium.com/unitychain/intro-to-casper-ffg-9ed944d98b2d)
 - [Gasper paper](https://arxiv.org/abs/2003.03052)
+- [lean Ethereum](https://blog.ethereum.org/2025/07/31/lean-ethereum)
 
 #### Recent research {#recent-research}
 
 - [Ethresear.ch Consensus](https://ethresear.ch/c/consensus/29)
 - [Availability/Finality dilemma](https://arxiv.org/abs/2009.04987)
-- [Single slot finality](https://ethresear.ch/t/a-model-for-cumulative-committee-based-finality/10259)
-- [Proposer-builder separation](https://notes.ethereum.org/@vbuterin/pbs_censorship_resistance)
+- [3-slot finality: SSF is not about "single" slot](https://ethresear.ch/t/3-slot-finality-ssf-is-not-about-single-slot/20927)
 
 ### Execution {#execution}
 
-The execution layer is concerned with executing transactions, running the [Ethereum virtual machine (EVM)](/developers/docs/evm/) and generating execution payloads to pass to the consensus layer. There are many active areas of research, including:
+The execution layer is concerned with executing transactions, running the [Ethereum virtual machine (EVM)](/developers/docs/evm/) and generating execution payloads to pass to the consensus layer. Research here divides into two strands: making state cheap to hold and prove, and raising throughput without pushing more cost onto the people running nodes. There are many active areas of research, including:
 
-- building out light client support;
-- researching gas limits;
-- and incorporating new data structures (e.g., Verkle Tries).
+- repricing the gas cost of operations that create state;
+- expiring history that nodes no longer need to serve;
+- block-level access lists that allow transactions to be validated in parallel;
+- multidimensional fee markets that price state, data and computation separately;
+- and proving the execution of L1 blocks with a zkEVM.
 
 #### Background reading {#background-reading-1}
 
-- [Introduction to the EVM](/developers/docs/evm)
+- [Introduction to the EVM](/developers/docs/evm/)
 - [Ethresear.ch execution layer](https://ethresear.ch/c/execution-layer-research/37)
+- [Ethereum execution layer specifications](https://github.com/ethereum/execution-specs)
+- [Database optimizations](https://github.com/erigontech/erigon/blob/main/docs/programmers_guide/db_faq.md)
 
 #### Recent research {#recent-research-1}
 
-- [Database optimizations](https://github.com/ledgerwatch/erigon/blob/devel/docs/programmers_guide/db_faq.md)
-- [State expiry](https://notes.ethereum.org/@vbuterin/state_expiry_eip)
-- [Paths to state expiry](https://hackmd.io/@vbuterin/state_expiry_paths)
-- [Verkle and state expiry proposal](https://notes.ethereum.org/@vbuterin/verkle_and_state_expiry_proposal)
-- [History management](https://eips.ethereum.org/EIPS/eip-4444)
-- [Verkle Trees](https://vitalik.eth.limo/general/2021/06/18/verkle.html)
-- [Data availability sampling](https://github.com/ethereum/research/wiki/A-note-on-data-availability-and-erasure-coding)
+- [EIP-7928: Block-level access lists](https://eips.ethereum.org/EIPS/eip-7928)
+- [EIP-8037: State creation gas cost increase](https://eips.ethereum.org/EIPS/eip-8037)
+- [EIP-7999: Unified multidimensional fee market](https://eips.ethereum.org/EIPS/eip-7999)
+- [EIP-7642: eth/69, history expiry and simpler receipts](https://eips.ethereum.org/EIPS/eip-7642)
+- [Shipping an L1 zkEVM: realtime proving](https://blog.ethereum.org/2025/07/10/realtime-proving)
+
+### Censorship resistance and block building {#censorship-resistance-and-block-building}
+
+Most Ethereum blocks are currently assembled by a small number of specialised builders, which concentrates the power to decide which transactions are included. Research in this area covers bringing the builder market into the protocol itself, so that the roles of proposing and building a block are separated by consensus rules rather than by out-of-protocol software, and giving validators a way to force the inclusion of transactions that builders leave out.
+
+#### Background reading {#background-reading-21}
+
+- [Proposer-builder separation](/roadmap/pbs/)
+- [Single secret leader election](/roadmap/secret-leader-election/)
+
+#### Recent research {#recent-research-21}
+
+- [EIP-7732: Enshrined proposer-builder separation](https://eips.ethereum.org/EIPS/eip-7732)
+- [EIP-7805: Fork-choice enforced inclusion lists](https://eips.ethereum.org/EIPS/eip-7805)
+- [Increasing censorship resistance of transactions under proposer/builder separation](https://notes.ethereum.org/@vbuterin/pbs_censorship_resistance)
+
+### State growth and statelessness {#state-growth-and-statelessness}
+
+Every full node stores Ethereum's state, so the rate at which that state grows sets a floor on the cost of running one. In the short term, research focuses on repricing the operations that create state and on expiring history that nodes no longer need to keep. In the longer term, the plan is to replace Ethereum's hexary Merkle-Patricia trie with a binary tree that produces much smaller proofs, and to move towards statelessness, so that a node can verify blocks without holding the entire state. Earlier work in this area assumed Verkle trees; the current proposal is a unified binary tree.
+
+#### Background reading {#background-reading-22}
+
+- [Statelessness and state expiry](/roadmap/statelessness/)
+- [Ethereum stateless book](https://stateless.fyi/)
+
+#### Recent research {#recent-research-22}
+
+- [EIP-7864: Ethereum state using a unified binary tree](https://eips.ethereum.org/EIPS/eip-7864)
+- [EIP-4762: Statelessness gas cost changes](https://eips.ethereum.org/EIPS/eip-4762)
+- [Why decentralized state is important for Ethereum](https://ethresear.ch/t/why-decentralized-state-is-important-for-ethereum/25622)
+
+### Post-quantum cryptography {#post-quantum-cryptography}
+
+Ethereum's validator signatures and much of its application layer rely on elliptic curve cryptography, which a sufficiently capable quantum computer would break. Making Ethereum quantum resistant means replacing those signatures with hash-based or lattice-based alternatives, keeping signature aggregation efficient enough for a large validator set, and giving existing accounts a migration path. The Ethereum Foundation runs a dedicated post-quantum team, and this is one of the longest-horizon programmes on the roadmap.
+
+#### Background reading {#background-reading-23}
+
+- [Quantum resistance](/roadmap/security/quantum-resistance/)
+- [Post-quantum Ethereum](https://pq.ethereum.org/)
+
+#### Recent research {#recent-research-23}
+
+- [lean Ethereum](https://blog.ethereum.org/2025/07/31/lean-ethereum)
+- [Ethresear.ch cryptography](https://ethresear.ch/c/cryptography/28)
+- [lean Ethereum implementations](https://github.com/leanEthereum)
 
 ## Client Development {#client-development}
 
@@ -80,6 +127,8 @@ An Ethereum node is required to run two pieces of software:
 
 1. a consensus client to keep track of the head of the blockchain, gossip blocks and handle consensus logic
 2. an execution client to support the Ethereum Virtual Machine and execute transactions and smart contracts
+
+New classes of client are being prototyped alongside those two, including clients that prove the execution of L1 blocks and lean consensus clients built around post-quantum signatures.
 
 See the [nodes and clients page](/developers/docs/nodes-and-clients/) for more details on nodes and clients and for a list of all current client implementations. You can also find a history of all Ethereum upgrades on the [history page](/ethereum-forks/).
 
@@ -91,130 +140,145 @@ See the [nodes and clients page](/developers/docs/nodes-and-clients/) for more d
 ### Consensus Clients {#consensus-clients}
 
 - [Consensus client specification](https://github.com/ethereum/consensus-specs)
-- [Beacon API specification](https://ethereum.github.io/beacon-APIs/#/Beacon/getStateRoot)
+- [Beacon API specification](https://ethereum.github.io/beacon-APIs/)
+
+### zkEVM clients {#zkevm-clients}
+
+- [zkEVM](/roadmap/zkevm/)
+- [Ethproofs](https://ethproofs.org/)
+- [Shipping an L1 zkEVM: the security foundations](https://blog.ethereum.org/2025/12/18/zkevm-security-foundations)
 
 ## Scaling and performance {#scaling-and-performance}
 
-Scaling Ethereum is a large area of focus for Ethereum researchers. Current approaches include offloading transactions onto rollups and making them as cheap as possible using data blobs. Introductory information on scaling Ethereum is available on our [scaling page](/developers/docs/scaling).
+Scaling Ethereum is a large area of focus for Ethereum researchers, and it runs on two tracks at the same time: raising the throughput of layer 1 itself, and moving execution onto rollups that post their data to Ethereum. Current work includes increasing the block gas limit, repricing state growth, expanding blob capacity for rollup data, and reducing what a node has to store and verify. Introductory information on scaling Ethereum is available on our [scaling page](/developers/docs/scaling/) and the [scaling roadmap](/roadmap/scaling/).
 
 ### Layer 2 {#layer-2}
 
-There are now several Layer 2 protocols that scale Ethereum using different techniques for batching transactions and securing them on Ethereum layer 1. This is a very rapidly growing topic with a lot of research and development potential.
+There are now several Layer 2 protocols that scale Ethereum using different techniques for batching transactions and securing them on Ethereum layer 1. Open research includes reducing the latency and cost of proving, shortening the time it takes for a transaction to reach trustless finality, and giving users a single coherent experience across many rollups.
 
 #### Background reading {#background-reading-2}
 
 - [Introduction to layer 2](/layer-2/)
-- [Polynya: Rollups, DA and modular chains](https://polynya.medium.com/rollups-data-availability-layers-modular-blockchains-introductory-meta-post-5a1e7a60119d)
+- [L2BEAT: scaling summary](https://l2beat.com/scaling/summary)
+- [A rollup-centric ethereum roadmap](https://ethereum-magicians.org/t/a-rollup-centric-ethereum-roadmap/4698)
 
 #### Recent research {#recent-research-2}
 
-- [Arbitrum's fair-ordering for sequencers](https://eprint.iacr.org/2021/1465)
 - [Ethresear.ch Layer 2](https://ethresear.ch/c/layer-2/32)
-- [Rollup-centric roadmap](https://ethereum-magicians.org/t/a-rollup-centric-ethereum-roadmap/4698)
-- [L2Beat](https://l2beat.com/)
+- [L2BEAT: onchain costs](https://l2beat.com/scaling/costs)
+- [Building on Ethereum in 2026: what has changed](/latest/building-on-ethereum-in-2026/)
 
-### Bridges {#bridges}
+### Interoperability {#interoperability}
 
-One particular area of layer 2 that requires more research and development is safe and performant bridges. This includes bridges between various Layer 2s and bridges between Layer 1 and Layer 2. This is a particularly important area of research because bridges are commonly targeted by hackers.
+Users and assets are spread across Ethereum layer 1 and many layer 2s, and the research problem is letting them move and act across those chains without trusting an intermediary. Work here covers intent-based transfers, standardised cross-chain addressing and naming, general message passing, and chain abstraction at the wallet level. This replaces a model in which custodial bridges held the assets, and bridges have historically been one of the largest sources of losses in the ecosystem, so the security of any cross-chain mechanism remains a central concern.
 
 #### Background reading {#background-reading-3}
 
 - [Introduction to blockchain bridges](/bridges/)
-- [Vitalik on bridges](https://old.reddit.com/r/ethereum/comments/rwojtk/ama_we_are_the_efs_research_team_pt_7_07_january/hrngyk8/)
-- [Blockchain bridges article](https://medium.com/1kxnetwork/blockchain-bridges-5db6afac44f8)
-- [Value locked in bridges](<https://dune.com/eliasimos/Bridge-Away-(from-Ethereum)>)
+- [Making Ethereum feel like one chain again](https://blog.ethereum.org/2025/11/18/eil)
+- [Open Intents Framework](https://openintents.xyz/)
+- [Validating bridges](https://stonecoldpat.github.io/images/validatingbridges.pdf)
 
 #### Recent research {#recent-research-3}
 
-- [Validating bridges](https://stonecoldpat.github.io/images/validatingbridges.pdf)
+- [ERC-7683: Cross chain intents](https://eips.ethereum.org/EIPS/eip-7683)
+- [ERC-7930: Interoperable addresses](https://eips.ethereum.org/EIPS/eip-7930)
+- [ERC-7828: Interoperable names](https://eips.ethereum.org/EIPS/eip-7828)
 
-### Sharding {#sharding}
+### Data availability and blob scaling {#data-availability-and-blob-scaling}
 
-Sharding Ethereum's blockchain has long been part of the development roadmap. However, new scaling solutions such as "Danksharding" are currently taking center stage.
-
-The precursor to full Danksharding known as Proto-Danksharding went live with the Cancun-Deneb ("Dencun") network upgrade.
-
-[More about the Dencun upgrade](/roadmap/dencun/)
+Rollups post their data to Ethereum in blobs, and scaling that data layer is a research problem in its own right, separate from scaling execution. Ethereum now uses data availability sampling, so validators can verify that blob data was published by sampling parts of it instead of downloading all of it, and blob capacity is raised incrementally through dedicated blob-parameter-only forks. Open questions include how far sampling can be pushed, how to keep bandwidth requirements manageable for people staking at home, and how blob pricing should respond to demand.
 
 #### Background reading {#background-reading-4}
 
+- [PeerDAS](/roadmap/fusaka/peerdas/)
+- [Fusaka upgrade](/roadmap/fusaka/)
+- [Danksharding](/roadmap/danksharding/)
+- [Data availability](/developers/docs/data-availability/)
 - [Proto-Danksharding notes](https://notes.ethereum.org/@vbuterin/proto_danksharding_faq)
-- [Bankless Danksharding video](https://www.youtube.com/watch?v=N5p0TB77flM)
-- [Ethereum Sharding Research Compendium](https://notes.ethereum.org/@serenity/H1PGqDhpm?type=view)
-- [Danksharding (Polynya)](https://polynya.medium.com/danksharding-36dc0c8067fe)
 
 #### Recent research {#recent-research-4}
 
-- [EIP-4844: Proto-Danksharding](https://eips.ethereum.org/EIPS/eip-4844)
-- [Vitalik on sharding and data availability sampling](https://hackmd.io/@vbuterin/sharding_proposal)
+- [EIP-7594: PeerDAS](https://eips.ethereum.org/EIPS/eip-7594)
+- [EIP-7892: Blob parameter only hardforks](https://eips.ethereum.org/EIPS/eip-7892)
+- [Ethresear.ch Sharding](https://ethresear.ch/c/sharding/6)
 
 ### Hardware {#hardware}
 
-[Running nodes](/developers/docs/nodes-and-clients/run-a-node/) on modest hardware is fundamental to keeping Ethereum decentralized. Therefore, active research into minimizing the hardware requirements to run nodes is an important area of research.
+[Running nodes](/developers/docs/nodes-and-clients/run-a-node/) on modest hardware is fundamental to keeping Ethereum decentralized, so every increase in throughput has to be weighed against what it costs a node operator. With the block gas limit rising and further increases planned, active research covers state growth and how to price it, sync and database performance on larger state, the disk savings available from history expiry, and eventually statelessness.
 
 #### Background reading {#background-reading-5}
 
+- [Spin up your own Ethereum node](/developers/docs/nodes-and-clients/run-a-node/)
+- [Statelessness and state expiry](/roadmap/statelessness/)
 - [Ethereum on ARM](https://ethereum-on-arm-documentation.readthedocs.io/en/latest/)
 
 #### Recent research {#recent-research-5}
 
-- [ecdsa on FPGAs](https://ethresear.ch/t/does-ecdsa-on-fpga-solve-the-scaling-problem/6738)
+- [Scaling Ethereum: the path to a higher gas limit and beyond](https://ethpandaops.io/posts/gaslimit-scaling/)
+- [EIP-8261: Gas limit schedule](https://eips.ethereum.org/EIPS/eip-8261)
+- [EIP-8037: State creation gas cost increase](https://eips.ethereum.org/EIPS/eip-8037)
 
 ## Security {#security}
 
-Security is a broad topic that might include spam/scam prevention, wallet security, hardware security, crypto-economic security, bug hunting and testing of applications and client software and key-management. Contributing to knowledge in these areas will help stimulate mainstream adoption.
+Security is a broad topic that might include spam and scam prevention, wallet security, hardware security, crypto-economic security, censorship resistance, post-quantum readiness, bug hunting, and the testing and verification of applications and client software. Ethereum's [security roadmap](/roadmap/security/) covers the protocol-level work.
 
 ### Cryptography & ZKP {#cryptography--zkp}
 
-Zero-knowledge proofs (ZKP) and cryptography are critical for building privacy and security into Ethereum and its applications. Zero-knowledge is a relatively young but fast-moving space with many open research and development opportunities. Some possibilities include developing more efficient implementations of the [Keccak hashing algorithm](https://hackmd.io/sK7v0lr8Txi1bgION1rRpw?view#Overview), finding better polynomial commitments than currently exist or reducing the cost of ecdsa public key generation and signature verification circuits.
+Zero-knowledge proofs (ZKP) and cryptography are critical for building privacy and security into Ethereum and its applications. Zero-knowledge proving has moved from research into production infrastructure: provers that prove real Ethereum blocks are now benchmarked publicly on latency, cost and soundness. The open problems have shifted accordingly, towards proving L1 blocks fast enough to do it in real time, accounting rigorously for the security of the proof systems in use, and preparing for post-quantum cryptography.
 
 #### Background reading {#background-reading-6}
 
-- [0xparc blog](https://0xparc.org/blog)
-- [zkp.science](https://zkp.science/)
+- [zkEVM](/roadmap/zkevm/)
+- [Privacy](/roadmap/privacy/)
 - [Zero Knowledge podcast](https://zeroknowledge.fm/)
 
 #### Recent research {#recent-research-6}
 
-- [Recent advance in elliptic curve cryptography](https://ethresear.ch/t/the-ec-fft-algorithm-without-elliptic-curve-and-isogenies/11346)
 - [Ethresear.ch ZK](https://ethresear.ch/c/zk-s-nt-arks/13)
+- [Ethresear.ch cryptography](https://ethresear.ch/c/cryptography/28)
+- [Soundness calculator for hash-based zkEVM proof systems](https://github.com/ethereum/soundcalc)
+- [Shipping an L1 zkEVM: the security foundations](https://blog.ethereum.org/2025/12/18/zkevm-security-foundations)
 
 ### Wallets {#wallets}
 
-Ethereum wallets can be browser extensions, desktop and mobile apps or smart contracts on Ethereum. There is active research into social recovery wallets that reduce some of the risk associated with individual-user key management. Associated with development of wallets is research into alternative forms of account abstraction, which is an important area of nascent research.
+Ethereum wallets can be browser extensions, desktop and mobile apps or smart contracts on Ethereum. Account abstraction is no longer experimental: ERC-4337 provides smart accounts without protocol changes, and EIP-7702 lets an ordinary account set code so that transaction batching, gas sponsorship and social recovery work with the address a user already has. Open research now centres on native account abstraction in the protocol itself, on modular and auditable account architectures, and on key management and recovery that ordinary people can operate safely.
 
 #### Background reading {#background-reading-7}
 
 - [Introduction to wallets](/wallets/)
 - [Introduction to wallet security](/security/)
-- [Ethresear.ch Security](https://ethresear.ch/tag/security)
-- [EIP-2938 Account Abstraction](https://eips.ethereum.org/EIPS/eip-2938)
-- [EIP-4337 Account Abstraction](https://eips.ethereum.org/EIPS/eip-4337)
+- [Account abstraction](/roadmap/account-abstraction/)
+- [EIP-7702](/roadmap/pectra/7702/)
+- [Ethresear.ch Security](https://ethresear.ch/c/security/25)
 
 #### Recent research {#recent-research-7}
 
+- [EIP-8141: Frame transaction](https://eips.ethereum.org/EIPS/eip-8141)
+- [ERC-5792: Wallet call API](https://eips.ethereum.org/EIPS/eip-5792)
+- [ERC-6963: Multi injected provider discovery](https://eips.ethereum.org/EIPS/eip-6963)
 - [Validation focused smart contract wallets](https://ethereum-magicians.org/t/validation-focused-smart-contract-wallets/6603)
-- [The future of accounts](https://ethereum-magicians.org/t/validation-focused-smart-contract-wallets/6603)
-- [EIP-3074 AUTH and AUTHCALL Opcodes](https://eips.ethereum.org/EIPS/eip-3074)
-- [Publishing code at an EOA address](https://eips.ethereum.org/EIPS/eip-5003)
 
 ## Community, education and outreach {#community-education-and-outreach}
 
 Onboarding new users onto Ethereum requires new educational resources and approaches to outreach. This might include blog posts and articles, books, podcasts, memes, teaching resources, events and anything else that builds communities, welcomes new starters and educates people about Ethereum.
 
-### UX/UI {#uxui}
+### Design and UX {#design-and-ux}
 
-To onboard more people onto Ethereum, the ecosystem must improve the UX/UI. This will require designers and product experts to re-examine the design of wallets and apps.
+To onboard more people onto Ethereum, the ecosystem must improve its design and user experience. This requires designers and product experts to re-examine how wallets and apps work, and it increasingly means designing against standards that already exist: batched wallet calls, gas sponsorship, accounts that can be recovered, and human-readable addresses that carry the chain they belong to. There are comparatively few canonical venues for web3 UX research, so published studies and design guidance tend to be scattered.
 
 #### Background reading {#background-reading-8}
 
-- [Ethresear.ch UX/UI](https://ethresear.ch/c/ui-ux/24)
+- [Design and UX in web3](/developers/docs/design-and-ux/)
+- [Ethereum user experience roadmap](/roadmap/user-experience/)
+- [Web3 Design Playbook](https://learnweb3.design/)
+- [Web3 UX Design Handbook](https://web3ux.design/)
 
 #### Recent research {#recent-research-8}
 
-- [Web3 Design Discord](https://discord.gg/FsCFPMTSm9)
-- [Web3 Design Principles](https://www.web3designprinciples.com/)
-- [Ethereum Magicians UX discussion](https://ethereum-magicians.org/t/og-council-ux-follow-up/9032/3)
+- [Ethresear.ch UX/UI](https://ethresear.ch/c/ui-ux/24)
+- [ERC-5792: Wallet call API](https://eips.ethereum.org/EIPS/eip-5792)
+- [ERC-7828: Interoperable names](https://eips.ethereum.org/EIPS/eip-7828)
 
 ### Economics {#economics}
 
@@ -223,17 +287,17 @@ Economics research in Ethereum broadly follows two approaches: validate the secu
 #### Background reading {#background-reading-9}
 
 - [Robust Incentives Group](https://rig.ethereum.org/)
-- [ETHconomics workshop at Devconnect](https://www.youtube.com/playlist?list=PLTLjFJ0OQOj5PHRvA2snoOKt2udVsyXEm)
+- [Ethereum economics masterclass and economic model](https://github.com/CADLabs/ethereum-economic-model)
 
 #### Recent research {#recent-research-9}
 
-- [Empirical analysis of EIP1559](https://arxiv.org/abs/2201.05574)
+- [Ethresear.ch Economics](https://ethresear.ch/c/economics/16)
 - [Circulating supply equilibrium](https://ethresear.ch/t/circulating-supply-equilibrium-for-ethereum-and-minimum-viable-issuance-during-the-proof-of-stake-era/10954)
 - [Quantifying MEV: How dark is the forest?](https://arxiv.org/abs/2101.05511)
 
 ### Blockspace and fee markets {#blockspace-fee-markets}
 
-Blockspace markets govern the inclusion of end-user transactions, either directly on Ethereum (Layer 1) or on bridged networks, e.g., rollups (Layer 2). On Ethereum, transactions are submitted to the fee market deployed in-protocol as EIP-1559, protecting the chain from spam and pricing congestion. On both layers, transactions may produce externalities, known as Maximal Extractable Value (MEV), which induce new market structures to capture or manage these externalities.
+Blockspace markets govern the inclusion of end-user transactions, either directly on Ethereum (Layer 1) or on bridged networks, e.g., rollups (Layer 2). On Ethereum, transactions are submitted to the fee market deployed in-protocol as EIP-1559, protecting the chain from spam and pricing congestion. On both layers, transactions may produce externalities, known as Maximal Extractable Value (MEV), which induce new market structures to capture or manage these externalities. Current work extends this to pricing several resources at once, since state, data and computation congest independently, and to changing who assembles blocks and on what terms.
 
 #### Background reading {#background-reading-10}
 
@@ -244,22 +308,23 @@ Blockspace markets govern the inclusion of end-user transactions, either directl
 
 #### Recent research {#recent-research-10}
 
-- [Multidimensional EIP-1559 video presentation](https://youtu.be/QbR4MTgnCko)
+- [EIP-7999: Unified multidimensional fee market](https://eips.ethereum.org/EIPS/eip-7999)
+- [EIP-7928: Block-level access lists](https://eips.ethereum.org/EIPS/eip-7928)
 - [Cross domain MEV](https://arxiv.org/abs/2112.01472)
-- [MEV auctions](https://ethresear.ch/t/mev-auction-auctioning-transaction-ordering-rights-as-a-solution-to-miner-extractable-value/6788)
 
 ### Proof-of-stake incentives {#proof-of-stake-incentives}
 
-Validators use Ethereum's native asset (ether) as collateral against dishonest behavior. The cryptoeconomics of this determines the security of the network. Sophisticated validators may be able to exploit the nuances of the incentive layer to launch explicit attacks.
+Validators use Ethereum's native asset (ether) as collateral against dishonest behavior. The cryptoeconomics of this determines the security of the network. Sophisticated validators may be able to exploit the nuances of the incentive layer to launch explicit attacks. Since the Pectra upgrade, validators can also hold and earn on a much larger effective balance and consolidate several validators into one, which changes the economics of running them.
 
 #### Background reading {#background-reading-11}
 
+- [Maximum effective balance](/roadmap/pectra/maxeb/)
 - [Ethereum economics masterclass and economic model](https://github.com/CADLabs/ethereum-economic-model)
 - [Simulations of PoS incentives (Robust Incentives Group)](https://ethereum.github.io/beaconrunner/)
 
 #### Recent research {#recent-research-11}
 
-- [Increasing censorship resistance of transactions under proposer/builder separation (PBS)](https://notes.ethereum.org/s3JToeApTx6CKLJt8AbhFQ)
+- [Robust Incentives Group](https://rig.ethereum.org/)
 - [Three Attacks on PoS Ethereum](https://arxiv.org/abs/2110.10086)
 
 ### Liquid staking and derivatives {#liquid-staking-and-derivatives}
@@ -270,42 +335,58 @@ Liquid staking allows users with less than 32 ETH to receive staking yields by s
 
 - [Ethresear.ch liquid staking](https://ethresear.ch/search?q=liquid%20staking)
 - [Lido: The road to trustless Ethereum staking](https://blog.lido.fi/the-road-to-trustless-ethereum-staking/)
-- [Rocket Pool: Staking protocol introduction](https://medium.com/rocket-pool/rocket-pool-staking-protocol-part-1-8be4859e5fbd)
 
 #### Recent research {#recent-research-12}
 
-- [Handling withdrawals from Lido](https://ethresear.ch/t/handling-withdrawals-in-lidos-eth-liquid-staking-protocol/8873)
-- [Withdrawal credentials](https://ethresear.ch/t/withdrawal-credential-rotation-from-bls-to-eth1/8722)
 - [The risks of Liquid Staking Derivatives](https://notes.ethereum.org/@djrtwo/risks-of-lsd)
+- [Handling withdrawals from Lido](https://ethresear.ch/t/handling-withdrawals-in-lidos-eth-liquid-staking-protocol/8873)
 
 ## Testing {#testing}
 
+### Client and network testing {#client-and-network-testing}
+
+Ethereum's specifications are executable, and the test fixtures generated from them are what client teams check their implementations against. Alongside those, shared test harnesses run clients against each other and against deliberately hostile network conditions, and public testnets exercise upgrades before they reach mainnet. Improving this infrastructure is some of the highest-leverage work available, because it is how bugs are caught before they reach users.
+
+#### Background reading {#background-reading-24}
+
+- [Ethereum execution layer specifications](https://github.com/ethereum/execution-specs)
+- [Consensus client specification](https://github.com/ethereum/consensus-specs)
+
+#### Recent research {#recent-research-24}
+
+- [hive, an end-to-end client test harness](https://github.com/ethereum/hive)
+- [Assertoor, a testnet testing tool](https://github.com/ethpandaops/assertoor)
+
 ### Formal verification {#formal-verification}
 
-Formal verification is writing code to verify that Ethereum's consensus specifications are correct and bug-free. There is an executable version of the specification written in Python that requires maintenance and development. Further research can help to improve the Python implementation of the specification and add tools that can more robustly verify correctness and identify issues.
+Formal verification uses machine-checked mathematical proof to establish that a specification or an implementation behaves as intended. In Ethereum this covers proving that EVM implementations match a formal semantics, proving the soundness of the circuits and proof systems that zero-knowledge provers rely on, and verifying the cryptographic primitives underneath them. Further research can strengthen these proofs and extend them to more of the stack.
 
 #### Background reading {#background-reading-13}
 
-- [Introduction to formal verification](https://ptolemy.berkeley.edu/projects/embedded/research/vis/doc/VisUser/vis_user/node4.html)
+- [Verified zkEVMs](https://verified-zkevm.org/)
 - [Formal Verification (Intel)](https://www.cl.cam.ac.uk/~jrh13/papers/mark10.pdf)
 
 #### Recent research {#recent-research-13}
 
+- [Verified zkEVM project overview](https://github.com/Verified-zkEVM/Overview)
+- [KEVM: semantics of the EVM in K](https://github.com/runtimeverification/evm-semantics)
 - [Formal verification of the deposit contract](https://github.com/runtimeverification/deposit-contract-verification)
-- [Formal verification of the Beacon Chain specification](https://github.com/runtimeverification/deposit-contract-verification)
 
 ## Data science and analytics {#data-science-and-analytics}
 
-There is a need for more data analysis tools and dashboards that give detailed information about activity on Ethereum and the health of the network.
+There is a need for more data analysis tools and dashboards that give detailed information about activity on Ethereum and the health of the network. Much of the underlying data is public and queryable, so the gap is usually in analysis and presentation rather than in access.
 
 ### Background reading {#background-reading-14}
 
 - [Dune Analytics](https://dune.com/browse/dashboards)
 - [Client diversity dashboard](https://clientdiversity.org/)
+- [Ethereum JSON-RPC execution API specification](https://ethereum.github.io/execution-apis/)
 
 #### Recent research {#recent-research-14}
 
 - [Robust Incentives Group Data Analysis](https://rig.ethereum.org/)
+- [ethPandaOps open data](https://ethpandaops.io/data/)
+- [L2BEAT: scaling summary](https://l2beat.com/scaling/summary)
 
 ## Apps and tooling {#apps-and-tooling}
 
@@ -323,7 +404,7 @@ Decentralized finance (DeFi) is one of the primary classes of application built 
 #### Recent research {#recent-research-15}
 
 - [Decentralized finance, centralized ownership?](https://arxiv.org/pdf/2012.09306.pdf)
-- [Optimism: The road to sub-dollar transactions](https://medium.com/ethereum-optimism/the-road-to-sub-dollar-transactions-part-2-compression-edition-6bb2890e3e92)
+- [Ethresear.ch Applications](https://ethresear.ch/c/applications/18)
 
 ### DAOs {#daos}
 
@@ -332,7 +413,6 @@ An impactful use case for Ethereum is the ability to organize in a decentralized
 #### Background reading {#background-reading-16}
 
 - [Introduction to DAOs](/dao/)
-- [Dao Collective](https://daocollective.xyz/)
 
 #### Recent research {#recent-research-16}
 
@@ -346,13 +426,13 @@ Tools for Ethereum developers are rapidly improving. There is lots of active res
 
 - [Tooling by programming language](/developers/docs/programming-languages/)
 - [Developer Frameworks](/developers/docs/frameworks/)
-- [Consensus developer tools list](https://github.com/ConsenSys/ethereum-developer-tools-list)
+- [Introduction to dapps](/developers/docs/dapps/)
 - [Token standards](/developers/docs/standards/tokens/)
-- [CryptoDevHub: EVM Tools](https://cryptodevhub.io/wiki/ethereum-virtual-machine-tools)
 
 #### Recent research {#recent-research-17}
 
-- [Eth R&D Discord Consensus Tooling channel](https://discordapp.com/channels/595666850260713488/746343380900118528)
+- [Eth R&D Discord](https://discord.gg/qGpsxSA)
+- [Ethereum execution API specifications](https://github.com/ethereum/execution-apis)
 
 ### Oracles {#oracles}
 
@@ -365,7 +445,6 @@ Oracles import offchain data onto the blockchain in a permissionless and decentr
 #### Recent research {#recent-research-18}
 
 - [Survey of blockchain oracles](https://arxiv.org/pdf/2004.07140.pdf)
-- [Chainlink white paper](https://chain.link/whitepaper)
 
 ### App security {#app-security}
 
@@ -373,9 +452,10 @@ Hacks on Ethereum generally exploit vulnerabilities in individual applications r
 
 #### Background reading {#background-reading-19}
 
-- [Wormhole exploit report](https://blog.chainalysis.com/reports/wormhole-hack-february-2022/)
+- [Smart contract security](/developers/docs/smart-contracts/security/)
+- [Wormhole exploit report](https://www.chainalysis.com/blog/wormhole-hack-february-2022/)
 - [List of Ethereum contract hack post-mortems](https://forum.openzeppelin.com/t/list-of-ethereum-smart-contracts-post-mortems/1191)
-- [Rekt News](https://x.com/RektHQ?s=20&t=3otjYQdM9Bqk8k3n1a1Adg)
+- [Rekt News](https://rekt.news/)
 
 #### Recent research {#recent-research-19}
 
@@ -383,15 +463,16 @@ Hacks on Ethereum generally exploit vulnerabilities in individual applications r
 
 ### Technology stack {#technology-stack}
 
-Decentralizing the entire Ethereum tech stack is an important research area. Currently, dapps on Ethereum commonly have some points of centralization because they rely on centralized tooling or infrastructure.
+Decentralizing the entire Ethereum tech stack is an important research area. Currently, dapps on Ethereum commonly have some points of centralization because they rely on centralized tooling or infrastructure. Reducing that reliance means making it practical for applications to read Ethereum without trusting a single provider, which is where light clients and trustless access to node data come in.
 
 #### Background reading {#background-reading-20}
 
 - [Ethereum stack](/developers/docs/ethereum-stack/)
-- [Coinbase: Intro to Web3 Stack](https://blog.coinbase.com/a-simple-guide-to-the-web3-stack-785240e557f0)
+- [Light clients](/developers/docs/nodes-and-clients/light-clients/)
 - [Introduction to smart contracts](/developers/docs/smart-contracts/)
 - [Introduction to decentralized storage](/developers/docs/storage/)
 
 #### Recent research {#recent-research-20}
 
 - [Smart contract composability](/developers/docs/smart-contracts/composability/)
+- [Coinbase: Intro to Web3 Stack](https://www.coinbase.com/blog/a-simple-guide-to-the-web3-stack)


### PR DESCRIPTION
## Description

Refreshes `/community/research/`, whose last substantive edit was `3f1c3b14e0` (2024-03-14). Everything since has been punctuation, link rewrites, or the June 2026 `title` to `metaTitle` refactor, so the page described a pre-Pectra Ethereum while advertising "Page last update: June 6, 2026" (the date is git-derived).

Structure and voice are preserved. Existing prose is kept where it is still accurate, and existing heading anchors are kept where sections are unchanged, so the translation manifests only lose their incremental mapping for sections that genuinely changed.

### Factual corrections

- **Three Withdrawn EIPs removed.** EIP-2938 ("Very out of date; needs rewrite"), EIP-3074 and EIP-5003 (both "Superseded by EIP-7702"). EIP-4444 is Stagnant and is replaced by EIP-7642 (eth/69), the history expiry that actually shipped in Fusaka.
- **Verkle replaced by the binary tree.** EIP-6800 is Stagnant; the live proposal is EIP-7864. The three Verkle links were pointing readers at an abandoned direction.
- **Account abstraction is no longer called "nascent research."** ERC-4337 and EIP-7702 are Final, and 7702 has been live on mainnet since Pectra. Native AA (EIP-8141) is cited as the part that is still open.
- **Data availability updated to what shipped.** PeerDAS (EIP-7594) and blob parameter only forks (EIP-7892), rather than Dencun as the frontier.
- Liquid staking's "less than 32 ETH" framing is deliberately **unchanged**: EIP-7251 raised the ceiling to 2048 ETH but 32 ETH is still the minimum to activate a validator. The section gains the MaxEB consolidation dimension instead.

### Link fixes

- **`cryptodevhub.io` removed.** It now 301s to an Indonesian slot-gambling site, so the page was sending readers to gambling spam.
- Removed: `web3designprinciples.com` (404), `daocollective.xyz` (dead domain, parking IP), the Web3 Design Discord invite (Discord API: `Invite is expired`, code 50270), and the archived `ConsenSys/ethereum-developer-tools-list`.
- Fixed moved targets: erigon (`ledgerwatch` to `erigontech`, `devel` to `main`), chainalysis, coinbase.
- Fixed the `beacon-APIs` link to the spec root; the `#/Beacon/getStateRoot` anchor is JS-rendered and unverifiable.
- Fixed two duplicate-URL pairs where one label misdescribed its target ("The future of accounts", "Formal verification of the Beacon Chain specification") and the mislabelled `eprint.iacr.org/2021/1465`, which is the *Themis* paper rather than an Arbitrum paper.

### New sections

Censorship resistance and block building; state growth and statelessness; post-quantum cryptography; zkEVM clients; client and network testing. These cover work that is specified or shipped and had no presence on the page.

### Renamed sections

- **Bridges to Interoperability**, following [Making Ethereum Feel Like One Chain Again](https://blog.ethereum.org/2025/11/18/eil) and the ERC-7930/7828/7683 line of work. `/bridges/` stays as the first background link.
- **Sharding to "Data availability and blob scaling"**, since PeerDAS and BPO forks are what shipped. `/roadmap/danksharding/` stays as a background link so the older term remains discoverable.

"Formal verification" now describes machine-checked proof (verified-zkevm.org, KEVM) and the executable-specification and test-harness material moved to the testing section, where `execution-spec-tests` being archived into `execution-specs` is reflected.

The UX section now leads with the maintained `/developers/docs/design-and-ux/` hub and the wallet UX standards that exist today (ERC-5792, ERC-6963, ERC-7828), replacing two dead community links.

## Verification

- All **100 external links checked**: 96 return 200. The other 4 are Cloudflare or ResearchGate bot walls on pre-existing links (Dune, two Coinbase, ResearchGate) that work in a browser. **No dead links remain.**
- Every EIP status read from upstream frontmatter rather than from memory.
- Every internal path verified against this repo, including that `/layer-2/` and `/wallets/` are React routes rather than markdown.
- `markdownlint-cli2` clean on the file and repo-wide (342 files, 0 errors).
- Page renders locally at `/community/research/` with HTTP 200 and no MDX errors.
- I did not run the Playwright unit suite locally; CI covers it. This is a content-only change and touches no code.

Deliberately **not** asserted in the page: any Glamsterdam mainnet date. EIP-7773's activation table is empty and no `GLOAS_FORK_EPOCH` exists in the eth-clients configs, so the page links `/roadmap/glamsterdam/` and lets that page carry the timing.

## Translations

No translation files touched, per `AGENTS.md` ("Do not hand-propagate English changes into non-English files") and the intl-pipeline skill. Note that the pipeline cron was disabled in #19054, so propagation needs a manual `workflow_dispatch`. Expect `needs translations`.

Because several sections were restructured, the intl-pipeline drift manifests keyed by anchor id will lose their incremental mapping for those sections and retranslate them in full. Existing anchors were preserved wherever a section was unchanged to keep that churn as small as possible.

## Related Issue

Fixes #19106

🤖 Generated with [Claude Code](https://claude.com/claude-code)
