### PR TITLE
fix(ui): Devcon banner logo shrinking and headline overflow

### DIFF
--- a/app/[locale]/community/events/page.tsx
+++ b/app/[locale]/community/events/page.tsx
@@ -140,7 +140,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
       />
 
       {/* Devcon VIII India callout banner */}
-      <DevconIndiaLargeCallout />
+      <DevconIndiaLargeCallout preload />
 
       {/* What's on this page? + TabNav */}
       <StickyContainer className="top-6 space-y-4 p-4 md:top-2 md:p-8">

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -99,7 +99,7 @@ const Page = async (props: { params: Promise<PageParams> }) => {
           <Alert
             variant="banner"
             // Devcon colors: keep hex colors
-            className="relative grid grid-cols-[1fr_auto_1fr] gap-x-8 overflow-hidden bg-linear-to-b from-[#1A0D33] to-[#45326C] py-3 transition-[--tw-gradient-to-position] duration-300 hover:to-80% max-md:px-4! max-sm:px-8 **:[img]:transition-transform **:[img]:duration-500 hover:**:[img]:scale-105"
+            className="relative gap-x-4 overflow-hidden bg-linear-to-b from-[#1A0D33] to-[#45326C] py-3 transition-[--tw-gradient-to-position] duration-300 hover:to-80% max-md:px-4! max-sm:px-8 lg:gap-x-8 **:[img]:transition-transform **:[img]:duration-500 hover:**:[img]:scale-105"
           >
             <div className="absolute inset-x-0 grid place-items-center">
               <Image
@@ -111,13 +111,13 @@ const Page = async (props: { params: Promise<PageParams> }) => {
               />
             </div>
 
-            <div className="flex items-center justify-start gap-x-8">
+            <div className="flex flex-1 shrink-0 items-center justify-start gap-x-8">
               <Image
                 src="/images/assets/svgs/devcon-india-logo.svg"
                 alt={tDevcon("logo-alt")}
                 width="139"
                 height="60"
-                className="h-9.5 w-22 shrink-0"
+                className="h-9.5 w-22 max-w-none shrink-0"
               />
               <DevconDateLocation
                 longMonthBreakpoint="xl"
@@ -125,11 +125,11 @@ const Page = async (props: { params: Promise<PageParams> }) => {
               />
             </div>
 
-            <div className="grid place-items-center text-xs font-black sm:text-sm md:text-md lg:text-xl">
+            <div className="min-w-0 text-center text-xs font-black sm:text-sm md:text-md lg:text-xl">
               {tDevcon("headline")}
             </div>
 
-            <div className="flex justify-end">
+            <div className="flex flex-1 shrink-0 justify-end">
               {/* Overlay stretches the CTA's hit area across the whole banner */}
               <LinkOverlay asChild>
                 <ButtonLink

--- a/src/components/DevconIndia/large-callout.tsx
+++ b/src/components/DevconIndia/large-callout.tsx
@@ -10,7 +10,7 @@ import DevconDateLocation from "./date-location"
 
 import devconIndiaBanner from "@/public/images/assets/devcon-india-banner.webp"
 
-const DevconIndiaLargeCallout = async () => {
+const DevconIndiaLargeCallout = async ({ preload }: { preload?: boolean }) => {
   const tDevcon = await getTranslations("component-devcon-banner")
   return (
     <Card
@@ -28,7 +28,7 @@ const DevconIndiaLargeCallout = async () => {
         src={devconIndiaBanner}
         alt=""
         fill
-        preload
+        preload={preload}
         sizes="100vw"
         quality={90}
         className="-z-20 object-cover object-bottom"


### PR DESCRIPTION
## Summary

Fixes two problems with the homepage Devcon banner: the logo shrank on mobile Safari, and the headline did not wrap there, overflowing into the date/location block and the CTA just above the `md` breakpoint.

The banner row is now flex instead of a three-track `1fr auto 1fr` grid. Safari under-sizes the side tracks when the row is space-constrained, which let preflight's `img { max-width: 100% }` clamp the logo down and let the max-content headline spill over its neighbors. The side columns now grow from a zero basis and never shrink, and the headline is the only shrinkable item so it wraps instead.

## Screenshot
<img width="330" height="680" alt="Screenshot 2026-08-27 at 09 44 18" src="https://github.com/user-attachments/assets/13340208-0d3b-4950-8334-1d36c1b5e0d8" />

## Issue
<img width="330" height="680" alt="Screenshot 2026-08-27 at 09 46 45" src="https://github.com/user-attachments/assets/d8e5aea7-2317-48ce-a241-673acddcbe13" />

**Addendum**
Passes a `preload` prop through `DevconIndiaLargeCallout` to Next image, allowing for optional `preload` of large callout image. Defaults to `false`; applied `true` to `/community/events/` page where the callout is above-the-fold (prevents `preload` being used on homepage where it's at end-of-page)