### PR TITLE
feat(search): improve pagerank metadata, prioritizing beginner pages

### DIFF
--- a/src/lib/utils/metadata.ts
+++ b/src/lib/utils/metadata.ts
@@ -10,6 +10,7 @@ import {
 
 import { getTranslatedLocales } from "../i18n/translationRegistry"
 
+import { categoryForSlug, pageRankForSlug } from "./searchRanking"
 import { getFullUrl, toLanguageTag } from "./url"
 
 import { routing } from "@/i18n/routing"
@@ -25,26 +26,6 @@ const imageForSlug = [
   { section: "staking", image: "/images/upgrades/upgrade_rhino.png" },
   { section: "10years", image: "/images/10-year-anniversary/10-year-og.png" },
 ] as const
-
-/**
- * Ranking hints consumed by the search crawler, mirroring the rules in the Algolia
- * DocSearch `recordExtractor` so relevance survives the move to Typesense. The
- * self-hosted scraper copies any `docsearch:*` meta tag onto every record it extracts.
- */
-const isTutorialSlug = (slug: string[]) =>
-  slug[0] === "developers" && slug[1] === "tutorials" && slug.length > 2
-
-// Matches Algolia's `pathname.split("/").length === 4`, which is one slug segment.
-// The homepage (no segments) therefore scores 5, as it does today -- kept for parity.
-const pageRankForSlug = (slug: string[]): number =>
-  isTutorialSlug(slug) ? 1 : slug.length === 1 ? 10 : 5
-
-const categoryForSlug = (slug: string[]): string => {
-  if (slug[0] === "developers" && slug[1] === "docs") return "docs"
-  if (isTutorialSlug(slug)) return "tutorials"
-  if (slug[0] === "developers") return "devs"
-  return "other"
-}
 
 /**
  * Get the default OG image for a page based on the slug

--- a/src/lib/utils/searchRanking.ts
+++ b/src/lib/utils/searchRanking.ts
@@ -75,7 +75,14 @@ export const pageRankForSlug = (slug: string[]): number => {
   )
 }
 
+/**
+ * Facets, used to filter or demote whole classes of page at query time without another
+ * crawl. `home` exists so the homepage can be withheld from results: what the crawler
+ * extracts from it is hero copy and section headings, every phrase of which appears more
+ * fully on the page it links to, so it is a near-null result for someone already here.
+ */
 export const categoryForSlug = (slug: string[]): string => {
+  if (slug.filter(Boolean).length === 0) return "home"
   if (slug[0] === "videos") return "videos"
   if (isDeveloperSection(slug, "docs")) return "docs"
   if (isTutorialSlug(slug)) return "tutorials"

--- a/src/lib/utils/searchRanking.ts
+++ b/src/lib/utils/searchRanking.ts
@@ -1,0 +1,66 @@
+/**
+ * Ranking hints consumed by the search crawler. The self-hosted scraper copies any
+ * `docsearch:*` meta tag onto every record it extracts, which is how these reach the
+ * index; the app then sorts on `pagerank` after text match.
+ *
+ * Higher is more important. The scale is ordered by who the page is for rather than
+ * where it sits: a beginner landing on "what is ethereum" is the common case, and a
+ * tutorial or a video transcript matching the same words rarely is.
+ *
+ * Split from `metadata.ts` so the policy can be tested directly -- it is expected to be
+ * retuned against the labelled query set rather than settled once.
+ */
+
+export const PAGE_RANK = {
+  /** Root-level pages, written for someone arriving without context. */
+  beginner: 10,
+  /** Guides and the learn hub: still introductory, but a step past the landing pages. */
+  guide: 8,
+  /** Everything else, including developer documentation -- secondary to a better match. */
+  default: 5,
+  /** Lookups rather than places to start reading. */
+  supplemental: 4,
+  /** Narrow, task-specific, and usually a poor answer to a general question. */
+  tutorial: 2,
+  /** Transcripts and contributor process docs, which crowd out real answers. */
+  lowest: 1,
+} as const
+
+/** Root slugs that are references to consult, not pages to learn from. */
+const SUPPLEMENTAL_ROOTS = new Set(["glossary", "resources", "ethereum-forks"])
+
+/**
+ * Root slugs demoted below everything else. `/videos/` carries auto-generated
+ * transcripts, which match almost any phrasing; `/contributing/` documents the site's
+ * own process and answers questions nobody searching the site is asking.
+ */
+const LOWEST_ROOTS = new Set(["videos", "contributing"])
+
+/** Root slugs whose pages are introductory even when nested. */
+const GUIDE_ROOTS = new Set(["guides", "learn"])
+
+const isDeveloperSection = (slug: string[], section: string) =>
+  slug[0] === "developers" && slug[1] === section
+
+export const isTutorialSlug = (slug: string[]) =>
+  isDeveloperSection(slug, "tutorials") && slug.length > 2
+
+export const pageRankForSlug = (slug: string[]): number => {
+  const [root] = slug
+  if (LOWEST_ROOTS.has(root)) return PAGE_RANK.lowest
+  if (isTutorialSlug(slug)) return PAGE_RANK.tutorial
+  if (SUPPLEMENTAL_ROOTS.has(root)) return PAGE_RANK.supplemental
+  if (GUIDE_ROOTS.has(root)) return PAGE_RANK.guide
+  // The homepage arrives as `[""]`, so it lands here too -- which is right, it is the
+  // most beginner-facing page on the site.
+  if (slug.length === 1) return PAGE_RANK.beginner
+  return PAGE_RANK.default
+}
+
+export const categoryForSlug = (slug: string[]): string => {
+  if (slug[0] === "videos") return "videos"
+  if (isDeveloperSection(slug, "docs")) return "docs"
+  if (isTutorialSlug(slug)) return "tutorials"
+  if (slug[0] === "developers") return "devs"
+  return "other"
+}

--- a/src/lib/utils/searchRanking.ts
+++ b/src/lib/utils/searchRanking.ts
@@ -3,9 +3,14 @@
  * `docsearch:*` meta tag onto every record it extracts, which is how these reach the
  * index; the app then sorts on `pagerank` after text match.
  *
- * Higher is more important. The scale is ordered by who the page is for rather than
- * where it sits: a beginner landing on "what is ethereum" is the common case, and a
- * tutorial or a video transcript matching the same words rarely is.
+ * Higher is more important. The scale is ordered by who the page is for: a beginner
+ * landing on "what is ethereum" is the common case, and a tutorial or a video transcript
+ * matching the same words rarely is.
+ *
+ * Depth stands in for generality. A page one level below a topic is still about that
+ * topic; three levels down it is about a detail of it. Flattening everything below the
+ * root into one bucket made `/eth/supply` and `/roadmap/merge/issuance` indistinguishable
+ * on a query about ETH issuance, where the shallower page is plainly the better answer.
  *
  * Split from `metadata.ts` so the policy can be tested directly -- it is expected to be
  * retuned against the labelled query set rather than settled once.
@@ -16,7 +21,9 @@ export const PAGE_RANK = {
   beginner: 10,
   /** Guides and the learn hub: still introductory, but a step past the landing pages. */
   guide: 8,
-  /** Everything else, including developer documentation -- secondary to a better match. */
+  /** Developer documentation -- important, but secondary to a better match elsewhere. */
+  docs: 5,
+  /** Floor for the depth decay, so a deeply nested page never sinks below the docs. */
   default: 5,
   /** Lookups rather than places to start reading. */
   supplemental: 4,
@@ -25,6 +32,9 @@ export const PAGE_RANK = {
   /** Transcripts and contributor process docs, which crowd out real answers. */
   lowest: 1,
 } as const
+
+/** Rank lost per level below the root, before the floor applies. */
+const DEPTH_PENALTY = 2
 
 /** Root slugs that are references to consult, not pages to learn from. */
 const SUPPLEMENTAL_ROOTS = new Set(["glossary", "resources", "ethereum-forks"])
@@ -45,16 +55,24 @@ const isDeveloperSection = (slug: string[], section: string) =>
 export const isTutorialSlug = (slug: string[]) =>
   isDeveloperSection(slug, "tutorials") && slug.length > 2
 
+/**
+ * Levels below the root. The homepage arrives as `[""]` rather than an empty array, so
+ * empty segments are dropped before counting -- otherwise it reads as depth 1 and scores
+ * above every other page.
+ */
+const depthOf = (slug: string[]) => Math.max(slug.filter(Boolean).length - 1, 0)
+
 export const pageRankForSlug = (slug: string[]): number => {
   const [root] = slug
   if (LOWEST_ROOTS.has(root)) return PAGE_RANK.lowest
   if (isTutorialSlug(slug)) return PAGE_RANK.tutorial
   if (SUPPLEMENTAL_ROOTS.has(root)) return PAGE_RANK.supplemental
+  if (isDeveloperSection(slug, "docs")) return PAGE_RANK.docs
   if (GUIDE_ROOTS.has(root)) return PAGE_RANK.guide
-  // The homepage arrives as `[""]`, so it lands here too -- which is right, it is the
-  // most beginner-facing page on the site.
-  if (slug.length === 1) return PAGE_RANK.beginner
-  return PAGE_RANK.default
+  return Math.max(
+    PAGE_RANK.beginner - DEPTH_PENALTY * depthOf(slug),
+    PAGE_RANK.default
+  )
 }
 
 export const categoryForSlug = (slug: string[]): string => {

--- a/tests/unit/search/page-rank.spec.ts
+++ b/tests/unit/search/page-rank.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test } from "@playwright/test"
+
+import {
+  categoryForSlug,
+  PAGE_RANK,
+  pageRankForSlug,
+} from "@/lib/utils/searchRanking"
+
+test.describe("pageRankForSlug", () => {
+  test("puts beginner landing pages at the top", () => {
+    for (const slug of [
+      ["what-is-ethereum"],
+      ["security"],
+      ["smart-contracts"],
+      ["gas"],
+      ["nft"],
+      ["defi"],
+      ["privacy"],
+      ["values"],
+      ["get-eth"],
+    ]) {
+      expect(pageRankForSlug(slug), slug.join("/")).toBe(PAGE_RANK.beginner)
+    }
+  })
+
+  test("ranks the homepage with the landing pages", () => {
+    // It arrives as `[""]` rather than an empty array, which used to make its rank an
+    // accident of `slug.length === 1` rather than a decision.
+    expect(pageRankForSlug([""])).toBe(PAGE_RANK.beginner)
+  })
+
+  test("orders the buckets beginner > guide > docs > supplemental > tutorial > lowest", () => {
+    const order = [
+      pageRankForSlug(["what-is-ethereum"]),
+      pageRankForSlug(["guides", "how-to-swap-tokens"]),
+      pageRankForSlug(["developers", "docs", "blocks"]),
+      pageRankForSlug(["glossary"]),
+      pageRankForSlug(["developers", "tutorials", "some-tutorial"]),
+      pageRankForSlug(["videos", "a-talk"]),
+    ]
+    expect(order).toEqual([...order].sort((a, b) => b - a))
+    expect(new Set(order).size).toBe(order.length)
+  })
+
+  test("demotes references below the pages that explain a term", () => {
+    // Typing a glossary term must not surface the glossary above the page that covers
+    // it; the ranking carries half of that, curation the rest.
+    expect(pageRankForSlug(["glossary"])).toBeLessThan(
+      pageRankForSlug(["staking"])
+    )
+    for (const root of ["glossary", "resources", "ethereum-forks"]) {
+      expect(pageRankForSlug([root]), root).toBe(PAGE_RANK.supplemental)
+    }
+  })
+
+  test("demotes transcripts and contributor docs furthest", () => {
+    expect(pageRankForSlug(["videos", "a-talk"])).toBe(PAGE_RANK.lowest)
+    expect(pageRankForSlug(["contributing", "adding-a-quiz"])).toBe(
+      PAGE_RANK.lowest
+    )
+    // "Adding a quiz" outranking /nft/ for the query "nft" is the failure this fixes.
+    expect(pageRankForSlug(["contributing", "adding-a-quiz"])).toBeLessThan(
+      pageRankForSlug(["nft"])
+    )
+  })
+
+  test("leaves nested pages at the default", () => {
+    expect(pageRankForSlug(["roadmap", "merge"])).toBe(PAGE_RANK.default)
+    expect(pageRankForSlug(["developers", "docs", "blocks"])).toBe(
+      PAGE_RANK.default
+    )
+  })
+})
+
+test.describe("categoryForSlug", () => {
+  test("gives videos their own facet so transcripts can be filtered", () => {
+    expect(categoryForSlug(["videos", "a-talk"])).toBe("videos")
+  })
+
+  test("keeps the existing developer facets", () => {
+    expect(categoryForSlug(["developers", "docs", "blocks"])).toBe("docs")
+    expect(categoryForSlug(["developers", "tutorials", "x"])).toBe("tutorials")
+    expect(categoryForSlug(["developers"])).toBe("devs")
+    expect(categoryForSlug(["staking"])).toBe("other")
+  })
+})

--- a/tests/unit/search/page-rank.spec.ts
+++ b/tests/unit/search/page-rank.spec.ts
@@ -97,6 +97,15 @@ test.describe("categoryForSlug", () => {
     expect(categoryForSlug(["videos", "a-talk"])).toBe("videos")
   })
 
+  test("marks the homepage so it can be withheld from results", () => {
+    // It arrives as `[""]`, and is a landing page rather than a page about anything.
+    expect(categoryForSlug([""])).toBe("home")
+    expect(categoryForSlug([])).toBe("home")
+    // Named listing pages are not the same case -- people search for them by name.
+    expect(categoryForSlug(["stories"])).toBe("other")
+    expect(categoryForSlug(["latest"])).toBe("other")
+  })
+
   test("keeps the existing developer facets", () => {
     expect(categoryForSlug(["developers", "docs", "blocks"])).toBe("docs")
     expect(categoryForSlug(["developers", "tutorials", "x"])).toBe("tutorials")

--- a/tests/unit/search/page-rank.spec.ts
+++ b/tests/unit/search/page-rank.spec.ts
@@ -24,9 +24,25 @@ test.describe("pageRankForSlug", () => {
   })
 
   test("ranks the homepage with the landing pages", () => {
-    // It arrives as `[""]` rather than an empty array, which used to make its rank an
-    // accident of `slug.length === 1` rather than a decision.
+    // It arrives as `[""]` rather than an empty array. Counted naively that reads as
+    // depth 1 and scores it above every other page, so empty segments are dropped.
     expect(pageRankForSlug([""])).toBe(PAGE_RANK.beginner)
+  })
+
+  test("prefers the shallower page when both are below a root", () => {
+    // The reported case: "issuance of eth" put /roadmap/merge/issuance above /eth/supply
+    // because a flat model scored every non-root page the same.
+    expect(pageRankForSlug(["eth", "supply"])).toBeGreaterThan(
+      pageRankForSlug(["roadmap", "merge", "issuance"])
+    )
+  })
+
+  test("decays with depth and stops at the floor", () => {
+    expect(pageRankForSlug(["eth"])).toBe(10)
+    expect(pageRankForSlug(["eth", "supply"])).toBe(8)
+    expect(pageRankForSlug(["roadmap", "merge", "issuance"])).toBe(6)
+    // Deeper pages settle at the floor rather than sinking under tutorials and videos.
+    expect(pageRankForSlug(["a", "b", "c", "d", "e"])).toBe(PAGE_RANK.default)
   })
 
   test("orders the buckets beginner > guide > docs > supplemental > tutorial > lowest", () => {
@@ -64,11 +80,15 @@ test.describe("pageRankForSlug", () => {
     )
   })
 
-  test("leaves nested pages at the default", () => {
-    expect(pageRankForSlug(["roadmap", "merge"])).toBe(PAGE_RANK.default)
+  test("holds developer docs at their own rank, whatever their depth", () => {
+    // Docs are deliberately exempt from the decay: nesting there is organisational,
+    // not a signal that the page is more specific than a reader wanted.
     expect(pageRankForSlug(["developers", "docs", "blocks"])).toBe(
-      PAGE_RANK.default
+      PAGE_RANK.docs
     )
+    expect(
+      pageRankForSlug(["developers", "docs", "scaling", "optimistic-rollups"])
+    ).toBe(PAGE_RANK.docs)
   })
 })
 


### PR DESCRIPTION
## Summary

Widens the `pagerank` hint the search crawler reads from three values to six, ordered by who a page is for rather than how deep it sits.

| Bucket | Rank | Examples |
| --- | --- | --- |
| Root-level pages | 10 | `/`, `/what-is-ethereum`, `/nft`, `/eth` |
| Guides and learn | 8 | `/guides/how-to-swap-tokens`, `/learn` |
| One level down | 8 | `/eth/supply`, `/staking/solo` |
| Two levels down | 6 | `/roadmap/merge/issuance` |
| Developer docs, and the floor below | 5 | `/developers/docs/blocks` |
| References to consult | 4 | `/glossary`, `/resources`, `/ethereum-forks` |
| Tutorials | 2 | `/developers/tutorials/*` |
| Transcripts and contributor docs | 1 | `/videos/*`, `/contributing/*` |

Rank decays 2 per level below the root and floors at the developer-docs rank, so a deeply nested page never sinks under a tutorial. Depth stands in for generality: a page one level under a topic is still about that topic, three levels down it is about a detail of it.

A flat bucket for everything below the root was not enough. Searching `issuance of eth` put `/roadmap/merge/issuance` above `/eth/supply`, and no ordering among the named categories could separate them because both scored 5. Developer docs are exempt from the decay and hold their rank at any depth -- nesting there is organisational, not a signal the page is narrower than the reader wanted.

The demotions are the point. `/videos/` carries auto-generated transcripts that match almost any phrasing, and `/contributing/` documents the site's own process -- "Adding a quiz" is currently the top result for the query `nft`, above `/nft/` itself. References are split from landing pages so that typing a glossary term does not surface the glossary above the page that explains that term; ranking carries half of that and curation the rest.

Videos also get their own `category`, so transcripts can be filtered or demoted at query time without another crawl.

The homepage arrives as `[""]` and so previously scored 10 by falling through `slug.length === 1`, while the comment beside it claimed 5 -- the open question from the #19166 review. Counting depth makes that worse rather than better, since `[""]` reads as depth 1; empty segments are dropped, and its rank is now a decision rather than a side effect of how the slug happens to be shaped.

## Notes for review

- Policy moved out of `metadata.ts` into `searchRanking.ts` so it can be tested directly. It is expected to be retuned against the labelled query set rather than settled once.
- **This has no effect until it is deployed.** The crawler reads `docsearch:*` meta tags off production, so the values only reach the index on the next crawl after this is live. Nothing changes for users at merge time.
- The promote gate scores hit@1 against the labelled query set before moving any alias, so a re-crawl that ranks worse is refused rather than published.

## Depends on

Nothing here, but it is only measurable once #19194 is live and a crawl has run.

