### PR TITLE
chore(ci): upgrade Chromatic to v18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,11 @@ env:
 # gating automatically via `needs:` (skipped jobs propagate).
 #
 # Exception: Storybook Chromatic (`visual-tests`) runs on every non-draft PR.
-# TurboSnap (`onlyChanged`) keeps snapshot usage low, so PRs with no affected
-# stories cost nothing. The merge gate for visual changes is Chromatic's own
-# "UI Tests" check (posted by the Chromatic GitHub App), which updates live as a
-# maintainer accepts/rejects -- so this job just publishes and exits 0.
+# TurboSnap (`onlyChanged`) keeps snapshot usage low: a PR with no affected
+# stories is bypassed and billed nothing, and no build is published for it.
+# The merge gate for visual changes is Chromatic's own "UI Tests" check (posted
+# by the Chromatic GitHub App), which updates live as a maintainer
+# accepts/rejects -- so this job itself always exits 0.
 #
 # `fetch-depth: 0` is set selectively: lint needs it for `git diff`, and the
 # two Chromatic jobs need it for baseline detection. Other jobs use the default
@@ -75,9 +76,9 @@ jobs:
   visual-tests:
     name: Visual regression (Chromatic)
     # Runs on every non-draft PR. TurboSnap (`onlyChanged`) means PRs with no
-    # affected stories snapshot nothing, so this is cheap for content-only PRs.
-    # This job only publishes to Chromatic; the required merge gate is the
-    # Chromatic App's "UI Tests" check, so the job itself always exits 0.
+    # affected stories are bypassed: nothing is snapshotted, billed, or
+    # published. The required merge gate is the Chromatic App's "UI Tests"
+    # check, so the job itself always exits 0.
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
@@ -88,7 +89,7 @@ jobs:
       - uses: ./.github/actions/setup-pnpm-node
 
       - name: Publish to Chromatic
-        uses: chromaui/action@v18
+        uses: chromaui/action@v18.5.0
         with:
           projectToken: fee8e66c9916
           # Not named chromatic.config.json: that filename is auto-loaded by
@@ -100,6 +101,9 @@ jobs:
           skip: ${{ vars.CHROMATIC_SKIP || '__chromatic_skip_disabled__' }}
           exitZeroOnChanges: true
           onlyChanged: true
+          # Defaults to on whenever onlyChanged is set; keep it off so debug
+          # logs aren't published next to the public Storybook.
+          uploadMetadata: false
           # Release-train builds (dev/staging/master head branches) were
           # already reviewed per-PR on dev; auto-accept them as baselines.
           autoAcceptChanges: "{dev,staging,master}"
@@ -314,7 +318,7 @@ jobs:
 
       - name: Publish to Chromatic
         if: always()
-        uses: chromaui/action@v18
+        uses: chromaui/action@v18.5.0
         with:
           projectToken: ${{ secrets.CHROMATIC_PAGES_TOKEN }}
           playwright: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
       - uses: ./.github/actions/setup-pnpm-node
 
       - name: Publish to Chromatic
-        uses: chromaui/action@v16
+        uses: chromaui/action@v18
         with:
           projectToken: fee8e66c9916
           # Not named chromatic.config.json: that filename is auto-loaded by
@@ -314,7 +314,7 @@ jobs:
 
       - name: Publish to Chromatic
         if: always()
-        uses: chromaui/action@v16
+        uses: chromaui/action@v18
         with:
           projectToken: ${{ secrets.CHROMATIC_PAGES_TOKEN }}
           playwright: true

--- a/docs/applying-storybook.md
+++ b/docs/applying-storybook.md
@@ -209,7 +209,7 @@ When creating a story, Chromatic creates a "snapshot" of it and sets it as a bas
 
 ### Publishing builds
 
-CI publishes on every non-draft PR, so you don't normally need to run Chromatic yourself. Snapshots are billed against a monthly quota shared by the whole team, and a local run of `pnpm chromatic` costs up to a full rebuild, so prefer letting CI do it.
+CI runs on every non-draft PR, so you don't normally need to run Chromatic yourself. A PR that affects no story is bypassed and publishes no build at all -- that is expected, not a broken pipeline. Snapshots are billed against a monthly quota shared by the whole team, and a local run of `pnpm chromatic` costs up to a full rebuild, so prefer letting CI do it.
 
 If you do need a local run, the repo has two Chromatic projects and each script takes its own token:
 

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "@types/xml2js": "^0.4.14",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
-    "chromatic": "16.0.0",
+    "chromatic": "18.5.0",
     "decompress": "^4.2.1",
     "dotenv": "^16.5.0",
     "eslint": "^8.57.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -308,8 +308,8 @@ importers:
         specifier: ^7.18.0
         version: 7.18.0(eslint@8.57.1)(typescript@5.8.3)
       chromatic:
