### PR TITLE
[recovery] fix(sentry): also ignore LIDNotifyId injected-script errors (ETHORG-15N)

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -74,7 +74,8 @@ Sentry.init({
     // Cross-origin postMessage from extensions/embedded frames (ETHORG-87)
     /^Error: invalid origin$/,
     // Injected scripts from WebViews, adware, and OEM bloatware (ETHORG-14R, ETHORG-13N, ETHORG-JK, ETHORG-14B)
-    /LIDNotify is not defined/,
+    // Matches every global the LIDNotify injection references, e.g. `LIDNotifyId` (ETHORG-15N)
+    /LIDNotify\w* is not defined/,
     /tgetT is not defined/,
     /zaloJSV2 is not defined/,
     /onPagePause is not defined/,


### PR DESCRIPTION
## Production error

- **Message:** `[ERROR] ReferenceError: LIDNotifyId is not defined`
- **Sentry:** [ETHORG-15N](https://ethereumorg-ow.sentry.io/issues/7350058644/)
- **Occurrences:** 2 (0 users affected), first seen 2026-08-16, last seen 2026-08-20
- **Culprit:** `/:locale`, unhandled, no stacktrace

## Root cause

Not our code. `LIDNotifyId` — and in fact any `LIDNotify*` identifier — appears **nowhere** in this repository. It is a global referenced by a third-party script injected into the page by a WebView / adware / OEM-bloatware browser, the same family already documented in `instrumentation-client.ts` (ETHORG-14R, ETHORG-13N, ETHORG-JK, ETHORG-14B).

That family is already filtered, but the existing entry matched only the bare global:

```ts
/LIDNotify is not defined/,
```

Sentry matches `ignoreErrors` regexes with an **unanchored** `.test()` against the event message (`isMatchingPattern` in `@sentry/core@10.46.0`, `build/cjs/utils/string.js:114-116`). Because the injected script also references a *second*, longer global, the message is `ReferenceError: LIDNotifyId is not defined` — the substring `LIDNotify is not defined` never occurs in it, so the filter misses and the error reports as unhandled:

```
/LIDNotify is not defined/.test("ReferenceError: LIDNotifyId is not defined")  // false
```

## Fix

Widen the existing pattern by one token so it covers every global that injection references, rather than adding a near-duplicate line per variant:

```ts
/LIDNotify\w* is not defined/,
```

This matches both the original `LIDNotify` (ETHORG-14R) and the new `LIDNotifyId` (ETHORG-15N). Since no ethereum.org code defines or references any `LIDNotify*` identifier, the broadened pattern cannot mask a real first-party error. One line changed, plus a comment noting the new short ID.

## Verification

- `pnpm type-check` — passes (`next typegen && tsc --noEmit && tsc --noEmit -p netlify/edge-functions`, no errors)
- `pnpm exec eslint instrumentation-client.ts` — clean, no output
- Regex behaviour confirmed directly in Node: current pattern returns `false` against the production message; new pattern returns `true` against both `LIDNotifyId is not defined` and the original `LIDNotify is not defined`.
- Sentry's unanchored-`.test()` matching semantics confirmed by reading `isMatchingPattern` in the installed `@sentry/core@10.46.0`.

Filter-only change: no runtime behaviour, no rendered output, and no first-party error reporting is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
