### PR TITLE
chore: gitignore .claude/worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ storybook-static-pages
 
 # Playwright CLI session state
 .playwright-cli
+
+# Claude Code worktrees
+.claude/worktrees/


### PR DESCRIPTION
Tailwind v4 scans the whole project tree, bounded only by `.gitignore`. Claude Code worktrees live in `.claude/worktrees/` and were never ignored, so every CSS build walked them.

Cold dev build, 16 local worktrees: homepage **174s → 15.5s**, `next-server` RSS **15.7GB → 4.0GB**.

Local-only path — no effect on CI or production.