-        specifier: 16.0.0
-        version: 16.0.0(@chromatic-com/playwright@0.13.2(@playwright/test@1.53.1)(@testing-library/dom@10.4.0)(bufferutil@4.0.9)(prettier@3.5.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(utf-8-validate@5.0.10))
+        specifier: 18.5.0
+        version: 18.5.0(@chromatic-com/playwright@0.13.2(@playwright/test@1.53.1)(@testing-library/dom@10.4.0)(bufferutil@4.0.9)(prettier@3.5.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(utf-8-validate@5.0.10))
       decompress:
         specifier: ^4.2.1
         version: 4.2.1
@@ -6281,16 +6281,20 @@ packages:
       '@chromatic-com/playwright':
         optional: true
 
-  chromatic@16.0.0:
-    resolution: {integrity: sha512-O81RVGDXXoreNeG894hjaUx08xep+C/BA6aJNMZkwSjH7Lln8IweZekBpBEoQPNNpjmHyZvcTIwN/aGitdK53Q==}
+  chromatic@18.5.0:
+    resolution: {integrity: sha512-3oBcGP4V+6SV0qu2NJnutnPYsrxnPpOHhtQAbzxEtIQrDJNzn1wfXtzwkEiJGQm5eANTW0AvL4WxHtz+BTJbYg==}
+    engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
       '@chromatic-com/cypress': ^0.*.* || ^1.0.0
       '@chromatic-com/playwright': ^0.*.* || ^1.0.0
+      '@chromatic-com/vitest': ^0.*.* || ^1.0.0
     peerDependenciesMeta:
       '@chromatic-com/cypress':
         optional: true
       '@chromatic-com/playwright':
+        optional: true
+      '@chromatic-com/vitest':
         optional: true
 
   chrome-trace-event@1.0.4:
@@ -19596,7 +19600,9 @@ snapshots:
     optionalDependencies:
       '@chromatic-com/playwright': 0.13.2(@playwright/test@1.53.1)(@testing-library/dom@10.4.0)(bufferutil@4.0.9)(prettier@3.5.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(utf-8-validate@5.0.10)
 
-  chromatic@16.0.0(@chromatic-com/playwright@0.13.2(@playwright/test@1.53.1)(@testing-library/dom@10.4.0)(bufferutil@4.0.9)(prettier@3.5.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(utf-8-validate@5.0.10)):
+  chromatic@18.5.0(@chromatic-com/playwright@0.13.2(@playwright/test@1.53.1)(@testing-library/dom@10.4.0)(bufferutil@4.0.9)(prettier@3.5.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(utf-8-validate@5.0.10)):
+    dependencies:
+      semver: 7.8.5
     optionalDependencies:
       '@chromatic-com/playwright': 0.13.2(@playwright/test@1.53.1)(@testing-library/dom@10.4.0)(bufferutil@4.0.9)(prettier@3.5.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(utf-8-validate@5.0.10)
 
@@ -19852,7 +19858,7 @@ snapshots:
       postcss-modules-scope: 3.2.1(postcss@8.5.23)
       postcss-modules-values: 4.0.0(postcss@8.5.23)
       postcss-value-parser: 4.2.0
-      semver: 7.7.4
+      semver: 7.8.5
     optionalDependencies:
       webpack: 5.99.9(esbuild@0.28.2)
 
@@ -21125,7 +21131,7 @@ snapshots:
       minimatch: 3.1.2
       node-abort-controller: 3.1.1
       schema-utils: 3.3.0
-      semver: 7.7.4
+      semver: 7.8.5
       tapable: 2.2.2
       typescript: 5.8.3
       webpack: 5.99.9(esbuild@0.28.2)


### PR DESCRIPTION
Chromatic now bills **zero** for builds that don't touch any story ([Aug 2026 changelog](https://www.chromatic.com/blog/chromatic-changelog-august-2026/)). Before, those still cost ~50 snapshots each. Needs CLI >= 17.7.0; we're on 16.0.0.

**44 of the last 97 merged PRs (45%) touch no UI code**, so they should become free.

## Changes

- `chromaui/action@v16` -> `@v18.5.0` in both Chromatic jobs (exact pin — `@v18` is mutable and bundles its own CLI)
- devDep `chromatic` `16.0.0` -> `18.5.0`
- `uploadMetadata: false` — it silently defaults to **on** when `onlyChanged` is set (CLI 17.6+), which would publish an unredacted debug log next to our public Storybook
- Fixed `ci.yml` comments + `docs/applying-storybook.md`, which claimed every non-draft PR publishes a build

Heads up: the lockfile regen also bumps semver 7.7.4 -> 7.8.5 on the webpack path.
