### PR TITLE
Report unnamed EIPs on data-only upgrade syncs

### DIFF
--- a/.github/workflows/sync-upgrades.yml
+++ b/.github/workflows/sync-upgrades.yml
@@ -89,17 +89,23 @@ jobs:
             echo "Data-only change — notable keys unchanged."
           fi
 
-      # Snapshot of unnamed EIPs, not a diff. Runs on every store change so a
+      # Snapshot of the gap list, not a diff. Runs on every store change so a
       # data-only week still surfaces gaps classify ignores (testnet dates).
+      # Advisory only — a crash here must not cost the week's sync. Printed as
+      # well as saved, so a quiet week still leaves the list in the log.
       - name: Measure content coverage
         id: coverage
         if: steps.diff.outputs.changed == 'true'
-        run: pnpm exec tsx src/scripts/sync-upgrades/coverage.ts > coverage.txt
+        continue-on-error: true
+        run: |
+          pnpm exec tsx src/scripts/sync-upgrades/coverage.ts > coverage.txt
+          cat coverage.txt
 
       # Report before advancing the sync branch. If issue creation fails, the
       # old branch remains the baseline and the same report is retried.
       # Comment when classify found prose-facing keys, or when coverage still
-      # has unnamed EIPs. Stay quiet only when both are empty.
+      # has an unnamed non-networking EIP or a page-less upgrade. Stay quiet
+      # only when both are empty.
       - name: Open or append the content-review issue
         if: steps.classify.outputs.notable == 'true' || steps.coverage.outputs.gaps == 'true'
         env:

--- a/.github/workflows/sync-upgrades.yml
+++ b/.github/workflows/sync-upgrades.yml
@@ -86,24 +86,35 @@ jobs:
             echo "notable=true" >> "$GITHUB_OUTPUT"
           else
             echo "notable=false" >> "$GITHUB_OUTPUT"
-            echo "Data-only change — no content review needed."
+            echo "Data-only change — notable keys unchanged."
           fi
+
+      # Snapshot of unnamed EIPs, not a diff. Runs on every store change so a
+      # data-only week still surfaces gaps classify ignores (testnet dates).
+      - name: Measure content coverage
+        id: coverage
+        if: steps.diff.outputs.changed == 'true'
+        run: pnpm exec tsx src/scripts/sync-upgrades/coverage.ts > coverage.txt
 
       # Report before advancing the sync branch. If issue creation fails, the
       # old branch remains the baseline and the same report is retried.
+      # Comment when classify found prose-facing keys, or when coverage still
+      # has unnamed EIPs. Stay quiet only when both are empty.
       - name: Open or append the content-review issue
-        if: steps.classify.outputs.notable == 'true'
+        if: steps.classify.outputs.notable == 'true' || steps.coverage.outputs.gaps == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           {
             echo "### $(date -u +'%Y-%m-%d') · [data sync](https://github.com/ethereum/ethereum-org-website/compare/dev...$BRANCH)"
             echo
-            echo '```'
-            cat notable.txt
-            echo '```'
-            echo
-            pnpm exec tsx src/scripts/sync-upgrades/coverage.ts
+            if [ -s notable.txt ]; then
+              echo '```'
+              cat notable.txt
+              echo '```'
+              echo
+            fi
+            cat coverage.txt
             echo
             echo "<details><summary>Store diff</summary>"
             echo

--- a/src/scripts/sync-upgrades/coverage.ts
+++ b/src/scripts/sync-upgrades/coverage.ts
@@ -5,9 +5,9 @@
  *
  * Deterministic by design: it lists candidates for a human to judge, it never
  * decides that prose is owed. The Friday workflow runs it on every store
- * change, including data-only weeks, and comments when this list is non-empty.
- * Only unshipped upgrades are checked — a live fork's EIP set is frozen, so a
- * missing explainer there is not news.
+ * change, including data-only weeks, and comments when a gap it can trust
+ * remains. Only unshipped upgrades are checked — a live fork's EIP set is
+ * frozen, so a missing explainer there is not news.
  *
  * Translated pages are out of scope: the intl pipeline owns them, and English
  * is where a gap gets closed.
@@ -108,9 +108,17 @@ export const renderReport = (gaps: CoverageGap[]): string => {
   return sections.join("\n\n")
 }
 
-/** The Actions output the Friday workflow branches on. */
+/**
+ * The Actions output the Friday workflow branches on. Networking EIPs alone
+ * never raise it: a number-only match cannot see their wire names, so they sit
+ * in the list indefinitely and would comment every week. They still print.
+ */
 export const coverageGapFlag = (gaps: CoverageGap[]): "true" | "false" =>
-  gaps.length > 0 ? "true" : "false"
+  gaps.some(
+    (gap) => gap.pageMissing || gap.uncovered.some((eip) => !eip.networking)
+  )
+    ? "true"
+    : "false"
 
 if (process.argv[1]?.endsWith("coverage.ts")) {
   const gaps = findGaps()

--- a/src/scripts/sync-upgrades/coverage.ts
+++ b/src/scripts/sync-upgrades/coverage.ts
@@ -4,13 +4,15 @@
  *   pnpm exec tsx src/scripts/sync-upgrades/coverage.ts
  *
  * Deterministic by design: it lists candidates for a human to judge, it never
- * decides that prose is owed. Only unshipped upgrades are checked — a live
- * fork's EIP set is frozen, so a missing explainer there is not news.
+ * decides that prose is owed. The Friday workflow runs it on every store
+ * change, including data-only weeks, and comments when this list is non-empty.
+ * Only unshipped upgrades are checked — a live fork's EIP set is frozen, so a
+ * missing explainer there is not news.
  *
  * Translated pages are out of scope: the intl pipeline owns them, and English
  * is where a gap gets closed.
  */
-import { readFileSync } from "node:fs"
+import { appendFileSync, readFileSync } from "node:fs"
 
 import { upgrades } from "@/data/upgrades"
 import type { UpgradeData, UpgradeEip } from "@/data/upgrades/types"
@@ -106,6 +108,14 @@ export const renderReport = (gaps: CoverageGap[]): string => {
   return sections.join("\n\n")
 }
 
+/** The Actions output the Friday workflow branches on. */
+export const coverageGapFlag = (gaps: CoverageGap[]): "true" | "false" =>
+  gaps.length > 0 ? "true" : "false"
+
 if (process.argv[1]?.endsWith("coverage.ts")) {
-  console.log(renderReport(findGaps()))
+  const gaps = findGaps()
+  console.log(renderReport(gaps))
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, `gaps=${coverageGapFlag(gaps)}\n`)
+  }
 }

