### PR TITLE
chore(ci): add dependabot config for security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    # Zero means "no version-update PRs". Security PRs are exempt from this
+    # limit, so advisories still open PRs while minor/patch churn does not.
+    open-pull-requests-limit: 0
+    labels:
+      - "dependencies 📦"
+    commit-message:
+      prefix: chore(deps)
+      prefix-development: chore(deps-dev)
+    groups:
+      security-production:
+        applies-to: security-updates
+        dependency-type: production
+        patterns:
+          - "*"
+      security-development:
+        applies-to: security-updates
+        dependency-type: development
+        patterns:
+          - "*"


### PR DESCRIPTION
## What

Adds the `.github/dependabot.yml` the repo never had, scoped deliberately narrow: **security advisories only, grouped into two PRs.**

```yaml
version: 2

updates:
  - package-ecosystem: npm
    directory: "/"
    schedule:
      interval: weekly
    open-pull-requests-limit: 0
    labels:
      - "dependencies 📦"
    commit-message:
      prefix: chore(deps)
      prefix-development: chore(deps-dev)
    groups:
      security-production:
        applies-to: security-updates
        dependency-type: production
        patterns: ["*"]
      security-development:
        applies-to: security-updates
        dependency-type: development
        patterns: ["*"]
```

## Why this shape

**No version updates.** `open-pull-requests-limit: 0` disables them; [security PRs are exempt from the limit and don't count toward it](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference). We don't want a steady drip of minor/patch PRs.

Restricting a group to `update-types: [minor, patch]` would not have been enough on its own — [majors are still raised as individual PRs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates) (*\"All major updates will continue to be raised as individual pull requests\"*), and they share the same PR budget as the group PRs. `pnpm outdated` currently reports **99 outdated direct deps, 28 with a major available** (eslint 8→10, typescript 5→7, wagmi 2→3, recharts 2→3, @types/node 20→26, …). Those would have saturated any small limit and silently starved the grouped PRs, indistinguishable from \"no updates this week\".

**Two security groups, not one.** Splitting production from development means one unfixable advisory can't head-of-line block the fixes bundled alongside it, and the prod PR is the one that actually ships.

**No `ignore` block.** `ignore` filters security updates as well as version updates, so with version updates off its only remaining effect would be muting advisories — including for the deps we hold back by hand (`sharp` pinned below 0.35, `@netlify/plugin-nextjs` at ≤5.15.11). Better to see those PRs and close them per case than to silence the channel. Worth noting `hono` isn't a direct dependency at all (it resolves transitively via `@modelcontextprotocol/sdk`), so an ignore entry for it could only ever have muted its advisories.

**No `github-actions` ecosystem.** It would rewrite the four generated gh-aw workflows — `backlog-sweeper.lock.yml`, `intake-decisions.lock.yml`, `issue-triager.lock.yml`, `pr-reviewer.lock.yml` — which carry `DO NOT EDIT` plus an embedded `gh-aw-manifest` listing the exact SHAs they were compiled from. Dependabot would bump the SHAs in the body and leave the manifest stale, and nothing in CI runs `gh aw compile` to catch the drift. It would also bump `github/gh-aw-actions/setup`, which is version-tied to the `compiler_version` in that same header. A name-based `ignore` can't fix it either: `actions/checkout`, `setup-node`, `github-script`, `upload-artifact`, and `download-artifact` appear in both the lock files and our hand-written workflows.

**Label** matches `.github/labeler.yml` (`dependencies 📦`) rather than GitHub's auto-created `dependencies`, so PRs don't end up carrying both.

## Notes

- This file doesn't enable security updates — that's a repo setting, which is why advisory PRs already existed without any config.
- The default branch currently has 123 open alerts, so expect the first grouped PR to be substantial.
- To do a controlled catch-up later: raise `open-pull-requests-limit` and add a minor/patch group on `interval: monthly`. Two PRs a month rather than twenty.