### PR TITLE
Add eth.zig to backend API libraries

### DIFF
--- a/public/content/developers/docs/apis/backend/index.md
+++ b/public/content/developers/docs/apis/backend/index.md
@@ -100,6 +100,12 @@ These libraries abstract away much of the complexity of interacting directly wit
 
 ### Development tools {#development-tools}
 
+**eth.zig -** **_A Zig library for Ethereum, with compile-time ABI encoding and contract bindings._**
+
+- [GitHub](https://github.com/StrobeLabs/eth.zig)
+- [Documentation](https://ethzig.org)
+- [Examples](https://github.com/StrobeLabs/eth.zig/tree/main/examples)
+
 **ethers-kt -** **_Async, high-performance Kotlin/Java/Android library for EVM-based blockchains._**
 
 - [GitHub](https://github.com/Kr1ptal/ethers-kt)


### PR DESCRIPTION
## Description

Adds eth.zig to the "Development tools" list on `/developers/docs/apis/backend/`, alongside ethers-kt, Nethereum, and web3j -- the equivalent entries for their language ecosystems.

eth.zig is an Ethereum client library written in Zig: ABI encoding/decoding, RLP, secp256k1, Keccak-256, BIP-32/39/44 HD wallets, EIP-712, transaction types through EIP-155/2930/1559/4844/7702, JSON-RPC over HTTP/WebSocket/SSE, ENS with full ENSIP-15 normalization via the Universal Resolver, ERC-20/721, Multicall3, and Web3 Secret Storage keystores. Function selectors, event topics, and contract bindings are all resolved at compile time, so no ABI parsing happens at runtime.

No Zig library is listed anywhere on the developer portal today, so a developer coming from that ecosystem currently has nothing to go on.

Against the [listing criteria](https://ethereum.org/contributing/adding-developer-tools/):

- **Open source**: MIT.
- **Documentation**: https://ethzig.org, roughly two dozen pages, plus eight runnable examples in the repo.
- **Maintenance**: released continuously since v0.1.0 in February 2026; current release v0.9.1. CI runs unit tests, official ENSIP-15 and Unicode conformance vectors, coverage, and a format check on Linux and macOS for every PR.
- **Quality**: crypto is cross-validated against reference vectors -- KZG byte-for-byte against the official `c-kzg-4844` v2.1.1 vectors, keystores against the canonical Web3 Secret Storage vectors, BIP-39 against the Trezor vectors.
- **Usage**: stated plainly rather than dressed up -- 82 stars and 11 forks. Zig is a small ecosystem, so the case here rests on covering a language the portal does not cover at all rather than on adoption numbers.

## Placement note

I put the entry at the top of "Development tools" because that section reads as alphabetically ordered today (ethers-kt, Nethereum, Python Tooling, Tatum, web3j) and `eth.zig` sorts before `ethers-kt`. The listing policy's default is newest-at-the-bottom, so if you would rather it go last in the section, say the word and I will move it -- or feel free to move it yourself in a suggestion.

## Related Issue

Closes #19212
