### PR TITLE
fix(sentry): drop unlocatable stacks

### DIFF
--- a/src/lib/sentry/filter-event.ts
+++ b/src/lib/sentry/filter-event.ts
@@ -41,6 +41,12 @@ const NO_LOCATION = new Set(["", "undefined", "null", "<anonymous>"])
 const hasUsableLocation = (filename?: string, absPath?: string): boolean =>
   [filename, absPath].some((v) => v !== undefined && !NO_LOCATION.has(v))
 
+// For a non-Error throw the SDK synthesizes an exception and prepends its own
+// eventbuilder frame. It resolves to app:///node_modules/@sentry/..., so left
+// in it would count as a location and hide that nothing else can be placed.
+const isSdkFrame = (filename = "", absPath = ""): boolean =>
+  [filename, absPath].some((v) => v.includes("/@sentry/"))
+
 // Not app:/// -- nextjsClientStackFrameNormalization rewrites our own frames to
 // that scheme before beforeSend runs, so it marks first-party code too.
 const isThirdPartyLocation = (filename = "", absPath = ""): boolean =>
@@ -99,7 +105,9 @@ export function getDropReason(event: ErrorEvent): DropReason {
   // ETHORG-1AC's `AutoScroll` scraper). Our own frames are always rewritten to
   // app:///, so an event where *no* frame has a location cannot be ours. A
   // genuinely frameless event is kept: absence of frames is not evidence.
-  const frames = values.flatMap((v) => v.stacktrace?.frames ?? [])
+  const frames = values
+    .flatMap((v) => v.stacktrace?.frames ?? [])
+    .filter((f) => !isSdkFrame(f.filename, f.abs_path))
   if (
     frames.length > 0 &&
     !frames.some((f) => hasUsableLocation(f.filename, f.abs_path))

--- a/src/lib/sentry/filter-event.ts
+++ b/src/lib/sentry/filter-event.ts
@@ -4,7 +4,8 @@ import type { ErrorEvent } from "@sentry/nextjs"
 export type DropReason =
   | "extension-payload"
   | "extension-throw"
-  | "unattributable-overflow"
+  | "unattributable"
+  | "unsupported-browser"
   | "wallet-provider"
   | null
 
@@ -27,7 +28,11 @@ const EIP_1193_CODES = new Set([4001, 4100, 4200, 4900, 4901])
 const isProviderErrorCode = (code: number): boolean =>
   EIP_1193_CODES.has(code) || (code >= -32768 && code <= -32000)
 
-const OVERFLOW_MESSAGE = /Maximum call stack size exceeded|too much recursion/i
+// Abandoned Firefox/Pale Moon forks that fail on modern baseline features, so
+// nothing they report is actionable here. Sentry's legacy-browser inbound
+// filter only knows the mainstream engines and never matches these.
+const UNSUPPORTED_BROWSER =
+  /^(?:Basilisk|Pale ?Moon|Waterfox|SeaMonkey|K-Meleon)$/i
 
 // window.onerror reports cross-origin scripts with no URL, which the SDK
 // stringifies into a frame filename.
@@ -47,10 +52,13 @@ const isThirdPartyLocation = (filename = "", absPath = ""): boolean =>
   )
 
 /**
- * Decide whether a client error event is third-party noise.
+ * Decide whether a client error event is worth keeping.
  *
- * Every rule requires positive evidence that the event did not originate in our
- * bundle, so a genuine first-party regression is never silently swallowed.
+ * Every rule but the last requires positive evidence that the event did not
+ * originate in our bundle, so a genuine first-party regression is never
+ * silently swallowed. `unsupported-browser` is the one exception: those events
+ * may well be ours, but the engine is one we cannot support, so the report is
+ * unactionable either way.
  */
 export function getDropReason(event: ErrorEvent): DropReason {
   const values = event.exception?.values ?? []
@@ -86,15 +94,26 @@ export function getDropReason(event: ErrorEvent): DropReason {
     return "extension-throw"
   }
 
-  // Stack overflows inside a cross-origin script arrive with a single
-  // location-less frame, which no URL-based rule can match (ETHORG-9Q).
-  const message = values.map((v) => v.value ?? "").join("\n")
-  if (OVERFLOW_MESSAGE.test(message)) {
-    const frames = values.flatMap((v) => v.stacktrace?.frames ?? [])
-    const attributable = frames.some((f) =>
-      hasUsableLocation(f.filename, f.abs_path)
-    )
-    if (frames.length > 0 && !attributable) return "unattributable-overflow"
+  // Cross-origin scripts are reported with frames the browser refuses to
+  // locate, so no URL-based rule can match them (ETHORG-9Q's stack overflow,
+  // ETHORG-1AC's `AutoScroll` scraper). Our own frames are always rewritten to
+  // app:///, so an event where *no* frame has a location cannot be ours. A
+  // genuinely frameless event is kept: absence of frames is not evidence.
+  const frames = values.flatMap((v) => v.stacktrace?.frames ?? [])
+  if (
+    frames.length > 0 &&
+    !frames.some((f) => hasUsableLocation(f.filename, f.abs_path))
+  ) {
+    return "unattributable"
+  }
+
+  // `Contexts` types every field as unknown, so narrow before matching.
+  const browserName = event.contexts?.browser?.name
+  if (
+    typeof browserName === "string" &&
+    UNSUPPORTED_BROWSER.test(browserName)
+  ) {
+    return "unsupported-browser"
   }
 
   return null

--- a/src/lib/sentry/filter-event.ts
+++ b/src/lib/sentry/filter-event.ts
@@ -5,7 +5,6 @@ export type DropReason =
   | "extension-payload"
   | "extension-throw"
   | "unattributable"
-  | "unsupported-browser"
   | "wallet-provider"
   | null
 
@@ -28,24 +27,12 @@ const EIP_1193_CODES = new Set([4001, 4100, 4200, 4900, 4901])
 const isProviderErrorCode = (code: number): boolean =>
   EIP_1193_CODES.has(code) || (code >= -32768 && code <= -32000)
 
-// Abandoned Firefox/Pale Moon forks that fail on modern baseline features, so
-// nothing they report is actionable here. Sentry's legacy-browser inbound
-// filter only knows the mainstream engines and never matches these.
-const UNSUPPORTED_BROWSER =
-  /^(?:Basilisk|Pale ?Moon|Waterfox|SeaMonkey|K-Meleon)$/i
-
 // window.onerror reports cross-origin scripts with no URL, which the SDK
 // stringifies into a frame filename.
 const NO_LOCATION = new Set(["", "undefined", "null", "<anonymous>"])
 
 const hasUsableLocation = (filename?: string, absPath?: string): boolean =>
   [filename, absPath].some((v) => v !== undefined && !NO_LOCATION.has(v))
-
-// For a non-Error throw the SDK synthesizes an exception and prepends its own
-// eventbuilder frame. It resolves to app:///node_modules/@sentry/..., so left
-// in it would count as a location and hide that nothing else can be placed.
-const isSdkFrame = (filename = "", absPath = ""): boolean =>
-  [filename, absPath].some((v) => v.includes("/@sentry/"))
 
 // Not app:/// -- nextjsClientStackFrameNormalization rewrites our own frames to
 // that scheme before beforeSend runs, so it marks first-party code too.
@@ -60,11 +47,8 @@ const isThirdPartyLocation = (filename = "", absPath = ""): boolean =>
 /**
  * Decide whether a client error event is worth keeping.
  *
- * Every rule but the last requires positive evidence that the event did not
- * originate in our bundle, so a genuine first-party regression is never
- * silently swallowed. `unsupported-browser` is the one exception: those events
- * may well be ours, but the engine is one we cannot support, so the report is
- * unactionable either way.
+ * Every rule requires positive evidence that the event did not originate in
+ * our bundle, so a genuine first-party regression is never silently swallowed.
  */
 export function getDropReason(event: ErrorEvent): DropReason {
   const values = event.exception?.values ?? []
@@ -105,23 +89,12 @@ export function getDropReason(event: ErrorEvent): DropReason {
   // ETHORG-1AC's `AutoScroll` scraper). Our own frames are always rewritten to
   // app:///, so an event where *no* frame has a location cannot be ours. A
   // genuinely frameless event is kept: absence of frames is not evidence.
-  const frames = values
-    .flatMap((v) => v.stacktrace?.frames ?? [])
-    .filter((f) => !isSdkFrame(f.filename, f.abs_path))
+  const frames = values.flatMap((v) => v.stacktrace?.frames ?? [])
   if (
     frames.length > 0 &&
     !frames.some((f) => hasUsableLocation(f.filename, f.abs_path))
   ) {
     return "unattributable"
-  }
-
-  // `Contexts` types every field as unknown, so narrow before matching.
-  const browserName = event.contexts?.browser?.name
-  if (
-    typeof browserName === "string" &&
-    UNSUPPORTED_BROWSER.test(browserName)
-  ) {
-    return "unsupported-browser"
   }
 
   return null

--- a/tests/unit/sentry/filter-event.spec.ts
+++ b/tests/unit/sentry/filter-event.spec.ts
@@ -26,6 +26,9 @@ const event = (
     ...(extra && { extra }),
   }) as ErrorEvent
 
+const inBrowser = (name: string, base: ErrorEvent): ErrorEvent =>
+  ({ ...base, contexts: { browser: { name } } }) as ErrorEvent
+
 const cases: Array<[name: string, event: ErrorEvent, expected: DropReason]> = [
   // Wallet providers vary the message per wallet but not the code
   // (ETHORG-7Q, ETHORG-73).
@@ -91,12 +94,12 @@ const cases: Array<[name: string, event: ErrorEvent, expected: DropReason]> = [
     event([
       { value: "Maximum call stack size exceeded.", frames: ["undefined"] },
     ]),
-    "unattributable-overflow",
+    "unattributable",
   ],
   [
     "overflow, Firefox wording",
     event([{ value: "too much recursion", frames: ["<anonymous>"] }]),
-    "unattributable-overflow",
+    "unattributable",
   ],
   [
     // Sentry prepends causes, so the thrown error is the last value.
@@ -105,13 +108,71 @@ const cases: Array<[name: string, event: ErrorEvent, expected: DropReason]> = [
       { value: "some upstream cause", frames: ["undefined"] },
       { value: "Maximum call stack size exceeded", frames: ["undefined"] },
     ]),
-    "unattributable-overflow",
+    "unattributable",
   ],
   [
     "overflow in our own bundle",
     event([
       { value: "Maximum call stack size exceeded", frames: [OURS, OURS] },
     ]),
+    null,
+  ],
+  // The message no longer gates the rule, so any unlocatable stack is dropped
+  // whatever it says. ETHORG-1AC: a third-party `AutoScroll` scraper whose
+  // frames carry a line/column but no filename at all.
+  [
+    "unlocatable stack, arbitrary message",
+    event([
+      {
+        value:
+          "Failed to execute 'querySelector' on 'Document': The provided selector is empty.",
+        frames: ["", "", ""],
+      },
+    ]),
+    "unattributable",
+  ],
+  [
+    "one locatable frame among unlocatable ones is enough to keep",
+    event([
+      { value: "Cannot read properties of null", frames: ["undefined", OURS] },
+    ]),
+    null,
+  ],
+  // Absence of frames is not evidence of anything, so these still come through
+  // and remain the residue that only a message rule could catch.
+  [
+    "frameless event with a noisy message",
+    event([{ value: "Failed to connect to MetaMask" }]),
+    null,
+  ],
+  // Pale Moon forks fail on modern baseline features -- ETHORG-1AY is Next's
+  // own runtime throwing because Basilisk has no document.currentScript.
+  [
+    "unsupported engine",
+    inBrowser(
+      "Basilisk",
+      event([
+        {
+          value:
+            "Invariant: Expected document.currentScript to be a <script> element.",
+          frames: [OURS],
+        },
+      ])
+    ),
+    "unsupported-browser",
+  ],
+  [
+    "supported engine, same error",
+    inBrowser(
+      "Firefox",
+      event([
+        {
+          value:
+            "Invariant: Expected document.currentScript to be a <script> element.",
+          frames: [OURS],
+        },
+      ])
+    ),
     null,
   ],
   [

--- a/tests/unit/sentry/filter-event.spec.ts
+++ b/tests/unit/sentry/filter-event.spec.ts
@@ -10,6 +10,9 @@ import { type DropReason, getDropReason } from "@/lib/sentry/filter-event"
 // this is what a first-party frame actually looks like at filter time.
 const OURS = "app:///_next/static/chunks/app.js"
 
+// The SDK prepends this to any non-Error throw it has to synthesize.
+const SDK = "app:///node_modules/@sentry/core/src/utils/eventbuilder.ts"
+
 const event = (
   values: Array<{ value: string; frames?: string[] }>,
   extra?: Record<string, unknown>
@@ -143,6 +146,29 @@ const cases: Array<[name: string, event: ErrorEvent, expected: DropReason]> = [
   [
     "frameless event with a noisy message",
     event([{ value: "Failed to connect to MetaMask" }]),
+    null,
+  ],
+  // ETHORG-1AV: an injected script on Baidu Explorer calls a non-standard
+  // `.unLoad`. The SDK's own frame is the only locatable one, so it has to be
+  // discounted or the stack looks attributable.
+  [
+    "SDK frame is not evidence of attribution",
+    event([
+      {
+        value: "Cannot read properties of undefined (reading 'unLoad')",
+        frames: [SDK, "<anonymous>"],
+      },
+    ]),
+    "unattributable",
+  ],
+  [
+    "SDK frame alongside a real first-party frame still keeps",
+    event([
+      {
+        value: "Cannot read properties of null (reading 'click')",
+        frames: [SDK, OURS],
+      },
+    ]),
     null,
   ],
   // Pale Moon forks fail on modern baseline features -- ETHORG-1AY is Next's

--- a/tests/unit/sentry/filter-event.spec.ts
+++ b/tests/unit/sentry/filter-event.spec.ts
@@ -10,9 +10,6 @@ import { type DropReason, getDropReason } from "@/lib/sentry/filter-event"
 // this is what a first-party frame actually looks like at filter time.
 const OURS = "app:///_next/static/chunks/app.js"
 
-// The SDK prepends this to any non-Error throw it has to synthesize.
-const SDK = "app:///node_modules/@sentry/core/src/utils/eventbuilder.ts"
-
 const event = (
   values: Array<{ value: string; frames?: string[] }>,
   extra?: Record<string, unknown>
@@ -28,9 +25,6 @@ const event = (
     },
     ...(extra && { extra }),
   }) as ErrorEvent
-
-const inBrowser = (name: string, base: ErrorEvent): ErrorEvent =>
-  ({ ...base, contexts: { browser: { name } } }) as ErrorEvent
 
 const cases: Array<[name: string, event: ErrorEvent, expected: DropReason]> = [
   // Wallet providers vary the message per wallet but not the code
@@ -146,59 +140,6 @@ const cases: Array<[name: string, event: ErrorEvent, expected: DropReason]> = [
   [
     "frameless event with a noisy message",
     event([{ value: "Failed to connect to MetaMask" }]),
-    null,
-  ],
-  // ETHORG-1AV: an injected script on Baidu Explorer calls a non-standard
-  // `.unLoad`. The SDK's own frame is the only locatable one, so it has to be
-  // discounted or the stack looks attributable.
-  [
-    "SDK frame is not evidence of attribution",
-    event([
-      {
-        value: "Cannot read properties of undefined (reading 'unLoad')",
-        frames: [SDK, "<anonymous>"],
-      },
-    ]),
-    "unattributable",
-  ],
-  [
-    "SDK frame alongside a real first-party frame still keeps",
-    event([
-      {
-        value: "Cannot read properties of null (reading 'click')",
-        frames: [SDK, OURS],
-      },
-    ]),
-    null,
-  ],
-  // Pale Moon forks fail on modern baseline features -- ETHORG-1AY is Next's
-  // own runtime throwing because Basilisk has no document.currentScript.
-  [
-    "unsupported engine",
-    inBrowser(
-      "Basilisk",
-      event([
-        {
-          value:
-            "Invariant: Expected document.currentScript to be a <script> element.",
-          frames: [OURS],
-        },
-      ])
-    ),
-    "unsupported-browser",
-  ],
-  [
-    "supported engine, same error",
-    inBrowser(
-      "Firefox",
-      event([
-        {
-          value:
-            "Invariant: Expected document.currentScript to be a <script> element.",
-          frames: [OURS],
-        },
-      ])
-    ),
     null,
   ],
   [


### PR DESCRIPTION
Generalises one rule in `getDropReason()` so third-party client noise stops needing a new `ignoreErrors` regex per error message.

## Why

`instrumentation-client.ts` is, by design, the noise gate for the Sentry pipeline — `feeds/sentry-feed.mjs` on the recovery box says so explicitly:

> Client-side extension/adware noise is already filtered upstream in instrumentation-client.ts (denyUrls / ignoreErrors / beforeSend); anything reaching Sentry has passed that gate, so this list stays short by design.

But the gate's only general-purpose tool was a message list, so every new wording of the same third-party failure produced another PR. There were **13 open `[recovery]` PRs doing exactly that**, all touching this one file, so merging any one conflicted the rest. Sentry's server-side *Error Message* filter would be the alternative home, but it's Business-plan gated and unavailable on this account.

## What changed

**`unattributable-overflow` → `unattributable`.** The rule already detected the right shape — frames present, none carrying a location — but gated it behind `Maximum call stack size exceeded|too much recursion`. Removing the message gate makes it general.

Safe because `nextjsClientStackFrameNormalization` rewrites our own frames to `app:///` before `beforeSend` runs, and `app:///` passes `hasUsableLocation`. A stack where *no* frame has any location therefore cannot be ours — browsers withhold URLs for cross-origin scripts. This keeps the file's "positive evidence it isn't ours" invariant.

A genuinely frameless event is still **kept**: absence of frames is not evidence, and that residue is what a message rule would still be needed for.

That is the whole diff. The docstring's carve-out is gone too, so the invariant is unconditional again.

## Two rules were removed after review

The first version of this PR also added an SDK-frame discount and an `unsupported-browser` engine rule. Both were **removed** — neither could ever fire.

Credit to @wackerow for catching it. Root cause was shared: the fixtures were transcribed from payloads read *out* of Sentry, which are post-enrichment and post-symbolication, so they didn't reflect what `beforeSend` actually receives. The unit tests couldn't catch it because they hand-built the event objects to match those same downstream shapes.

**`isSdkFrame`** looked for `/@sentry/` in a frame path. That path is produced by Sentry resolving the sourcemaps we upload (`widenClientFileUpload: true`); in the browser the SDK is bundled into our own chunks, and `eventbuilder.js` parses frames off a synthetic `Error`'s stack, so the frame arrives as `app:///_next/static/chunks/<hash>.js`. Filename cannot separate the SDK's own frame from ours once `rewriteFrames` has run — `mechanism.synthetic` is the only real discriminator, and using it needs a captured fixture first.

**`unsupported-browser`** read `contexts.browser.name`. No `@sentry/*` package writes that field client-side — Relay derives it server-side from the User-Agent — so it is `undefined` at `beforeSend` and the rule never fired. ETHORG-1AY is already archived forever in Sentry, so nothing regresses by dropping it. If an engine rule is ever wanted, the UA *is* available: `httpContextIntegration` (default, `sdk.js:34`) sets `event.request.headers["User-Agent"]` in `preprocessEvent`, which runs at `client.js:708` inside `_prepareEvent` — before `beforeSend` at `client.js:827`.

Waterfox was also in that engine list and shouldn't have been: it tracks Firefox ESR, is actively maintained, and would have suppressed real errors.

## Tests

`tests/unit/sentry/filter-event.spec.ts` — 16 pass. Existing overflow cases retargeted to `unattributable`, plus new coverage for:

- an unlocatable stack with an arbitrary (non-overflow) message
- one locatable frame among unlocatable ones → kept
- a frameless event with a noisy message → kept (documents the deliberate residue)

`pnpm type-check` and `pnpm exec eslint` clean.

## Follow-ups (not in this PR)

- Once this ships, the `ignoreErrors` **message array** can likely be trimmed hard — but only after checking Sentry for what still arrives, since the rule can't see zero-frame events.
- Any future rule that reads event fields needs a real fixture first: `console.log(JSON.stringify(event))` in `beforeSend` on a deploy preview, or Sentry's raw stack-trace view. That one missing fixture caused both removals above.
- ETHORG-1AV is not handled by this PR (`isSdkFrame` was its intended fix). It needs the `mechanism.synthetic` approach and a captured payload.
- The agent still opens one PR per Sentry issue; that's an agent-side change, tracked separately.
