### PR TITLE
fix(homepage): send the privacy slide to the privacy hub

### DIFF
--- a/src/components/Homepage/SavingsCarousel.tsx
+++ b/src/components/Homepage/SavingsCarousel.tsx
@@ -80,7 +80,7 @@ function useSlides(): Slide[] {
       subtitle: t("page-index-carousel-privacy-subtitle"),
       description: t("page-index-carousel-privacy-description"),
       cta: t("page-index-carousel-privacy-cta"),
-      href: "/apps/categories/privacy/",
+      href: "/privacy/",
       image: defiImage,
       imagePortrait: defiImagePortrait,
       comparison: {

--- a/src/intl/en/page-index.json
+++ b/src/intl/en/page-index.json
@@ -35,7 +35,7 @@
   "page-index-carousel-privacy-title": "Use the internet without being watched",
   "page-index-carousel-privacy-subtitle": "Most apps track what you do, who you talk to, and what you own. They sell that data or hand it over when asked. On Ethereum, your activity can stay private.",
   "page-index-carousel-privacy-description": "No account tied to your name. No company watching your balance.",
-  "page-index-carousel-privacy-cta": "Use privacy preserving apps",
+  "page-index-carousel-privacy-cta": "Why privacy matters",
   "page-index-carousel-privacy-traditional-label": "TRADITIONAL APPS",
   "page-index-carousel-privacy-traditional-value": "Your data is their product",
   "page-index-carousel-privacy-ethereum-label": "ETHEREUM APPS",


### PR DESCRIPTION
## Description

The homepage savings carousel's privacy slide ("Use the internet without being watched") pointed at `/apps/categories/privacy/`, a filtered product listing, while the slide copy is about surveillance and why privacy matters. This points it at the `/privacy/` hub and changes the CTA to match the destination.

- `href`: `/apps/categories/privacy/` → `/privacy/`
- CTA: "Use privacy preserving apps" → **"Why privacy matters"**

The apps listing is still one click away: `/privacy/` links to it from the "Getting started" pathway card ("Protect your privacy online"). The other two slides in the carousel already use hub-level CTAs ("Try it yourself" → `/payments/`, "Learn more about DeFi" → `/defi/`), so the set stays consistent.

Only `src/intl/en/page-index.json` is touched; the 24 locale files pick the new string up through the intl pipeline.

The Matomo event name for the slide (`savings_carousel/privacy`) is unchanged, so the click series stays continuous across the change.

## Preview

The privacy slide is the first slide of the carousel on the homepage.

## Related issue

Closes #19249
