### PR TITLE
chore(chromatic): untrace .storybook/*.mdx

### DIFF
--- a/chromatic.storybook.json
+++ b/chromatic.storybook.json
@@ -3,6 +3,7 @@
   "untraced": [
     "public/content/**",
     "src/intl/**",
-    "src/data/**"
+    "src/data/**",
+    ".storybook/*.mdx"
   ]
 }


### PR DESCRIPTION
Adds `.storybook/*.mdx` to the `untraced` list in `chromatic.storybook.json`.

### Why

`.storybook/Overview.mdx` is a docs-only `<Meta title="Overview" />` page — it renders no story and produces no snapshot. But because it lives under `.storybook/`, TurboSnap classifies it as Storybook config, so any branch whose diff includes it bails to a **full 242-snapshot capture**.

It has not been edited since 15 Aug, yet it kept resurfacing: TurboSnap diffs against a branch's *last Chromatic build*, so any branch that had not built in a while saw that old edit as new.

**Cost:** 10 of the 13 `changedStorybookFiles` bails this billing cycle, ~2,400 snapshots. That bail class was 64% of last cycle, which finished at 34,994 against a 35,000 allowance — i.e. it hit the cap, which pauses testing and blocks merges.

Current cycle is projecting ~105% of cap. This change takes it to roughly 75%.

### Why this is safe

- Chromatic v18.3.0 already filters `.storybook/*.md` and `*.txt` for exactly this reason; it just missed `.mdx`.
- Verified in the vendored CLI that `untraced` genuinely suppresses this bail: `changedStorybookFiles` is only set inside the traversal over the changed-file list *after* the untraced filter is applied.
- The glob is deliberately narrow. Checked against picomatch 4.0.4 with the CLI's own `{dot:true}` options: it matches `Overview.mdx` but **not** `preview.tsx`, `main.ts` or `modes.ts`, which are real config and must keep forcing a full build.

### Verifying

Not from this PR's own build — `chromatic.storybook.json` sits outside the Storybook module graph and outside `staticDirs`, so this PR should itself be bypassed. The proof is the first *other* branch that would have bailed: watch for `Found a Storybook config change in .storybook/Overview.mdx` to stop appearing in `visual-tests` logs.