### PR TITLE
feat(search): add docsearch ranking meta tags

### DIFF
--- a/src/lib/utils/metadata.ts
+++ b/src/lib/utils/metadata.ts
@@ -27,6 +27,26 @@ const imageForSlug = [
 ] as const
 
 /**
+ * Ranking hints consumed by the search crawler, mirroring the rules in the Algolia
+ * DocSearch `recordExtractor` so relevance survives the move to Typesense. The
+ * self-hosted scraper copies any `docsearch:*` meta tag onto every record it extracts.
+ */
+const isTutorialSlug = (slug: string[]) =>
+  slug[0] === "developers" && slug[1] === "tutorials" && slug.length > 2
+
+// Matches Algolia's `pathname.split("/").length === 4`, which is one slug segment.
+// The homepage (no segments) therefore scores 5, as it does today -- kept for parity.
+const pageRankForSlug = (slug: string[]): number =>
+  isTutorialSlug(slug) ? 1 : slug.length === 1 ? 10 : 5
+
+const categoryForSlug = (slug: string[]): string => {
+  if (slug[0] === "developers" && slug[1] === "docs") return "docs"
+  if (isTutorialSlug(slug)) return "tutorials"
+  if (slug[0] === "developers") return "devs"
+  return "other"
+}
+
+/**
  * Get the default OG image for a page based on the slug
  * @param slug - the slug of the page
  * @returns relative path of image
@@ -146,6 +166,11 @@ export const getMetadata = async ({
     },
     other: {
       "docsearch:description": description,
+      // The self-hosted scraper does not read `<html lang>`; the filter the app
+      // sends (`language:=<locale>`) is only populated from this tag.
+      "docsearch:language": locale,
+      "docsearch:pagerank": pageRankForSlug(slug),
+      "docsearch:category": categoryForSlug(slug),
     },
   }
 


### PR DESCRIPTION
## Summary

Adds three `docsearch:*` meta tags that the self-hosted Typesense DocSearch scraper copies onto every record it extracts, replacing what Algolia's hosted crawler currently supplies from its dashboard-side `recordExtractor`.

`pagerank` and `category` mirror that extractor's rules exactly (tutorials 1, root-level pages 10, everything else 5; categories docs / tutorials / devs / other). Both rules were reimplemented and compared across all 392 page slugs in the repo -- zero mismatches. Without `pagerank` the Typesense collection carries no page-importance signal, so ambiguous single-word queries like `staking` and `erc20` can't be ranked: every matching document scores the same on text match and `sort_by` has nothing to break the tie on.

`language` is required for the app's `filter_by: language:=<locale>` to return anything, since the self-hosted scraper doesn't derive it from `<html lang>` the way Algolia's hosted crawler does. This supersedes the same one-line change in the draft PR #18346, which can drop it.

Note for collection setup: meta values arrive as strings, so `pagerank` needs declaring as `int32` in the Typesense schema or numeric sorting will order `"10"` below `"5"`.