### PR TITLE
fix(intl): normalize Intl whitespace through one shared helper

### DIFF
--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -3,6 +3,8 @@ import type { PartialDate } from "@/data/upgrades/types"
 import { DEFAULT_LOCALE } from "../constants"
 import type { Lang } from "../types"
 
+import { normalizeIntlSpaces } from "./intl"
+
 /**
  * A wrapper for Intl.DateTimeFormat that enforces Web3 date standards.
  * - Forces the Gregorian calendar universally.
@@ -65,12 +67,14 @@ export const formatDate = (
   if (!isValidDate(date)) {
     return ""
   }
-  return dateTimeFormat(locale, {
-    month: "long",
-    day: "numeric",
-    year: "numeric",
-    ...options,
-  }).format(new Date(date))
+  return normalizeIntlSpaces(
+    dateTimeFormat(locale, {
+      month: "long",
+      day: "numeric",
+      year: "numeric",
+      ...options,
+    }).format(new Date(date))
+  )
 }
 
 /**
@@ -109,18 +113,13 @@ export const formatDateRange = (
   locale: string = DEFAULT_LOCALE,
   options?: Intl.DateTimeFormatOptions
 ) =>
-  dateTimeFormat(locale, {
-    month: "short",
-    day: "numeric",
-    ...options,
-  })
-    .formatRange(new Date(start), new Date(end || start))
-    // Normalize whitespace to avoid SSR/client hydration mismatches: Node's ICU
-    // and the browser's ICU can emit different space characters (e.g. U+202F
-    // narrow no-break space vs a regular U+0020) around the range en-dash. The
-    // two render identically but differ byte-for-byte, tripping React's
-    // hydration check. Collapsing whitespace makes the output deterministic.
-    .replace(/\s+/g, " ")
+  normalizeIntlSpaces(
+    dateTimeFormat(locale, {
+      month: "short",
+      day: "numeric",
+      ...options,
+    }).formatRange(new Date(start), new Date(end || start))
+  )
 
 /**
  * Date range split into parts so callers can style them individually (e.g. a
@@ -139,7 +138,7 @@ export const formatDateRangeToParts = (
     ...options,
   })
     .formatRangeToParts(new Date(start), new Date(end))
-    .map(({ type, value }) => ({ type, value: value.replace(/\s+/g, " ") }))
+    .map(({ type, value }) => ({ type, value: normalizeIntlSpaces(value) }))
 
 export const getLocaleYear = (
   locale: string = "en-US",

--- a/src/lib/utils/intl.ts
+++ b/src/lib/utils/intl.ts
@@ -13,3 +13,22 @@ export const getCountryCodeName = (countryCode: string, locale: string) => {
     type: "region",
   }).of(countryCode) as string
 }
+
+/**
+ * Collapse whitespace in an `Intl`-formatted string so SSR and client output
+ * match byte-for-byte.
+ *
+ * Node's ICU and the browser's ICU disagree on which space character to emit
+ * around formatted parts -- U+202F narrow no-break space vs U+00A0 vs a plain
+ * U+0020, varying by locale, engine and ICU version. The results render
+ * identically, so nothing looks wrong, but React's hydration check compares
+ * strings and bails out into a full client re-render.
+ *
+ * `\s` already covers U+00A0 and every Unicode space separator (U+2000-U+200A,
+ * U+202F, U+205F, U+3000), so one pass normalizes them all. Intl output never
+ * contains a meaningful run of spaces, so collapsing runs is safe.
+ *
+ * Apply this to anything derived from `Intl` that gets rendered.
+ */
+export const normalizeIntlSpaces = (formatted: string): string =>
+  formatted.replace(/\s+/g, " ")

