### PR TITLE
fix(prepare-release): never leave a deploy PR without a published release

### DIFF
--- a/.claude/commands/prepare-release.md
+++ b/.claude/commands/prepare-release.md
@@ -123,11 +123,30 @@ EOF
 RELEASE_URL=$(./src/scripts/prepare-release.sh $DRY_RUN_FLAG publish "$VERSION" "$DRAFT_TAG" /tmp/claude/release-notes.md)
 ```
 
+**This step is a hard gate. If it fails for ANY reason — a `gh` error, or a
+permission prompt you cannot get approved — STOP HERE.** Do not run Step 8, and
+do not work around the block. Report to the user that the version was bumped and
+`staging` was merged, that the release is NOT published, and that the deploy PR
+was deliberately not created. A deploy PR without a published release is the one
+state that ships silently: the PR can be merged by anyone, and the missing
+release notes are invisible until someone checks the releases page.
+
+(This is exactly how v11.22.0 shipped on 2026-08-25 with no release.)
+
 ### Step 8: Create Deploy PR
 
 ```bash
 PR_URL=$(./src/scripts/prepare-release.sh $DRY_RUN_FLAG create-pr "$VERSION" /tmp/claude/release-notes.md)
 ```
+
+### Step 8b: Verify the Release Published
+
+```bash
+./src/scripts/prepare-release.sh $DRY_RUN_FLAG verify "$VERSION"
+```
+
+If this fails, say so loudly in the final report — the deploy PR must not be
+merged until the release exists.
 
 ### Step 9: Cleanup Worktree
 

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -107,6 +107,14 @@ jobs:
           echo "url=$url"       >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
+      # A deploy PR can merge with no published release, which ships a version
+      # whose notes never went out (v11.22.0, 2026-08-25). Fail before review.
+      - name: Verify the release was published
+        if: steps.skip_check.outputs.skip == 'false'
+        run: |
+          version="${{ steps.capture_pr.outputs.version }}"
+          ./src/scripts/prepare-release.sh verify "${version#v}"
+
       - name: Announce prepared
         id: announce_prepared
         if: steps.skip_check.outputs.skip == 'false'

--- a/src/scripts/prepare-release.sh
+++ b/src/scripts/prepare-release.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 #   ./src/scripts/prepare-release.sh [--dry-run] fetch-draft        # Fetch draft release body
 #   ./src/scripts/prepare-release.sh [--dry-run] publish <version> <draft_tag> <body_file>  # Publish release
 #   ./src/scripts/prepare-release.sh [--dry-run] create-pr <version> <body_file>            # Create deploy PR
+#   ./src/scripts/prepare-release.sh [--dry-run] verify <version>   # Assert the release was published
 #   ./src/scripts/prepare-release.sh cleanup            # Remove worktree if created
 #   ./src/scripts/prepare-release.sh reset              # Reset worktree to clean state
 #
@@ -382,6 +383,37 @@ cmd_create_pr() {
   fi
 }
 
+# A deploy PR can merge even when publishing was skipped, shipping a version
+# whose release notes never went out. Fail loudly instead.
+cmd_verify() {
+  local VERSION="${1:-}"
+
+  if [[ -z "$VERSION" ]]; then
+    log_error "Usage: prepare-release.sh verify <version>"
+    exit 1
+  fi
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    log_dry "gh release view v$VERSION --repo $REPO --json isDraft"
+    log_info "✓ Would verify release v$VERSION"
+    return 0
+  fi
+
+  local IS_DRAFT
+  if ! IS_DRAFT=$(gh release view "v$VERSION" --repo "$REPO" --json isDraft -q .isDraft 2>/dev/null); then
+    log_error "No release exists for v$VERSION — it was never published."
+    log_error "Publish it before merging the deploy PR."
+    exit 1
+  fi
+
+  if [[ "$IS_DRAFT" == "true" ]]; then
+    log_error "Release v$VERSION is still a draft — it was not published."
+    exit 1
+  fi
+
+  log_info "✓ Release v$VERSION is published"
+}
+
 # Parse --dry-run flag
 if [[ "${1:-}" == "--dry-run" ]]; then
   DRY_RUN=true
@@ -409,6 +441,9 @@ case "${1:-}" in
   create-pr)
     cmd_create_pr "${2:-}" "${3:-}"
     ;;
+  verify)
+    cmd_verify "${2:-}"
+    ;;
   cleanup)
     cmd_cleanup
     ;;
@@ -428,6 +463,7 @@ case "${1:-}" in
     echo "  fetch-draft            Fetch draft release body (JSON)"
     echo "  publish <ver> <tag> <body_file>   Publish release"
     echo "  create-pr <ver> <body_file>       Create deploy PR"
+    echo "  verify <ver>           Assert the release for <ver> was published"
     echo "  cleanup                Remove worktree if created"
     echo "  reset                  Reset worktree to clean state (recovery)"
     exit 1

--- a/src/scripts/prepare-release.sh
+++ b/src/scripts/prepare-release.sh
@@ -153,6 +153,21 @@ cmd_reset() {
   log_info "✓ Worktree reset and updated"
 }
 
+# Fast-forward a release branch onto its origin counterpart before merging into
+# it. The worktree checks out the *local* ref, which on a dev machine is usually
+# stale; merging into it rewinds the branch and the push is rejected.
+sync_branch_to_origin() {
+  local branch="$1"
+  local ahead
+  ahead=$(run_in_workdir git rev-list --count "origin/$branch..$branch")
+  if [[ "$ahead" -gt 0 ]]; then
+    log_error "Local $branch has $ahead commit(s) not on origin/$branch."
+    log_error "Release branches must mirror origin. Resolve manually."
+    exit 1
+  fi
+  run_in_workdir_or_dry git reset --hard "origin/$branch"
+}
+
 cmd_preflight() {
   log_info "Running pre-flight checks..."
 
@@ -176,6 +191,7 @@ cmd_preflight() {
   # Fetch latest from origin
   log_info "Fetching latest from origin..."
   run_in_workdir git fetch origin
+  sync_branch_to_origin dev
 
   # Back-merge: master -> staging (if needed)
   log_info "Checking if master needs to be merged into staging..."
@@ -183,6 +199,7 @@ cmd_preflight() {
   if [[ "$MASTER_AHEAD" -gt 0 ]]; then
     log_info "Merging origin/master into staging ($MASTER_AHEAD commits)..."
     run_in_workdir_or_dry git checkout staging
+    sync_branch_to_origin staging
     run_in_workdir_or_dry git merge origin/master -m "Merge master into staging"
     run_in_workdir_or_dry git push origin staging
     run_in_workdir_or_dry git checkout dev
@@ -263,7 +280,9 @@ cmd_merge_staging() {
 
   log_info "Merging dev into staging..."
 
+  run_in_workdir git fetch origin
   run_in_workdir_or_dry git checkout staging
+  sync_branch_to_origin staging
   run_in_workdir_or_dry git merge dev -m "Merge dev into staging for release"
   run_in_workdir_or_dry git push origin staging
   run_in_workdir_or_dry git checkout dev


### PR DESCRIPTION
## Why

v11.22.0 shipped to production on 2026-08-25 with **no GitHub release**. It went unnoticed for two days.

What happened:

1. The scheduled `weekly-release.yml` run died 1.1s into its first API call (`num_turns: 1`, `$0` spent). Discord got the failure alarm.
2. The release was then prepared locally. Tag `v11.22.0` was pushed, `staging` merged.
3. The `publish` step was blocked by a permission prompt.
4. The flow **continued to `create-pr` anyway** — the command doc orders publish (Step 7) before create-pr (Step 8) but never says "stop if publish fails".
5. The deploy PR (#19152) merged. Version live in prod, release notes never published, draft still sitting at `v11.21.1`.

A deploy PR without a published release is the one failure state that ships silently — the PR is mergeable by anyone and the gap is invisible unless someone opens the releases page.

## What this changes

- **`verify <version>`** — new script command asserting a published, non-draft release exists for a version. Exits non-zero with a clear message otherwise.
- **`weekly-release.yml`** — runs `verify` right after the deploy PR is captured, so a missing release fails the `prepare` job and trips the existing Discord alarm before the review job ever starts. Strips the `v` prefix, since the script adds its own.
- **Command doc** — Step 7 is now an explicit hard gate: if publish fails for any reason, stop, do not create the deploy PR, and report the exact state.
- **Stale-dev fix** (first commit, written 2026-08-20, never pushed) — `setup_worktree` checks out the *local* `dev`, which on a dev machine is usually stale; back-merging into it then rewinds the branch and the push is rejected as non-fast-forward. Both the Aug 25 run and a run today hit this. Now the release branches are fast-forwarded to their origin counterparts first, and it hard-errors if a local release branch has commits origin doesn't.

## Verification

- `bash -n` on the script; `yaml.safe_load` on the workflow
- `verify 11.21.0` → passes; `verify 11.22.0` → failed correctly while that release was missing, passes now that it is published
- `--dry-run verify` → no-ops without calling `gh`
- `--dry-run preflight` → confirms the branch now resets to `origin/dev` before back-merging

The missing v11.22.0 release has been published separately: https://github.com/ethereum/ethereum-org-website/releases/tag/v11.22.0
