### PR TITLE
content(quizzes): move the energy quiz into "How Ethereum works", reorder "Security and privacy" below it

### DIFF
--- a/src/data/quizzes/index.ts
+++ b/src/data/quizzes/index.ts
@@ -251,18 +251,7 @@ const quizzesSectionsRaw: QuizzesHubSection[] = [
       { id: "wallets", level: "beginner" },
       { id: "what-are-apps", level: "beginner" },
       { id: "web3", level: "beginner" },
-      { id: "energy-consumption", level: "beginner" },
       { id: "ethereum-vs-bitcoin", level: "beginner" },
-    ],
-  },
-  {
-    id: "security-and-privacy",
-    titleKey: "security-and-privacy",
-    descriptionKey: "security-and-privacy-description",
-    quizzes: [
-      { id: "security", level: "beginner" },
-      { id: "privacy", level: "beginner" },
-      { id: "zero-knowledge-proofs", level: "intermediate" },
     ],
   },
   {
@@ -284,10 +273,21 @@ const quizzesSectionsRaw: QuizzesHubSection[] = [
     quizzes: [
       { id: "accounts", level: "beginner" },
       { id: "smart-contracts", level: "beginner" },
+      { id: "energy-consumption", level: "beginner" },
       { id: "transactions", level: "intermediate" },
       { id: "blocks", level: "intermediate" },
       { id: "gas", level: "advanced" },
       { id: "evm", level: "advanced" },
+    ],
+  },
+  {
+    id: "security-and-privacy",
+    titleKey: "security-and-privacy",
+    descriptionKey: "security-and-privacy-description",
+    quizzes: [
+      { id: "security", level: "beginner" },
+      { id: "privacy", level: "beginner" },
+      { id: "zero-knowledge-proofs", level: "intermediate" },
     ],
   },
   {


### PR DESCRIPTION
## Description

Reorders the Quiz Hub (https://ethereum.org/quizzes/). Two moves, no content changes:

- **`energy-consumption` ("Ethereum: a green and efficient blockchain") moves from "Ethereum basics" into "How Ethereum works"**, placed after "Smart contracts" with the other beginner-level quizzes so the section keeps its beginner → advanced order.
- **The "Security and privacy" section moves below "How Ethereum works"**, so the page runs basics → what people do onchain → how the network works → security and privacy → scaling.

Section order before and after:

| Before | After |
| --- | --- |
| Ethereum basics | Ethereum basics |
| Security and privacy | Apps and money |
| Apps and money | How Ethereum works |
| How Ethereum works | Security and privacy |
| Scaling, staking and nodes | Scaling, staking and nodes |

Everything on the hub renders from `quizzesSectionsRaw` in `src/data/quizzes/index.ts`, so the diff is confined to that array — 11 lines moved. No quizzes added or removed, no questions touched, no i18n keys changed, so no locale files are affected.

### Related issue

Closes #19224

## Testing

Verified against the resulting `quizzesSectionsRaw`: 5 sections, all 28 declared quizzes placed exactly once, no unplaced quizzes, every section still ordered beginner → intermediate → advanced (which is what the per-section `addNextQuiz` chain relies on), and every `titleKey`/`descriptionKey` resolves in `src/intl/en/learn-quizzes.json`. `eslint` and `prettier` pass on the changed file. I have not run the page in a local dev server — the change is data-only and the rendering component maps over the array generically, so the deploy preview is the more useful check here.

## Note for reviewers

The "How Ethereum works" description reads "A closer look at the machinery of the network itself, from accounts and transactions to the software that keeps Ethereum running" and does not mention energy or consensus. I left it untouched to keep this a pure reorder — say the word and I will add a clause in this PR.