--- a/src/lib/utils/numbers.ts
+++ b/src/lib/utils/numbers.ts
@@ -1,3 +1,5 @@
+import { normalizeIntlSpaces } from "./intl"
+
 /**
  * A wrapper for Intl.NumberFormat that enforces Web3 numeral standards.
  * - Arabic ('ar') defaults to Western Arabic numerals (1, 2, 3).
@@ -65,11 +67,13 @@ export const formatCompactNumber = (
   locale: string,
   options?: Intl.NumberFormatOptions
 ): string =>
-  numberFormat(locale, {
-    notation: "compact",
-    maximumSignificantDigits: 3,
-    ...options,
-  }).format(value)
+  normalizeIntlSpaces(
+    numberFormat(locale, {
+      notation: "compact",
+      maximumSignificantDigits: 3,
+      ...options,
+    }).format(value)
+  )
 
 export const formatPriceUSD = (
   value: number,

--- a/src/lib/utils/time.ts
+++ b/src/lib/utils/time.ts
@@ -3,6 +3,7 @@ import humanizeDuration from "humanize-duration"
 import { Lang } from "../types"
 
 import { dateTimeFormat } from "./date"
+import { normalizeIntlSpaces } from "./intl"
 import { numberFormat } from "./numbers"
 
 export const getLocaleTimestamp = (
@@ -18,7 +19,7 @@ export const getLocaleTimestamp = (
       day: "numeric",
     } as Intl.DateTimeFormatOptions)
   const date = new Date(timestamp)
-  return dateTimeFormat(locale, opts).format(date)
+  return normalizeIntlSpaces(dateTimeFormat(locale, opts).format(date))
 }
 
 /**

--- a/tests/unit/utils/intl.spec.ts
+++ b/tests/unit/utils/intl.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "@playwright/test"
+
+import type { Lang } from "@/lib/types"
+
+import { formatDate, formatDateRange } from "@/lib/utils/date"
+import { normalizeIntlSpaces } from "@/lib/utils/intl"
+import { formatCompactNumber } from "@/lib/utils/numbers"
+import { getLocaleTimestamp } from "@/lib/utils/time"
+
+const EXOTIC_SPACE = /[\u00a0\u2009\u205f\u202f\u3000\u2000-\u200a]/
+
+// The space characters ICU actually varies between Node and the browser.
+const cases: Array<[name: string, input: string, expected: string]> = [
+  ["narrow no-break space (U+202F)", "123\u202fM", "123 M"],
+  ["no-break space (U+00A0)", "1\u00a0Jan\u00a02026", "1 Jan 2026"],
+  ["thin space (U+2009)", "5\u2009%", "5 %"],
+  ["ideographic space (U+3000)", "2026\u3000\u5e74", "2026 \u5e74"],
+  ["medium mathematical space (U+205F)", "a\u205fb", "a b"],
+  ["run of mixed spaces collapses to one", "a\u00a0\u2009 \u202fb", "a b"],
+  ["plain output is untouched", "January 1, 2026", "January 1, 2026"],
+  ["empty string", "", ""],
+]
+
+for (const [name, input, expected] of cases) {
+  test(`normalizeIntlSpaces: ${name}`, () => {
+    expect(normalizeIntlSpaces(input)).toBe(expected)
+  })
+}
+
+// Guards against a formatter being reintroduced without normalization: every
+// renderer below feeds Intl output straight into JSX, where a Node-vs-browser
+// space mismatch costs a full client re-render.
+const formatters: Array<[name: string, produce: () => string]> = [
+  ["formatDate", () => formatDate("2026-09-02", "en-US")],
+  ["formatDate (ar)", () => formatDate("2026-09-02", "ar")],
+  [
+    "formatDateRange",
+    () => formatDateRange("2026-09-02", "2026-09-05", "en-US"),
+  ],
+  ["formatCompactNumber", () => formatCompactNumber(123_000_000, "en-US")],
+  ["formatCompactNumber (ur)", () => formatCompactNumber(123_000_000, "ur")],
+  [
+    "getLocaleTimestamp",
+    () => getLocaleTimestamp("en" as Lang, "2026-09-02T12:00:00Z"),
+  ],
+]
+
+for (const [name, produce] of formatters) {
+  test(`${name} emits no exotic whitespace`, () => {
+    const out = produce()
+    expect(out).not.toMatch(EXOTIC_SPACE)
+    expect(out).toBe(normalizeIntlSpaces(out))
+  })
+}


### PR DESCRIPTION
Consolidates #19191, #19195 and #19201 into one change with a shared helper.

## Why

Node's ICU and the browser's ICU disagree on which space character to emit around formatted parts — U+202F narrow no-break space vs U+00A0 vs a plain U+0020, varying by locale, engine and ICU version. The results render identically, so nothing looks wrong, but React's hydration check compares strings and bails out into a full client re-render.

`formatDateRange` and `formatDateRangeToParts` already worked around this inline. Three separate recovery-agent PRs then proposed adding the same `.replace(/\s+/g, " ")` plus a six-line comment to three more formatters — which would have left five inline copies of one rule.

## What changed

`normalizeIntlSpaces` added to the existing `src/lib/utils/intl.ts`, and all five call sites routed through it:

| formatter | file | was |
| --- | --- | --- |
| `formatDate` | `date.ts` | unnormalized (#19191) |
| `formatDateRange` | `date.ts` | inline regex |
| `formatDateRangeToParts` | `date.ts` | inline regex |
| `getLocaleTimestamp` | `time.ts` | unnormalized (#19195) |
| `formatCompactNumber` | `numbers.ts` | unnormalized (#19201) |

## Which of these were actually broken

I measured the raw `Intl` output under Node 22 rather than assuming:

```
compact 123M (en-US)   "123M"        clean
compact 123M (ar)      "123 مليون"   EXOTIC U+00A0
compact 123M (ur)      "۱۲٫۳ کروڑ"   EXOTIC U+00A0
compact 123M (fr)      "123 M"       EXOTIC U+00A0
compact 123M (de)      "123 Mio."    EXOTIC U+00A0
compact 123M (ru)      "123 млн"     EXOTIC U+00A0
date long  (all)                     clean
date+time  (all)                     clean
```

So **`formatCompactNumber` is a real mismatch today** in 5 of 8 locales tested. The date formatters come out clean on Node's side — which is precisely the ICU-72 hazard rather than a reason to skip them: Node emits U+0020 where a browser on newer ICU emits U+202F before AM/PM, and only normalizing *both* sides makes them agree. A one-sided probe can't see the browser half.

## Tests

New `tests/unit/utils/intl.spec.ts` — 14 pass. Covers each space character ICU actually varies (U+202F, U+00A0, U+2009, U+3000, U+205F), run collapsing, and pass-through of already-clean strings. It also asserts every one of the five formatters emits no exotic whitespace, so a formatter added later without normalization fails the suite rather than shipping a silent hydration bailout.

`pnpm type-check` and `pnpm exec eslint` clean. Full `pnpm test:unit` shows 1103 passing and 20 failures, all in `tests/unit/data-layer/getters.spec.ts` — I verified those 20 fail identically on unmodified `dev`, so they are pre-existing and unrelated.

## Note on `wallets.ts`

`src/lib/utils/wallets.ts:103` normalizes with an explicit `[ -   　]` class. `\s` is a strict superset of that (it also covers U+00A0), so that call site should move onto the helper too — but #19202 is currently in review against the same lines, so it is left alone here to avoid a conflict. Worth a one-line follow-up once that lands.

Closes #19191, closes #19195, closes #19201.
