### PR TITLE
fix(i18n): use CLDR country names for zh-tw and te

### DIFF
--- a/src/lib/utils/geography.ts
+++ b/src/lib/utils/geography.ts
@@ -132,6 +132,28 @@ const COUNTRY_NAME_ALIASES: Record<string, string> = {
   // Add more here as needed
 }
 
+// i18n-iso-countries is keyed by base language and ships no Traditional
+// Chinese or Telugu data, so zh-tw fell back to Simplified zh and te to English.
+const ICU_LOCALES = new Set(["zh-tw", "te"])
+
+// CLDR's long form for the SARs is a descriptor ("中國香港特別行政區"); its short
+// form is the plain city name. Elsewhere the short form is an abbreviation.
+const SHORT_FORM_REGIONS = new Set(["HK", "MO"])
+
+const regionNamesCache = new Map<string, Intl.DisplayNames>()
+
+function getRegionName(code: string, locale: string): string | undefined {
+  const style = SHORT_FORM_REGIONS.has(code) ? "short" : "long"
+  const cacheKey = `${locale}:${style}`
+
+  let displayNames = regionNamesCache.get(cacheKey)
+  if (!displayNames) {
+    displayNames = new Intl.DisplayNames([locale], { type: "region", style })
+    regionNamesCache.set(cacheKey, displayNames)
+  }
+  return displayNames.of(code)
+}
+
 /**
  * Translate an English country name into the target locale.
  *
@@ -149,7 +171,11 @@ export function getCountryTranslation(country: string, locale: string): string {
   const code = countries.getAlpha2Code(normalized, "en")
   if (!code) return country
 
-  // Strip region suffix: "pt-br" -> "pt", "zh-tw" -> "zh"
+  if (ICU_LOCALES.has(locale)) {
+    return getRegionName(code, locale) ?? country
+  }
+
+  // Strip region suffix: "pt-br" -> "pt"
   // (i18n-iso-countries uses base language codes)
   const baseLocale = locale.split("-")[0]
   return countries.getName(code, baseLocale) ?? country


### PR DESCRIPTION
Closes #19126.

`getCountryTranslation` strips the region subtag before the lookup, because `i18n-iso-countries` is keyed by base language. That's right for `pt-br` → `pt`, but the package ships no Traditional Chinese data, so `zh-tw` resolved through `zh` and event locations rendered in Simplified script — with Taiwan as "中国台湾省".

This routes the two locales the package can't serve through `Intl.DisplayNames` (CLDR) instead. Node ships full ICU, so there's no new dependency.

| locale | before | after |
| --- | --- | --- |
| `zh-tw` | `Taipei, 中国台湾省` | `Taipei, 台灣` |
| `zh-tw` | `美国` / `南韩` / `德国` | `美國` / `南韓` / `德國` |
| `te` | `Taiwan` (untranslated) | `తైవాన్` |

**Scope.** Only `zh-tw` and `te` change — `zh` and the other 22 locales keep reading from the package, unchanged. Switching everything to ICU would move ~350 country names, and not all of them for the better (ICU renders Italy as "Italy" in `vi` and Croatia as "Croatia" in `sw`), so that's better left to someone who can review those languages.

The CLDR long form for the SARs is a descriptor ("中國香港特別行政區"), so `HK`/`MO` read the short form; elsewhere the short form is an abbreviation, so long is the default.

**Testing.** Verified on `/zh-tw/community/events/meetups` — the `Taipei, Taiwan` and `Hong Kong SAR` entries in `community-meetups.json` render as `Taipei, 台灣` and `香港`, and `/zh/` is unchanged. `pnpm test:unit`, `pnpm type-check` and `eslint` pass.
