### PR TITLE
fix: make getDayOfYear immune to daylight saving shifts

### DIFF
--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -179,7 +179,10 @@ export const getWeekNumber = (date: Date): number => {
  * @returns Day of year (1-365 or 1-366 for leap years)
  */
 export const getDayOfYear = (date: Date): number => {
-  const start = new Date(date.getFullYear(), 0, 0)
-  const diff = date.getTime() - start.getTime()
-  return Math.floor(diff / 86400000)
+  // Differences are taken in UTC so a DST shift between January and `date`
+  // cannot move the result to the neighbouring day, the same way
+  // getWeekNumber normalizes.
+  const start = Date.UTC(date.getFullYear(), 0, 0)
+  const current = Date.UTC(date.getFullYear(), date.getMonth(), date.getDate())
+  return Math.round((current - start) / 86400000)
 }

--- a/tests/unit/date/day-of-year.spec.ts
+++ b/tests/unit/date/day-of-year.spec.ts
@@ -1,0 +1,34 @@
+/**
+ * getDayOfYear used to subtract two local timestamps, so a daylight saving
+ * shift between January and the given date left a remainder that pushed the
+ * floored result onto the neighbouring day. It is the seed for the daily app
+ * rotation, so an off-by-one there repeats or skips a day's order.
+ *
+ * The timezone is set per assertion because the bug is invisible in UTC, which
+ * is where CI runs.
+ */
+
+import { expect, test } from "@playwright/test"
+
+import { getDayOfYear } from "@/lib/utils/date"
+
+test("getDayOfYear is unaffected by daylight saving shifts", () => {
+  const originalTZ = process.env.TZ
+  try {
+    // Clocks go forward in March, so June used to read one day low.
+    process.env.TZ = "America/New_York"
+    expect(getDayOfYear(new Date(2026, 5, 15, 0, 30))).toBe(166)
+
+    // Southern hemisphere shifts the other way, one day high.
+    process.env.TZ = "Australia/Sydney"
+    expect(getDayOfYear(new Date(2026, 5, 15, 23, 30))).toBe(166)
+
+    // Leap year boundaries.
+    process.env.TZ = "Europe/Berlin"
+    expect(getDayOfYear(new Date(2024, 1, 29, 12, 0))).toBe(60)
+    expect(getDayOfYear(new Date(2024, 11, 31, 12, 0))).toBe(366)
+    expect(getDayOfYear(new Date(2026, 0, 1, 12, 0))).toBe(1)
+  } finally {
+    process.env.TZ = originalTZ
+  }
+})

--- a/tests/unit/date/day-of-year.spec.ts
+++ b/tests/unit/date/day-of-year.spec.ts
@@ -29,6 +29,10 @@ test("getDayOfYear is unaffected by daylight saving shifts", () => {
     expect(getDayOfYear(new Date(2024, 11, 31, 12, 0))).toBe(366)
     expect(getDayOfYear(new Date(2026, 0, 1, 12, 0))).toBe(1)
   } finally {
-    process.env.TZ = originalTZ
+    if (originalTZ === undefined) {
+      delete process.env.TZ
+    } else {
+      process.env.TZ = originalTZ
+    }
   }
 })


### PR DESCRIPTION
`getDayOfYear` subtracted two local timestamps:

```ts
const start = new Date(date.getFullYear(), 0, 0)
const diff = date.getTime() - start.getTime()
return Math.floor(diff / 86400000)
```

A DST shift between January and `date` leaves the elapsed time short of (or over) a whole number of days, so `Math.floor` lands on the neighbouring day. Its sibling `getWeekNumber` already avoids this by going through `Date.UTC`.

Measured against a DST-free reference over 1344 sampled instants in 2026:

| timezone | wrong |
| --- | --- |
| UTC | 0 |
| Europe/Berlin | 193 |
| America/New_York | 217 |
| Australia/Sydney | 167 |
| America/Santiago | 141 |

One day low after the northern spring shift, one day high in southern hemisphere zones.

## Impact today

Both callers (`CategoryAppsGrid`, the `open-source` page) use it for the daily app rotation seed and run on the server, so a UTC deployment is not affected right now. The function is exported and its doc comment promises 1–365/366 for any date, so this is about the utility being correct rather than a visible bug on the site.

## Change

Take the difference in UTC from the local calendar fields, matching `getWeekNumber`.

## Test

`tests/unit/date/day-of-year.spec.ts` sets `process.env.TZ` per assertion, because the bug is invisible in UTC where CI runs. It fails on `dev` with `Expected: 166, Received: 165` and passes with the change.

`eslint`, `prettier --check` and `tsc --noEmit` are clean for the touched files. The full `unit` project is 1128 passed / 20 failed, and those 20 are the `data-layer/getters` specs, which fail identically on unmodified `dev` here (they need live data).
