### PR TITLE
fix(sentry): drop infra spans that exhaust the span quota

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -39,6 +39,14 @@ Sentry.init({
     // 1% for everything else
     return 0.01
   },
+  // Web Vitals ride on the pageload span; its resource children are pure quota
+  // cost. browser.* and LoAF stay: TTFB and INP diagnosis needs them.
+  ignoreSpans: [
+    { op: /^resource\./ },
+    { op: "paint" },
+    { op: "mark" },
+    { op: "measure" },
+  ],
   debug: environment === "development",
   environment,
   enabled: environment === "production",

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -10,4 +10,10 @@ Sentry.init({
   enabled: environment === "production",
   initialScope: { tags: { module: "app" } },
   ignoreTransactions: ["proxy"],
+  // Netlify Blobs cache reads and Next.js internals dominate our span quota.
+  ignoreSpans: [
+    { op: "http.client", name: /netlifyblobs\.com/ },
+    { name: "resolve page components" },
+    { name: "start response" },
+  ],
 })


### PR DESCRIPTION
Sentry stopped accepting spans on **Aug 31 02:33 UTC** and has accepted none since. Errors still land fine — it's the span quota that's exhausted, so we have no traces and no Web Vitals. It's not new: the same thing happened last cycle (dark Aug 5–20), and the quota appears to reset around the 21st.

We burn ~**16M spans/month**, and most of it is infrastructure chatter:

| Source | Share | Action |
| --- | ---: | --- |
| Netlify Blobs cache reads (`http.client` to `netlifyblobs.com`) | 44% | drop |
| Next.js internals (`resolve page components`, `start response`) | 19% | drop |
| `resource.*` — ~37 script/link/img children per pageload | 16% | drop |
| `paint` / `mark` / `measure` | 1% | drop |
| `browser.*` — DNS/TLS/connect/request/response | 2.6% | **keep** |
| `ui.long-animation-frame` | 1.2% | **keep** |
| Everything else, including all Web Vitals | ~16% | keep |

Web Vitals ride on the `pageload` span alone — **0.33%** of the budget. We're dark on the fraction we care about because of the ~80% we don't.

This adds `ignoreSpans` to the server and client configs. Expected: ~**3.1M spans/month**, down from ~16M.

### Why `browser.*` and LoAF stay

The obvious move is to cut every pageload child span, which would get us to ~2.5M. It isn't worth it. `browser.*` is the DNS/TLS/connect/TTFB waterfall — 2.6% of the budget and exactly what's needed to act on our TTFB P75, and `ui.long-animation-frame` is the main lever for INP attribution (INP sampling is already thin at ~424 clicks/9 days). Cutting those two saves 3.8% and blinds the two metrics we most want to improve. `resource.*` at 16% is the real bloat and the least useful per span.

### Notes

- `ignoreSpans` is supported in our `@sentry/nextjs` 10.46.0.
- Dropped spans are children of `http.server` / `pageload` transactions, so the transactions themselves stay intact.
- Orthogonal to #19210: that filters **errors** via `beforeSend`/`getDropReason` in `src/lib/sentry/filter-event.ts`; this filters **spans** via `ignoreSpans`. No file overlap, no conflict.
- This prevents the *next* blackout; it doesn't backfill. Data should return on its own at the reset unless the budget is topped up sooner.