--- a/tests/unit/upgrades/coverage.spec.ts
+++ b/tests/unit/upgrades/coverage.spec.ts
@@ -14,6 +14,7 @@ import type {
   UpgradeStore,
 } from "../../../src/data/upgrades/types"
 import {
+  coverageGapFlag,
   findGaps,
   mentionedEips,
   renderReport,
@@ -85,6 +86,27 @@ test("an unscheduled upgrade is not chased for a page it does not owe", () => {
 
 test("the report says so when there is nothing to write", () => {
   expect(renderReport([])).toContain("Every scheduled EIP")
+  expect(coverageGapFlag([])).toBe("false")
+})
+
+test("a non-empty gap list is the signal to comment on a data-only week", () => {
+  expect(
+    coverageGapFlag([
+      {
+        upgrade: upgrade({}),
+        path: "public/content/roadmap/example/index.md",
+        pageMissing: false,
+        uncovered: [
+          {
+            id: 8246,
+            status: "scheduled",
+            networking: false,
+            decidedAt: null,
+          },
+        ],
+      },
+    ])
+  ).toBe("true")
 })
 
 test("a networking EIP carries the wire-protocol caveat", () => {

--- a/tests/unit/upgrades/coverage.spec.ts
+++ b/tests/unit/upgrades/coverage.spec.ts
@@ -109,6 +109,37 @@ test("a non-empty gap list is the signal to comment on a data-only week", () => 
   ).toBe("true")
 })
 
+test("networking EIPs alone are printed but never trigger a comment", () => {
+  expect(
+    coverageGapFlag([
+      {
+        upgrade: upgrade({}),
+        path: "public/content/roadmap/example/index.md",
+        pageMissing: false,
+        uncovered: [
+          { id: 8070, status: "scheduled", networking: true, decidedAt: null },
+          { id: 8136, status: "scheduled", networking: true, decidedAt: null },
+        ],
+      },
+    ])
+  ).toBe("false")
+})
+
+test("a page that does not exist yet is a gap whatever its EIPs are", () => {
+  expect(
+    coverageGapFlag([
+      {
+        upgrade: upgrade({}),
+        path: "public/content/roadmap/example/index.md",
+        pageMissing: true,
+        uncovered: [
+          { id: 8070, status: "scheduled", networking: true, decidedAt: null },
+        ],
+      },
+    ])
+  ).toBe("true")
+})
+
 test("a networking EIP carries the wire-protocol caveat", () => {
   const gap = {
     upgrade: upgrade({}),


### PR DESCRIPTION
## Summary

- run EIP coverage on every store change, not only when classify finds a notable key
- comment on the standing content-review issue when there are unnamed EIPs, even if the week was testnet-date noise
- stay quiet when classify is empty and coverage has no gaps

Networking EIPs are printed but never trigger a comment on their own: a number-only match cannot see their wire names (`eth/72`), so they would sit in the list and comment every Friday.

Today the gap list is Glamsterdam EIP-8070 / 8136 / 8189 (networking, reported only) and Hegotá EIP-8141 (the one that raises the flag).

## Test plan

- `pnpm exec playwright test tests/unit/upgrades/coverage.spec.ts --project=unit`
- `GITHUB_OUTPUT` from `pnpm exec tsx src/scripts/sync-upgrades/coverage.ts` prints `gaps=true` against the current store

Made with [Cursor](https://cursor.com)
