### PR TITLE
fix(sentry): filter third-party noise on positive evidence

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -74,11 +74,6 @@ Sentry.init({
     /DApp request timeout/,
     // Cross-origin postMessage from extensions/embedded frames (ETHORG-87)
     /^Error: invalid origin$/,
-    // Injected scripts from WebViews, adware, and OEM bloatware (ETHORG-14R, ETHORG-13N, ETHORG-JK, ETHORG-14B, ETHORG-15N)
-    /LIDNotify\w* is not defined/,
-    /tgetT is not defined/,
-    /zaloJSV2 is not defined/,
-    /onPagePause is not defined/,
   ],
 
   beforeSend(event) {

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,5 +1,7 @@
 import * as Sentry from "@sentry/nextjs"
 
+import { getDropReason } from "@/lib/sentry/filter-event"
+
 const environment = process.env.NEXT_PUBLIC_CONTEXT || "development"
 
 /**
@@ -50,7 +52,6 @@ Sentry.init({
     /safari-extension:\/\//,
     // Netlify RUM analytics (blocked by ad blockers, not actionable)
     /\.netlify\/scripts\/rum/,
-    /ingesteer\.services-prod\.nsvcs\.net/,
   ],
 
   // Filter common extension error messages and non-actionable errors
@@ -63,9 +64,9 @@ Sentry.init({
     /Could not establish connection\. Receiving end does not exist/,
     /Attempting to use a disconnected port object/,
     /Invalid call to runtime\.sendMessage\(\)/,
-    // Resource loading errors - network/ad blocker issues, not actionable (ETHORG-A8, ETHORG-8N)
-    /Event `Event` \(type=error\) captured as promise rejection/,
-    /NetworkError when attempting to fetch resource/,
+    // Netlify RUM fetch blocked by ad blockers - the host is only in the
+    // message, so denyUrls cannot match it (ETHORG-76)
+    /Failed to fetch \(ingesteer\.services-prod\.nsvcs\.net\)/,
     // WebView circular reference serialization failures - wallet app injections (ETHORG-72)
     /JSON\.stringify cannot serialize cyclic structures/,
     // Extension IPC / DApp bridge errors (ETHORG-FN, ETHORG-AT)
@@ -73,8 +74,7 @@ Sentry.init({
     /DApp request timeout/,
     // Cross-origin postMessage from extensions/embedded frames (ETHORG-87)
     /^Error: invalid origin$/,
-    // Injected scripts from WebViews, adware, and OEM bloatware (ETHORG-14R, ETHORG-13N, ETHORG-JK, ETHORG-14B)
-    // Matches every global the LIDNotify injection references, e.g. `LIDNotifyId` (ETHORG-15N)
+    // Injected scripts from WebViews, adware, and OEM bloatware (ETHORG-14R, ETHORG-13N, ETHORG-JK, ETHORG-14B, ETHORG-15N)
     /LIDNotify\w* is not defined/,
     /tgetT is not defined/,
     /zaloJSV2 is not defined/,
@@ -82,38 +82,9 @@ Sentry.init({
   ],
 
   beforeSend(event) {
-    // Filter wallet extension JSON-RPC errors that have no stacktrace (ETHORG-7Q)
-    const values = event.exception?.values ?? []
-    const hasNoStacktrace = values.every((v) => !v.stacktrace?.frames?.length)
-    if (hasNoStacktrace) {
-      const message = values[0]?.value ?? ""
-      if (/Internal JSON-RPC error/i.test(message)) return null
-    }
-
-    // Filter extension injection script errors not caught by denyUrls
-    const frames = values.flatMap((v) => v.stacktrace?.frames ?? [])
-    const isExtensionScript = frames.some((f) => {
-      const filename = f.filename || ""
-      const absPath = f.abs_path || ""
-      return (
-        // Extension preload scripts
-        filename.includes("preload/document.js") ||
-        absPath.includes("preload/document.js") ||
-        // Wallet extension injection scripts (ETHORG-Z1: TronLink, ETHORG-115: wallet bridges)
-        /injected\/injected\.js/.test(filename) ||
-        /bridge\/inject\.js/.test(filename) ||
-        /content[-_]?script\.js/i.test(filename) ||
-        /inpage\.js/.test(filename) ||
-        // Generic app:// protocol used by extension injected scripts (ETHORG-117: BitVisionWeb wallet)
-        filename.startsWith("app:///") ||
-        absPath.startsWith("app:///") ||
-        // Extension code injected via about:blank contexts (ETHORG-96)
-        filename === "about:blank" ||
-        absPath === "about:blank"
-      )
-    })
-    return isExtensionScript ? null : event
+    return getDropReason(event) ? null : event
   },
+
   // Normalize transaction names to strip locale prefixes so all locales
   // group under one page (e.g., "/en/staking/", "/ko/staking/" → "/staking/")
   beforeSendTransaction(event) {

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -49,7 +49,7 @@ Sentry.init({
     // Browser extension protocols
     /chrome-extension:\/\//,
     /moz-extension:\/\//,
-    /safari-extension:\/\//,
+    /safari(-web)?-extension:\/\//,
     // Netlify RUM analytics (blocked by ad blockers, not actionable)
     /\.netlify\/scripts\/rum/,
   ],
@@ -66,7 +66,7 @@ Sentry.init({
     /Invalid call to runtime\.sendMessage\(\)/,
     // Netlify RUM fetch blocked by ad blockers - the host is only in the
     // message, so denyUrls cannot match it (ETHORG-76)
-    /Failed to fetch \(ingesteer\.services-prod\.nsvcs\.net\)/,
+    /\(ingesteer\.services-prod\.nsvcs\.net\)/,
     // WebView circular reference serialization failures - wallet app injections (ETHORG-72)
     /JSON\.stringify cannot serialize cyclic structures/,
     // Extension IPC / DApp bridge errors (ETHORG-FN, ETHORG-AT)

--- a/src/lib/sentry/filter-event.ts
+++ b/src/lib/sentry/filter-event.ts
@@ -1,0 +1,79 @@
+import type { ErrorEvent } from "@sentry/nextjs"
+
+/** Reason an event was dropped, or null to keep it. */
+export type DropReason =
+  | "extension-payload"
+  | "extension-throw"
+  | "unattributable-overflow"
+  | null
+
+const EXTENSION_PROTOCOL = /(?:chrome|moz|safari|ms-browser)-extension:\/\//
+
+// Injected third-party scripts whose frames carry no extension protocol.
+const INJECTED_SCRIPT = [
+  /preload\/document\.js/,
+  /injected\/injected\.js/,
+  /bridge\/inject\.js/,
+  /content[-_]?script\.js/i,
+  /inpage\.js/,
+]
+
+const OVERFLOW_MESSAGE = /Maximum call stack size exceeded|too much recursion/i
+
+// window.onerror reports cross-origin scripts with no URL, which the SDK
+// stringifies into a frame filename.
+const NO_LOCATION = new Set(["", "undefined", "null", "<anonymous>"])
+
+const hasUsableLocation = (filename?: string, absPath?: string): boolean =>
+  [filename, absPath].some((v) => v !== undefined && !NO_LOCATION.has(v))
+
+const isThirdPartyLocation = (filename = "", absPath = ""): boolean =>
+  [filename, absPath].some(
+    (v) =>
+      EXTENSION_PROTOCOL.test(v) ||
+      v.startsWith("app:///") ||
+      INJECTED_SCRIPT.some((re) => re.test(v))
+  )
+
+/**
+ * Decide whether a client error event is third-party noise.
+ *
+ * Every rule requires positive evidence that the event did not originate in our
+ * bundle, so a genuine first-party regression is never silently swallowed.
+ */
+export function getDropReason(event: ErrorEvent): DropReason {
+  const values = event.exception?.values ?? []
+
+  // Wallet extensions reject with a plain object, so the SDK produces a
+  // frameless event and stashes the real stack in extra (ETHORG-73).
+  if (EXTENSION_PROTOCOL.test(JSON.stringify(event.extra ?? {}))) {
+    return "extension-payload"
+  }
+
+  // Sentry orders frames oldest-first, so the throwing frame is the last one.
+  // Matching any frame would discard our own bugs whenever injected wallet code
+  // appears anywhere in the stack.
+  const throwingFrames = values
+    .map((v) => v.stacktrace?.frames)
+    .filter((frames) => frames?.length)
+    .map((frames) => frames![frames!.length - 1])
+
+  if (
+    throwingFrames.some((f) => isThirdPartyLocation(f.filename, f.abs_path))
+  ) {
+    return "extension-throw"
+  }
+
+  // Stack overflows inside a cross-origin script arrive with a single
+  // location-less frame, which no URL-based rule can match (ETHORG-9Q).
+  const message = values.map((v) => v.value ?? "").join("\n")
+  if (OVERFLOW_MESSAGE.test(message)) {
+    const frames = values.flatMap((v) => v.stacktrace?.frames ?? [])
+    const attributable = frames.some((f) =>
+      hasUsableLocation(f.filename, f.abs_path)
+    )
+    if (!attributable) return "unattributable-overflow"
+  }
+
+  return null
+}

--- a/src/lib/sentry/filter-event.ts
+++ b/src/lib/sentry/filter-event.ts
@@ -5,6 +5,7 @@ export type DropReason =
   | "extension-payload"
   | "extension-throw"
   | "unattributable-overflow"
+  | "wallet-provider"
   | null
 
 const EXTENSION_PROTOCOL = /(?:chrome|moz|safari|ms-browser)-extension:\/\//
@@ -17,6 +18,13 @@ const INJECTED_SCRIPT = [
   /content[-_]?script\.js/i,
   /inpage\.js/,
 ]
+
+// EIP-1193 provider errors, plus the -32768..-32000 block JSON-RPC reserves
+// for pre-defined errors. Our code never mints either, so the code alone
+// identifies a wallet.
+const EIP_1193_CODES = new Set([4001, 4100, 4200, 4900, 4901])
+const isProviderErrorCode = (code: number): boolean =>
+  EIP_1193_CODES.has(code) || (code >= -32768 && code <= -32000)
 
 const OVERFLOW_MESSAGE = /Maximum call stack size exceeded|too much recursion/i
 
@@ -48,6 +56,17 @@ export function getDropReason(event: ErrorEvent): DropReason {
   // frameless event and stashes the real stack in extra (ETHORG-73).
   if (EXTENSION_PROTOCOL.test(JSON.stringify(event.extra ?? {}))) {
     return "extension-payload"
+  }
+
+  // Wallet providers reject with an EIP-1193 object rather than an Error, so
+  // the message varies per wallet but the code does not (ETHORG-7Q, ETHORG-73).
+  const serialized = (event.extra as { __serialized__?: { code?: unknown } })
+    ?.__serialized__
+  if (
+    typeof serialized?.code === "number" &&
+    isProviderErrorCode(serialized.code)
+  ) {
+    return "wallet-provider"
   }
 
   // Sentry orders frames oldest-first, so the throwing frame is the last one.

--- a/src/lib/sentry/filter-event.ts
+++ b/src/lib/sentry/filter-event.ts
@@ -8,7 +8,8 @@ export type DropReason =
   | "wallet-provider"
   | null
 
-const EXTENSION_PROTOCOL = /(?:chrome|moz|safari|ms-browser)-extension:\/\//
+const EXTENSION_PROTOCOL =
+  /(?:chrome|moz|ms-browser|safari(?:-web)?)-extension:\/\//
 
 // Injected third-party scripts whose frames carry no extension protocol.
 const INJECTED_SCRIPT = [
@@ -35,11 +36,13 @@ const NO_LOCATION = new Set(["", "undefined", "null", "<anonymous>"])
 const hasUsableLocation = (filename?: string, absPath?: string): boolean =>
   [filename, absPath].some((v) => v !== undefined && !NO_LOCATION.has(v))
 
+// Not app:/// -- nextjsClientStackFrameNormalization rewrites our own frames to
+// that scheme before beforeSend runs, so it marks first-party code too.
 const isThirdPartyLocation = (filename = "", absPath = ""): boolean =>
   [filename, absPath].some(
     (v) =>
       EXTENSION_PROTOCOL.test(v) ||
-      v.startsWith("app:///") ||
+      v === "about:blank" ||
       INJECTED_SCRIPT.some((re) => re.test(v))
   )
 
@@ -91,7 +94,7 @@ export function getDropReason(event: ErrorEvent): DropReason {
     const attributable = frames.some((f) =>
       hasUsableLocation(f.filename, f.abs_path)
     )
-    if (!attributable) return "unattributable-overflow"
+    if (frames.length > 0 && !attributable) return "unattributable-overflow"
   }
 
   return null

--- a/tests/unit/sentry/filter-event.spec.ts
+++ b/tests/unit/sentry/filter-event.spec.ts
@@ -6,7 +6,9 @@ import type { ErrorEvent } from "@sentry/nextjs"
 
 import { type DropReason, getDropReason } from "@/lib/sentry/filter-event"
 
-const OURS = "https://ethereum.org/_next/static/chunks/app.js"
+// @sentry/nextjs rewrites our origin to app:/// before beforeSend runs, so
+// this is what a first-party frame actually looks like at filter time.
+const OURS = "app:///_next/static/chunks/app.js"
 
 const event = (
   values: Array<{ value: string; frames?: string[] }>,
@@ -110,6 +112,16 @@ const cases: Array<[name: string, event: ErrorEvent, expected: DropReason]> = [
     event([
       { value: "Maximum call stack size exceeded", frames: [OURS, OURS] },
     ]),
+    null,
+  ],
+  [
+    "about:blank throw site",
+    event([{ value: "x is not a function", frames: [OURS, "about:blank"] }]),
+    "extension-throw",
+  ],
+  [
+    "frameless overflow, no third-party evidence",
+    event([{ value: "Maximum call stack size exceeded" }]),
     null,
   ],
   [

--- a/tests/unit/sentry/filter-event.spec.ts
+++ b/tests/unit/sentry/filter-event.spec.ts
@@ -1,204 +1,128 @@
-// Fixtures are trimmed copies of real payloads pulled from the Sentry issues
-// named in each test, so the rules stay pinned to events we actually receive.
+// Fixtures are trimmed copies of real payloads from the Sentry issues named
+// below, so the rules stay pinned to events we actually receive.
 
 import { expect, test } from "@playwright/test"
 import type { ErrorEvent } from "@sentry/nextjs"
 
-import { getDropReason } from "@/lib/sentry/filter-event"
+import { type DropReason, getDropReason } from "@/lib/sentry/filter-event"
 
-type Frame = { filename?: string; abs_path?: string }
+const OURS = "https://ethereum.org/_next/static/chunks/app.js"
 
-const errorEvent = (
-  values: Array<{ value: string; frames?: Frame[] }>,
+const event = (
+  values: Array<{ value: string; frames?: string[] }>,
   extra?: Record<string, unknown>
 ): ErrorEvent =>
   ({
     exception: {
       values: values.map(({ value, frames }) => ({
-        type: "Error",
         value,
-        ...(frames ? { stacktrace: { frames } } : {}),
+        ...(frames && {
+          stacktrace: { frames: frames.map((f) => ({ filename: f })) },
+        }),
       })),
     },
-    ...(extra ? { extra } : {}),
+    ...(extra && { extra }),
   }) as ErrorEvent
 
-test.describe("extension payloads in serialized extra (ETHORG-73)", () => {
-  test("drops a frameless rejection whose extra holds an extension stack", () => {
-    const event = errorEvent(
-      [
-        {
-          value:
-            "Object captured as promise rejection with keys: code, message, stack",
-        },
-      ],
-      {
-        __serialized__: {
-          code: 4900,
-          message: "The provider is disconnected from all chains.",
-          stack:
-            "Error: The provider is disconnected from all chains.\n    at s (chrome-extension://acmacodkjbdgmoleebolmdjonilkdbch/background.js:4:8154377)",
-        },
-      }
-    )
-
-    expect(getDropReason(event)).toBe("extension-payload")
-  })
-
-  test("keeps a frameless rejection with no extension evidence", () => {
-    const event = errorEvent(
-      [{ value: "Non-Error promise rejection captured with value: null" }],
-      {
-        __serialized__: { message: "upstream timeout" },
-      }
-    )
-
-    expect(getDropReason(event)).toBeNull()
-  })
-})
-
-test.describe("wallet provider errors (ETHORG-7Q, ETHORG-73)", () => {
-  test("drops an EIP-1193 rejection identified only by its code", () => {
-    const event = errorEvent(
-      [
-        {
-          value:
-            "Object captured as promise rejection with keys: code, message",
-        },
-      ],
-      {
-        __serialized__: {
-          code: 4001,
-          message: "wallet must has at least one account",
-        },
-      }
-    )
-
-    expect(getDropReason(event)).toBe("wallet-provider")
-  })
-
-  test("drops a reserved JSON-RPC provider code", () => {
-    const event = errorEvent(
-      [{ value: "Object captured as promise rejection" }],
-      {
-        __serialized__: { code: -32603, message: "Internal JSON-RPC error" },
-      }
-    )
-
-    expect(getDropReason(event)).toBe("wallet-provider")
-  })
-
-  test("keeps an unrelated numeric code", () => {
-    const event = errorEvent(
-      [{ value: "Object captured as promise rejection" }],
-      {
-        __serialized__: { code: 500, message: "upstream failure" },
-      }
-    )
-
-    expect(getDropReason(event)).toBeNull()
-  })
-})
-
-test.describe("third-party throwing frame", () => {
-  test("drops when the last frame is an injected wallet script", () => {
-    const event = errorEvent([
-      {
-        value: "Cannot read properties of undefined",
-        frames: [
-          { filename: "https://ethereum.org/_next/static/chunks/main.js" },
-          { filename: "chrome-extension://abc/inpage.js" },
-        ],
+const cases: Array<[name: string, event: ErrorEvent, expected: DropReason]> = [
+  // Wallet providers vary the message per wallet but not the code
+  // (ETHORG-7Q, ETHORG-73).
+  [
+    "EIP-1193 code",
+    event([{ value: "Object captured as promise rejection" }], {
+      __serialized__: {
+        code: 4001,
+        message: "wallet must has at least one account",
       },
-    ])
-
-    expect(getDropReason(event)).toBe("extension-throw")
-  })
-
-  test("keeps our own bug when injected code only appears deeper in the stack", () => {
-    const event = errorEvent([
-      {
-        value: "Cannot read properties of undefined",
-        frames: [
-          { filename: "chrome-extension://abc/inpage.js" },
-          { filename: "https://ethereum.org/_next/static/chunks/app.js" },
-        ],
+    }),
+    "wallet-provider",
+  ],
+  [
+    "reserved JSON-RPC code",
+    event([{ value: "Object captured as promise rejection" }], {
+      __serialized__: { code: -32603, message: "Internal JSON-RPC error" },
+    }),
+    "wallet-provider",
+  ],
+  [
+    "unrelated numeric code",
+    event([{ value: "Object captured as promise rejection" }], {
+      __serialized__: { code: 500, message: "upstream failure" },
+    }),
+    null,
+  ],
+  [
+    "extension stack in serialized extra",
+    event([{ value: "Object captured as promise rejection" }], {
+      __serialized__: {
+        stack:
+          "at s (chrome-extension://acmacodkjbdgmoleebolmdjonilkdbch/background.js:4)",
       },
-    ])
-
-    expect(getDropReason(event)).toBeNull()
-  })
-
-  test("keeps an about:blank frame that is not the throw site", () => {
-    const event = errorEvent([
+    }),
+    "extension-payload",
+  ],
+  // Frames are oldest-first, so only the last is the throw site. Matching any
+  // frame would discard our own bugs whenever a wallet wraps our functions.
+  [
+    "injected script throws",
+    event([
       {
-        value: "TypeError: x is not a function",
-        frames: [
-          { filename: "about:blank" },
-          { filename: "https://ethereum.org/_next/static/chunks/app.js" },
-        ],
+        value: "x is not a function",
+        frames: [OURS, "chrome-extension://a/inpage.js"],
       },
-    ])
-
-    expect(getDropReason(event)).toBeNull()
-  })
-})
-
-test.describe("unattributable stack overflow (ETHORG-9Q)", () => {
-  test("drops the single location-less onerror frame", () => {
-    const event = errorEvent([
+    ]),
+    "extension-throw",
+  ],
+  [
+    "injected script deeper in the stack, ours throws",
+    event([
       {
-        value: "Maximum call stack size exceeded.",
-        frames: [{ filename: "undefined", abs_path: "undefined" }],
+        value: "x is not a function",
+        frames: ["chrome-extension://a/inpage.js", OURS],
       },
-    ])
-
-    expect(getDropReason(event)).toBe("unattributable-overflow")
-  })
-
-  test("drops the Firefox wording too", () => {
-    const event = errorEvent([
-      { value: "too much recursion", frames: [{ filename: "undefined" }] },
-    ])
-
-    expect(getDropReason(event)).toBe("unattributable-overflow")
-  })
-
-  test("keeps a real recursion bug in our bundle", () => {
-    const event = errorEvent([
-      {
-        value: "Maximum call stack size exceeded",
-        frames: [
-          { filename: "https://ethereum.org/_next/static/chunks/app.js" },
-          { filename: "https://ethereum.org/_next/static/chunks/app.js" },
-        ],
-      },
-    ])
-
-    expect(getDropReason(event)).toBeNull()
-  })
-
-  test("reads the message from a chained cause, not just values[0]", () => {
+    ]),
+    null,
+  ],
+  // A cross-origin script that onerror cannot attribute (ETHORG-9Q).
+  [
+    "overflow with no usable location",
+    event([
+      { value: "Maximum call stack size exceeded.", frames: ["undefined"] },
+    ]),
+    "unattributable-overflow",
+  ],
+  [
+    "overflow, Firefox wording",
+    event([{ value: "too much recursion", frames: ["<anonymous>"] }]),
+    "unattributable-overflow",
+  ],
+  [
     // Sentry prepends causes, so the thrown error is the last value.
-    const event = errorEvent([
-      { value: "some upstream cause", frames: [{ filename: "undefined" }] },
-      {
-        value: "Maximum call stack size exceeded",
-        frames: [{ filename: "undefined" }],
-      },
-    ])
+    "overflow reported on a chained cause",
+    event([
+      { value: "some upstream cause", frames: ["undefined"] },
+      { value: "Maximum call stack size exceeded", frames: ["undefined"] },
+    ]),
+    "unattributable-overflow",
+  ],
+  [
+    "overflow in our own bundle",
+    event([
+      { value: "Maximum call stack size exceeded", frames: [OURS, OURS] },
+    ]),
+    null,
+  ],
+  [
+    "ordinary first-party error",
+    event([
+      { value: "The router state header could not be parsed.", frames: [OURS] },
+    ]),
+    null,
+  ],
+]
 
-    expect(getDropReason(event)).toBe("unattributable-overflow")
+for (const [name, errorEvent, expected] of cases) {
+  test(`${expected ?? "keeps"}: ${name}`, () => {
+    expect(getDropReason(errorEvent)).toBe(expected)
   })
-})
-
-test("keeps an ordinary first-party error", () => {
-  const event = errorEvent([
-    {
-      value: "The router state header was sent but could not be parsed.",
-      frames: [{ filename: "https://ethereum.org/_next/static/chunks/app.js" }],
-    },
-  ])
-
-  expect(getDropReason(event)).toBeNull()
-})
+}

--- a/tests/unit/sentry/filter-event.spec.ts
+++ b/tests/unit/sentry/filter-event.spec.ts
@@ -57,6 +57,49 @@ test.describe("extension payloads in serialized extra (ETHORG-73)", () => {
   })
 })
 
+test.describe("wallet provider errors (ETHORG-7Q, ETHORG-73)", () => {
+  test("drops an EIP-1193 rejection identified only by its code", () => {
+    const event = errorEvent(
+      [
+        {
+          value:
+            "Object captured as promise rejection with keys: code, message",
+        },
+      ],
+      {
+        __serialized__: {
+          code: 4001,
+          message: "wallet must has at least one account",
+        },
+      }
+    )
+
+    expect(getDropReason(event)).toBe("wallet-provider")
+  })
+
+  test("drops a reserved JSON-RPC provider code", () => {
+    const event = errorEvent(
+      [{ value: "Object captured as promise rejection" }],
+      {
+        __serialized__: { code: -32603, message: "Internal JSON-RPC error" },
+      }
+    )
+
+    expect(getDropReason(event)).toBe("wallet-provider")
+  })
+
+  test("keeps an unrelated numeric code", () => {
+    const event = errorEvent(
+      [{ value: "Object captured as promise rejection" }],
+      {
+        __serialized__: { code: 500, message: "upstream failure" },
+      }
+    )
+
+    expect(getDropReason(event)).toBeNull()
+  })
+})
+
 test.describe("third-party throwing frame", () => {
   test("drops when the last frame is an injected wallet script", () => {
     const event = errorEvent([

--- a/tests/unit/sentry/filter-event.spec.ts
+++ b/tests/unit/sentry/filter-event.spec.ts
@@ -1,0 +1,161 @@
+// Fixtures are trimmed copies of real payloads pulled from the Sentry issues
+// named in each test, so the rules stay pinned to events we actually receive.
+
+import { expect, test } from "@playwright/test"
+import type { ErrorEvent } from "@sentry/nextjs"
+
+import { getDropReason } from "@/lib/sentry/filter-event"
+
+type Frame = { filename?: string; abs_path?: string }
+
+const errorEvent = (
+  values: Array<{ value: string; frames?: Frame[] }>,
+  extra?: Record<string, unknown>
+): ErrorEvent =>
+  ({
+    exception: {
+      values: values.map(({ value, frames }) => ({
+        type: "Error",
+        value,
+        ...(frames ? { stacktrace: { frames } } : {}),
+      })),
+    },
+    ...(extra ? { extra } : {}),
+  }) as ErrorEvent
+
+test.describe("extension payloads in serialized extra (ETHORG-73)", () => {
+  test("drops a frameless rejection whose extra holds an extension stack", () => {
+    const event = errorEvent(
+      [
+        {
+          value:
+            "Object captured as promise rejection with keys: code, message, stack",
+        },
+      ],
+      {
+        __serialized__: {
+          code: 4900,
+          message: "The provider is disconnected from all chains.",
+          stack:
+            "Error: The provider is disconnected from all chains.\n    at s (chrome-extension://acmacodkjbdgmoleebolmdjonilkdbch/background.js:4:8154377)",
+        },
+      }
+    )
+
+    expect(getDropReason(event)).toBe("extension-payload")
+  })
+
+  test("keeps a frameless rejection with no extension evidence", () => {
+    const event = errorEvent(
+      [{ value: "Non-Error promise rejection captured with value: null" }],
+      {
+        __serialized__: { message: "upstream timeout" },
+      }
+    )
+
+    expect(getDropReason(event)).toBeNull()
+  })
+})
+
+test.describe("third-party throwing frame", () => {
+  test("drops when the last frame is an injected wallet script", () => {
+    const event = errorEvent([
+      {
+        value: "Cannot read properties of undefined",
+        frames: [
+          { filename: "https://ethereum.org/_next/static/chunks/main.js" },
+          { filename: "chrome-extension://abc/inpage.js" },
+        ],
+      },
+    ])
+
+    expect(getDropReason(event)).toBe("extension-throw")
+  })
+
+  test("keeps our own bug when injected code only appears deeper in the stack", () => {
+    const event = errorEvent([
+      {
+        value: "Cannot read properties of undefined",
+        frames: [
+          { filename: "chrome-extension://abc/inpage.js" },
+          { filename: "https://ethereum.org/_next/static/chunks/app.js" },
+        ],
+      },
+    ])
+
+    expect(getDropReason(event)).toBeNull()
+  })
+
+  test("keeps an about:blank frame that is not the throw site", () => {
+    const event = errorEvent([
+      {
+        value: "TypeError: x is not a function",
+        frames: [
+          { filename: "about:blank" },
+          { filename: "https://ethereum.org/_next/static/chunks/app.js" },
+        ],
+      },
+    ])
+
+    expect(getDropReason(event)).toBeNull()
+  })
+})
+
+test.describe("unattributable stack overflow (ETHORG-9Q)", () => {
+  test("drops the single location-less onerror frame", () => {
+    const event = errorEvent([
+      {
+        value: "Maximum call stack size exceeded.",
+        frames: [{ filename: "undefined", abs_path: "undefined" }],
+      },
+    ])
+
+    expect(getDropReason(event)).toBe("unattributable-overflow")
+  })
+
+  test("drops the Firefox wording too", () => {
+    const event = errorEvent([
+      { value: "too much recursion", frames: [{ filename: "undefined" }] },
+    ])
+
+    expect(getDropReason(event)).toBe("unattributable-overflow")
+  })
+
+  test("keeps a real recursion bug in our bundle", () => {
+    const event = errorEvent([
+      {
+        value: "Maximum call stack size exceeded",
+        frames: [
+          { filename: "https://ethereum.org/_next/static/chunks/app.js" },
+          { filename: "https://ethereum.org/_next/static/chunks/app.js" },
+        ],
+      },
+    ])
+
+    expect(getDropReason(event)).toBeNull()
+  })
+
+  test("reads the message from a chained cause, not just values[0]", () => {
+    // Sentry prepends causes, so the thrown error is the last value.
+    const event = errorEvent([
+      { value: "some upstream cause", frames: [{ filename: "undefined" }] },
+      {
+        value: "Maximum call stack size exceeded",
+        frames: [{ filename: "undefined" }],
+      },
+    ])
+
+    expect(getDropReason(event)).toBe("unattributable-overflow")
+  })
+})
+
+test("keeps an ordinary first-party error", () => {
+  const event = errorEvent([
+    {
+      value: "The router state header was sent but could not be parsed.",
+      frames: [{ filename: "https://ethereum.org/_next/static/chunks/app.js" }],
+    },
+  ])
+
+  expect(getDropReason(event)).toBeNull()
+})


### PR DESCRIPTION
Follow-up to #19119, which is closed in favour of this.

## Why

`beforeSend` matched third-party paths in `exception.values[].stacktrace.frames`, and `ignoreErrors` matched noise message by message. Checked against live Sentry data, that combination has three problems:

- **It misses the two biggest noise sources.** ETHORG-73 (3,794 events) and ETHORG-7Q (2,819 events) are wallet providers rejecting with a plain object. The SDK emits a frameless event and puts the detail in `extra.__serialized__` — no frame to match, and the message differs per wallet, so neither mechanism sees them.
- **`frames.some(...)` drops our own bugs.** Frames are ordered oldest-first, so the throwing frame is the last one. Wallet extensions wrap our functions, making mixed stacks routine — one injected frame anywhere was enough to discard an event we caused.
- **Two message filters catch first-party failures.** `NetworkError when attempting to fetch resource` is Firefox's generic message for any failed fetch, ours included; the `Event`-as-promise-rejection pattern fires on any failed image or script load.

## What changed

Filtering moves to a pure, unit-tested `getDropReason(event)` in `src/lib/sentry/filter-event.ts`. Each rule requires positive evidence the event did not come from our bundle:

| Rule | Evidence | Retires |
| --- | --- | --- |
| `wallet-provider` | EIP-1193 code, or a code in JSON-RPC's reserved `-32768..-32000` block | ETHORG-7Q (2,819), ETHORG-73 (3,794) |
| `extension-payload` | `*-extension://` in serialized `extra` | remaining extension rejections |
| `extension-throw` | throwing frame is an extension/injected script | existing extension classes |
| `unattributable-overflow` | overflow message **and** no frame has a usable location | ETHORG-9Q (2,666) |

Matching wallet errors by code rather than message is the substantive change: our code mints neither an EIP-1193 code nor a reserved JSON-RPC one, so this covers present and future wallet variants without enumerating strings.

Removed the `about:blank` frame match, the two message filters above, and the four injected-global patterns — a one-character rename (`LIDNotify` → `LIDNotifyId`) defeated one of those anyway, so that long tail belongs in UI archives. The message is now read across all exception values; Sentry prepends causes, so `values[0]` was the deepest cause rather than the thrown error.

## On ETHORG-9Q

#19119 blamed a browser extension. All 242 events in 30d are iOS (231 Chrome Mobile iOS, 11 Google app), where extensions don't exist. Mobile Safari has 90 error events in the same window and contributes none, so it isn't WebKit's stack limit or our bundle either. The single frame has `filename: "undefined"` — a cross-origin script `onerror` can't attribute — which is what the new rule keys on. A real recursion bug in our bundle keeps real filenames and still reports.
