### PR TITLE
[recovery] fix(sentry): drop frameless stack-overflow noise (ETHORG-9Q)

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -87,6 +87,13 @@ Sentry.init({
     if (hasNoStacktrace) {
       const message = values[0]?.value ?? ""
       if (/Internal JSON-RPC error/i.test(message)) return null
+      // Extension-injected recursion (see #17146: wrappers around
+      // HTMLMediaElement.canPlayType) overflows the stack inside the injected
+      // frame, so the event arrives with no frames at all and the
+      // `preload/document.js` filter below never sees it. Real recursion bugs
+      // in our own bundle always carry frames, so they still get reported.
+      // (ETHORG-9Q)
+      if (/Maximum call stack size exceeded/i.test(message)) return null
     }
 
     // Filter extension injection script errors not caught by denyUrls


### PR DESCRIPTION
## Production error

- **Message:** `RangeError: Maximum call stack size exceeded.`
- **Sentry:** [ETHORG-9Q](https://ethereumorg-ow.sentry.io/issues/6813688416/)
- **Occurrences:** 31 (cumulative, first seen 2026-08-13, last seen 2026-08-20)
- **Culprit:** `/:locale/what-is-ethereum` · unhandled · 0 users affected

## Root cause

This is the residue of an error class the team already diagnosed. Issue #17146
established that "Maximum call stack size exceeded" on this site is **not a
codebase bug** — a browser extension injects `src/preload/document.js` and wraps
`HTMLMediaElement.canPlayType` with improper recursion. At the time it was
generating ~1,700 events/month.

The fix from #17146 landed in `instrumentation-client.ts` and works: it walks the
event's stack frames and drops anything referencing `preload/document.js`. Volume
is down roughly 90%+.

What it can't catch is the case where the stack overflows *inside* the injected
frame, so Sentry receives the event with **no stack frames at all**. Three
signals in ETHORG-9Q line up with that:

- the alert carries no stack/detail
- `culprit` is the transaction name (`/:locale/what-is-ethereum`) rather than a
  function or module — Sentry only falls back to the transaction when there is no
  usable in-app frame
- 0 users across 31 events

With no frames, the `frames.some(...)` filter has nothing to match on and the
event passes through. I also audited the server and client render path for
`/what-is-ethereum` (page, `page-jsonld`, `ContentLayout`, `TableOfContents`,
`Breadcrumbs`, `CrawlableNav`) and swept `src/` and `app/` for self-recursive
functions; every recursion reachable from this route is depth-bounded or bounded
by static data. There is no unbounded recursion of our own on this page — it just
happens to be the site's highest-traffic content page, which is why the residual
noise groups here.

## Fix

`instrumentation-client.ts` already has a no-stacktrace branch in `beforeSend`,
added for the same reason (frameless wallet-extension JSON-RPC errors,
ETHORG-7Q). This adds one more message check to that existing branch:

```ts
if (hasNoStacktrace) {
  const message = values[0]?.value ?? ""
  if (/Internal JSON-RPC error/i.test(message)) return null
  if (/Maximum call stack size exceeded/i.test(message)) return null
}
```

The `hasNoStacktrace` guard is what keeps this narrow, and it's the reason this
went in `beforeSend` rather than `ignoreErrors`. An `ignoreErrors` entry would
match on message alone and permanently blind us to genuine infinite-recursion
regressions in our own code — exactly the kind of severe bug you want paged on.
Anything thrown from our bundle carries frames and is still reported; only the
frameless third-party variant is dropped.

## Verification

```
$ pnpm type-check
> next typegen && tsc --noEmit && tsc --noEmit -p netlify/edge-functions
Generating route types...
✓ Types generated successfully
```

```
$ pnpm exec eslint instrumentation-client.ts
(no output — clean)
```

Behavioural verification requires production traffic: after deploy, ETHORG-9Q
should stop accruing events. If it keeps growing, the events do carry frames and
this diagnosis is wrong — revert and pull a raw event off the Sentry issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
