### PR TITLE
feat: label automated traffic with a Matomo custom dimension

### DIFF
--- a/src/components/Matomo.tsx
+++ b/src/components/Matomo.tsx
@@ -4,7 +4,11 @@ import { useEffect, useState } from "react"
 import { usePathname } from "next/navigation"
 import { init, push } from "@socialgouv/matomo-next"
 
-import { isOptedOut } from "@/lib/utils/matomo"
+import {
+  AUTOMATION_DIMENSION_ID,
+  detectAutomation,
+  isOptedOut,
+} from "@/lib/utils/matomo"
 
 // Module-level flag to prevent double initialization in React Strict Mode
 let matomoInitialized = false
@@ -19,6 +23,15 @@ export default function Matomo() {
       init({
         url: process.env.NEXT_PUBLIC_MATOMO_URL!,
         siteId: process.env.NEXT_PUBLIC_MATOMO_SITE_ID!,
+        // Must reach _paq before init queues its own trackPageView, or
+        // single-action visits -- most automated ones -- arrive unlabelled.
+        onInitialization: () => {
+          push([
+            "setCustomDimension",
+            AUTOMATION_DIMENSION_ID,
+            detectAutomation(),
+          ])
+        },
       })
 
       // Use sendBeacon API for reliable tracking during page navigation

--- a/src/lib/utils/matomo.ts
+++ b/src/lib/utils/matomo.ts
@@ -53,3 +53,30 @@ export const trackCustomEvent = ({
     push([`trackEvent`, eventCategory, eventAction, eventName, eventValue])
   })
 }
+
+// Dimension 1 is the A/B variant; 2 must exist in Matomo with visit scope.
+export const AUTOMATION_DIMENSION_ID = 2
+
+export type AutomationVerdict = "human" | "webdriver" | "headless-ua"
+
+type AutomationSignals = {
+  webdriver: boolean
+  userAgent: string
+}
+
+// Independent of the resolution/version heuristics the bot census uses -- don't
+// add screen-size checks, that independence is what makes agreement meaningful.
+export const classifyAutomation = ({
+  webdriver,
+  userAgent,
+}: AutomationSignals): AutomationVerdict => {
+  if (webdriver) return "webdriver"
+  if (/headless/i.test(userAgent)) return "headless-ua"
+  return "human"
+}
+
+export const detectAutomation = (): AutomationVerdict =>
+  classifyAutomation({
+    webdriver: navigator.webdriver,
+    userAgent: navigator.userAgent,
+  })

--- a/tests/unit/matomo/automation.spec.ts
+++ b/tests/unit/matomo/automation.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "@playwright/test"
+
+import { classifyAutomation } from "../../../src/lib/utils/matomo"
+
+const CHROME_UA =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36"
+
+test.describe("classifyAutomation", () => {
+  test("flags navigator.webdriver regardless of user agent", () => {
+    expect(classifyAutomation({ webdriver: true, userAgent: CHROME_UA })).toBe(
+      "webdriver"
+    )
+    expect(classifyAutomation({ webdriver: true, userAgent: "" })).toBe(
+      "webdriver"
+    )
+  })
+
+  test("flags headless user agents", () => {
+    expect(
+      classifyAutomation({
+        webdriver: false,
+        userAgent: CHROME_UA.replace("Chrome/", "HeadlessChrome/"),
+      })
+    ).toBe("headless-ua")
+    expect(
+      classifyAutomation({ webdriver: false, userAgent: "headless" })
+    ).toBe("headless-ua")
+  })
+
+  test("webdriver takes precedence over the user-agent signal", () => {
+    expect(
+      classifyAutomation({ webdriver: true, userAgent: "HeadlessChrome/144" })
+    ).toBe("webdriver")
+  })
+
+  test("leaves ordinary browsers alone", () => {
+    const humanUserAgents = [
+      CHROME_UA,
+      "Mozilla/5.0 (X11; Linux x86_64; rv:130.0) Gecko/20100101 Firefox/130.0",
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.6 Safari/605.1.15",
+      // versionless Safari: the census flags this cohort by resolution, which
+      // this classifier deliberately does not look at
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Safari/605.1.15",
+      "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/150.0.0.0 Mobile Safari/537.36",
+    ]
+
+    for (const userAgent of humanUserAgents) {
+      expect(classifyAutomation({ webdriver: false, userAgent })).toBe("human")
+    }
+  })
+})


### PR DESCRIPTION
## Description

Matomo counts headless browsers that spoof real user agents as visitors, so site 4 numbers can't be trusted. Identifying them afterwards means maintaining an exclusion list keyed to screen resolutions and browser versions, which goes stale as soon as an operator bumps its Chrome version.

This records the verdict on arrival instead. Visit-scoped **custom dimension 2** holds `human`, `webdriver` or `headless-ua`, so one segment replaces the exclusion list and doesn't rot.

Two details worth knowing:

- **Only `navigator.webdriver` and a headless UA token are used.** Both are near-zero false positive. Screen-size and browser-version signals are deliberately left out — the existing bot census already filters on those, so keeping them out is what lets agreement between the two methods count as evidence rather than a restatement.
- **Set via `init`'s `onInitialization`.** That's the only hook that reaches `_paq` before `init` queues its own `trackPageView`. Setting it any later leaves single-action visits unlabelled, which is most automated ones.

Reporting only — nothing is excluded, suppressed or blocked.

### Before this reports anything

Create dimension 2 in Matomo for site 4 (Administration → Websites → Custom Dimensions), **visit scope**. Until it exists Matomo accepts the value and discards it. Dimension 1 is already the A/B variant; if Matomo assigns a different index, update `AUTOMATION_DIMENSION_ID`.

Then the clean-traffic segment is `dimension2==human`.

## Related Issue

None — follow-up to the bot traffic analysis.
