### PR TITLE
content(about): drop stale roadmap section, closed issue links, and a broken anchor

### DIFF
--- a/public/content/about/index.md
+++ b/public/content/about/index.md
@@ -21,6 +21,8 @@ Ethereum is a public network, a blockchain, and an open-source protocol -- opera
 
 [More on Ethereum governance](/governance/)
 
+[More on Ethereum's core principles](/values/)
+
 ### Ether (ETH) {#ether-or-eth}
 
 Ether (also known by its ticker symbol, ETH) is the native currency transacted on Ethereum. ETH is needed to pay for usage of the Ethereum network (in the form of transaction fees). ETH is also used to secure the network with staking. When people talk about the price of Ethereum, they're referring to ETH the asset.
@@ -71,7 +73,7 @@ To achieve this mission, our team focuses on two primary goals on ethereum.org:
 - Facilitate greater diversity of contributions: code, content, design, translation, moderation
 - Keep the codebase modern, clean, and well-documented
 
-## Core principles {#core-principles}
+## Our core principles {#core-principles}
 
 We have some core principles that help guide us to accomplish our mission.
 
@@ -85,20 +87,17 @@ We want our users to have their interest piqued and their questions answered. So
 Ethereum and the community are always evolving, so ethereum.org will too. That's why the site has a simple design system & modular structure. We make iterative changes as we learn more about how people use the site and what the community wants from it.
 We're open source, with a community of contributors, so you can propose changes or help us out too.
 [Learn about contributing](/contributing/)
+[Why open source matters](/open-source/)
 
 ### 3. ethereum.org is not a typical product website 🦄 {#core-principles-3}
 
 Ethereum is a big thing: it includes a community, a technology, a set of ideas and ideologies, and more.
-This means the website needs to handle many different user journeys, from “a developer who wants a specific tool” and “a newcomer who just bought some ETH and doesn’t know what a wallet is".
+This means the website needs to handle many different user journeys, from “a developer who wants a specific tool” to “a newcomer who just bought some ETH and doesn’t know what a wallet is”.
 "What is the best website for a blockchain platform?" remains an open question - we are pioneers. Building this requires experimentation.
 
-## Product roadmap {#roadmap}
+## Get involved {#get-involved}
 
-To make our work more accessible and to foster more community collaboration, the ethereum.org core team publishes an overview of our [shape up cycle](https://www.productplan.com/glossary/shape-up-method/) roadmap goals.
-
-[View our 2025 Cycle 1 product roadmap](https://github.com/ethereum/ethereum-org-website/issues/14726)
-
-**How's that sound?** We always appreciate feedback on our roadmap - if there's something you think we should work on, please let us know! We welcome ideas and PRs from anyone in the community.
+**How's that sound?** We always appreciate feedback on our work - if there's something you think we should work on, please let us know! We welcome ideas and PRs from anyone in the community.
 
 **Want to get involved?** [Learn more about contributing](/contributing/), [hit us up on Twitter](https://x.com/ethdotorg), or join the community discussions in [our Discord server](https://discord.gg/ethereum-org).
 
@@ -110,7 +109,7 @@ We use a set of [design principles](/contributing/design-principles/) to guide o
 
 We built and released a [design system](https://www.figma.com/file/NrNxGjBL0Yl1PrNrOT8G2B/ethereum.org-Design-System?node-id=0%3A1&t=QBt9RkhpPqzE3Aa6-1) to ship features more quickly and let community members participate in the open design of ethereum.org.
 
-Want to get involved? [Follow along in Figma](https://www.figma.com/file/NrNxGjBL0Yl1PrNrOT8G2B/ethereum.org-Design-System), the [GitHub issue](https://github.com/ethereum/ethereum-org-website/issues/6284) and join the conversation in our [#design Discord channel](https://discord.gg/ethereum-org).
+Want to get involved? [Follow along in Figma](https://www.figma.com/file/NrNxGjBL0Yl1PrNrOT8G2B/ethereum.org-Design-System) and join the conversation in our [#design Discord channel](https://discord.gg/ethereum-org).
 
 ## Style guide {#style-guide}
 
@@ -128,6 +127,6 @@ The ethereum.org website is open source and built under an [MIT License](https:/
 
 Although this website is open-source and anyone can work on it, we do have a team dedicated to ethereum.org and other Ethereum Foundation web projects.
 
-We'll post any job openings here. If you don't see a role here for you, head over to [our Discord server](https://discord.gg/ethereum-org) and let us know how you'd like to work with us!
+When we're hiring, we'll list open roles here. If you don't see a role for you, head over to [our Discord server](https://discord.gg/ethereum-org) and let us know how you'd like to work with us!
 
-Looking beyond the ethereum.org team? [Check out other Ethereum related jobs](/community/get-involved/#ethereum-jobs/).
+Looking beyond the ethereum.org team? [Check out other Ethereum related jobs](/community/get-involved/#ethereum-jobs).


### PR DESCRIPTION
## Description

Fixes the five stale or broken things on `/about/` catalogued in #19242, plus the two internal links that issue identified as missing. All changes are in `public/content/about/index.md`; no code, no component, no locale files.

**1. Removed the "Product roadmap" section.** #14726 ("Cycle 1 2025 ethereum.org product roadmap") closed on 2025-04-01 and no successor issue was ever opened, so the section advertised an ongoing practice that no longer exists and linked to a closed issue. Its last two paragraphs are the only place on the page that funnels people to contributing, Twitter, and Discord together, so they survive in the same slot under a new `## Get involved {#get-involved}` heading. The only wording change to the surviving copy is "feedback on our roadmap" → "feedback on our work". Nothing in the repo links to `/about/#roadmap`, so dropping that anchor breaks nothing.

**2. Dropped the design system section's link to #6284** ("Epic: open design system V1", closed 2023-02-08). The Figma and `#design` Discord links in the same sentence were both fine and are untouched.

**3. Fixed the jobs anchor.** `/community/get-involved/#ethereum-jobs/` → `/community/get-involved/#ethereum-jobs`. The target is `id="ethereum-jobs"`, so the trailing slash after the fragment matched nothing and the jump silently failed.

**4. Reworded the empty "Open jobs" section** so the empty state reads as intentional rather than unmaintained, without asserting anything about headcount. The `{#open-jobs}` anchor is unchanged — `src/lib/nav/footerLinks.ts:112`, `public/content/community/get-involved/index.md:103`, and two `redirects.config.js` entries (`/about/web-developer`, `/about/product-designer`) all depend on it.

**5. Fixed the typo in core principle 3.** "from X **and** Y" → "from X **to** Y", and the straight closing `"` is now a curly `”` to match the rest of the sentence.

**6. Added two missing internal links.** `/values/` now appears in the "A note on names" block, which is exactly the Ethereum-the-protocol vs ethereum.org-the-website distinction that page sits on. `/open-source/` now appears in core principle 2, where being open source is the subject rather than a passing detail — before this it had one inbound internal link across the whole site. To keep the page's own principles section readable next to the new `/values/` link, `## Core principles` is retitled `## Our core principles`; the `{#core-principles}` anchor is unchanged.

### Verification

- `pnpm lint:md` — 343 files, 0 errors. The pre-commit markdownlint hook also passed.
- Rendered `/about/` against a local dev server and asserted on the HTML: the `#roadmap` anchor and both closed-issue URLs are gone; `#get-involved`, `#open-jobs`, `#core-principles`, the `/values/` and `/open-source/` hrefs, the corrected `#ethereum-jobs` href, and the fixed typo are all present.
- Confirmed the three link targets resolve: `/values/` 200, `/open-source/` 200, and `/community/get-involved/` 200 with `id="ethereum-jobs"` present on the page.

### Translation impact

English only. `public/content/about/index.md` has locale copies under `public/content/translations/`; those are left to the intl pipeline and will lag until it next runs. Item 3 is a link-target change with no translation cost.

## Related Issue

Closes #19242