### PR TITLE
fix(developers/tools): render catalog thumbnails and banners unoptimized

### DIFF
--- a/app/[locale]/developers/tools/[tool]/page.tsx
+++ b/app/[locale]/developers/tools/[tool]/page.tsx
@@ -1,10 +1,11 @@
+import { AppWindowMac } from "lucide-react"
 import { notFound } from "next/navigation"
 import { getTranslations, setRequestLocale } from "next-intl/server"
 
 import type { Lang, PageParams } from "@/lib/types"
 
 import ContentFeedback from "@/components/ContentFeedback"
-import { Image } from "@/components/Image"
+import { ImageWithFallback } from "@/components/Image/ImageWithFallback"
 import MainArticle from "@/components/MainArticle"
 import {
   Breadcrumb,
@@ -120,23 +121,32 @@ const Page = async (props: { params: Promise<ToolPageParams> }) => {
       <main className="px-page pb-page">
         <MainArticle className="flex flex-col gap-10">
           {tool.banner_url && (
-            <Image
+            <ImageWithFallback
+              unoptimized
               src={tool.banner_url}
               alt=""
               width={1200}
               height={300}
               className="h-40 w-full rounded-base object-cover sm:h-56"
+              fallback={null}
             />
           )}
 
           <div className="flex flex-col gap-6 lg:flex-row lg:gap-10">
             {tool.thumbnail_url && (
-              <Image
+              <ImageWithFallback
+                unoptimized
+                loading="eager"
                 src={tool.thumbnail_url}
                 alt={tool.name}
                 width={124}
                 height={124}
                 className="size-16 shrink-0 rounded-xl object-cover xl:size-32"
+                fallback={
+                  <div className="grid size-16 shrink-0 place-items-center rounded-xl border xl:size-32">
+                    <AppWindowMac className="size-8 text-body-medium xl:size-12" />
+                  </div>
+                }
               />
             )}
             <div className="flex flex-col gap-4">

--- a/app/[locale]/developers/tools/_components/InterceptedToolDetail.tsx
+++ b/app/[locale]/developers/tools/_components/InterceptedToolDetail.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation"
 import { getTranslations } from "next-intl/server"
 
-import { Image } from "@/components/Image"
+import { ImageWithFallback } from "@/components/Image/ImageWithFallback"
 import { Tag, TagsInlineText } from "@/components/ui/tag"
 
 import {
@@ -58,12 +58,14 @@ const InterceptedToolDetail = async ({
       <div className="flex flex-col bg-background">
         {tool.banner_url && (
           <div className="h-24 w-full shrink-0 sm:h-36">
-            <Image
+            <ImageWithFallback
+              unoptimized
               src={tool.banner_url}
               alt=""
               width={23 * 16}
               height={23 * 4}
               className="size-full object-cover"
+              fallback={null}
             />
           </div>
         )}

--- a/app/[locale]/developers/tools/_components/ToolCard.tsx
+++ b/app/[locale]/developers/tools/_components/ToolCard.tsx
@@ -28,6 +28,7 @@ const ToolCard = memo(function ToolCard({
         descriptionMaxLines={2}
         descriptionExpandable={false}
         thumbnail={tool.thumbnail_url ?? undefined}
+        thumbnailUnoptimized
         fallbackIcon={
           <AppWindowMac className="size-12 text-body-medium group-hover/appcard:text-primary-hover" />
         }

--- a/src/components/AppCard/index.tsx
+++ b/src/components/AppCard/index.tsx
@@ -75,6 +75,13 @@ export interface AppCardProps
   descriptionMaxLines?: number
   descriptionExpandable?: boolean
   thumbnail?: string
+  /**
+   * Render the thumbnail as a raw `<img>` rather than through `next/image`.
+   * Use when the source is an arbitrary third-party URL that isn't in
+   * `images.remotePatterns` -- the optimizer 400s on those instead of
+   * serving the image.
+   */
+  thumbnailUnoptimized?: boolean
   category?: string
   categoryTagStatus?: TagProps["status"]
   tags?: string[]
@@ -104,6 +111,7 @@ const AppCard = React.forwardRef<HTMLDivElement, AppCardProps>(
       descriptionMaxLines,
       descriptionExpandable = true,
       thumbnail,
+      thumbnailUnoptimized,
       category,
       categoryTagStatus,
       tags,
@@ -130,20 +138,28 @@ const AppCard = React.forwardRef<HTMLDivElement, AppCardProps>(
       </div>
     ) : null
 
+    const thumbnailProps = {
+      src: thumbnail as string,
+      alt: name,
+      className: "size-full object-contain",
+      width: imageSize ? imageSizePixels[imageSize] : 64,
+      height: imageSize ? imageSizePixels[imageSize] : 64,
+      fallback: fallbackNode,
+    }
+
     const innerContent = (
       <div className={cn(layoutVariants({ layout }))}>
         {/* Image or fallback */}
         {(thumbnail || fallbackIcon) && (
           <div className={cn(imageSizeVariants({ size: imageSize }))}>
             {thumbnail ? (
-              <ImageWithFallback
-                src={thumbnail}
-                alt={name}
-                className="size-full object-contain"
-                width={imageSize ? imageSizePixels[imageSize] : 64}
-                height={imageSize ? imageSizePixels[imageSize] : 64}
-                fallback={fallbackNode}
-              />
+              // `unoptimized` is the discriminant of ImageWithFallback's prop
+              // union, so it has to be a literal, not a variable.
+              thumbnailUnoptimized ? (
+                <ImageWithFallback unoptimized {...thumbnailProps} />
+              ) : (
+                <ImageWithFallback {...thumbnailProps} />
+              )
             ) : (
               fallbackNode
             )}


### PR DESCRIPTION
[this PR was made by claude]

Tool thumbnails and banners come from the community [`builder-resources`](https://github.com/ethereum/builder-resources) catalog, which points at arbitrary third-party hosts. `images.remotePatterns` is a hostname allowlist, so `/_next/image` returns 400 for any host that isn't on it — currently **33 of 275 thumbnails and 28 of 172 banners, across 19 hosts** (worst offenders: `raw.githubusercontent.com` with 16 thumbnails + 12 banners, and `pse.dev` with 16 banners). The images simply don't render, and the standalone tool page had no fallback, so the hero logo showed as blank space.

Renders these through `ImageWithFallback`'s `unoptimized` branch (raw `<img>`), which the component already documents as the path for arbitrary external URLs. Also fixes `.ico` sources and a `415` case, which fail even from allowlisted hosts.

Extending `remotePatterns` was considered and rejected: the catalog is maintained in another repo, so each new tool on a new host would reintroduce the bug.

**Trade-off:** unoptimized means original bytes, no WebP, no resizing. Mitigated by lazy loading (default in that branch), the catalog grid's existing `content-visibility:auto`, and these being 40–56px icons.

Flagged by Ahrefs Site Audit as "Page has broken image" on 1,240 pages (+261 week over week).

### Before / after

`/developers/tools/w3pk/` — hero logo is `https://w3pk.w3hc.org/favicon.ico`:

| | before (live) | after |
|---|---|---|
| hero request | `GET /_next/image/?url=…w3pk.w3hc.org%2Ffavicon.ico&w=256&q=75` → **400** | `GET https://w3pk.w3hc.org/favicon.ico` → **200** |
| rendered | broken-image glyph + alt text | logo renders (256×256) |
| `/_next/image` refs on page | 1 (failing) | 0 |

Same for `/developers/tools/speedrunethereum/` (`speedrunethereum.com/favicon.ico`, 48×48).

Worth noting the failure is more severe than a broken image alone: with a non-allowlisted host, `next/image` throws `Invalid src prop … hostname is not configured`, which **500s the whole route** in dev. Production degrades to a broken image rather than a 500, but the same invalid-src path is what's being removed here.

### Verification

- `pnpm type-check` — clean. The `unoptimized` discriminant is passed as a literal via two branches, since `ImageWithFallbackProps` is a discriminated union and a variable won't narrow.
- `pnpm lint` — clean on all four files.
- `pnpm test:unit` — 1147 passed, 1 skipped.
- `pnpm exec playwright test --project=e2e tests/e2e/horizontal-overflow.spec.ts` — 5 passed (includes `/developers/tools/`).
- `/developers/tools/` catalog: **0** `_next/image` refs remain; 171 thumbnails now raw `<img>`.
- Fallback regression: 285 catalog tools − 114 without `thumbnail_url` = 171 images; the other 114 render the `AppWindowMac` fallback.
- `/apps/` regression: still **174** `_next/image` refs, 0 raw — the new prop is opt-in and only `ToolCard` sets it. The other 9 `AppCard` callers are untouched.

### Follow-ups (not in this PR)

- `raw.githubusercontent.com` looks like a genuine allowlist omission given `github.com` is already listed — worth its own PR.
- Oversized catalog images, now shipped as original bytes. Checked all 61 non-allowlisted URLs: median 15 KB, and 3 banners over 500 KB — `walletchan-mcp.png` (765 KB), `noir.png` (730 KB), `light-account.jpg` (710 KB). No multi-MB assets, so not blocking; largest thumbnail is 345 KB. Best fixed upstream in the catalog.
- `ToolCard` opts in unconditionally, so tool thumbnails already re-hosted on the allowlisted S3 bucket also skip the optimizer now. That's the intended trade-off (the catalog's host set is unpredictable), but it does mean the tools grid no longer gets WebP/resizing for the ~80% of images that were already optimizable.



