### PR TITLE
Add Blockchain.info to Block explorers services

### DIFF
--- a/public/content/developers/docs/data-and-analytics/block-explorers/index.md
+++ b/public/content/developers/docs/data-and-analytics/block-explorers/index.md
@@ -21,6 +21,7 @@ You should understand the basic concepts of Ethereum so you can make sense of th
 
 ## Services {#services}
 
+- [Blockchain.info](https://www.blockchain.com/explorer) - Multichain block explorer with wallet, price, and transaction data
 - [Blockchair](https://blockchair.com/ethereum) - Private Ethereum explorer. Also for sorting and filtering (mempool) data. Available in Spanish, French, Italian, Dutch, Portuguese, Russian, Chinese, and Farsi
 - [Chainlens](https://www.chainlens.com/)
 - [DexGuru Block Explorer](https://ethereum.dex.guru/)


### PR DESCRIPTION
## Description

Adds Blockchain.info to the "Services" list on the [Block explorers](https://ethereum.org/developers/docs/data-and-analytics/block-explorers/) page

## Related Issue

N/A
