### PR TITLE
fix(bug-bounty): guard leaderboard against invalid GitHub handles

### DIFF
--- a/app/[locale]/bug-bounty/_components/bug-bounty-leaderboard.tsx
+++ b/app/[locale]/bug-bounty/_components/bug-bounty-leaderboard.tsx
@@ -9,6 +9,22 @@ import { List, ListItem } from "@/components/ui/list"
 
 import { GITHUB_URL } from "@/lib/constants"
 
+/**
+ * GitHub handles are alphanumeric, may contain hyphens, must not start with
+ * one, and cap at 39 characters. Leaderboard data is hand-maintained and has
+ * held a display name in `username` before, which produced a 404 avatar and a
+ * dead profile link -- so validate the shape rather than just checking
+ * truthiness, since a display name is truthy.
+ *
+ * Deliberately looser than GitHub's current signup rule, which also forbids
+ * trailing and consecutive hyphens: legacy accounts predate it (`p-` in
+ * `execution-bounty-hunters.json` is a live account), and rejecting a working
+ * handle would swap a good link for initials. Catching the actual failure mode
+ * -- characters that can't appear in a handle at all, such as the space in
+ * "Jeongmin Choi" -- is what matters here.
+ */
+const GITHUB_USERNAME_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9-]{0,38}$/
+
 type Person = {
   name: string
   username: string
@@ -34,9 +50,16 @@ const BugBountyLeaderboard = async ({
       {content
         .filter((_, idx) => idx < limit)
         .map(({ name, username, score }, idx) => {
-          const hasGitHub = !!username
-          const avatarImg = GITHUB_URL + (username || "random") + ".png?size=40"
-          const avatarAlt = hasGitHub ? `${username} GitHub avatar` : ""
+          const hasGitHub = GITHUB_USERNAME_REGEX.test(username ?? "")
+          // Empty src lets Avatar fall back to initials. The old `"random"`
+          // placeholder requested github.com/random.png -- a real, unrelated user.
+          const avatarImg = hasGitHub
+            ? `${GITHUB_URL}${username}.png?size=40`
+            : ""
+          // Doubles as the image alt when there is an avatar and as the source
+          // of Avatar's initials when there isn't, so fall back to the person's
+          // name -- `""` renders an empty circle instead of initials.
+          const avatarAlt = hasGitHub ? `${username} GitHub avatar` : name
 
           let emoji: string | null = null
           if (idx === 0) {

--- a/src/data/consensus-bounty-hunters.json
+++ b/src/data/consensus-bounty-hunters.json
@@ -150,7 +150,7 @@
     "score": 1000
   },
   {
-    "username": "Jeongmin Choi",
+    "username": "",
     "name": "Jeongmin Choi",
     "score": 1000
   },

--- a/tests/unit/bug-bounty/github-handles.spec.ts
+++ b/tests/unit/bug-bounty/github-handles.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * Every `username` in the bounty-hunter data must either be empty or be a
+ * usable GitHub handle.
+ *
+ * The failure this catches is silent: `bug-bounty-leaderboard.tsx`
+ * interpolates `username` straight into both the avatar URL and the profile
+ * link, so a display name in that field ships a 404 avatar and two dead links
+ * to `https://github.com/First Last` in the same row. Nothing throws, the row
+ * still renders, and the only visible symptom is a missing image -- which the
+ * `Avatar` fallback then hides behind initials.
+ *
+ * The regex mirrors the component's guard. It is deliberately looser than
+ * GitHub's current signup rule (which also forbids trailing and consecutive
+ * hyphens) because legacy accounts predate that rule: `p-` is a live account
+ * in the execution list. Failing it here would push someone to "fix" a working
+ * handle.
+ *
+ * An empty string is allowed and meaningful: it is how a hunter with no known
+ * handle is recorded, and the component renders those as plain unlinked rows.
+ */
+
+import fs from "fs"
+import path from "path"
+
+import { expect, test } from "@playwright/test"
+
+const GITHUB_USERNAME_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9-]{0,38}$/
+
+type BountyHunter = { username: string; name: string; score: number }
+
+const dataDir = path.resolve(__dirname, "../../../src/data")
+
+const load = (file: string): BountyHunter[] =>
+  JSON.parse(fs.readFileSync(path.join(dataDir, file), "utf8"))
+
+for (const file of [
+  "consensus-bounty-hunters.json",
+  "execution-bounty-hunters.json",
+]) {
+  test(`${file}: every username is empty or a valid GitHub handle`, () => {
+    const invalid = load(file)
+      .filter(({ username }) => username !== "")
+      .filter(({ username }) => !GITHUB_USERNAME_REGEX.test(username))
+      .map(({ username, name }) => `${name}: ${JSON.stringify(username)}`)
+
+    expect(
+      invalid,
+      `Invalid GitHub handle(s) in ${file}. Use the person's handle, or "" to ` +
+        `render them as an unlinked row with initials.`
+    ).toEqual([])
+  })
+}


### PR DESCRIPTION
One entry in `consensus-bounty-hunters.json` had a display name in its `username` field (`"Jeongmin Choi"`), which the leaderboard interpolates directly into both the avatar URL and the profile link. On production that renders as a 404 avatar and **two dead links** to `https://github.com/Jeongmin Choi` in the same row (verified in the live DOM, Consensus Layer row 31). The `!!username` guard can't catch it, since a display name is truthy.

Blanks the bad `username` (keeping the display name for attribution) and replaces the truthiness check with a GitHub handle shape check, so future bad data degrades to the initials fallback that `Avatar` already provides instead of emitting a broken image and a dead link.

`execution-bounty-hunters.json` was checked and its 87 handles all resolve.

**Reviewers (@wackerow / @pettinarip):** if the bounty submission records have Jeongmin Choi's actual GitHub handle, please substitute it for the empty string — that's the better fix than blanking it.

Flagged by Ahrefs Site Audit as a broken image with 25 inlinks (the locale variants of `/bug-bounty/`).

### Before / after — Consensus Layer row 31

| | before (live) | after |
|---|---|---|
| avatar | `_next/image?url=…/Jeongmin Choi.png` → **404** | no request; initials **JC** |
| initials shown | `JCGA`, overflowing the circle | `JC` |
| links in row | 2 × `https://github.com/Jeongmin Choi` (dead) | none (row unlinked) |

### Two things found while verifying, beyond the reported defect

**1. The `"random"` placeholder is live, not hypothetical.** `GITHUB_URL + (username || "random")` affects every entry with an empty `username`, and there are **14** of them (2 consensus + 12 execution). Production currently makes 14 requests for `https://github.com/random.png` — the avatar of an unrelated real GitHub user — one on each of those rows. Now zero.

**2. The initials fallback was rendering garbage.** `Avatar` derives initials from its `name` prop, which the leaderboard was passing as `"<username> GitHub avatar"`. Any errored avatar therefore showed initials like **`JCGA`** ("Jeongmin Choi GitHub Avatar") rather than `JC`, and the 14 username-less rows passed `""` and got an empty circle. `avatarAlt` now falls back to the person's name when there's no handle, so those rows show real initials. Alt text for the 110 rows that do have a handle is unchanged.

### On the regex

The handle rule here is deliberately **looser** than GitHub's current signup rule (which also forbids trailing and consecutive hyphens):

```ts
const GITHUB_USERNAME_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9-]{0,38}$/
```

The stricter rule rejects `p-` (Peter Stöckli, execution list) — but `https://github.com/p-` is a **live account** that renders fine today, so enforcing the signup rule would have swapped a working avatar and link for initials. Legacy accounts predate the rule. This regex still rejects the actual failure mode decisively: characters that can't appear in a handle at all, such as a space.

### Test

`tests/unit/bug-bounty/github-handles.spec.ts` asserts every `username` in both files is empty or a valid handle. Confirmed it fails on the pre-fix data and passes after.

### Follow-ups (not in this PR)

Grepped for other hand-maintained usernames interpolated into GitHub URLs. Nothing else is exposed to this class of bad data — the remaining call sites take their login from the GitHub API rather than from a checked-in file:

- `src/components/IssuesList/index.tsx:44` — `issue.user.login`, API-derived
- `src/data-layer/fetchers/fetchGitHubContributors.ts:162,163,177,403` — API-derived
- `src/data-layer/fetchers/developer-tools/ranking.ts:55,68` — repo paths from the `builder-resources` catalog; hand-maintained upstream, but they're `owner/repo` paths rather than usernames and feed ranking, not a rendered link

### Verification

- `pnpm type-check`, `pnpm lint` — clean
- `pnpm test:unit` — 1149 passed (1147 before + 2 new)
- `/bug-bounty/` locally: **0** hrefs containing a space, **0** `random.png` requests, **0** broken images on the page; 116 GitHub avatars still render (production's 131 minus the 14 `random` and 1 broken)
- Row 1 of all three lists still shows a real avatar, a working profile link, and its medal
