### PR TITLE
Add BoltRPC to nodes-as-a-service providers

### DIFF
--- a/public/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
+++ b/public/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
@@ -147,6 +147,15 @@ Here is a list of some of the most popular Ethereum node providers, feel free to
     - Pay in crypto
     - Direct support & Technical support
 
+- [**BoltRPC**](https://boltrpc.io/)
+  - [Docs](https://boltrpc.io/docs)
+  - Features
+    - 20+ chains including Ethereum, Solana, Arbitrum, Base, Polygon, Optimism, and more
+    - HTTPS and WebSocket RPC endpoints on every plan
+    - Single API key across all supported chains with multi-region failover
+    - Transparent request-unit (RU) pricing with published per-method weights
+    - 14-day free trial (no credit card required); plans from $49/mo
+
 - [**Chainbase**](https://www.chainbase.com/)
   - [Docs](https://docs.chainbase.com)
   - Features


### PR DESCRIPTION
## What does this PR add?

Adds [BoltRPC](https://boltrpc.io) to the "Popular node services" section of the nodes-as-a-service documentation page.

BoltRPC is a multi-chain RPC provider supporting 20+ networks (Ethereum, Solana, Arbitrum, Base, Polygon, Optimism, and more) with HTTPS and WebSocket endpoints, a single API key across all chains, and automatic multi-region failover. Operated by Matrixed.Link (ISO/IEC 27001:2022 certified).

**Free trial:** 14 days on any tier, no credit card required.  
**Docs:** https://boltrpc.io/docs

## Checklist

- [x] Added in alphabetical order (between BlockPI and Chainbase)
- [x] Format matches existing entries
- [x] Links verified and working