### PR TITLE
intl: restore daily cron, fix CJK length floor

### DIFF
--- a/.claude/skills/intl-pipeline/SKILL.md
+++ b/.claude/skills/intl-pipeline/SKILL.md
@@ -5,7 +5,7 @@ description: Use when working on the translation pipeline (`src/scripts/intl-pip
 
 # intl-pipeline
 
-LLM-based, manifest-driven, incremental translation pipeline for ethereum.org. Translates English content (markdown in `public/content/`, JSON UI strings in `src/intl/en/`) into 24 target languages via Gemini — reached either directly or through OpenRouter (`LLM_PROVIDER`), whose keys carry a server-side spend limit — with a post-import sanitizer normalizing common artifacts. **The workflow is manual-dispatch only**; the daily cron was removed after a run billed $1,108 unattended (`references/runbooks/cost-guard-tripped.md`). ETHGlossary is the authoritative source for all Ethereum-ecosystem term translations consumed by the pipeline. Read this file fully on activation; pull from `references/` only when the listed trigger applies.
+LLM-based, manifest-driven, incremental translation pipeline for ethereum.org. Translates English content (markdown in `public/content/`, JSON UI strings in `src/intl/en/`) into 24 target languages via Gemini — reached either directly or through OpenRouter (`LLM_PROVIDER`), whose keys carry a server-side spend limit — with a post-import sanitizer normalizing common artifacts. **The workflow runs daily at 04:20 UTC and on manual dispatch**; the cron was off between 2026-08-12 and 2026-08-27 after a run billed $1,108 unattended, and was restored once the input-side bounds had supervised runs behind them (`references/runbooks/cost-guard-tripped.md`). ETHGlossary is the authoritative source for all Ethereum-ecosystem term translations consumed by the pipeline. Read this file fully on activation; pull from `references/` only when the listed trigger applies.
 
 ## The Core Rule: Don't Hand-Propagate English Changes
 

--- a/.claude/skills/intl-pipeline/references/gotchas.md
+++ b/.claude/skills/intl-pipeline/references/gotchas.md
@@ -76,3 +76,10 @@ There is no `TARGET_FILES` env var — the sanitizer only reads `TARGET_LANGUAGE
 
 ETHGlossary entries have `id` (slug, e.g., `"vitalik-buterin"`) and `term` (display form, e.g., `"Vitalik Buterin"`). Per-term lookups use the ID; the API also matches aliases intelligently. When searching, prefer the slug ID; for display, use the term.
 
+## Output length floor is script-aware
+
+`validateTranslatedMarkdown` rejects output below a fraction of the English character count as truncated. That fraction is not one number: CJK renders the same content in far fewer characters, so `zh`, `zh-tw`, `ja` and `ko` get a 0.2 floor and everything else 0.3 (`LENGTH_FLOOR_*` in `output-validation.ts`). Measured across `public/content`, whole-file translated/English ratios are median 0.49 / min 0.34 for zh and zh-tw, 0.64 / 0.47 for ja and ko, and >=0.76 for every other locale; chunk-level ratios run lower than whole-file ones.
+
+The flat 0.3 floor that predated this is what kept `whitepaper/index.md` zh + zh-tw failing every scheduled run from 2026-07-30 to 2026-08-20 — a correct 0.245-ratio chunk read as truncation, three retries burned, no manifest stamped, and the next run repeated the entire 90KB file. If you see `Suspiciously short` for a locale that legitimately compresses, check the floor before blaming the model. Keep in mind this floor is the only truncation check in the run path: `verify-structure.ts` exists but is a standalone CLI, not wired into `main.ts`.
+
+The call site must pass `targetLanguage` — omitting it silently falls back to the 0.3 default.

--- a/.claude/skills/intl-pipeline/references/runbooks/cost-guard-tripped.md
+++ b/.claude/skills/intl-pipeline/references/runbooks/cost-guard-tripped.md
@@ -89,5 +89,5 @@ Assembles every prompt, sends none, prints projected prompt bytes / requests / t
 ## What not to do
 
 - Do not raise `INTL_MAX_COST_USD` or the per-call ceiling to make a run pass. Both are calibrated ~30% above measured worst cases; hitting them means the call pattern changed.
-- Do not restore the cron. The workflow is manual-dispatch only until the bounds have supervised runs behind them.
+- Do not disable a bound to make a run pass, and do not treat the cron as the thing that went wrong. The cron was off from 2026-08-12 to 2026-08-27 and was restored once the bounds had supervised runs behind them; the incident was a batching bug, and it would have cost the same on a manual dispatch.
 - Do not add an LLM call site that bypasses `callGeminiRaw` — it is the single choke point where the per-call ceiling and the run fuse are enforced.

--- a/.github/workflows/intl-pipeline.yml
+++ b/.github/workflows/intl-pipeline.yml
@@ -1,6 +1,9 @@
 name: Intl Pipeline
 
 on:
+  schedule:
+    # Daily 04:20 UTC; empty inputs fall through to pipeline defaults (dev, auto, all locales)
+    - cron: "20 4 * * *"
   workflow_dispatch:
     inputs:
       target_path:

--- a/src/scripts/intl-pipeline/lib/llm/gemini.ts
+++ b/src/scripts/intl-pipeline/lib/llm/gemini.ts
@@ -1280,7 +1280,7 @@ async function callGemini(
     const validation: ValidationResult =
       fileType === "json"
         ? validateTranslatedJson(text, fileContent)
-        : validateTranslatedMarkdown(text, fileContent)
+        : validateTranslatedMarkdown(text, fileContent, targetLanguage)
 
     if (validation.valid) {
       return {

--- a/src/scripts/intl-pipeline/lib/llm/output-validation.ts
+++ b/src/scripts/intl-pipeline/lib/llm/output-validation.ts
@@ -8,6 +8,19 @@ export interface ValidationResult {
   error?: string
 }
 
+// Truncation floor as a fraction of the English character count. CJK renders
+// the same content in roughly half the characters, so a flat floor reads
+// correct output as truncated (see intl-pipeline skill, references/gotchas.md).
+const LENGTH_FLOOR_DEFAULT = 0.3
+const LENGTH_FLOOR_CJK = 0.2
+const CJK_LOCALES = new Set(["zh", "zh-tw", "ja", "ko"])
+
+function lengthFloor(targetLanguage?: string): number {
+  return targetLanguage && CJK_LOCALES.has(targetLanguage)
+    ? LENGTH_FLOOR_CJK
+    : LENGTH_FLOOR_DEFAULT
+}
+
 /**
  * Validate translated JSON output.
  */
@@ -68,7 +81,8 @@ export function validateTranslatedJson(
  */
 export function validateTranslatedMarkdown(
   translated: string,
-  english: string
+  english: string,
+  targetLanguage?: string
 ): ValidationResult {
   const base = validateCommon(translated)
   if (!base.valid) return base
@@ -86,11 +100,13 @@ export function validateTranslatedMarkdown(
     }
   }
 
-  // Suspiciously short (truncated output)
-  if (translated.length < english.length * 0.3) {
+  // Suspiciously short (truncated output). This is the only truncation check in
+  // the run path -- verify-structure.ts is a standalone CLI, not wired in.
+  const floor = lengthFloor(targetLanguage)
+  if (translated.length < english.length * floor) {
     return {
       valid: false,
-      error: `Suspiciously short: ${translated.length} chars vs ${english.length} English chars`,
+      error: `Suspiciously short: ${translated.length} chars vs ${english.length} English chars (floor ${floor})`,
     }
   }
 

--- a/tests/unit/intl-pipeline/output-validation.spec.ts
+++ b/tests/unit/intl-pipeline/output-validation.spec.ts
@@ -119,6 +119,74 @@ Contenido aqui.
     expect(result.error).toContain("Suspiciously short")
   })
 
+  // Regression: whitepaper/index.md zh + zh-tw failed every scheduled run from
+  // 2026-07-30 on, three attempts each, at a stable 381-393 chars against the
+  // same 1571-char English chunk. Chinese renders that content in ~0.245 of the
+  // characters; the flat 0.3 floor read correct output as truncation, the
+  // manifest never stamped, and the next run repeated the whole file.
+  const longEnglish = `---
+title: Test Page
+description: A test description
+---
+
+# Heading {#heading}
+
+${"The quick brown fox jumps over the lazy dog. ".repeat(34)}
+`
+  const denseTranslation = `---
+title: 測試頁面
+description: 測試說明
+---
+
+# 標題 {#heading}
+
+${"敏捷的棕色狐狸跳過懶狗。".repeat(30)}
+`
+
+  test("dense CJK output passes the CJK floor", () => {
+    const ratio = denseTranslation.length / longEnglish.length
+    expect(ratio).toBeGreaterThan(0.2)
+    expect(ratio).toBeLessThan(0.3)
+
+    expect(
+      validateTranslatedMarkdown(denseTranslation, longEnglish, "zh").valid
+    ).toBe(true)
+    expect(
+      validateTranslatedMarkdown(denseTranslation, longEnglish, "zh-tw").valid
+    ).toBe(true)
+  })
+
+  test("the same ratio still fails for a non-CJK locale", () => {
+    const result = validateTranslatedMarkdown(
+      denseTranslation,
+      longEnglish,
+      "es"
+    )
+    expect(result.valid).toBe(false)
+    expect(result.error).toContain("Suspiciously short")
+  })
+
+  test("genuinely truncated CJK output still fails", () => {
+    const truncated = `---
+title: 測試頁面
+description: 測試說明
+---
+
+# 標題 {#heading}
+
+敏捷的棕色狐狸。
+`
+    const result = validateTranslatedMarkdown(truncated, longEnglish, "zh")
+    expect(result.valid).toBe(false)
+    expect(result.error).toContain("Suspiciously short")
+  })
+
+  test("omitting targetLanguage keeps the default floor", () => {
+    const result = validateTranslatedMarkdown(denseTranslation, longEnglish)
+    expect(result.valid).toBe(false)
+    expect(result.error).toContain("Suspiciously short")
+  })
+
   test("untranslated frontmatter (both title and desc) fails", () => {
     const translated = `---
 title: Test Page


### PR DESCRIPTION
## Summary

Re-enables the daily 04:20 UTC cron on the intl pipeline, and fixes the one thing that would otherwise have made it fail most mornings.

The cost bug that took the cron off (run 31149083965, $1,108 unattended) is closed -- the input-side bounds landed in 0390ed18d9 / c14ff63804 / 6e519b4a3f, OpenRouter's server-side credit limit backs them, and five supervised dispatch runs have gone through since. Stacked runs don't re-translate: when `intl/pending-dev` already exists, the pipeline merges `dev` into it, syncs the working tree from it, and branches off pending, so drift detection reads the manifests that unmerged work already stamped and only genuinely changed sections are sent. Manifest coverage on `dev` is 9,838 of 9,840 pairs.

The remaining 2 are `whitepaper/index.md` for zh and zh-tw, which fail output validation on a flat 0.3 character-count floor that Chinese legitimately sits below -- measured min 0.34 whole-file, and the failing chunk is 0.245. Six recorded attempts across the two locales, from 2026-07-30 through the 2026-08-20 OpenRouter run, all landed in a 381-393 band against the same 1571-char chunk: stable correct output read as truncation, no manifest stamped, and the next run retranslating the whole 90KB file. CJK locales now use a 0.2 floor, everything else keeps 0.3.

RECITATION, the other recurring scheduled-run failure, needed nothing -- it's a Gemini-direct finish reason and went away with the move to OpenRouter.

One caveat: the fix clears the known blocker for those two pairs, but they have never completed end-to-end. A dispatch run with `base_branch: intl/restore-cron`, `target_path: public/content/whitepaper/index.md`, `target_languages: zh,zh-tw` would confirm before merge.
