### PR TITLE
feat: per-placement Matomo tracking for Devcon banners

### DIFF
--- a/app/[locale]/community/events/page.tsx
+++ b/app/[locale]/community/events/page.tsx
@@ -140,7 +140,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
       />
 
       {/* Devcon VIII India callout banner */}
-      <DevconIndiaLargeCallout />
+      <DevconIndiaLargeCallout eventCategory="devcon_banner_events" />
 
       {/* What's on this page? + TabNav */}
       <StickyContainer className="top-6 space-y-4 p-4 md:top-2 md:p-8">

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -135,8 +135,8 @@ const Page = async (props: { params: Promise<PageParams> }) => {
                 <ButtonLink
                   href={DEVCON_INDIA_TICKET_URL}
                   customEventOptions={{
-                    eventCategory: "devcon",
-                    eventAction: `get_tickets`,
+                    eventCategory: "devcon_banner_homepage_alert",
+                    eventAction: "get_tickets",
                     eventName: "visit",
                   }}
                   hideArrow
@@ -195,7 +195,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
             <FeatureCards eventCategory={eventCategory} />
 
             {/* Devcon VIII India callout banner */}
-            <DevconIndiaLargeCallout />
+            <DevconIndiaLargeCallout eventCategory="devcon_banner_homepage" />
 
             <LatestUpdates eventCategory={eventCategory} />
 

--- a/src/components/DevconIndia/large-callout.tsx
+++ b/src/components/DevconIndia/large-callout.tsx
@@ -10,14 +10,21 @@ import DevconDateLocation from "./date-location"
 
 import devconIndiaBanner from "@/public/images/assets/devcon-india-banner.webp"
 
-const DevconIndiaLargeCallout = async () => {
+type DevconIndiaLargeCalloutProps = {
+  /** Distinct per placement so Matomo can tell the banners apart */
+  eventCategory: string
+}
+
+const DevconIndiaLargeCallout = async ({
+  eventCategory,
+}: DevconIndiaLargeCalloutProps) => {
   const tDevcon = await getTranslations("component-devcon-banner")
   return (
     <Card
       href={DEVCON_INDIA_TICKET_URL}
       customEventOptions={{
-        eventCategory: "devcon",
-        eventAction: `get_tickets`,
+        eventCategory,
+        eventAction: "get_tickets",
         eventName: "visit",
       }}
       variant="ghost"


### PR DESCRIPTION
Follow-up to #19123.

The Devcon banner ships in three places, and all three fired the byte-identical event (`devcon` / `get_tickets` / `visit`), so clicks could not be attributed to a placement.

Threads an `eventCategory` prop through `DevconIndiaLargeCallout` and gives each placement its own category, per the "different category per position" rule in `docs/event-tracking.md`:

| Placement | Category |
| --- | --- |
| `/community/events` big banner | `devcon_banner_events` |
| Homepage big banner | `devcon_banner_homepage` |
| Homepage top alert strip | `devcon_banner_homepage_alert` |

Action (`get_tickets`) and name (`visit`) are unchanged. The shared `devcon_banner_` prefix keeps the three adjacent in Matomo for a roll-up while each stays separately filterable — and keeps them out of the events page's `Events` / `Events_navigation` categories.

Requested by @wackerow: a dedicated Devcon banner category so events-page banner clicks don't get mixed with other events clicks.

### Testing

- `pnpm type-check` and ESLint pass.
- Verified on a local dev server that the homepage renders `devcon_banner_homepage` + `devcon_banner_homepage_alert` and `/community/events` renders `devcon_banner_events`, with no bare `"devcon"` category remaining.
